### PR TITLE
Improve performance of the cohort lists

### DIFF
--- a/app/controllers/cohorts/clients_controller.rb
+++ b/app/controllers/cohorts/clients_controller.rb
@@ -30,7 +30,8 @@ module Cohorts
             if params[:cohort_client_id].present?
               @cohort_clients = @cohort_clients.where(id: params[:cohort_client_id].to_i)
             end
-            render json: data_for_table() and return
+            render json: data_for_table
+            return
           else
             render json: @cohort.cohort_clients.pluck(:id, :updated_at).map{|k,v| [k, v.to_i]}.to_h
           end
@@ -42,7 +43,7 @@ module Cohorts
       end
     end
 
-    def data_for_table
+    private def data_for_table
       data = []
 
       @visible_columns = [CohortColumns::Meta.new]
@@ -59,8 +60,8 @@ module Cohorts
           cohort_column.cohort = @cohort
           cohort_column.cohort_names = @cohort_names
 
-          # set the cohort_client we want this for this column
-          # it will be used to render the corisponding cell
+          # # set the cohort_client we want this for this column
+          # # it will be used to render the corisponding cell
           cohort_column.cohort_client = cohort_client
           editable = cohort_column.display_as_editable?(current_user, cohort_client) && cohort_column.column_editable?
           row[cohort_column.column] = {
@@ -71,7 +72,7 @@ module Cohorts
             comments: cohort_column.comments,
           }
           if cohort_column.column == 'meta'
-            cohort_client_data[cohort_column.column].merge!(cohort_column.metadata)
+            row[cohort_column.column].merge!(cohort_column.metadata)
           end
         end
         data << row
@@ -188,7 +189,7 @@ module Cohorts
     end
 
     def load_cohort_names
-      @cohort_names = cohort_source.pluck(:id, :name, :short_name).
+      @cohort_names ||= cohort_source.pluck(:id, :name, :short_name).
       map do |id, name, short_name|
         [id, short_name.presence || name]
       end.to_h

--- a/app/controllers/cohorts/clients_controller.rb
+++ b/app/controllers/cohorts/clients_controller.rb
@@ -62,8 +62,8 @@ module Cohorts
           cohort_column.cohort = @cohort
           cohort_column.cohort_names = @cohort_names
 
