### PR TITLE
Stories/consent form notifications 152149661

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -9,8 +9,10 @@ module Admin
 
     def update
       tag_list = config_params[:tag_list].select(&:present?)
+      file_notification_list = config_params[:file_notification_list].select(&:present?)
       @config.assign_attributes(config_params)
       @config.document_ready_list = tag_list
+      @config.file_notification_list = file_notification_list
       config_source.invalidate_cache
       if @config.save
         redirect_to({action: :index}, notice: 'Configuration updated')
@@ -34,6 +36,7 @@ module Admin
         :cas_url,
         :allow_partial_release,
         tag_list: [],
+        file_notification_list: [],
       )
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -71,6 +71,7 @@ module Admin
         :last_name,
         :first_name,
         :email,
+        :receive_file_upload_notifications,
         role_ids: [],
         contact_attributes: [:id, :first_name, :last_name, :phone, :email, :role]
       )

--- a/app/controllers/clients/files_controller.rb
+++ b/app/controllers/clients/files_controller.rb
@@ -17,8 +17,15 @@ module Clients
           note: file_params[:note],
           name: file_params[:name],
         )
-        @file.tag_list.add(file_params[:tag_list].select(&:present?))
+        tag_list = file_params[:tag_list].select(&:present?)
+        @file.tag_list.add(tag_list)
         @file.save!
+
+        # Send notifications if appropriates
+        tag_list = ActsAsTaggableOn::Tag.where(name: tag_list).pluck(:id)
+        notification_triggers = GrdaWarehouse::Config.get(:file_notifications).pluck(:id)
+        to_send = tag_list & notification_triggers
+        FileNotificationMailer.notify(to_send, @client.id).deliver_later if to_send.any?
       rescue Exception => e
         flash[:error] = e.message
         render action: :new

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -46,6 +46,7 @@ class Users::InvitationsController < Devise::InvitationsController
         :first_name,
         :last_name,
         :email,
+        :receive_file_upload_notifications,
         role_ids: [],
         )
     end

--- a/app/controllers/window/clients/files_controller.rb
+++ b/app/controllers/window/clients/files_controller.rb
@@ -33,8 +33,15 @@ module Window::Clients
           note: file_params[:note],
           name: file_params[:name],
         )
-        @file.tag_list.add(file_params[:tag_list].select(&:present?))
+        tag_list = file_params[:tag_list].select(&:present?)
+        @file.tag_list.add(tag_list)
         @file.save!
+
+        # Send notifications if appropriates
+        tag_list = ActsAsTaggableOn::Tag.where(name: tag_list).pluck(:id)
+        notification_triggers = GrdaWarehouse::Config.get(:file_notifications).pluck(:id)
+        to_send = tag_list & notification_triggers
+        FileNotificationMailer.notify(to_send, @client.id).deliver_later if to_send.any?
       rescue Exception => e
         flash[:error] = e.message
         render action: :new

--- a/app/mailers/file_notification_mailer.rb
+++ b/app/mailers/file_notification_mailer.rb
@@ -1,0 +1,11 @@
+class FileNotificationMailer < ApplicationMailer
+
+  def notify tag_ids, client_id
+    # @tags = ActsAsTaggableOn::Tag.where(id: tag_ids)
+    @client_id = client_id
+    @notify = User.receives_file_notifications
+    @notify.each do |user|
+      mail(to: user.email, subject: "[Warehouse] File upload notification")
+    end
+  end
+end

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -3,6 +3,7 @@ module GrdaWarehouse
     after_save :invalidate_cache
     acts_as_taggable
     acts_as_taggable_on :document_ready
