### PR TITLE
169323434 ie11 fixes

### DIFF
--- a/app/assets/javascripts/polyfills.js
+++ b/app/assets/javascripts/polyfills.js
@@ -92,3 +92,34 @@ if (!Array.prototype.includes) {
     }
   });
 }
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+if (typeof Object.assign !== 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target === null || target === undefined) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource !== null && nextSource !== undefined) {
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}

--- a/app/assets/javascripts/select_2.js.coffee
+++ b/app/assets/javascripts/select_2.js.coffee
@@ -15,8 +15,7 @@ App.select2.initToggleSelectAll = ($select) =>
     $selectAllLink = $formGroup.find('.select2-select-all')
     allSelected = $selectAllLink.data('selected')
     $selectAllLink.data('selected', !allSelected)
-
-    if $select.select2('data').length == 0
+    if $formGroup.find('select').val() == 0 || $select.select2('data').length == 0
       classAction = 'removeClass'
       html = """
         <span class='mr-2'>Select all</span>
@@ -58,13 +57,18 @@ App.select2.initToggleSelectAll = ($select) =>
   # Init here
   $formGroup = $select.closest('.form-group')
   $formGroup.addClass('select2-wrapper')
-  $select2Container = $select.next('.select2-container')
-  $select2Container.append $("""
+  $label = $formGroup.find('> label')
+  $labelWrapper = $("<div class='select2__label-wrapper'></div>")
+  allOrNone = 'all'
+  $labelWrapper.append $("""
     <div class="select2-select-all j-select2-select-all" data-selected="false" >
       <span class='mr-2'>Select all</span>
       <i class='icon-checkbox-checked' />
     </div>
   """)
+  $label.prependTo $labelWrapper
+  $formGroup.prepend $labelWrapper
+  $select2Container = $select.next('.select2-container')
   $select.closest('.form-group').on 'click', '.j-select2-select-all', (event)=>
     toggleSelectAll()
   $select.on 'select2:select', (event)=>

--- a/app/assets/stylesheets/application/components/filters.scss
+++ b/app/assets/stylesheets/application/components/filters.scss
@@ -13,19 +13,21 @@
   align-items: flex-end;
   flex-wrap: wrap;
   margin-bottom: space(4);
-  width: 100%;
-  flex: 1 1 50%;
-  &:last-of-type {
-    margin-bottom: 0;
-  }
 }
 
 .c-filters__group {
-  margin-right: space(6);
+  flex: 1 1 50%;
+  max-width: 50%;
+}
+
+// Fix for IE11
+.c-filters__group > .row {
+  flex: 1 1 atuo;
+  min-width: 100%;
 }
 
 .c-filters__group--w-100 {
-  width: 100%;
+  max-width: 100%;
   flex: 1 1 100%;
   margin-right: 0;
   margin-bottom: 0;

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -89,24 +89,29 @@
   margin: 2px 2px 2px 0;
 }
 
+.select2__label-wrapper {
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: .5rem;
+}
+
+.select2__label-wrapper label {
+  margin-bottom: 0;
+}
+
 .select2-select-all {
-  position: absolute;
-  right: 1px;
-  top: 2px;
-  z-index: 10;
-  background: rgba($gray-100, .8);
+  margin-left: auto;
   cursor: pointer;
   color: $link-color;
-  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: space(4);
+  white-space: nowrap;
   &:hover {
     color: $link-hover-color;
     cursor: pointer;
   }
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-right: space(6);
-  padding-left: space(4);
   // Fix for IE11 bug with align-center in container with
   // min-height
   &::after {

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -107,4 +107,12 @@
   justify-content: center;
   padding-right: space(6);
   padding-left: space(4);
+  // Fix for IE11 bug with align-center in container with
+  // min-height
+  &::after {
+    display: block;
+    content: '';
+    min-height: inherit;
+    font-size: 0;
+  }
 }

--- a/app/views/data_quality_reports/_bed_utilization.haml
+++ b/app/views/data_quality_reports/_bed_utilization.haml
@@ -4,7 +4,7 @@
     .col-sm-4
       %h3 Bed Utilization
     .col-sm-8
-      = render 'bed_utilization_description'  
+      = render 'bed_utilization_description'
   .well.overflow-scroll
     %table.table.data-quality__table
       %thead
@@ -35,7 +35,7 @@
                 .enrollment__project_type{class: p_class}
                   %em.service-type__program-type= p_type
             %td.text-center{style: "background-color: #{grade.color}; color: white; font-weight: bold;"}= grade.grade
-            
+
             %td.text-center= project[:capacity]
             - @report.class.bed_utilization_attributes.each_with_index do |measure, index|
               - odd_class = if index % 2 == 1 then '' else 'data-quality__odd-columns' end
@@ -56,11 +56,10 @@
             - @report.class.bed_utilization_attributes.each_with_index do |measure, index|
               - key = "bed_utilization_totals_#{measure}"
               - grade = GrdaWarehouse::Grades::Utilization.grade_from_score(totals[:counts]["#{measure}_percentage"])
-              - odd_class = if index % 2 == 1 then '' else 'data-quality__odd-columns' end 
+              - odd_class = if index % 2 == 1 then '' else 'data-quality__odd-columns' end
               %td.text-center{class: odd_class, style: "color: #{grade.color};"}
                 = totals[:counts]["#{measure}_percentage"] || 0
                 %span.text-muted
                   = link_to polymorphic_path(support_path, {key: key}), data: {loads_in_pjax_modal: true} do
                     (#{totals[:counts][measure]})
 
-                

--- a/app/views/warehouse_reports/bed_utilization/index.haml
+++ b/app/views/warehouse_reports/bed_utilization/index.haml
@@ -10,12 +10,14 @@
     - content_for :filters_col_l do
       .row
         .col-sm-6
-          = f.input :month, collection: @mo.months, label: false, class: 'form-control', input_html: {class: 'select2'}
+          = f.input :month, collection: @mo.months, label: 'Month', class: 'form-control', input_html: {class: 'select2'}
         .col-sm-6
-          = f.input :year, collection: @mo.years, label: false, class: 'form-control', input_html: {class: 'select2'}
+          = f.input :year, collection: @mo.years, label: 'Year', class: 'form-control', input_html: {class: 'select2'}
 
     - content_for :filters_col_r do
-      = f.input :org, collection: @mo.organizations, label: 'Organization', class: 'form-control', input_html: {class: 'select2'}
+      .row
+        .col-sm-6
+          = f.input :org, collection: @mo.organizations, label: 'Organization', class: 'form-control', input_html: {class: 'select2'}
 
     - content_for :filter_actions do
       = f.button :submit, value: 'Update View'


### PR DESCRIPTION
Fixes IE11 bugs on these pages
- https://boston-hmis.dev/dashboards/individual_adults
- https://boston-hmis.dev/warehouse_reports/bed_utilization
- https://boston-hmis.dev/warehouse_reports/recidivism

I'm not sure about this issue:
_Massachusetts reported that the DHCD logo in the footer of the website is missing http://staging.rehousingdatacollective.ocd.mass.gov (Reported on IE 11.805.17763.0)_
Maybe it's an issue with the particular app instance?

I added a few questions in the [PT story](https://www.pivotaltracker.com/story/show/169323434)