### PR TITLE
Idea: Add resetting of test dbs in bin/update script

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -24,6 +24,7 @@ chdir APP_ROOT do
   system! 'bundle exec rake health:db:migrate'
   system! 'bundle exec rake reporting:db:migrate'
 
+
   puts "\n== Updating NPM =="
   system! 'npm install'
 
@@ -34,6 +35,26 @@ chdir APP_ROOT do
   system 'puma-dev -stop'
   restart = File.join ['tmp', 'restart.txt']
   FileUtils.touch restart
+
+  puts "\n== Resetting test db =="
+  require 'dotenv/load'
+  [
+    'DATABASE_DB_TEST',
+    'DATABASE_APP_DB_TEST',
+    'WAREHOUSE_DATABASE_DB_TEST',
+    'HEALTH_DATABASE_DB_TEST',
+    'REPORTING_DATABASE_DB_TEST',
+  ].each do |var|
+    db_name = ENV[var]
+    if db_name.to_s != ''
+      system "dropdb #{db_name}; createdb #{db_name}";
+    end
+  end
+  system! 'RAILS_ENV=test; bundle exec rake db:schema:load'
+  system! 'RAILS_ENV=test; bundle exec rake warehouse:db:schema:load'
+  system! 'RAILS_ENV=test; bundle exec rake health:db:schema:load'
+  system! 'RAILS_ENV=test; bundle exec rake reporting:db:schema:load'
+
 
   puts "\n== TODO: You may need to restart background workers etc and clear caches"
 end

--- a/db/health/schema.rb
+++ b/db/health/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.datetime "appointment_time"
     t.string   "id_in_source"
     t.string   "patient_id"
-    t.integer  "data_source_id",   default: 6, null: false
+    t.integer  "data_source_id",   default: 1, null: false
   end
 
   create_table "careplan_equipment", force: :cascade do |t|
@@ -426,7 +426,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.datetime "goal_created_at"
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
-    t.integer  "data_source_id",           default: 6, null: false
+    t.integer  "data_source_id",           default: 1, null: false
   end
 
   add_index "epic_goals", ["patient_id"], name: "index_epic_goals_on_patient_id", using: :btree
@@ -453,7 +453,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.string   "housing_status"
     t.datetime "housing_status_timestamp"
     t.boolean  "pilot",                    default: false, null: false
-    t.integer  "data_source_id",           default: 6,     null: false
+    t.integer  "data_source_id",           default: 1,     null: false
     t.datetime "deleted_at"
     t.date     "death_date"
   end
@@ -590,7 +590,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.datetime "updated_at",                 null: false
     t.string   "id_in_source"
     t.string   "patient_id"
-    t.integer  "data_source_id", default: 6, null: false
+    t.integer  "data_source_id", default: 1, null: false
   end
 
   create_table "member_status_report_patients", force: :cascade do |t|
@@ -688,6 +688,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.integer  "rejected_reason",                  default: 0,     null: false
     t.integer  "patient_id"
     t.integer  "accountable_care_organization_id"
+    t.datetime "effective_date"
     t.string   "middle_initial"
     t.string   "suffix"
     t.string   "gender"
@@ -734,7 +735,6 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.date     "record_updated_on"
     t.date     "exported_on"
     t.boolean  "removal_acknowledged",             default: false
-    t.datetime "effective_date"
     t.date     "disenrollment_date"
     t.string   "stop_reason_description"
     t.date     "pending_disenrollment_date"
@@ -763,10 +763,10 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.string   "housing_status"
     t.datetime "housing_status_timestamp"
     t.boolean  "pilot",                    default: false, null: false
-    t.integer  "data_source_id",           default: 6,     null: false
+    t.datetime "deleted_at"
+    t.integer  "data_source_id",           default: 1,     null: false
     t.date     "engagement_date"
     t.integer  "care_coordinator_id"
-    t.datetime "deleted_at"
     t.date     "death_date"
     t.string   "coverage_level"
     t.date     "coverage_inquiry_date"
@@ -802,7 +802,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.datetime "updated_at",                 null: false
     t.string   "id_in_source"
     t.string   "patient_id"
-    t.integer  "data_source_id", default: 6, null: false
+    t.integer  "data_source_id", default: 1, null: false
   end
 
   create_table "qualifying_activities", force: :cascade do |t|
@@ -1069,7 +1069,7 @@ ActiveRecord::Schema.define(version: 20190905170546) do
     t.datetime "updated_at",                  null: false
     t.string   "patient_id"
     t.datetime "date_of_service"
-    t.integer  "data_source_id",  default: 6, null: false
+    t.integer  "data_source_id",  default: 1, null: false
   end
 
   add_foreign_key "comprehensive_health_assessments", "health_files"

--- a/db/reporting/schema.rb
+++ b/db/reporting/schema.rb
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 20190802160019) do
     t.integer  "prior_exit_project_type"
     t.integer  "prior_exit_destination_id"
     t.datetime "calculated_at",                             null: false
-    t.integer  "enrollment_id"
+    t.integer  "enrollment_id",                             null: false
   end
 
   add_index "warehouse_monthly_reports", ["active"], name: "index_warehouse_monthly_reports_on_active", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 20191022181527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "fuzzystrmatch"
   enable_extension "hstore"
+  enable_extension "fuzzystrmatch"
 
   create_table "activity_logs", force: :cascade do |t|
     t.string   "item_model"
@@ -36,8 +36,6 @@ ActiveRecord::Schema.define(version: 20191022181527) do
 
   add_index "activity_logs", ["controller_name"], name: "index_activity_logs_on_controller_name", using: :btree
   add_index "activity_logs", ["created_at", "item_model", "user_id"], name: "index_activity_logs_on_created_at_and_item_model_and_user_id", using: :btree
-  add_index "activity_logs", ["created_at"], name: "activity_logs_created_at_idx", using: :brin
-  add_index "activity_logs", ["created_at"], name: "created_at_idx", using: :brin
   add_index "activity_logs", ["item_model", "user_id", "created_at"], name: "index_activity_logs_on_item_model_and_user_id_and_created_at", using: :btree
   add_index "activity_logs", ["item_model", "user_id"], name: "index_activity_logs_on_item_model_and_user_id", using: :btree
   add_index "activity_logs", ["item_model"], name: "index_activity_logs_on_item_model", using: :btree
@@ -49,29 +47,6 @@ ActiveRecord::Schema.define(version: 20191022181527) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
-  create_table "cas_reports", force: :cascade do |t|
-    t.integer  "client_id",                                          null: false
-    t.integer  "match_id",                                           null: false
-    t.integer  "decision_id",                                        null: false
-    t.integer  "decision_order",                                     null: false
-    t.string   "match_step",                                         null: false
-    t.string   "decision_status",                                    null: false
-    t.boolean  "current_step",                       default: false, null: false
-    t.boolean  "active_match",                       default: false, null: false
-    t.datetime "created_at",                                         null: false
-    t.datetime "updated_at",                                         null: false
-    t.integer  "elapsed_days",                       default: 0,     null: false
-    t.datetime "client_last_seen_date"
-    t.datetime "criminal_hearing_date"
-    t.string   "decline_reason"
-    t.string   "not_working_with_client_reason"
-    t.string   "administrative_cancel_reason"
-    t.boolean  "client_spoken_with_services_agency"
-    t.boolean  "cori_release_form_submitted"
-  end
-
-  add_index "cas_reports", ["client_id", "match_id", "decision_id"], name: "index_cas_reports_on_client_id_and_match_id_and_decision_id", unique: true, using: :btree
 
   create_table "client_service_history", id: false, force: :cascade do |t|
     t.integer "unduplicated_client_id"
@@ -264,109 +239,104 @@ ActiveRecord::Schema.define(version: 20191022181527) do
     t.string   "verb"
     t.datetime "created_at",                                                          null: false
     t.datetime "updated_at",                                                          null: false
+    t.boolean  "can_edit_anything_super_user",                        default: false
     t.boolean  "can_view_clients",                                    default: false
     t.boolean  "can_edit_clients",                                    default: false
