### PR TITLE
Stories/r14/providers csv format  2  156618257

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
     carrierwave-i18n (0.2.0)
-    charlock_holmes (0.7.5)
+    charlock_holmes (0.7.6)
     choice (0.2.0)
     chronic (0.10.2)
     coderay (1.1.1)

--- a/app/models/concerns/arel_helper.rb
+++ b/app/models/concerns/arel_helper.rb
@@ -134,7 +134,7 @@ module ArelHelper
   def f_t
     GrdaWarehouse::Hud::Funder.arel_table
   end
-  def st_t
+  def site_t
     GrdaWarehouse::Hud::Site.arel_table
   end
 
@@ -331,7 +331,7 @@ module ArelHelper
     def f_t
       GrdaWarehouse::Hud::Funder.arel_table
     end
-    def st_t
+    def site_t
       GrdaWarehouse::Hud::Site.arel_table
     end
   end

--- a/app/models/concerns/arel_helper.rb
+++ b/app/models/concerns/arel_helper.rb
@@ -131,6 +131,12 @@ module ArelHelper
   def hdv_t
     GrdaWarehouse::Hud::HealthAndDv.arel_table
   end
+  def f_t
+    GrdaWarehouse::Hud::Funder.arel_table
+  end
+  def st_t
+    GrdaWarehouse::Hud::Site.arel_table
+  end
 
   # and to the class itself (so they can be used in scopes, for example)
   class_methods do
@@ -321,6 +327,12 @@ module ArelHelper
     end
     def hdv_t
       GrdaWarehouse::Hud::HealthAndDv.arel_table
+    end
+    def f_t
+      GrdaWarehouse::Hud::Funder.arel_table
+    end
+    def st_t
+      GrdaWarehouse::Hud::Site.arel_table
     end
   end
 end

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -145,8 +145,8 @@ module GrdaWarehouse::Hud
     has_many :self_sufficiency_assessments, -> { where(name: 'Self-Sufficiency Matrix')}, class_name: GrdaWarehouse::HmisForm.name, through: :source_clients, source: :hmis_forms
     has_many :case_management_notes, -> { where(name: 'SDH Case Management Note')}, class_name: GrdaWarehouse::HmisForm.name, through: :source_clients, source: :hmis_forms
     has_many :health_touch_points, -> do
-      f_t = GrdaWarehouse::HmisForm.arel_table
-      where(f_t[:collection_location].matches('Social Determinants of Health%'))
+      hmisf_t = GrdaWarehouse::HmisForm.arel_table
+      where(hmisf_t[:collection_location].matches('Social Determinants of Health%'))
     end, class_name: GrdaWarehouse::HmisForm.name, through: :source_clients, source: :hmis_forms
     has_many :cas_reports, class_name: 'GrdaWarehouse::CasReport', inverse_of: :client
 

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -425,7 +425,7 @@ module GrdaWarehouse::Hud
             when :current_continuum_project
               ::HUD.ad_hoc_yes_no_1 project[h.to_s].presence&.to_i
             when :fed_partner_program
-              ::HUD.funding_source project['fed_partner_program']
+              ::HUD.funding_source project[h.to_s]
             else
               project[h.to_s]
             end

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -421,7 +421,7 @@ module GrdaWarehouse::Hud
               "#{project['provider']} (#{project['_provider']})".squish
             when :grant_start_date, :grant_end_date
               d = project[h.to_s].presence
-              d && Date.parse(d).to_s(:long)
+              d && DateTime.parse(d).strftime('%Y-%m-%d %H:%M:%S')
             when :current_continuum_project
               ::HUD.ad_hoc_yes_no_1 project[h.to_s].presence&.to_i
             when :fed_partner_program

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -381,6 +381,61 @@ module GrdaWarehouse::Hud
       @answer
     end
 
