### PR TITLE
Clear the removal_acknowledged flag when a patient rejection is removed

### DIFF
--- a/app/controllers/admin/health/patient_referrals_controller.rb
+++ b/app/controllers/admin/health/patient_referrals_controller.rb
@@ -62,6 +62,8 @@ module Admin::Health
           flash[:notice] = "Patient has been rejected."
         else
           patient.restore if patient.present?
+          # Clean up any removal acknowledgement with the patient
+          @patient_referral.update(removal_acknowledged: false)
           flash[:notice] = "Patient rejection removed."
         end
       else


### PR DESCRIPTION
If a patient rejection is reversed after the removal is marked as acknowledged, the `Health::PatientReferral` instance was left in an inconsistent state.