+    t.boolean  "can_audit_clients",                                   default: false
     t.boolean  "can_view_censuses",                                   default: false
     t.boolean  "can_view_census_details",                             default: false
     t.boolean  "can_edit_users",                                      default: false
+    t.boolean  "can_edit_roles",                                      default: false
+    t.boolean  "can_audit_users",                                     default: false
     t.boolean  "can_view_full_ssn",                                   default: false
     t.boolean  "can_view_full_dob",                                   default: false
     t.boolean  "can_view_hiv_status",                                 default: false
     t.boolean  "can_view_dmh_status",                                 default: false
     t.boolean  "can_view_imports",                                    default: false
-    t.boolean  "can_edit_roles",                                      default: false
     t.boolean  "can_view_projects",                                   default: false
-    t.boolean  "can_view_organizations",                              default: false
-    t.boolean  "can_view_client_window",                              default: false
-    t.boolean  "can_upload_hud_zips",                                 default: false
-    t.boolean  "can_administer_health",                               default: false
-    t.boolean  "can_edit_client_health",                              default: false
-    t.boolean  "can_view_client_health",                              default: false
-    t.boolean  "health_role",                                         default: false, null: false
-    t.boolean  "can_edit_project_groups",                             default: false
-    t.boolean  "can_edit_anything_super_user",                        default: false
     t.boolean  "can_edit_projects",                                   default: false
+    t.boolean  "can_edit_project_groups",                             default: false
+    t.boolean  "can_view_organizations",                              default: false
     t.boolean  "can_edit_organizations",                              default: false
     t.boolean  "can_edit_data_sources",                               default: false
+    t.boolean  "can_search_window",                                   default: false
+    t.boolean  "can_view_client_window",                              default: false
+    t.boolean  "can_upload_hud_zips",                                 default: false
     t.boolean  "can_edit_translations",                               default: false
     t.boolean  "can_manage_assessments",                              default: false
-    t.boolean  "can_manage_config",                                   default: false
-    t.boolean  "can_edit_dq_grades",                                  default: false
     t.boolean  "can_manage_client_files",                             default: false
     t.boolean  "can_manage_window_client_files",                      default: false
+    t.boolean  "can_see_own_file_uploads",                            default: false
+    t.boolean  "can_manage_config",                                   default: false
+    t.boolean  "can_edit_dq_grades",                                  default: false
     t.boolean  "can_view_vspdat",                                     default: false
     t.boolean  "can_edit_vspdat",                                     default: false
+    t.boolean  "can_submit_vspdat",                                   default: false
+    t.boolean  "can_view_youth_intake",                               default: false
+    t.boolean  "can_edit_youth_intake",                               default: false
+    t.boolean  "can_view_own_agency_youth_intake",                    default: false
+    t.boolean  "can_edit_own_agency_youth_intake",                    default: false
     t.boolean  "can_create_clients",                                  default: false
     t.boolean  "can_view_client_history_calendar",                    default: false
-    t.boolean  "can_view_aggregate_health",                           default: false
-    t.boolean  "can_assign_users_to_clients",                         default: false
-    t.boolean  "can_view_client_user_assignments",                    default: false
-    t.boolean  "can_export_hmis_data",                                default: false
-    t.boolean  "can_confirm_housing_release",                         default: false
-    t.boolean  "can_see_own_file_uploads",                            default: false
-    t.boolean  "can_search_window",                                   default: false
-    t.boolean  "can_submit_vspdat",                                   default: false
     t.boolean  "can_edit_client_notes",                               default: false
     t.boolean  "can_edit_window_client_notes",                        default: false
     t.boolean  "can_see_own_window_client_notes",                     default: false
-    t.boolean  "can_track_anomalies",                                 default: false
-    t.boolean  "can_view_all_reports",                                default: false
-    t.boolean  "can_assign_reports",                                  default: false
-    t.boolean  "can_view_assigned_reports",                           default: false
-    t.boolean  "can_view_reports",                                    default: false
     t.boolean  "can_manage_cohorts",                                  default: false
     t.boolean  "can_edit_cohort_clients",                             default: false
     t.boolean  "can_edit_assigned_cohorts",                           default: false
     t.boolean  "can_view_assigned_cohorts",                           default: false
-    t.boolean  "can_manage_organization_users",                       default: false
-    t.boolean  "can_add_administrative_event",                        default: false
+    t.boolean  "can_assign_users_to_clients",                         default: false
+    t.boolean  "can_view_client_user_assignments",                    default: false
+    t.boolean  "can_export_hmis_data",                                default: false
+    t.boolean  "can_export_anonymous_hmis_data",                      default: false
+    t.boolean  "can_confirm_housing_release",                         default: false
+    t.boolean  "can_track_anomalies",                                 default: false
+    t.boolean  "can_view_all_reports",                                default: false
+    t.boolean  "can_assign_reports",                                  default: false
+    t.boolean  "can_view_assigned_reports",                           default: false
     t.boolean  "can_view_project_data_quality_client_details",        default: false
-    t.boolean  "can_manage_health_agency",                            default: false, null: false
+    t.boolean  "can_view_all_user_client_assignments",                default: false
+    t.boolean  "can_add_administrative_event",                        default: false
+    t.boolean  "can_see_clients_in_window_for_assigned_data_sources", default: false
+    t.boolean  "can_upload_deidentified_hud_hmis_files",              default: false
+    t.boolean  "can_upload_whitelisted_hud_hmis_files",               default: false
+    t.boolean  "can_edit_warehouse_alerts",                           default: false
+    t.boolean  "can_upload_dashboard_extras",                         default: false
+    t.boolean  "can_view_all_secure_uploads",                         default: false
+    t.boolean  "can_view_assigned_secure_uploads",                    default: false
+    t.boolean  "can_manage_agency",                                   default: false
+    t.boolean  "can_manage_all_agencies",                             default: false
+    t.boolean  "can_view_clients_with_roi_in_own_coc",                default: false
+    t.boolean  "can_administer_health",                               default: false
+    t.boolean  "can_edit_client_health",                              default: false
+    t.boolean  "can_view_client_health",                              default: false
+    t.boolean  "can_view_aggregate_health",                           default: false
+    t.boolean  "can_manage_health_agency",                            default: false
     t.boolean  "can_approve_patient_assignments",                     default: false
     t.boolean  "can_manage_claims",                                   default: false
     t.boolean  "can_manage_all_patients",                             default: false
     t.boolean  "can_manage_patients_for_own_agency",                  default: false
+    t.boolean  "can_manage_care_coordinators",                        default: false
+    t.boolean  "can_approve_cha",                                     default: false
+    t.boolean  "can_approve_ssm",                                     default: false
+    t.boolean  "can_approve_release",                                 default: false
+    t.boolean  "can_approve_participation",                           default: false
     t.boolean  "can_edit_all_patient_items",                          default: false
     t.boolean  "can_edit_patient_items_for_own_agency",               default: false
     t.boolean  "can_create_care_plans_for_own_agency",                default: false
     t.boolean  "can_view_all_patients",                               default: false
     t.boolean  "can_view_patients_for_own_agency",                    default: false
     t.boolean  "can_add_case_management_notes",                       default: false
-    t.boolean  "can_see_clients_in_window_for_assigned_data_sources", default: false
-    t.boolean  "can_approve_patient_items_for_agency",                default: false
-    t.boolean  "can_approve_cha",                                     default: false
-    t.boolean  "can_approve_ssm",                                     default: false
-    t.boolean  "can_approve_release",                                 default: false
-    t.boolean  "can_approve_participation",                           default: false
-    t.boolean  "can_manage_care_coordinators",                        default: false
     t.boolean  "can_manage_accountable_care_organizations",           default: false
     t.boolean  "can_view_member_health_reports",                      default: false
