### PR TITLE
Claims reconn tests

### DIFF
--- a/app/models/health/patient_referral.rb
+++ b/app/models/health/patient_referral.rb
@@ -238,7 +238,7 @@ module Health
     end
 
     def enrolled_days_to_date
-      (enrollment_start_date .. (disenrollment_date || Date.current)).to_a
+      (enrollment_start_date .. (actual_or_pending_disenrollment_date || Date.current)).to_a
     end
 
     def name

--- a/app/models/health/qualifying_activity.rb
+++ b/app/models/health/qualifying_activity.rb
@@ -696,7 +696,11 @@ module Health
       contributing_care_plans = pcp_signed_plans.select do |cp|
         # Not sure on this... dont penalize the patient if the provider was late signing it
         cp_date = [cp.provider_signed_on, cp.patient_signed_on].compact.min
-        cp_date >= first_enrollment_date && (last_enrollment_date.nil? || cp_date <= last_enrollment_date)
+        (
+          (cp.expires_on.nil? || date_of_activity <= cp.expires_on) &&
+          (cp_date >= first_enrollment_date) &&
+          (last_enrollment_date.nil? || cp_date <= last_enrollment_date)
+        )
       end
       return false if contributing_care_plans.any? && !activity.in?(%w/care_planning pctp_signed/)
 

--- a/app/models/health/qualifying_activity.rb
+++ b/app/models/health/qualifying_activity.rb
@@ -32,8 +32,8 @@ module Health
     phi_attr :duplicate_id, Phi::OtherIdentifier
     phi_attr :epic_source_id, Phi::OtherIdentifier
 
-    MODE_OF_CONTACT_OTHER = 'other'
-    REACHED_CLIENT_OTHER = 'collateral'
+    MODE_OF_CONTACT_OTHER = 'other'.freeze
+    REACHED_CLIENT_OTHER = 'collateral'.freeze
 
     scope :submitted, -> do
       where.not(claim_submitted_on: nil)
@@ -101,11 +101,11 @@ module Health
         and(
           hpr_t[:disenrollment_date].eq(nil).
           or(
-            arel_table[:date_of_activity].lteq(hpr_t[:disenrollment_date])
-          )
-        )
+            arel_table[:date_of_activity].lteq(hpr_t[:disenrollment_date]),
+          ),
+        ),
       ).
-      joins(patient: :patient_referrals).
+        joins(patient: :patient_referrals).
         merge(Health::PatientReferral.contributing)
     end
 
@@ -141,7 +141,7 @@ module Health
           code: '',
           weight: 40,
         },
-      }.sort_by{|_, m| m[:weight]}.to_h
+      }.sort_by { |_, m| m[:weight]}.to_h
     end
 
     def self.client_reached
@@ -166,7 +166,7 @@ module Health
           code: 'UK',
           weight: 30,
         },
-      }.sort_by{|_, m| m[:weight]}.to_h
+      }.sort_by { |_, m| m[:weight]}.to_h
     end
 
     def self.activities
@@ -231,22 +231,22 @@ module Health
           code: 'T2024>U4',
           weight: 100,
         },
-      }.sort_by{|_, m| m[:weight]}.to_h
+      }.sort_by { |_, m| m[:weight]}.to_h
     end
 
     def self.date_search(start_date, end_date)
       if start_date.present? && end_date.present?
-        self.where("date_of_activity >= ? AND date_of_activity <= ?", start_date, end_date)
+        where('date_of_activity >= ? AND date_of_activity <= ?', start_date, end_date)
       elsif start_date.present?
-        self.where("date_of_activity >= ?", start_date)
+        where('date_of_activity >= ?', start_date)
       elsif end_date.present?
-        self.where("date_of_activity <= ?", end_date)
+        where('date_of_activity <= ?', end_date)
       else
         QualifyingActivity.all
       end
     end
 
-    def self.face_to_face? value
+    def self.face_to_face?(value)
       face_to_face_modes.include?(value&.to_sym)
     end
 
@@ -255,14 +255,14 @@ module Health
       keys = [
         :in_person,
       ]
