### PR TITLE
Stories/veteran status adjustments

### DIFF
--- a/app/controllers/clients/cas_readiness_controller.rb
+++ b/app/controllers/clients/cas_readiness_controller.rb
@@ -23,6 +23,8 @@ module Clients
       if @client.update(update_params)
         # Keep various client fields in sync with files if appropriate
         @client.sync_cas_attributes_with_files
+        # Maintain the veteran status
+        @client.adjust_veteran_status
         
         flash[:notice] = 'Client updated'
         ::Cas::SyncToCasJob.perform_later

--- a/app/controllers/warehouse_reports/chronic_controller.rb
+++ b/app/controllers/warehouse_reports/chronic_controller.rb
@@ -60,7 +60,7 @@ module WarehouseReports
         @counts = @counts.where(dmh: true)
       end
       if @filter.veteran
-        @counts = @counts.joins(:client).where(Client: {VeteranStatus: true})
+        @counts = @counts.joins(:client).where(Client: {VeteranStatus: 1})
       end
       @counts = @counts.group(:date).
         order(date: :asc).

--- a/app/controllers/warehouse_reports/hud_chronics_controller.rb
+++ b/app/controllers/warehouse_reports/hud_chronics_controller.rb
@@ -55,7 +55,7 @@ module WarehouseReports
         @counts = @counts.where(dmh: true)
       end
       if @filter.veteran
-        @counts = @counts.joins(:client).where(Client: {VeteranStatus: true})
+        @counts = @counts.joins(:client).where(Client: {VeteranStatus: 1})
       end
       @counts = @counts.group(:date).
         order(date: :asc).

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -178,12 +178,17 @@ module GrdaWarehouse::Tasks
 
     def choose_best_veteran_status dest_attr, source_clients
       # Get the best Veteran status (has 0/1, newest breaks the tie)
-      no_yes = [0, 1]
-      yes_no_vet_status_clients = source_clients.select{|sc| no_yes.include?(sc[:VeteranStatus])}
-      if !no_yes.include?(dest_attr[:VeteranStatus]) or yes_no_vet_status_clients.any?
-        yes_no_vet_status_clients = source_clients if yes_no_vet_status_clients.none? #if none have yes/no we consider them all in the sort test
-        dest_attr[:VeteranStatus] = yes_no_vet_status_clients.sort{|a, b| a[:DateUpdated] <=> b[:DateUpdated]}.last[:VeteranStatus]
+      # As of 2/16/2019 calculate using if ever yes, override with verified_veteran_status == non_veteran
+      if dest_attr[:verified_veteran_status] == 'non_veteran'
+        dest_attr[:VeteranStatus] = 0
+      elsif source_clients.map { |sc| sc[:VeteranStatus] }.include?(1)
+        dest_attr[:VeteranStatus] = 1
+      else
+        dest_attr[:VeteranStatus] = source_clients.sort do |a, b| 
+          a[:DateUpdated] <=> b[:DateUpdated]
+        end.last[:VeteranStatus]
       end
+
       dest_attr
     end
 

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -290,17 +290,18 @@ module GrdaWarehouse::Tasks
 
     def client_columns 
       @client_columns ||= {
-        FirstName: c_t[:FirstName].as('FirstName').to_sql, 
-        LastName: c_t[:LastName].as('LastName').to_sql, 
-        SSN: c_t[:SSN].as('SSN').to_sql, 
-        DOB: c_t[:DOB].as('DOB').to_sql,
-        Gender: c_t[:Gender].as('Gender').to_sql,
-        VeteranStatus: c_t[:VeteranStatus].as('VeteranStatus').to_sql, 
-        NameDataQuality: cl(c_t[:NameDataQuality], 99).as('NameDataQuality').to_sql, 
-        SSNDataQuality: cl(c_t[:SSNDataQuality], 99).as('SSNDataQuality').to_sql, 
-        DOBDataQuality: cl(c_t[:DOBDataQuality], 99).as('DOBDataQuality').to_sql, 
-        DateCreated: cl(c_t[:DateCreated], 10.years.ago.to_date).as('DateCreated').to_sql,
-        DateUpdated: cl(c_t[:DateUpdated], 10.years.ago.to_date).as('DateUpdated').to_sql,
+        FirstName: c_t[:FirstName].to_sql, 
+        LastName: c_t[:LastName].to_sql, 
+        SSN: c_t[:SSN].to_sql, 
+        DOB: c_t[:DOB].to_sql,
+        Gender: c_t[:Gender].to_sql,
+        VeteranStatus: c_t[:VeteranStatus].to_sql,
+        verified_veteran_status: c_t[:verified_veteran_status].to_sql,
+        NameDataQuality: cl(c_t[:NameDataQuality], 99).to_sql, 
+        SSNDataQuality: cl(c_t[:SSNDataQuality], 99).to_sql, 
+        DOBDataQuality: cl(c_t[:DOBDataQuality], 99).to_sql, 
+        DateCreated: cl(c_t[:DateCreated], 10.years.ago.to_date).to_sql,
+        DateUpdated: cl(c_t[:DateUpdated], 10.years.ago.to_date).to_sql,
       }
     end
 