-          # # set the cohort_client we want this for this column
-          # # it will be used to render the corisponding cell
+          # set the cohort_client we want this for this column
+          # it will be used to render the corresponding cell
           cohort_column.cohort_client = cohort_client
           editable = cohort_column.display_as_editable?(current_user, cohort_client) && cohort_column.column_editable?
           row[cohort_column.column] = {

--- a/app/controllers/cohorts/clients_controller.rb
+++ b/app/controllers/cohorts/clients_controller.rb
@@ -33,8 +33,7 @@ module Cohorts
             end
             render text: JSON::fast_generate(data_for_table), type: :json
             # The above is > 50% faster then
-            # render json: data_for_table), type: :json
-            return
+            # render json: data_for_table
           else
             render json: @cohort.cohort_clients.pluck(:id, :updated_at).map{|k,v| [k, v.to_i]}.to_h
           end
@@ -68,12 +67,15 @@ module Cohorts
           cohort_column.cohort_client = cohort_client
           editable = cohort_column.display_as_editable?(current_user, cohort_client) && cohort_column.column_editable?
           row[cohort_column.column] = {
-            editable: editable,
             value: cohort_column.display_read_only(current_user),
             renderer: cohort_column.renderer,
             cohort_client_id: cohort_client.id,
             comments: cohort_column.comments,
           }
+          if editable
+            # save some bytes
+            row[cohort_column.column][:editable]=true
+          end
           if cohort_column.column == 'meta'
             row[cohort_column.column].merge!(cohort_column.metadata)
           end

--- a/app/controllers/cohorts/clients_controller.rb
+++ b/app/controllers/cohorts/clients_controller.rb
@@ -1,3 +1,4 @@
+require 'json/ext'
 module Cohorts
   class ClientsController < ApplicationController
     include PjaxModalController
@@ -30,7 +31,9 @@ module Cohorts
             if params[:cohort_client_id].present?
               @cohort_clients = @cohort_clients.where(id: params[:cohort_client_id].to_i)
             end
-            render json: data_for_table
+            render text: JSON::fast_generate(data_for_table), type: :json
+            # The above is > 50% faster then
+            # render json: data_for_table), type: :json
             return
           else
             render json: @cohort.cohort_clients.pluck(:id, :updated_at).map{|k,v| [k, v.to_i]}.to_h

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -16,14 +16,9 @@ class CohortsController < ApplicationController
   def show
     params[:population] ||= :active
     load_cohort_names
-    cohort_with_preloads = cohort_scope.where(id: cohort_id).
-      preload(cohort_clients: [:cohort_client_notes, {client: :processed_service_history}])
-    # missing_document_state = @cohort.column_state.detect{|m| m.class == ::CohortColumns::MissingDocuments}
-    @cohort = cohort_with_preloads.first
-  
+    @cohort = cohort_scope.find(cohort_id)
     set_cohort_clients
-    
-    @cohort_client_updates = @cohort.cohort_clients.map{|m| [m.id, m.updated_at.to_i]}.to_h
+    @cohort_client_updates = @cohort.cohort_clients.select(:id, :updated_at).map{|m| [m.id, m.updated_at.to_i]}.to_h
     @population = params[:population]
     respond_to do |format|
       format.html do
@@ -50,7 +45,7 @@ class CohortsController < ApplicationController
             options.merge!({type: m.renderer})
           else
             options.merge!({renderer: m.renderer})
-            options.merge!({readOnly: true}) unless m.editable 
+            options.merge!({readOnly: true}) unless m.editable
           end
           options
         end
@@ -114,7 +109,7 @@ class CohortsController < ApplicationController
       end.to_h
     end
 
-  
+
   def flash_interpolation_options
     { resource_name: @cohort&.name }
   end

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -103,7 +103,7 @@ class CohortsController < ApplicationController
   end
 
   def load_cohort_names
-      @cohort_names = cohort_source.pluck(:id, :name, :short_name).
+      @cohort_names ||= cohort_source.pluck(:id, :name, :short_name).
       map do |id, name, short_name|
         [id, short_name.presence || name]
       end.to_h

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -17,7 +17,11 @@ class CohortsController < ApplicationController
     params[:population] ||= :active
     load_cohort_names
     @cohort = cohort_scope.find(cohort_id)
-    set_cohort_clients
+    # leave off the pagination here and return all the data
+    @cohort_clients = @cohort.search_clients(
+      inactive:  params[:inactive],
+      population: params[:population],
+    )
     @cohort_client_updates = @cohort.cohort_clients.select(:id, :updated_at).map{|m| [m.id, m.updated_at.to_i]}.to_h
     @population = params[:population]
     respond_to do |format|

--- a/app/controllers/concerns/cohort_clients.rb
+++ b/app/controllers/concerns/cohort_clients.rb
@@ -3,27 +3,12 @@ module CohortClients
 
   included do
     def set_cohort_clients
-      if params[:inactive].present?
-        @cohort_clients = @cohort.cohort_clients
-      else
-        @cohort_clients = @cohort.cohort_clients.where(active: true)
-      end
-      
-      @all_cohort_clients = @cohort_clients
-      @show_housed = @all_cohort_clients.where.not(housed_date: nil).where(ineligible: [nil, false]).exists?
-      @show_inactive = @all_cohort_clients.where(ineligible: true).exists?
-      
-      case params[:population]&.to_sym
-        when :housed
-          @cohort_clients = @cohort_clients.where.not(housed_date: nil).where(ineligible: [nil, false])
-        when nil
-          @cohort_clients = @cohort_clients.where(housed_date: nil, ineligible: [nil, false])
-        when :active
-          @cohort_clients = @cohort_clients.where(housed_date: nil, ineligible: [nil, false])
-        when :ineligible
-          @cohort_clients = @cohort_clients.where(ineligible: true)
-      end
+      @cohort_clients = @cohort.search_clients(
+        page: params[:page].to_i,
+        per: params[:per].to_i,
+        inactive:  params[:inactive],
+        population: params[:population],
+      )
     end
-
   end
 end

--- a/app/jobs/add_cohort_clients_job.rb
+++ b/app/jobs/add_cohort_clients_job.rb
@@ -3,6 +3,7 @@ class AddCohortClientsJob < ActiveJob::Base
   queue_as :low_priority
 
   def perform(cohort_id, client_ids, user_id)
+    GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts(client_ids: client_ids)
     client_ids.split(',').map(&:strip).compact.each do |id|
       create_cohort_client(cohort_id, id.to_i, user_id)
     end

--- a/app/jobs/service_history/rebuild_enrollments_job.rb
+++ b/app/jobs/service_history/rebuild_enrollments_job.rb
@@ -8,10 +8,10 @@ module ServiceHistory
       @log_id = log_id
     end
 
-    def perform 
+    def perform
       Rails.logger.debug "===RebuildEnrollmentsJob=== Starting to rebuild enrollments for #{@client_ids.size} clients"
       log = GrdaWarehouse::GenerateServiceHistoryBatchLog.create(
-        to_process: @client_ids.count, 
+        to_process: @client_ids.count,
         generate_service_history_log_id: @log_id,
         delayed_job_id: self.job_id
       )
@@ -53,7 +53,7 @@ module ServiceHistory
         end
         processor = GrdaWarehouse::Tasks::ServiceHistory::Base.new
         processor.ensure_there_are_no_extra_enrollments_in_service_history(client_id)
-        GrdaWarehouse::WarehouseClientsProcessed.new.update_cached_counts(client_ids: [client_id])
+        GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts(client_ids: [client_id])
 
       end
       GrdaWarehouse::Tasks::SanityCheckServiceHistory.new(to_sanity_check.size, to_sanity_check).run!

--- a/app/models/cohort_columns/active_cohorts.rb
+++ b/app/models/cohort_columns/active_cohorts.rb
@@ -3,7 +3,8 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :active_cohorts
     attribute :title, String, lazy: true, default: 'Cohorts'
 
-    def value(cohort_client)
+
+    def value(cohort_client) # TODO N+1 move_to_processed
       cohort_ids = cohort_client.client.active_cohort_ids - [cohort.id]
       cohort_names.select{|k,_| cohort_ids.include?(k)}.values.join('; ')
     end

--- a/app/models/cohort_columns/active_cohorts.rb
+++ b/app/models/cohort_columns/active_cohorts.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Cohorts'
 
 
-    def value(cohort_client) # TODO N+1 move_to_processed
+    def value(cohort_client) # OK
       cohort_ids = cohort_client.client.active_cohort_ids - [cohort.id]
       cohort_names.select{|k,_| cohort_ids.include?(k)}.values.join('; ')
     end

--- a/app/models/cohort_columns/active_cohorts.rb
+++ b/app/models/cohort_columns/active_cohorts.rb
@@ -6,7 +6,7 @@ module CohortColumns
 
     def value(cohort_client) # OK
       cohort_ids = cohort_client.client.active_cohort_ids - [cohort.id]
-      cohort_names.select{|k,_| cohort_ids.include?(k)}.values.join('; ')
+      cohort_names.values_at(*cohort_ids).join('; ')
     end
   end
 end

--- a/app/models/cohort_columns/age.rb
+++ b/app/models/cohort_columns/age.rb
@@ -2,8 +2,9 @@ module CohortColumns
   class Age < ReadOnly
     attribute :column, String, lazy: true, default: :age
     attribute :title, String, lazy: true, default: 'Age*'
-    
-    def value(cohort_client)
+
+
+    def value(cohort_client) # OK
       cohort_client.client.age_on(cohort_client.cohort.effective_date || Date.today)
     end
   end

--- a/app/models/cohort_columns/available_for_matching_in_cas.rb
+++ b/app/models/cohort_columns/available_for_matching_in_cas.rb
@@ -8,7 +8,7 @@ module CohortColumns
     end
 
 
-    def value(cohort_client) # TODO: slow in some configs
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/available_for_matching_in_cas.rb
+++ b/app/models/cohort_columns/available_for_matching_in_cas.rb
@@ -2,12 +2,13 @@ module CohortColumns
   class AvailableForMatchingInCas < ReadOnly
     attribute :column, String, lazy: true, default: :available_for_matching_in_cas
     attribute :title, String, lazy: true, default: 'Available in CAS'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+
+    def value(cohort_client) # TODO: slow in some configs
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/base.rb
+++ b/app/models/cohort_columns/base.rb
@@ -50,7 +50,7 @@ module CohortColumns
     def date_format
       nil
     end
-    
+
     def width
       100
     end
@@ -61,7 +61,7 @@ module CohortColumns
 
     def form_group
       "cohort_client[#{cohort_client.id}]"
-    end  
+    end
 
     def value cohort_client
       cohort_client.send(column)
@@ -69,6 +69,10 @@ module CohortColumns
 
     def input_class
       'jCohortClientInput'
+    end
+
+    def effective_date
+      cohort.effective_date || Date.today
     end
   end
 end

--- a/app/models/cohort_columns/base.rb
+++ b/app/models/cohort_columns/base.rb
@@ -70,9 +70,5 @@ module CohortColumns
     def input_class
       'jCohortClientInput'
     end
-
-    def effective_date
-      cohort.effective_date || Date.today
-    end
   end
 end

--- a/app/models/cohort_columns/calculated_days_homeless.rb
+++ b/app/models/cohort_columns/calculated_days_homeless.rb
@@ -9,9 +9,9 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
-      return "FIXME"
-      Rails.cache.fetch([cohort_client.client.id, 'calculated_days_homeless'], expires_at: 8.hours) do
-        cohort_client.client.days_homeless(on_date: (cohort_client.cohort.effective_date || Date.today))
+      #return "FIXME"
+      Rails.cache.fetch([cohort_client.client, effective_date, 'calculated_days_homeless'], expires_in: 8.hours) do
+        cohort_client.client.days_homeless(on_date: effective_date)
       end
     end
   end

--- a/app/models/cohort_columns/calculated_days_homeless.rb
+++ b/app/models/cohort_columns/calculated_days_homeless.rb
@@ -7,12 +7,8 @@ module CohortColumns
       'Days homeless on the effective date, or today'
     end
 
-
-    def value(cohort_client) # TODO: N+1 & and time dependant
-      #return "FIXME"
-      Rails.cache.fetch([cohort_client.client, effective_date, 'calculated_days_homeless'], expires_in: 8.hours) do
-        cohort_client.client.days_homeless(on_date: effective_date)
-      end
+    def value(cohort_client) # OK
+      cohort.time_dependant_client_data[cohort_client.client_id][:calculated_days_homeless]
     end
   end
 end

--- a/app/models/cohort_columns/calculated_days_homeless.rb
+++ b/app/models/cohort_columns/calculated_days_homeless.rb
@@ -9,6 +9,7 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
+      return "FIXME"
       Rails.cache.fetch([cohort_client.client.id, 'calculated_days_homeless'], expires_at: 8.hours) do
         cohort_client.client.days_homeless(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/calculated_days_homeless.rb
+++ b/app/models/cohort_columns/calculated_days_homeless.rb
@@ -2,12 +2,13 @@ module CohortColumns
   class CalculatedDaysHomeless < ReadOnly
     attribute :column, String, lazy: true, default: :calculated_days_homeless
     attribute :title, String, lazy: true, default: 'Calculated Days Homeless*'
-    
+
     def description
       'Days homeless on the effective date, or today'
     end
 
-    def value(cohort_client)
+
+    def value(cohort_client) # TODO: N+1 & and time dependant
       Rails.cache.fetch([cohort_client.client.id, 'calculated_days_homeless'], expires_at: 8.hours) do
         cohort_client.client.days_homeless(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/consent_confirmed.rb
+++ b/app/models/cohort_columns/consent_confirmed.rb
@@ -2,7 +2,7 @@ module CohortColumns
   class ConsentConfirmed < ReadOnly
     attribute :column, String, lazy: true, default: :consent_confirmed
     attribute :title, String, lazy: true, default: 'Consent Confirmed'
-    
+
     def renderer
       'html'
     end
@@ -12,7 +12,7 @@ module CohortColumns
     end
 
     def text_value cohort_client
-      cohort_client.client.consent_confirmed?
+      cohort_client.client.consent_form_id.present? && cohort_client.client.consent_form_signed_on.present?
     end
   end
 end

--- a/app/models/cohort_columns/days_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_homeless_last_three_years.rb
@@ -5,6 +5,7 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
+      return "FIXME"
       Rails.cache.fetch([cohort_client.client.id, 'days_homeless_last_three_years'], expires_at: 8.hours) do
         cohort_client.client.days_homeless_in_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/days_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_homeless_last_three_years.rb
@@ -3,13 +3,8 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :days_homeless_last_three_years
     attribute :title, String, lazy: true, default: 'Days Homeless in the last 3 years*'
 
-
     def value(cohort_client) # TODO: N+1 & and time dependant
-      #return "FIXME"
-      Rails.cache.fetch([cohort_client.client, effective_date, 'days_homeless_last_three_years'], expires_in: 8.hours) do
-        cohort_client.client.days_homeless_in_last_three_years(on_date: effective_date)
-      end
+      cohort.time_dependant_client_data[cohort_client.client_id][:days_homeless_last_three_years]
     end
-
   end
 end

--- a/app/models/cohort_columns/days_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_homeless_last_three_years.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Days Homeless in the last 3 years*'
 
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 & and time dependant
       Rails.cache.fetch([cohort_client.client.id, 'days_homeless_last_three_years'], expires_at: 8.hours) do
         cohort_client.client.days_homeless_in_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/days_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_homeless_last_three_years.rb
@@ -5,9 +5,9 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
-      return "FIXME"
-      Rails.cache.fetch([cohort_client.client.id, 'days_homeless_last_three_years'], expires_at: 8.hours) do
-        cohort_client.client.days_homeless_in_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
+      #return "FIXME"
+      Rails.cache.fetch([cohort_client.client, effective_date, 'days_homeless_last_three_years'], expires_in: 8.hours) do
+        cohort_client.client.days_homeless_in_last_three_years(on_date: effective_date)
       end
     end
 

--- a/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
@@ -5,10 +5,7 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
-      #return "FIXME"
-      Rails.cache.fetch([cohort_client.client, effective_date, 'days_literally_homeless_last_three_years'], expires_in: 8.hours) do
-        cohort_client.client.literally_homeless_last_three_years(on_date: effective_date)
-      end
+      cohort.time_dependant_client_data[cohort_client.client_id][:days_literally_homeless_last_three_years]
     end
 
   end

--- a/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Days Literally Homeless in the last 3 years*'
 
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 & and time dependant
       Rails.cache.fetch([cohort_client.client.id, 'days_literally_homeless_last_three_years'], expires_at: 8.hours) do
         cohort_client.client.literally_homeless_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
@@ -5,9 +5,9 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
-      return "FIXME"
-      Rails.cache.fetch([cohort_client.client.id, 'days_literally_homeless_last_three_years'], expires_at: 8.hours) do
-        cohort_client.client.literally_homeless_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
+      #return "FIXME"
+      Rails.cache.fetch([cohort_client.client, effective_date, 'days_literally_homeless_last_three_years'], expires_in: 8.hours) do
+        cohort_client.client.literally_homeless_last_three_years(on_date: effective_date)
       end
     end
 

--- a/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
+++ b/app/models/cohort_columns/days_literally_homeless_last_three_years.rb
@@ -5,6 +5,7 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1 & and time dependant
+      return "FIXME"
       Rails.cache.fetch([cohort_client.client.id, 'days_literally_homeless_last_three_years'], expires_at: 8.hours) do
         cohort_client.client.literally_homeless_last_three_years(on_date: (cohort_client.cohort.effective_date || Date.today))
       end

--- a/app/models/cohort_columns/delete.rb
+++ b/app/models/cohort_columns/delete.rb
@@ -3,7 +3,7 @@ module CohortColumns
     include ArelHelper
     attribute :column, String, lazy: true, default: :delete
     attribute :title, String, lazy: true, default: 'Delete'
-    
+
     def column_editable?
       false
     end
@@ -16,12 +16,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
-      nil     
+    def value(cohort_client) # OK
+      nil
     end
 
     def display_for user
-      if user.can_manage_cohorts? || user.can_edit_cohort_clients?  
+      if user.can_manage_cohorts? || user.can_edit_cohort_clients?
         display_read_only(user)
       else
         ''

--- a/app/models/cohort_columns/destination_from_homelessness.rb
+++ b/app/models/cohort_columns/destination_from_homelessness.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :destination_from_homelessness
     attribute :title, String, lazy: true, default: 'Recent Exits from Homelessness'
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 & and time dependant
       effective_date = cohort.effective_date || Date.today
       cohort_client.client.
         permanent_source_exits_from_homelessness.
@@ -12,7 +12,7 @@ module CohortColumns
         pluck(:ExitDate, :Destination).map do |exit_date, destination|
           "#{exit_date} to #{HUD.destination(destination)}"
         end.join('; ')
-     
+
     end
   end
 end

--- a/app/models/cohort_columns/destination_from_homelessness.rb
+++ b/app/models/cohort_columns/destination_from_homelessness.rb
@@ -5,14 +5,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Recent Exits from Homelessness'
 
     def value(cohort_client) # TODO: N+1 & and time dependant
-      Rails.cache.fetch([cohort_client.client, 'destination_from_homelessness'], expires_in: 8.hours) do
-        cohort_client.client.
-          permanent_source_exits_from_homelessness.
-          where(ex_t[:ExitDate].gteq(90.days.ago.to_date)).
-          pluck(:ExitDate, :Destination).map do |exit_date, destination|
-            "#{exit_date} to #{HUD.destination(destination)}"
-          end.join('; ')
-      end
+      cohort.time_dependant_client_data[cohort_client.client_id][:destination_from_homelessness]
     end
   end
 end

--- a/app/models/cohort_columns/destination_from_homelessness.rb
+++ b/app/models/cohort_columns/destination_from_homelessness.rb
@@ -5,6 +5,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Recent Exits from Homelessness'
 
     def value(cohort_client) # TODO: N+1 & and time dependant
+      return "FIXME"
       effective_date = cohort.effective_date || Date.today
       cohort_client.client.
         permanent_source_exits_from_homelessness.

--- a/app/models/cohort_columns/disability_verification_date.rb
+++ b/app/models/cohort_columns/disability_verification_date.rb
@@ -2,12 +2,12 @@ module CohortColumns
   class DisabilityVerificationDate < ReadOnly
     attribute :column, String, lazy: true, default: :disability_verification_date
     attribute :title, String, lazy: true, default: 'Disability Verification Upload Date'
-    
+
     def date_format
       'll'
     end
-    
-    def value(cohort_client)
+
+    def value(cohort_client) # TODO: N+1 move_to_processed
       cohort_client.client.most_recent_verification_of_disability&.created_at&.to_date&.to_s
     end
   end

--- a/app/models/cohort_columns/disability_verification_date.rb
+++ b/app/models/cohort_columns/disability_verification_date.rb
@@ -7,8 +7,8 @@ module CohortColumns
       'll'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
-      cohort_client.client.most_recent_verification_of_disability&.created_at&.to_date&.to_s
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.disability_verification_date&.to_s
     end
   end
 end

--- a/app/models/cohort_columns/enrolled_homeless_shelter.rb
+++ b/app/models/cohort_columns/enrolled_homeless_shelter.rb
@@ -7,14 +7,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client
-      Rails.cache.fetch([cohort_client.client.id, :enrolled_homeless_shelter], expires_at: 8.hours) do
-        cohort_client.client.service_history_enrollments.homeless_sheltered.ongoing.exists?
-      end
+      cohort_client.client.processed_service_history&.enrolled_homeless_shelter
     end
   end
 end

--- a/app/models/cohort_columns/enrolled_homeless_shelter.rb
+++ b/app/models/cohort_columns/enrolled_homeless_shelter.rb
@@ -7,7 +7,7 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/enrolled_homeless_unsheltered.rb
+++ b/app/models/cohort_columns/enrolled_homeless_unsheltered.rb
@@ -7,14 +7,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # TODO: N+1
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client
-      Rails.cache.fetch([cohort_client.client.id, :enrolled_homeless_unsheltered], expires_at: 8.hours) do
-        cohort_client.client.service_history_enrollments.homeless_unsheltered.ongoing.exists?
-      end
+      cohort_client.client.processed_service_history&.enrolled_homeless_unsheltered
     end
   end
 end

--- a/app/models/cohort_columns/enrolled_homeless_unsheltered.rb
+++ b/app/models/cohort_columns/enrolled_homeless_unsheltered.rb
@@ -7,7 +7,7 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/enrolled_permanent_housing.rb
+++ b/app/models/cohort_columns/enrolled_permanent_housing.rb
@@ -7,14 +7,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client
-      Rails.cache.fetch([cohort_client.client.id, :enrolled_permanent_housing], expires_at: 8.hours) do
-        cohort_client.client.service_history_enrollments.permanent_housing.ongoing.exists?
-      end
+      cohort_client.client.processed_service_history&.enrolled_permanent_housing
     end
   end
 end

--- a/app/models/cohort_columns/enrolled_permanent_housing.rb
+++ b/app/models/cohort_columns/enrolled_permanent_housing.rb
@@ -7,10 +7,8 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
-      Rails.cache.fetch([cohort_client.client.id, :enrolled_permanent_housing], expires_at: 8.hours) do
-        checkmark_or_x text_value(cohort_client)
-      end
+    def value(cohort_client) # TODO: N+1 move_to_processed
+      checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client

--- a/app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb
+++ b/app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb
@@ -7,10 +7,8 @@ module CohortColumns
       'Most recent score from ETO'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
-      Rails.cache.fetch([cohort_client.client.id, 'eto_coordinated_entry_assessment_score'], expires_at: 8.hours) do
-        cohort_client.client.most_recent_coc_assessment_score
-      end
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.eto_coordinated_entry_assessment_score
     end
   end
 end

--- a/app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb
+++ b/app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb
@@ -2,12 +2,12 @@ module CohortColumns
   class EtoCoordinatedEntryAssessmentScore < ReadOnly
     attribute :column, String, lazy: true, default: :eto_coordinated_entry_assessment_score
     attribute :title, String, lazy: true, default: 'Coordinated Entry Assessment Score'
-    
+
     def description
       'Most recent score from ETO'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       Rails.cache.fetch([cohort_client.client.id, 'eto_coordinated_entry_assessment_score'], expires_at: 8.hours) do
         cohort_client.client.most_recent_coc_assessment_score
       end

--- a/app/models/cohort_columns/first_date_homeless.rb
+++ b/app/models/cohort_columns/first_date_homeless.rb
@@ -10,8 +10,8 @@ module CohortColumns
     def renderer
       'date'
     end
-    
-    def value(cohort_client)
+
+    def value(cohort_client) # OK
       cohort_client.client.first_homeless_date&.to_date&.to_s
     end
 

--- a/app/models/cohort_columns/first_name.rb
+++ b/app/models/cohort_columns/first_name.rb
@@ -11,16 +11,16 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       cohort_client.client.FirstName
-    end 
+    end
 
     def display_for(user)
       display_read_only(user)
     end
 
     def display_read_only(user)
-      html = content_tag(:span, class: "hidden") do 
+      html = content_tag(:span, class: "hidden") do
         value(cohort_client)
       end
       if user.can_view_clients?

--- a/app/models/cohort_columns/gender.rb
+++ b/app/models/cohort_columns/gender.rb
@@ -3,7 +3,7 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :gender
     attribute :title, String, lazy: true, default: 'Gender'
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       cohort_client.client.gender
     end
   end

--- a/app/models/cohort_columns/household_members.rb
+++ b/app/models/cohort_columns/household_members.rb
@@ -3,16 +3,8 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :household_members
     attribute :title, String, lazy: true, default: 'Household Members'
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
-      Rails.cache.fetch([cohort_client.client.id, 'household_members'], expires_at: 8.hours) do
-        households = cohort_client.client.households
-        if households.present?
-          households.values.flatten.
-            map do |member|
-              "#{member['FirstName']} #{member['LastName']} (#{member['age']} in #{member['date'].year})"
-            end.uniq.join('; ')
-        end
-      end
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.household_members
     end
 
   end

--- a/app/models/cohort_columns/household_members.rb
+++ b/app/models/cohort_columns/household_members.rb
@@ -3,12 +3,12 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :household_members
     attribute :title, String, lazy: true, default: 'Household Members'
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       Rails.cache.fetch([cohort_client.client.id, 'household_members'], expires_at: 8.hours) do
         households = cohort_client.client.households
         if households.present?
           households.values.flatten.
-            map do |member| 
+            map do |member|
               "#{member['FirstName']} #{member['LastName']} (#{member['age']} in #{member['date'].year})"
             end.uniq.join('; ')
         end

--- a/app/models/cohort_columns/housing_search_agency.rb
+++ b/app/models/cohort_columns/housing_search_agency.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Housing Search Agency'
 
     def available_options
-      Rails.cache.fetch("all_project_names", expires_at: 5.minutes) do
+      Rails.cache.fetch("all_project_names", expires_in: 5.minutes) do
         agencies = Set.new
         GrdaWarehouse::Hud::Project.distinct.
           joins(:organization).

--- a/app/models/cohort_columns/last_homeless_visit.rb
+++ b/app/models/cohort_columns/last_homeless_visit.rb
@@ -7,7 +7,7 @@ module CohortColumns
       'Date of last homeless service in ongoing enrollments'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       Rails.cache.fetch([cohort_client.client.id, 'last_seen'], expires_at: 8.hours) do
         cohort_client.client.last_homeless_visits.map do |row|
           row.join(': ')

--- a/app/models/cohort_columns/last_homeless_visit.rb
+++ b/app/models/cohort_columns/last_homeless_visit.rb
@@ -7,12 +7,8 @@ module CohortColumns
       'Date of last homeless service in ongoing enrollments'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
-      Rails.cache.fetch([cohort_client.client.id, 'last_seen'], expires_at: 8.hours) do
-        cohort_client.client.last_homeless_visits.map do |row|
-          row.join(': ')
-        end.join('; ')
-      end
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.last_homeless_visit
     end
   end
 end

--- a/app/models/cohort_columns/last_name.rb
+++ b/app/models/cohort_columns/last_name.rb
@@ -10,17 +10,17 @@ module CohortColumns
     def renderer
       'html'
     end
-    
-    def value(cohort_client)
+
+    def value(cohort_client) # OK
       cohort_client.client.LastName
-    end 
+    end
 
     def display_for(user)
       display_read_only(user)
     end
 
     def display_read_only(user)
-      html = content_tag(:span, class: "hidden") do 
+      html = content_tag(:span, class: "hidden") do
         value(cohort_client)
       end
       if user.can_view_clients?

--- a/app/models/cohort_columns/location.rb
+++ b/app/models/cohort_columns/location.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Location'
 
     def available_options
-      Rails.cache.fetch("all_project_names", expires_at: 5.minutes) do
+      Rails.cache.fetch("all_project_names", expires_in: 5.minutes) do
         GrdaWarehouse::Hud::Project.distinct.order(ProjectName: :asc).pluck(:ProjectName)
       end
     end

--- a/app/models/cohort_columns/meta.rb
+++ b/app/models/cohort_columns/meta.rb
@@ -3,7 +3,7 @@ module CohortColumns
     include ArelHelper
     attribute :column, String, lazy: true, default: :meta
     attribute :title, String, lazy: true, default: 'Alerts'
-    
+
     def column_editable?
       false
     end
@@ -43,7 +43,7 @@ module CohortColumns
     end
 
     def last_activity
-      @last_activity ||= cohort_client.client.service_history_services.homeless.maximum(:date) rescue nil
+      @cohort.last_activity_by_client_id[cohort_client.client_id]
     end
 
     def inactive
@@ -65,10 +65,10 @@ module CohortColumns
 
     def metadata
       {
-        activity: inactivity_class, 
-        ineligible: cohort_client.ineligible?, 
-        cohort_client_id: cohort_client.id, 
-        client_id: cohort_client&.client&.id, 
+        activity: inactivity_class,
+        ineligible: cohort_client.ineligible?,
+        cohort_client_id: cohort_client.id,
+        client_id: cohort_client&.client&.id,
         cohort_client_updated_at: cohort_client.updated_at.to_i,
         last_activity: last_activity,
         inactive: inactive,

--- a/app/models/cohort_columns/meta.rb
+++ b/app/models/cohort_columns/meta.rb
@@ -31,7 +31,7 @@ module CohortColumns
       return comments
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       html = ''
       if inactive
         html += content_tag(:i, ' ', class: "icon-warning warning")

--- a/app/models/cohort_columns/meta.rb
+++ b/app/models/cohort_columns/meta.rb
@@ -21,6 +21,7 @@ module CohortColumns
     end
 
     def comments
+      return ""
       comments = ''
       if inactive
         comments += "No homeless service in #{@cohort.days_of_inactivity} days\r\n"
@@ -43,14 +44,16 @@ module CohortColumns
     end
 
     def last_activity
-      @cohort.last_activity_by_client_id[cohort_client.client_id]
+      cohort_client.client.processed_service_history&.last_homeless_date
     end
 
     def inactive
       @inactive ||= begin
-        Date.today - cohort.days_of_inactivity > last_activity.to_date
-      rescue
-        true
+        if cohort.days_of_inactivity && last_activity
+          (Date.today - cohort.days_of_inactivity) > last_activity.to_date
+        else
+          true
+        end
       end
     end
 

--- a/app/models/cohort_columns/missing_documents.rb
+++ b/app/models/cohort_columns/missing_documents.rb
@@ -3,11 +3,8 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :missing_documents
     attribute :title, String, lazy: true, default: 'Missing Documents'
 
-
-
-    def value(cohort_client) # TODO: N+1 (many really) move_to_processed
-      required_documents = GrdaWarehouse::AvailableFileTag.document_ready
-      cohort_client.client.document_readiness(required_documents).select{|m| m.available == false}.map(&:name).join('; ')
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.missing_documents
     end
   end
 end

--- a/app/models/cohort_columns/missing_documents.rb
+++ b/app/models/cohort_columns/missing_documents.rb
@@ -5,7 +5,7 @@ module CohortColumns
 
 
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 (many really) move_to_processed
       required_documents = GrdaWarehouse::AvailableFileTag.document_ready
       cohort_client.client.document_readiness(required_documents).select{|m| m.available == false}.map(&:name).join('; ')
     end

--- a/app/models/cohort_columns/notes.rb
+++ b/app/models/cohort_columns/notes.rb
@@ -2,7 +2,7 @@ module CohortColumns
   class Notes < Base
     attribute :column, String, lazy: true, default: :notes
     attribute :title, String, lazy: true, default: 'Notes'
-    
+
 
     def column_editable?
       false
@@ -12,7 +12,7 @@ module CohortColumns
       :notes
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       nil
     end
 

--- a/app/models/cohort_columns/open_enrollments.rb
+++ b/app/models/cohort_columns/open_enrollments.rb
@@ -21,7 +21,6 @@ module CohortColumns
     end
 
     def text_value cohort_client
-      return 'FIXME' # FIXME: move_to_process this needs to be a serialized Hash?
       value(cohort_client).map(&:last).join(' ')
     end
 
@@ -30,7 +29,6 @@ module CohortColumns
     end
 
     def display_read_only user
-      return 'FIXME'
       value(cohort_client).map do |project_type, text|
         content_tag(:div, class: "enrollment__project_type client__service_type_#{project_type}") do
           content_tag(:em, class: 'service-type__program-type') do

--- a/app/models/cohort_columns/open_enrollments.rb
+++ b/app/models/cohort_columns/open_enrollments.rb
@@ -16,20 +16,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
-      cohort_client.client.
-        service_history_enrollments.ongoing.
-        distinct.residential.
-        pluck(:project_type).map do |project_type|
-          if project_type == 13
-            [project_type, 'RRH']
-          else
-            [project_type, HUD.project_type_brief(project_type)]
-          end
-        end
+    def value(cohort_client) # FIXME: move_to_process this needs to be a serialized Hash?
+      cohort_client.client.processed_service_history&.open_enrollments
     end
 
     def text_value cohort_client
+      return 'FIXME'
       value(cohort_client).map(&:last).join(' ')
     end
 
@@ -38,6 +30,7 @@ module CohortColumns
     end
 
     def display_read_only user
+      return 'FIXME'
       value(cohort_client).map do |project_type, text|
         content_tag(:div, class: "enrollment__project_type client__service_type_#{project_type}") do
           content_tag(:em, class: 'service-type__program-type') do

--- a/app/models/cohort_columns/open_enrollments.rb
+++ b/app/models/cohort_columns/open_enrollments.rb
@@ -3,7 +3,7 @@ module CohortColumns
     include ArelHelper
     attribute :column, String, lazy: true, default: :open_enrollments
     attribute :title, String, lazy: true, default: 'Open Residential Enrollments'
-    
+
     def column_editable?
       false
     end
@@ -16,7 +16,7 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       cohort_client.client.
         service_history_enrollments.ongoing.
         distinct.residential.

--- a/app/models/cohort_columns/open_enrollments.rb
+++ b/app/models/cohort_columns/open_enrollments.rb
@@ -16,12 +16,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # FIXME: move_to_process this needs to be a serialized Hash?
+    def value(cohort_client) # OK
       cohort_client.client.processed_service_history&.open_enrollments
     end
 
     def text_value cohort_client
-      return 'FIXME'
+      return 'FIXME' # FIXME: move_to_process this needs to be a serialized Hash?
       value(cohort_client).map(&:last).join(' ')
     end
 

--- a/app/models/cohort_columns/related_users.rb
+++ b/app/models/cohort_columns/related_users.rb
@@ -5,13 +5,7 @@ module CohortColumns
 
 
     def value(cohort_client) # TODO: N+1
-      Rails.cache.fetch([cohort_client.client.id, :related_users], expires_at: 8.hours) do
-        users = cohort_client.client.user_clients.
-          non_confidential.
-          active.
-          pluck(:user_id, :relationship).to_h
-        User.where(id: users.keys).map{|u| "#{users[u.id]} (#{u.name})"}.join('; ')
-      end
+      cohort.time_dependant_client_data[cohort_client.client_id][:related_users]
     end
   end
 end

--- a/app/models/cohort_columns/related_users.rb
+++ b/app/models/cohort_columns/related_users.rb
@@ -4,7 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'Related Users'
 
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1
       Rails.cache.fetch([cohort_client.client.id, :related_users], expires_at: 8.hours) do
         users = cohort_client.client.user_clients.
           non_confidential.

--- a/app/models/cohort_columns/rrh_assessment_contact_info.rb
+++ b/app/models/cohort_columns/rrh_assessment_contact_info.rb
@@ -8,7 +8,7 @@ module CohortColumns
     end
 
     def value(cohort_client) # OK
-      # FIXME: contact_info_for_rrh_assessment already checks consent_form_valid?
+      # FIXME?: contact_info_for_rrh_assessment already checks consent_form_valid?
       cohort_client.client.contact_info_for_rrh_assessment if cohort_client.client.consent_form_valid?
     end
 

--- a/app/models/cohort_columns/rrh_assessment_contact_info.rb
+++ b/app/models/cohort_columns/rrh_assessment_contact_info.rb
@@ -2,12 +2,13 @@ module CohortColumns
   class RrhAssessmentContactInfo < ReadOnly
     attribute :column, String, lazy: true, default: :rrh_assessment_contact_info
     attribute :title, String, lazy: true, default: 'RRH Income Maximization Contact'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
+      # FIXME: contact_info_for_rrh_assessment already checks consent_form_valid?
       cohort_client.client.contact_info_for_rrh_assessment if cohort_client.client.consent_form_valid?
     end
 

--- a/app/models/cohort_columns/rrh_desired.rb
+++ b/app/models/cohort_columns/rrh_desired.rb
@@ -2,17 +2,17 @@ module CohortColumns
   class RrhDesired < ReadOnly
     attribute :column, String, lazy: true, default: :rrh_desired
     attribute :title, String, lazy: true, default: 'Interested in RRH'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N+1 move_to_processed
       checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client
-      cohort_client.client.rrh_desired
+      cohort_client.client.rrh_desired # < N+1 here
     end
   end
 end

--- a/app/models/cohort_columns/rrh_desired.rb
+++ b/app/models/cohort_columns/rrh_desired.rb
@@ -7,12 +7,12 @@ module CohortColumns
       'html'
     end
 
-    def value(cohort_client) # TODO: N+1 move_to_processed
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 
     def text_value cohort_client
-      cohort_client.client.rrh_desired # < N+1 here
+      cohort_client.client.processed_service_history&.rrh_desired
     end
   end
 end

--- a/app/models/cohort_columns/rrh_ssvf_eligible.rb
+++ b/app/models/cohort_columns/rrh_ssvf_eligible.rb
@@ -2,12 +2,12 @@ module CohortColumns
   class RrhSsvfEligible < ReadOnly
     attribute :column, String, lazy: true, default: :rrh_ssvf_eligible
     attribute :title, String, lazy: true, default: 'SSVF Eligible (from RRH Assessment)'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/sober.rb
+++ b/app/models/cohort_columns/sober.rb
@@ -2,12 +2,12 @@ module CohortColumns
   class Sober < ReadOnly
     attribute :column, String, lazy: true, default: :sober
     attribute :title, String, lazy: true, default: 'Appropriate for Sober Supportive Housing'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/cohort_columns/veteran.rb
+++ b/app/models/cohort_columns/veteran.rb
@@ -3,8 +3,7 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :veteran
     attribute :title, String, lazy: true, default: 'Veteran'
 
-
-    def value(cohort_client)
+    def value(cohort_client) # OK
       cohort_client.client.veteran?
     end
   end

--- a/app/models/cohort_columns/vispdat_priority_score.rb
+++ b/app/models/cohort_columns/vispdat_priority_score.rb
@@ -4,10 +4,8 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'VI-SPDAT Priority Score'
 
 
-    def value(cohort_client) # TODO: N=1 move_to_processed
-      Rails.cache.fetch([cohort_client.client, 'vispdat_priority_score'], expires_at: 8.hours) do
-        cohort_client.client.calculate_vispdat_priority_score
-      end
+    def value(cohort_client) # OK
+      cohort_client.client.processed_service_history&.vispdat_priority_score
     end
   end
 end

--- a/app/models/cohort_columns/vispdat_priority_score.rb
+++ b/app/models/cohort_columns/vispdat_priority_score.rb
@@ -3,7 +3,8 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :vispdat_priority_score
     attribute :title, String, lazy: true, default: 'VI-SPDAT Priority Score'
 
-    def value(cohort_client)
+
+    def value(cohort_client) # TODO: N=1 move_to_processed
       Rails.cache.fetch([cohort_client.client, 'vispdat_priority_score'], expires_at: 8.hours) do
         cohort_client.client.calculate_vispdat_priority_score
       end

--- a/app/models/cohort_columns/vispdat_score.rb
+++ b/app/models/cohort_columns/vispdat_score.rb
@@ -3,7 +3,7 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :vispdat_score
     attribute :title, String, lazy: true, default: 'VI-SPDAT Score'
 
-    def value(cohort_client) # TODO: N=1 move_to_processed
+    def value(cohort_client) # OK
       cohort_client.client.processed_service_history&.vispdat_score
     end
   end

--- a/app/models/cohort_columns/vispdat_score.rb
+++ b/app/models/cohort_columns/vispdat_score.rb
@@ -4,9 +4,7 @@ module CohortColumns
     attribute :title, String, lazy: true, default: 'VI-SPDAT Score'
 
     def value(cohort_client) # TODO: N=1 move_to_processed
-      Rails.cache.fetch([cohort_client.client.id, 'vispdat_score'], expires_at: 8.hours) do
-        cohort_client.client.most_recent_vispdat_score
-      end
+      cohort_client.client.processed_service_history&.vispdat_score
     end
   end
 end

--- a/app/models/cohort_columns/vispdat_score.rb
+++ b/app/models/cohort_columns/vispdat_score.rb
@@ -3,7 +3,7 @@ module CohortColumns
     attribute :column, String, lazy: true, default: :vispdat_score
     attribute :title, String, lazy: true, default: 'VI-SPDAT Score'
 
-    def value(cohort_client)
+    def value(cohort_client) # TODO: N=1 move_to_processed
       Rails.cache.fetch([cohort_client.client.id, 'vispdat_score'], expires_at: 8.hours) do
         cohort_client.client.most_recent_vispdat_score
       end

--- a/app/models/cohort_columns/youth_rrh_desired.rb
+++ b/app/models/cohort_columns/youth_rrh_desired.rb
@@ -2,12 +2,12 @@ module CohortColumns
   class YouthRrhDesired < ReadOnly
     attribute :column, String, lazy: true, default: :youth_rrh_desired
     attribute :title, String, lazy: true, default: 'Interested in Youth RRH'
-    
+
     def renderer
       'html'
     end
 
-    def value(cohort_client)
+    def value(cohort_client) # OK
       checkmark_or_x text_value(cohort_client)
     end
 

--- a/app/models/eto_api/base.rb
+++ b/app/models/eto_api/base.rb
@@ -54,7 +54,7 @@ module EtoApi
     end
 
     private def debug_log(msg)
-      puts msg if self.trace
+      puts msg if self.trace && Rails.env.development?
     end
 
     private def api_get_json(url, headers={})

--- a/app/models/eto_api/base.rb
+++ b/app/models/eto_api/base.rb
@@ -54,7 +54,7 @@ module EtoApi
     end
 
     private def debug_log(msg)
-      puts msg if self.trace && Rails.env.development?
+      puts msg.gsub(@credentials[:security]['Password'], '') if self.trace && Rails.env.development?
     end
 
     private def api_get_json(url, headers={})

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -61,7 +61,7 @@ module GrdaWarehouse
       # clear caches
       @last_activity_by_client_id = nil
 
-      @client_search_result = scope.page(page).per(per).preload(
+      @client_search_result = scope.order(id: :asc).page(page).per(per).preload(
         :cohort_client_notes, {
           client: :processed_service_history
         }

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -32,14 +32,6 @@ module GrdaWarehouse
       end
     end
 
-    def _scope(inactive: nil)
-      if inactive.present?
-        cohort_clients
-      else
-        cohort_clients.where(active: true)
-      end
-    end
-
     def search_clients(page:, per:, inactive: nil, population: nil)
       @client_search_scope = if inactive.present?
         cohort_clients

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -249,11 +249,11 @@ module GrdaWarehouse
     end
 
     private def days_homeless_last_three_years(client)
-      client.days_homeless_in_last_three_years(on_date: effective_date)
+      client.days_homeless_in_last_three_years(on_date: effective_date || Date.today)
     end
 
     private def days_literally_homeless_last_three_years(client)
-      client.literally_homeless_last_three_years(on_date: effective_date)
+      client.literally_homeless_last_three_years(on_date: effective_date || Date.today)
     end
 
     private def destination_from_homelessness(client)

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -47,7 +47,7 @@ module GrdaWarehouse
     end
 
     def self.get(config)
-      cache_store.fetch(config, expires_in: 1.second) do
+      cache_store.fetch(config, expires_in: 10.seconds) do
         first_or_create.public_send(config)
       end
     end

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1730,7 +1730,7 @@ module GrdaWarehouse::Hud
 
     # ES, SO, SH, or TH with no overlapping PH
     def self.dates_homeless_in_last_three_years_scope client_id:, on_date: Date.today
-      Rails.cache.fetch([client_id, "dates_homeless_in_last_three_years_scope", on_date], expires_at: CACHE_EXPIRY) do
+      Rails.cache.fetch([self.cache_key, "dates_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
         end_date = on_date.to_date
         start_date = end_date - 3.years
         GrdaWarehouse::ServiceHistoryService.where(client_id: client_id).
@@ -1743,7 +1743,7 @@ module GrdaWarehouse::Hud
 
     # ES, SO, or SH with no overlapping TH or PH
     def self.dates_literally_homeless_in_last_three_years_scope client_id:, on_date: Date.today
-      Rails.cache.fetch([client_id, "dates_literally_homeless_in_last_three_years_scope", on_date], expires_at: CACHE_EXPIRY) do
+      Rails.cache.fetch([self.cache_key, "dates_literally_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
         end_date = on_date.to_date
         start_date = end_date - 3.years
         GrdaWarehouse::ServiceHistoryService.where(client_id: client_id).

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -137,11 +137,11 @@ module GrdaWarehouse::Hud
     has_many :source_hmis_clients, through: :source_clients, source: :hmis_client
     has_many :source_hmis_forms, through: :source_clients, source: :hmis_forms
     has_many :source_non_confidential_hmis_forms, through: :source_clients, source: :non_confidential_hmis_forms
-    
+
     has_many :cas_reports, class_name: 'GrdaWarehouse::CasReport', inverse_of: :client
 
     has_many :chronics, class_name: GrdaWarehouse::Chronic.name, inverse_of: :client
-    
+
     has_many :chronics_in_range, -> (range) do
       where(date: range)
     end, class_name: GrdaWarehouse::Chronic.name, inverse_of: :client
@@ -159,13 +159,15 @@ module GrdaWarehouse::Hud
     has_many :users, through: :user_clients, inverse_of: :clients
 
     has_many :cohort_clients, dependent: :destroy
-    has_many :active_cohort_clients, -> do
-      active
-    end, class_name: GrdaWarehouse::CohortClient.name
     has_many :cohorts, through: :cohort_clients, class_name: 'GrdaWarehouse::Cohort'
-    has_many :active_cohorts, -> do
-      where(active_cohort: true)
-    end, through: :active_cohort_clients, class_name: 'GrdaWarehouse::Cohort', source: :cohort
+
+    def active_cohorts
+      cohort_clients.select{|cc| cc.active? && cc.cohort&.active?}.map(&:cohort).compact.uniq
+    end
+
+    def active_cohort_ids
+      active_cohorts.map(&:id)
+    end
 
     has_one :active_consent_form, class_name: GrdaWarehouse::ClientFile.name, primary_key: :consent_form_id, foreign_key: :id
 
@@ -176,7 +178,7 @@ module GrdaWarehouse::Hud
     delegate :last_chronic_date, to: :processed_service_history, allow_nil: true
     delegate :first_date_served, to: :processed_service_history, allow_nil: true
     delegate :last_date_served, to: :processed_service_history, allow_nil: true
-    
+
 
     scope :destination, -> do
       where(data_source: GrdaWarehouse::DataSource.destination)
@@ -192,23 +194,23 @@ module GrdaWarehouse::Hud
     # scope :unmatched, -> do
     #   source.where.not(id: GrdaWarehouse::WarehouseClient.select(:source_id))
     # end
-    # 
-         
+    #
+
     scope :child, -> (on: Date.today) do
       where(c_t[:DOB].gt(on - 18.years))
     end
-    
+
     scope :youth, -> (on: Date.today) do
       where(DOB: (on - 24.years .. on - 18.years))
     end
-    
+
     scope :adult, -> (on: Date.today) do
       where(c_t[:DOB].lteq(on - 18.years))
     end
-    
+
     #################################
-    # Standard Cohort Scopes    
-         
+    # Standard Cohort Scopes
+
     scope :individual_adult, -> (start_date: Date.today, end_date: Date.today) do
       adult(on: start_date).
       where(id: GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(start_date: start_date, end_date: end_date).distinct.individual_adult.select(:client_id))
@@ -228,7 +230,7 @@ module GrdaWarehouse::Hud
       youth(on: start_date).
       where(id: GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(start_date: start_date, end_date: end_date).distinct.parenting_youth.select(:client_id))
     end
-    
+
     scope :parenting_juvenile, -> (start_date: Date.today, end_date: Date.today) do
       youth(on: start_date).
       where(id: GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(start_date: start_date, end_date: end_date).distinct.parenting_juvenile.select(:client_id))
@@ -237,7 +239,7 @@ module GrdaWarehouse::Hud
     scope :family, -> (start_date: Date.today, end_date: Date.today) do
       where(id: GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(start_date: start_date, end_date: end_date).distinct.family.select(:client_id))
     end
-      
+
     scope :veteran, -> do
       where(VeteranStatus: 1)
     end
@@ -279,13 +281,13 @@ module GrdaWarehouse::Hud
       # this is somewhat involved in order to make it composable and somewhat efficient
       # more efficient is a join + distinct, but the distinct makes it less composable
       # clearer and composable but less efficient would be to use an exists subquery
-      
+
       if chronic_types_only
         project_types = GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES
       else
         project_types = GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES
-      end 
-      
+      end
+
       inner_table = sh_t.
         project(sh_t[:client_id]).
         group(sh_t[:client_id]).
@@ -299,7 +301,7 @@ module GrdaWarehouse::Hud
     #   dt = Disability.arel_table
     #   where Disability.where( dt[:data_source_id].eq c_t[:data_source_id] ).where( dt[:PersonalID].eq c_t[:PersonalID] ).exists
     # end
-    # 
+    #
     # clients whose first residential service record is within the given date range
     scope :entered_in_range, -> (range) do
       s, e, exclude = range.first, range.last, range.exclude_end?   # the exclusion bit's a little pedantic...
@@ -530,7 +532,7 @@ module GrdaWarehouse::Hud
           ).where(
             wc_t[:destination_id].eq(c_t1[:id])
           ).
-          exists.not 
+          exists.not
         ).distinct.exists?
     end
 
@@ -564,7 +566,7 @@ module GrdaWarehouse::Hud
           ).where(
             wc_t[:destination_id].eq(c_t1[:id])
           ).
-          exists.not 
+          exists.not
         ).distinct.pluck(:id)
     end
 
@@ -732,7 +734,7 @@ module GrdaWarehouse::Hud
     def self.release_duration
       @release_duration ||= GrdaWarehouse::Config.get(:release_duration)
     end
-    
+
     def release_valid?
       housing_release_status == self.class.full_release_string
     end
@@ -753,7 +755,7 @@ module GrdaWarehouse::Hud
 
     def newest_consent_form
       # Regardless of confirmation status
-      client_files.consent_forms.order(updated_at: :desc)&.first 
+      client_files.consent_forms.order(updated_at: :desc)&.first
     end
 
     def release_status_for_cas
@@ -779,7 +781,7 @@ module GrdaWarehouse::Hud
     # End Release information
     ##############################
     def most_recent_verification_of_disability
-      client_files.verification_of_disability.order(updated_at: :desc)&.first 
+      client_files.verification_of_disability.order(updated_at: :desc)&.first
     end
 
     # cas needs a simplified version of this
@@ -967,7 +969,7 @@ module GrdaWarehouse::Hud
             source_api_ids.detect do |api_id|
               api ||= EtoApi::Base.new.tap{|api| api.connect} rescue nil
               image_data = api.client_image(
-                client_id: api_id.id_in_data_source, 
+                client_id: api_id.id_in_data_source,
                 site_id: api_id.site_id_in_data_source
               ) rescue nil
               (image_data && image_data.length > 0)
@@ -1021,7 +1023,7 @@ module GrdaWarehouse::Hud
       end
     end
 
-    # These need to be flagged as available in the Window. Since we cache these 
+    # These need to be flagged as available in the Window. Since we cache these
     # in the file-system, we'll only show those that would be available to people
     # with window access
     def local_client_image_data
@@ -1354,7 +1356,7 @@ module GrdaWarehouse::Hud
         where(where).
         preload(:destination_client).
         map{|m| m.destination_client.id}
-      
+
       client_ids << text if numeric && self.destination.where(id: text).exists?
       where(id: client_ids)
     end
@@ -1481,8 +1483,8 @@ module GrdaWarehouse::Hud
       end
     end
 
-    def document_ready?(required_documents)  
-      @document_ready ||= required_documents.size == document_readiness(required_documents).select{|m| m.available}.size 
+    def document_ready?(required_documents)
+      @document_ready ||= required_documents.size == document_readiness(required_documents).select{|m| m.available}.size
     end
 
     # Build a set of potential client matches grouped by criteria
@@ -1602,7 +1604,7 @@ module GrdaWarehouse::Hud
           prev_destination_client.delete if prev_destination_client.source_clients(true).empty?
 
           move_dependent_items(prev_destination_client.id, self.id)
-          
+
         end
         # and invalidate our own service history
         force_full_service_history_rebuild
@@ -1705,7 +1707,7 @@ module GrdaWarehouse::Hud
     end
 
 
-    def self.dates_homeless_scope client_id:, on_date: Date.today 
+    def self.dates_homeless_scope client_id:, on_date: Date.today
       GrdaWarehouse::ServiceHistoryService.where(client_id: client_id).
         homeless.
         where(shs_t[:date].lteq(on_date)).
@@ -1837,8 +1839,8 @@ module GrdaWarehouse::Hud
 
     def homeless_dates_for_chronic_in_past_three_years(date: Date.today)
       GrdaWarehouse::Tasks::ChronicallyHomeless.new(
-        date: date.to_date, 
-        dry_run: true, 
+        date: date.to_date,
+        dry_run: true,
         client_ids: [id]
         ).residential_history_for_client(client_id: id)
     end
@@ -2005,8 +2007,8 @@ module GrdaWarehouse::Hud
       elsif enrollment.project.bed_night_tracking?
           enrollment.last_date_in_program
       else
-        enrollments.select do |m| 
-          m.computed_project_type == enrollment.computed_project_type && 
+        enrollments.select do |m|
+          m.computed_project_type == enrollment.computed_project_type &&
             m.first_date_in_program > enrollment.first_date_in_program
         end.
         sort_by(&:first_date_in_program)&.first&.first_date_in_program || enrollment.last_date_in_program

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1730,7 +1730,7 @@ module GrdaWarehouse::Hud
 
     # ES, SO, SH, or TH with no overlapping PH
     def self.dates_homeless_in_last_three_years_scope client_id:, on_date: Date.today
-      Rails.cache.fetch([self.cache_key, "dates_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
+      Rails.cache.fetch([client_id, "dates_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
         end_date = on_date.to_date
         start_date = end_date - 3.years
         GrdaWarehouse::ServiceHistoryService.where(client_id: client_id).
@@ -1743,7 +1743,7 @@ module GrdaWarehouse::Hud
 
     # ES, SO, or SH with no overlapping TH or PH
     def self.dates_literally_homeless_in_last_three_years_scope client_id:, on_date: Date.today
-      Rails.cache.fetch([self.cache_key, "dates_literally_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
+      Rails.cache.fetch([client_id, "dates_literally_homeless_in_last_three_years_scope", on_date], expires_in: CACHE_EXPIRY) do
         end_date = on_date.to_date
         start_date = end_date - 3.years
         GrdaWarehouse::ServiceHistoryService.where(client_id: client_id).

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -39,7 +39,7 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
         days_homeless_last_three_years: calcs.all_homeless_in_last_three_years[client_id] || 0,
         literally_homeless_last_three_years: calcs.all_literally_homeless_last_three_years[client_id] || 0,
       )
-      cohort_attributes(processed.client)
+      processed.assign_attributes cohort_attributes(processed.client)
       processed.save if processed.changed?
       GrdaWarehouse::Hud::Client.destination.clear_view_cache(client_id)
     end

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -270,14 +270,14 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
 
     def as_hash
       {
-        disability_verification_date: client.most_recent_verification_of_disability&.created_at&.to_date,
+        disability_verification_date: client.most_recent_verification_of_disability&.created_at&.to_date, # sub-daily
+        missing_documents: missing_documents, # sub-daily
         enrolled_homeless_shelter: client.service_history_enrollments.homeless_sheltered.ongoing.exists?,
         enrolled_homeless_unsheltered: client.service_history_enrollments.homeless_unsheltered.ongoing.exists?,
         enrolled_permanent_housing: client.service_history_enrollments.permanent_housing.ongoing.exists?,
         eto_coordinated_entry_assessment_score: client.most_recent_coc_assessment_score,
         household_members: household_members,
         last_homeless_visit: last_homeless_visit,
-        missing_documents: missing_documents,
         open_enrollments: open_enrollments,
         rrh_desired: client.rrh_desired,
         vispdat_priority_score: client.calculate_vispdat_priority_score,

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -18,7 +18,7 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
       routine: :service_history
     ).index_by(&:client_id)
 
-    cohort_client_ids = GrdaWarehouse::CohortClient.active.joins(:cohort, :client).
+    cohort_client_ids = GrdaWarehouse::CohortClient.joins(:cohort, :client).
       merge(GrdaWarehouse::Cohort.active).distinct.pluck(:client_id).to_set
 
     calcs = StatsCalculator.new(client_ids: client_ids)

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -23,7 +23,6 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
 
     calcs = StatsCalculator.new(client_ids: client_ids)
     client_ids.each do |client_id|
-      puts "#{client_id}..."
       processed = existing_by_client_id[client_id] || where(
         client_id: client_id,
         routine: :service_history

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -14,8 +14,8 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
   # def chronic?
   #   chronically_homeless
   # end
-  
-  def update_cached_counts client_ids: []
+
+  def self.update_cached_counts client_ids: []
     client_ids.each do |client_id|
       processed = self.class.where(client_id: client_id, routine: :service_history).
         first_or_initialize

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -39,7 +39,9 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
         days_homeless_last_three_years: calcs.all_homeless_in_last_three_years[client_id] || 0,
         literally_homeless_last_three_years: calcs.all_literally_homeless_last_three_years[client_id] || 0,
       )
-      processed.assign_attributes cohort_attributes(processed.client)
+      processed.assign_attributes(
+        CohortCalcs.new(processed.client).as_hash
+      )
       processed.save if processed.changed?
       GrdaWarehouse::Hud::Client.destination.clear_view_cache(client_id)
     end
@@ -255,56 +257,66 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
     end
   end
 
-  # stats used by Cohort reports
-  def self.cohort_attributes(client)
-    puts "cohort_attributes   #{client.to_s}"
-    {
-      disability_verification_date: client.most_recent_verification_of_disability&.created_at&.to_date,
-      enrolled_homeless_shelter: client.service_history_enrollments.homeless_sheltered.ongoing.exists?,
-      enrolled_homeless_unsheltered: client.service_history_enrollments.homeless_unsheltered.ongoing.exists?,
-      enrolled_permanent_housing: client.service_history_enrollments.permanent_housing.ongoing.exists?,
-      eto_coordinated_entry_assessment_score: client.most_recent_coc_assessment_score,
-      household_members: cohort_household_members(client),
-      last_homeless_visit: cohort_last_homeless_visit(client),
-      missing_documents: cohort_missing_documents(client),
-      open_enrollments: cohort_open_enrollments(client),
-      rrh_desired: client.rrh_desired,
-      vispdat_priority_score: client.calculate_vispdat_priority_score,
-      vispdat_score: client.most_recent_vispdat_score
-    }
-  end
+  # stats used by Cohort reports --
+  # FIXME: these are N+1 on client *and then some* so ideally
+  # thy get rewritten as batched versions
+  # like StatsCalculator
+  class CohortCalcs
+    attr_reader :client
 
-  def self.cohort_household_members(client)
-    households = client.households
-    if households.present?
-      households.values.flatten.map do |member|
-        "#{member['FirstName']} #{member['LastName']} (#{member['age']} in #{member['date'].year})"
-      end.uniq.join('; ')
+    def initialize(client)
+      @client = client
     end
-  end
 
-  def self.cohort_last_homeless_visit(client)
-    client.last_homeless_visits.map do |row|
-      row.join(': ')
-    end.join('; ')
-  end
+    def as_hash
+      {
+        disability_verification_date: client.most_recent_verification_of_disability&.created_at&.to_date,
+        enrolled_homeless_shelter: client.service_history_enrollments.homeless_sheltered.ongoing.exists?,
+        enrolled_homeless_unsheltered: client.service_history_enrollments.homeless_unsheltered.ongoing.exists?,
+        enrolled_permanent_housing: client.service_history_enrollments.permanent_housing.ongoing.exists?,
+        eto_coordinated_entry_assessment_score: client.most_recent_coc_assessment_score,
+        household_members: cohort_household_members(client),
+        last_homeless_visit: cohort_last_homeless_visit(client),
+        missing_documents: cohort_missing_documents(client),
+        open_enrollments: cohort_open_enrollments(client),
+        rrh_desired: client.rrh_desired,
+        vispdat_priority_score: client.calculate_vispdat_priority_score,
+        vispdat_score: client.most_recent_vispdat_score
+      }
+    end
 
-  def self.cohort_missing_documents(client)
-    required_documents = GrdaWarehouse::AvailableFileTag.document_ready
-    client.document_readiness(required_documents).select do |m|
-      m.available == false
-    end.map(&:name).join('; ')
-  end
-
-  def self.cohort_open_enrollments(client)
-    client.service_history_enrollments.ongoing.
-      distinct.residential.
-      pluck(:project_type).map do |project_type|
-        if project_type == 13
-          [project_type, 'RRH']
-        else
-          [project_type, ::HUD.project_type_brief(project_type)]
-        end
+    private def cohort_household_members(client)
+      households = client.households
+      if households.present?
+        households.values.flatten.map do |member|
+          "#{member['FirstName']} #{member['LastName']} (#{member['age']} in #{member['date'].year})"
+        end.uniq.join('; ')
       end
+    end
+
+    private def cohort_last_homeless_visit(client)
+      client.last_homeless_visits.map do |row|
+        row.join(': ')
+      end.join('; ')
+    end
+
+    private def cohort_missing_documents(client)
+      required_documents = GrdaWarehouse::AvailableFileTag.document_ready
+      client.document_readiness(required_documents).select do |m|
+        m.available == false
+      end.map(&:name).join('; ')
+    end
+
+    private def cohort_open_enrollments(client)
+      client.service_history_enrollments.ongoing.
+        distinct.residential.
+        pluck(:project_type).map do |project_type|
+          if project_type == 13
+            [project_type, 'RRH']
+          else
+            [project_type, ::HUD.project_type_brief(project_type)]
+          end
+        end
+    end
   end
 end

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -43,6 +43,44 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
     end
   end
 
+  def cohort_attributes(client)
+    # app/models/cohort_columns/disability_verification_date.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/enrolled_homeless_shelter.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/enrolled_homeless_unsheltered.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/enrolled_permanent_housing.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/household_members.rb:
+    #     6:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/last_homeless_visit.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/missing_documents.rb:
+    #     8:     def value(cohort_client) # TODO: N+1 (many really) move_to_processed
+
+    # app/models/cohort_columns/open_enrollments.rb:
+    #    19:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/rrh_desired.rb:
+    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+
+    # app/models/cohort_columns/vispdat_priority_score.rb:
+    #     7:     def value(cohort_client) # TODO: N=1 move_to_processed
+
+    # app/models/cohort_columns/vispdat_score.rb:
+    #     6:     def value(cohort_client) # TODO: N=1 move_to_processed
+  end
+
   def most_recent_homeless_dates client_ids: []
     @most_recent_homeless_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless.
       where(client_id: client_ids).

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -275,17 +275,17 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
         enrolled_homeless_unsheltered: client.service_history_enrollments.homeless_unsheltered.ongoing.exists?,
         enrolled_permanent_housing: client.service_history_enrollments.permanent_housing.ongoing.exists?,
         eto_coordinated_entry_assessment_score: client.most_recent_coc_assessment_score,
-        household_members: cohort_household_members(client),
-        last_homeless_visit: cohort_last_homeless_visit(client),
-        missing_documents: cohort_missing_documents(client),
-        open_enrollments: cohort_open_enrollments(client),
+        household_members: household_members,
+        last_homeless_visit: last_homeless_visit,
+        missing_documents: missing_documents,
+        open_enrollments: open_enrollments,
         rrh_desired: client.rrh_desired,
         vispdat_priority_score: client.calculate_vispdat_priority_score,
         vispdat_score: client.most_recent_vispdat_score
       }
     end
 
-    private def cohort_household_members(client)
+    private def household_members
       households = client.households
       if households.present?
         households.values.flatten.map do |member|
@@ -294,20 +294,20 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
       end
     end
 
-    private def cohort_last_homeless_visit(client)
+    private def last_homeless_visit
       client.last_homeless_visits.map do |row|
         row.join(': ')
       end.join('; ')
     end
 
-    private def cohort_missing_documents(client)
+    private def missing_documents
       required_documents = GrdaWarehouse::AvailableFileTag.document_ready
       client.document_readiness(required_documents).select do |m|
         m.available == false
       end.map(&:name).join('; ')
     end
 
-    private def cohort_open_enrollments(client)
+    private def open_enrollments
       client.service_history_enrollments.ongoing.
         distinct.residential.
         pluck(:project_type).map do |project_type|

--- a/app/models/grda_warehouse/warehouse_clients_processed.rb
+++ b/app/models/grda_warehouse/warehouse_clients_processed.rb
@@ -1,3 +1,5 @@
+require 'util/hud'
+
 class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
   include RandomScope
   include ArelHelper
@@ -9,272 +11,300 @@ class GrdaWarehouse::WarehouseClientsProcessed < GrdaWarehouseBase
   has_many :service_history_enrollments, class_name: GrdaWarehouse::ServiceHistoryEnrollment.name, primary_key: :client_id, foreign_key: :client_id
 
   scope :service_history, -> {where(routine: 'service_history')}
-  # scope :chronic?, -> {where chronically_homeless: true}
-
-  # def chronic?
-  #   chronically_homeless
-  # end
 
   def self.update_cached_counts client_ids: []
+    existing_by_client_id = where(
+      client_id: client_ids,
+      routine: :service_history
+    ).index_by(&:client_id)
+    calcs = StatsCalculator.new(client_ids: client_ids)
     client_ids.each do |client_id|
-      processed = self.class.where(client_id: client_id, routine: :service_history).
-        first_or_initialize
-      homeless_in_last_three = all_homeless_in_last_three_years(client_ids: client_ids).try(:[], client_id) || 0
-      literally_homeless_in_last_three = all_literally_homeless_last_three_years(client_ids: client_ids).try(:[], client_id) || 0
-      homeless_ever = homeless_counts(client_ids: client_ids).try(:[], client_id) || 0
-      attrs = {
-        last_service_updated_at: Date.today,
-        first_homeless_date: first_homeless_dates(client_ids: client_ids).try(:[], client_id),
-        last_homeless_date: most_recent_homeless_dates(client_ids: client_ids).try(:[], client_id),
-        homeless_days: homeless_ever,
-        first_chronic_date: first_chronic_dates(client_ids: client_ids).try(:[], client_id),
-        last_chronic_date: most_recent_chronic_dates(client_ids: client_ids).try(:[], client_id),
-        chronic_days: chronic_counts(client_ids: client_ids).try(:[], client_id),
-        first_date_served: first_total_dates(client_ids: client_ids).try(:[], client_id),
-        last_date_served: most_recent_total_dates(client_ids: client_ids).try(:[], client_id),
-        days_served: total_counts(client_ids: client_ids).try(:[], client_id),
-        days_homeless_last_three_years: homeless_in_last_three,
-        literally_homeless_last_three_years: literally_homeless_in_last_three,
-      }
+      puts "#{client_id}..."
+      processed = existing_by_client_id[client_id] || where(
+        client_id: client_id,
+        routine: :service_history
+      ).first_or_initialize
 
-      processed.update_attributes(attrs)
-      processed.save
+      processed.assign_attributes(
+        last_service_updated_at: Date.today,
+        first_homeless_date: calcs.first_homeless_dates[client_id],
+        last_homeless_date: calcs.most_recent_homeless_dates[client_id],
+        homeless_days: calcs.homeless_counts[client_id] || 0,
+        first_chronic_date: calcs.first_chronic_dates[client_id],
+        last_chronic_date: calcs.most_recent_chronic_dates[client_id],
+        chronic_days: calcs.chronic_counts[client_id],
+        first_date_served: calcs.first_total_dates[client_id],
+        last_date_served: calcs.most_recent_total_dates[client_id],
+        days_served: calcs.total_counts[client_id],
+        days_homeless_last_three_years: calcs.all_homeless_in_last_three_years[client_id] || 0,
+        literally_homeless_last_three_years: calcs.all_literally_homeless_last_three_years[client_id] || 0,
+      )
+      cohort_attributes(processed.client)
+      processed.save if processed.changed?
       GrdaWarehouse::Hud::Client.destination.clear_view_cache(client_id)
     end
+    nil
   end
 
-  def cohort_attributes(client)
-    # app/models/cohort_columns/disability_verification_date.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+  class StatsCalculator
+    def initialize(client_ids: )
+      @client_ids
+    end
 
-    # app/models/cohort_columns/enrolled_homeless_shelter.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+    def most_recent_homeless_dates
+      @most_recent_homeless_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless.
+        where(client_id: @client_ids).
+        group(:client_id).
+        maximum(:date)
+    end
 
-    # app/models/cohort_columns/enrolled_homeless_unsheltered.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+    def first_homeless_dates
+      @first_homeless_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless.
+        where(client_id: @client_ids).
+        group(:client_id).
+        minimum(:date)
+    end
 
-    # app/models/cohort_columns/enrolled_permanent_housing.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+    def homeless_counts
+      @homeless_counts ||= begin
+        shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
+        shsm = Arel::Table.new(shsm_table_name.to_sym)
+        shsm_a = shsm.alias('a')
+        shsm_b = shsm.alias('b')
+        shsm_c = shsm.alias('c')
 
-    # app/models/cohort_columns/eto_coordinated_entry_assessment_score.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+        non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_a[:project_type].in(r_non_homeless(chronic: false))).
+          where(shsm_a[:client_id].in(@client_ids)).
+          where(shsm_a[:date].eq(shsm_b[:date])).
+          where(shsm_a[:client_id].eq(shsm_b[:client_id])).
+          select(shsm_a[:client_id], shsm_a[:date]).
+          exists.not.
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
 
-    # app/models/cohort_columns/household_members.rb:
-    #     6:     def value(cohort_client) # TODO: N+1 move_to_processed
+        homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
+          where(shsm_b[:client_id].in(@client_ids)).
+          where(non_homeless_sql).
+          select(shsm_b[:client_id], shsm_b[:date]).
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
 
-    # app/models/cohort_columns/last_homeless_visit.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+        GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          from("(#{homeless_sql}) as c").
+          distinct.
+          group(shsm_c[:client_id]).
+          count('c.date')
+      end
 
-    # app/models/cohort_columns/missing_documents.rb:
-    #     8:     def value(cohort_client) # TODO: N+1 (many really) move_to_processed
+    end
 
-    # app/models/cohort_columns/open_enrollments.rb:
-    #    19:     def value(cohort_client) # TODO: N+1 move_to_processed
+    # days in ES, SO, SH, or TH that don't overlap with PH
+    def all_literally_homeless_last_three_years
+      @all_literally_homeless_last_three_years ||= begin
+        shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
+        shsm = Arel::Table.new(shsm_table_name.to_sym)
+        shsm_a = shsm.alias('a')
+        shsm_b = shsm.alias('b')
+        shsm_c = shsm.alias('c')
 
-    # app/models/cohort_columns/rrh_desired.rb:
-    #    10:     def value(cohort_client) # TODO: N+1 move_to_processed
+        non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_a[:project_type].in(r_non_homeless(chronic: true))).
+          where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_a[:client_id].in(@client_ids)).
+          where(shsm_a[:date].eq(shsm_b[:date])).
+          where(shsm_a[:client_id].eq(shsm_b[:client_id])).
+          select(shsm_a[:client_id], shsm_a[:date]).
+          exists.not.
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
 
-    # app/models/cohort_columns/vispdat_priority_score.rb:
-    #     7:     def value(cohort_client) # TODO: N=1 move_to_processed
+        homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
+          where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_b[:client_id].in(@client_ids)).
+          where(non_homeless_sql).
+          select(shsm_b[:client_id], shsm_b[:date]).
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
 
-    # app/models/cohort_columns/vispdat_score.rb:
-    #     6:     def value(cohort_client) # TODO: N=1 move_to_processed
-  end
+        GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          from("(#{homeless_sql}) as c").
+          distinct.
+          group(shsm_c[:client_id]).
+          count('c.date')
+      end
+    end
 
-  def most_recent_homeless_dates client_ids: []
-    @most_recent_homeless_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless.
-      where(client_id: client_ids).
-      group(:client_id).
-      maximum(:date)
-  end
-  def first_homeless_dates client_ids: []
-    @first_homeless_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless.
-      where(client_id: client_ids).
-      group(:client_id).
-      minimum(:date)
-  end
-  def homeless_counts client_ids: []
-    @homeless_counts ||= begin
-      shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
-      shsm = Arel::Table.new(shsm_table_name.to_sym)
-      shsm_a = shsm.alias('a')
-      shsm_b = shsm.alias('b')
-      shsm_c = shsm.alias('c')
+    # days in ES, SO, or SH that don't overlap with TH or PH
+    def all_homeless_in_last_three_years
+      @all_homeless_in_last_three_years ||= begin
+        shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
+        shsm = Arel::Table.new(shsm_table_name.to_sym)
+        shsm_a = shsm.alias('a')
+        shsm_b = shsm.alias('b')
+        shsm_c = shsm.alias('c')
 
-      non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_a[:project_type].in(r_non_homeless)).
-        where(shsm_a[:client_id].in(client_ids)).
-        where(shsm_a[:date].eq(shsm_b[:date])).
-        where(shsm_a[:client_id].eq(shsm_b[:client_id])).
-        select(shsm_a[:client_id], shsm_a[:date]).
-        exists.not.
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
+        non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_a[:project_type].in(r_non_homeless(chronic: false))).
+          where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_a[:client_id].in(@client_ids)).
+          where(shsm_a[:date].eq(shsm_b[:date])).
+          where(shsm_a[:client_id].eq(shsm_b[:client_id])).
+          select(shsm_a[:client_id], shsm_a[:date]).
+          exists.not.
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
 
-      homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
-        where(shsm_b[:client_id].in(client_ids)).
-        where(non_homeless_sql).
-        select(shsm_b[:client_id], shsm_b[:date]).
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
+        homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
+          where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_b[:client_id].in(@client_ids)).
+          where(non_homeless_sql).
+          select(shsm_b[:client_id], shsm_b[:date]).
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
 
-      GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        from("(#{homeless_sql}) as c").
+        GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          from("(#{homeless_sql}) as c").
+          distinct.
+          group(shsm_c[:client_id]).
+          count('c.date')
+      end
+    end
+
+    def most_recent_chronic_dates
+      @most_recent_chronic_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless(chronic_types_only: true).
+        where(client_id: @client_ids).
+        group(:client_id).
+        maximum(:date)
+    end
+
+    def first_chronic_dates
+      @first_chronic_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless(chronic_types_only: true).
+        where(client_id: @client_ids).
+        group(:client_id).
+        minimum(:date)
+    end
+
+    def chronic_counts
+      @chronic_counts ||= begin
+        shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
+        shsm = Arel::Table.new(shsm_table_name.to_sym)
+        shsm_a = shsm.alias('a')
+        shsm_b = shsm.alias('b')
+        shsm_c = shsm.alias('c')
+
+        non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_a[:project_type].in(r_non_homeless(chronic: true))).
+          where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_a[:client_id].in(@client_ids)).
+          where(shsm_a[:date].eq(shsm_b[:date])).
+          where(shsm_a[:client_id].eq(shsm_b[:client_id])).
+          select(shsm_a[:client_id], shsm_a[:date]).
+          exists.not.
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
+
+        homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES)).
+          where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
+          where(shsm_b[:client_id].in(@client_ids)).
+          where(non_homeless_sql).
+          select(shsm_b[:client_id], shsm_b[:date]).
+          to_sql.
+          sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
+
+        GrdaWarehouse::ServiceHistoryServiceMaterialized.
+          from("(#{homeless_sql}) as c").
+          distinct.
+          group(shsm_c[:client_id]).
+          count('c.date')
+      end
+    end
+
+    def most_recent_total_dates
+      @most_recent_total_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
+        where(client_id: @client_ids).
+        group(:client_id).
+        maximum(:date)
+    end
+
+    def first_total_dates
+      @first_total_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
+        where(client_id: @client_ids).
+        group(:client_id).
+        minimum(:date)
+    end
+
+    def total_counts
+      @total_counts ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
+        where(client_id: @client_ids).
+        group(:client_id).
         distinct.