-      Health::QualifyingActivity.modes_of_contact.select{ |k,_| keys.include? k }.
-        map{ |_,m| m[:title] } + keys
+      Health::QualifyingActivity.modes_of_contact.select { |k, _| keys.include? k }.
+        map { |_, m| m[:title] } + keys
     end
 
     # These validations must come after the above methods
-    validates :mode_of_contact, inclusion: {in: Health::QualifyingActivity.modes_of_contact.keys.map(&:to_s)}, allow_blank: true
-    validates :reached_client, inclusion: {in: Health::QualifyingActivity.client_reached.keys.map(&:to_s)}, allow_blank: true
-    validates :activity, inclusion: {in: Health::QualifyingActivity.activities.keys.map(&:to_s)}, allow_blank: true
+    validates :mode_of_contact, inclusion: { in: Health::QualifyingActivity.modes_of_contact.keys.map(&:to_s) }, allow_blank: true
+    validates :reached_client, inclusion: { in: Health::QualifyingActivity.client_reached.keys.map(&:to_s) }, allow_blank: true
+    validates :activity, inclusion: { in: Health::QualifyingActivity.activities.keys.map(&:to_s) }, allow_blank: true
     validates_presence_of(
       :user,
       :user_full_name,
@@ -297,45 +297,48 @@ module Health
     end
 
     def self.load_string_collection(collection)
-      collection.map{|k, v| [v, k]}
+      collection.map { |k, v| [v, k]}
     end
 
     def self.mode_of_contact_collection
-      self.load_string_collection(
+      load_string_collection(
         modes_of_contact.
         # select{ |k,_| k != :other }.
-        map{|k, mode| [k, mode[:title]] }
+        map { |k, mode| [k, mode[:title]] },
       )
     end
 
     def self.reached_client_collection
-      self.load_string_collection(
+      load_string_collection(
         client_reached.
-        map{|k, mode| [k, mode[:title]] }
+        map { |k, mode| [k, mode[:title]] },
       )
     end
 
     def self.activity_collection
       # suppress_from_view = [:pctp_signed]
-      self.load_string_collection(
+      load_string_collection(
         activities.
         # reject{|k| suppress_from_view.include?(k)}.
-        map{|k, mode| [k, mode[:title]] }
+        map { |k, mode| [k, mode[:title]] },
       )
     end
 
     def activity_title key
       return '' unless key
+
       self.class.activities[key&.to_sym].try(:[], :title) || key
     end
 
     def mode_of_contact_title key
       return '' unless key
+
       self.class.modes_of_contact[key&.to_sym].try(:[], :title) || key
     end
 
     def client_reached_title key
       return '' unless key
+
       self.class.client_reached[key&.to_sym].try(:[], :title) || key
     end
 
@@ -357,37 +360,29 @@ module Health
 
     def display_sections(index)
       section = {
-        subtitle: "Qualifying Activity ##{index+1}",
+        subtitle: "Qualifying Activity ##{index + 1}",
         values: [
-          {key: 'Mode of Contact:', value: title_for_mode_of_contact, other: (mode_of_contact_is_other? ? {key: 'Other:', value: mode_of_contact_other} : false)},
-          {key: 'Reached Client:', value: title_for_client_reached, other: (reached_client_is_collateral_contact? ? {key: 'Collateral Contact:', value: reached_client_collateral_contact} : false)},
-          {key: 'Which type of activity took place?', value: title_for_activity, include_br_before: true},
-          {key: 'Date of Activity:', value: date_of_activity&.strftime('%b %d, %Y')},
-          {key: 'Follow up:', value: follow_up, text_area: true}
-        ]
+          { key: 'Mode of Contact:', value: title_for_mode_of_contact, other: (mode_of_contact_is_other? ? { key: 'Other:', value: mode_of_contact_other } : false) },
+          { key: 'Reached Client:', value: title_for_client_reached, other: (reached_client_is_collateral_contact? ? { key: 'Collateral Contact:', value: reached_client_collateral_contact } : false) },
+          { key: 'Which type of activity took place?', value: title_for_activity, include_br_before: true },
+          { key: 'Date of Activity:', value: date_of_activity&.strftime('%b %d, %Y') },
+          { key: 'Follow up:', value: follow_up, text_area: true },
+        ],
       }
-      if claim_submitted_on.present?
-        section[:values].push({key: 'Claim submitted on:', value: claim_submitted_on.strftime('%b %d, %Y')})
-      end
+      section[:values].push({ key: 'Claim submitted on:', value: claim_submitted_on.strftime('%b %d, %Y') }) if claim_submitted_on.present?
       section
     end
 
     def title_for_mode_of_contact
-      if mode_of_contact.present?
-        self.class.modes_of_contact[mode_of_contact&.to_sym].try(:[], :title)
-      end
+      self.class.modes_of_contact[mode_of_contact&.to_sym].try(:[], :title) if mode_of_contact.present?
     end
 
     def title_for_client_reached
-      if reached_client.present?
-        self.class.client_reached[reached_client&.to_sym].try(:[], :title)
-      end
+      self.class.client_reached[reached_client&.to_sym].try(:[], :title) if reached_client.present?
     end
 
     def title_for_activity
-      if activity.present?
-        self.class.activities[activity&.to_sym].try(:[], :title)
-      end
+      self.class.activities[activity&.to_sym].try(:[], :title) if activity.present?
     end
 
     def procedure_code
@@ -409,7 +404,7 @@ module Health
     end
 
     def compute_procedure_valid?
-      return false unless date_of_activity.present? && activity.present? && mode_of_contact.present? && self.reached_client.present?
+      return false unless date_of_activity.present? && activity.present? && mode_of_contact.present? && reached_client.present?
 
       procedure_code = self.procedure_code
       modifiers = self.modifiers
@@ -446,7 +441,7 @@ module Health
     def first_of_type_for_day_for_patient?
       # Assumes ids are strictly increasing, so the lowest id will
       # be the id of the first QA on the day
-      same_of_type_for_day_for_patient.minimum(:id) == self.id
+      same_of_type_for_day_for_patient.minimum(:id) == id
     end
 
     # Find the id of the first_of_type_for_day_for_patient if is
@@ -480,9 +475,9 @@ module Health
       ).where(
         hqa_t[:date_of_activity].lteq(date_of_activity),
       ).group(
-        Arel.sql("DATE_TRUNC('month', date_of_activity)")
+        Arel.sql("DATE_TRUNC('month', date_of_activity)"),
       ).count
-      outreaches_by_month.reject{|k, v| v.zero?}.keys.count
+      outreaches_by_month.reject { |_k, v| v.zero?}.keys.count
     end
 
     def number_of_non_outreach_activity_months
@@ -494,9 +489,9 @@ module Health
       ).where(
         hqa_t[:date_of_activity].lteq(date_of_activity),
       ).group(
-        Arel.sql("DATE_TRUNC('month', date_of_activity)")
+        Arel.sql("DATE_TRUNC('month', date_of_activity)"),
       ).count
-      non_outreaches_by_month.reject{|k, v| v.zero?}.keys.count
+      non_outreaches_by_month.reject { |_k, v| v.zero?}.keys.count
     end
 
     def same_of_type_for_day_for_patient
@@ -512,7 +507,7 @@ module Health
         patient_id: patient_id,
         date_of_activity: (date_of_activity.beginning_of_month..date_of_activity.end_of_month),
       ).where(
-        activity: :outreach
+        activity: :outreach,
       )
     end
 