-    t.boolean  "can_edit_warehouse_alerts",                           default: false
-    t.boolean  "can_upload_deidentified_hud_hmis_files",              default: false
-    t.boolean  "can_upload_whitelisted_hud_hmis_files",               default: false
-    t.boolean  "can_upload_dashboard_extras",                         default: false
-    t.boolean  "can_view_all_user_client_assignments",                default: false
-    t.boolean  "can_audit_users",                                     default: false
-    t.boolean  "can_audit_clients",                                   default: false
-    t.boolean  "can_export_anonymous_hmis_data",                      default: false
-    t.boolean  "can_view_youth_intake",                               default: false
-    t.boolean  "can_edit_youth_intake",                               default: false
-    t.boolean  "can_view_all_secure_uploads",                         default: false
     t.boolean  "can_unsubmit_submitted_claims",                       default: false
-    t.boolean  "can_view_assigned_secure_uploads",                    default: false
-    t.boolean  "can_manage_agency",                                   default: false
-    t.boolean  "can_manage_all_agencies",                             default: false
-    t.boolean  "can_view_own_agency_youth_intake",                    default: false
-    t.boolean  "can_edit_own_agency_youth_intake",                    default: false
-    t.boolean  "can_view_clients_with_roi_in_own_coc",                default: false
+    t.boolean  "health_role",                                         default: false, null: false
     t.boolean  "can_enable_2fa",                                      default: false
+    t.boolean  "enforced_2fa",                                        default: false
     t.boolean  "can_view_ce_assessment",                              default: false
     t.boolean  "can_edit_ce_assessment",                              default: false
     t.boolean  "can_submit_ce_assessment",                            default: false
     t.boolean  "can_edit_help",                                       default: false
-    t.boolean  "can_view_all_hud_reports",                            default: false
-    t.boolean  "can_view_own_hud_reports",                            default: false
-    t.boolean  "enforced_2fa",                                        default: false
   end
 
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree

--- a/db/warehouse/schema.rb
+++ b/db/warehouse/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "fuzzystrmatch"
-  enable_extension "hstore"
   enable_extension "pgcrypto"
 
   create_table "Affiliation", force: :cascade do |t|
@@ -204,6 +203,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "Client", ["LastName"], name: "client_last_name", using: :btree
   add_index "Client", ["PersonalID"], name: "client_personal_id", using: :btree
   add_index "Client", ["creator_id"], name: "index_Client_on_creator_id", using: :btree
+  add_index "Client", ["data_source_id", "PersonalID"], name: "index_Client_on_data_source_id_PersonalID", using: :btree
   add_index "Client", ["data_source_id"], name: "index_Client_on_data_source_id", using: :btree
   add_index "Client", ["pending_date_deleted"], name: "index_Client_on_pending_date_deleted", using: :btree
 
@@ -264,17 +264,14 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   end
 
   add_index "Disabilities", ["DateCreated"], name: "disabilities_date_created", using: :btree
-  add_index "Disabilities", ["DateDeleted", "data_source_id"], name: "Disabilities_DateDeleted_data_source_id_idx", where: "(\"DateDeleted\" IS NULL)", using: :btree
-  add_index "Disabilities", ["DateDeleted", "data_source_id"], name: "Disabilities_DateDeleted_data_source_id_idx1", where: "(\"DateDeleted\" IS NULL)", using: :btree
   add_index "Disabilities", ["DateDeleted", "data_source_id"], name: "index_Disabilities_on_DateDeleted_and_data_source_id", using: :btree
-  add_index "Disabilities", ["DateDeleted"], name: "Disabilities_DateDeleted_idx", where: "(\"DateDeleted\" IS NULL)", using: :btree
   add_index "Disabilities", ["DateUpdated"], name: "disabilities_date_updated", using: :btree
   add_index "Disabilities", ["DisabilityType", "DisabilityResponse", "InformationDate", "PersonalID", "EnrollmentID", "DateDeleted"], name: "disabilities_disability_type_response_idx", using: :btree
   add_index "Disabilities", ["EnrollmentID"], name: "index_Disabilities_on_EnrollmentID", using: :btree
   add_index "Disabilities", ["ExportID"], name: "disabilities_export_id", using: :btree
   add_index "Disabilities", ["PersonalID"], name: "index_Disabilities_on_PersonalID", using: :btree
   add_index "Disabilities", ["data_source_id", "DisabilitiesID"], name: "unk_Disabilities", unique: true, using: :btree
-  add_index "Disabilities", ["data_source_id", "PersonalID"], name: "index_Disabilities_on_data_source_id_and_PersonalID", using: :btree
+  add_index "Disabilities", ["data_source_id", "PersonalID"], name: "index_Disabilities_on_data_source_id_PersonalID", using: :btree
   add_index "Disabilities", ["data_source_id"], name: "index_Disabilities_on_data_source_id", using: :btree
   add_index "Disabilities", ["pending_date_deleted"], name: "index_Disabilities_on_pending_date_deleted", using: :btree
 
@@ -306,7 +303,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "EmploymentEducation", ["ExportID"], name: "employment_education_export_id", using: :btree
   add_index "EmploymentEducation", ["PersonalID"], name: "index_EmploymentEducation_on_PersonalID", using: :btree
   add_index "EmploymentEducation", ["data_source_id", "EmploymentEducationID"], name: "unk_EmploymentEducation", unique: true, using: :btree
-  add_index "EmploymentEducation", ["data_source_id", "PersonalID"], name: "index_EmploymentEducation_on_data_source_id_and_PersonalID", using: :btree
+  add_index "EmploymentEducation", ["data_source_id", "PersonalID"], name: "index_EmploymentEducation_on_data_source_id_PersonalID", using: :btree
   add_index "EmploymentEducation", ["data_source_id"], name: "index_EmploymentEducation_on_data_source_id", using: :btree
   add_index "EmploymentEducation", ["pending_date_deleted"], name: "index_EmploymentEducation_on_pending_date_deleted", using: :btree
 
@@ -442,7 +439,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "Enrollment", ["ProjectID"], name: "index_Enrollment_on_ProjectID", using: :btree
   add_index "Enrollment", ["data_source_id", "EnrollmentID", "PersonalID"], name: "unk_Enrollment", unique: true, using: :btree
   add_index "Enrollment", ["data_source_id", "HouseholdID", "ProjectID"], name: "idx_enrollment_ds_id_hh_id_p_id", using: :btree
-  add_index "Enrollment", ["data_source_id", "PersonalID"], name: "index_Enrollment_on_data_source_id_and_PersonalID", using: :btree
+  add_index "Enrollment", ["data_source_id", "PersonalID"], name: "index_Enrollment_on_data_source_id_PersonalID", using: :btree
   add_index "Enrollment", ["data_source_id"], name: "index_Enrollment_on_data_source_id", using: :btree
   add_index "Enrollment", ["pending_date_deleted"], name: "index_Enrollment_on_pending_date_deleted", using: :btree
 
@@ -471,7 +468,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "EnrollmentCoC", ["EnrollmentCoCID"], name: "index_EnrollmentCoC_on_EnrollmentCoCID", using: :btree
   add_index "EnrollmentCoC", ["ExportID"], name: "enrollment_coc_export_id", using: :btree
   add_index "EnrollmentCoC", ["data_source_id", "EnrollmentCoCID"], name: "unk_EnrollmentCoC", unique: true, using: :btree
-  add_index "EnrollmentCoC", ["data_source_id", "PersonalID"], name: "index_EnrollmentCoC_on_data_source_id_and_PersonalID", using: :btree
+  add_index "EnrollmentCoC", ["data_source_id", "PersonalID"], name: "index_EnrollmentCoC_on_data_source_id_PersonalID", using: :btree
   add_index "EnrollmentCoC", ["data_source_id"], name: "index_EnrollmentCoC_on_data_source_id", using: :btree
   add_index "EnrollmentCoC", ["pending_date_deleted"], name: "index_EnrollmentCoC_on_pending_date_deleted", using: :btree
 
@@ -571,7 +568,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "Exit", ["ExportID"], name: "exit_export_id", using: :btree
   add_index "Exit", ["PersonalID"], name: "index_Exit_on_PersonalID", using: :btree
   add_index "Exit", ["data_source_id", "ExitID"], name: "unk_Exit", unique: true, using: :btree