-        group(shsm_c[:client_id]).
-        count('c.date')
+        count(:date)
     end
 
-  end
-
-  # days in ES, SO, SH, or TH that don't overlap with PH
-  def all_literally_homeless_last_three_years client_ids: []
-    @all_literally_homeless_last_three_years ||= begin
-      shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
-      shsm = Arel::Table.new(shsm_table_name.to_sym)
-      shsm_a = shsm.alias('a')
-      shsm_b = shsm.alias('b')
-      shsm_c = shsm.alias('c')
-
-      non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_a[:project_type].in(r_non_homeless(chronic: true))).
-        where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_a[:client_id].in(client_ids)).
-        where(shsm_a[:date].eq(shsm_b[:date])).
-        where(shsm_a[:client_id].eq(shsm_b[:client_id])).
-        select(shsm_a[:client_id], shsm_a[:date]).
-        exists.not.
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
-
-      homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
-        where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_b[:client_id].in(client_ids)).
-        where(non_homeless_sql).
-        select(shsm_b[:client_id], shsm_b[:date]).
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
-
-      GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        from("(#{homeless_sql}) as c").
-        distinct.
-        group(shsm_c[:client_id]).
-        count('c.date')
+    def r_non_homeless(chronic: false)
+      if chronic
+        GrdaWarehouse::Hud::Project::RESIDENTIAL_PROJECT_TYPE_IDS - GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES
+      else
+        GrdaWarehouse::Hud::Project::RESIDENTIAL_PROJECT_TYPE_IDS - GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES
+      end
     end
   end
 