@@ -521,7 +516,7 @@ module Health
         patient_id: patient_id,
         date_of_activity: (date_of_activity.beginning_of_month..date_of_activity.end_of_month),
       ).where.not(
-        activity: :outreach
+        activity: :outreach,
       )
     end
 
@@ -530,13 +525,13 @@ module Health
       # 10/31/2018 removed meets_date_restrictions? check.  QA that are valid but unpayable
       # will still be submitted
       self.naturally_payable = compute_procedure_valid?
-      if self.naturally_payable && once_per_day_procedure_codes.include?(procedure_code.to_s)
+      if naturally_payable && once_per_day_procedure_codes.include?(procedure_code.to_s)
         # Log duplicates for any that aren't the first of type for a type that can't be repeated on the same day
         self.duplicate_id = first_of_type_for_day_for_patient_not_self
       else
         self.duplicate_id = nil
       end
-      self.save(validate: false) if self.changed?
+      save(validate: false) if changed?
     end
 
     def maintain_cached_values
@@ -546,12 +541,12 @@ module Health
 
     def maintain_valid_unpayable
       self.valid_unpayable = compute_valid_unpayable?
-      self.save(validate: false)
+      save(validate: false)
     end
 
     def maintain_procedure_valid
       self.procedure_valid = compute_procedure_valid?