-  add_index "Exit", ["data_source_id", "PersonalID"], name: "index_Exit_on_data_source_id_and_PersonalID", using: :btree
+  add_index "Exit", ["data_source_id", "PersonalID"], name: "index_Exit_on_data_source_id_PersonalID", using: :btree
   add_index "Exit", ["data_source_id"], name: "index_Exit_on_data_source_id", using: :btree
   add_index "Exit", ["pending_date_deleted"], name: "index_Exit_on_pending_date_deleted", using: :btree
 
@@ -659,7 +656,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "Geography", ["DateUpdated"], name: "site_date_updated", using: :btree
   add_index "Geography", ["ExportID"], name: "site_export_id", using: :btree
   add_index "Geography", ["data_source_id", "GeographyID"], name: "unk_Geography", unique: true, using: :btree
-  add_index "Geography", ["data_source_id", "GeographyID"], name: "unk_Site", unique: true, using: :btree
   add_index "Geography", ["data_source_id"], name: "index_Geography_on_data_source_id", using: :btree
   add_index "Geography", ["pending_date_deleted"], name: "index_Geography_on_pending_date_deleted", using: :btree
 
@@ -694,7 +690,7 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "HealthAndDV", ["ExportID"], name: "health_and_dv_export_id", using: :btree
   add_index "HealthAndDV", ["PersonalID"], name: "index_HealthAndDV_on_PersonalID", using: :btree
   add_index "HealthAndDV", ["data_source_id", "HealthAndDVID"], name: "unk_HealthAndDV", unique: true, using: :btree
-  add_index "HealthAndDV", ["data_source_id", "PersonalID"], name: "index_HealthAndDV_on_data_source_id_and_PersonalID", using: :btree
+  add_index "HealthAndDV", ["data_source_id", "PersonalID"], name: "index_HealthAndDV_on_data_source_id_PersonalID", using: :btree
   add_index "HealthAndDV", ["data_source_id"], name: "index_HealthAndDV_on_data_source_id", using: :btree
   add_index "HealthAndDV", ["pending_date_deleted"], name: "index_HealthAndDV_on_pending_date_deleted", using: :btree
 
@@ -784,16 +780,13 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   end
 
   add_index "IncomeBenefits", ["DateCreated"], name: "income_benefits_date_created", using: :btree
-  add_index "IncomeBenefits", ["DateDeleted", "data_source_id"], name: "IncomeBenefits_DateDeleted_data_source_id_idx", where: "(\"DateDeleted\" IS NULL)", using: :btree
   add_index "IncomeBenefits", ["DateDeleted", "data_source_id"], name: "index_IncomeBenefits_on_DateDeleted_and_data_source_id", using: :btree
-  add_index "IncomeBenefits", ["DateDeleted"], name: "IncomeBenefits_DateDeleted_idx", where: "(\"DateDeleted\" IS NULL)", using: :btree
   add_index "IncomeBenefits", ["DateUpdated"], name: "income_benefits_date_updated", using: :btree
   add_index "IncomeBenefits", ["EnrollmentID"], name: "index_IncomeBenefits_on_EnrollmentID", using: :btree
   add_index "IncomeBenefits", ["ExportID"], name: "income_benefits_export_id", using: :btree
   add_index "IncomeBenefits", ["PersonalID"], name: "index_IncomeBenefits_on_PersonalID", using: :btree
-  add_index "IncomeBenefits", ["data_source_id", "DateDeleted"], name: "IncomeBenefits_data_source_id_DateDeleted_idx", where: "(\"DateDeleted\" IS NULL)", using: :btree
   add_index "IncomeBenefits", ["data_source_id", "IncomeBenefitsID"], name: "unk_IncomeBenefits", unique: true, using: :btree
-  add_index "IncomeBenefits", ["data_source_id", "PersonalID"], name: "index_IncomeBenefits_on_data_source_id_and_PersonalID", using: :btree
+  add_index "IncomeBenefits", ["data_source_id", "PersonalID"], name: "index_IncomeBenefits_on_data_source_id_PersonalID", using: :btree
   add_index "IncomeBenefits", ["data_source_id"], name: "index_IncomeBenefits_on_data_source_id", using: :btree
   add_index "IncomeBenefits", ["pending_date_deleted"], name: "index_IncomeBenefits_on_pending_date_deleted", using: :btree
 
@@ -1076,19 +1069,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "cas_availabilities", ["available_at"], name: "index_cas_availabilities_on_available_at", using: :btree
   add_index "cas_availabilities", ["client_id"], name: "index_cas_availabilities_on_client_id", using: :btree
   add_index "cas_availabilities", ["unavailable_at"], name: "index_cas_availabilities_on_unavailable_at", using: :btree
-
-  create_table "cas_enrollments", force: :cascade do |t|
-    t.integer  "client_id"
-    t.integer  "enrollment_id"
-    t.date     "entry_date"
-    t.date     "exit_date"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.json     "history"
-  end
-
-  add_index "cas_enrollments", ["client_id"], name: "index_cas_enrollments_on_client_id", using: :btree
-  add_index "cas_enrollments", ["enrollment_id"], name: "index_cas_enrollments_on_enrollment_id", using: :btree
 
   create_table "cas_houseds", force: :cascade do |t|
     t.integer "client_id",                     null: false
@@ -1678,10 +1658,10 @@ ActiveRecord::Schema.define(version: 20191017141927) do
     t.integer  "data_source_id",              null: false
     t.integer  "client_id",                   null: false
     t.string   "enterprise_guid",             null: false
+    t.integer  "participant_site_identifier", null: false
     t.integer  "site_id",                     null: false
     t.integer  "subject_id",                  null: false
     t.datetime "last_updated"
-    t.integer  "participant_site_identifier"
   end
 
   add_index "eto_client_lookups", ["client_id"], name: "index_eto_client_lookups_on_client_id", using: :btree
@@ -2298,163 +2278,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
   end
