### PR TITLE
Health DB PHI Review

### DIFF
--- a/app/models/health/accountable_care_organization.rb
+++ b/app/models/health/accountable_care_organization.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class AccountableCareOrganization < HealthBase
 

--- a/app/models/health/agency.rb
+++ b/app/models/health/agency.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class Agency < HealthBase
     acts_as_paranoid

--- a/app/models/health/agency_patient_referral.rb
+++ b/app/models/health/agency_patient_referral.rb
@@ -1,6 +1,9 @@
-# ### HIPPA Risk Assessment TODO
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient
+# Control: PHI attributes documented
 module Health
   class AgencyPatientReferral < HealthBase
+    phi_attr :patient_referral_id, Phi::OtherIdentifier
 
     scope :claimed, -> {where(claimed: true)}
     scope :unclaimed, -> {where(claimed: false)}

--- a/app/models/health/agency_patient_referral.rb
+++ b/app/models/health/agency_patient_referral.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment TODO
 module Health
   class AgencyPatientReferral < HealthBase
 

--- a/app/models/health/agency_user.rb
+++ b/app/models/health/agency_user.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class AgencyUser < HealthBase
 
@@ -6,6 +8,6 @@ module Health
 
     belongs_to :agency, class_name: 'Health::Agency', foreign_key: 'agency_id'
     belongs_to :user
-    
+
   end
 end

--- a/app/models/health/appointment.rb
+++ b/app/models/health/appointment.rb
@@ -1,13 +1,16 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Appointment < EpicBase
     phi_patient :patient_id
     phi_attr :id, Phi::OtherIdentifier
-    phi_attr :date_of_service, Phi::Date
-    phi_attr :appointment_time, Phi::Date
     phi_attr :notes, Phi::FreeText
     phi_attr :doctor, Phi::SmallPopulation
-    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :department, Phi::SmallPopulation
     phi_attr :sa, Phi::NeedsReview
+    phi_attr :appointment_time, Phi::Date
+    phi_attr :id_in_source, Phi::OtherIdentifier
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :appointments
     scope :limited, -> do

--- a/app/models/health/appointment.rb
+++ b/app/models/health/appointment.rb
@@ -1,5 +1,13 @@
 module Health
   class Appointment < EpicBase
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :date_of_service, Phi::Date
+    phi_attr :appointment_time, Phi::Date
+    phi_attr :notes, Phi::FreeText
+    phi_attr :doctor, Phi::SmallPopulation
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :sa, Phi::NeedsReview
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :appointments
     scope :limited, -> do

--- a/app/models/health/base.rb
+++ b/app/models/health/base.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class Base < HealthBase
     self.abstract_class = true

--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -31,7 +31,7 @@ module Health
     phi_attr :team_members_archive, Phi::FreeText
     phi_attr :patient_signature_requested_at, Phi::Date
     phi_attr :provider_signature_requested_at, Phi::Date
-    phr_attr :health_file_id, Phi::OtherIdentifier
+    phi_attr :health_file_id, Phi::OtherIdentifier
 
     # has_many :goals, class_name: Health::Goal::Base.name
     # has_many :hpc_goals, class_name: Health::Goal::Hpc.name

--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Careplan < HealthBase
     acts_as_paranoid
@@ -11,6 +14,24 @@ module Health
     phi_attr :self_sufficiency_final_due_date, Phi::Date
     phi_attr :self_sufficiency_baseline_completed_date, Phi::Date
     phi_attr :self_sufficiency_final_completed_date, Phi::Date
+    phi_attr :patient_signed_on, Phi::Date
+    phi_attr :provider_signed_on, Phi::Date
+    phi_attr :initial_date, Phi::Date
+    phi_attr :patient_health_problems, Phi::FreeText
+    phi_attr :patient_strengths, Phi::FreeText
+    phi_attr :patient_goals, Phi::FreeText
+    phi_attr :patient_barriers, Phi::FreeText
+    phi_attr :responsible_team_member_id, Phi::SmallPopulation
+    phi_attr :provider_id, Phi::SmallPopulation
+    phi_attr :representative_id, Phi::SmallPopulation
+    phi_attr :responsible_team_member_signed_on, Phi::Date
+    phi_attr :representative_signed_on, Phi::Date
+    phi_attr :service_archive, Phi::FreeText
+    phi_attr :equipment_archive, Phi::FreeText
+    phi_attr :team_members_archive, Phi::FreeText
+    phi_attr :patient_signature_requested_at, Phi::Date
+    phi_attr :provider_signature_requested_at, Phi::Date
+    phr_attr :health_file_id, Phi::OtherIdentifier
 
     # has_many :goals, class_name: Health::Goal::Base.name
     # has_many :hpc_goals, class_name: Health::Goal::Hpc.name

--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -1,7 +1,17 @@
 module Health
   class Careplan < HealthBase
-
     acts_as_paranoid
+
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :user_id, Phi::SmallPopulation
+    phi_attr :sdh_enroll_date, Phi::SmallPopulation
+    phi_attr :first_meeting_with_case_manager_date, Phi::Date
+    phi_attr :self_sufficiency_baseline_due_date, Phi::Date
+    phi_attr :self_sufficiency_final_due_date, Phi::Date
+    phi_attr :self_sufficiency_baseline_completed_date, Phi::Date
+    phi_attr :self_sufficiency_final_completed_date, Phi::Date
+
     # has_many :goals, class_name: Health::Goal::Base.name
     # has_many :hpc_goals, class_name: Health::Goal::Hpc.name
     has_one :team, class_name: Health::Team.name, dependent: :destroy

--- a/app/models/health/careplan_equipment.rb
+++ b/app/models/health/careplan_equipment.rb
@@ -1,6 +1,8 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class CareplanEquipment < HealthBase
-    
+
     acts_as_paranoid
 
     belongs_to :careplans, class_name: Health::Careplan.name

--- a/app/models/health/careplan_file.rb
+++ b/app/models/health/careplan_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class CareplanFile < Health::HealthFile
 

--- a/app/models/health/careplan_service.rb
+++ b/app/models/health/careplan_service.rb
@@ -1,6 +1,8 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class CareplanService < HealthBase
-    
+
     acts_as_paranoid
 
     belongs_to :careplans, class_name: Health::Careplan.name

--- a/app/models/health/claim.rb
+++ b/app/models/health/claim.rb
@@ -1,8 +1,16 @@
+# ### HIPPA Risk Assessment
+# Risk: Attached claims_file contains EDI serialized PHI
+# Control: PHI attributes documented
+
 require "stupidedi"
 module Health
   class Claim < HealthBase
     include ArelHelper
     acts_as_paranoid
+
+    phi_attr :id, Phi::SmallPopulation
+    phi_attr :claims_file, Phi::Bulk # contains EDI serialized PHI
+
     has_many :qualifying_activities
     validates_presence_of :max_date
 
@@ -234,7 +242,7 @@ module Health
         "Running since #{started_at}"
       end
     end
-    
+
     def implementation_convention_reference_number
       '005010X222A1'
     end

--- a/app/models/health/claims/amount_paid.rb
+++ b/app/models/health/claims/amount_paid.rb
@@ -1,6 +1,21 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class AmountPaid < Base
     self.table_name = :claims_amount_paid_location_month
+
+    phi_patient :medicaid_id
+    # phr_attr :year, OK
+    phi_attr :month, Phi::Date # OK if the year is not also included
+    phi_attr :ip, Phi::NeedsReview
+    phi_attr :emerg, Phi::NeedsReview
+    phi_attr :respite, Phi::NeedsReview
+    phi_attr :op, Phi::NeedsReview
+    phi_attr :rx, Phi::NeedsReview
+    phi_attr :other, Phi::NeedsReview
+    phi_attr :total, Phi::NeedsReview
+    phi_attr :year_month, Phi::Date
+    phi_attr :study_period, Phi::Date # probably...
 
     scope :implementation, -> do
       where(arel_table[:study_period].matches('%Implement%'))
@@ -10,7 +25,7 @@ module Health::Claims
       where(arel_table[:study_period].matches('%Baseline%'))
     end
 
-    def column_headers 
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         year: "Year",

--- a/app/models/health/claims/amount_paid.rb
+++ b/app/models/health/claims/amount_paid.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/base.rb
+++ b/app/models/health/claims/base.rb
@@ -1,10 +1,12 @@
+# ### HIPPA Risk Assessment
+# Risk: None - abstract_class contains no PHI
 require 'roo'
 module Health::Claims
   class Base < HealthBase
     self.abstract_class = true
     include TsqlImport
     attr_accessor :sheet
-    
+
     def initialize(sheet)
       @sheet = sheet
     end
@@ -32,7 +34,7 @@ module Health::Claims
             value
           end
         end
-      end 
+      end
     end
 
     def validate_headers

--- a/app/models/health/claims/claims_volume.rb
+++ b/app/models/health/claims/claims_volume.rb
@@ -1,8 +1,23 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class ClaimsVolume < Base
     self.table_name = :claims_claim_volume_location_month
-    
-    def column_headers 
+
+    phi_patient :medicaid_id
+    # phr_attr :year, OK
+    phi_attr :month, Phi::Date # OK if the year is not also included
+    phi_attr :ip, Phi::NeedsReview
+    phi_attr :emerg, Phi::NeedsReview
+    phi_attr :respite, Phi::NeedsReview
+    phi_attr :op, Phi::NeedsReview
+    phi_attr :rx, Phi::NeedsReview
+    phi_attr :other, Phi::NeedsReview
+    phi_attr :total, Phi::NeedsReview
+    phi_attr :year_month, Phi::Date
+    phi_attr :study_period, Phi::Date # probably...
+
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         year: "Year",

--- a/app/models/health/claims/claims_volume.rb
+++ b/app/models/health/claims/claims_volume.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/ed_nyu_severity.rb
+++ b/app/models/health/claims/ed_nyu_severity.rb
@@ -1,8 +1,12 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class EdNyuSeverity < Base
     self.table_name = :claims_ed_nyu_severity
 
-    def column_headers 
+    phi_patient :medicaid_id
+
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         category: "Category",
@@ -22,7 +26,7 @@ module Health::Claims
             value
           end
         end
-      end 
+      end
     end
 
   end

--- a/app/models/health/claims/ed_nyu_severity.rb
+++ b/app/models/health/claims/ed_nyu_severity.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/roster.rb
+++ b/app/models/health/claims/roster.rb
@@ -1,8 +1,40 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class Roster < Base
     self.table_name = :claims_roster
 