-      self.save(validate: false)
+      save(validate: false)
     end
 
     def compute_valid_unpayable?
@@ -564,9 +559,7 @@ module Health
       return true if computed_procedure_valid && ! occurred_during_any_enrollment?
 
       # Unpayable if this was a phone/video call where the client wasn't reached
-      if reached_client == 'no' && ['phone_call', 'video_call'].include?(mode_of_contact)
-        return true
-      end
+      return true if reached_client == 'no' && ['phone_call', 'video_call'].include?(mode_of_contact)
 
       # Signing a care plan is payable regardless of engagement status
       return false if activity == 'pctp_signed'
@@ -579,7 +572,7 @@ module Health
         return true if number_of_outreach_activity_months > 3
       else
         # Non-outreach activities are payable at 1 per month before engagement unless there is a care-plan
-        if ! patient_has_signed_careplan?
+        unless patient_has_signed_careplan?
           return true unless first_non_outreach_of_month_for_patient?
           return true if patient.engagement_date.blank?
           return true if date_of_activity > patient.engagement_date
@@ -592,7 +585,7 @@ module Health
 
     def validity_class
       return 'qa-ignored' if ignored?
-      return 'qa-valid-unpayable'if valid_unpayable?
+      return 'qa-valid-unpayable' if valid_unpayable?
       return 'qa-valid' if procedure_valid?
 
       'qa-invalid'
@@ -628,7 +621,6 @@ module Health
       date_of_activity >= patient.care_plan_provider_signed_date && date_of_activity < patient.care_plan_renewal_date
     end
 
-
     # Is a valid care_plan missing for the date_of_activity?. This is much
     # slower and more complex than patient_has_valid_care_plan? which
     # can be used to determine if a patent currently has a care plan more efficiently.
@@ -663,6 +655,7 @@ module Health
       patient_referrals.reverse_each do |r|
         next if r.enrollment_start_date > date_of_activity # don't need to consider this one, it started after the QA
         next if r.in?(contributing_referrals) # already found it
+
         close_enough = contributing_referrals.any? do |r2|
           r_disnrollment = r.actual_or_pending_disenrollment_date
           r_disnrollment.nil? || (r2.enrollment_start_date - r_disnrollment).to_i.between?(0, allowed_gap_in_days)
@@ -702,7 +695,7 @@ module Health
           (last_enrollment_date.nil? || cp_date <= last_enrollment_date)
         )
       end
-      return false if contributing_care_plans.any? && !activity.in?(%w/care_planning pctp_signed/)
+      return false if contributing_care_plans.any? && !activity.in?(['care_planning', 'pctp_signed'])
 
       # Couldn't find one meeting any of or conditions, thus it's missing
       return true

--- a/bin/containers/ssh
+++ b/bin/containers/ssh
@@ -99,7 +99,7 @@ class ContainerList
   def ensure_profile_and_ip
     my_ip = `dig +short myip.opendns.com @resolver1.opendns.com`.chomp
 
-    raise 'Wrong IP' unless my_ip.match?(/^(54\.85|64.223)/)
+    raise 'Check you VPN. Your public IP seems incorrect' unless my_ip.match?(/^(54\.85|64.223)/)
 
     raise 'set AWS_PROFILE' if ENV['AWS_PROFILE'].nil?
   end

--- a/bin/portainer
+++ b/bin/portainer
@@ -16,7 +16,7 @@ class Portainer
   def ensure_profile_and_ip
     my_ip = `dig +short myip.opendns.com @resolver1.opendns.com`.chomp
 