-
-  create_table "recent_report_enrollments", id: false, force: :cascade do |t|
-    t.string   "EnrollmentID",                                 limit: 50
-    t.string   "PersonalID"
-    t.string   "ProjectID",                                    limit: 50
-    t.date     "EntryDate"
-    t.string   "HouseholdID"
-    t.integer  "RelationshipToHoH"
-    t.integer  "LivingSituation"
-    t.string   "OtherResidencePrior"
-    t.integer  "LengthOfStay"
-    t.integer  "DisablingCondition"
-    t.integer  "EntryFromStreetESSH"
-    t.date     "DateToStreetESSH"
-    t.integer  "ContinuouslyHomelessOneYear"
-    t.integer  "TimesHomelessPastThreeYears"
-    t.integer  "MonthsHomelessPastThreeYears"
-    t.integer  "MonthsHomelessThisTime"
-    t.integer  "StatusDocumented"
-    t.integer  "HousingStatus"
-    t.date     "DateOfEngagement"
-    t.integer  "InPermanentHousing"
-    t.date     "MoveInDate"
-    t.date     "DateOfPATHStatus"
-    t.integer  "ClientEnrolledInPATH"
-    t.integer  "ReasonNotEnrolled"
-    t.integer  "WorstHousingSituation"
-    t.integer  "PercentAMI"
-    t.string   "LastPermanentStreet"
-    t.string   "LastPermanentCity",                            limit: 50
-    t.string   "LastPermanentState",                           limit: 2
-    t.string   "LastPermanentZIP",                             limit: 10
-    t.integer  "AddressDataQuality"
-    t.date     "DateOfBCPStatus"
-    t.integer  "EligibleForRHY"
-    t.integer  "ReasonNoServices"
-    t.integer  "SexualOrientation"
-    t.integer  "FormerWardChildWelfare"
-    t.integer  "ChildWelfareYears"
-    t.integer  "ChildWelfareMonths"
-    t.integer  "FormerWardJuvenileJustice"
-    t.integer  "JuvenileJusticeYears"
-    t.integer  "JuvenileJusticeMonths"
-    t.integer  "HouseholdDynamics"
-    t.integer  "SexualOrientationGenderIDYouth"
-    t.integer  "SexualOrientationGenderIDFam"
-    t.integer  "HousingIssuesYouth"
-    t.integer  "HousingIssuesFam"
-    t.integer  "SchoolEducationalIssuesYouth"
-    t.integer  "SchoolEducationalIssuesFam"
-    t.integer  "UnemploymentYouth"
-    t.integer  "UnemploymentFam"
-    t.integer  "MentalHealthIssuesYouth"
-    t.integer  "MentalHealthIssuesFam"
-    t.integer  "HealthIssuesYouth"
-    t.integer  "HealthIssuesFam"
-    t.integer  "PhysicalDisabilityYouth"
-    t.integer  "PhysicalDisabilityFam"
-    t.integer  "MentalDisabilityYouth"
-    t.integer  "MentalDisabilityFam"
-    t.integer  "AbuseAndNeglectYouth"
-    t.integer  "AbuseAndNeglectFam"
-    t.integer  "AlcoholDrugAbuseYouth"
-    t.integer  "AlcoholDrugAbuseFam"
-    t.integer  "InsufficientIncome"
-    t.integer  "ActiveMilitaryParent"
-    t.integer  "IncarceratedParent"
-    t.integer  "IncarceratedParentStatus"
-    t.integer  "ReferralSource"
-    t.integer  "CountOutreachReferralApproaches"
-    t.integer  "ExchangeForSex"
-    t.integer  "ExchangeForSexPastThreeMonths"
-    t.integer  "CountOfExchangeForSex"
-    t.integer  "AskedOrForcedToExchangeForSex"
-    t.integer  "AskedOrForcedToExchangeForSexPastThreeMonths"
-    t.integer  "WorkPlaceViolenceThreats"
-    t.integer  "WorkplacePromiseDifference"
-    t.integer  "CoercedToContinueWork"
-    t.integer  "LaborExploitPastThreeMonths"
-    t.integer  "HPScreeningScore"
-    t.integer  "VAMCStation"
-    t.datetime "DateCreated"
-    t.datetime "DateUpdated"
-    t.string   "UserID",                                       limit: 100
-    t.datetime "DateDeleted"
-    t.string   "ExportID"
-    t.integer  "data_source_id"
-    t.integer  "id"
-    t.integer  "LOSUnderThreshold"
-    t.integer  "PreviousStreetESSH"
-    t.integer  "UrgentReferral"
-    t.integer  "TimeToHousingLoss"
-    t.integer  "ZeroIncome"
-    t.integer  "AnnualPercentAMI"
-    t.integer  "FinancialChange"
-    t.integer  "HouseholdChange"
-    t.integer  "EvictionHistory"
-    t.integer  "SubsidyAtRisk"
-    t.integer  "LiteralHomelessHistory"
-    t.integer  "DisabledHoH"
-    t.integer  "CriminalRecord"
-    t.integer  "SexOffender"
-    t.integer  "DependentUnder6"
-    t.integer  "SingleParent"
-    t.integer  "HH5Plus"
-    t.integer  "IraqAfghanistan"
-    t.integer  "FemVet"
-    t.integer  "ThresholdScore"
-    t.integer  "ERVisits"
-    t.integer  "JailNights"
-    t.integer  "HospitalNights"
-    t.integer  "RunawayYouth"
-    t.string   "processed_hash"
-    t.string   "processed_as"
-    t.boolean  "roi_permission"
-    t.string   "last_locality"
-    t.string   "last_zipcode"
-    t.string   "source_hash"
-    t.datetime "pending_date_deleted"
-    t.integer  "demographic_id"
-    t.integer  "client_id"
-  end
-
-  add_index "recent_report_enrollments", ["EntryDate"], name: "entrydate_ret_index", using: :btree
-  add_index "recent_report_enrollments", ["client_id"], name: "client_id_ret_index", using: :btree
-  add_index "recent_report_enrollments", ["id"], name: "id_ret_index", unique: true, using: :btree
-
-  create_table "recent_service_history", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.integer "client_id"
-    t.integer "data_source_id"
-    t.date    "date"
-    t.date    "first_date_in_program"
-    t.date    "last_date_in_program"
-    t.string  "enrollment_group_id",     limit: 50
-    t.integer "age",                     limit: 2
-    t.integer "destination"
-    t.string  "head_of_household_id",    limit: 50
-    t.string  "household_id",            limit: 50
-    t.integer "project_id"
-    t.integer "project_type",            limit: 2
-    t.integer "project_tracking_method"
-    t.integer "organization_id"
-    t.integer "housing_status_at_entry"
-    t.integer "housing_status_at_exit"
-    t.integer "service_type",            limit: 2
-    t.integer "computed_project_type",   limit: 2
-    t.boolean "presented_as_individual"
-  end
-
-  add_index "recent_service_history", ["client_id"], name: "client_id_rsh_index", using: :btree
-  add_index "recent_service_history", ["computed_project_type"], name: "computed_project_type_rsh_index", using: :btree
-  add_index "recent_service_history", ["date"], name: "date_rsh_index", using: :btree
-  add_index "recent_service_history", ["household_id"], name: "household_id_rsh_index", using: :btree
-  add_index "recent_service_history", ["id"], name: "id_rsh_index", unique: true, using: :btree
-  add_index "recent_service_history", ["project_tracking_method"], name: "project_tracking_method_rsh_index", using: :btree
-  add_index "recent_service_history", ["project_type"], name: "project_type_rsh_index", using: :btree
 
   create_table "recurring_hmis_export_links", force: :cascade do |t|
     t.integer "hmis_export_id"
@@ -3771,48 +3594,37 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_index "vispdats", ["user_id"], name: "index_vispdats_on_user_id", using: :btree
 
   create_table "warehouse_client_service_history", force: :cascade do |t|
-    t.integer "client_id",                                                   null: false
+    t.integer "client_id",                          null: false
     t.integer "data_source_id"
-    t.date    "date",                                                        null: false
-    t.date    "first_date_in_program",                                       null: false
+    t.date    "date",                               null: false
+    t.date    "first_date_in_program",              null: false
     t.date    "last_date_in_program"
-    t.string  "enrollment_group_id",             limit: 50
+    t.string  "enrollment_group_id",     limit: 50
     t.integer "age"
     t.integer "destination"
-    t.string  "head_of_household_id",            limit: 50
-    t.string  "household_id",                    limit: 50
-    t.string  "project_id",                      limit: 50
-    t.string  "project_name",                    limit: 150
+    t.string  "head_of_household_id",    limit: 50
+    t.string  "household_id"
+    t.string  "project_id"
+    t.string  "project_name"
     t.integer "project_type"
     t.integer "project_tracking_method"
-    t.string  "organization_id",                 limit: 50
-    t.string  "record_type",                     limit: 50,                  null: false
+    t.string  "organization_id"
+    t.string  "record_type",                        null: false
     t.integer "housing_status_at_entry"
     t.integer "housing_status_at_exit"
     t.integer "service_type"
     t.integer "computed_project_type"
     t.boolean "presented_as_individual"
-    t.integer "other_clients_over_25",                       default: 0,     null: false
-    t.integer "other_clients_under_18",                      default: 0,     null: false
-    t.integer "other_clients_between_18_and_25",             default: 0,     null: false
-    t.boolean "unaccompanied_youth",                         default: false, null: false
-    t.boolean "parenting_youth",                             default: false, null: false
-    t.boolean "parenting_juvenile",                          default: false, null: false
-    t.boolean "children_only",                               default: false, null: false
-    t.boolean "individual_adult",                            default: false, null: false
-    t.boolean "individual_elder",                            default: false, null: false
-    t.boolean "head_of_household",                           default: false, null: false
   end
 
   add_index "warehouse_client_service_history", ["client_id"], name: "index_service_history_on_client_id", using: :btree
   add_index "warehouse_client_service_history", ["computed_project_type"], name: "index_warehouse_client_service_history_on_computed_project_type", using: :btree
   add_index "warehouse_client_service_history", ["data_source_id", "organization_id", "project_id", "record_type"], name: "index_sh_ds_id_org_id_proj_id_r_type", using: :btree
   add_index "warehouse_client_service_history", ["data_source_id"], name: "index_warehouse_client_service_history_on_data_source_id", using: :btree
