### PR TITLE
Don't process enrollment changes if the receiver id is not in the Cps

### DIFF
--- a/app/jobs/health/process_enrollment_changes_job.rb
+++ b/app/jobs/health/process_enrollment_changes_job.rb
@@ -9,6 +9,13 @@ module Health
     def perform(enrollment_id)
       enrollment = Health::Enrollment.find(enrollment_id)
 
+      pidsls = Health::Cp.all.map { |cp| cp.pid + cp.sl }
+      receiver_id = enrollment.receiver_id
+      unless pidsls.include?(receiver_id)
+        enrollment.update(status: "Unexpected receiver ID #{receiver_id}")
+        return
+      end
+
       begin
         # counters
         new_patients = 0

--- a/app/models/health/enrollment.rb
+++ b/app/models/health/enrollment.rb
@@ -127,6 +127,13 @@ module Health
         detect{|h| h.keys.include? :I08}[:I08][:value][:raw])
     end
 
+    def receiver_id
+      return nil unless as_json.present?
+      as_json[:interchanges].
+        detect{|h| h.keys.include? :ISA}[:ISA].
+        detect{|h| h.keys.include? :I07}[:I07][:value][:raw]
+    end
+
     def as_json
       return {} unless content.present?
       @json ||= begin

--- a/spec/factories/health/cps.rb
+++ b/spec/factories/health/cps.rb
@@ -4,4 +4,9 @@ FactoryBot.define do
     receiver_name { 'Test Receiver' }
     trace_id { 'OPENPATH00' }
   end
+
+  factory :receiver, class: 'Health::Cp' do
+    pid { '110999999' }
+    sl { 'B' }
+  end
 end

--- a/spec/models/health/process_enrollment_changes_spec.rb
+++ b/spec/models/health/process_enrollment_changes_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Health::ProcessEnrollmentChangesJob, type: :model do
+  let!(:receiver) { create :receiver }
+
   it 'enrolls a new patient' do
     referrals = Health::PatientReferral.count
 


### PR DESCRIPTION
Uses the PID/SLs in the CP model to decide if an 834 is appropriate.