-    raise 'Wrong IP' unless my_ip.match?(/^(54\.85|64.223)/)
+    raise 'Check you VPN. Your public IP seems incorrect' unless my_ip.match?(/^(54\.85|64.223)/)
 
     raise 'set AWS_PROFILE' if ENV['AWS_PROFILE'].nil?
   end

--- a/drivers/claims_reporting/app/models/claims_reporting/reconcilation_report.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/reconcilation_report.rb
@@ -68,10 +68,6 @@ module ClaimsReporting
       patient_qas(patient.id).select(&:missing_care_plan?).size
     end
 
-    def acos_for_patient(patient)
-      patient.patient_referrals.select { |r| r.active_within?(report_date_range) }.map { |r| r.aco&.name }.compact.uniq
-    end
-
     def careplan_dates_for_patient(patient)
       patient.careplans.select(&:provider_signed_on).map { |d| d.provider_signed_on.to_date }.to_sentence
     end

--- a/drivers/claims_reporting/spec/reconciliation_report_spec.rb
+++ b/drivers/claims_reporting/spec/reconciliation_report_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'ClaimsReporting::ReconcilationReport', type: :model do
+  it 'works' do
+    # done as one big example since we need all sorts of state setup and torn down
+    # and with terser mini test assertions so we can have helpful output per assertion
+
+    month = Date.iso8601('2020-06-15')
+    # old_patients
+    (1..3).map do |_n|
+      end_date = month.beginning_of_month - 1.day
+      create(:patient,
+             patient_referral: create(:prior_referral,
+                                      disenrollment_date: end_date,
+                                      enrollment_start_date: end_date - 1.year))
+    end
+
+    active_patients = (1..10).map do |_n|
+      create(:patient,
+             patient_referral: create(:prior_referral,
+                                      enrollment_start_date: month.beginning_of_month - 1.day,
+                                      disenrollment_date: month.end_of_month))
+    end
+
+    # active careplan
+    # unsigned careplan
+    # expired careplan
+
+    ClaimsReporting::CpPaymentUpload.new.save(
+      validate: false,
+    )
+
+    report = ClaimsReporting::ReconcilationReport.new(
+      month: month,
+    )
+
+    # it 'covers the expected month' do
+    expect(report.report_date_range.first).to eq(month.beginning_of_month)
+    expect(report.report_date_range.last).to eq(month.end_of_month)
+
+    # 'has active patients' do
+    expect(report.active_patient_count).to eq(active_patients.size)
+    assert_equal active_patients.map(&:id).to_set, report.active_patients.map(&:id).to_set, 'finds active patients'
+
+    # it 'knows the latest_payment_report_upload' do
+    expect(report.latest_payment_report_upload.class).to eq(ClaimsReporting::CpPaymentUpload)
+
+    patient = active_patients.first
+
+    assert_equal 0, report.qa_count_for_patient(patient), 'qa_count_for_patient'
+    assert_equal 0, report.qa_missing_enrollment_count_for_patient(patient), 'qa_missing_enrollment_count_for_patient'
+    assert_equal 0, report.qa_missing_careplan_count_for_patient(patient), 'qa_missing_careplan_count_for_patient'
+    assert_equal 0, report.careplan_dates_for_patient(patient).size, 'careplan_dates_for_patient'
+
+    assert_instance_of Array, report.patients_without_payments_columns, 'patients_without_payments_columns'
+    assert_instance_of Array, report.patients_without_payments_columns, 'patients_without_payments_rows'
+    assert_instance_of String, report.to_csv, 'can make a CSV string'
+  end
+end

--- a/drivers/claims_reporting/spec/reconciliation_report_spec.rb
+++ b/drivers/claims_reporting/spec/reconciliation_report_spec.rb
@@ -161,6 +161,24 @@ RSpec.describe 'ClaimsReporting::ReconcilationReport', type: :model do
              claim_submitted_on: claim_submitted_on)
       active_patients << [patient, 0, 1, [cp.provider_signed_on.to_date]]
     end
