### PR TITLE
Fix HUD DQ Version

### DIFF
--- a/lib/tasks/report_seeds.rake
+++ b/lib/tasks/report_seeds.rake
@@ -217,8 +217,7 @@ namespace :reports do
     # r = Reports::DataQuality::Fy2016::Q7.where(name: 'HUD Data Quality Report FY 2016 - Q7').first_or_create
     # r.update(weight: 7, report_results_summary: rs)
 
-
-    rs = ReportResultsSummaries::DataQuality::Fy2016.where(name: 'HUD Data Quality Report 2017').first_or_create
+    rs = ReportResultsSummaries::DataQuality::Fy2017.where(name: 'HUD Data Quality Report 2017').first_or_create
     rs.update(weight: 0)
 
     r = Reports::DataQuality::Fy2017::Q1.where(name: 'HUD Data Quality Report FY 2017 - Q1').first_or_create


### PR DESCRIPTION
HUD DQ Summary 2017 was pointing to the wrong class.
Since the only thing specified in the summary class is the date range,
and since the reports point to it, not worrying about existing installs.