-  add_index "warehouse_client_service_history", ["date", "data_source_id", "organization_id", "project_id", "project_type"], name: "sh_date_ds_id_org_id_proj_id_proj_type", using: :btree
-  add_index "warehouse_client_service_history", ["date", "record_type", "presented_as_individual"], name: "index_sh_date_r_type_indiv", using: :btree
-  add_index "warehouse_client_service_history", ["enrollment_group_id"], name: "index_warehouse_client_service_history_on_enrollment_group_id", using: :btree
+  add_index "warehouse_client_service_history", ["date", "data_source_id", "organization_id", "project_id"], name: "index_sh_date_ds_id_org_id_proj_id", using: :btree
+  add_index "warehouse_client_service_history", ["date"], name: "index_warehouse_client_service_history_on_date", using: :btree
+  add_index "warehouse_client_service_history", ["date"], name: "service_history_date_desc", order: {"date"=>:desc}, using: :btree
   add_index "warehouse_client_service_history", ["first_date_in_program"], name: "index_warehouse_client_service_history_on_first_date_in_program", using: :btree
-  add_index "warehouse_client_service_history", ["household_id"], name: "index_warehouse_client_service_history_on_household_id", using: :btree
   add_index "warehouse_client_service_history", ["last_date_in_program"], name: "index_warehouse_client_service_history_on_last_date_in_program", using: :btree
   add_index "warehouse_client_service_history", ["project_tracking_method"], name: "index_sh_tracking_method", using: :btree
   add_index "warehouse_client_service_history", ["project_type"], name: "index_warehouse_client_service_history_on_project_type", using: :btree
@@ -3869,8 +3681,8 @@ ActiveRecord::Schema.define(version: 20191017141927) do
     t.boolean  "active_in_cas_match",                    default: false
     t.string   "last_exit_destination"
     t.datetime "last_cas_match_date"
-    t.string   "lgbtq_from_hmis"
     t.integer  "days_homeless_plus_overrides"
+    t.string   "lgbtq_from_hmis"
   end
 
   add_index "warehouse_clients_processed", ["chronic_days"], name: "index_warehouse_clients_processed_on_chronic_days", using: :btree
@@ -4066,266 +3878,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
   add_foreign_key "warehouse_clients", "data_sources"
   add_foreign_key "warehouse_clients_processed", "\"Client\"", column: "client_id"
 
