### PR TITLE
Re-enable CurrentLivingSituation Import

### DIFF
--- a/app/models/grda_warehouse/import/hmis_twenty_twenty/assessment.rb
+++ b/app/models/grda_warehouse/import/hmis_twenty_twenty/assessment.rb
@@ -19,5 +19,16 @@ module GrdaWarehouse::Import::HmisTwentyTwenty
       'Assessment.csv'
     end
 
+    def self.fix_row(row)
+      # Enforce a date (HMISs keep sending them without dates)
+      row['AssessmentDate'] = row['AssessmentDate'].presence || row['CreatedDate']
+      row['AssessmentLocation'] = row['AssessmentLocation'].presence || 'Unknown'
+      row['AssessmentType'] = row['AssessmentType'].presence || 'Unknown'
+      row['AssessmentLevel'] = row['AssessmentLevel'].presence || 'Unknown'
+      row['PrioritizationStatus'] = row['PrioritizationStatus'].presence || 'Unknown'
+
+      row
+    end
+
   end
 end

--- a/app/models/importers/hmis_twenty_twenty/base.rb
+++ b/app/models/importers/hmis_twenty_twenty/base.rb
@@ -88,8 +88,7 @@ module Importers::HmisTwentyTwenty
           @import.save
           import_services()
           @import.save
-          # FIXME: commented out 10/19/2019 until HMIS's correct export implementations
-          # import_current_living_situations()
+          import_current_living_situations()
           import_assessments()
           import_assessment_questions()
           import_assessment_results()
@@ -451,9 +450,13 @@ module Importers::HmisTwentyTwenty
         begin
           # remove any internal newlines
           row.each{ |k,v| row[k] = v&.gsub(/[\r\n]+/, ' ')&.strip }
-
-          if @deidentified && klass.name == 'GrdaWarehouse::Import::HmisTwentyTwenty::Client'
-            klass.deidentify_client_name row
+          case klass.name
+          when 'GrdaWarehouse::Import::HmisTwentyTwenty::Client'
+            row = klass.deidentify_client_name(row) if @deidentified
+          when 'GrdaWarehouse::Import::HmisTwentyTwenty::Assessment'
+            next unless row['AssessmentDate'].present?
+          when 'GrdaWarehouse::Import::HmisTwentyTwenty::CurrentLivingSituation'
+            next unless row['CurrentLivingSituation'].present?
           end
           if row.count == header.count
             row = set_useful_export_id(row: row, export_id: export_id_addition)

--- a/spec/fixtures/files/importers/hmis_twenty_twenty/enrollment_test_files/source/CurrentLivingSituation.csv
+++ b/spec/fixtures/files/importers/hmis_twenty_twenty/enrollment_test_files/source/CurrentLivingSituation.csv
@@ -1,3 +1,4 @@
 "CurrentLivingSitID","EnrollmentID","PersonalID","InformationDate","CurrentLivingSituation","VerifiedBy","LeaveSituation14Days","SubsequentResidence","ResourcesToObtain","LeaseOwn60Day","MovedTwoOrMore","LocationDetails","DateCreated","DateUpdated","UserID","DateDeleted","ExportID"
 "1","2141","6805","2016-09-01","2","freddie","1","2","3","8","9","A long location detail","2016-09-02 15:42:06","2016-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"
 "2","2148","6791","2015-09-01","2","freddie","1","2","3","8","9","A second long location detail","2015-09-02 15:42:06","2015-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"
+"3","2148","6791","","2","freddie","1","2","3","8","9","A third long location detail, this row will be ignored","2015-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"

--- a/spec/fixtures/files/importers/hmis_twenty_twenty/initial/source/CurrentLivingSituation.csv
+++ b/spec/fixtures/files/importers/hmis_twenty_twenty/initial/source/CurrentLivingSituation.csv
@@ -1,3 +1,4 @@
 "CurrentLivingSitID","EnrollmentID","PersonalID","InformationDate","CurrentLivingSituation","VerifiedBy","LeaveSituation14Days","SubsequentResidence","ResourcesToObtain","LeaseOwn60Day","MovedTwoOrMore","LocationDetails","DateCreated","DateUpdated","UserID","DateDeleted","ExportID"
 "1","2141","6805","2019-09-01","2","freddie","1","2","3","8","9","A long location detail","2019-09-02 15:42:06","2019-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"
 "2","2148","6791","2019-09-01","2","freddie","1","2","3","8","9","A second long location detail","2019-09-02 15:42:06","2019-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"
+"3","2148","6791","","2","freddie","1","2","3","8","9","A third long location detail, this row will be ignored","2019-09-02 15:42:06","2019-09-02 15:42:06","3","","b6585c2320f69a2b920adb507cc9d82f"

--- a/spec/models/importers/hmis_twenty_twenty/base_spec.rb
+++ b/spec/models/importers/hmis_twenty_twenty/base_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Importers::HmisTwentyTwenty::Base, type: :model do
     it 'the database will have two events' do
       expect(GrdaWarehouse::Hud::Event.count).to eq(2)
     end
-    xit 'the database will have two living situations' do
+    it 'the database will have two living situations' do
       expect(GrdaWarehouse::Hud::CurrentLivingSituation.count).to eq(2)
     end
     it 'the database will have four users' do


### PR DESCRIPTION
This also quietly ignores records of GrdaWarehouse::Import::HmisTwentyTwenty::Assessment and
GrdaWarehouse::Import::HmisTwentyTwenty::CurrentLivingSituation that are missing key pieces of required  information.