+    acts_as_taggable_on :file_notifications
 
     def self.available_cas_methods
       {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ActiveRecord::Base
   has_many :user_clients, class_name: GrdaWarehouse::UserClient.name
   has_many :clients, through: :user_clients, inverse_of: :users, dependent: :destroy
 
+  scope :receives_file_notifications, -> do
+    where(receive_file_upload_notifications: true)
+  end
+
   # NOTE: users and rows in this join table are in different databases, so transactions
   # aren't going to play well across this boundary
   after_destroy do |user|

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -14,6 +14,7 @@
       = f.input :release_duration, collection: GrdaWarehouse::Config.available_release_durations
       = f.input :allow_partial_release, label: 'Allow partial CAS releases?'
       = f.input :cas_url, label: 'CAS Site URL'
+      = f.input :file_notification_list, collection: GrdaWarehouse::ClientFile.available_tags, label: 'Files that should trigger notifications', input_html: {value: f.object.tag_list_on(:file_notifications), multiple: :multiple, class: 'select2'}
     .col-sm-6
       = f.input :site_coc_codes, as: :string, label: 'Default CoC Codes', hint: 'comma separated.  eg. MA-500, MA-504'
       = f.input :continuum_name, as: :string, label: 'Continuum Name'

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -7,6 +7,7 @@
         = f.input :first_name, required: true
         = f.input :last_name, required: true
         = f.input :email, as: :email, required: true
+        = f.input :receive_file_upload_notifications, label: 'User should receive notifications for file uploads'
       .form--checkbox-groups
         %h3 Roles for Access Permissions
         = f.association :roles, as: :check_boxes, label_method: :role_name, collection: Role.editable

--- a/app/views/file_notification_mailer/notify.haml
+++ b/app/views/file_notification_mailer/notify.haml
@@ -1,0 +1,3 @@
+%h2 File Uploaded
+%p Files were added to a client record that you may be interested in.
+%p= link_to @client_id, client_files_url(client_id: @client_id)

--- a/app/views/users/invitations/new.html.haml
+++ b/app/views/users/invitations/new.html.haml
@@ -9,6 +9,7 @@
       = f.input :last_name, required: true
       - resource.class.invite_key_fields.each do |field| 
         = f.input field
+      = f.input :receive_file_upload_notifications, label: 'User should receive notifications for file uploads'
       .form--checkbox-groups
         %h3 Roles for Access Permissions
         = f.association :roles, as: :check_boxes, label_method: :role_name, collection: Role.editable

--- a/db/migrate/20171024183915_add_receive_file_upload_notifications_flag.rb
+++ b/db/migrate/20171024183915_add_receive_file_upload_notifications_flag.rb
@@ -1,0 +1,5 @@
+class AddReceiveFileUploadNotificationsFlag < ActiveRecord::Migration
+  def change
+    add_column :users, :receive_file_upload_notifications, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023174425) do
+ActiveRecord::Schema.define(version: 20171024183915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,28 @@ ActiveRecord::Schema.define(version: 20171023174425) do
   add_index "activity_logs", ["controller_name"], :name=>"index_activity_logs_on_controller_name", :using=>:btree
   add_index "activity_logs", ["item_model"], :name=>"index_activity_logs_on_item_model", :using=>:btree
   add_index "activity_logs", ["user_id"], :name=>"index_activity_logs_on_user_id", :using=>:btree
+
+  create_table "cas_reports", force: :cascade do |t|
+    t.integer  "client_id",                          :null=>false
+    t.integer  "match_id",                           :null=>false
+    t.integer  "decision_id",                        :null=>false
+    t.integer  "decision_order",                     :null=>false
+    t.string   "match_step",                         :null=>false
+    t.string   "decision_status",                    :null=>false
+    t.boolean  "current_step",                       :default=>false, :null=>false
+    t.boolean  "active_match",                       :default=>false, :null=>false
+    t.datetime "created_at",                         :null=>false
+    t.datetime "updated_at",                         :null=>false
+    t.integer  "elapsed_days",                       :default=>0, :null=>false
+    t.datetime "client_last_seen_date"
+    t.datetime "criminal_hearing_date"
+    t.string   "decline_reason"
+    t.string   "not_working_with_client_reason"
+    t.string   "administrative_cancel_reason"
+    t.boolean  "client_spoken_with_services_agency"
+    t.boolean  "cori_release_form_submitted"
+  end
+  add_index "cas_reports", ["client_id", "match_id", "decision_id"], :name=>"index_cas_reports_on_client_id_and_match_id_and_decision_id", :unique=>true, :using=>:btree
 
   create_table "client_service_history", id: false, force: :cascade do |t|
     t.integer "unduplicated_client_id"
@@ -170,34 +192,34 @@ ActiveRecord::Schema.define(version: 20171023174425) do
     t.boolean  "can_view_imports",                 :default=>false
     t.boolean  "can_edit_roles",                   :default=>false
     t.boolean  "can_view_projects",                :default=>false
-    t.boolean  "can_edit_projects",                :default=>false
-    t.boolean  "can_edit_project_groups",          :default=>false
     t.boolean  "can_view_organizations",           :default=>false
-    t.boolean  "can_edit_organizations",           :default=>false
-    t.boolean  "can_edit_data_sources",            :default=>false
     t.boolean  "can_view_client_window",           :default=>false
     t.boolean  "can_upload_hud_zips",              :default=>false
-    t.boolean  "can_edit_translations",            :default=>false
-    t.boolean  "can_manage_assessments",           :default=>false
-    t.boolean  "can_edit_anything_super_user",     :default=>false
     t.boolean  "can_administer_health",            :default=>false
     t.boolean  "can_edit_client_health",           :default=>false
     t.boolean  "can_view_client_health",           :default=>false
     t.boolean  "health_role",                      :default=>false, :null=>false
+    t.boolean  "can_edit_project_groups",          :default=>false
+    t.boolean  "can_edit_anything_super_user",     :default=>false
+    t.boolean  "can_edit_projects",                :default=>false
+    t.boolean  "can_edit_organizations",           :default=>false
+    t.boolean  "can_edit_data_sources",            :default=>false
+    t.boolean  "can_edit_translations",            :default=>false
+    t.boolean  "can_manage_assessments",           :default=>false
     t.boolean  "can_manage_config",                :default=>false
+    t.boolean  "can_edit_dq_grades",               :default=>false
     t.boolean  "can_manage_client_files",          :default=>false
     t.boolean  "can_manage_window_client_files",   :default=>false
-    t.boolean  "can_edit_dq_grades",               :default=>false
     t.boolean  "can_view_vspdat",                  :default=>false
     t.boolean  "can_edit_vspdat",                  :default=>false
     t.boolean  "can_create_clients",               :default=>false
     t.boolean  "can_view_client_history_calendar", :default=>false
-    t.boolean  "can_create_cohorts",               :default=>false
-    t.boolean  "can_view_cohorts",                 :default=>false
+    t.boolean  "can_view_aggregate_health",        :default=>false
     t.boolean  "can_assign_users_to_clients",      :default=>false
     t.boolean  "can_view_client_user_assignments", :default=>false
     t.boolean  "can_export_hmis_data",             :default=>false
-    t.boolean  "can_view_aggregate_health",        :default=>false
+    t.boolean  "can_create_cohorts",               :default=>false
+    t.boolean  "can_view_cohorts",                 :default=>false
     t.boolean  "can_confirm_housing_release",      :default=>false
   end
   add_index "roles", ["name"], :name=>"index_roles_on_name", :using=>:btree
@@ -262,13 +284,13 @@ ActiveRecord::Schema.define(version: 20171023174425) do
   add_index "user_roles", ["user_id"], :name=>"index_user_roles_on_user_id", :using=>:btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "last_name",              :null=>false
-    t.string   "email",                  :null=>false
-    t.string   "encrypted_password",     :default=>"", :null=>false
+    t.string   "last_name",                         :null=>false
+    t.string   "email",                             :null=>false
+    t.string   "encrypted_password",                :default=>"", :null=>false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default=>0, :null=>false
+    t.integer  "sign_in_count",                     :default=>0, :null=>false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -279,11 +301,11 @@ ActiveRecord::Schema.define(version: 20171023174425) do
     t.string   "unconfirmed_email"
     t.string   "invitation_token"
     t.datetime "invitation_created_at"
-    t.integer  "failed_attempts",        :default=>0, :null=>false
+    t.integer  "failed_attempts",                   :default=>0, :null=>false
     t.string   "unlock_token"
     t.datetime "locked_at"
-    t.datetime "created_at",             :null=>false
-    t.datetime "updated_at",             :null=>false
+    t.datetime "created_at",                        :null=>false
+    t.datetime "updated_at",                        :null=>false
     t.datetime "deleted_at"
     t.string   "first_name"
     t.datetime "invitation_sent_at"
@@ -291,7 +313,8 @@ ActiveRecord::Schema.define(version: 20171023174425) do
     t.integer  "invitation_limit"
     t.integer  "invited_by_id"
     t.string   "invited_by_type"
-    t.integer  "invitations_count",      :default=>0
+    t.integer  "invitations_count",                 :default=>0
+    t.boolean  "receive_file_upload_notifications", :default=>false
   end
   add_index "users", ["confirmation_token"], :name=>"index_users_on_confirmation_token", :unique=>true, :using=>:btree
   add_index "users", ["deleted_at"], :name=>"index_users_on_deleted_at", :using=>:btree


### PR DESCRIPTION
This completes:

https://www.pivotaltracker.com/story/show/152149661

It provides a means of setting an admin config to keep track of which file tags should trigger a notification, a means of indicating which users should receive the notification and a mailer to notify those users when one of the indicated files is uploaded.