+    # 11. after grace period, before pending dis-enrollment, an expired signed careplan after engagement period
+    # this is not payable and should be considered as a missed care plan
+    create(:patient).tap do |patient|
+      referral = create(:prior_referral,
+                        patient: patient,
+                        enrollment_start_date: month.beginning_of_month - 2.years,
+                        pending_disenrollment_date: month.end_of_month,
+                        disenrollment_date: nil)
+      cp = create(:careplan,
+                  patient: patient,
+                  provider_signed_on: referral.enrollment_start_date,
+                  patient_signed_on: referral.enrollment_start_date)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 11.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, [cp.provider_signed_on.to_date]]
+    end
 
     ClaimsReporting::CpPaymentUpload.new.save(
       validate: false,

--- a/drivers/claims_reporting/spec/reconciliation_report_spec.rb
+++ b/drivers/claims_reporting/spec/reconciliation_report_spec.rb
@@ -2,29 +2,148 @@ require 'rails_helper'
 
 RSpec.describe 'ClaimsReporting::ReconcilationReport', type: :model do
   it 'works' do
-    # done as one big example since we need all sorts of state setup and torn down
-    # and with terser mini test assertions so we can have helpful output per assertion
+    # Done as one big example since we need all sorts of state setup
+    # and torn down. And with terser mini test assertions so we can
+    # have helpful output per assertion since this is a single Example
 
     month = Date.iso8601('2020-06-15')
-    # old_patients
-    (1..3).map do |_n|
-      end_date = month.beginning_of_month - 1.day
-      create(:patient,
-             patient_referral: create(:prior_referral,
-                                      disenrollment_date: end_date,
-                                      enrollment_start_date: end_date - 1.year))
+    claim_submitted_on = month >> 2
+    active_patients = []
+    engagement_days = ::Health::PatientReferral::ENGAGEMENT_IN_DAYS.days
+    # | QA occurs...
+    # 0. before enrollment
+    create(:patient).tap do |patient|
+      referral = create(:prior_referral,
+                        patient: patient,
+                        enrollment_start_date: month.beginning_of_month + 15.days,
+                        disenrollment_date: month.beginning_of_month + 15.days)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: referral.enrollment_start_date - 1.day,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 1, 0, []]
     end
-
-    active_patients = (1..10).map do |_n|
-      create(:patient,
-             patient_referral: create(:prior_referral,
-                                      enrollment_start_date: month.beginning_of_month - 1.day,
-                                      disenrollment_date: month.end_of_month))
+    # 1. during grace period
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - 30.days,
+             disenrollment_date: month.end_of_month)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 1.day,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 0, []]
     end