+    # generate a CSV file
+    # there may be multiple lines per project
+    def self.export_providers(coc_codes)
+      spec = {
+        hud_org_id:          o_t[:OrganizationID],
+        _hud_org_name:       o_t[:OrganizationName],
+        provider:            p_t[:ProjectName],
+        _provider:           p_t[:ProjectID],
+        hud_prog_type:       p_t[project_type_column],
+        fed_funding_source:  f_t[:Funder],   # almost certainly wrong
+        fed_partner_program: f_t[:FunderID], # almost certainly wrong
+        grant_id:            f_t[:GrantID],
+        grant_start_date:    f_t[:StartDate],
+        grant_end_date:      f_t[:EndDate],
+        coc_code:            pc_t[:CoCCode],
+        hud_geocode:         st_t[:Geocode],
+        current_continuum_project: p_t[:ContinuumProject],
+      }
+      projects = joins( :funders, :organization, :project_cocs, :sites ).
+        order( arel_table[:ProjectID], pc_t[:CoCCode], f_t[:FunderID] ).
+        where( pc_t[:CoCCode].in coc_codes )
+      spec.each do |header, selector|
+        projects = projects.select selector.as(header.to_s)
+      end
+
+      csv = CSV.generate headers: true do |csv|
+        headers = spec.keys.reject{ |k| k.to_s.starts_with? '_' }
+        csv << headers
+
+        last = nil
+        connection.select_all(projects.to_sql).each do |project|
+          row = []
+          headers.each do |h|
+            value = case h
+            when :hud_org_id
+              "#{project['_hud_org_name']} (#{project['hud_org_id']})".squish
+            when :provider
+              "#{project['provider']} (#{project['_provider']})".squish
+            when :grant_start_date, :grant_end_date
+              d = project[h.to_s].presence
+              d && Date.parse(d).to_s(:long)
+            when :current_continuum_project
+              ::HUD.ad_hoc_yes_no_1 project[h.to_s].presence&.to_i
+            else
+              project[h.to_s]
+            end
+            row << value
+          end
+          next if row == last
+          last = row
+          csv << row
+        end
+      end
+    end
+
     # when we export, we always need to replace ProjectID with the value of id
     # and OrganizationID with the id of the related organization
     def self.to_csv(scope:, override_project_type:)

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -390,13 +390,13 @@ module GrdaWarehouse::Hud
         provider:            p_t[:ProjectName],
         _provider:           p_t[:ProjectID],
         hud_prog_type:       p_t[project_type_column],
-        fed_funding_source:  f_t[:Funder],   # almost certainly wrong
-        fed_partner_program: f_t[:FunderID], # almost certainly wrong
+        fed_funding_source:  f_t[:FunderID],
+        fed_partner_program: f_t[:FunderID],
         grant_id:            f_t[:GrantID],
         grant_start_date:    f_t[:StartDate],
         grant_end_date:      f_t[:EndDate],
         coc_code:            pc_t[:CoCCode],
-        hud_geocode:         st_t[:Geocode],
+        hud_geocode:         site_t[:Geocode],
         current_continuum_project: p_t[:ContinuumProject],
       }
       projects = joins( :funders, :organization, :project_cocs, :sites ).
@@ -424,6 +424,8 @@ module GrdaWarehouse::Hud
               d && Date.parse(d).to_s(:long)
             when :current_continuum_project
               ::HUD.ad_hoc_yes_no_1 project[h.to_s].presence&.to_i
+            when :fed_partner_program
+              ::HUD.funding_source project['fed_partner_program']
             else
               project[h.to_s]
             end

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -425,7 +425,7 @@ module GrdaWarehouse::Hud
             when :current_continuum_project
               ::HUD.ad_hoc_yes_no_1 project[h.to_s].presence&.to_i
             when :fed_partner_program
-              ::HUD.funding_source project[h.to_s]
+              ::HUD.funding_source project[h.to_s].presence&.to_i
             else
               project[h.to_s]
             end


### PR DESCRIPTION
Made a new branch, cherry-picked the commits in, and am now copying over the comments.

The only <strike>real</strike> changes are in these files:
```
hmis-warehouse (stories/r14/providers_csv_format-156618257=) $ git diff --name-only release-14
Gemfile.lock
app/models/concerns/arel_helper.rb
app/models/grda_warehouse/hud/client.rb
app/models/grda_warehouse/hud/project.rb
```
The Gemfile.lock change was to get charlock_holmes to work in my development environment, as you know. The arel_helper.rb change just adds an arel_table method or two. The client file change is just removing some shadowing of arel_helper stuff I noticed. So the significant stuff is in the `export_providers` method of  the projects model.

This returns a string -- as I said elsewhere, I'm doing that instead of writing straight to a file because I figure this separates concerns better for the sake of hypothetical tests.