-  # days in ES, SO, or SH that don't overlap with TH or PH
-  def all_homeless_in_last_three_years client_ids: []
-    @all_homeless_in_last_three_years ||= begin
-      shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
-      shsm = Arel::Table.new(shsm_table_name.to_sym)
-      shsm_a = shsm.alias('a')
-      shsm_b = shsm.alias('b')
-      shsm_c = shsm.alias('c')
+  # stats used by Cohort reports
+  def self.cohort_attributes(client)
+    puts "cohort_attributes   #{client.to_s}"
+    {
+      disability_verification_date: client.most_recent_verification_of_disability&.created_at&.to_date,
+      enrolled_homeless_shelter: client.service_history_enrollments.homeless_sheltered.ongoing.exists?,
+      enrolled_homeless_unsheltered: client.service_history_enrollments.homeless_unsheltered.ongoing.exists?,
+      enrolled_permanent_housing: client.service_history_enrollments.permanent_housing.ongoing.exists?,
+      eto_coordinated_entry_assessment_score: client.most_recent_coc_assessment_score,
+      household_members: cohort_household_members(client),
+      last_homeless_visit: cohort_last_homeless_visit(client),
+      missing_documents: cohort_missing_documents(client),
+      open_enrollments: cohort_open_enrollments(client),
+      rrh_desired: client.rrh_desired,
+      vispdat_priority_score: client.calculate_vispdat_priority_score,
+      vispdat_score: client.most_recent_vispdat_score
+    }
+  end
 
