### PR TITLE
Add xlsx to claims recon

### DIFF
--- a/drivers/claims_reporting/app/controllers/claims_reporting/warehouse_reports/reconciliation_controller.rb
+++ b/drivers/claims_reporting/app/controllers/claims_reporting/warehouse_reports/reconciliation_controller.rb
@@ -11,10 +11,14 @@ module ClaimsReporting::WarehouseReports
     def index
       @report = ClaimsReporting::ReconcilationReport.new(**filter_params)
       @file = ::ClaimsReporting::CpPaymentUpload.new
+      export_name = "unmatched-claims-for-#{@report.month.end_of_month.to_s(:number)}"
       respond_to do |format|
         format.html {} # render the default template
+        format.xlsx do
+          render xlsx: 'index', filename: "#{export_name}.xlsx"
+        end
         format.csv do
-          send_data @report.to_csv, filename: "unmatched-claims-#{Time.current.to_s(:number)}.csv"
+          send_data @report.to_csv, filename: "#{export_name}.csv"
         end
       end
     end

--- a/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/_table.haml
+++ b/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/_table.haml
@@ -8,9 +8,9 @@
       - if @report.patients_without_payments.any?
         %p No record of payment could be found for the following #{pluralize(@report.patients_without_payments&.size, 'patient')}:
     .ml-auto
-      = link_to(link_params.merge({format: :csv}),{class: 'btn btn-secondary'}) do
-        %i.icon.icon-download2
-        Download
+      = link_to(link_params.merge({format: :xlsx}),{class: 'btn btn-secondary'}) do
+        %i.icon-icon-download2
+        Download Excel
   .card
     %table.table.table-striped.datatable
       %thead
@@ -31,7 +31,7 @@
             %td= @report.qa_count_for_patient(patient)
             %td= @report.qa_missing_enrollment_count_for_patient(patient)
             %td= @report.qa_missing_careplan_count_for_patient(patient)
-            %td= patient.careplans.select(&:provider_signed_on).map{|d| d.provider_signed_on.to_date }.to_sentence
+            %td= @report.careplan_dates_for_patient(patient)
 = content_for :page_js do
   :javascript
     $('.datatable').DataTable({

--- a/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/_table.haml
+++ b/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/_table.haml
@@ -9,7 +9,7 @@
         %p No record of payment could be found for the following #{pluralize(@report.patients_without_payments&.size, 'patient')}:
     .ml-auto
       = link_to(link_params.merge({format: :xlsx}),{class: 'btn btn-secondary'}) do
-        %i.icon-icon-download2
+        %i.icon.icon-download2
         Download Excel
   .card
     %table.table.table-striped.datatable

--- a/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/index.xlsx.axlsx
+++ b/drivers/claims_reporting/app/views/claims_reporting/warehouse_reports/reconciliation/index.xlsx.axlsx
@@ -1,0 +1,8 @@
+wb = xlsx_package.workbook
+wb.add_worksheet(name: "Patients without Payments") do |sheet|
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  sheet.add_row(@report.patients_without_payments_columns, :style => title)
+  @report.patients_without_payments_rows.each do |row|
+    sheet.add_row(row)
+  end
+end


### PR DESCRIPTION
Add's XLSX to claims reconciliation export formats and updates filenames to reflect the month selection rather than the download date 