### PR TITLE
Make HMIS 2020 key lookup static

### DIFF
--- a/app/models/concerns/hmis/structure/base.rb
+++ b/app/models/concerns/hmis/structure/base.rb
@@ -140,11 +140,9 @@ module HMIS::Structure::Base
     end
 
     def hmis_structure(version: nil)
-      hmis_configuration(version: version).transform_values { |v| v.select { |k| k.in?(hmis_structure_keys) } }
+      hmis_configuration(version: version).transform_values { |v| v.select { |k| k.in?(HMIS_STRUCTURE_KEYS) } }
     end
 
-    def hmis_structure_keys
-      [:type, :limit, :null]
-    end
+    HMIS_STRUCTURE_KEYS = [:type, :limit, :null].freeze
   end
 end

--- a/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/importer/import_concern.rb
+++ b/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/importer/import_concern.rb
@@ -240,8 +240,12 @@ module HmisCsvTwentyTwenty::Importer::ImportConcern
       []
     end
 
+    def self.hmis_2020_keys
+      @hmis_2020_keys ||= hmis_structure(version: '2020').keys
+    end
+
     def hmis_data
-      slice(*self.class.hmis_structure(version: '2020').keys)
+      slice(*self.class.hmis_2020_keys) # self.class.hmis_2020_keys is used to avoid realloc/calc'ing these static keys in tight import loops
     end
 
     def calculate_source_hash


### PR DESCRIPTION
Extracted from WIP on on reducing CPU time for `#preprocess` in the 2020 HMIS loader. 

ruby-prof show a incremental (5%) improvement in load time  on spec/fixtures/files/importers/hmis_twenty_twenty/hud_sample and saving a few zillion allocs/method calls