--- a/app/views/clients/_service_summary.haml
+++ b/app/views/clients/_service_summary.haml
@@ -37,7 +37,7 @@
         - if window
           %span= yes_no @client.source_clients.visible_in_window_to(current_user).map(&:veteran?).include?(true)
         - else
-          %span= yes_no @client.source_clients.map(&:veteran?).include?(true)
+          %span= yes_no @client.veteran?
       %li
         %h4 Disabled:
         %span= yes_no @client.currently_disabled?

--- a/app/views/clients/cas_readiness/_file.haml
+++ b/app/views/clients/cas_readiness/_file.haml
@@ -33,6 +33,10 @@
     .col-lg-8.col-xl-6
       = render 'vispdat', f: f
 
+  .row
+    .col-lg-8.col-xl-6
+      = render 'veteran', f: f
+
   %section.o-section-card.row
     .col-lg-8.col-xl-6
       %h3 Release

--- a/app/views/clients/cas_readiness/_manual.haml
+++ b/app/views/clients/cas_readiness/_manual.haml
@@ -49,6 +49,10 @@
     .col-lg-8.col-xl-6
       = render 'vispdat', f: f
 
+  .row
+    .col-lg-8.col-xl-6
+      = render 'veteran', f: f
+
   .row.mb-4
     .col-lg-8.col-xl-6
       = render 'window/clients/required_documents'

--- a/app/views/clients/cas_readiness/_veteran.haml
+++ b/app/views/clients/cas_readiness/_veteran.haml
@@ -1,0 +1,6 @@
+%section.o-section-card
+  %header
+    %h3 Veteran Status
+  .c-card.c-card--flush.c-card--padded.c-card--block
+    - ever_vet = if @client.ever_veteran? then 'Yes' else 'No' end
+    = f.input :verified_veteran_status, collection: [['Verified non-veteran', :non_veteran]], include_blank: "Use if ever responded yes. Currently: #{ ever_vet }", input_html: {class: :select2}

