### PR TITLE
Avoid(?) future confusion over cases where we want to consider pending disenrollments

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -334,7 +334,7 @@ module Health
       referral = patient_referral
       return 0 unless referral
 
-      end_date = referral.disenrollment_date || referral.pending_disenrollment_date || Date.current
+      end_date = referral.actual_or_pending_disenrollment_date || Date.current
       # This only happens with demo data
       return 0 unless referral.enrollment_start_date
 
@@ -363,7 +363,7 @@ module Health
     end
 
     def current_disenrollment_date
-      patient_referral.disenrollment_date || patient_referral.pending_disenrollment_date
+      patient_referral.actual_or_pending_disenrollment_date
     end
 
     def current_enrollment_range
@@ -373,14 +373,13 @@ module Health
 
     def prior_contributed_enrollment_ranges
       patient_referrals.contributing.prior.map do |referral|
-        end_date = referral.disenrollment_date || referral.pending_disenrollment_date
-        (referral.enrollment_start_date..end_date)
+        (referral.enrollment_start_date..referral.actual_or_pending_disenrollment_date)
       end
     end
 
     def contributed_enrollment_ranges
       patient_referrals.contributing.map do |referral|
-        end_date = referral.disenrollment_date || referral.pending_disenrollment_date || Date.current
+        end_date = referral.actual_or_pending_disenrollment_date || Date.current
         (referral.enrollment_start_date..end_date)
       end
     end

--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -528,7 +528,7 @@ module Health
     end
 
     def disenrolled?
-      pending_disenrollment_date.present? || disenrollment_date.present?
+      actual_or_pending_disenrollment_date.present?
     end
 
     def self.encounter_report_details

--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -75,7 +75,14 @@ module Health
     phi_attr :exported_on, Phi::Date
     # phi_attr :removal_acknowledge
     phi_attr :disenrollment_date, Phi::Date
-    phi_attr :stop_reason_description, Phi::FreeText
+    phi_attr :pending_disenrollment_date, Phi::Date, <<~DESC
+      A disenrollment date received via ANSI 834. Once acknowledged it is copied
+      to disenrollment_date. However for the purposes of payments it can be
+      considered to be the effective disenrollment date.
+    DESC
+    phi_attr :stop_reason_description, Phi::FreeText, <<~DESC
+      A description of why the enrollment was cancelled.
+    DESC
 
     before_validation :update_rejected_from_reason
 
@@ -320,11 +327,6 @@ module Health
     # Note: respects pending_disenrollment_date if there is no disenrollment_date
     def active_on?(date)
       was_active_range&.cover?(range)
-    end
-
-
-    def disenrolled?
-      actual_or_pending_disenrollment_date.present? || removal_acknowledged? || rejected?
     end
 
     def re_enrollment_blackout?(on_date)

--- a/app/views/admin/health/patient_referrals/_reject.haml
+++ b/app/views/admin/health/patient_referrals/_reject.haml
@@ -23,5 +23,5 @@
           - unless reason[0] == pr.rejected_reason
             %li
               = link_to Health::PatientReferral.display_rejected_reason(reason[0]), '#', data: {behavior: 'reject patient referral', rejected_reason: reason[0]}
-    - value = pr.disenrollment_date || pr.pending_disenrollment_date || Date.current.end_of_month
+    - value = pr.actual_or_pending_disenrollment_date || Date.current.end_of_month
     = f.input :disenrollment_date, as: :date_picker,  label: 'Disenrollment date:', input_html: { value: value }


### PR DESCRIPTION
We have a similar chain of `||` in many places and i think i'm seeing that pending disenrollments are often considered when looking for active date ranges.

I think that the new reconciliation report not always considering pending disenrollments  explains an issue an issue I was seeing there. In the process i noticed we have `def disenrolled?` defined twice in two different ways with the same overall effect.

Note: `disenrolled` was defined here https://github.com/greenriver/hmis-warehouse/blob/ce0cd8e7b82ad0a04de709274eb32c78f7b7e764/app/models/health/patient_referral.rb#L326 and https://github.com/greenriver/hmis-warehouse/blob/ce0cd8e7b82ad0a04de709274eb32c78f7b7e764/app/models/health/patient_referral.rb#L528 but the last two terms would never have been hit with current code.

Added some notes using our new description feature for the fields i had a hard time understanding after talking with @awisema. Figured we might start using that but happy to move to comments or refine if my understanding isn't quite there.
