### PR TITLE
Issues/177403107 select2 select all in modal

### DIFF
--- a/app/assets/javascripts/remote_select_load.js.coffee
+++ b/app/assets/javascripts/remote_select_load.js.coffee
@@ -10,11 +10,9 @@ App.remoteSelectLoad.init = (root) =>
     loading_placeholder = 'Loading...'
     $select.attr('placeholder', loading_placeholder)
     if $select.hasClass('select2')
-      $select.select2('destroy')
       new App.Form.Select2Input this, { placeholder: loading_placeholder }
     $.post url, data, (data) =>
       $select.append(data)
       $select.attr('placeholder', original_placeholder)
       if $select.hasClass('select2')
-        $select.select2('destroy')
         new App.Form.Select2Input this, { placeholder: original_placeholder }

--- a/app/assets/javascripts/select_two.js.es6
+++ b/app/assets/javascripts/select_two.js.es6
@@ -59,6 +59,14 @@ App.Form.Select2Input = class Select2Input {
     }
   }
 
+  getGroupSelectors() {
+    const resultsId = `select2-${this.select.id}-results`
+    return {
+      groupSelector: `#${resultsId} .select2-results__group`,
+      resultsId,
+    }
+  }
+
   selectAllHtml() {
     let text = 'all'
     if (this.someItemsSelected() || this.allItemsSelected()) {
@@ -84,11 +92,11 @@ App.Form.Select2Input = class Select2Input {
       (this.$select.select2('data').length === 0)
   }
 
+
   initToggleSelectAll() {
     // Init optgroup select all
     const self = this
-    const resultsId = `select2-${this.select.id}-results`
-    const groupSelector = `#${resultsId} .select2-results__group`
+    const { resultsId, groupSelector } =  this.getGroupSelectors()
     $(document).on('click', groupSelector, function() {
       const label = this.parentElement.getAttribute('aria-label')
       const selected = !!this.dataset.allSelected
@@ -101,7 +109,9 @@ App.Form.Select2Input = class Select2Input {
       } else {
         this.setAttribute('data-all-selected', true)
       }
+      // Trigger change on the select2 instance so items are added/subtracted
       self.$select.trigger("change")
+      // Update class of list items so they are visually highlighted
       $(`#${resultsId} .select2-results__options--nested  li`).each((i, el) => {
         el.setAttribute('aria-selected', !selected)
       })

--- a/app/assets/stylesheets/application/overrides/_select2.scss
+++ b/app/assets/stylesheets/application/overrides/_select2.scss
@@ -42,16 +42,19 @@
   display: flex;
   justify-content: space-between;
   cursor: pointer;
+  &:focus,
+  &:hover {
+    background: #5897fb;
+    color: $white;
+  }
   &::after {
     font-weight: normal;
-    font-family: 'icons';
-    content: 'select all #{get-icon-code('checkmark2')}'
+    content: 'select all'
   }
-  &.j-all-selected {
+  &[data-all-selected] {
     &::after {
       font-weight: normal;
-      font-family: 'icons';
-      content: 'select none #{get-icon-code('checkmark')}'
+      content: 'select none'
     }
   }
 }

--- a/app/views/filters/_filters.haml
+++ b/app/views/filters/_filters.haml
@@ -35,5 +35,4 @@
 
 = content_for :page_js do
   :javascript
-    App.select2.init()
     App.remoteSelectLoad.init()

--- a/app/views/filters/filter_controls/projects/_input.haml
+++ b/app/views/filters/filter_controls/projects/_input.haml
@@ -1,1 +1,1 @@
-= f.input :project_ids, label: control.label, collection: [], as: :select_two, input_html: {multiple: true, placeholder: 'Any Project', data: {'collection-path' => api_projects_path(selected_project_ids: @filter.project_ids)}}, include_blank: false
+= f.input :project_ids, label: control.label, collection: [], as: :grouped_select, input_html: {class: 'select2', multiple: true, placeholder: 'Any Project', data: {'collection-path' => api_projects_path(selected_project_ids: @filter.project_ids)}}, include_blank: false

--- a/app/views/style_guides/form.haml
+++ b/app/views/style_guides/form.haml
@@ -90,15 +90,26 @@
             %h4 Select 2 - Ajax load of Options for Projects with Blank (warehouse)
             = f.input :huge_collection_options_with_blank, collection: [], as: :select_two, input_html: { data: { 'collection-path' => api_projects_path() }}, label: 'Projects', include_blank: 'Please choose'
 
-            - selected = GrdaWarehouse::Hud::Project.joins(:data_source, :organization).viewable_by(current_user).last.id
-            %h4 Select 2 - Ajax load of Options for Projects #{selected} pre-selected (warehouse)
-            = f.input :huge_collection_options, collection: [], as: :select_two, input_html: { data: { 'collection-path' => api_projects_path(selected_project_ids: [selected]) }}, label: 'Projects'
-
             %h4 Select 2 - Ajax load of Options for Projects Multiple without pre-selected projects (warehouse)
             = f.input :huge_collection_options_multi_none, collection: [], as: :select_two, input_html: { data: { 'collection-path' => api_projects_path() }, multiple: true}, label: 'Projects'
 
             %h4 Select 2 - Ajax load of Options for Projects Multiple with pre-selected projects (warehouse)
             = f.input :huge_collection_options_multi, collection: [], as: :select_two, input_html: { data: { 'collection-path' => api_projects_path(selected_project_ids: GrdaWarehouse::Hud::Project.pluck(:id).sample(2)) }, multiple: true}, label: 'Projects'
+
+            - title = 'Grouped collection with select all in modal'
+            %h4 Select 2 - #{title}
+            - modal_slug = 'grouped_collection_modal'
+            %a.btn.btn-primary{href: '#', data: {toggle: 'modal', target: "\#modal-#{modal_slug}"}}  Open Modal
+            .modal.fade{id: "modal-#{modal_slug}", role: 'dialog'}
+              .modal-dialog{role: 'document'}
+                .modal-content
+                  .modal-header
+                    %h4= title
+                    %button.close{data: {dismiss: 'modal'}}
+                      %i.modal-icon-close
+                  .modal-body
+                    = f.input :grouped_collection_in_modal, label: title, collection: [], as: :select_two, input_html: {multiple: true, placeholder: 'Any Project', data: {'collection-path' => api_projects_path()}}, include_blank: false
+
           %h4 Password
           = f.input :password, as: :password, required: true, **validate_html
 


### PR DESCRIPTION
@eanders I finally had a chance to look at the select2 select all option group issue. Turns out the Classes (the wrapper classes that handles init of select2 and the selection logic) associated with the select elements were being initialized twice. The `select2` instances were subsequently being destroyed in `app/assets/javascripts/remote_select_load.js.coffee` but the  events associated with the elements were still kicking around so they were being triggered multiple times. I removed the init within the view partial and removed the select2 instance destructions since those are now instantiated after the remote stuff is requested and loaded in `app/assets/javascripts/remote_select_load.js.coffee`.

In the process of debugging I heavily refactored/simplified the select all option group logic and I think it's a bit more straightforward now (and I think it works as intended). I also removed the check icon, added a focus/hover state and updated the text based on the selected state.

Todos:
- [ ] Handle updating the selected state of the option group when all items are selected/deselected externally
- [ ] Handle updating the selected state of the option group after close and re-open (since it's added and removed from the DOM each time)