### PR TITLE
[#167765561] Add ability to select all/none select2 items

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -57,6 +57,7 @@
 //= require table_search
 //= require selectable_list
 //= require viewable_entities
+//= require select_2
 //= require_directory ./census
 //= require_directory ./filter
 //= require_directory ./maps

--- a/app/assets/javascripts/init.js.coffee
+++ b/app/assets/javascripts/init.js.coffee
@@ -1,51 +1,9 @@
 #= require namespace
 App.init = ->
+  App.select2.init()
   $('abbr').tooltip();
   $('[data-toggle="tooltip"]').tooltip();
   $('[data-toggle="popover"]').popover();
-  $('.select2').each () ->
-    $select = $(this)
-    $formGroup = $select.closest('.form-group')
-    $formGroup.addClass('select2-wrapper')
-    $select.select2()
-    if this.getAttribute('allowSelectAll')
-      $select2Container = $select.next('.select2-container')
-      $select2Container.append $("""
-        <div class="select2-select-all j-select2-select-all" data-selected="false" >
-          Select all
-        </div>
-      """)
-      $select.on 'select2:unselect', () =>
-        if $select2Container.hasClass('all-selected')
-          $select2Container.removeClass('all-selected')
-          toggleSelectAll(false)
-      $select.closest('.form-group').on 'click', '.j-select2-select-all', (event)=>
-        toggleSelectAll()
-
-      toggleSelectAll = (updateOptions=true) =>
-        $selectAllLink = $formGroup.find('.select2-select-all')
-        allSelected = $selectAllLink.data('selected')
-        $selectAllLink.data('selected', !allSelected)
-        classAction = 'removeClass'
-        html = 'Select all'
-        if !allSelected
-          classAction = 'addClass'
-          html = 'Select none'
-          $select2Container.find('.select2-selection').append """
-            <div class='select2-selection__choice select2-select-all-message'>
-              <span class='j-select2-select-all' role='presentation'>×</span>
-              All items selected
-            </div>
-          """
-        else
-          $select2Container.find('.select2-select-all-message').remove()
-        $selectAllLink.html(html)
-        $select2Container[classAction]('all-selected')
-        if (updateOptions)
-          $select.find('option').prop("selected", !allSelected);
-        $select.trigger('change')
-        $select.select2('close')
-
   $.fn.datepicker.defaults.format = "M d, yyyy";
   $('.nav-tabs .active-tab').on 'click', 'a', (e)->
     e.preventDefault()

--- a/app/assets/javascripts/init.js.coffee
+++ b/app/assets/javascripts/init.js.coffee
@@ -3,10 +3,49 @@ App.init = ->
   $('abbr').tooltip();
   $('[data-toggle="tooltip"]').tooltip();
   $('[data-toggle="popover"]').popover();
-  # $('.select2').each () ->
-  #   $(this).closest('.form-group').addClass('select2-wrapper')
-  #   $(this).select2()
-  $('.select2').select2()
+  $('.select2').each () ->
+    $select = $(this)
+    $formGroup = $select.closest('.form-group')
+    $formGroup.addClass('select2-wrapper')
+    $select.select2()
+    if this.getAttribute('allowSelectAll')
+      $select2Container = $select.next('.select2-container')
+      $select2Container.append $("""
+        <div class="select2-select-all j-select2-select-all" data-selected="false" >
+          Select all
+        </div>
+      """)
+      $select.on 'select2:unselect', () =>
+        if $select2Container.hasClass('all-selected')
+          $select2Container.removeClass('all-selected')
+          toggleSelectAll(false)
+      $select.closest('.form-group').on 'click', '.j-select2-select-all', (event)=>
+        toggleSelectAll()
+
+      toggleSelectAll = (updateOptions=true) =>
+        $selectAllLink = $formGroup.find('.select2-select-all')
+        allSelected = $selectAllLink.data('selected')
+        $selectAllLink.data('selected', !allSelected)
+        classAction = 'removeClass'
+        html = 'Select all'
+        if !allSelected
+          classAction = 'addClass'
+          html = 'Select none'
+          $select2Container.find('.select2-selection').append """
+            <div class='select2-selection__choice select2-select-all-message'>
+              <span class='j-select2-select-all' role='presentation'>×</span>
+              All items selected
+            </div>
+          """
+        else
+          $select2Container.find('.select2-select-all-message').remove()
+        $selectAllLink.html(html)
+        $select2Container[classAction]('all-selected')
+        if (updateOptions)
+          $select.find('option').prop("selected", !allSelected);
+        $select.trigger('change')
+        $select.select2('close')
+
   $.fn.datepicker.defaults.format = "M d, yyyy";
   $('.nav-tabs .active-tab').on 'click', 'a', (e)->
     e.preventDefault()

--- a/app/assets/javascripts/select_2.js.coffee
+++ b/app/assets/javascripts/select_2.js.coffee
@@ -1,0 +1,45 @@
+#= require ./namespace
+App.select2 ||= {}
+
+App.select2.init = () =>
+  $('.select2').each () ->
+    $select = $(this)
+    $select.select2()
+    # Add select all functionality if has `multiple` attribute
+    if this.hasAttribute('multiple')
+      App.select2.initToggleSelectAll($select)
+
+App.select2.initToggleSelectAll = ($select) =>
+  $formGroup = $select.closest('.form-group')
+  $formGroup.addClass('select2-wrapper')
+  $select2Container = $select.next('.select2-container')
+  $select2Container.append $("""
+    <div class="select2-select-all j-select2-select-all" data-selected="false" >
+      <span class='mr-2'>Select all</span>
+      <i class='icon-checkbox-checked' />
+    </div>
+  """)
+  $select.closest('.form-group').on 'click', '.j-select2-select-all', (event)=>
+    toggleSelectAll()
+
+  toggleSelectAll = (updateOptions=true, options={}) =>
+    $selectAllLink = $formGroup.find('.select2-select-all')
+    allSelected = $selectAllLink.data('selected')
+    $selectAllLink.data('selected', !allSelected)
+    classAction = 'removeClass'
+    html = """
+      <span class='mr-2'>Select all</span>
+      <i class='icon-checkbox-checked' />
+    """
+    if !allSelected
+      classAction = 'addClass'
+      html = """
+        <span class='mr-2'>Select none</span>
+        <i class='icon-checkbox-unchecked' />
+      """
+    $selectAllLink.html(html)
+    $select2Container[classAction]('all-selected')
+    if (updateOptions)
+      $select.find('option').prop("selected", !allSelected);
+    $select.trigger('change')
+    $select.select2('close')

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -8,6 +8,11 @@
 .select2-container {
   display: inline-flex;
   width: 100% !important;
+  &.all-selected {
+    .select2-selection__rendered {
+      display: none;
+    }
+  }
 }
 
 .select2-container .selection {
@@ -87,4 +92,25 @@
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice {
   margin: 2px 2px 2px 0;
+}
+
+.select2-select-all {
+  position: absolute;
+  right: space(4);
+  z-index: 10;
+  cursor: pointer;
+  color: $link-color;
+  max-height: 40px;
+  &:hover {
+    color: $link-hover-color;
+  }
+  top: 50%;
+  transform: translate(0, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.select2-select-all-message {
+
 }

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -8,11 +8,6 @@
 .select2-container {
   display: inline-flex;
   width: 100% !important;
-  &.all-selected {
-    .select2-selection__rendered {
-      display: none;
-    }
-  }
 }
 
 .select2-container .selection {
@@ -96,21 +91,20 @@
 
 .select2-select-all {
   position: absolute;
-  right: space(4);
+  right: 1px;
+  top: 2px;
   z-index: 10;
+  background: rgba($gray-100, .9);
   cursor: pointer;
   color: $link-color;
-  max-height: 40px;
+  min-height: 40px;
   &:hover {
     color: $link-hover-color;
+    cursor: pointer;
   }
-  top: 50%;
-  transform: translate(0, -50%);
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.select2-select-all-message {
-
+  padding-right: space(6);
+  padding-left: space(4);
 }

--- a/app/inputs/select2_input.rb
+++ b/app/inputs/select2_input.rb
@@ -1,0 +1,7 @@
+# class Select2Input < ::CollectionSelectInput
+#   def input_html_options
+#     super.tap do |opts|
+#       opts[:multiple] = "#{options[:multiple].present? ? options[:multiple] : false}"
+#     end
+#   end
+# end

--- a/app/views/warehouse_reports/psh/_form.haml
+++ b/app/views/warehouse_reports/psh/_form.haml
@@ -1,6 +1,6 @@
 = simple_form_for @filter, as: :filter, url: warehouse_reports_psh_index_path, method: :get do |f|
   - content_for :filters_col_full do
-    = f.input :project_ids, collection: @available_projects, input_html: {class: :select2, multiple: true, data: {placeholder: 'All' }}, include_blank: false, label: 'Projects'
+    = f.input :project_ids, collection: @available_projects, input_html: {class: :select2, multiple: true, data: {placeholder: 'All' }, allowSelectAll: true}, include_blank: false, label: 'Projects'
     .row
       .col-sm-3
         = f.input :start_date, collection: @start_months, label: 'Start', input_html: {class: :select2}

--- a/app/views/warehouse_reports/psh/_form.haml
+++ b/app/views/warehouse_reports/psh/_form.haml
@@ -1,6 +1,6 @@
 = simple_form_for @filter, as: :filter, url: warehouse_reports_psh_index_path, method: :get do |f|
   - content_for :filters_col_full do
-    = f.input :project_ids, collection: @available_projects, input_html: {class: :select2, multiple: true, data: {placeholder: 'All' }, allowSelectAll: true}, include_blank: false, label: 'Projects'
+    = f.input :project_ids, collection: @available_projects, input_html: {class: :select2, multiple: true, data: {placeholder: 'All'}}, include_blank: false, label: 'Projects'
     .row
       .col-sm-3
         = f.input :start_date, collection: @start_months, label: 'Start', input_html: {class: :select2}


### PR DESCRIPTION
@eanders This commit adds functionality to select all/none for select2s:
It's dependent on the select having the `allowSelectAll` attribute.
There is one weird UX thing: when all are selected and one is removed from the selection, the input expands with chips with all but that one unselected item. It's what needs to happen but the change in UI may be jarring. I suppose we could implement something that controls the number of chips showing?

![Screen Shot 2019-08-22 at 1 28 36 PM](https://user-images.githubusercontent.com/4105343/63540152-2f31f680-c4e1-11e9-9e54-d05d9d854368.png)


![Screen Shot 2019-08-22 at 1 28 41 PM](https://user-images.githubusercontent.com/4105343/63540156-31945080-c4e1-11e9-8a43-45885b00e8f3.png)


**Also**: I ran into a few issues with creating the select2 simple_form type (or an extended subclass, i suppose). I think there a some instances where the select tags are generated in a class (`Select`). I suppose we can circle back to this.