Dates are formatted like so:
```ruby
DateTime.parse(d).strftime('%Y-%m-%d %H:%M:%S')
```
Note that the strings being formatted are *dates*, not *datetimes*, so the hour:minute:second bit is always 00:00:00. Do we just want yyyy-mm-dd?

Here's some sample output with my fake data:
```csv
hud_org_id,provider,hud_prog_type,fed_funding_source,fed_partner_program,grant_id,grant_start_date,grant_end_date,coc_code,hud_geocode,current_continuum_project
Omnibus Services (1),Emergency Shelter - Night-by-Night (2),1,2F,HUD: CoC – Permanent Supportive Housing,,2000-01-01 00:00:00,,XX-500,101010,Yes
Omnibus Services (1),Emergency Shelter - Entry/Exit Date (3),1,3F,HUD: CoC – Rapid Re-Housing,,2000-01-01 00:00:00,,XX-500,101010,Yes
Omnibus Services (1),Transitional Housing (4),2,4F,HUD: CoC – Supportive Services Only,,2000-01-01 00:00:00,,XX-500,101010,Yes
Elevator Slight Home (105),Outstanding Scarlet Tuna Inn (405),2,293,293,,2016-02-08 00:00:00,,KY-500,250282,Yes
Omnibus Services (1),RRH (5),13,5F,HUD: CoC – Transitional Housing,,2000-01-01 00:00:00,,XX-500,101010,Yes
Quality Weeknight Creek (119),Simple Jupiter Inn (510),3,186,186,MA0051L1T001306,1996-07-01 00:00:00,,KY-500,250282,Yes
Late Slide Place (108),Trombone Alien Hill (569),4,19,HUD: HOPWA – Transitional Housing (facility based or TBRA),Outreach van,2017-01-01 00:00:00,2017-12-31 00:00:00,KY-500,250282,Yes
Late Slide Place (108),Trombone Alien Hill (569),4,482,482,,2016-10-01 00:00:00,2017-09-30 00:00:00,KY-500,250282,Yes
Late Slide Place (108),Rainbow Minimum Falcon Center (574),4,133,133,,2015-01-01 00:00:00,,KY-500,,Yes
Omnibus Services (1),Permanent Supportive Housing (6),3,6F,HUD: CoC – Safe Haven,,2000-01-01 00:00:00,,XX-500,101010,Yes
Orange Slide Home (125),Simple Jupiter Hotel (639),3,80,80,,2016-08-01 00:00:00,2017-07-31 00:00:00,KY-500,250282,Yes
Empty Eagle Hotel (109),Late Avenue House (641),10,77,77,MA002SR00140001,2013-10-01 00:00:00,2014-09-30 00:00:00,OH-964,250282,Yes
Metaphor Pink Creek (112),Ring Iron Lake (752),8,257,257,,2014-02-15 00:00:00,2017-02-14 00:00:00,KY-500,,Yes
Brave Rhinestone Lake (151),Autumn Acorn Creek (810),1,423,423,DHCD,2016-07-01 00:00:00,2017-06-30 00:00:00,KY-500,250282,Yes
Brave Rhinestone Lake (151),Everyday Oxygen Center (818),1,434,434,DHCD,2016-07-01 00:00:00,2017-06-30 00:00:00,KY-500,250282,Yes
Late Slide Place (108),Modern Warehouse Center (819),13,435,435,RapidHome-Stab,2017-10-01 00:00:00,2018-09-30 00:00:00,KY-500,,Yes
Elastic Bird Hill (152),Rainbow Minimum Falcon Hill (822),1,438,438,,2016-09-20 00:00:00,,KY-500,250282,Yes
Elastic Bird Hill (152),Rainbow Minimum Falcon Hill (822),1,882,882,,2017-10-17 00:00:00,,KY-500,250282,Yes
Rocky Sleepy Emerald Place (131),Manual Drill Place (831),8,495,495,,2017-02-07 00:00:00,,KY-500,,Yes
Orange Slide Home (125),Steep Elevator Inn (838),13,493,493,MA0533L1T001601,2016-09-01 00:00:00,,KY-500,250282,Yes
Late Slide Place (108),Autumn Acorn Center (853),13,501,501,RRHHI-Stab,2017-02-02 00:00:00,2018-02-01 00:00:00,KY-500,MA-500,Yes
```
I am not sure this is because of the fake data or what, but the `FunderID` column is not always translatable via `HUD.funding_source`. When it isn't, you just get whatever was there.