-    def column_headers 
+    phi_patient :medicaid_id
+    phi_attr :last_name, Phi::Name
+    phi_attr :first_name, Phi::Name
+    # phi_attr :gender
+    phi_attr :dob, Phi::Date
+    # phi_attr :race
+    # phi_attr :primary_language
+    # phi_attr :disability_flag
+    # phi_attr :norm_risk_scores
+    # phi_attr :mbr_months
+    # phi_attr :total_ty
+    # phi_attr :ed_visits
+    # phi_attr :acute_ip_admits
+    # phi_attr :average_days_to_readmit
+    phi_attr :pcp, Phi::SmallPopulation
+    phi_attr :epic_team, Phi::SmallPopulation
+    # phi_attr :member_months_baseline
+    # phi_attr :member_months_implementation
+    # phi_attr :cost_rank_ty
+    # phi_attr :average_ed_visits_baseline
+    # phi_attr#  :average_ed_visits_implementation
+    # phi_attr :average_ip_admits_baseline
+    # phi_attr :average_ip_admits_implementation
+    # phi_attr :average_days_to_readmit_baseline
+    # phi_attr :average_days_to_implementation
+    phi_attr :case_manager, Phi::SmallPopulation
+    # phi_attr :housing_status
+    # phi_attr :baseline_admits
+    # phi_attr :implementation_admits
+
+    def column_headers
       {
         medicaid_id: "id_medicaid",
         member_months_baseline: 'Baseline_mem_mos',

--- a/app/models/health/claims/roster.rb
+++ b/app/models/health/claims/roster.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/top_conditions.rb
+++ b/app/models/health/claims/top_conditions.rb
@@ -1,8 +1,13 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class TopConditions < Base
     self.table_name = :claims_top_conditions
 
-    def column_headers 
+    phi_patient :medicaid_id
+    phi_attr :description, Phi::SmallPopulation
+
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         rank: "Rank",

--- a/app/models/health/claims/top_conditions.rb
+++ b/app/models/health/claims/top_conditions.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/top_ip_conditions.rb
+++ b/app/models/health/claims/top_ip_conditions.rb
@@ -1,8 +1,13 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class TopIpConditions < Base
     self.table_name = :claims_top_ip_conditions
 
-    def column_headers 
+    phi_patient :medicaid_id
+    phi_attr :description, Phi::SmallPopulation
+
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         rank: "Rank",

--- a/app/models/health/claims/top_ip_conditions.rb
+++ b/app/models/health/claims/top_ip_conditions.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/top_providers.rb
+++ b/app/models/health/claims/top_providers.rb
@@ -1,8 +1,13 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health::Claims
   class TopProviders < Base
     self.table_name = :claims_top_providers
 
-    def column_headers 
+    phi_patient :medicaid_id
+    phi_attr :provider_name, Phi::SmallPopulation
+
+    def column_headers
       {
         medicaid_id: "ID_MEDICAID",
         rank: "Rank",

--- a/app/models/health/claims/top_providers.rb
+++ b/app/models/health/claims/top_providers.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Describes a patient and contains PHI
 # Control: PHI attributes documented
 module Health::Claims

--- a/app/models/health/claims/view_model.rb
+++ b/app/models/health/claims/view_model.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: View model. Refers to PHI related models thru their documents public interfaces.
+# Controls should be implemented there
 module Health::Claims
   class ViewModel
 

--- a/app/models/health/comprehensive_health_assessment.rb
+++ b/app/models/health/comprehensive_health_assessment.rb
@@ -9,7 +9,7 @@ module Health
     phi_attr :reviewer, Phi::SmallPopulation
     phi_attr :completed_at, Phi::Date
     phi_attr :reviewed_at, Phi::Date
-    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::OtherIdentifier
     phi_attr :answers, Phi::FreeText
 
     # Generates translation keys of the form "CHA A_Q5_A6"

--- a/app/models/health/comprehensive_health_assessment.rb
+++ b/app/models/health/comprehensive_health_assessment.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class ComprehensiveHealthAssessment < HealthBase
     phi_patient :patient_id

--- a/app/models/health/comprehensive_health_assessment.rb
+++ b/app/models/health/comprehensive_health_assessment.rb
@@ -1,5 +1,13 @@
 module Health
   class ComprehensiveHealthAssessment < HealthBase
+    phi_patient :patient_id
+    phi_attr :user_id, Phi::SmallPopulation
+    phi_attr :reviewed_by_id, Phi::SmallPopulation
+    phi_attr :reviewer, Phi::SmallPopulation
+    phi_attr :completed_at, Phi::Date
+    phi_attr :reviewed_at, Phi::Date
+    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :answers, Phi::FreeText
 
     # Generates translation keys of the form "CHA A_Q5_A6"
     def self.answers_for section: nil, question: nil, number: 0

--- a/app/models/health/comprehensive_health_assessment_file.rb
+++ b/app/models/health/comprehensive_health_assessment_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class ComprehensiveHealthAssessmentFile < Health::HealthFile
 

--- a/app/models/health/cp.rb
+++ b/app/models/health/cp.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class Cp < HealthBase
     # You should only ever have one sender

--- a/app/models/health/data_source.rb
+++ b/app/models/health/data_source.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class DataSource < Base
     acts_as_paranoid
@@ -8,6 +10,6 @@ module Health
     has_many :appointments
     has_many :visits
     has_many :epic_goals
-    
+
   end
 end

--- a/app/models/health/epic_base.rb
+++ b/app/models/health/epic_base.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class EpicBase < Base
     self.abstract_class = true

--- a/app/models/health/epic_careplan.rb
+++ b/app/models/health/epic_careplan.rb
@@ -1,5 +1,18 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicCareplan < EpicBase
+    phi_patient :patient_id
+
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :encounter_id, Phi::OtherIdentifier
+    phi_attr :careplan_updated_at, Phi::Date
+    phi_attr :staff, Phi::SmallPopulation
+    phi_attr :part_1, Phi::FreeText
+    phi_attr :part_1, Phi::FreeText
+    phi_attr :part_2, Phi::FreeText
 
     belongs_to :epic_patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_careplans
     has_one :patient, through: :epic_patient

--- a/app/models/health/epic_case_note.rb
+++ b/app/models/health/epic_case_note.rb
@@ -1,5 +1,26 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicCaseNote < EpicBase
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :contact_date, Phi::Date
+    # phi_attr :closed
+    # phi_attr :encounter_type
+    phi_attr :provider_name, Phi::SmallPopulation
+    phi_attr :location, Phi::Location
+    phi_attr :chief_complaint_1, Phi::FreeText
+    phi_attr :chief_complaint_1_comment, Phi::FreeText
+    phi_attr :chief_complaint_2, Phi::FreeText
+    phi_attr :chief_complaint_2_comment, Phi::FreeText
+    phi_attr :dx_1_icd10, Phi::SmallPopulation
+    phi_attr :dx_1_name, Phi::FreeText
+    phi_attr :dx_2_icd10, Phi::SmallPopulation
+    phi_attr :dx_2_name, Phi::FreeText
+    #phi_attr :homeless_status
+
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_case_notes
     has_many :epic_case_note_qualifying_activities, primary_key: :id_in_source, foreign_key: :epic_case_note_source_id, inverse_of: :epic_case_note
 

--- a/app/models/health/epic_case_note_qualifying_activity.rb
+++ b/app/models/health/epic_case_note_qualifying_activity.rb
@@ -1,5 +1,20 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicCaseNoteQualifyingActivity < EpicBase
+    phi_patient :patient_id
+
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :epic_case_note_source_id, Phi::OtherIdentifier
+    #phi_attr :encounter_type
+    phi_attr :update_date, Phi::Date
+    phi_attr :staff, Phi::SmallPopulation
+    phi_attr :part_1, Phi::FreeText
+    phi_attr :part_2, Phi::FreeText
+    phi_attr :part_3, Phi::FreeText
+
+
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_case_note_qualifying_activities
     belongs_to :epic_case_note, primary_key: :id_in_source, foreign_key: :epic_case_note_source_id, inverse_of: :epic_case_note_qualifying_activities
 

--- a/app/models/health/epic_cha.rb
+++ b/app/models/health/epic_cha.rb
@@ -1,5 +1,33 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicCha < EpicBase
+    phi_patient :patient_id
+
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :encounter_id, Phi::OtherIdentifier
+    # phi_attr :encounter_type
+    phi_attr :cha_updated_at, Phi::Date
+    phi_attr :staff, Phi::SmallPopulation
+    # phi_attr :provider_type
+    phi_attr :reviewer_name, Phi::SmallPopulation
+    # phi_attr :reviewer_provider_type
+    phi_attr :part_1, Phi::FreeText
+    phi_attr :part_2, Phi::FreeText
+    phi_attr :part_3, Phi::FreeText
+    phi_attr :part_4, Phi::FreeText
+    phi_attr :part_5, Phi::FreeText
+    phi_attr :part_6, Phi::FreeText
+    phi_attr :part_7, Phi::FreeText
+    phi_attr :part_8, Phi::FreeText
+    phi_attr :part_9, Phi::FreeText
+    phi_attr :part_10, Phi::FreeText
+    phi_attr :part_11, Phi::FreeText
+    phi_attr :part_12, Phi::FreeText
+    phi_attr :part_13, Phi::FreeText
+    phi_attr :part_14, Phi::FreeText
+    phi_attr :part_15, Phi::FreeText\
 
     belongs_to :epic_patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_ssms
     has_one :patient, through: :epic_patient

--- a/app/models/health/epic_goal.rb
+++ b/app/models/health/epic_goal.rb
@@ -1,5 +1,16 @@
 module Health
   class EpicGoal < EpicBase
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :entered_by, Phi::NeedsReview
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :entered_by, Phi::NeedsReview
+    phi_attr :ordered_date, Phi::Date
+    phi_attr :goal_created_at, Phi::Date
+    phi_attr :title, Phi::FreeText
+    phi_attr :contents, Phi::FreeText
+    phi_attr :received_valid_complaint, Phi::NeedsReview
+
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_goals
 
     scope :visible, -> do

--- a/app/models/health/epic_goal.rb
+++ b/app/models/health/epic_goal.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicGoal < EpicBase
     phi_patient :patient_id

--- a/app/models/health/epic_goal.rb
+++ b/app/models/health/epic_goal.rb
@@ -4,7 +4,6 @@ module Health
     phi_attr :id, Phi::OtherIdentifier
     phi_attr :entered_by, Phi::NeedsReview
     phi_attr :id_in_source, Phi::OtherIdentifier
-    phi_attr :entered_by, Phi::NeedsReview
     phi_attr :ordered_date, Phi::Date
     phi_attr :goal_created_at, Phi::Date
     phi_attr :title, Phi::FreeText

--- a/app/models/health/epic_patient.rb
+++ b/app/models/health/epic_patient.rb
@@ -1,7 +1,29 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicPatient < EpicBase
-
     acts_as_paranoid
+
+    phi_patient :medicaid_id
+    phi_attr :id_in_source, Phi::MedicalRecordNumber
+    phi_attr :first_name, Phi::Name
+    phi_attr :middle_name, Phi::Name
+    phi_attr :last_name, Phi::Name
+    phi_attr :aliases, Phi::Name
+    phi_attr :birthdate, Phi::Date
+    phi_attr :allergy_list, Phi::NeedsReview
+    phi_attr :primary_care_physician, Phi::SmallPopulation
+    phi_attr :transgender, Phi::SmallPopulation
+    phi_attr :race, Phi::SmallPopulation
+    phi_attr :ethnicity, Phi::SmallPopulation
+    phi_attr :veteran_status, Phi::SmallPopulation
+    phi_attr :ssn, Phi::Ssn
+    phi_attr :gender, Phi::SmallPopulation
+    phi_attr :consent_revoked, Phi::Date
+    phi_attr :medicaid_id, Phi::HealthPlan
+    phi_attr :housing_status_timestamp, Phi::Date
+    phi_attr :death_date, Phi::Date
+
     has_one :patient, primary_key: :medicaid_id, foreign_key: :medicaid_id
     has_many :appointments, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :patient
     has_many :medications, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :patient

--- a/app/models/health/epic_patient.rb
+++ b/app/models/health/epic_patient.rb
@@ -1,4 +1,5 @@
-# Risk: Describes a patient and contains PHI
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
 # Control: PHI attributes documented
 module Health
   class EpicPatient < EpicBase

--- a/app/models/health/epic_qualifying_activity.rb
+++ b/app/models/health/epic_qualifying_activity.rb
@@ -1,5 +1,19 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicQualifyingActivity < EpicBase
+    phi_patient :patient_id
+    phi_attr :epic_patient_id, Phi::OtherIdentifier
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :entered_by, Phi::SmallPopulation
+    # phi_attr :role
+    phi_attr :date_of_activity, Phi::Date
+    # phi_attr :activity
+    # phi_attr :mode
+    # phi_attr :reached
+
     include NotifierConfig
     belongs_to :epic_patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_qualifying_activities
     has_one :patient, through: :epic_patient

--- a/app/models/health/epic_ssm.rb
+++ b/app/models/health/epic_ssm.rb
@@ -1,5 +1,18 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicSsm < EpicBase
+    phi_patient :patient_id
+
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :encounter_id, Phi::OtherIdentifier
+    # phi_attr :encounter_type
+    phi_attr :ssm_updated_at, Phi::Date
+    phi_attr :staff, Phi::SmallPopulation
+    phi_attr :part_1, Phi::FreeText
+    phi_attr :part_2, Phi::FreeText
+    phi_attr :part_3, Phi::FreeText
 
     belongs_to :epic_patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_ssms
     has_one :patient, through: :epic_patient

--- a/app/models/health/epic_team_member.rb
+++ b/app/models/health/epic_team_member.rb
@@ -1,5 +1,18 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class EpicTeamMember < EpicBase
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :name, Phi::SmallPopulation
+    # phi_attr :pcp_type
+    # phi_attr :relationship
+    phi_attr :email, Phi::SmallPopulation
+    phi_attr :phone, Phi::SmallPopulation
+    # phi_attr :processed
+
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :epic_team_members
 
     scope :unprocessed, -> do

--- a/app/models/health/equipment.rb
+++ b/app/models/health/equipment.rb
@@ -1,10 +1,15 @@
 # ### HIPPA Risk Assessment
-# Risk: None - contains no PHI
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Equipment < HealthBase
-    phi_attr :patient_referral_id, Phi::OtherIdentifier
-
     acts_as_paranoid
+
+    phi_patient :patient_id
+
+    phi_attr :effective_date, Phi::Date
+    phi_attr :provider, Phi::FreeText
+    phi_attr :comments, Phi::FreeText
 
     has_many :careplans
     belongs_to :patient, required: true

--- a/app/models/health/equipment.rb
+++ b/app/models/health/equipment.rb
@@ -1,15 +1,18 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class Equipment < HealthBase
-    
+    phi_attr :patient_referral_id, Phi::OtherIdentifier
+
     acts_as_paranoid
 
     has_many :careplans
     belongs_to :patient, required: true
 
-    validates_presence_of :item 
+    validates_presence_of :item
     validates :quantity, numericality: { only_integer: true, allow_blank: true }
     def self.available_items
-      [ 
+      [
         'Diapers',
         'Pullups',
         'Liners',

--- a/app/models/health/goal/base.rb
+++ b/app/models/health/goal/base.rb
@@ -1,8 +1,53 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Goal::Base < HealthBase
     self.table_name = 'health_goals'
     has_paper_trail class_name: Health::HealthVersion.name
     acts_as_paranoid
+
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :user_id, Phi::SmallPopulation
+    # phi_attr :type,
+    # phi_attr :number,
+    phi_attr :name, Phi::FreeText
+    phi_attr :associated_dx, Phi::FreeText
+    phi_attr :barriers, Phi::FreeText
+    phi_attr :provider_plan, Phi::FreeText
+    phi_attr :case_manager_plan, Phi::FreeText
+    phi_attr :rn_plan, Phi::FreeText
+    phi_attr :bh_plan, Phi::FreeText
+    phi_attr :other_plan, Phi::FreeText
+    # phi_attr :confidence,
+    phi_attr :az_housing, Phi::FreeText
+    phi_attr :az_income, Phi::FreeText
+    phi_attr :az_non_cash_benefits, Phi::FreeText
+    phi_attr :az_disabilities, Phi::FreeText
+    phi_attr :az_food, Phi::FreeText
+    phi_attr :az_employment, Phi::FreeText
+    phi_attr :az_training, Phi::FreeText
+    phi_attr :az_transportation, Phi::FreeText
+    phi_attr :az_life_skills, Phi::FreeText
+    phi_attr :az_health_care_coverage, Phi::FreeText
+    phi_attr :az_physical_health, Phi::FreeText
+    phi_attr :az_mental_health, Phi::FreeText
+    phi_attr :az_substance_use, Phi::FreeText
+    phi_attr :az_criminal_justice, Phi::FreeText
+    phi_attr :az_legal, Phi::FreeText
+    phi_attr :az_safety, Phi::FreeText
+    phi_attr :az_risk, Phi::FreeText
+    phi_attr :az_family, Phi::FreeText
+    phi_attr :az_community, Phi::FreeText
+    phi_attr :az_time_management, Phi::FreeText
+    phi_attr :goal_details, Phi::FreeText
+    phi_attr :problem, Phi::FreeText
+    phi_attr :start_date, Phi::Date
+    phi_attr :intervention, Phi::FreeText
+    # phi_attr :status,
+    phi_attr :responsible_team_member_id, Phi::SmallPopulation
+
 
     # belongs_to :careplan, class_name: Health::Careplan.name
     # delegate :patient, to: :careplan

--- a/app/models/health/goal/clinical.rb
+++ b/app/models/health/goal/clinical.rb
@@ -1,8 +1,11 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Goal::Clinical < Goal::Base
     def self.type_name
       'Clinical'
     end
-  
+
   end
 end

--- a/app/models/health/goal/housing.rb
+++ b/app/models/health/goal/housing.rb
@@ -1,9 +1,12 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Goal::Housing < Goal::Base
     def self.type_name
       'Housing'
     end
-  
+
     def to_partial_path
       "health/goal/clinicals/clinical"
     end

--- a/app/models/health/goal/hpc.rb
+++ b/app/models/health/goal/hpc.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Goal::Hpc < Goal::Base
     def self.type_name

--- a/app/models/health/goal/self_management.rb
+++ b/app/models/health/goal/self_management.rb
@@ -1,8 +1,11 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Goal::SelfManagement < Goal::Base
     def self.type_name
       'Self Management'
     end
-  
+
   end
 end

--- a/app/models/health/goal/social.rb
+++ b/app/models/health/goal/social.rb
@@ -1,8 +1,11 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Goal::Social < Goal::Base
     def self.type_name
       'Social'
     end
-  
+
   end
 end

--- a/app/models/health/health_file.rb
+++ b/app/models/health/health_file.rb
@@ -1,6 +1,14 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented
 module Health
   class HealthFile < HealthBase
     acts_as_paranoid
+
+    phi_attr :file, Phi::FreeText
+    phi_attr :content, Phi::FreeText
+    phi_attr :note, Phi::FreeText
+
     belongs_to :user, required: true
     belongs_to :client, class_name: 'GrdaWarehouse::Hud::Client'
 

--- a/app/models/health/health_version.rb
+++ b/app/models/health/health_version.rb
@@ -2,4 +2,7 @@
 # Risk: Audit-log containing PHI
 class Health::HealthVersion < PaperTrail::Version
   establish_connection DB_HEALTH
+
+  # phi_attr :object, Phi::Bulk # contains serialize model data that depends on the model
+  # phi_attr :object_changes, Phi::Bulk # contains serialize model data that depends on the model
 end

--- a/app/models/health/health_version.rb
+++ b/app/models/health/health_version.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: Audit-log containing PHI
 class Health::HealthVersion < PaperTrail::Version
   establish_connection DB_HEALTH
 end

--- a/app/models/health/medication.rb
+++ b/app/models/health/medication.rb
@@ -1,11 +1,15 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Medication < EpicBase
     phi_patient :patient_id
-    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :id, Phi::OtherIdentifier
     phi_attr :start_date, Phi::Date
     phi_attr :ordered_date, Phi::Date
-    phi_attr :instructions, Phi::FreeText
     phi_attr :name, Phi::NeedsReview
+    phi_attr :instructions, Phi::FreeText
+    phi_attr :id_in_source, Phi::OtherIdentifier
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :medications
 

--- a/app/models/health/medication.rb
+++ b/app/models/health/medication.rb
@@ -1,5 +1,11 @@
 module Health
   class Medication < EpicBase
+    phi_patient :patient_id
+    phi_attr :id_in_source, Phi::OtherIdentifier
+    phi_attr :start_date, Phi::Date
+    phi_attr :ordered_date, Phi::Date
+    phi_attr :instructions, Phi::FreeText
+    phi_attr :name, Phi::NeedsReview
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :medications
 

--- a/app/models/health/member_status_report.rb
+++ b/app/models/health/member_status_report.rb
@@ -1,8 +1,14 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient
+# Control: PHI attributes documented
 module Health
   class MemberStatusReport < HealthBase
     include ArelHelper
 
     acts_as_paranoid
+
+    phi_attr :id, Phi::SmallPopulation
+
     has_many :member_status_report_patients
     belongs_to :user, required: true
 
@@ -33,7 +39,7 @@ module Health
         # We will only know the date requested for hello-sign signatures, default to the signed date
         pcp_signature_requested = patient&.careplans&.maximum(:provider_signature_requested_at) || patient&.careplans&.maximum(:provider_signed_on)
         aco_mco_name = pr.aco&.name || pr.aco_name
-        aco_mco_pid = pr.aco&.mco_pid || pr.aco_mco_pid 
+        aco_mco_pid = pr.aco&.mco_pid || pr.aco_mco_pid
         aco_mco_sl = pr.aco&.mco_sl || pr.aco_mco_sl
         attributes = {
           medicaid_id: pr.medicaid_id,
@@ -73,7 +79,7 @@ module Health
 
         next if receiver.present? && attributes[:aco_mco_name] != receiver
         report_patient = member_status_report_patients.create!(attributes)
-        
+
       end
       complete_report
     end

--- a/app/models/health/member_status_report_patient.rb
+++ b/app/models/health/member_status_report_patient.rb
@@ -1,6 +1,45 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class MemberStatusReportPatient < HealthBase
     acts_as_paranoid
+
+    phi_patient :medicaid_id
+    phi_attr :member_status_report_id, Phi::SmallPopulation
+    phi_attr :medicaid_id, Phi::HealthPlan
+    phi_attr :member_first_name, Phi::Name
+    phi_attr :member_last_name, Phi::Name
+    phi_attr :member_middle_initial, Phi::Name
+    phi_attr :member_suffix, Phi::Name
+    phi_attr :member_date_of_birth, Phi::Date
+    # phi_attr :member_sex
+    # phi_attr :aco_mco_name, Phi::SmallPopulation
+    # phi_attr :aco_mco_pid, Phi::SmallPopulation
+    # phi_attr :aco_mco_sl, Phi::SmallPopulation
+    # phi_attr :cp_name_official, Phi::SmallPopulation
+    # phi_attr :cp_pid, Phi::SmallPopulation
+    # phi_attr :cp_sl, Phi::SmallPopulation
+    # phi_attr :cp_outreach_status
+    phi_attr :cp_last_contact_date, Phi::Date
+    # phi_attr :cp_last_contact_face
+    phi_attr :cp_contact_face, Phi::NeedsReview
+    phi_attr :cp_participation_form_date, Phi::Date
+    phi_attr :cp_care_plan_sent_pcp_date, Phi::Date
+    phi_attr :cp_care_plan_returned_pcp_date, Phi::Date
+    phi_attr :key_contact_name_first, Phi::Name # Phi::NeedsReview?
+    phi_attr :key_contact_name_last, Phi::Name # Phi::NeedsReview?
+    phi_attr :key_contact_phone, Phi::Telephone # Phi::NeedsReview?
+    phi_attr :key_contact_email, Phi::Email # Phi::NeedsReview?
+    phi_attr :care_coordinator_first_name, Phi::Name # Phi::NeedsReview?
+    phi_attr :care_coordinator_last_name, Phi::Name # Phi::NeedsReview?
+    phi_attr :care_coordinator_phone, Phi::Telephone # Phi::NeedsReview?
+    phi_attr :care_coordinator_email, Phi::Email # Phi::NeedsReview?
+    # phi_attr :record_status
+    phi_attr :record_update_date, Phi::Date # Phi::NeedsReview?
+    phi_attr :export_date, Phi::Date # Phi::NeedsReview?
+
+
     belongs_to :member_status_report
     has_one :patient, primary_key: :medicaid_id, foreign_key: :medicaid_id
     has_one :patient_referral, through: :patient

--- a/app/models/health/participation_form.rb
+++ b/app/models/health/participation_form.rb
@@ -1,6 +1,19 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class ParticipationForm < HealthBase
     include ArelHelper
+    phi_patient :patient_id
+
+    phi_attr :signature_on, Phi::Date
+    phi_attr :case_manager_id, Phi::SmallPopulation
+    phi_attr :reviewed_by_id, Phi::SmallPopulation
+    phi_attr :location, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :reviewed_at, Phi::Date
+    phi_attr :reviewer, Phi::SmallPopulation
+
     belongs_to :case_manager, class_name: 'User'
     belongs_to :reviewed_by, class_name: 'User'
 

--- a/app/models/health/participation_form.rb
+++ b/app/models/health/participation_form.rb
@@ -10,7 +10,7 @@ module Health
     phi_attr :case_manager_id, Phi::SmallPopulation
     phi_attr :reviewed_by_id, Phi::SmallPopulation
     phi_attr :location, Phi::SmallPopulation
-    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::OtherIdentifier
     phi_attr :reviewed_at, Phi::Date
     phi_attr :reviewer, Phi::SmallPopulation
 

--- a/app/models/health/participation_form_file.rb
+++ b/app/models/health/participation_form_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class ParticipationFormFile < Health::HealthFile
 

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -1,3 +1,5 @@
+# Risk: Describes a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Patient < Base
     include ArelHelper
@@ -18,11 +20,15 @@ module Health
     phi_attr :veteran_status, Phi::SmallPopulation
     phi_attr :ssn, Phi::Ssn
     phi_attr :client_id, Phi::OtherIdentifier
-    phi_attr :medicaid_id, Phi::HealthPlan
     phi_attr :gender, Phi::SmallPopulation
+    phi_attr :consent_revoked, Phi::Date
+    phi_attr :medicaid_id, Phi::HealthPlan
     phi_attr :housing_status, Phi::NeedsReview
     phi_attr :housing_status_timestamp, Phi::Date
     phi_attr :pilot, Phi::SmallPopulation
+    phi_attr :engagement_date, Phi::Date
+    phi_attr :death_date, Phi::Date
+    phi_attr :care_coordinator_id, Phi::SmallPopulation
 
     has_many :epic_patients, primary_key: :medicaid_id, foreign_key: :medicaid_id, inverse_of: :patient
     has_many :appointments, through: :epic_patients

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -15,12 +15,12 @@ module Health
     phi_attr :allergy_list, Phi::NeedsReview
     phi_attr :primary_care_physician, Phi::SmallPopulation
     phi_attr :transgender, Phi::SmallPopulation
-    phi_attr :race, Phi::SmallPopulation
-    phi_attr :ethnicity, Phi::SmallPopulation
+    # phi_attr :race, Phi::SmallPopulation
+    # phi_attr :ethnicity, Phi::SmallPopulation
     phi_attr :veteran_status, Phi::SmallPopulation
     phi_attr :ssn, Phi::Ssn
     phi_attr :client_id, Phi::OtherIdentifier
-    phi_attr :gender, Phi::SmallPopulation
+    # phi_attr :gender, Phi::SmallPopulation
     phi_attr :consent_revoked, Phi::Date
     phi_attr :medicaid_id, Phi::HealthPlan
     phi_attr :housing_status, Phi::NeedsReview

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -2,6 +2,28 @@ module Health
   class Patient < Base
     include ArelHelper
     acts_as_paranoid
+
+    phi_patient :id
+    phi_attr :id_in_source, Phi::MedicalRecordNumber
+    phi_attr :first_name, Phi::Name
+    phi_attr :middle_name, Phi::Name
+    phi_attr :last_name, Phi::Name
+    phi_attr :aliases, Phi::Name
+    phi_attr :birthdate, Phi::Date
+    phi_attr :allergy_list, Phi::NeedsReview
+    phi_attr :primary_care_physician, Phi::SmallPopulation
+    phi_attr :transgender, Phi::SmallPopulation
+    phi_attr :race, Phi::SmallPopulation
+    phi_attr :ethnicity, Phi::SmallPopulation
+    phi_attr :veteran_status, Phi::SmallPopulation
+    phi_attr :ssn, Phi::Ssn
+    phi_attr :client_id, Phi::OtherIdentifier
+    phi_attr :medicaid_id, Phi::HealthPlan
+    phi_attr :gender, Phi::SmallPopulation
+    phi_attr :housing_status, Phi::NeedsReview
+    phi_attr :housing_status_timestamp, Phi::Date
+    phi_attr :pilot, Phi::SmallPopulation
+
     has_many :epic_patients, primary_key: :medicaid_id, foreign_key: :medicaid_id, inverse_of: :patient
     has_many :appointments, through: :epic_patients
     has_many :medications, through: :epic_patients

--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -1,7 +1,71 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class PatientReferral < HealthBase
     include PatientReferralImporter
     include ArelHelper
+
+    phi_patient :patient_id
+    phi_attr :first_name, Phi::Name
+    phi_attr :last_name, Phi::Name
+    phi_attr :birthdate, Phi::Date
+    phi_attr :ssn, Phi::Ssn
+    phi_attr :medicaid_id, Phi::HealthPlan
+    # phi_attr  :agency_id
+    # phi_attr  :rejected
+    # phi_attr :rejected_reason
+    phi_attr :accountable_care_organization_id, Phi::OtherIdentifier
+    phi_attr :effective_date, Phi::Date
+    phi_attr :middle_initial, Phi::Name
+    phi_attr :suffix, Phi::Name
+    # phi_attr :gender
+    phi_attr :aco_name, Phi::NeedsReview
+    phi_attr :aco_mco_pid, Phi::HealthPlan
+    phi_attr :aco_mco_sl, Phi::NeedsReview
+    phi_attr :health_plan_id, Phi::OtherIdentifier
+    phi_attr :cp_assignment_plan, Phi::NeedsReview
+    phi_attr :cp_name_dsrip, Phi::NeedsReview
+    phi_attr :cp_name_official, Phi::NeedsReview
+    phi_attr :cp_pid, Phi::OtherIdentifier
+    phi_attr :cp_sl, Phi::NeedsReview
+    phi_attr :enrollment_start_date, Phi::Date
+    phi_attr :start_reason_description, Phi::FreeText
+    phi_attr :address_line_1, Phi::Location
+    phi_attr :address_line_2, Phi::Location
+    phi_attr :address_city, Phi::Location
+    phi_attr :address_zip, Phi::Location
+    phi_attr :address_zip_plus_4, Phi::Location
+    # phi_attr :address_state, Phi::Location # this is OK on its own
+    phi_attr :email, Phi::Email
+    phi_attr :phone_cell, Phi::Telephone
+    phi_attr :phone_day, Phi::Telephone
+    phi_attr :phone_night, Phi::Telephone
+    # phi_attr :primary_language
+    phi_attr :primary_diagnosis, Phi::SmallPopulation
+    phi_attr :secondary_diagnosis, Phi::SmallPopulation
+    phi_attr :pcp_last_name, Phi::SmallPopulation
+    phi_attr :pcp_first_name, Phi::SmallPopulation
+    phi_attr :pcp_npi, Phi::SmallPopulation
+    phi_attr :pcp_address_line_1, Phi::Location
+    phi_attr :pcp_address_line_2, Phi::Location
+    phi_attr :pcp_address_city, Phi::Location
+    # phi_attr :pcp_address_state
+    phi_attr :pcp_address_zip, Phi::Location
+    phi_attr :pcp_address_phone, Phi::SmallPopulation
+    phi_attr :dmh, Phi::NeedsReview
+    phi_attr :dds, Phi::NeedsReview
+    phi_attr :eoea, Phi::NeedsReview
+    phi_attr :ed_visits, Phi::NeedsReview
+    phi_attr :snf_discharge, Phi::NeedsReview
+    phi_attr :identification, Phi::LicenceNumber #Phi::NeedsReview ??
+    # phi_attr :record_status
+    phi_attr :updated_on, Phi::Date
+    phi_attr :exported_on, Phi::Date
+    # phi_attr :removal_acknowledge
+    phi_attr :disenrollment_date, Phi::Date
+    phi_attr :stop_reason_description, Phi::FreeText
+
     before_validation :update_rejected_from_reason
 
     # rejected_reason_none: 0 always needs to be there
@@ -135,7 +199,7 @@ module Health
     end
 
     def record_status
-      # patient has an inactive status, or has been rejected 
+      # patient has an inactive status, or has been rejected
       if inactive_outreach_stati.include?(outreach_status) || rejected?
         'I'
       else

--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -7,6 +7,7 @@ module Health
     include ArelHelper
 
     phi_patient :patient_id
+
     phi_attr :first_name, Phi::Name
     phi_attr :last_name, Phi::Name
     phi_attr :birthdate, Phi::Date

--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -21,15 +21,15 @@ module Health
     phi_attr :middle_initial, Phi::Name
     phi_attr :suffix, Phi::Name
     # phi_attr :gender
-    phi_attr :aco_name, Phi::NeedsReview
-    phi_attr :aco_mco_pid, Phi::HealthPlan
-    phi_attr :aco_mco_sl, Phi::NeedsReview
+    # phi_attr :aco_name, Phi::NeedsReview
+    # phi_attr :aco_mco_pid, Phi::NeedsReview
+    # phi_attr :aco_mco_sl, Phi::NeedsReview
     phi_attr :health_plan_id, Phi::OtherIdentifier
     phi_attr :cp_assignment_plan, Phi::NeedsReview
     phi_attr :cp_name_dsrip, Phi::NeedsReview
     phi_attr :cp_name_official, Phi::NeedsReview
-    phi_attr :cp_pid, Phi::OtherIdentifier
-    phi_attr :cp_sl, Phi::NeedsReview
+    # phi_attr :cp_pid, Phi::NeedsReview
+    # phi_attr :cp_sl, Phi::NeedsReview
     phi_attr :enrollment_start_date, Phi::Date
     phi_attr :start_reason_description, Phi::FreeText
     phi_attr :address_line_1, Phi::Location

--- a/app/models/health/patient_referral_import.rb
+++ b/app/models/health/patient_referral_import.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class PatientReferralImport < HealthBase
 

--- a/app/models/health/problem.rb
+++ b/app/models/health/problem.rb
@@ -1,6 +1,10 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Problem < EpicBase
     phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
     phi_attr :onset_date, Phi::Date
     phi_attr :last_assessed, Phi::Date
     phi_attr :name, Phi::FreeText

--- a/app/models/health/problem.rb
+++ b/app/models/health/problem.rb
@@ -1,5 +1,12 @@
 module Health
   class Problem < EpicBase
+    phi_patient :patient_id
+    phi_attr :onset_date, Phi::Date
+    phi_attr :last_assessed, Phi::Date
+    phi_attr :name, Phi::FreeText
+    phi_attr :comment, Phi::FreeText
+    phi_attr :icd10_list, Phi::SmallPopulation
+    phi_attr :id_in_source, Phi::OtherIdentifier
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :problems
 

--- a/app/models/health/qualifying_activity.rb
+++ b/app/models/health/qualifying_activity.rb
@@ -1,6 +1,31 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class QualifyingActivity < HealthBase
     include ArelHelper
+
+    phi_patient :patient_id
+
+    phi_attr :mode_of_contact, Phi::FreeText
+    phi_attr :mode_of_contact_other, Phi::FreeText
+    phi_attr :reached_client, Phi::FreeText
+    phi_attr :reached_client_collateral_contact, Phi::FreeText
+    phi_attr :activity, Phi::FreeText
+    # phi_attr :source_type
+    # phi_attr :source_id
+    phi_attr :claim_submitted_on, Phi::Date
+    phi_attr :date_of_activity, Phi::Date
+    phi_attr :user_id, Phi::OtherIdentifier
+    phi_attr :user_full_name, Phi::NeedsReview
+    phi_attr :follow_up, Phi::FreeText
+    phi_attr :claim_id, Phi::OtherIdentifier
+    # phi_attr :force_payable
+    # phi_attr :naturally_payable
+    phi_attr :sent_at, Phi::Date
+    phi_attr :duplicate_id, Phi::OtherIdentifier
+    phi_attr :epic_source_id, Phi::OtherIdentifier
+
 
     MODE_OF_CONTACT_OTHER = 'other'
     REACHED_CLIENT_OTHER = 'collateral'

--- a/app/models/health/qualifying_activity.rb
+++ b/app/models/health/qualifying_activity.rb
@@ -19,7 +19,7 @@ module Health
     phi_attr :user_id, Phi::OtherIdentifier
     phi_attr :user_full_name, Phi::NeedsReview
     phi_attr :follow_up, Phi::FreeText
-    phi_attr :claim_id, Phi::OtherIdentifier
+    phi_attr :claim_id, Phi::SmallPopulation # belongs_to Health::Claim
     # phi_attr :force_payable
     # phi_attr :naturally_payable
     phi_attr :sent_at, Phi::Date

--- a/app/models/health/release_form.rb
+++ b/app/models/health/release_form.rb
@@ -1,6 +1,20 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class ReleaseForm < HealthBase
     include ArelHelper
+
+    phi_patient :patient_id
+
+    phi_attr :user_id, Phi::SmallPopulation
+    phi_attr :signature_on, Phi::Date
+    # phi_attr :file_location, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :reviewed_by_id, Phi::SmallPopulation
+    phi_attr :reviewed_at, Phi::Date
+    phi_attr :reviewer, Phi::SmallPopulation
+
     belongs_to :patient
     belongs_to :user
     belongs_to :reviewed_by, class_name: 'User'

--- a/app/models/health/release_form.rb
+++ b/app/models/health/release_form.rb
@@ -10,7 +10,7 @@ module Health
     phi_attr :user_id, Phi::SmallPopulation
     phi_attr :signature_on, Phi::Date
     # phi_attr :file_location, Phi::SmallPopulation
-    phi_attr :health_file_id, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::OtherIdentifier
     phi_attr :reviewed_by_id, Phi::SmallPopulation
     phi_attr :reviewed_at, Phi::Date
     phi_attr :reviewer, Phi::SmallPopulation

--- a/app/models/health/release_form_file.rb
+++ b/app/models/health/release_form_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class ReleaseFormFile < Health::HealthFile
 

--- a/app/models/health/sdh_case_management_note.rb
+++ b/app/models/health/sdh_case_management_note.rb
@@ -1,5 +1,26 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class SdhCaseManagementNote < HealthBase
+    phi_patient :patient_id
+
+    phi_attr :user_id, Phi::SmallPopulation
+    # phi_attr :topics
+    phi_attr :title, Phi::FreeText
+    # phi_attr :total_time_spent_in_minutes
+    phi_attr :date_of_contact, Phi::Date
+    phi_attr :place_of_contact, Phi::Location
+    # phi_attr :housing_status
+    phi_attr :place_of_contact_other, Phi::FreeText
+    phi_attr :housing_status_other, Phi::FreeText
+    phi_attr :housing_placement_date, Phi::Date
+    # phi_attr :client_action
+    phi_attr :notes_from_encounter, Phi::FreeText
+    phi_attr :client_phone_number, Phi::Telephone
+    phi_attr :completed_on, Phi::Date
+    phi_attr :health_file_id, Phi::OtherIdentifier
+    phi_attr :client_action_medication_reconciliation_clinician, Phi::OtherIdentifier
 
     US_PHONE_NUMBERS = /\A(\+1)?\(?(\d{3})\)?\s*-?\s*(\d{3})\s*-?\s*(\d{4})\s*-?\s*\z/
 
@@ -53,7 +74,7 @@ module Health
 
     belongs_to :patient
     belongs_to :user
-    
+
     has_one :health_file, class_name: 'Health::SdhCaseManagementNoteFile', foreign_key: :parent_id, dependent: :destroy
     include HealthFiles
 

--- a/app/models/health/sdh_case_management_note_file.rb
+++ b/app/models/health/sdh_case_management_note_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class SdhCaseManagementNoteFile < Health::HealthFile
 

--- a/app/models/health/self_sufficiency_matrix_form.rb
+++ b/app/models/health/self_sufficiency_matrix_form.rb
@@ -1,8 +1,60 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class SelfSufficiencyMatrixForm < HealthBase
+    phi_patient :patient_id
+
+    phi_attr :user_id, Phi::SmallPopulation
+    phi_attr :point_completed, Phi::FreeText
+    # phi_attr :housing_score,
+    phi_attr :housing_notes, Phi::FreeText
+    # phi_attr :income_score,
+    phi_attr :income_notes, Phi::FreeText
+    # phi_attr :benefits_score,
+    phi_attr :benefits_notes, Phi::FreeText
+    # phi_attr :disabilities_score,
+    phi_attr :disabilities_notes, Phi::FreeText
+    # phi_attr :food_score,
+    phi_attr :food_notes, Phi::FreeText
+    # phi_attr :employment_score,
+    phi_attr :employment_notes, Phi::FreeText
+    # phi_attr :education_score,
+    phi_attr :education_notes, Phi::FreeText
+    # phi_attr :mobility_score,
+    phi_attr :mobility_notes, Phi::FreeText
+    # phi_attr :life_score,
+    phi_attr :life_notes, Phi::FreeText
+    # phi_attr :healthcare_score,
+    phi_attr :healthcare_notes, Phi::FreeText
+    # phi_attr :physical_health_score,
+    phi_attr :physical_health_notes, Phi::FreeText
+    # phi_attr :mental_health_score,
+    phi_attr :mental_health_notes, Phi::FreeText
+    # phi_attr :substance_abuse_score,
+    phi_attr :substance_abuse_notes, Phi::FreeText
+    # phi_attr :criminal_score,
+    phi_attr :criminal_notes, Phi::FreeText
+    # phi_attr :legal_score,
+    phi_attr :legal_notes, Phi::FreeText
+    # phi_attr :safety_score,
+    phi_attr :safety_notes, Phi::FreeText
+    # phi_attr :risk_score,
+    phi_attr :risk_notes, Phi::FreeText
+    # phi_attr :family_score,
+    phi_attr :family_notes, Phi::FreeText
+    # phi_attr :community_score,
+    phi_attr :community_notes, Phi::FreeText
+    # phi_attr :time_score,
+    phi_attr :time_notes, Phi::FreeText
+    phi_attr :completed_at, Phi::Date
+    phi_attr :collection_location, Phi::SmallPopulation
+    phi_attr :health_file_id, Phi::OtherIdentifier
+
+
     belongs_to :patient
     belongs_to :user
-    
+
     has_one :health_file, class_name: 'Health::SsmFile', foreign_key: :parent_id, dependent: :destroy
     include HealthFiles
 

--- a/app/models/health/service.rb
+++ b/app/models/health/service.rb
@@ -1,9 +1,17 @@
 # ### HIPPA Risk Assessment
-# Risk: None - contains no PHI
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Service < HealthBase
-
     acts_as_paranoid
+
+    phi_patient :patient_id
+
+    phi_attr :effective_date, Phi::Date
+    phi_attr :date_requested, Phi::Date
+    phi_attr :end_date, Phi::Date
+    phi_attr :item, Phi::FreeText
+    phi_attr :comments, Phi::FreeText
 
     has_many :careplans
     belongs_to :patient, required: true

--- a/app/models/health/service.rb
+++ b/app/models/health/service.rb
@@ -1,6 +1,8 @@
+# ### HIPPA Risk Assessment
+# Risk: None - contains no PHI
 module Health
   class Service < HealthBase
-    
+
     acts_as_paranoid
 
     has_many :careplans
@@ -9,7 +11,7 @@ module Health
     validates_presence_of :service_type
 
     def self.available_types
-      [ 
+      [
         'Primary Care Physician (PCP)',
         'Home Health',
         'Psychiatrist',

--- a/app/models/health/signable_document.rb
+++ b/app/models/health/signable_document.rb
@@ -1,6 +1,27 @@
 # https://app.hellosign.com/api/reference
+#
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient
+# Control: PHI attributes documented
 module Health
   class SignableDocument < HealthBase
+    # phi_attr :signable_id
+    # phi_attr :signable_type
+    # phi_attr :primary
+    # phi_attr :user_id
+    # phi_attr :hs_initial_request
+    # phi_attr :hs_initial_response
+    phi_attr :hs_initial_response_at, Phi::Date
+    # phi_attr :hs_last_response
+    phi_attr :hs_last_response_at, Phi::Date
+    # phi_attr :hs_subject
+    # phi_attr :hs_title
+    phi_attr :hs_message, Phi::FreeText
+    phi_attr :signers, Phi::FreeText
+    phi_attr :signed_by, Phi::FreeText
+    phi_attr :expires_at, Phi::Date
+    phi_attr :health_file_id, Phi::OtherIdentifier
+
     attr_accessor :pdf_content_to_upload
 
     validates :signable_id, presence: true

--- a/app/models/health/signable_document_file.rb
+++ b/app/models/health/signable_document_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class SignableDocumentFile < Health::HealthFile
 

--- a/app/models/health/signature_request.rb
+++ b/app/models/health/signature_request.rb
@@ -1,6 +1,20 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class SignatureRequest < HealthBase
     acts_as_paranoid
+
+    phi_patient :patient_id
+
+    phi_attr :to_email, Phi::Email
+    phi_attr :to_name, Phi::Name
+    phi_attr :requestor_email, Phi::Email
+    phi_attr :requestor_name, Phi::Name
+    phi_attr :expires_at, Phi::Date
+    phi_attr :sent_at, Phi::Date
+    phi_attr :completed_at, Phi::Date
+    phi_attr :signable_document_id, Phi::OtherIdentifier
 
     belongs_to :signable_document, required: false
     belongs_to :careplan

--- a/app/models/health/signature_requests/aco_signature_request.rb
+++ b/app/models/health/signature_requests/aco_signature_request.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class SignatureRequests::AcoSignatureRequest < SignatureRequest
 

--- a/app/models/health/signature_requests/patient_signature_request.rb
+++ b/app/models/health/signature_requests/patient_signature_request.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class SignatureRequests::PatientSignatureRequest < SignatureRequest
 

--- a/app/models/health/signature_requests/pcp_signature_request.rb
+++ b/app/models/health/signature_requests/pcp_signature_request.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class SignatureRequests::PcpSignatureRequest < SignatureRequest
     def pcp_request?

--- a/app/models/health/ssm_file.rb
+++ b/app/models/health/ssm_file.rb
@@ -1,3 +1,6 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient. Binary data may contain PHI
+# Control: PHI attributes documented in base class
 module Health
   class SsmFile < Health::HealthFile
 

--- a/app/models/health/team.rb
+++ b/app/models/health/team.rb
@@ -1,3 +1,5 @@
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Team < HealthBase
     acts_as_paranoid

--- a/app/models/health/team.rb
+++ b/app/models/health/team.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Relates to a patient and contains PHI
 # Control: PHI attributes documented
 module Health

--- a/app/models/health/team.rb
+++ b/app/models/health/team.rb
@@ -1,8 +1,10 @@
 module Health
   class Team < HealthBase
-    # TODO remove me
-    has_paper_trail
     acts_as_paranoid
+
+    phi_patient :patient_id
+    phi_attr :id, ::Phi::OtherIdentifier
+
     has_many :members, class_name: Health::Team::Member.name
     # has_one :pcp_designee, class_name: Health::Team::PcpDesignee.name
     belongs_to :patient

--- a/app/models/health/team/aco_care_manager.rb
+++ b/app/models/health/team/aco_care_manager.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::AcoCareManager < Team::Member
-    
+
     def self.member_type_name
       'ACO Care Manager'
     end

--- a/app/models/health/team/behavioral.rb
+++ b/app/models/health/team/behavioral.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::Behavioral < Team::Member
-    
+
     def self.member_type_name
       'Behavioral Health'
     end

--- a/app/models/health/team/care_coordinator.rb
+++ b/app/models/health/team/care_coordinator.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::CareCoordinator < Team::Member
-    
+
     def self.member_type_name
       'Care Coordinator'
     end

--- a/app/models/health/team/case_manager.rb
+++ b/app/models/health/team/case_manager.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::CaseManager < Team::Member
-    
+
     def self.member_type_name
       'SDH Case Manager'
     end

--- a/app/models/health/team/member.rb
+++ b/app/models/health/team/member.rb
@@ -1,3 +1,4 @@
+# ### HIPPA Risk Assessment
 # Risk: Relates to a patient and contains PHI
 # Control: PHI attributes documented
 module Health

--- a/app/models/health/team/member.rb
+++ b/app/models/health/team/member.rb
@@ -1,11 +1,17 @@
-# ### HIPPA Risk Assessment
-# Risk:
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Team::Member < HealthBase
     include ArelHelper
     self.table_name = 'team_members'
     has_paper_trail class_name: Health::HealthVersion.name
     acts_as_paranoid
+
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :user_id, Phi::SmallPopulation
+    phi_attr :last_contact, Phi::Date
+
 
     # belongs_to :team, class_name: Health::Team.name
     belongs_to :patient

--- a/app/models/health/team/member.rb
+++ b/app/models/health/team/member.rb
@@ -1,5 +1,5 @@
 # ### HIPPA Risk Assessment
-
+# Risk:
 module Health
   class Team::Member < HealthBase
     include ArelHelper

--- a/app/models/health/team/member.rb
+++ b/app/models/health/team/member.rb
@@ -1,3 +1,5 @@
+# ### HIPPA Risk Assessment
+
 module Health
   class Team::Member < HealthBase
     include ArelHelper

--- a/app/models/health/team/nurse.rb
+++ b/app/models/health/team/nurse.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::Nurse < Team::Member
-    
+
     def self.member_type_name
       'Nurse Care Manager'
     end

--- a/app/models/health/team/other.rb
+++ b/app/models/health/team/other.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::Other < Team::Member
-    
+
     validates_presence_of :title
     def self.member_type_name
       'Other Important Contact'

--- a/app/models/health/team/pcp_designee.rb
+++ b/app/models/health/team/pcp_designee.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::PcpDesignee < Team::Member
-    
+
     def self.member_type_name
       'PCP Designee'
     end

--- a/app/models/health/team/provider.rb
+++ b/app/models/health/team/provider.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::Provider < Team::Member
-    
+
     def self.member_type_name
       'Provider (MD/NP/PA)'
     end

--- a/app/models/health/team/representative.rb
+++ b/app/models/health/team/representative.rb
@@ -1,6 +1,9 @@
+# ### HIPPA Risk Assessment
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented in base class
 module Health
   class Team::Representative < Team::Member
-    
+
     def self.member_type_name
       'Designated Representative'
     end

--- a/app/models/health/user_care_coordinator.rb
+++ b/app/models/health/user_care_coordinator.rb
@@ -1,5 +1,10 @@
+# ### HIPPA Risk Assessment
+# Risk: Indirectly relates to a patient
+# Control: PHI attributes documented
 module Health
   class UserCareCoordinator < HealthBase
+    phi_attr :care_coordinator_id, Phi::SmallPopulation
+
     belongs_to :user
     belongs_to :care_coordinator, class_name: User.name
     validates_presence_of :user_id

--- a/app/models/health/visit.rb
+++ b/app/models/health/visit.rb
@@ -1,8 +1,12 @@
+# Risk: Relates to a patient and contains PHI
+# Control: PHI attributes documented
 module Health
   class Visit < EpicBase
     phi_patient :patient_id
     phi_attr :id, Phi::OtherIdentifier
+    phi_attr :department, Phi::SmallPopulation
     phi_attr :date_of_service, Phi::Date
+    phi_attr :id_in_source, Phi::OtherIdentifier
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :visits
 

--- a/app/models/health/visit.rb
+++ b/app/models/health/visit.rb
@@ -1,5 +1,8 @@
 module Health
   class Visit < EpicBase
+    phi_patient :patient_id
+    phi_attr :id, Phi::OtherIdentifier
+    phi_attr :date_of_service, Phi::Date
 
     belongs_to :patient, primary_key: :id_in_source, foreign_key: :patient_id, inverse_of: :visits
 

--- a/app/models/health_base.rb
+++ b/app/models/health_base.rb
@@ -2,4 +2,35 @@ class HealthBase < ActiveRecord::Base
   establish_connection DB_HEALTH
   self.abstract_class = true
   has_paper_trail class_name: Health::HealthVersion.name
+
+  class << self
+    cattr_accessor :phi_dictionary
+
+    def phi_dictionary_entry
+      self.phi_dictionary ||= {}
+      self.phi_dictionary[self.name] ||= {
+        patient_id: nil,
+        attrbutes: Set.new
+      }
+    end
+
+    def phi_attr(attribute, category)
+      raise ArgumentError, "category (#{category}) must be a ::Phi::Category" unless category < ::Phi::Category
+      raise ArgumentError, "attr (#{attr})  must method name as a symbol" unless attribute.is_a?(::Symbol)
+      self.phi_dictionary_entry[:attrbutes] << ::Phi::Attribute.new(
+        self.name,
+        attribute,
+        category
+      )
+    end
+
+    def phi_patient(attribute)
+      raise ArgumentError, "attr (#{attr})  must method name as a symbol" unless attribute.is_a?(::Symbol)
+      if (existing = phi_dictionary_entry[:patient_id])
+        raise ArgumentError, "Cannot set more then one phi_patient per class: class:#{self.class} existing: #{existing}, new: #{attr}"
+      end
+      self.phi_dictionary_entry[:table_name] = table_name
+      self.phi_dictionary_entry[:patient_id] = attribute
+    end
+  end
 end

--- a/app/models/health_base.rb
+++ b/app/models/health_base.rb
@@ -27,7 +27,7 @@ class HealthBase < ActiveRecord::Base
     def phi_patient(attribute)
       raise ArgumentError, "attr (#{attr})  must method name as a symbol" unless attribute.is_a?(::Symbol)
       if (existing = phi_dictionary_entry[:patient_id])
-        raise ArgumentError, "Cannot set more then one phi_patient per class: class:#{self.class} existing: #{existing}, new: #{attr}"
+        raise ArgumentError, "Cannot set more then one phi_patient per class: class:#{self} existing: #{existing}, new: #{attr}"
       end
       self.phi_dictionary_entry[:table_name] = table_name
       self.phi_dictionary_entry[:patient_id] = attribute

--- a/app/models/health_base.rb
+++ b/app/models/health_base.rb
@@ -26,8 +26,8 @@ class HealthBase < ActiveRecord::Base
 
     def phi_patient(attribute)
       raise ArgumentError, "attr (#{attr})  must method name as a symbol" unless attribute.is_a?(::Symbol)
-      if (existing = phi_dictionary_entry[:patient_id])
-        raise ArgumentError, "Cannot set more then one phi_patient per class: class:#{self} existing: #{existing}, new: #{attr}"
+      if (existing = phi_dictionary_entry[:patient_id]) && existing != attribute
+        raise ArgumentError, "Cannot set more then one phi_patient per class: class:#{self} existing: #{existing}, new: #{attribute}"
       end
       self.phi_dictionary_entry[:table_name] = table_name
       self.phi_dictionary_entry[:patient_id] = attribute

--- a/app/models/phi.rb
+++ b/app/models/phi.rb
@@ -1,5 +1,14 @@
 module Phi
-  class Category; end;
+  class Category
+    def self.as_json
+      name
+    end
+  end
+
+  # blog or attachment contains serialzied bulk PHI
+  class Bulk < Category;
+  end
+
   # Safe Harbor Identifiers
   class Name < Category; end
   class Location < Category; end

--- a/app/models/phi.rb
+++ b/app/models/phi.rb
@@ -1,0 +1,35 @@
+module Phi
+  class Category; end;
+  # Safe Harbor Identifiers
+  class Name < Category; end
+  class Location < Category; end
+  class Date < Category; end
+  class Telephone < Category; end
+  class Fax < Category; end
+  class Email < Category; end
+  class Ssn < Category; end
+  class MedicalRecordNumber < Category; end
+  class HealthPlan < Category; end
+  class AccountNumber < Category; end
+  class LicenceNumber < Category; end
+  class VehicleId < Category; end
+  class DeviceId < Category; end
+  class IpAddress < Category; end
+  class BiometricId < Category; end
+  class PhotoIdentity < Category; end
+  class OtherIdentifier < Category; end
+
+  # Labels for attributes that need
+  # careful review:
+  class NeedsReview < Category; end
+
+  # This free text might contain PHI
+  class FreeText < NeedsReview; end
+
+  # This categorical field might result in
+  # small populations that can be corrilated
+  # with public data to re-identify the user
+  class SmallPopulation < NeedsReview; end
+
+  Attribute = Struct.new(:class, :name, :category)
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = true
+  config.eager_load = false
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -1,12 +1,14 @@
 # PHI-fere
 - [x] accountable_care_organizations
 - [x] agencies
-- [ ] AgencyPatientReferral
 - [x] agency_users
 - [x] data_sources
+- [x] equipment
+- [x] services
 
-
-
+# PHI referred to - patient not IDed directly
+- [x] agency_patient_referrals
+- [x] user_care_coordinators
 
 # PHI annotated
 - [x] patients
@@ -14,14 +16,15 @@
 - [x] careplans (belong_to patient)
 - [x] epic_goals (belong_to patient)
 - [x] epic_patients (belong_to patient)
-- [-] health_goals (belong_to patient) - STI modal
-- [-] medications (belong_to patient)
-- [-] problems (belong_to patient)
-- [-] teams (belong_to patient)
-  - [-] team_members (belong_to team) - No direct PHI but see notes
-- [-] visits (belong_to patient)
-- [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
+- [x] health_goals (belong_to patient) - STI modal
+- [x] medications (belong_to patient)
+- [x] problems (belong_to patient)
+- [x] teams (belong_to patient)
+- [x] team_members (belong_to patient)
+- [x] visits (belong_to patient)
 - [x] comprehensive_health_assessments
+- [x] health_files
+- [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
 
 # TODO
 - [ ] claims
@@ -33,6 +36,7 @@
 - [ ] claims_top_ip_conditions
 - [ ] claims_top_providers
 - [ ] cps
+
 - [ ] epic_careplans
 - [ ] epic_case_note_qualifying_activities
 - [ ] epic_case_notes
@@ -42,8 +46,7 @@
 - [ ] epic_qualifying_activities
 - [ ] epic_ssms
 - [ ] epic_team_members
-- [ ] equipment
-- [ ] health_files
+
 - [ ] member_status_report_patients
 - [ ] member_status_reports
 - [ ] participation_forms
@@ -53,7 +56,6 @@
 - [ ] release_forms
 - [ ] sdh_case_management_notes
 - [ ] self_sufficiency_matrix_forms
-- [ ] services
+
 - [ ] signable_documents
 - [ ] signature_requests
-- [ ] user_care_coordinators

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -53,9 +53,7 @@
 - [x] claims_top_conditions (medicare_id)
 - [x] claims_top_ip_conditions (medicare_id)
 - [x] claims_amount_paid_location_month (medicare_id)
+- [x] claims_claim_volume_location_month (medicare_id)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
-
-# TODO
-- [ ] claims_claim_volume_location_month

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -11,7 +11,7 @@
 - [x] user_care_coordinators
 - [x] epic_qualifying_activities
 - [x] signable_documents
-- [x] member_status_reports - there may be only small number of member_status_report_patients with the same member_status_reports.id
+- [x] member_status_reports via member_status_report_patients
 
 # PHI bulks transfers - model documents a bulk echange of PHI with a authorized agency
 - [x] claims
@@ -45,16 +45,17 @@
 - [x] equipment (belong_to patient)
 - [x] signature_requests (belong_to patient team member -- which might be the patiant)
 - [x] sdh_case_management_notes (belong_to patient)
+
 - [x] member_status_report_patients (medicare_id)
+- [x] claims_roster (medicare_id)
+- [x] claims_ed_nyu_severity (medicare_id)
+- [x] claims_top_providers (medicare_id)
+- [x] claims_top_conditions (medicare_id)
+- [x] claims_top_ip_conditions (medicare_id)
+- [x] claims_amount_paid_location_month (medicare_id)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
 
 # TODO
-- [ ] claims_amount_paid_location_month
 - [ ] claims_claim_volume_location_month
-- [ ] claims_ed_nyu_severity
-- [ ] claims_roster
-- [ ] claims_top_conditions
-- [ ] claims_top_ip_conditions
-- [ ] claims_top_providers

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -4,7 +4,7 @@
 - [x] agency_users
 - [x] data_sources
 - [x] patient_referral_imports (file_name but not contents?)
-- [x] cps
+- [x] cps "Community Partners"
 
 # PHI referred to ??? - patient not IDed directly
 - [x] agency_patient_referrals
@@ -12,6 +12,9 @@
 - [x] epic_qualifying_activities
 - [x] signable_documents
 - [x] member_status_reports - there may be only small number of member_status_report_patients with the same member_status_reports.id
+
+# PHI bulks transfers - model documents a bulk echange of PHI with a authorized agency
+- [x] claims
 
 # PHI related models - annotated
 - [x] patients
@@ -48,7 +51,6 @@
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
 
 # TODO
-- [ ] claims
 - [ ] claims_amount_paid_location_month
 - [ ] claims_claim_volume_location_month
 - [ ] claims_ed_nyu_severity

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -32,6 +32,7 @@
 - [x] participation_forms (belong_to patient)
 - [x] release_forms (belong_to patient)
 - [x] self_sufficiency_matrix_forms (belong_to patient)
+- [x] patient_referrals (belong_to patient)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
@@ -56,7 +57,7 @@
 - [ ] member_status_reports
 
 - [ ] patient_referral_imports
-- [ ] patient_referrals
+
 
 - [ ] sdh_case_management_notes
 

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -1,15 +1,30 @@
+# PHI-fere
+- [x] accountable_care_organizations
+- [x] agencies
+- [ ] AgencyPatientReferral
+- [x] agency_users
+- [x] data_sources
+
+
+
+
+# PHI annotated
 - [x] patients
 - [x] appointments (belong_to patient)
 - [x] careplans (belong_to patient)
 - [x] epic_goals (belong_to patient)
-- [ ] health_goals (belong_to patient) - STI modal
-- [x] medications (belong_to patient)
-- [x] problems (belong_to patient)
-- [x] visits (belong_to patient)
-- [ ] teams (belong_to patient)
-  - [ ] team_members (belong_to team) - No direct PHI but see notes
+- [x] epic_patients (belong_to patient)
+- [-] health_goals (belong_to patient) - STI modal
+- [-] medications (belong_to patient)
+- [-] problems (belong_to patient)
+- [-] teams (belong_to patient)
+  - [-] team_members (belong_to team) - No direct PHI but see notes
+- [-] visits (belong_to patient)
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
+- [x] comprehensive_health_assessments
 
+# TODO
+- [ ] claims
 - [ ] claims_amount_paid_location_month
 - [ ] claims_claim_volume_location_month
 - [ ] claims_ed_nyu_severity
@@ -17,4 +32,28 @@
 - [ ] claims_top_conditions
 - [ ] claims_top_ip_conditions
 - [ ] claims_top_providers
-- [ ] ...
+- [ ] cps
+- [ ] epic_careplans
+- [ ] epic_case_note_qualifying_activities
+- [ ] epic_case_notes
+- [ ] epic_chas
+- [ ] epic_goals
+- [ ] epic_patients
+- [ ] epic_qualifying_activities
+- [ ] epic_ssms
+- [ ] epic_team_members
+- [ ] equipment
+- [ ] health_files
+- [ ] member_status_report_patients
+- [ ] member_status_reports
+- [ ] participation_forms
+- [ ] patient_referral_imports
+- [ ] patient_referrals
+- [ ] qualifying_activities
+- [ ] release_forms
+- [ ] sdh_case_management_notes
+- [ ] self_sufficiency_matrix_forms
+- [ ] services
+- [ ] signable_documents
+- [ ] signature_requests
+- [ ] user_care_coordinators

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -3,15 +3,14 @@
 - [x] agencies
 - [x] agency_users
 - [x] data_sources
-- [x] equipment
-- [x] services
 
-# PHI referred to - patient not IDed directly
+# PHI referred to ??? - patient not IDed directly
 - [x] agency_patient_referrals
 - [x] user_care_coordinators
 - [x] epic_qualifying_activities
+- [x] signable_documents
 
-# PHI annotated
+# PHI related models - annotated
 - [x] patients
 - [x] appointments (belong_to patient)
 - [x] careplans (belong_to patient)
@@ -33,10 +32,11 @@
 - [x] release_forms (belong_to patient)
 - [x] self_sufficiency_matrix_forms (belong_to patient)
 - [x] patient_referrals (belong_to patient)
+- [x] services (belong_to patient)
+- [x] equipment (belong_to patient)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
-
 
 # TODO
 - [ ] claims
@@ -48,18 +48,12 @@
 - [ ] claims_top_ip_conditions
 - [ ] claims_top_providers
 - [ ] cps
-
 - [ ] epic_case_note_qualifying_activities
 - [ ] epic_chas
 - [ ] epic_ssms
-
 - [ ] member_status_report_patients
 - [ ] member_status_reports
-
 - [ ] patient_referral_imports
-
-
 - [ ] sdh_case_management_notes
 
-- [ ] signable_documents
 - [ ] signature_requests

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -54,7 +54,6 @@
 - [ ] participation_forms
 - [ ] patient_referral_imports
 - [ ] patient_referrals
-
 - [ ] release_forms
 - [ ] sdh_case_management_notes
 - [ ] self_sufficiency_matrix_forms

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -1,0 +1,20 @@
+- [x] patients
+- [x] appointments (belong_to patient)
+- [x] careplans (belong_to patient)
+- [x] epic_goals (belong_to patient)
+- [ ] health_goals (belong_to patient) - STI modal
+- [x] medications (belong_to patient)
+- [x] problems (belong_to patient)
+- [x] visits (belong_to patient)
+- [ ] teams (belong_to patient)
+  - [ ] team_members (belong_to team) - No direct PHI but see notes
+- [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
+
+- [ ] claims_amount_paid_location_month
+- [ ] claims_claim_volume_location_month
+- [ ] claims_ed_nyu_severity
+- [ ] claims_roster
+- [ ] claims_top_conditions
+- [ ] claims_top_ip_conditions
+- [ ] claims_top_providers
+- [ ] ...

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -1,4 +1,4 @@
-# PHI-fere
+# PHI-free
 - [x] accountable_care_organizations
 - [x] agencies
 - [x] agency_users

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -3,23 +3,29 @@
 - [x] agencies
 - [x] agency_users
 - [x] data_sources
+- [x] patient_referral_imports (file_name but not contents?)
+- [x] cps
 
 # PHI referred to ??? - patient not IDed directly
 - [x] agency_patient_referrals
 - [x] user_care_coordinators
 - [x] epic_qualifying_activities
 - [x] signable_documents
+- [x] member_status_reports - there may be only small number of member_status_report_patients with the same member_status_reports.id
 
 # PHI related models - annotated
 - [x] patients
 - [x] appointments (belong_to patient)
 - [x] careplans (belong_to patient)
 - [x] comprehensive_health_assessments (belong_to patient)
-- [x] epic_careplans (belong_to patient)
-- [x] epic_case_notes
-- [x] epic_goals (belong_to patient)
-- [x] epic_patients (belong_to patient)
-- [x] epic_team_members (belong_to patient)
+- [x] epic_careplans (belong_to epic_patients)
+- [x] epic_case_notes (belong_to epic_patients)
+- [x] epic_goals (belong_to epic_patients)
+- [x] epic_patients (belong_to epic_patients)
+- [x] epic_team_members (belong_to epic_patients)
+- [x] epic_ssms (belong_to epic_patients)
+- [x] epic_chas (belong_to epic_patients)
+- [x] epic_case_note_qualifying_activities (belong_to epic_patients, epic_case_note)
 - [x] health_files (belong_to patient indirectly)
 - [x] health_goals (belong_to patient) - STI modal
 - [x] medications (belong_to patient)
@@ -34,6 +40,9 @@
 - [x] patient_referrals (belong_to patient)
 - [x] services (belong_to patient)
 - [x] equipment (belong_to patient)
+- [x] signature_requests (belong_to patient team member -- which might be the patiant)
+- [x] sdh_case_management_notes (belong_to patient)
+- [x] member_status_report_patients (medicare_id)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
@@ -47,13 +56,3 @@
 - [ ] claims_top_conditions
 - [ ] claims_top_ip_conditions
 - [ ] claims_top_providers
-- [ ] cps
-- [ ] epic_case_note_qualifying_activities
-- [ ] epic_chas
-- [ ] epic_ssms
-- [ ] member_status_report_patients
-- [ ] member_status_reports
-- [ ] patient_referral_imports
-- [ ] sdh_case_management_notes
-
-- [ ] signature_requests

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -9,13 +9,16 @@
 # PHI referred to - patient not IDed directly
 - [x] agency_patient_referrals
 - [x] user_care_coordinators
+- [x] epic_qualifying_activities
 
 # PHI annotated
 - [x] patients
 - [x] appointments (belong_to patient)
 - [x] careplans (belong_to patient)
+- [x] epic_careplans (belong_to patient)
 - [x] epic_goals (belong_to patient)
 - [x] epic_patients (belong_to patient)
+- [x] epic_case_notes
 - [x] health_goals (belong_to patient) - STI modal
 - [x] medications (belong_to patient)
 - [x] problems (belong_to patient)
@@ -25,6 +28,7 @@
 - [x] comprehensive_health_assessments
 - [x] health_files
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
+
 
 # TODO
 - [ ] claims
@@ -37,13 +41,8 @@
 - [ ] claims_top_providers
 - [ ] cps
 
-- [ ] epic_careplans
 - [ ] epic_case_note_qualifying_activities
-- [ ] epic_case_notes
 - [ ] epic_chas
-- [ ] epic_goals
-- [ ] epic_patients
-- [ ] epic_qualifying_activities
 - [ ] epic_ssms
 - [ ] epic_team_members
 

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -15,18 +15,21 @@
 - [x] patients
 - [x] appointments (belong_to patient)
 - [x] careplans (belong_to patient)
+- [x] comprehensive_health_assessments (belong_to patient)
 - [x] epic_careplans (belong_to patient)
+- [x] epic_case_notes
 - [x] epic_goals (belong_to patient)
 - [x] epic_patients (belong_to patient)
-- [x] epic_case_notes
+- [x] health_files (belong_to patient indirectly)
 - [x] health_goals (belong_to patient) - STI modal
 - [x] medications (belong_to patient)
 - [x] problems (belong_to patient)
-- [x] teams (belong_to patient)
+- [x] qualifying_activities (belong_to patient)
 - [x] team_members (belong_to patient)
+- [x] teams (belong_to patient)
 - [x] visits (belong_to patient)
-- [x] comprehensive_health_assessments
-- [x] health_files
+
+# Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
 
 
@@ -51,7 +54,7 @@
 - [ ] participation_forms
 - [ ] patient_referral_imports
 - [ ] patient_referrals
-- [ ] qualifying_activities
+
 - [ ] release_forms
 - [ ] sdh_case_management_notes
 - [ ] self_sufficiency_matrix_forms

--- a/db/health/phi_review.md
+++ b/db/health/phi_review.md
@@ -20,6 +20,7 @@
 - [x] epic_case_notes
 - [x] epic_goals (belong_to patient)
 - [x] epic_patients (belong_to patient)
+- [x] epic_team_members (belong_to patient)
 - [x] health_files (belong_to patient indirectly)
 - [x] health_goals (belong_to patient) - STI modal
 - [x] medications (belong_to patient)
@@ -28,6 +29,9 @@
 - [x] team_members (belong_to patient)
 - [x] teams (belong_to patient)
 - [x] visits (belong_to patient)
+- [x] participation_forms (belong_to patient)
+- [x] release_forms (belong_to patient)
+- [x] self_sufficiency_matrix_forms (belong_to patient)
 
 # Sensitive logs
 - [x] versions - PaperTrail audit log. May contain PHIs from any other Health model!
@@ -47,16 +51,14 @@
 - [ ] epic_case_note_qualifying_activities
 - [ ] epic_chas
 - [ ] epic_ssms
-- [ ] epic_team_members
 
 - [ ] member_status_report_patients
 - [ ] member_status_reports
-- [ ] participation_forms
+
 - [ ] patient_referral_imports
 - [ ] patient_referrals
-- [ ] release_forms
+
 - [ ] sdh_case_management_notes
-- [ ] self_sufficiency_matrix_forms
 
 - [ ] signable_documents
 - [ ] signature_requests


### PR DESCRIPTION
I reviewed and annotated every model in `app/models/health/*`and cross-checked against `db/health/schema.rb`

* For each model I added a 'HIPPA Risk Assessment' header to the model file indicating if PHI was present or referred to in that model
* Added some class methods to `HealthBase` (the base class for all health models.
   `phi_patient` flags the unique patient identifier used by the model. It might be either 
   `phi_attr` identifies an PHI sensitive attribute of the model and its `Phi::Category`. categories are listed in `app/models/phi.rb` and correspond categories of PHI identified in the HHS [rules for de-identification](https://www.hhs.gov/hipaa/for-professionals/privacy/special-topics/de-identification/index.html) (as well as a few "Needs Review" or "bulk data" categories) 
* The class methods add data to `HealthBase.phi_dictionary`. 
* `/db/health/phi_review.md` was my checklist

Running `Rails.application.eager_load!; HealthBase.phi_dictionary` will load and create a machine readable data dictionary of the models, attributes and categories. I'm hoping was can use this in the future to augment any audit logs with a clear indication of the patient and what category of information was accessed

