### PR TITLE
build slack config only if env variables present

### DIFF
--- a/config/exception_notifier.yml
+++ b/config/exception_notifier.yml
@@ -1,4 +1,4 @@
-<% if ENV['EXCEPTION_WEBHOOK_URL'] && ENV['EXCEPTION_WEBHOOK_CHANNEL'] %>
+<% if ENV['EXCEPTION_WEBHOOK_URL'].present? && ENV['EXCEPTION_WEBHOOK_CHANNEL'].present? %>
 <%= ENV['RAILS_ENV'] %>:
   slack:
     webhook_url: <%= ENV['EXCEPTION_WEBHOOK_URL'] %>
@@ -6,4 +6,4 @@
     additional_parameters:
       mrkdwn: true
       icon_url: <%= ENV.fetch('EXCEPTION_WEBHOOK_ICON') %>
-<% end %> 
+<% end %>


### PR DESCRIPTION
allows `bin/rake grda_warehouse:daily` to run even if slack ENV not configured.