### PR TITLE
[#172605311] Adds Workoff jobs For Real

### DIFF
--- a/app/jobs/workoff_arbiter.rb
+++ b/app/jobs/workoff_arbiter.rb
@@ -61,7 +61,7 @@ class WorkoffArbiter
 
     ecs.run_task(payload)
 
-    @notifier.ping("Added a workoff worker. Metric was #{metric} with #{_current_worker_count} workers right now (this might include the just-created one).")
+    @notifier.ping("Added a workoff worker. Metric was #{metric.round} with #{_current_worker_count} workers right now (this might include the just-created one).")
   end
 
   private

--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -115,11 +115,12 @@ class RollOut
   end
 
   def run!
+    # Needs to go first so the others can know the task definition
+    register_workoff_worker!
+
     register_cron_job_worker!
 
     mark_spot_instances!
-
-    register_workoff_worker!
 
     run_deploy_tasks!
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -54,6 +54,12 @@ every 5.minutes do
   rake 'reporting:frequent'
 end
 
+if ENV['ECS'] == 'true'
+  every 2.minutes do
+    rake 'jobs:arbitrate_workoff'
+  end
+end
+
 every 4.hours do
   # Defers to delayed jobs
   rake "grda_warehouse:save_service_history_snapshots"

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -11,4 +11,11 @@ namespace :jobs do
       arbiter.add_worker!
     end
   end
+
+  desc "fill the queue test"
+  task :fill_queue, [] => [:environment] do |t, args|
+    200.times do
+      TestJob.perform_later(length_in_seconds: 60, memory_bloat_per_second: 10)
+    end
+  end
 end


### PR DESCRIPTION
* spot capacity providers in use now
* deploy task uses them: If capacity is down to zero, the next deployment will be a bit slower to happen, but this is a good canary for if this is working.
* workoff jobs use them