### PR TITLE
Stories/tableau exports/vispdat export 157022452

### DIFF
--- a/app/models/concerns/arel_helper.rb
+++ b/app/models/concerns/arel_helper.rb
@@ -140,6 +140,9 @@ module ArelHelper
   def site_t
     GrdaWarehouse::Hud::Site.arel_table
   end
+  def enx_t
+    GrdaWarehouse::EnrollmentExtra.arel_table
+  end
 
   # and to the class itself (so they can be used in scopes, for example)
   class_methods do
@@ -339,6 +342,9 @@ module ArelHelper
     end
     def site_t
       GrdaWarehouse::Hud::Site.arel_table
+    end
+    def enx_t
+      GrdaWarehouse::EnrollmentExtra.arel_table
     end
   end
 end

--- a/app/models/exporters/tableau.rb
+++ b/app/models/exporters/tableau.rb
@@ -4,6 +4,66 @@ module Exporters::Tableau
 
   module_function
 
+    def null
+      lit 'NULL'
+    end
+    private_class_method :null
+
+    def vispdat(start_date: 3.years.ago, end_date: DateTime.current, local_planning_group:)
+      spec = {
+        client_uid:               e_t[:PersonalID],
+        vispdat_1_recordset_id:   null,
+        vispdat_1_provider:       null,
+        vispdat_1_start_date:     null,
+        vispdat_1_grand_total:    null,
+        vispdat_2_recordset_id:   enx_t[:id],
+        vispdat_2_provider:       o_t[:OrganizationName],
+        _pn:                      p_t[:ProjectName],
+        _pid:                     p_t[:ProjectID],
+        vispdat_2_start_date:     enx_t[:vispdat_started_at],
+        vispdat_2_grand_total:    enx_t[:vispdat_grand_total],
+        vispdat_fam_recordset_id: null,
+        vispdat_fam_provider:     null,
+        vispdat_fam_start_date:   null,
+        vispdat_fam_grand_total:  null,
+      }
+
+      model = enx_t.engine
+
+      vispdats = model.
+        joins( enrollment: [ :service_history_enrollment, { project: :organization } ] ).
+        merge( she_t.engine.open_between start_date: start_date, end_date: end_date ).
+        where( p_t[:local_planning_group].eq local_planning_group ).
+        # for aesthetics
+        order( e_t[:PersonalID].asc ).
+        order( o_t[:OrganizationName] ).
+        order( p_t[:ProjectName] ).
+        order( enx_t[:vispdat_started_at] )
+      spec.each do |header, selector|
+        vispdats = vispdats.select selector.as(header.to_s)
+      end
+
+      CSV.generate headers: true do |csv|
+        headers = spec.keys.reject{ |k| k.to_s.starts_with? '_' }
+        csv << headers
+
+        model.connection.select_all(vispdats.to_sql).each do |vispdat|
+          row = []
+          headers.each do |h|
+            value = vispdat[h.to_s].presence
+            value = case h
+            when :vispdat_2_provider
+              "#{value}: #{vispdat['_pn']} (#{vispdat['_pid']})"
+            else
+              value
+            end
+            row << value
+          end
+          csv << row
+        end
+      end
+    end
+
     def disability(start_date: 3.years.ago, end_date: DateTime.current, coc_code:)
       spec = {
         entry_exit_uid:       e_t[:ProjectEntryID],

--- a/app/models/exporters/tableau.rb
+++ b/app/models/exporters/tableau.rb
@@ -9,7 +9,7 @@ module Exporters::Tableau
     end
     private_class_method :null
 
-    def vispdat(start_date: 3.years.ago, end_date: DateTime.current, local_planning_group:)
+    def vispdat(start_date: 3.years.ago, end_date: DateTime.current, coc_code:)
       spec = {
         client_uid:               e_t[:PersonalID],
         vispdat_1_recordset_id:   null,
@@ -31,9 +31,15 @@ module Exporters::Tableau
       model = enx_t.engine
 
       vispdats = model.
-        joins( enrollment: [ :service_history_enrollment, { project: :organization } ] ).
+        joins(
+          enrollment: [
+            :enrollment_coc_at_entry,
+            :service_history_enrollment,
+            { project: :organization }
+          ]
+        ).
         merge( she_t.engine.open_between start_date: start_date, end_date: end_date ).
-        where( p_t[:local_planning_group].eq local_planning_group ).
+        where( ec_t[:CoCCode].eq coc_code ).
         # for aesthetics
         order( e_t[:PersonalID].asc ).
         order( o_t[:OrganizationName] ).


### PR DESCRIPTION
So this is merging onto the non-HMIS import branch, which is to be merged onto the tableau branch, which is to be merged onto the release-14 branch, which is to be merged onto master. It's pretty straightforward. I made one executive decision: I figured there new CoC-like project group identifier should be used as the limiting parameter instead of CoCCode. This of course will give you nothing if you don't have data, imported via the importer on the base branch, which can be exported.

Test invocation that works for me:
```ruby
[21] pry(main)> Exporters::Tableau.vispdat local_planning_group: "Some Planning Group Name"
   (106.4ms)  SELECT "Enrollment"."PersonalID" AS client_uid, NULL AS vispdat_1_recordset_id, NULL AS vispdat_1_provider, NULL AS vispdat_1_start_date, NULL AS vispdat_1_grand_total, "enrollment_extras"."id" AS vispdat_2_recordset_id, "Organization"."OrganizationName" AS vispdat_2_provider, "Project"."ProjectName" AS _pn, "Project"."ProjectID" AS _pid, "enrollment_extras"."vispdat_started_at" AS vispdat_2_start_date, "enrollment_extras"."vispdat_grand_total" AS vispdat_2_grand_total, NULL AS vispdat_fam_recordset_id, NULL AS vispdat_fam_provider, NULL AS vispdat_fam_start_date, NULL AS vispdat_fam_grand_total FROM "enrollment_extras" INNER JOIN "Enrollment" ON "Enrollment"."id" = "enrollment_extras"."enrollment_id" AND "Enrollment"."DateDeleted" IS NULL INNER JOIN "service_history_enrollments" ON "service_history_enrollments"."data_source_id" = "Enrollment"."data_source_id" AND "service_history_enrollments"."enrollment_group_id" = "Enrollment"."ProjectEntryID" AND "service_history_enrollments"."project_id" = "Enrollment"."ProjectID" AND "service_history_enrollments"."record_type" = 'entry' INNER JOIN "Project" ON "Project"."ProjectID" = "Enrollment"."ProjectID" AND "Project"."data_source_id" = "Enrollment"."data_source_id" AND "Project"."DateDeleted" IS NULL INNER JOIN "Organization" ON "Organization"."OrganizationID" = "Project"."OrganizationID" AND "Organization"."data_source_id" = "Project"."data_source_id" AND "Organization"."DateDeleted" IS NULL WHERE (("service_history_enrollments"."last_date_in_program" >= '2015-04-26' OR "service_history_enrollments"."last_date_in_program" IS NULL) AND "service_history_enrollments"."first_date_in_program" <= '2018-04-26') AND "Project"."local_planning_group" = 'Some Planning Group Name'  ORDER BY "Enrollment"."PersonalID" ASC, "Organization"."OrganizationName", "Project"."ProjectName", "enrollment_extras"."vispdat_started_at"
=> "client_uid,vispdat_1_recordset_id,vispdat_1_provider,vispdat_1_start_date,vispdat_1_grand_total,vispdat_2_recordset_id,vispdat_2_provider,vispdat_2_start_date,vispdat_2_grand_total,vispdat_fam_recordset_id,vispdat_fam_provider,vispdat_fam_start_date,vispdat_fam_grand_total\n" +
"71fde484f20b44bdac71bb8a3b463140,,,,,26,Late Slide Place: Orange Slide House (567),2015-11-26,8,,,,\n" +
"bbfb7fafeafa42878470f9d233bdb1a6,,,,,25,Late Slide Place: Orange Slide House (567),2015-08-05,6,,,,\n" +
"c24040351d004f9cacad0b2b4ae4e984,,,,,24,Late Slide Place: Orange Slide House (567),2017-08-06,4,,,,\n" +
"c9f6b2cf72eb4cafb710c21fa1a9d2bd,,,,,23,Late Slide Place: Orange Slide House (567),2016-10-15,7,,,,\n" +
"cb08b2010ffe42cc81993a67e792807d,,,,,22,Late Slide Place: Orange Slide House (567),2017-07-15,5,,,,\n"
```