### PR TITLE
[pt#145611715] stick the organization list in there

### DIFF
--- a/app/assets/javascripts/rollups/loader.js.coffee
+++ b/app/assets/javascripts/rollups/loader.js.coffee
@@ -15,7 +15,7 @@ class App.Rollups.Loader
             # if $id.data().always or @manyClients
             # Just always show the squares since they also provide a means of accessing the client GUID
             id = $id.data().id
-            [ point, personalID, dataSourceID ] = @clients[id]
+            [ point, personalID, dataSourceID, organization ] = @clients[id]
             $square = App.util.colorSquare
               point:     point
               low:       0
@@ -25,10 +25,15 @@ class App.Rollups.Loader
               center:    true
             $square.addClass('rollup__square')
             $square.append dataSourceID
-            $html = $ '<div>PersonalID: <span class="pid"/><br>data source: <span/><br><i>click to copy personal id</i></div>'
+            $html = $ '<div><div class="org"/>PersonalID: <span class="pid"/><br>data source: <span/><br><i>click to copy personal id</i></div>'
             $html.css textAlign: 'left', fontSize: 'smaller'
-            $html.find('span:first').text personalID
+            $html.find('.pid').text personalID
             $html.find('span:last').text dataSourceID
+            $org = $html.find '.org'
+            if organization
+              $org.text organization
+            else
+              $org.remove()
             $square.tooltip html: true, title: $html
             $id.append $square
             $square.click ->

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -83,6 +83,7 @@ module GrdaWarehouse::Hud
     has_many :employment_educations, **hud_many(EmploymentEducation), inverse_of: :client
     has_many :hmis_forms, class_name: GrdaWarehouse::HmisForm.name
 
+    has_many :organizations, -> { order(:OrganizationName).uniq }, through: :enrollments
     has_many :source_services, through: :source_clients, source: :services
     has_many :source_enrollments, through: :source_clients, source: :enrollments
     has_many :source_enrollment_cocs, through: :source_clients, source: :enrollment_cocs

--- a/app/views/clients/show.haml
+++ b/app/views/clients/show.haml
@@ -65,10 +65,10 @@
 
 -# load in al the bits of aggregate statistics via ajax
 = content_for :page_js do
-  - source_clients = @client.source_clients.preload(:data_source)
+  - source_clients = @client.source_clients.preload(:data_source, :organizations)
   :javascript
     var rollupPath = #{rollup_client_path(@client).to_json};
-    var clients = #{source_clients.each_with_index.map{ |c, i| [ c.id, [ i, c.uuid, c.data_source.short_name ] ] }.to_h.to_json};
+    var clients = #{source_clients.each_with_index.map{ |c, i| [ c.id, [ i, c.uuid, c.data_source.short_name, c.organizations.map(&:name).to_sentence ] ] }.to_h.to_json};
     var manyClients = #{source_clients.many?.to_json};
     var high = #{@client.source_clients.size + 1};
     var rollups = new App.Rollups.Loader($('.rollup'), rollupPath, manyClients, clients, high);

--- a/app/views/window/clients/_rollups.haml
+++ b/app/views/window/clients/_rollups.haml
@@ -45,7 +45,7 @@
   - source_clients = @client.source_clients.preload(:data_source)
   :javascript
     var rollupPath = #{rollup_client_path(@client).to_json};
-    var clients = #{source_clients.each_with_index.map{ |c, i| [ c.id, [ i, c.uuid, c.data_source.short_name ] ] }.to_h.to_json};
+    var clients = #{source_clients.each_with_index.map{ |c, i| [ c.id, [ i, c.uuid, c.data_source.short_name, c.organizations.map(&:name).to_sentence ] ] }.to_h.to_json};
     var manyClients = #{source_clients.many?.to_json};
     var high = #{@client.source_clients.size + 1};
     var rollups = new App.Rollups.Loader($('.rollup'), rollupPath, manyClients, clients, high);

--- a/app/views/window/clients/_rollups.haml
+++ b/app/views/window/clients/_rollups.haml
@@ -42,7 +42,7 @@
 
 -# load in al the bits of aggregate statistics via ajax
 = content_for :page_js do
-  - source_clients = @client.source_clients.preload(:data_source)
+  - source_clients = @client.source_clients.preload(:data_source, :organizations)
   :javascript
     var rollupPath = #{rollup_client_path(@client).to_json};
     var clients = #{source_clients.each_with_index.map{ |c, i| [ c.id, [ i, c.uuid, c.data_source.short_name, c.organizations.map(&:name).to_sentence ] ] }.to_h.to_json};


### PR DESCRIPTION
There isn't terribly much to this. I found all the places where that little colored widget was called, found how the list of clients was being created, and added the organization name to the the tuples mapped to client ids. This seemed to be only in two places. I wasn't sure how to navigate to where `app/views/window/clients/_rollups.haml` was being used (perhaps I should have persisted), but I figure the logic is straightforward. If the organization name is absent, it simply isn't displayed, so this isn't likely to produce any egregious bugs.