### PR TITLE
Change Health::PatientReferral.active_within_range to fall back to pending_disenrollment_date

### DIFF
--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -121,6 +121,7 @@ module Health
     scope :pending_disenrollment, -> { current.where.not(pending_disenrollment_date: nil) }
     scope :not_disenrolled, -> { current.where(pending_disenrollment_date: nil, disenrollment_date: nil)}
 
+    # Note: respects pending_disenrollment_date if there is no disenrollment_date
     scope :active_within_range, -> (start_date:, end_date:) do
       at = arel_table
       # Excellent discussion of why this works:
@@ -128,7 +129,7 @@ module Health
       d_1_start = start_date
       d_1_end = end_date
       d_2_start = at[:enrollment_start_date]
-      d_2_end = at[:disenrollment_date]
+      d_2_end = cl(at[:disenrollment_date], at[:pending_disenrollment_date])
       # Currently does not count as an overlap if one starts on the end of the other
       where(d_2_end.gteq(d_1_start).or(d_2_end.eq(nil)).and(d_2_start.lteq(d_1_end)))
     end


### PR DESCRIPTION
It appears that in all places where this is called we are better off considering a pending disenrollment as likely to happen. Doing so will at least fix the claims reconciliation report.

Known existing callers outside of the report where I need this changed behaviour:
- [x] `Health::AgencyPerformance.patient_referrals`
- [x] `Health::Patient.active_between` called by `Health::MemberStatusReport#patient_enrolled_during_report?`
- [x] `Health::QualifyingActivity#occurred_during_any_enrollment?`


Thoughts @awisema ?