--- a/db/warehouse/migrate/20190216193115_veteran_override.rb
+++ b/db/warehouse/migrate/20190216193115_veteran_override.rb
@@ -1,0 +1,5 @@
+class VeteranOverride < ActiveRecord::Migration
+  def change
+    add_column :Client, :verified_veteran_status, :string
+  end
+end

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -11,12 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190204194825) do
+ActiveRecord::Schema.define(version: 20190216193115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "fuzzystrmatch"
   enable_extension "pgcrypto"
+  enable_extension "pg_stat_statements"
 
   create_table "Affiliation", force: :cascade do |t|
     t.string   "AffiliationID"
@@ -116,6 +117,8 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.integer  "required_number_of_bedrooms",                        default: 1
     t.integer  "required_minimum_occupancy",                         default: 1
     t.boolean  "requires_elevator_access",                           default: false
+    t.jsonb    "neighborhood_interests",                             default: [],    null: false
+    t.string   "verified_veteran_status"
   end
 
   add_index "Client", ["DateCreated"], name: "client_date_created", using: :btree
@@ -834,6 +837,19 @@ ActiveRecord::Schema.define(version: 20190204194825) do
   add_index "cas_availabilities", ["client_id"], name: "index_cas_availabilities_on_client_id", using: :btree
   add_index "cas_availabilities", ["unavailable_at"], name: "index_cas_availabilities_on_unavailable_at", using: :btree
 
+  create_table "cas_enrollments", force: :cascade do |t|
+    t.integer  "client_id"
+    t.integer  "enrollment_id"
+    t.date     "entry_date"
+    t.date     "exit_date"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.json     "history"
+  end
+
+  add_index "cas_enrollments", ["client_id"], name: "index_cas_enrollments_on_client_id", using: :btree
+  add_index "cas_enrollments", ["enrollment_id"], name: "index_cas_enrollments_on_enrollment_id", using: :btree
+
   create_table "cas_houseds", force: :cascade do |t|
     t.integer "client_id",                     null: false
     t.integer "cas_client_id",                 null: false
@@ -1054,7 +1070,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.string   "legal_barriers"
     t.string   "criminal_record_status"
     t.string   "document_ready"
-    t.string   "sif_eligible"
+    t.boolean  "sif_eligible",                                               default: false
     t.string   "sensory_impaired"
     t.date     "housed_date"
     t.string   "destination"
@@ -1064,7 +1080,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.date     "last_group_review_date"
     t.date     "pre_contemplative_last_date_approached"
     t.string   "va_eligible"
-    t.string   "vash_eligible"
+    t.boolean  "vash_eligible",                                              default: false
     t.string   "chapter_115"
     t.date     "first_date_homeless"
     t.date     "last_date_approached"
@@ -1413,6 +1429,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.text     "counselor_attributes"
     t.string   "outreach_counselor_name"
     t.integer  "subject_id"
+    t.jsonb    "processed_fields"
   end
 
   add_index "hmis_clients", ["client_id"], name: "index_hmis_clients_on_client_id", using: :btree
@@ -1553,15 +1570,6 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.boolean "individual_elder",                            default: false, null: false
     t.boolean "head_of_household",                           default: false, null: false
   end
-
-  add_index "new_service_history", ["client_id", "record_type"], name: "index_sh_on_client_id", using: :btree
-  add_index "new_service_history", ["computed_project_type", "record_type", "client_id"], name: "index_sh_on_computed_project_type", using: :btree
-  add_index "new_service_history", ["data_source_id", "project_id", "organization_id", "record_type"], name: "index_sh_ds_proj_org_r_type", using: :btree
-  add_index "new_service_history", ["date", "household_id", "record_type"], name: "index_sh_on_household_id", using: :btree
-  add_index "new_service_history", ["enrollment_group_id", "project_tracking_method"], name: "index_sh__enrollment_id_track_meth", using: :btree
-  add_index "new_service_history", ["first_date_in_program", "last_date_in_program", "record_type", "date"], name: "index_wsh_on_last_date_in_program", using: :btree
-  add_index "new_service_history", ["first_date_in_program"], name: "index_new_service_history_on_first_date_in_program", using: :brin
-  add_index "new_service_history", ["record_type", "date", "data_source_id", "organization_id", "project_id", "project_type", "project_tracking_method"], name: "index_sh_date_ds_org_proj_proj_type", using: :btree
 
   create_table "nightly_census_by_project_clients", force: :cascade do |t|
     t.date     "date",                             null: false
@@ -1823,15 +1831,15 @@ ActiveRecord::Schema.define(version: 20190204194825) do
   end
 
   create_table "recent_report_enrollments", id: false, force: :cascade do |t|
-    t.string   "ProjectEntryID",                               limit: 50
+    t.string   "EnrollmentID",                                 limit: 50
     t.string   "PersonalID"
     t.string   "ProjectID",                                    limit: 50
     t.date     "EntryDate"
     t.string   "HouseholdID"
     t.integer  "RelationshipToHoH"
-    t.integer  "ResidencePrior"
+    t.integer  "LivingSituation"
     t.string   "OtherResidencePrior"
-    t.integer  "ResidencePriorLengthOfStay"
+    t.integer  "LengthOfStay"
     t.integer  "DisablingCondition"
     t.integer  "EntryFromStreetESSH"
     t.date     "DateToStreetESSH"
@@ -1843,7 +1851,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.integer  "HousingStatus"
     t.date     "DateOfEngagement"
     t.integer  "InPermanentHousing"
-    t.date     "ResidentialMoveInDate"
+    t.date     "MoveInDate"
     t.date     "DateOfPATHStatus"
     t.integer  "ClientEnrolledInPATH"
     t.integer  "ReasonNotEnrolled"
@@ -1855,7 +1863,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.string   "LastPermanentZIP",                             limit: 10
     t.integer  "AddressDataQuality"
     t.date     "DateOfBCPStatus"
-    t.integer  "FYSBYouth"
+    t.integer  "EligibleForRHY"
     t.integer  "ReasonNoServices"
     t.integer  "SexualOrientation"
     t.integer  "FormerWardChildWelfare"
@@ -1938,6 +1946,7 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.boolean  "roi_permission"
     t.string   "last_locality"
     t.string   "last_zipcode"
+    t.string   "source_hash"
     t.integer  "demographic_id"
     t.integer  "client_id"
   end
@@ -1976,6 +1985,37 @@ ActiveRecord::Schema.define(version: 20190204194825) do
   add_index "recent_service_history", ["id"], name: "id_rsh_index", unique: true, using: :btree
   add_index "recent_service_history", ["project_tracking_method"], name: "project_tracking_method_rsh_index", using: :btree
   add_index "recent_service_history", ["project_type"], name: "project_type_rsh_index", using: :btree
+
+  create_table "recurring_hmis_exports", force: :cascade do |t|
+    t.integer  "every_n_days"
+    t.string   "reporting_range"
+    t.integer  "reporting_range_days"
+    t.integer  "hmis_export_id"
+    t.date     "start_date"
+    t.date     "end_date"
+    t.integer  "hash_status"
+    t.integer  "period_type"
+    t.integer  "directive"
+    t.boolean  "include_deleted"
+    t.integer  "user_id"
+    t.boolean  "faked_pii"
+    t.string   "project_ids"
+    t.string   "project_group_ids"
+    t.string   "organization_ids"
+    t.string   "data_source_ids"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "s3_region"
+    t.string   "s3_bucket"
+    t.string   "s3_prefix"
+    t.string   "encrypted_s3_access_key_id"
+    t.string   "encrypted_s3_access_key_id_iv"
+    t.string   "encrypted_s3_secret"
+    t.string   "encrypted_s3_secret_iv"
+  end
+
+  add_index "recurring_hmis_exports", ["encrypted_s3_access_key_id_iv"], name: "index_recurring_hmis_exports_on_encrypted_s3_access_key_id_iv", unique: true, using: :btree
+  add_index "recurring_hmis_exports", ["encrypted_s3_secret_iv"], name: "index_recurring_hmis_exports_on_encrypted_s3_secret_iv", unique: true, using: :btree
 
   create_table "report_definitions", force: :cascade do |t|
     t.string  "report_group"
@@ -3136,7 +3176,6 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.integer "destination"
     t.string  "head_of_household_id",            limit: 50
     t.string  "household_id",                    limit: 50
-    t.string  "project_id",                      limit: 50
     t.string  "project_name",                    limit: 150
     t.integer "project_type"
     t.integer "project_tracking_method"
@@ -3157,20 +3196,18 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.boolean "individual_adult",                            default: false, null: false
     t.boolean "individual_elder",                            default: false, null: false
     t.boolean "head_of_household",                           default: false, null: false
+    t.string  "project_id",                      limit: 50
   end
 
-  add_index "warehouse_client_service_history", ["client_id"], name: "index_service_history_on_client_id", using: :btree
-  add_index "warehouse_client_service_history", ["computed_project_type"], name: "index_warehouse_client_service_history_on_computed_project_type", using: :btree
-  add_index "warehouse_client_service_history", ["data_source_id", "organization_id", "project_id", "record_type"], name: "index_sh_ds_id_org_id_proj_id_r_type", using: :btree
-  add_index "warehouse_client_service_history", ["data_source_id"], name: "index_warehouse_client_service_history_on_data_source_id", using: :btree
-  add_index "warehouse_client_service_history", ["date", "data_source_id", "organization_id", "project_id", "project_type"], name: "sh_date_ds_id_org_id_proj_id_proj_type", using: :btree
-  add_index "warehouse_client_service_history", ["enrollment_group_id"], name: "index_warehouse_client_service_history_on_enrollment_group_id", using: :btree
-  add_index "warehouse_client_service_history", ["first_date_in_program"], name: "index_warehouse_client_service_history_on_first_date_in_program", using: :btree
-  add_index "warehouse_client_service_history", ["household_id"], name: "index_warehouse_client_service_history_on_household_id", using: :btree
-  add_index "warehouse_client_service_history", ["last_date_in_program"], name: "index_warehouse_client_service_history_on_last_date_in_program", using: :btree
-  add_index "warehouse_client_service_history", ["project_tracking_method"], name: "index_sh_tracking_method", using: :btree
-  add_index "warehouse_client_service_history", ["project_type"], name: "index_warehouse_client_service_history_on_project_type", using: :btree
-  add_index "warehouse_client_service_history", ["record_type"], name: "index_warehouse_client_service_history_on_record_type", using: :btree
+  add_index "warehouse_client_service_history", ["client_id", "record_type"], name: "index_sh_on_client_id", using: :btree
+  add_index "warehouse_client_service_history", ["computed_project_type", "record_type", "client_id"], name: "index_sh_on_computed_project_type", using: :btree
+  add_index "warehouse_client_service_history", ["data_source_id", "project_id", "organization_id", "record_type"], name: "index_sh_ds_proj_org_r_type", using: :btree
+  add_index "warehouse_client_service_history", ["date", "household_id", "record_type"], name: "index_sh_on_household_id", using: :btree
+  add_index "warehouse_client_service_history", ["date", "record_type", "presented_as_individual"], name: "index_sh_date_r_type_indiv", using: :btree
+  add_index "warehouse_client_service_history", ["enrollment_group_id", "project_tracking_method"], name: "index_sh__enrollment_id_track_meth", using: :btree
+  add_index "warehouse_client_service_history", ["first_date_in_program", "last_date_in_program", "record_type", "date"], name: "index_wsh_on_last_date_in_program", using: :btree
+  add_index "warehouse_client_service_history", ["first_date_in_program"], name: "index_warehouse_client_service_history_on_first_date_in_program", using: :brin
+  add_index "warehouse_client_service_history", ["record_type", "date", "data_source_id", "organization_id", "project_id", "project_type", "project_tracking_method"], name: "index_sh_date_ds_org_proj_proj_type", using: :btree
 
   create_table "warehouse_clients", force: :cascade do |t|
     t.string   "id_in_source",    null: false
@@ -3213,13 +3250,13 @@ ActiveRecord::Schema.define(version: 20190204194825) do
     t.boolean  "enrolled_homeless_shelter"
     t.boolean  "enrolled_homeless_unsheltered"
     t.boolean  "enrolled_permanent_housing"
-    t.integer  "eto_coordinated_entry_assessment_score"
+    t.decimal  "eto_coordinated_entry_assessment_score"
     t.string   "household_members"
     t.string   "last_homeless_visit"
     t.jsonb    "open_enrollments"
     t.boolean  "rrh_desired"
-    t.integer  "vispdat_priority_score"
-    t.integer  "vispdat_score"
+    t.decimal  "vispdat_priority_score"
+    t.decimal  "vispdat_score"
     t.boolean  "active_in_cas_match",                    default: false
   end
 

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -587,7 +587,6 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         map do |row|
           Hash[@cleanup.client_columns.keys.zip(row)]
         end
-
       @dest_attr = @cleanup.choose_attributes_from_sources(@dest_attr, client_sources)
       expect(@ssn1).to eq(@dest_attr[:SSN])
     end

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       expect(destination_client.VeteranStatus).to eq(99)
     end
 
-    it 'only updates veteran status yes/no if some client is yes/no' do
+    it 'maintains the newest veteran status if there is no yes' do
       destination_client.update(VeteranStatus: @veteran)
       source_1.update({VeteranStatus: 99, DateUpdated: 3.days.ago})
       source_2.update({VeteranStatus: 8, DateUpdated: 2.days.ago})
@@ -292,10 +292,23 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         end
       @cleanup.update_client_demographics_based_on_sources
       destination_client.reload
-      expect(destination_client.VeteranStatus).to eq(@veteran)
+      expect(destination_client.VeteranStatus).to eq(8)
     end
 
-    it "overwrites veteran status with the newest yes/no value" do
+    it 'sets to no when override is set, even if newer answer is yes' do
+      destination_client.update(VeteranStatus: @veteran, verified_veteran_status: :non_veteran)
+      source_1.update({VeteranStatus: 99, DateUpdated: 3.days.ago})
+      source_2.update({VeteranStatus: @veteran, DateUpdated: 2.days.ago})
+      client_sources = destination_client.source_clients.pluck(*@cleanup.client_columns.values).
+        map do |row|
+          Hash[@cleanup.client_columns.keys.zip(row)]
+        end
+      @cleanup.update_client_demographics_based_on_sources
+      destination_client.reload
+      expect(destination_client.VeteranStatus).to eq(@civilian)
+    end
+
+    it "maintains veteran status of yes, even when no is newer" do
       destination_client.update(VeteranStatus: @veteran)
       source_1.update({VeteranStatus: @civilian, DateUpdated: 1.day.ago})
       source_2.update({VeteranStatus: @veteran, DateUpdated: 2.days.ago})
@@ -305,7 +318,7 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         end
       @cleanup.update_client_demographics_based_on_sources
       destination_client.reload
-      expect(destination_client.VeteranStatus).to eq(@civilian)
+      expect(destination_client.VeteranStatus).to eq(@veteran)
     end
 
     it "updates veteran status with the newest yes/no value" do
@@ -615,7 +628,7 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       expect(99).to eq(@dest_attr[:VeteranStatus])
     end
 
-    it 'only updates veteran status yes/no if some client is yes/no' do
+    it 'maintains the newest veteran status if there is no yes' do
       @dest_attr[:VeteranStatus] = @veteran
       source_1.update({VeteranStatus: 99, DateUpdated: 3.days.ago})
       source_2.update({VeteranStatus: 8, DateUpdated: 2.days.ago})
@@ -625,10 +638,10 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         end
 
       @dest_attr = @cleanup.choose_attributes_from_sources(@dest_attr, client_sources)
-      expect(@dest_attr[:VeteranStatus]).to eq(@veteran)
+      expect(@dest_attr[:VeteranStatus]).to eq(8)
     end
 
-    it "overwrites veteran status with the newest yes/no value" do
+    it "maintains veteran status of yes, even when no is newer" do
       @dest_attr[:VeteranStatus] = @veteran
       source_1.update({VeteranStatus: @civilian, DateUpdated: 1.day.ago})
       source_2.update({VeteranStatus: @veteran, DateUpdated: 2.days.ago})
@@ -638,7 +651,21 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         end
 
       @dest_attr = @cleanup.choose_attributes_from_sources(@dest_attr, client_sources)
-      expect(@civilian).to eq(@dest_attr[:VeteranStatus])
+      expect(@veteran).to eq(@dest_attr[:VeteranStatus])
+    end
+
+    it 'sets to no when override is set, even if newer answer is yes' do
+      @dest_attr[:VeteranStatus] = @veteran
+      @dest_attr[:verified_veteran_status] = 'non_veteran'
+      source_1.update({VeteranStatus: 99, DateUpdated: 3.days.ago})
+      source_2.update({VeteranStatus: @veteran, DateUpdated: 2.days.ago})
+      client_sources = GrdaWarehouse::Hud::Client.where(id: [source_1.id, source_2.id]).pluck(*@cleanup.client_columns.values).
+        map do |row|
+          Hash[@cleanup.client_columns.keys.zip(row)]
+        end
+
+      @dest_attr = @cleanup.choose_attributes_from_sources(@dest_attr, client_sources)
+      expect(@dest_attr[:VeteranStatus]).to eq(@civilian)
     end
 
     it "updates veteran status with the newest yes/no value" do


### PR DESCRIPTION
This adjusts the veteran status on the warehouse record to use the following logic:
1. If a "verified not a veteran" override has been set on the CAS readiness page, the records is set to VeteranStatus = 0
2. If the client has any "Yes" answers to VeteranStatus, the client is marked a veteran.
3. Otherwise the most recent response is used.

This will need to be back-filled as client cleanup, the main mechanism of maintaining veteran status, only handles client records changed in the past two weeks by default.

Adjusting the setting on the CAS readiness page should have an immediate effect on the warehouse record.

The Veteran? value displayed in the client summary now tracks the warehouse client value instead of the "ever responded veteran yes."