### PR TITLE
[#173547599] Possible fix for dangerous email flagging

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,5 +1,22 @@
-%p
-  Welcome #{@email}!
-%p You can confirm your account email through the link below:
-%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)
-%p= confirmation_url(@resource, confirmation_token: @token)
+%p.content
+  Hello #{@resource.name},
+
+%p.content
+  An account has been created for you for the
+  #{_('City of Boston DND Warehouse')}.
+  Please follow the link below to finish confirming your
+  account:
+  %br
+  %strong
+    = link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)
+
+%p.content
+  If the link doesn't work, you can copy and paste
+  %br
+  = confirmation_url(@resource, confirmation_token: @token)
+  %br
+  into a browser window.
+
+%p.content
+  If you are not #{@resource.name} or do not want to create an account at this
+  time, please ignore this email.

--- a/app/views/devise/mailer/invitation_instructions.html.haml
+++ b/app/views/devise/mailer/invitation_instructions.html.haml
@@ -1,11 +1,26 @@
-%p
+%p.intro
   Hello #{@resource.name},
 
-%p
-  = "An account has been created for you for the #{_('City of Boston DND Warehouse')}.  Please follow the link below to finish setting up your account:"
+%p.content
+  An account has been created for you for the
+  #{_('City of Boston DND Warehouse')}.  Please follow the link below to finish
+  setting up your account:
+  %br
+  = link_to accept_invitation_url(@resource, invitation_token: @token), accept_invitation_url(@resource, invitation_token: @token)
 
-%p= link_to accept_invitation_url(@resource, invitation_token: @token), accept_invitation_url(@resource, invitation_token: @token)
+%p.content
+  If the link doesn't work, you can copy and paste
+  %br
+  = accept_invitation_url(@resource, invitation_token: @token)
+  %br
+  into a browser window.
 
-%p This invitation will expire at #{@resource.invitation_due_at.strftime("%B %d, %Y %I:%M %p")}.  Your account will not be active until you access the link above and set your password.
 
-%p If you are not #{@resource.name}, or do not want to create an account at this time, please ignore this email.
+%p.content
+  This invitation will expire at
+  #{@resource.invitation_due_at.strftime("%B %d, %Y %I:%M %p")}. Your account
+  will not be active until you access the link above and set your password.
+
+%p.content
+  If you are not #{@resource.name} or do not want to create an account at this
+  time, please ignore this email.

--- a/app/views/devise/mailer/password_change.html.haml
+++ b/app/views/devise/mailer/password_change.html.haml
@@ -1,3 +1,9 @@
-%p
-  Hello #{@resource.email}!
-%p We're contacting you to notify you that your password has been changed.
+%p.intro
+  Hello #{@resource.name},
+
+%p.content
+  We're contacting you to let you know that your password has been changed on
+  = link_to _('City of Boston DND Warehouse'), root_url
+
+%p.closing
+  Thank you.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,7 +1,22 @@
-%p
-  Hello #{@resource.email}!
-%p Someone has requested a link to change your password. You can do this through the link below.
-%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
-%p= edit_password_url(@resource, reset_password_token: @token)
-%p If you didn't request this, please ignore this email.
-%p Your password won't change until you access the link above and create a new one.
+%p.intro
+  Hello #{@resource.name},
+
+%p.content
+  Someone has requested a link to change your password. You can do this through
+  the link below.
+  %br
+  %strong
+    = link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+
+%p.content
+  If the link doesn't work, you can copy and paste
+  %br
+  = edit_password_url(@resource, reset_password_token: @token)
+  %br
+  into a browser window.
+
+%p.content
+  If you didn't request a password reset, please ignore this email.
+
+%p.content
+  Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,6 +1,20 @@
-%p
-  Hello #{@resource.email}!
-%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
-%p Click the link below to unlock your account:
-%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)
-%p= unlock_url(@resource, unlock_token: @token)
+%p.content
+  Hello #{@resource.name}!
+
+%p.content
+  Your account has been locked due to an excessive number of unsuccessful sign
+  in attempts.
+
+%p.content
+  Click the link below to unlock your account:
+  %br
+  %strong
+    = link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)
+
+%p.content
+  If the link doesn't work, you can copy and paste
+  %br
+  = unlock_url(@resource, unlock_token: @token)
+  %br
+  into a browser window.
+


### PR DESCRIPTION
I could never reproduce the problem, but I tried to make the emails less terse with a little more markup. I really don't know if we should merge this or not. I hit all of the emails except unlock.

Doesn't look like dkim, from address, or spf are problems.

I added a dmarc record in case that's related.

After I see a raw email with this problem, I'll convert into a non-draft PR.