### PR TITLE
[#174146938] Bring in select2 changes from CAS

### DIFF
--- a/app/assets/javascripts/select_2.js.coffee
+++ b/app/assets/javascripts/select_2.js.coffee
@@ -1,4 +1,6 @@
-#= require ./namespace
+#= require namespace
+#= require select_two
+
 App.select2 ||= {}
 
 App.select2.init = (root) =>
@@ -8,103 +10,5 @@ App.select2.init = (root) =>
     options = {}
     if placeholder
       options.placeholder = placeholder
-    $select.select2(options)
-    # Add select all functionality if has `multiple` attribute
-    if this.hasAttribute('multiple')
-      App.select2.initToggleSelectAll($select)
-    # CoCs get special functionality
-    if this.classList.contains('select2-id-when-selected')
-      App.select2.initIdWhenSelected($select)
-    if this.classList.contains('select2-parenthetical-when-selected')
-      App.select2.initParentheticalWhenSelected($select)
-  $(".select2-search__field").attr("aria-label", 'Search')
 
-App.select2.initToggleSelectAll = ($select) =>
-  # If we made any changes manually, and there are any selected, set the link to "select none"
-  updateSelectAllState = () =>
-    $selectAllLink = $formGroup.find('.select2-select-all')
-    allSelected = $selectAllLink.data('selected')
-    $selectAllLink.data('selected', !allSelected)
-    if $formGroup.find('select').val() == 0 || $select.select2('data').length == 0
-      classAction = 'removeClass'
-      html = """
-        <span class='mr-2'>Select all</span>
-      """
-    else# if $select.select2('data').length < $select.find('option').length
-      classAction = 'addClass'
-      html = """
-        <span class='mr-2'>Select none</span>
-      """
-    $selectAllLink.html(html)
-    $select2Container[classAction]('all-selected')
-    $select.trigger('change')
-    $select.select2('close')
-
-  toggleSelectAll = (updateOptions=true, options={}) =>
-    $selectAllLink = $formGroup.find('.select2-select-all')
-    allSelected = $selectAllLink.data('selected')
-    $selectAllLink.data('selected', !allSelected)
-    classAction = 'removeClass'
-    html = """
-      <span class='mr-2'>Select all</span>
-    """
-    if !allSelected
-      classAction = 'addClass'
-      html = """
-        <span class='mr-2'>Select none</span>
-      """
-    $selectAllLink.html(html)
-    $select2Container[classAction]('all-selected')
-    if (updateOptions)
-      $select.find('option').prop("selected", !allSelected);
-    $select.trigger('change')
-    $select.select2('close')
-
-  # Init here
-  $formGroup = $select.closest('.form-group')
-  $formGroup.addClass('select2-wrapper')
-  $label = $formGroup.find('> label')
-  $labelWrapper = $("<div class='select2__label-wrapper'></div>")
-  allOrNone = 'all'
-  $labelWrapper.append $("""
-    <div class="select2-select-all j-select2-select-all" data-selected="false" >
-      <span class='mr-2'>Select all</span>
-    </div>
-  """)
-  $label.prependTo $labelWrapper
-  $formGroup.prepend $labelWrapper
-  $select2Container = $select.next('.select2-container')
-  $select.closest('.form-group').on 'click', '.j-select2-select-all', (event)=>
-    toggleSelectAll()
-  $select.on 'select2:select', (event)=>
-    updateSelectAllState()
-  $select.on 'select2:unselect', (event)=>
-    updateSelectAllState()
-  # initial state
-  updateSelectAllState()
-
-App.select2.initIdWhenSelected = ($select) =>
-  $select.select2(
-    {
-      templateSelection: (selected) =>
-        if !selected.id
-          return selected.text
-        # use the code to keep the select smaller
-        return selected.id
-    }
-  )
-
-App.select2.initParentheticalWhenSelected = ($select) =>
-  $select.select2(
-    {
-      templateSelection: (selected) =>
-        if !selected.id
-          return selected.text
-        # use the parenthetical text to keep the select smaller
-        regex = /\((.+?)\)/
-        matched = selected.text.match(regex)
-        if !matched.length == 2
-          return selected.text
-        return matched[1]
-    }
-  )
+    new App.Form.Select2Input this, options

--- a/app/assets/javascripts/select_two.es6
+++ b/app/assets/javascripts/select_two.es6
@@ -15,8 +15,8 @@ App.Form.Select2Input = class Select2Input {
       this.$select2Container = this.$select.next('.select2-container')
 
       // Add options based on use-case
-      // CoCs get special functionality
-      if (field.classList.contains('select2-id-when-selected')) {
+      // CoCs get special functionality "My Coc (MA-500)" becomes MA-500 when selected
+      if (field.classList.contains('select2-parenthetical-when-selected')) {
         options.templateSelection = (selected) => {
           if (!selected.id) {
             return selected.text
@@ -27,11 +27,13 @@ App.Form.Select2Input = class Select2Input {
             return selected.text
           } else if (matched && matched.length) {
             return matched[1]
+          } else {
+            return selected.text
           }
         }
       }
 
-      if (field.classList.contains('select2-parenthetical-when-selected')) {
+      if (field.classList.contains('select2-id-when-selected')) {
         options.templateSelection = (selected) => {
           if (!selected.id) {
             return selected.text

--- a/app/assets/javascripts/select_two.es6
+++ b/app/assets/javascripts/select_two.es6
@@ -1,0 +1,133 @@
+window.App.Form = window.App.Form || {}
+
+App.Form.Select2Input = class Select2Input {
+  constructor(element, options={}) {
+    let field = null
+    if (typeof(element) === 'string') {
+      field = document.getElementById(element)
+    } else {
+      field = element
+    }
+    if (!field) {
+      console.debug(`Select2Input could not find element: ${element}`)
+    } else {
+      this.$select = $(field)
+      this.$select2Container = this.$select.next('.select2-container')
+
+      // Add options based on use-case
+      // CoCs get special functionality
+      if (field.classList.contains('select2-id-when-selected')) {
+        options.templateSelection = (selected) => {
+          if (!selected.id) {
+            return selected.text
+          }
+          // use the parenthetical text to keep the select smaller
+          const matched = selected.text.match(/\((.+?)\)/)
+          if (matched && !matched.length == 2) {
+            return selected.text
+          } else if (matched && matched.length) {
+            return matched[1]
+          }
+        }
+      }
+
+      if (field.classList.contains('select2-parenthetical-when-selected')) {
+        options.templateSelection = (selected) => {
+          if (!selected.id) {
+            return selected.text
+          }
+          // use the code to keep the select smaller
+          return selected.id
+        }
+      }
+
+      // Init!
+      this.$select.select2(options)
+
+      // Add select all functionality if has `multiple` attribute
+      if (field.hasAttribute('multiple')) {
+        this.initToggleSelectAll()
+      }
+
+      // Parenthetical
+      $(".select2-search__field").attr('aria-label', 'Search')
+    }
+  }
+
+  selectAllHtml() {
+    let text = 'all'
+    if (this.someItemsSelected() || this.allItemsSelected()) {
+      text = 'none'
+    }
+    return `<span class='mr-2'>Select ${text}</span>`
+  }
+
+  numberOfSelectedItems() {
+    return this.$select.find('option:selected').length
+  }
+
+  someItemsSelected() {
+    return this.numberOfSelectedItems() && !this.allItemsSelected()
+  }
+
+  allItemsSelected() {
+    return this.numberOfSelectedItems() === this.$select.find('option').length
+  }
+
+  toggleSelectAll(isManualChange=false) {
+    if (!isManualChange) {
+      this.$select.find('option').prop('selected', !this.allItemsAreSelected)
+      this.allItemsAreSelected = !this.allItemsAreSelected
+    } else {
+      if (this.someItemsSelected() || this.allItemsSelected()) {
+        this.allItemsAreSelected = true
+      } else {
+        this.allItemsAreSelected = false
+      }
+    }
+    this.$select.trigger('change')
+    this.$select.select2('close')
+
+    // Update DOM element to reflect selections
+    const $selectAllLink = this.$formGroup.find('.select2-select-all')
+    // this.$select2Container[classAction]('all-selected')
+    let html = this.selectAllHtml()
+    if (this.allItemsSelected() || this.numberOfSelectedItems()) {
+      html = this.selectAllHtml()
+    }
+    $selectAllLink.html(html)
+  }
+
+
+  noneSelected() {
+    return (this.$formGroup.find('select').val() === 0) ||
+      (this.$select.select2('data').length === 0)
+  }
+
+  initToggleSelectAll() {
+    // Init here
+    const hasItemsSelectedOnInit = this.numberOfSelectedItems()
+    this.$formGroup = this.$select.closest('.form-group')
+    this.$formGroup.addClass('select2-wrapper')
+    const $label = this.$formGroup.find('> label')
+    const $labelWrapper = $("<div class='select2__label-wrapper'></div>")
+    // Add select all/none link to select2 input
+    $labelWrapper.append($(`
+      <div class="select2-select-all j-select2-select-all">
+        ${this.selectAllHtml()}
+      </div>
+    `))
+    $label.prependTo($labelWrapper)
+    this.$formGroup.prepend($labelWrapper)
+
+    // Init events on select2
+    // Trigger toggle on manual update: 'select2:select select2:unselect
+    // Trigger toggle on select all/ none click: '.j-select2-select-all'
+    this.$select.closest('.form-group')
+      .on( 'click', '.j-select2-select-all', this.toggleSelectAll.bind(this, false) )
+    this.$select.on( 'select2:select select2:unselect', this.toggleSelectAll.bind(this, true) )
+
+    // Initial state based on existing options
+    this.allItemsAreSelected = this.numberOfSelectedItems()
+  }
+}

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -26,7 +26,7 @@
   border-color: $input-border-color;
   display: flex;
   align-items: center;
-  background-color: #f9f9f9;
+  // background-color: #f9f9f9;
 }
 
 .select2-container--bootstrap .select2-results__option--highlighted[aria-selected] {

--- a/app/inputs/select2_input.rb
+++ b/app/inputs/select2_input.rb
@@ -1,7 +1,0 @@
-# class Select2Input < ::CollectionSelectInput
-#   def input_html_options
-#     super.tap do |opts|
-#       opts[:multiple] = "#{options[:multiple].present? ? options[:multiple] : false}"
-#     end
-#   end
-# end

--- a/app/inputs/select_two_input.rb
+++ b/app/inputs/select_two_input.rb
@@ -1,0 +1,5 @@
+class SelectTwoInput < CollectionSelectInput
+  def input_html_classes
+    super + ['select2']
+  end
+end

--- a/app/views/style_guides/form.haml
+++ b/app/views/style_guides/form.haml
@@ -55,7 +55,7 @@
             %h3 Select 2 Inputs
             %hr
 
-            - collection = ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']
+            - collection = {'Choice 1 (ES)' => 'One', 'Choice 2 (SO)' => 'Two', 'Choice 3 (TH)' => 'Three',  'Choice 4 (RRH)' => 'Four', 'Choice 5' => 'Five'}
             %h4 Select 2 - Default
             = f.input :select2, collection: collection, input_html: { class: :select2 }
 
@@ -64,11 +64,11 @@
 
             %h4 Select 2 - CoC special behavior
             %p.font-italic Select inputs have class name: <strong>.select2-id-when-selected</strong>
-            = f.input :select2_coc_behavior, collection: collection, input_html: { class: [:select2, 'select2-id-when-selected'] }
+            = f.input :select2_coc_behavior, collection: collection, input_html: { class: [:select2, 'select2-id-when-selected'] }, hint: 'Show value instead of label when selected'
 
             %h4 Select 2 - Parenthetical
             %p.font-italic Select inputs have class name: <strong>.select2-parenthetical-when-selected</strong>
-            = f.input :select2_parenthetical, collection: collection, input_html: { class: [:select2, 'select2-parenthetical-when-selected'] }
+            = f.input :select2_parenthetical, collection: collection, input_html: { class: [:select2, 'select2-parenthetical-when-selected'] }, hint: 'Show only parenthetical details when selected'
 
           %h4 Password
           = f.input :password, as: :password, required: true, **validate_html

--- a/app/views/style_guides/form.haml
+++ b/app/views/style_guides/form.haml
@@ -51,8 +51,24 @@
           %h4 "Pretty" boolean
           = f.input :is_currently_youth, as: :pretty_boolean, wrapper: :custom_boolean, disabled: false
 
-          -# %h4 Select 2
-          -# = f.input :select2, as: :select2, collection: ['Choice 1', 'Choice 2']
+          %section.my-6.mb-8
+            %h3 Select 2 Inputs
+            %hr
+
+            - collection = ['Choice 1', 'Choice 2', 'Choice 3', 'Choice 4']
+            %h4 Select 2 - Default
+            = f.input :select2, collection: collection, input_html: { class: :select2 }
+
+            %h4 Select 2 - Multiselect (with select all/none)
+            = f.input :select2_multi, collection: collection, input_html: { class: :select2, multiple: true }
+
+            %h4 Select 2 - CoC special behavior
+            %p.font-italic Select inputs have class name: <strong>.select2-id-when-selected</strong>
+            = f.input :select2_coc_behavior, collection: collection, input_html: { class: [:select2, 'select2-id-when-selected'] }
+
+            %h4 Select 2 - Parenthetical
+            %p.font-italic Select inputs have class name: <strong>.select2-parenthetical-when-selected</strong>
+            = f.input :select2_parenthetical, collection: collection, input_html: { class: [:select2, 'select2-parenthetical-when-selected'] }
 
           %h4 Password
           = f.input :password, as: :password, required: true, **validate_html

--- a/app/views/style_guides/form.haml
+++ b/app/views/style_guides/form.haml
@@ -26,7 +26,7 @@
 
 - validate_html = { input_html: {class: 'validate'}}
 - form_defaults = { required: false }
-
+- collection = {'Choice 1 (ES)' => 'One', 'Choice 2 (SO)' => 'Two', 'Choice 3 (TH)' => 'Three',  'Choice 4 (RRH)' => 'Four', 'Choice 5' => 'Five'}
 .container.py-4
   %h1 Form
   %section
@@ -46,7 +46,7 @@
           = f.input :random_number, as: :numeric, required: true, **validate_html
 
           %h4 Normal Select
-          = f.input :sel,  collection: ['Choice 1', 'Choice 2']
+          = f.input :sel,  collection: collection
 
           %h4 "Pretty" boolean
           = f.input :is_currently_youth, as: :pretty_boolean, wrapper: :custom_boolean, disabled: false
@@ -55,7 +55,6 @@
             %h3 Select 2 Inputs
             %hr
 
-            - collection = {'Choice 1 (ES)' => 'One', 'Choice 2 (SO)' => 'Two', 'Choice 3 (TH)' => 'Three',  'Choice 4 (RRH)' => 'Four', 'Choice 5' => 'Five'}
             %h4 Select 2 - Default
             = f.input :select2, collection: collection, input_html: { class: :select2 }
 
@@ -69,6 +68,20 @@
             %h4 Select 2 - Parenthetical
             %p.font-italic Select inputs have class name: <strong>.select2-parenthetical-when-selected</strong>
             = f.input :select2_parenthetical, collection: collection, input_html: { class: [:select2, 'select2-parenthetical-when-selected'] }, hint: 'Show only parenthetical details when selected'
+
+            %h4 Select 2 - simple form input - Default
+            = f.input :select2_simple_form, collection: collection, as: :select_two
+
+            %h4 Select 2 - simple form input - Multiselect (with select all/none)
+            = f.input :select2_multi_simple_form, collection: collection, as: :select_two, input_html: { multiple: true }
+
+            %h4 Select 2 - simple form input - CoC special behavior
+            %p.font-italic Select inputs have class name: <strong>.select2-id-when-selected</strong>
+            = f.input :select2_coc_behavior_simple_form, collection: collection, as: :select_two, input_html: { class: ['select2-id-when-selected'] }, hint: 'Show value instead of label when selected'
+
+            %h4 Select 2 - simple form input - Parenthetical
+            %p.font-italic Select inputs have class name: <strong>.select2-parenthetical-when-selected</strong>
+            = f.input :select2_parenthetical_simple_form, collection: collection, as: :select_two, input_html: { class: ['select2-parenthetical-when-selected'] }, hint: 'Show only parenthetical details when selected'
 
           %h4 Password
           = f.input :password, as: :password, required: true, **validate_html
@@ -85,7 +98,11 @@
             %h4 Submit
             = f.submit value: 'Create', class: 'btn btn-primary'
             = f.submit value: 'Cancel', class: 'btn btn-secondary'
-            = f.submit value: 'Breaking Change', class: 'btn btn-warning'
-            = f.submit value: 'Delete (Descructive)', class: 'btn btn-danger'
+            = link_to root_path, class: 'btn btn-warning ml-1' do
+              %i.icon-warning
+              Breaking Change
+            = link_to root_path, class: 'btn btn-danger ml-1' do
+              %i.icon-cross
+              Delete (Destructive)
 
           %section


### PR DESCRIPTION
@eanders This brings parity to the select2 implementation between HMIS and CAS.
[Pivotal Story](https://www.pivotaltracker.com/story/show/174146938)

#### Notes

- I refactored the JS to handle initing HMIS-style (on page load) and CAS-style (using a simpleform input type which instantiates the JS class).
- I also brought in the refactoring when porting to CAS
- I wasn't sure what "CoCs get special functionality" or the _Parenthetical_-related function so those may require testing
- I added the select 2 inputs in the styleguide form