-  create_view "Site",  sql_definition: <<-SQL
-      SELECT "Geography"."GeographyID",
-      "Geography"."ProjectID",
-      "Geography"."CoCCode",
-      "Geography"."PrincipalSite",
-      "Geography"."Geocode",
-      "Geography"."Address1",
-      "Geography"."City",
-      "Geography"."State",
-      "Geography"."ZIP",
-      "Geography"."DateCreated",
-      "Geography"."DateUpdated",
-      "Geography"."UserID",
-      "Geography"."DateDeleted",
-      "Geography"."ExportID",
-      "Geography".data_source_id,
-      "Geography".id,
-      "Geography"."InformationDate",
-      "Geography"."Address2",
-      "Geography"."GeographyType",
-      "Geography".source_hash
-     FROM "Geography";
-  SQL
-
-  create_view "combined_cohort_client_changes",  sql_definition: <<-SQL
-      SELECT cc.id,
-      cohort_clients.client_id,
-      cc.cohort_client_id,
-      cc.cohort_id,
-      cc.user_id,
-      cc.change AS entry_action,
-      cc.changed_at AS entry_date,
-      cc_ex.change AS exit_action,
-      cc_ex.changed_at AS exit_date,
-      cc_ex.reason
-     FROM (((( SELECT cohort_client_changes.id,
-              cohort_client_changes.cohort_client_id,
-              cohort_client_changes.cohort_id,
-              cohort_client_changes.user_id,
-              cohort_client_changes.change,
-              cohort_client_changes.changed_at,
-              cohort_client_changes.reason
-             FROM cohort_client_changes
-            WHERE ((cohort_client_changes.change)::text = ANY (ARRAY[('create'::character varying)::text, ('activate'::character varying)::text]))) cc
-       LEFT JOIN LATERAL ( SELECT cohort_client_changes.id,
-              cohort_client_changes.cohort_client_id,
-              cohort_client_changes.cohort_id,
-              cohort_client_changes.user_id,
-              cohort_client_changes.change,
-              cohort_client_changes.changed_at,
-              cohort_client_changes.reason
-             FROM cohort_client_changes
-            WHERE (((cohort_client_changes.change)::text = ANY (ARRAY[('destroy'::character varying)::text, ('deactivate'::character varying)::text])) AND (cc.cohort_client_id = cohort_client_changes.cohort_client_id) AND (cc.cohort_id = cohort_client_changes.cohort_id) AND (cc.changed_at < cohort_client_changes.changed_at))
-            ORDER BY cohort_client_changes.changed_at
-           LIMIT 1) cc_ex ON (true))
-       JOIN cohort_clients ON ((cc.cohort_client_id = cohort_clients.id)))
-       JOIN "Client" ON (((cohort_clients.client_id = "Client".id) AND ("Client"."DateDeleted" IS NULL))))
-    WHERE ((cc_ex.reason IS NULL) OR ((cc_ex.reason)::text <> 'Mistake'::text))
-    ORDER BY cc.id;
-  SQL
-
-  create_view "index_stats",  sql_definition: <<-SQL
-      WITH table_stats AS (
-           SELECT psut.relname,
-              psut.n_live_tup,
-              ((1.0 * (psut.idx_scan)::numeric) / (GREATEST((1)::bigint, (psut.seq_scan + psut.idx_scan)))::numeric) AS index_use_ratio
-             FROM pg_stat_user_tables psut
-            ORDER BY psut.n_live_tup DESC
-          ), table_io AS (
-           SELECT psiut.relname,
-              sum(psiut.heap_blks_read) AS table_page_read,
-              sum(psiut.heap_blks_hit) AS table_page_hit,
-              (sum(psiut.heap_blks_hit) / GREATEST((1)::numeric, (sum(psiut.heap_blks_hit) + sum(psiut.heap_blks_read)))) AS table_hit_ratio
-             FROM pg_statio_user_tables psiut
-            GROUP BY psiut.relname
-            ORDER BY (sum(psiut.heap_blks_read)) DESC
-          ), index_io AS (
-           SELECT psiui.relname,
-              psiui.indexrelname,
-              sum(psiui.idx_blks_read) AS idx_page_read,
-              sum(psiui.idx_blks_hit) AS idx_page_hit,
-              ((1.0 * sum(psiui.idx_blks_hit)) / GREATEST(1.0, (sum(psiui.idx_blks_hit) + sum(psiui.idx_blks_read)))) AS idx_hit_ratio
-             FROM pg_statio_user_indexes psiui
-            GROUP BY psiui.relname, psiui.indexrelname
-            ORDER BY (sum(psiui.idx_blks_read)) DESC
-          )
-   SELECT ts.relname,
-      ts.n_live_tup,
-      ts.index_use_ratio,
-      ti.table_page_read,
-      ti.table_page_hit,
-      ti.table_hit_ratio,
-      ii.indexrelname,
-      ii.idx_page_read,
-      ii.idx_page_hit,
-      ii.idx_hit_ratio
-     FROM ((table_stats ts
-       LEFT JOIN table_io ti ON ((ti.relname = ts.relname)))
-       LEFT JOIN index_io ii ON ((ii.relname = ts.relname)))
-    ORDER BY ti.table_page_read DESC, ii.idx_page_read DESC;
-  SQL
-
-  create_view "report_clients",  sql_definition: <<-SQL
-      SELECT "Client"."PersonalID",
-      "Client"."FirstName",
-      "Client"."MiddleName",
-      "Client"."LastName",
-      "Client"."NameSuffix",
-      "Client"."NameDataQuality",
-      "Client"."SSN",
-      "Client"."SSNDataQuality",
-      "Client"."DOB",
-      "Client"."DOBDataQuality",
-      "Client"."AmIndAKNative",
-      "Client"."Asian",
-      "Client"."BlackAfAmerican",
-      "Client"."NativeHIOtherPacific",
-      "Client"."White",
-      "Client"."RaceNone",
-      "Client"."Ethnicity",
-      "Client"."Gender",
-      "Client"."OtherGender",
-      "Client"."VeteranStatus",
-      "Client"."YearEnteredService",
-      "Client"."YearSeparated",
-      "Client"."WorldWarII",
-      "Client"."KoreanWar",
-      "Client"."VietnamWar",
-      "Client"."DesertStorm",
-      "Client"."AfghanistanOEF",
-      "Client"."IraqOIF",
-      "Client"."IraqOND",
-      "Client"."OtherTheater",
-      "Client"."MilitaryBranch",
-      "Client"."DischargeStatus",
-      "Client"."DateCreated",
-      "Client"."DateUpdated",
-      "Client"."UserID",
-      "Client"."DateDeleted",
-      "Client"."ExportID",
-      "Client".id
-     FROM "Client"
-    WHERE (("Client"."DateDeleted" IS NULL) AND ("Client".data_source_id IN ( SELECT data_sources.id
-             FROM data_sources
-            WHERE (data_sources.source_type IS NULL))));
-  SQL
-
-  create_view "report_demographics",  sql_definition: <<-SQL
-      SELECT "Client"."PersonalID",
-      "Client"."FirstName",
-      "Client"."MiddleName",
-      "Client"."LastName",
-      "Client"."NameSuffix",
-      "Client"."NameDataQuality",
-      "Client"."SSN",
-      "Client"."SSNDataQuality",
-      "Client"."DOB",
-      "Client"."DOBDataQuality",
-      "Client"."AmIndAKNative",
-      "Client"."Asian",
-      "Client"."BlackAfAmerican",
-      "Client"."NativeHIOtherPacific",
-      "Client"."White",
-      "Client"."RaceNone",
-      "Client"."Ethnicity",
-      "Client"."Gender",
-      "Client"."OtherGender",
-      "Client"."VeteranStatus",
-      "Client"."YearEnteredService",
-      "Client"."YearSeparated",
-      "Client"."WorldWarII",
-      "Client"."KoreanWar",
-      "Client"."VietnamWar",
-      "Client"."DesertStorm",
-      "Client"."AfghanistanOEF",
-      "Client"."IraqOIF",
-      "Client"."IraqOND",
-      "Client"."OtherTheater",
-      "Client"."MilitaryBranch",
-      "Client"."DischargeStatus",
-      "Client"."DateCreated",
-      "Client"."DateUpdated",
-      "Client"."UserID",
-      "Client"."DateDeleted",
-      "Client"."ExportID",
-      "Client".data_source_id,
-      "Client".id,
-      report_clients.id AS client_id
-     FROM (("Client"
-       JOIN warehouse_clients ON ((warehouse_clients.source_id = "Client".id)))
-       JOIN report_clients ON ((warehouse_clients.destination_id = report_clients.id)))
-    WHERE ("Client"."DateDeleted" IS NULL);
-  SQL
-
-  create_view "report_disabilities",  sql_definition: <<-SQL
-      SELECT "Disabilities"."DisabilitiesID",
-      "Disabilities"."EnrollmentID" AS "ProjectEntryID",
-      "Disabilities"."PersonalID",
-      "Disabilities"."InformationDate",
-      "Disabilities"."DisabilityType",
-      "Disabilities"."DisabilityResponse",
-      "Disabilities"."IndefiniteAndImpairs",
-      "Disabilities"."DocumentationOnFile",
-      "Disabilities"."ReceivingServices",
-      "Disabilities"."PATHHowConfirmed",
-      "Disabilities"."PATHSMIInformation",
-      "Disabilities"."TCellCountAvailable",
-      "Disabilities"."TCellCount",
-      "Disabilities"."TCellSource",
-      "Disabilities"."ViralLoadAvailable",
-      "Disabilities"."ViralLoad",
-      "Disabilities"."ViralLoadSource",
-      "Disabilities"."DataCollectionStage",
-      "Disabilities"."DateCreated",
-      "Disabilities"."DateUpdated",
-      "Disabilities"."UserID",
-      "Disabilities"."DateDeleted",
-      "Disabilities"."ExportID",
-      "Disabilities".data_source_id,
-      "Disabilities".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("Disabilities"
-       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("Disabilities"."DateDeleted" IS NULL);
-  SQL
-
-  create_view "report_employment_educations",  sql_definition: <<-SQL
-      SELECT "EmploymentEducation"."EmploymentEducationID",
-      "EmploymentEducation"."EnrollmentID" AS "ProjectEntryID",
-      "EmploymentEducation"."PersonalID",
-      "EmploymentEducation"."InformationDate",
-      "EmploymentEducation"."LastGradeCompleted",
-      "EmploymentEducation"."SchoolStatus",
-      "EmploymentEducation"."Employed",
-      "EmploymentEducation"."EmploymentType",
-      "EmploymentEducation"."NotEmployedReason",
-      "EmploymentEducation"."DataCollectionStage",
-      "EmploymentEducation"."DateCreated",
-      "EmploymentEducation"."DateUpdated",
-      "EmploymentEducation"."UserID",
-      "EmploymentEducation"."DateDeleted",
-      "EmploymentEducation"."ExportID",
-      "EmploymentEducation".data_source_id,
-      "EmploymentEducation".id,
-      "Enrollment".id AS enrollment_id,
-      source_clients.id AS demographic_id,
-      destination_clients.id AS client_id
-     FROM (((("EmploymentEducation"
-       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
-  SQL
-
   create_view "report_enrollments",  sql_definition: <<-SQL
       SELECT "Enrollment"."EnrollmentID" AS "ProjectEntryID",
       "Enrollment"."PersonalID",
@@ -4437,7 +3989,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
       "Enrollment"."JailNights",
       "Enrollment"."HospitalNights",
       "Enrollment"."RunawayYouth",
-      "Enrollment".processed_hash,
       source_clients.id AS demographic_id,
       destination_clients.id AS client_id
      FROM ((("Enrollment"
@@ -4445,6 +3996,72 @@ ActiveRecord::Schema.define(version: 20191017141927) do
        JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
        JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
     WHERE ("Enrollment"."DateDeleted" IS NULL);
+  SQL
+
+  create_view "report_disabilities",  sql_definition: <<-SQL
+      SELECT "Disabilities"."DisabilitiesID",
+      "Disabilities"."EnrollmentID" AS "ProjectEntryID",
+      "Disabilities"."PersonalID",
+      "Disabilities"."InformationDate",
+      "Disabilities"."DisabilityType",
+      "Disabilities"."DisabilityResponse",
+      "Disabilities"."IndefiniteAndImpairs",
+      "Disabilities"."DocumentationOnFile",
+      "Disabilities"."ReceivingServices",
+      "Disabilities"."PATHHowConfirmed",
+      "Disabilities"."PATHSMIInformation",
+      "Disabilities"."TCellCountAvailable",
+      "Disabilities"."TCellCount",
+      "Disabilities"."TCellSource",
+      "Disabilities"."ViralLoadAvailable",
+      "Disabilities"."ViralLoad",
+      "Disabilities"."ViralLoadSource",
+      "Disabilities"."DataCollectionStage",
+      "Disabilities"."DateCreated",
+      "Disabilities"."DateUpdated",
+      "Disabilities"."UserID",
+      "Disabilities"."DateDeleted",
+      "Disabilities"."ExportID",
+      "Disabilities".data_source_id,
+      "Disabilities".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("Disabilities"
+       JOIN "Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("Disabilities"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("Disabilities"."DateDeleted" IS NULL);
+  SQL
+
+  create_view "report_employment_educations",  sql_definition: <<-SQL
+      SELECT "EmploymentEducation"."EmploymentEducationID",
+      "EmploymentEducation"."EnrollmentID" AS "ProjectEntryID",
+      "EmploymentEducation"."PersonalID",
+      "EmploymentEducation"."InformationDate",
+      "EmploymentEducation"."LastGradeCompleted",
+      "EmploymentEducation"."SchoolStatus",
+      "EmploymentEducation"."Employed",
+      "EmploymentEducation"."EmploymentType",
+      "EmploymentEducation"."NotEmployedReason",
+      "EmploymentEducation"."DataCollectionStage",
+      "EmploymentEducation"."DateCreated",
+      "EmploymentEducation"."DateUpdated",
+      "EmploymentEducation"."UserID",
+      "EmploymentEducation"."DateDeleted",
+      "EmploymentEducation"."ExportID",
+      "EmploymentEducation".data_source_id,
+      "EmploymentEducation".id,
+      "Enrollment".id AS enrollment_id,
+      source_clients.id AS demographic_id,
+      destination_clients.id AS client_id
+     FROM (((("EmploymentEducation"
+       JOIN "Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
+       JOIN warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
+       JOIN "Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
+       JOIN "Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."PersonalID")::text = ("Enrollment"."PersonalID")::text) AND (("EmploymentEducation"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
+    WHERE ("EmploymentEducation"."DateDeleted" IS NULL);
   SQL
 
   create_view "report_exits",  sql_definition: <<-SQL
@@ -4742,30 +4359,6 @@ ActiveRecord::Schema.define(version: 20191017141927) do
      FROM service_history_enrollments;
   SQL
 
-  create_view "todd_stats",  sql_definition: <<-SQL
-      SELECT pg_stat_all_tables.relname,
-      round((
-          CASE
-              WHEN ((pg_stat_all_tables.n_live_tup + pg_stat_all_tables.n_dead_tup) = 0) THEN (0)::double precision
-              ELSE ((pg_stat_all_tables.n_dead_tup)::double precision / ((pg_stat_all_tables.n_dead_tup + pg_stat_all_tables.n_live_tup))::double precision)
-          END * (100.0)::double precision)) AS "Frag %",
-      pg_stat_all_tables.n_live_tup AS "Live rows",
-      pg_stat_all_tables.n_dead_tup AS "Dead rows",
-      pg_stat_all_tables.n_mod_since_analyze AS "Rows modified since analyze",
-          CASE
-              WHEN (COALESCE(pg_stat_all_tables.last_vacuum, '1999-01-01 00:00:00+00'::timestamp with time zone) > COALESCE(pg_stat_all_tables.last_autovacuum, '1999-01-01 00:00:00+00'::timestamp with time zone)) THEN pg_stat_all_tables.last_vacuum
-              ELSE COALESCE(pg_stat_all_tables.last_autovacuum, '1999-01-01 00:00:00+00'::timestamp with time zone)
-          END AS last_vacuum,
-          CASE
-              WHEN (COALESCE(pg_stat_all_tables.last_analyze, '1999-01-01 00:00:00+00'::timestamp with time zone) > COALESCE(pg_stat_all_tables.last_autoanalyze, '1999-01-01 00:00:00+00'::timestamp with time zone)) THEN pg_stat_all_tables.last_analyze
-              ELSE COALESCE(pg_stat_all_tables.last_autoanalyze, '1999-01-01 00:00:00+00'::timestamp with time zone)
-          END AS last_analyze,
-      (pg_stat_all_tables.vacuum_count + pg_stat_all_tables.autovacuum_count) AS vacuum_count,
-      (pg_stat_all_tables.analyze_count + pg_stat_all_tables.autoanalyze_count) AS analyze_count
-     FROM pg_stat_all_tables
-    WHERE (pg_stat_all_tables.schemaname <> ALL (ARRAY['pg_toast'::name, 'information_schema'::name, 'pg_catalog'::name]));
-  SQL
-
   create_view "service_history_services_materialized", materialized: true,  sql_definition: <<-SQL
       SELECT service_history_services.id,
       service_history_services.service_history_enrollment_id,
@@ -4774,17 +4367,73 @@ ActiveRecord::Schema.define(version: 20191017141927) do
       service_history_services.age,
       service_history_services.service_type,
       service_history_services.client_id,
-      service_history_services.project_type,
-      service_history_services.homeless,
-      service_history_services.literally_homeless
+      service_history_services.project_type
      FROM service_history_services;
   SQL
 
-  add_index "service_history_services_materialized", ["client_id", "date"], name: "index_shsm_c_id_date", using: :btree
   add_index "service_history_services_materialized", ["client_id", "project_type", "record_type"], name: "index_shsm_c_id_p_type_r_type", using: :btree
-  add_index "service_history_services_materialized", ["homeless", "project_type", "client_id"], name: "index_shsm_homeless_p_type_c_id", using: :btree
   add_index "service_history_services_materialized", ["id"], name: "index_service_history_services_materialized_on_id", unique: true, using: :btree
-  add_index "service_history_services_materialized", ["literally_homeless", "project_type", "client_id"], name: "index_shsm_literally_homeless_p_type_c_id", using: :btree
-  add_index "service_history_services_materialized", ["service_history_enrollment_id"], name: "index_shsm_shse_id", using: :btree
+  add_index "service_history_services_materialized", ["project_type", "record_type"], name: "index_shsm_p_type_r_type", using: :btree
+
+  create_view "Site",  sql_definition: <<-SQL
+      SELECT "Geography"."GeographyID",
+      "Geography"."ProjectID",
+      "Geography"."CoCCode",
+      "Geography"."PrincipalSite",
+      "Geography"."Geocode",
+      "Geography"."Address1",
+      "Geography"."City",
+      "Geography"."State",
+      "Geography"."ZIP",
+      "Geography"."DateCreated",
+      "Geography"."DateUpdated",
+      "Geography"."UserID",
+      "Geography"."DateDeleted",
+      "Geography"."ExportID",
+      "Geography".data_source_id,
+      "Geography".id,
+      "Geography"."InformationDate",
+      "Geography"."Address2",
+      "Geography"."GeographyType",
+      "Geography".source_hash
+     FROM "Geography";
+  SQL
+
+  create_view "combined_cohort_client_changes",  sql_definition: <<-SQL
+      SELECT cc.id,
+      cohort_clients.client_id,
+      cc.cohort_client_id,
+      cc.cohort_id,
+      cc.user_id,
+      cc.change AS entry_action,
+      cc.changed_at AS entry_date,
+      cc_ex.change AS exit_action,
+      cc_ex.changed_at AS exit_date,
+      cc_ex.reason
+     FROM (((( SELECT cohort_client_changes.id,
+              cohort_client_changes.cohort_client_id,
+              cohort_client_changes.cohort_id,
+              cohort_client_changes.user_id,
+              cohort_client_changes.change,
+              cohort_client_changes.changed_at,
+              cohort_client_changes.reason
+             FROM cohort_client_changes
+            WHERE ((cohort_client_changes.change)::text = ANY ((ARRAY['create'::character varying, 'activate'::character varying])::text[]))) cc
+       LEFT JOIN LATERAL ( SELECT cohort_client_changes.id,
+              cohort_client_changes.cohort_client_id,
+              cohort_client_changes.cohort_id,
+              cohort_client_changes.user_id,
+              cohort_client_changes.change,
+              cohort_client_changes.changed_at,
+              cohort_client_changes.reason
+             FROM cohort_client_changes
+            WHERE (((cohort_client_changes.change)::text = ANY ((ARRAY['destroy'::character varying, 'deactivate'::character varying])::text[])) AND (cc.cohort_client_id = cohort_client_changes.cohort_client_id) AND (cc.cohort_id = cohort_client_changes.cohort_id) AND (cc.changed_at < cohort_client_changes.changed_at))
+            ORDER BY cohort_client_changes.changed_at
+           LIMIT 1) cc_ex ON (true))
+       JOIN cohort_clients ON ((cc.cohort_client_id = cohort_clients.id)))
+       JOIN "Client" ON (((cohort_clients.client_id = "Client".id) AND ("Client"."DateDeleted" IS NULL))))
+    WHERE ((cc_ex.reason IS NULL) OR ((cc_ex.reason)::text <> 'Mistake'::text))
+    ORDER BY cc.id;
+  SQL
 
 end


### PR DESCRIPTION
My local rspec tests where frequently failing on subsequent runs if i stopped them in the middle since they do not reset schema/data for the various databases. There is a better way to do this I'm sure but if followed along with `.github/actions/ci.yml` and set things up to run `dropdb`, `createdb` and `db:schema:load` if you have them in your local `ENV`