-      non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_a[:project_type].in(r_non_homeless)).
-        where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_a[:client_id].in(client_ids)).
-        where(shsm_a[:date].eq(shsm_b[:date])).
-        where(shsm_a[:client_id].eq(shsm_b[:client_id])).
-        select(shsm_a[:client_id], shsm_a[:date]).
-        exists.not.
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
-
-      homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES)).
-        where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_b[:client_id].in(client_ids)).
-        where(non_homeless_sql).
-        select(shsm_b[:client_id], shsm_b[:date]).
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
-
-      GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        from("(#{homeless_sql}) as c").
-        distinct.
-        group(shsm_c[:client_id]).
-        count('c.date')
+  def self.cohort_household_members(client)
+    households = client.households
+    if households.present?
+      households.values.flatten.map do |member|
+        "#{member['FirstName']} #{member['LastName']} (#{member['age']} in #{member['date'].year})"
+      end.uniq.join('; ')
     end
   end
 
-  def most_recent_chronic_dates client_ids: []
-    @most_recent_chronic_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless(chronic_types_only: true).
-      where(client_id: client_ids).
-      group(:client_id).
-      maximum(:date)
-  end
-  def first_chronic_dates client_ids: []
-    @first_chronic_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.homeless(chronic_types_only: true).
-      where(client_id: client_ids).
-      group(:client_id).
-      minimum(:date)
-  end
-  def chronic_counts client_ids: []
-    @chronic_counts ||= begin
-      shsm_table_name = GrdaWarehouse::ServiceHistoryServiceMaterialized.table_name
-      shsm = Arel::Table.new(shsm_table_name.to_sym)
-      shsm_a = shsm.alias('a')
-      shsm_b = shsm.alias('b')
-      shsm_c = shsm.alias('c')
-
-      non_homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_a[:project_type].in(r_non_homeless(chronic: true))).
-        where(shsm_a[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_a[:client_id].in(client_ids)).
-        where(shsm_a[:date].eq(shsm_b[:date])).
-        where(shsm_a[:client_id].eq(shsm_b[:client_id])).
-        select(shsm_a[:client_id], shsm_a[:date]).
-        exists.not.
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as a")
-
-      homeless_sql = GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        where(shsm_b[:project_type].in(GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES)).
-        where(shsm_b[:date].between(3.years.ago.to_date..Date.today)).
-        where(shsm_b[:client_id].in(client_ids)).
-        where(non_homeless_sql).
-        select(shsm_b[:client_id], shsm_b[:date]).
-        to_sql.
-        sub("\"#{shsm_table_name}\"", "\"#{shsm_table_name}\" as b")
-
-      GrdaWarehouse::ServiceHistoryServiceMaterialized.
-        from("(#{homeless_sql}) as c").
-        distinct.
-        group(shsm_c[:client_id]).
-        count('c.date')
-    end
+  def self.cohort_last_homeless_visit(client)
+    client.last_homeless_visits.map do |row|
+      row.join(': ')
+    end.join('; ')
   end
 
-  def most_recent_total_dates client_ids: []
-    @most_recent_total_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
-      where(client_id: client_ids).
-      group(:client_id).
-      maximum(:date)
-  end
-  def first_total_dates client_ids: []
-    @first_total_dates ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
-      where(client_id: client_ids).
-      group(:client_id).
-      minimum(:date)
-  end
-  def total_counts client_ids: []
-    @total_counts ||= GrdaWarehouse::ServiceHistoryServiceMaterialized.
-      where(client_id: client_ids).
-      group(:client_id).
-      distinct.
-      count(:date)
+  def self.cohort_missing_documents(client)
+    required_documents = GrdaWarehouse::AvailableFileTag.document_ready
+    client.document_readiness(required_documents).select do |m|
+      m.available == false
+    end.map(&:name).join('; ')
   end
 
-  def r_non_homeless(chronic: false)
-    if chronic
-      GrdaWarehouse::Hud::Project::RESIDENTIAL_PROJECT_TYPE_IDS - GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES
-    else
-      GrdaWarehouse::Hud::Project::RESIDENTIAL_PROJECT_TYPE_IDS - GrdaWarehouse::Hud::Project::HOMELESS_PROJECT_TYPES
-    end
+  def self.cohort_open_enrollments(client)
+    client.service_history_enrollments.ongoing.
+      distinct.residential.
+      pluck(:project_type).map do |project_type|
+        if project_type == 13
+          [project_type, 'RRH']
+        else
+          [project_type, ::HUD.project_type_brief(project_type)]
+        end
+      end
   end
 end

--- a/app/models/similarity_metric/tasks/generate_candidates.rb
+++ b/app/models/similarity_metric/tasks/generate_candidates.rb
@@ -5,7 +5,7 @@ module SimilarityMetric::Tasks
     end
 
     def run!
-      puts "Generating some match candiates: #{@opts.to_json}..."
+      Rails.logger.info "Generating some match candidates: #{@opts.to_json}..."
       start_time = Time.now
       metrics = SimilarityMetric::Base.usable.all.reject(&:bogus?)
       clients = GrdaWarehouse::Hud::Client
@@ -21,10 +21,10 @@ module SimilarityMetric::Tasks
 
       scope.each do |dest|
         if Time.now > (start_time + @opts[:run_length].to_i.minutes)
-          puts "Ending after #{@opts[:run_length]} minutes"
+          Rails.logger.info "Ending after #{@opts[:run_length]} minutes"
           break
         end
-        print "Checking #{dest.id}..."
+        Rails.logger.info "Checking #{dest.id}..."
         candidates = matches.create_candidates!(dest, threshold: @opts[:threshold], metrics: metrics)
         match = matches.create! do |m|
           m.destination_client_id = dest.id
@@ -32,10 +32,10 @@ module SimilarityMetric::Tasks
           m.status = 'processed_sources'
         end
         if candidates.size == 0
-          print "...none found\n"
+          Rails.logger.info "...none found\n"
         end
         candidates.each do |match|
-          print "...added #{match.source_client_id} #{match.destination_client_id} #{match.score}....\n"
+          Rails.logger.info "...added #{match.source_client_id} #{match.destination_client_id} #{match.score}....\n"
         end
       end
     end

--- a/app/views/cohorts/_client_table.haml
+++ b/app/views/cohorts/_client_table.haml
@@ -4,7 +4,7 @@
 .table-wrapper
   .row
     .col-sm-7.cohort--table-info
-      = "Cohort: #{pluralize(@cohort_clients.size, 'client')}; #{@cohort.cohort_clients.active.size} active."
+      = "Cohort: #{pluralize(@cohort.cohort_clients.count, 'client')}; #{@cohort.cohort_clients.active.size} active."
     .col-sm-1.text-right
       .jSearchActions
         %span.jSearchStatus.text-muted.hide
@@ -16,6 +16,6 @@
         .jSearchActions.input-group-btn
           %a.disabled.jSearchBack.icon-arrow-left.btn.btn-sm.btn-secondary{href: '#back'}
           %a.disabled.jSearchForward.icon-arrow-right.btn.btn-sm.btn-secondary{href: '#forward'}
-          
-    
+
+
   .cohort-client__table.datatable{class: size}

--- a/app/views/cohorts/_cohort_client_tabs.haml
+++ b/app/views/cohorts/_cohort_client_tabs.haml
@@ -6,11 +6,11 @@
     },
     cohort_path(@cohort, population: :housed) => {
       title: 'Housed Clients',
-      permission: @show_housed,
+      permission: @cohort.show_housed,
     },
     cohort_path(@cohort, population: :ineligible) => {
       title: 'Ineligible Clients',
-      permission: @show_inactive,
+      permission: @cohort.show_inactive,
     },
   }
 