-
-    # active careplan
-    # unsigned careplan
-    # expired careplan
+    # 2. after grace period, before  dis-enrollment, no careplan
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             disenrollment_date: month.end_of_month)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 11.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, []]
+    end
+    # 3. after grace period, before pending dis-enrollment, careplan missing signature
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: month.end_of_month,
+             disenrollment_date: nil)
+      create(:careplan, patient: patient)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 11.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, []]
+    end
+    # 4. after grace period, before pending dis-enrollment, after careplan signed by engagement period end
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: month.end_of_month,
+             disenrollment_date: nil)
+      cp = create(:careplan, patient: patient, provider_signed_on: month.beginning_of_month)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 11.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 0, [cp.provider_signed_on.to_date]]
+    end
+    # 5. after grace period, before pending dis-enrollment, after careplan signed after engagement period
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: month.end_of_month,
+             disenrollment_date: nil)
+      cp = create(:careplan, patient: patient, provider_signed_on: month.beginning_of_month + 11.days)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 15.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, [cp.provider_signed_on.to_date]] # FIXME?
+    end
+    # 6. after grace period, before pending dis-enrollment, before careplan signed after engagement period
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: month.end_of_month,
+             disenrollment_date: nil)
+      cp = create(:careplan, patient: patient, provider_signed_on: month.beginning_of_month + 15.days)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 11.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, [cp.provider_signed_on.to_date]] # FIXME?
+    end
+    # 7. after pending disenrollment before actual disenrollment, after valid careplan
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: month.beginning_of_month + 10.days,
+             disenrollment_date: month.end_of_month)
+      cp = create(:careplan, patient: patient, provider_signed_on: month.beginning_of_month)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 15.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 0, [cp.provider_signed_on.to_date]]
+    end
+    # 8. during an open/current enrollment more than a year after last signed careplan
+    create(:patient).tap do |patient|
+      create(:prior_referral,
+             patient: patient,
+             enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+             pending_disenrollment_date: nil,
+             disenrollment_date: nil)
+      cp = create(:careplan, patient: patient, provider_signed_on: month.beginning_of_month - 2.years)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 15.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 0, 1, [cp.provider_signed_on.to_date]]
+    end
+    # 9. after disenrollment
+    create(:patient).tap do |patient|
+      referral = create(:prior_referral,
+                        patient: patient,
+                        enrollment_start_date: month.beginning_of_month - (engagement_days - 10.days),
+                        disenrollment_date: month.beginning_of_month + 10.days)
+      cp = create(:careplan, patient: patient, provider_signed_on: referral.enrollment_start_date + 1.days)
+      create(:qualifying_activity,
+             patient: patient,
+             date_of_activity: month.beginning_of_month + 15.days,
+             claim_submitted_on: claim_submitted_on)
+      active_patients << [patient, 1, 0, [cp.provider_signed_on.to_date]]
+    end
 
     ClaimsReporting::CpPaymentUpload.new.save(
       validate: false,
@@ -33,6 +152,7 @@ RSpec.describe 'ClaimsReporting::ReconcilationReport', type: :model do
     report = ClaimsReporting::ReconcilationReport.new(
       month: month,
     )
+    # end of example setup...
 
     # it 'covers the expected month' do
     expect(report.report_date_range.first).to eq(month.beginning_of_month)
@@ -40,20 +160,28 @@ RSpec.describe 'ClaimsReporting::ReconcilationReport', type: :model do
 
     # 'has active patients' do
     expect(report.active_patient_count).to eq(active_patients.size)
-    assert_equal active_patients.map(&:id).to_set, report.active_patients.map(&:id).to_set, 'finds active patients'
 
     # it 'knows the latest_payment_report_upload' do
     expect(report.latest_payment_report_upload.class).to eq(ClaimsReporting::CpPaymentUpload)
 
-    patient = active_patients.first
+    active_patients.each_with_index do |(patient, missing_enrollment, missing_cp, pcp_dates), idx|
+      assert_equal 1, report.qa_count_for_patient(patient), "qa_count_for_patient(#{idx})"
+      assert_equal missing_enrollment, report.qa_missing_enrollment_count_for_patient(patient), "qa_missing_enrollment_count_for_patient(#{idx})"
+      assert_equal missing_cp, report.qa_missing_careplan_count_for_patient(patient), "qa_missing_careplan_count_for_patient(#{idx})"
+      assert_equal pcp_dates&.to_sentence, report.careplan_dates_for_patient(patient), "careplan_dates_for_patient(#{idx})"
+    end
 
-    assert_equal 0, report.qa_count_for_patient(patient), 'qa_count_for_patient'
-    assert_equal 0, report.qa_missing_enrollment_count_for_patient(patient), 'qa_missing_enrollment_count_for_patient'
-    assert_equal 0, report.qa_missing_careplan_count_for_patient(patient), 'qa_missing_careplan_count_for_patient'
-    assert_equal 0, report.careplan_dates_for_patient(patient).size, 'careplan_dates_for_patient'
-
-    assert_instance_of Array, report.patients_without_payments_columns, 'patients_without_payments_columns'
-    assert_instance_of Array, report.patients_without_payments_columns, 'patients_without_payments_rows'
-    assert_instance_of String, report.to_csv, 'can make a CSV string'
+    assert_equal [
+      'Medicaid ID',
+      'Last Name',
+      'First Name',
+      'Submitted QAs',
+      'QAs Outside Enrollment',
+      'QAs Without Required Careplan',
+      'Careplan PCP signatures',
+    ], report.patients_without_payments_columns, 'patients_without_payments_columns'
+    assert_instance_of Array, report.patients_without_payments_rows, 'patients_without_payments_rows'
+    assert_equal active_patients.size, report.patients_without_payments_rows.size, 'patients_without_payments_rows'
+    assert_instance_of Array, CSV.parse(report.to_csv), 'can make a CSV'
   end
 end

--- a/spec/factories/health/patient_referrals.rb
+++ b/spec/factories/health/patient_referrals.rb
@@ -1,43 +1,33 @@
+require 'faker'
+
 FactoryBot.define do
   factory :patient_referral, class: 'Health::PatientReferral' do
-    first_name { 'First' }
-    last_name { 'Last' }
-    birthdate { Date.current }
     sequence(:medicaid_id)
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    birthdate { rand(18..64).years.ago + rand(365) }
     enrollment_start_date { Date.current }
     current { true }
     contributing { true }
-  end
 
-  factory :prior_referral, class: 'Health::PatientReferral' do
-    first_name { 'Patient' }
-    last_name { 'A' }
-    birthdate { Date.current }
-    sequence(:medicaid_id)
-    enrollment_start_date { Date.current - 1.year }
-    disenrollment_date { Date.current - 11.months }
-    current { false }
-    contributing { false }
-  end
+    factory :prior_referral do
+      enrollment_start_date { Date.current - 1.year }
+      disenrollment_date { Date.current - 11.months }
+      current { false }
+      contributing { false }
+    end
 
-  factory :contributing_referral, class: 'Health::PatientReferral' do
-    first_name { 'Patient' }
-    last_name { 'A' }
-    birthdate { Date.current }
-    sequence(:medicaid_id)
-    enrollment_start_date { Date.current - 2.months }
-    disenrollment_date { Date.current - 1.months }
-    current { false }
-    contributing { true }
-  end
+    factory :contributing_referral do
+      enrollment_start_date { Date.current - 2.months }
+      disenrollment_date { Date.current - 1.months }
+      current { false }
+      contributing { true }
+    end
 
-  factory :current_referral, class: 'Health::PatientReferral' do
-    first_name { 'Patient' }
-    last_name { 'A' }
-    birthdate { Date.current }
-    sequence(:medicaid_id)
-    enrollment_start_date { Date.current - 2.weeks }
-    current { true }
-    contributing { true }
+    factory :current_referral do
+      enrollment_start_date { Date.current - 2.weeks }
+      current { true }
+      contributing { true }
+    end
   end
 end

--- a/spec/factories/health/patients.rb
+++ b/spec/factories/health/patients.rb
@@ -1,13 +1,9 @@
+require 'faker'
+
 FactoryBot.define do
   factory :patient, class: 'Health::Patient' do
     sequence(:id_in_source)
     patient_referral
-    association :client, factory: :hud_client
-  end
-
-  factory :patient_a, class: 'Health::Patient' do
-    sequence(:id_in_source)
-    patient_referrals { [create(:prior_referral), create(:contributing_referral), create(:current_referral)] }
     association :client, factory: :hud_client
   end
 end

--- a/spec/factories/health/qualifying_activities.rb
+++ b/spec/factories/health/qualifying_activities.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     activity { :outreach }
     association :source, factory: :qa_source
     user
-    association :patient, factory: :patient_a
+    association :patient
   end
 
   trait :old_qa do


### PR DESCRIPTION
Add some unit test coverage to the (surprisingly complex) logic for determining/reporting if a qualifying activity occurred during a valid enrollment and with a valid care plan.

@awisema Take a scan of the `active_patient` cases in `drivers/claims_reporting/spec/reconciliation_report_spec.rb.` I'm fairly confident i got them correct and they match all real world examples I'm aware off. There are a number of cases each described by a block ending in `active_patients << [patient, 1, 0, [cp.provider_signed_on.to_date]]` where the tuple fields are: 
- patient
- enrollment_missing?
- careplan_missing?
- Array of all care plan provider dates for that patient.

We consider a care plan signed if the provider has signed it at the time of the report and we consider it applicable to an enrollment/activity if either the provider or patient signed it at any time during the enrollment and it has not expired by the time of the activity. Effectively, this gives everyone the benefit of the doubt on the exact dates of signature as long as it gets signed around the time of the activity.