### PR TITLE
Tunes ECS deployment

### DIFF
--- a/bin/db_prep
+++ b/bin/db_prep
@@ -55,3 +55,5 @@ Dir.chdir APP_ROOT do
     puts "\n== NOT Seeding test Database =="
   end
 end
+# do not modify this line:
+puts "---DONE---"

--- a/config/deploy/docker/assets/deploy_tasks.open-path-cas.sh
+++ b/config/deploy/docker/assets/deploy_tasks.open-path-cas.sh
@@ -29,3 +29,4 @@ echo installing cron
 # keep this always at the end of this file
 echo making interface aware this script completed
 bundle exec rake deploy:mark_deployment_id
+echo ---DONE---

--- a/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
+++ b/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
@@ -29,3 +29,4 @@ echo Installing cron
 # keep this always at the end of this file
 echo Making interface aware this script completed
 bundle exec rake deploy:mark_deployment_id
+echo ---DONE---


### PR DESCRIPTION
Tunes log tailing in deployments to both catch explict completion and give up
after 5 minutes instead of one minute of no new events.