--- a/app/views/cohorts/_cohorts_js.haml
+++ b/app/views/cohorts/_cohorts_js.haml
@@ -4,9 +4,9 @@
       var cohort_options = {
         wrapper_selector: '.cohorts',
         table_selector: '.datatable',
-        batch_size: 25,
+        batch_size: 500,
         static_column_count: #{@cohort.static_column_count + 1},
-        client_count: #{@cohort_clients.count},
+        client_count: #{@cohort.client_search_scope.count},
         sort_direction: '#{@cohort.default_sort_direction}',
         column_order: #{(@visible_columns.map(&:column)).to_json},
         column_headers: #{@column_headers.to_json},
@@ -27,5 +27,5 @@
         population: "#{@population}"
       }
       $('body').data('cohort', new App.Cohorts.Cohort(cohort_options));
-      
+
     })(jQuery);

--- a/app/views/cohorts/_cohorts_js.haml
+++ b/app/views/cohorts/_cohorts_js.haml
@@ -4,7 +4,7 @@
       var cohort_options = {
         wrapper_selector: '.cohorts',
         table_selector: '.datatable',
-        batch_size: 500,
+        batch_size: 100,
         static_column_count: #{@cohort.static_column_count + 1},
         client_count: #{@cohort.client_search_scope.count},
         sort_direction: '#{@cohort.default_sort_direction}',

--- a/app/views/cohorts/show.xlsx.axlsx
+++ b/app/views/cohorts/show.xlsx.axlsx
@@ -1,9 +1,10 @@
 wb = xlsx_package.workbook
 wb.add_worksheet(name: @cohort.name.slice(0,30)) do |sheet|
   title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
-  sheet.add_row(@cohort.visible_columns.map(&:title), :style => title)
+  sheet.add_row(['Warehouse ID'] + @cohort.visible_columns.map(&:title), :style => title)
   @cohort_clients.each do |cohort_client|
-    row = @cohort.visible_columns.map do |column|
+    row = [cohort_client.client_id]
+    row += @cohort.visible_columns.map do |column|
       column.cohort = @cohort
       column.cohort_names = @cohort_names
       if column.renderer == 'html'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,8 +60,12 @@ Rails.application.configure do
 
   config.force_ssl = false
 
-  config.cache_store = :redis_store, Rails.application.config_for(:cache_store), { expires_in: 8.hours }
-  config.action_controller.perform_caching = true
+  config.cache_store = ActiveSupport::Cache::RedisStore.new(
+    Rails.application.config_for(:cache_store).merge(expires_in: 8.hours)
+  )
+  config.cache_store.logger = Logger.new(Rails.root.join("log/cache.log"))
+  config.cache_store.logger.level = Logger::DEBUG
+
 
   # config.middleware.use ExceptionNotification::Rack,
   #   :slack => {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,6 +67,10 @@ Rails.application.configure do
   config.cache_store.logger.level = Logger::DEBUG
 
 
+  # do gzip compressing in dev mode to simulate nginx config in production
+  config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
+
+
   # config.middleware.use ExceptionNotification::Rack,
   #   :slack => {
   #     :webhook_url => Rails.application.config_for(:exception_notifier)['slack']['webhook_url'],

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,6 +28,10 @@ if environment == 'production'
     rake "grda_warehouse:daily"
   end
 
+  every 1.day, at: '7:15 am' do
+    rake "grda_warehouse:warm_cohort_cache"
+  end
+
   every 4.hours do
     rake "grda_warehouse:save_service_history_snapshots"
   end

--- a/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
+++ b/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
@@ -9,7 +9,7 @@ class AddCohortColumnsToClientsProcessed < ActiveRecord::Migration
     add_column :warehouse_clients_processed, :last_homeless_visit, :string
     add_column :warehouse_clients_processed, :missing_documents, :string
     add_column :warehouse_clients_processed, :open_enrollments, :jsonb
-    add_column :warehouse_clients_processed, :rrh_desired, :string
+    add_column :warehouse_clients_processed, :rrh_desired, :boolean
     add_column :warehouse_clients_processed, :vispdat_priority_score, :decimal
     add_column :warehouse_clients_processed, :vispdat_score, :decimal
   end

--- a/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
+++ b/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
@@ -4,13 +4,13 @@ class AddCohortColumnsToClientsProcessed < ActiveRecord::Migration
     add_column :warehouse_clients_processed, :enrolled_homeless_shelter, :boolean
     add_column :warehouse_clients_processed, :enrolled_homeless_unsheltered, :boolean
     add_column :warehouse_clients_processed, :enrolled_permanent_housing, :boolean
-    add_column :warehouse_clients_processed, :eto_coordinated_entry_assessment_score, :decimal
+    add_column :warehouse_clients_processed, :eto_coordinated_entry_assessment_score, :integer
     add_column :warehouse_clients_processed, :household_members, :string
     add_column :warehouse_clients_processed, :last_homeless_visit, :string
     add_column :warehouse_clients_processed, :missing_documents, :string
     add_column :warehouse_clients_processed, :open_enrollments, :jsonb
     add_column :warehouse_clients_processed, :rrh_desired, :boolean
-    add_column :warehouse_clients_processed, :vispdat_priority_score, :decimal
-    add_column :warehouse_clients_processed, :vispdat_score, :decimal
+    add_column :warehouse_clients_processed, :vispdat_priority_score, :integer
+    add_column :warehouse_clients_processed, :vispdat_score, :integer
   end
 end

--- a/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
+++ b/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
@@ -1,0 +1,16 @@
+class AddCohortColumnsToClientsProcessed < ActiveRecord::Migration
+  def change
+    add_column :warehouse_clients_processed, :disability_verification_date, :date
+    add_column :warehouse_clients_processed, :enrolled_homeless_shelter, :boolean
+    add_column :warehouse_clients_processed, :enrolled_homeless_unsheltered, :boolean
+    add_column :warehouse_clients_processed, :enrolled_permanent_housing, :boolean
+    add_column :warehouse_clients_processed, :eto_coordinated_entry_assessment_score, :decimal
+    add_column :warehouse_clients_processed, :household_members, :string
+    add_column :warehouse_clients_processed, :last_homeless_visit, :string
+    add_column :warehouse_clients_processed, :missing_documents, :string
+    add_column :warehouse_clients_processed, :open_enrollments, :string
+    add_column :warehouse_clients_processed, :rrh_desired, :string
+    add_column :warehouse_clients_processed, :vispdat_priority_score, :decimal
+    add_column :warehouse_clients_processed, :vispdat_score, :decimal
+  end
+end

--- a/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
+++ b/db/warehouse/migrate/20180613193551_add_cohort_columns_to_clients_processed.rb
@@ -8,7 +8,7 @@ class AddCohortColumnsToClientsProcessed < ActiveRecord::Migration
     add_column :warehouse_clients_processed, :household_members, :string
     add_column :warehouse_clients_processed, :last_homeless_visit, :string
     add_column :warehouse_clients_processed, :missing_documents, :string
-    add_column :warehouse_clients_processed, :open_enrollments, :string
+    add_column :warehouse_clients_processed, :open_enrollments, :jsonb
     add_column :warehouse_clients_processed, :rrh_desired, :string
     add_column :warehouse_clients_processed, :vispdat_priority_score, :decimal
     add_column :warehouse_clients_processed, :vispdat_score, :decimal

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "fuzzystrmatch"
-  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
+  enable_extension "pg_stat_statements"
 
   create_table "Affiliation", force: :cascade do |t|
     t.string   "AffiliationID"
@@ -3020,72 +3020,6 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     WHERE ("Client"."DateDeleted" IS NULL);
   SQL
 
-  create_view "report_disabilities",  sql_definition: <<-SQL
-      SELECT "Disabilities"."DisabilitiesID",
-      "Disabilities"."ProjectEntryID",
-      "Disabilities"."PersonalID",
-      "Disabilities"."InformationDate",
-      "Disabilities"."DisabilityType",
-      "Disabilities"."DisabilityResponse",
-      "Disabilities"."IndefiniteAndImpairs",
-      "Disabilities"."DocumentationOnFile",
-      "Disabilities"."ReceivingServices",
-      "Disabilities"."PATHHowConfirmed",
-      "Disabilities"."PATHSMIInformation",
-      "Disabilities"."TCellCountAvailable",
-      "Disabilities"."TCellCount",
-      "Disabilities"."TCellSource",
-      "Disabilities"."ViralLoadAvailable",
-      "Disabilities"."ViralLoad",
-      "Disabilities"."ViralLoadSource",
-      "Disabilities"."DataCollectionStage",
-      "Disabilities"."DateCreated",
-      "Disabilities"."DateUpdated",
-      "Disabilities"."UserID",
-      "Disabilities"."DateDeleted",
-      "Disabilities"."ExportID",
-      "Disabilities".data_source_id,
-      "Disabilities".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("Disabilities"
-       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("Disabilities"."DateDeleted" IS NULL);
-  SQL
-
-  create_view "report_employment_educations",  sql_definition: <<-SQL
-      SELECT "EmploymentEducation"."EmploymentEducationID",
-      "EmploymentEducation"."ProjectEntryID",
-      "EmploymentEducation"."PersonalID",
-      "EmploymentEducation"."InformationDate",
-      "EmploymentEducation"."LastGradeCompleted",
-      "EmploymentEducation"."SchoolStatus",
-      "EmploymentEducation"."Employed",
-      "EmploymentEducation"."EmploymentType",
-      "EmploymentEducation"."NotEmployedReason",
-      "EmploymentEducation"."DataCollectionStage",
-      "EmploymentEducation"."DateCreated",
-      "EmploymentEducation"."DateUpdated",
-      "EmploymentEducation"."UserID",
-      "EmploymentEducation"."DateDeleted",
-      "EmploymentEducation"."ExportID",
-      "EmploymentEducation".data_source_id,
-      "EmploymentEducation".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("EmploymentEducation"
-       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
-  SQL
-
   create_view "report_enrollments",  sql_definition: <<-SQL
       SELECT "Enrollment"."ProjectEntryID",
       "Enrollment"."PersonalID",
@@ -3205,6 +3139,72 @@ ActiveRecord::Schema.define(version: 20180614004301) do
        JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
        JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
     WHERE ("Enrollment"."DateDeleted" IS NULL);
+  SQL
+
+  create_view "report_disabilities",  sql_definition: <<-SQL
+      SELECT "Disabilities"."DisabilitiesID",
+      "Disabilities"."ProjectEntryID",
+      "Disabilities"."PersonalID",
+      "Disabilities"."InformationDate",
+      "Disabilities"."DisabilityType",
+      "Disabilities"."DisabilityResponse",
+      "Disabilities"."IndefiniteAndImpairs",
+      "Disabilities"."DocumentationOnFile",
+      "Disabilities"."ReceivingServices",
+      "Disabilities"."PATHHowConfirmed",
+      "Disabilities"."PATHSMIInformation",
+      "Disabilities"."TCellCountAvailable",
+      "Disabilities"."TCellCount",
+      "Disabilities"."TCellSource",
+      "Disabilities"."ViralLoadAvailable",
+      "Disabilities"."ViralLoad",
+      "Disabilities"."ViralLoadSource",
+      "Disabilities"."DataCollectionStage",
+      "Disabilities"."DateCreated",
+      "Disabilities"."DateUpdated",
+      "Disabilities"."UserID",
+      "Disabilities"."DateDeleted",
+      "Disabilities"."ExportID",
+      "Disabilities".data_source_id,
+      "Disabilities".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("Disabilities"
+       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("Disabilities"."DateDeleted" IS NULL);
+  SQL
+
+  create_view "report_employment_educations",  sql_definition: <<-SQL
+      SELECT "EmploymentEducation"."EmploymentEducationID",
+      "EmploymentEducation"."ProjectEntryID",
+      "EmploymentEducation"."PersonalID",
+      "EmploymentEducation"."InformationDate",
+      "EmploymentEducation"."LastGradeCompleted",
+      "EmploymentEducation"."SchoolStatus",
+      "EmploymentEducation"."Employed",
+      "EmploymentEducation"."EmploymentType",
+      "EmploymentEducation"."NotEmployedReason",
+      "EmploymentEducation"."DataCollectionStage",
+      "EmploymentEducation"."DateCreated",
+      "EmploymentEducation"."DateUpdated",
+      "EmploymentEducation"."UserID",
+      "EmploymentEducation"."DateDeleted",
+      "EmploymentEducation"."ExportID",
+      "EmploymentEducation".data_source_id,
+      "EmploymentEducation".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("EmploymentEducation"
+       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
   SQL
 
   create_view "report_exits",  sql_definition: <<-SQL

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "fuzzystrmatch"
-  enable_extension "pgcrypto"
   enable_extension "pg_stat_statements"
+  enable_extension "pgcrypto"
 
   create_table "Affiliation", force: :cascade do |t|
     t.string   "AffiliationID"
@@ -1662,10 +1662,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   end
 
   create_table "service_history_services_2000", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1679,10 +1679,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2000", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2000_date_en_id", using: :btree
 
   create_table "service_history_services_2001", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1696,10 +1696,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2001", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2001_date_en_id", using: :btree
 
   create_table "service_history_services_2002", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1713,10 +1713,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2002", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2002_date_en_id", using: :btree
 
   create_table "service_history_services_2003", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1730,10 +1730,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2003", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2003_date_en_id", using: :btree
 
   create_table "service_history_services_2004", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1747,10 +1747,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2004", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2004_date_en_id", using: :btree
 
   create_table "service_history_services_2005", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1764,10 +1764,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2005", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2005_date_en_id", using: :btree
 
   create_table "service_history_services_2006", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1781,10 +1781,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2006", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2006_date_en_id", using: :btree
 
   create_table "service_history_services_2007", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1798,10 +1798,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2007", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2007_date_en_id", using: :btree
 
   create_table "service_history_services_2008", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1815,10 +1815,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2008", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2008_date_en_id", using: :btree
 
   create_table "service_history_services_2009", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1832,10 +1832,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2009", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2009_date_en_id", using: :btree
 
   create_table "service_history_services_2010", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1849,10 +1849,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2010", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2010_date_en_id", using: :btree
 
   create_table "service_history_services_2011", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1866,10 +1866,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2011", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2011_date_en_id", using: :btree
 
   create_table "service_history_services_2012", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1883,10 +1883,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2012", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2012_date_en_id", using: :btree
 
   create_table "service_history_services_2013", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1900,10 +1900,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2013", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2013_date_en_id", using: :btree
 
   create_table "service_history_services_2014", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1917,10 +1917,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2014", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2014_date_en_id", using: :btree
 
   create_table "service_history_services_2015", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1934,10 +1934,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2015", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2015_date_en_id", using: :btree
 
   create_table "service_history_services_2016", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1951,10 +1951,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2016", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2016_date_en_id", using: :btree
 
   create_table "service_history_services_2017", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1968,10 +1968,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2017", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2017_date_en_id", using: :btree
 
   create_table "service_history_services_2018", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -1985,10 +1985,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2018", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2018_date_en_id", using: :btree
 
   create_table "service_history_services_2019", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2002,10 +2002,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2019", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2019_date_en_id", using: :btree
 
   create_table "service_history_services_2020", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2019,10 +2019,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2020", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2020_date_en_id", using: :btree
 
   create_table "service_history_services_2021", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2036,10 +2036,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2021", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2021_date_en_id", using: :btree
 
   create_table "service_history_services_2022", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2053,10 +2053,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2022", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2022_date_en_id", using: :btree
 
   create_table "service_history_services_2023", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2070,10 +2070,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2023", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2023_date_en_id", using: :btree
 
   create_table "service_history_services_2024", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2087,10 +2087,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2024", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2024_date_en_id", using: :btree
 
   create_table "service_history_services_2025", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2104,10 +2104,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2025", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2025_date_en_id", using: :btree
 
   create_table "service_history_services_2026", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2121,10 +2121,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2026", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2026_date_en_id", using: :btree
 
   create_table "service_history_services_2027", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2138,10 +2138,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2027", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2027_date_en_id", using: :btree
 
   create_table "service_history_services_2028", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2155,10 +2155,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2028", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2028_date_en_id", using: :btree
 
   create_table "service_history_services_2029", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2172,10 +2172,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2029", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2029_date_en_id", using: :btree
 
   create_table "service_history_services_2030", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2189,10 +2189,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2030", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2030_date_en_id", using: :btree
 
   create_table "service_history_services_2031", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2206,10 +2206,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2031", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2031_date_en_id", using: :btree
 
   create_table "service_history_services_2032", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2223,10 +2223,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2032", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2032_date_en_id", using: :btree
 
   create_table "service_history_services_2033", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2240,10 +2240,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2033", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2033_date_en_id", using: :btree
 
   create_table "service_history_services_2034", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2257,10 +2257,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2034", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2034_date_en_id", using: :btree
 
   create_table "service_history_services_2035", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2274,10 +2274,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2035", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2035_date_en_id", using: :btree
 
   create_table "service_history_services_2036", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2291,10 +2291,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2036", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2036_date_en_id", using: :btree
 
   create_table "service_history_services_2037", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2308,10 +2308,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2037", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2037_date_en_id", using: :btree
 
   create_table "service_history_services_2038", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2325,10 +2325,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2038", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2038_date_en_id", using: :btree
 
   create_table "service_history_services_2039", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2342,10 +2342,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2039", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2039_date_en_id", using: :btree
 
   create_table "service_history_services_2040", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2359,10 +2359,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2040", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2040_date_en_id", using: :btree
 
   create_table "service_history_services_2041", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2376,10 +2376,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2041", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2041_date_en_id", using: :btree
 
   create_table "service_history_services_2042", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2393,10 +2393,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2042", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2042_date_en_id", using: :btree
 
   create_table "service_history_services_2043", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2410,10 +2410,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2043", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2043_date_en_id", using: :btree
 
   create_table "service_history_services_2044", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2427,10 +2427,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2044", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2044_date_en_id", using: :btree
 
   create_table "service_history_services_2045", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2444,10 +2444,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2045", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2045_date_en_id", using: :btree
 
   create_table "service_history_services_2046", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2461,10 +2461,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2046", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2046_date_en_id", using: :btree
 
   create_table "service_history_services_2047", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2478,10 +2478,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2047", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2047_date_en_id", using: :btree
 
   create_table "service_history_services_2048", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2495,10 +2495,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2048", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2048_date_en_id", using: :btree
 
   create_table "service_history_services_2049", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2512,10 +2512,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2049", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2049_date_en_id", using: :btree
 
   create_table "service_history_services_2050", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2529,10 +2529,10 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_2050", ["service_history_enrollment_id", "date", "record_type"], name: "index_shs_2050_date_en_id", using: :btree
 
   create_table "service_history_services_remainder", id: false, force: :cascade do |t|
-    t.integer "id",                                       default: 0, null: false
-    t.integer "service_history_enrollment_id",                        null: false
-    t.string  "record_type",                   limit: 50,             null: false
-    t.date    "date",                                                 null: false
+    t.integer "id",                                       default: "nextval('service_history_services_id_seq'::regclass)", null: false
+    t.integer "service_history_enrollment_id",                                                                             null: false
+    t.string  "record_type",                   limit: 50,                                                                  null: false
+    t.date    "date",                                                                                                      null: false
     t.integer "age",                           limit: 2
     t.integer "service_type",                  limit: 2
     t.integer "client_id"
@@ -2819,7 +2819,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.string   "household_members"
     t.string   "last_homeless_visit"
     t.string   "missing_documents"
-    t.string   "open_enrollments"
+    t.jsonb    "open_enrollments"
     t.string   "rrh_desired"
     t.decimal  "vispdat_priority_score"
     t.decimal  "vispdat_score"
@@ -3020,6 +3020,72 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     WHERE ("Client"."DateDeleted" IS NULL);
   SQL
 
+  create_view "report_disabilities",  sql_definition: <<-SQL
+      SELECT "Disabilities"."DisabilitiesID",
+      "Disabilities"."ProjectEntryID",
+      "Disabilities"."PersonalID",
+      "Disabilities"."InformationDate",
+      "Disabilities"."DisabilityType",
+      "Disabilities"."DisabilityResponse",
+      "Disabilities"."IndefiniteAndImpairs",
+      "Disabilities"."DocumentationOnFile",
+      "Disabilities"."ReceivingServices",
+      "Disabilities"."PATHHowConfirmed",
+      "Disabilities"."PATHSMIInformation",
+      "Disabilities"."TCellCountAvailable",
+      "Disabilities"."TCellCount",
+      "Disabilities"."TCellSource",
+      "Disabilities"."ViralLoadAvailable",
+      "Disabilities"."ViralLoad",
+      "Disabilities"."ViralLoadSource",
+      "Disabilities"."DataCollectionStage",
+      "Disabilities"."DateCreated",
+      "Disabilities"."DateUpdated",
+      "Disabilities"."UserID",
+      "Disabilities"."DateDeleted",
+      "Disabilities"."ExportID",
+      "Disabilities".data_source_id,
+      "Disabilities".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("Disabilities"
+       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("Disabilities"."DateDeleted" IS NULL);
+  SQL
+
+  create_view "report_employment_educations",  sql_definition: <<-SQL
+      SELECT "EmploymentEducation"."EmploymentEducationID",
+      "EmploymentEducation"."ProjectEntryID",
+      "EmploymentEducation"."PersonalID",
+      "EmploymentEducation"."InformationDate",
+      "EmploymentEducation"."LastGradeCompleted",
+      "EmploymentEducation"."SchoolStatus",
+      "EmploymentEducation"."Employed",
+      "EmploymentEducation"."EmploymentType",
+      "EmploymentEducation"."NotEmployedReason",
+      "EmploymentEducation"."DataCollectionStage",
+      "EmploymentEducation"."DateCreated",
+      "EmploymentEducation"."DateUpdated",
+      "EmploymentEducation"."UserID",
+      "EmploymentEducation"."DateDeleted",
+      "EmploymentEducation"."ExportID",
+      "EmploymentEducation".data_source_id,
+      "EmploymentEducation".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("EmploymentEducation"
+       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
+  SQL
+
   create_view "report_enrollments",  sql_definition: <<-SQL
       SELECT "Enrollment"."ProjectEntryID",
       "Enrollment"."PersonalID",
@@ -3139,72 +3205,6 @@ ActiveRecord::Schema.define(version: 20180614004301) do
        JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
        JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
     WHERE ("Enrollment"."DateDeleted" IS NULL);
-  SQL
-
-  create_view "report_disabilities",  sql_definition: <<-SQL
-      SELECT "Disabilities"."DisabilitiesID",
-      "Disabilities"."ProjectEntryID",
-      "Disabilities"."PersonalID",
-      "Disabilities"."InformationDate",
-      "Disabilities"."DisabilityType",
-      "Disabilities"."DisabilityResponse",
-      "Disabilities"."IndefiniteAndImpairs",
-      "Disabilities"."DocumentationOnFile",
-      "Disabilities"."ReceivingServices",
-      "Disabilities"."PATHHowConfirmed",
-      "Disabilities"."PATHSMIInformation",
-      "Disabilities"."TCellCountAvailable",
-      "Disabilities"."TCellCount",
-      "Disabilities"."TCellSource",
-      "Disabilities"."ViralLoadAvailable",
-      "Disabilities"."ViralLoad",
-      "Disabilities"."ViralLoadSource",
-      "Disabilities"."DataCollectionStage",
-      "Disabilities"."DateCreated",
-      "Disabilities"."DateUpdated",
-      "Disabilities"."UserID",
-      "Disabilities"."DateDeleted",
-      "Disabilities"."ExportID",
-      "Disabilities".data_source_id,
-      "Disabilities".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("Disabilities"
-       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("Disabilities"."DateDeleted" IS NULL);
-  SQL
-
-  create_view "report_employment_educations",  sql_definition: <<-SQL
-      SELECT "EmploymentEducation"."EmploymentEducationID",
-      "EmploymentEducation"."ProjectEntryID",
-      "EmploymentEducation"."PersonalID",
-      "EmploymentEducation"."InformationDate",
-      "EmploymentEducation"."LastGradeCompleted",
-      "EmploymentEducation"."SchoolStatus",
-      "EmploymentEducation"."Employed",
-      "EmploymentEducation"."EmploymentType",
-      "EmploymentEducation"."NotEmployedReason",
-      "EmploymentEducation"."DataCollectionStage",
-      "EmploymentEducation"."DateCreated",
-      "EmploymentEducation"."DateUpdated",
-      "EmploymentEducation"."UserID",
-      "EmploymentEducation"."DateDeleted",
-      "EmploymentEducation"."ExportID",
-      "EmploymentEducation".data_source_id,
-      "EmploymentEducation".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("EmploymentEducation"
-       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."ProjectEntryID")::text = ("Enrollment"."ProjectEntryID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
   SQL
 
   create_view "report_exits",  sql_definition: <<-SQL

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "Disabilities", ["PersonalID"], name: "index_Disabilities_on_PersonalID", using: :btree
   add_index "Disabilities", ["ProjectEntryID"], name: "index_Disabilities_on_ProjectEntryID", using: :btree
   add_index "Disabilities", ["data_source_id", "DisabilitiesID"], name: "unk_Disabilities", unique: true, using: :btree
-  add_index "Disabilities", ["data_source_id", "PersonalID"], name: "index_Disabilities_on_data_source_id_PersonalID", using: :btree
+  add_index "Disabilities", ["data_source_id", "PersonalID"], name: "index_Disabilities_on_data_source_id_and_PersonalID", using: :btree
   add_index "Disabilities", ["data_source_id"], name: "index_Disabilities_on_data_source_id", using: :btree
 
   create_table "EmploymentEducation", force: :cascade do |t|
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "EmploymentEducation", ["PersonalID"], name: "index_EmploymentEducation_on_PersonalID", using: :btree
   add_index "EmploymentEducation", ["ProjectEntryID"], name: "index_EmploymentEducation_on_ProjectEntryID", using: :btree
   add_index "EmploymentEducation", ["data_source_id", "EmploymentEducationID"], name: "unk_EmploymentEducation", unique: true, using: :btree
-  add_index "EmploymentEducation", ["data_source_id", "PersonalID"], name: "index_EmploymentEducation_on_data_source_id_PersonalID", using: :btree
+  add_index "EmploymentEducation", ["data_source_id", "PersonalID"], name: "index_EmploymentEducation_on_data_source_id_and_PersonalID", using: :btree
   add_index "EmploymentEducation", ["data_source_id"], name: "index_EmploymentEducation_on_data_source_id", using: :btree
 
   create_table "Enrollment", force: :cascade do |t|
@@ -310,7 +310,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "Enrollment", ["PersonalID"], name: "index_Enrollment_on_PersonalID", using: :btree
   add_index "Enrollment", ["ProjectEntryID"], name: "index_Enrollment_on_ProjectEntryID", using: :btree
   add_index "Enrollment", ["ProjectID"], name: "index_Enrollment_on_ProjectID", using: :btree
-  add_index "Enrollment", ["data_source_id", "PersonalID"], name: "index_Enrollment_on_data_source_id_PersonalID", using: :btree
+  add_index "Enrollment", ["data_source_id", "PersonalID"], name: "index_Enrollment_on_data_source_id_and_PersonalID", using: :btree
   add_index "Enrollment", ["data_source_id", "ProjectEntryID", "PersonalID"], name: "unk_Enrollment", unique: true, using: :btree
   add_index "Enrollment", ["data_source_id"], name: "index_Enrollment_on_data_source_id", using: :btree
 
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "EnrollmentCoC", ["DateUpdated"], name: "enrollment_coc_date_updated", using: :btree
   add_index "EnrollmentCoC", ["EnrollmentCoCID"], name: "index_EnrollmentCoC_on_EnrollmentCoCID", using: :btree
   add_index "EnrollmentCoC", ["ExportID"], name: "enrollment_coc_export_id", using: :btree
-  add_index "EnrollmentCoC", ["data_source_id", "PersonalID"], name: "index_EnrollmentCoC_on_data_source_id_PersonalID", using: :btree
+  add_index "EnrollmentCoC", ["data_source_id", "PersonalID"], name: "index_EnrollmentCoC_on_data_source_id_and_PersonalID", using: :btree
   add_index "EnrollmentCoC", ["data_source_id"], name: "index_EnrollmentCoC_on_data_source_id", using: :btree
 
   create_table "Exit", force: :cascade do |t|
@@ -406,7 +406,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "Exit", ["PersonalID"], name: "index_Exit_on_PersonalID", using: :btree
   add_index "Exit", ["ProjectEntryID"], name: "index_Exit_on_ProjectEntryID", using: :btree
   add_index "Exit", ["data_source_id", "ExitID"], name: "unk_Exit", unique: true, using: :btree
-  add_index "Exit", ["data_source_id", "PersonalID"], name: "index_Exit_on_data_source_id_PersonalID", using: :btree
+  add_index "Exit", ["data_source_id", "PersonalID"], name: "index_Exit_on_data_source_id_and_PersonalID", using: :btree
   add_index "Exit", ["data_source_id"], name: "index_Exit_on_data_source_id", using: :btree
 
   create_table "Export", force: :cascade do |t|
@@ -484,7 +484,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "HealthAndDV", ["PersonalID"], name: "index_HealthAndDV_on_PersonalID", using: :btree
   add_index "HealthAndDV", ["ProjectEntryID"], name: "index_HealthAndDV_on_ProjectEntryID", using: :btree
   add_index "HealthAndDV", ["data_source_id", "HealthAndDVID"], name: "unk_HealthAndDV", unique: true, using: :btree
-  add_index "HealthAndDV", ["data_source_id", "PersonalID"], name: "index_HealthAndDV_on_data_source_id_PersonalID", using: :btree
+  add_index "HealthAndDV", ["data_source_id", "PersonalID"], name: "index_HealthAndDV_on_data_source_id_and_PersonalID", using: :btree
   add_index "HealthAndDV", ["data_source_id"], name: "index_HealthAndDV_on_data_source_id", using: :btree
 
   create_table "IncomeBenefits", force: :cascade do |t|
@@ -576,7 +576,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "IncomeBenefits", ["PersonalID"], name: "index_IncomeBenefits_on_PersonalID", using: :btree
   add_index "IncomeBenefits", ["ProjectEntryID"], name: "index_IncomeBenefits_on_ProjectEntryID", using: :btree
   add_index "IncomeBenefits", ["data_source_id", "IncomeBenefitsID"], name: "unk_IncomeBenefits", unique: true, using: :btree
-  add_index "IncomeBenefits", ["data_source_id", "PersonalID"], name: "index_IncomeBenefits_on_data_source_id_PersonalID", using: :btree
+  add_index "IncomeBenefits", ["data_source_id", "PersonalID"], name: "index_IncomeBenefits_on_data_source_id_and_PersonalID", using: :btree
   add_index "IncomeBenefits", ["data_source_id"], name: "index_IncomeBenefits_on_data_source_id", using: :btree
 
   create_table "Inventory", force: :cascade do |t|
@@ -791,19 +791,6 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.string   "note"
     t.boolean  "full_release",         default: false, null: false
   end
-
-  create_table "cas_enrollments", force: :cascade do |t|
-    t.integer  "client_id"
-    t.integer  "enrollment_id"
-    t.date     "entry_date"
-    t.date     "exit_date"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.json     "history"
-  end
-
-  add_index "cas_enrollments", ["client_id"], name: "index_cas_enrollments_on_client_id", using: :btree
-  add_index "cas_enrollments", ["enrollment_id"], name: "index_cas_enrollments_on_enrollment_id", using: :btree
 
   create_table "cas_houseds", force: :cascade do |t|
     t.integer "client_id",                     null: false
@@ -1366,39 +1353,51 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "import_logs", ["data_source_id"], name: "index_import_logs_on_data_source_id", using: :btree
   add_index "import_logs", ["updated_at"], name: "index_import_logs_on_updated_at", using: :btree
 
-  create_table "new_service_history", force: :cascade do |t|
-    t.integer "client_id",                                                   null: false
+  create_table "old_warehouse_client_service_history", force: :cascade do |t|
+    t.integer "client_id",                                   null: false
     t.integer "data_source_id"
-    t.date    "date",                                                        null: false
-    t.date    "first_date_in_program",                                       null: false
+    t.date    "date",                                        null: false
+    t.date    "first_date_in_program",                       null: false
     t.date    "last_date_in_program"
     t.string  "enrollment_group_id",             limit: 50
-    t.integer "age",                             limit: 2
+    t.integer "age"
     t.integer "destination"
     t.string  "head_of_household_id",            limit: 50
     t.string  "household_id",                    limit: 50
     t.string  "project_id",                      limit: 50
     t.string  "project_name",                    limit: 150
-    t.integer "project_type",                    limit: 2
+    t.integer "project_type"
     t.integer "project_tracking_method"
     t.string  "organization_id",                 limit: 50
-    t.string  "record_type",                     limit: 50,                  null: false
+    t.string  "record_type",                     limit: 50,  null: false
     t.integer "housing_status_at_entry"
     t.integer "housing_status_at_exit"
-    t.integer "service_type",                    limit: 2
-    t.integer "computed_project_type",           limit: 2
+    t.integer "service_type"
+    t.integer "computed_project_type"
     t.boolean "presented_as_individual"
-    t.integer "other_clients_over_25",           limit: 2,   default: 0,     null: false
-    t.integer "other_clients_under_18",          limit: 2,   default: 0,     null: false
-    t.integer "other_clients_between_18_and_25", limit: 2,   default: 0,     null: false
-    t.boolean "unaccompanied_youth",                         default: false, null: false
-    t.boolean "parenting_youth",                             default: false, null: false
-    t.boolean "parenting_juvenile",                          default: false, null: false
-    t.boolean "children_only",                               default: false, null: false
-    t.boolean "individual_adult",                            default: false, null: false
-    t.boolean "individual_elder",                            default: false, null: false
-    t.boolean "head_of_household",                           default: false, null: false
+    t.integer "other_clients_over_25"
+    t.integer "other_clients_under_18"
+    t.integer "other_clients_between_18_and_25"
+    t.boolean "unaccompanied_youth"
+    t.boolean "parenting_youth"
+    t.boolean "parenting_juvenile"
+    t.boolean "children_only"
+    t.boolean "individual_adult"
+    t.boolean "individual_elder"
+    t.boolean "head_of_household"
   end
+
+  add_index "old_warehouse_client_service_history", ["client_id"], name: "index_service_history_on_client_id", using: :btree
+  add_index "old_warehouse_client_service_history", ["computed_project_type"], name: "index_warehouse_client_service_history_on_computed_project_type", using: :btree
+  add_index "old_warehouse_client_service_history", ["data_source_id", "organization_id", "project_id", "record_type"], name: "index_sh_ds_id_org_id_proj_id_r_type", using: :btree
+  add_index "old_warehouse_client_service_history", ["date", "data_source_id", "organization_id", "project_id", "project_type"], name: "sh_date_ds_id_org_id_proj_id_proj_type", using: :btree
+  add_index "old_warehouse_client_service_history", ["enrollment_group_id"], name: "index_warehouse_client_service_history_on_enrollment_group_id", using: :btree
+  add_index "old_warehouse_client_service_history", ["first_date_in_program"], name: "index_warehouse_client_service_history_on_first_date_in_program", using: :btree
+  add_index "old_warehouse_client_service_history", ["household_id"], name: "index_warehouse_client_service_history_on_household_id", using: :btree
+  add_index "old_warehouse_client_service_history", ["last_date_in_program"], name: "index_warehouse_client_service_history_on_last_date_in_program", using: :btree
+  add_index "old_warehouse_client_service_history", ["project_tracking_method"], name: "index_sh_tracking_method", using: :btree
+  add_index "old_warehouse_client_service_history", ["project_type"], name: "index_warehouse_client_service_history_on_project_type", using: :btree
+  add_index "old_warehouse_client_service_history", ["record_type"], name: "index_warehouse_client_service_history_on_record_type", using: :btree
 
   create_table "project_data_quality", force: :cascade do |t|
     t.integer  "project_id"
@@ -1547,6 +1546,9 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.integer  "RunawayYouth"
     t.string   "processed_hash"
     t.string   "processed_as"
+    t.boolean  "roi_permission"
+    t.string   "last_locality"
+    t.string   "last_zipcode"
     t.integer  "demographic_id"
     t.integer  "client_id"
   end
@@ -2729,30 +2731,31 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "vispdats", ["client_id"], name: "index_vispdats_on_client_id", using: :btree
   add_index "vispdats", ["user_id"], name: "index_vispdats_on_user_id", using: :btree
 
-  create_table "warehouse_client_service_history", force: :cascade do |t|
+  create_table "warehouse_client_service_history_to_delete", force: :cascade do |t|
     t.integer "client_id",                                                   null: false
     t.integer "data_source_id"
     t.date    "date",                                                        null: false
     t.date    "first_date_in_program",                                       null: false
     t.date    "last_date_in_program"
     t.string  "enrollment_group_id",             limit: 50
-    t.integer "age"
+    t.integer "age",                             limit: 2
     t.integer "destination"
     t.string  "head_of_household_id",            limit: 50
     t.string  "household_id",                    limit: 50
+    t.string  "project_id",                      limit: 50
     t.string  "project_name",                    limit: 150
-    t.integer "project_type"
+    t.integer "project_type",                    limit: 2
     t.integer "project_tracking_method"
     t.string  "organization_id",                 limit: 50
     t.string  "record_type",                     limit: 50,                  null: false
     t.integer "housing_status_at_entry"
     t.integer "housing_status_at_exit"
-    t.integer "service_type"
-    t.integer "computed_project_type"
+    t.integer "service_type",                    limit: 2
+    t.integer "computed_project_type",           limit: 2
     t.boolean "presented_as_individual"
-    t.integer "other_clients_over_25",                       default: 0,     null: false
-    t.integer "other_clients_under_18",                      default: 0,     null: false
-    t.integer "other_clients_between_18_and_25",             default: 0,     null: false
+    t.integer "other_clients_over_25",           limit: 2,   default: 0,     null: false
+    t.integer "other_clients_under_18",          limit: 2,   default: 0,     null: false
+    t.integer "other_clients_between_18_and_25", limit: 2,   default: 0,     null: false
     t.boolean "unaccompanied_youth",                         default: false, null: false
     t.boolean "parenting_youth",                             default: false, null: false
     t.boolean "parenting_juvenile",                          default: false, null: false
@@ -2760,18 +2763,18 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.boolean "individual_adult",                            default: false, null: false
     t.boolean "individual_elder",                            default: false, null: false
     t.boolean "head_of_household",                           default: false, null: false
-    t.string  "project_id",                      limit: 50
   end
 
-  add_index "warehouse_client_service_history", ["client_id", "record_type"], name: "index_sh_on_client_id", using: :btree
-  add_index "warehouse_client_service_history", ["computed_project_type", "record_type", "client_id"], name: "index_sh_on_computed_project_type", using: :btree
-  add_index "warehouse_client_service_history", ["data_source_id", "project_id", "organization_id", "record_type"], name: "index_sh_ds_proj_org_r_type", using: :btree
-  add_index "warehouse_client_service_history", ["date", "household_id", "record_type"], name: "index_sh_on_household_id", using: :btree
-  add_index "warehouse_client_service_history", ["date", "record_type", "presented_as_individual"], name: "index_sh_date_r_type_indiv", using: :btree
-  add_index "warehouse_client_service_history", ["enrollment_group_id", "project_tracking_method"], name: "index_sh__enrollment_id_track_meth", using: :btree
-  add_index "warehouse_client_service_history", ["first_date_in_program", "last_date_in_program", "record_type", "date"], name: "index_wsh_on_last_date_in_program", using: :btree
-  add_index "warehouse_client_service_history", ["first_date_in_program"], name: "index_warehouse_client_service_history_on_first_date_in_program", using: :brin
-  add_index "warehouse_client_service_history", ["record_type", "date", "data_source_id", "organization_id", "project_id", "project_type", "project_tracking_method"], name: "index_sh_date_ds_org_proj_proj_type", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["client_id", "record_type"], name: "index_sh_on_client_id", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["computed_project_type", "record_type", "client_id"], name: "index_sh_on_computed_project_type", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["data_source_id", "project_id", "organization_id", "record_type"], name: "index_sh_ds_proj_org_r_type", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["date", "household_id", "record_type"], name: "index_sh_on_household_id", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["date", "record_type", "presented_as_individual"], name: "index_sh_date_r_type_indiv", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["enrollment_group_id", "project_tracking_method"], name: "index_sh__enrollment_id_track_meth", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["first_date_in_program", "last_date_in_program", "record_type", "date"], name: "index_wsh_on_last_date_in_program", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["first_date_in_program"], name: "index_new_service_history_on_first_date_in_program", using: :brin
+  add_index "warehouse_client_service_history_to_delete", ["project_id", "data_source_id"], name: "index_sh_proj_ds_id", using: :btree
+  add_index "warehouse_client_service_history_to_delete", ["record_type", "date", "data_source_id", "organization_id", "project_id", "project_type", "project_tracking_method"], name: "index_sh_date_ds_org_proj_proj_type", using: :btree
 
   create_table "warehouse_clients", force: :cascade do |t|
     t.string   "id_in_source",    null: false
@@ -2815,14 +2818,14 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.boolean  "enrolled_homeless_shelter"
     t.boolean  "enrolled_homeless_unsheltered"
     t.boolean  "enrolled_permanent_housing"
-    t.decimal  "eto_coordinated_entry_assessment_score"
+    t.integer  "eto_coordinated_entry_assessment_score"
     t.string   "household_members"
     t.string   "last_homeless_visit"
     t.string   "missing_documents"
     t.jsonb    "open_enrollments"
     t.boolean  "rrh_desired"
-    t.decimal  "vispdat_priority_score"
-    t.decimal  "vispdat_score"
+    t.integer  "vispdat_priority_score"
+    t.integer  "vispdat_score"
   end
 
   add_index "warehouse_clients_processed", ["chronic_days"], name: "index_warehouse_clients_processed_on_chronic_days", using: :btree
@@ -3517,5 +3520,46 @@ ActiveRecord::Schema.define(version: 20180614004301) do
   add_index "service_history_services_materialized", ["client_id", "project_type", "record_type"], name: "index_shsm_c_id_p_type_r_type", using: :btree
   add_index "service_history_services_materialized", ["id"], name: "index_service_history_services_materialized_on_id", unique: true, using: :btree
   add_index "service_history_services_materialized", ["project_type", "record_type"], name: "index_shsm_p_type_r_type", using: :btree
+
+  create_view "index_stats",  sql_definition: <<-SQL
+      WITH table_stats AS (
+           SELECT psut.relname,
+              psut.n_live_tup,
+              ((1.0 * (psut.idx_scan)::numeric) / (GREATEST((1)::bigint, (psut.seq_scan + psut.idx_scan)))::numeric) AS index_use_ratio
+             FROM pg_stat_user_tables psut
+            ORDER BY psut.n_live_tup DESC
+          ), table_io AS (
+           SELECT psiut.relname,
+              sum(psiut.heap_blks_read) AS table_page_read,
+              sum(psiut.heap_blks_hit) AS table_page_hit,
+              (sum(psiut.heap_blks_hit) / GREATEST((1)::numeric, (sum(psiut.heap_blks_hit) + sum(psiut.heap_blks_read)))) AS table_hit_ratio
+             FROM pg_statio_user_tables psiut
+            GROUP BY psiut.relname
+            ORDER BY (sum(psiut.heap_blks_read)) DESC
+          ), index_io AS (
+           SELECT psiui.relname,
+              psiui.indexrelname,
+              sum(psiui.idx_blks_read) AS idx_page_read,
+              sum(psiui.idx_blks_hit) AS idx_page_hit,
+              ((1.0 * sum(psiui.idx_blks_hit)) / GREATEST(1.0, (sum(psiui.idx_blks_hit) + sum(psiui.idx_blks_read)))) AS idx_hit_ratio
+             FROM pg_statio_user_indexes psiui
+            GROUP BY psiui.relname, psiui.indexrelname
+            ORDER BY (sum(psiui.idx_blks_read)) DESC
+          )
+   SELECT ts.relname,
+      ts.n_live_tup,
+      ts.index_use_ratio,
+      ti.table_page_read,
+      ti.table_page_hit,
+      ti.table_hit_ratio,
+      ii.indexrelname,
+      ii.idx_page_read,
+      ii.idx_page_hit,
+      ii.idx_hit_ratio
+     FROM ((table_stats ts
+       LEFT JOIN table_io ti ON ((ti.relname = ts.relname)))
+       LEFT JOIN index_io ii ON ((ii.relname = ts.relname)))
+    ORDER BY ti.table_page_read DESC, ii.idx_page_read DESC;
+  SQL
 
 end

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -2820,7 +2820,7 @@ ActiveRecord::Schema.define(version: 20180614004301) do
     t.string   "last_homeless_visit"
     t.string   "missing_documents"
     t.jsonb    "open_enrollments"
-    t.string   "rrh_desired"
+    t.boolean  "rrh_desired"
     t.decimal  "vispdat_priority_score"
     t.decimal  "vispdat_score"
   end

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -291,4 +291,10 @@ namespace :grda_warehouse do
       app.get(pdf_window_client_history_path(client_id: client.id))
     end
   end
+
+  desc "Warm Cohort Cache"
+  task :warm_cohort_cache, [] => [:environment, "log:info_to_stdout"] do |task, args|
+    GrdaWarehouse::Cohort.prepare_active_cohorts
+  end
+
 end


### PR DESCRIPTION
This refactors the logic for searching/listing cohort clients to get rid of N+1 queries. The changes move 
most of the N+1 generating fields to `GrdaWarehouse::WarehouseClientsProcessed` where they are now updated daily as part of the existing call to `GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts`. Some columns cannot be maintained per client, these have been moved to batch cache in 'GrdaWarehouse::Cohort#update_cached_counts`. 'GrdaWarehouse::Cohort.prepare_active_cohorts` is connivence wrapper to ensure fresh content for the current active cohorts.

The data returned by 3 of the columns has changed slightly as a result:

* Consent Confirmed: Now returns `TRUE` or 'FALSE' instead of 'TRUE' or blank
* Enrolled in PH: The download included the html instead of TRUE/FALSE. This was a bug and is fixed
* Cohorts: This is is sorted in a different order.

As a side-effect of this work a number of caching bugs were also fixed an support for logging Rails.cache calls added in the Rails.env.development? env. Also added in dev mode is gzip compression in puma which nginx does in production.


