### PR TITLE
Workoff workers added when there are up to three pending long jobs

### DIFF
--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -276,7 +276,7 @@ class RollOut
     desired_count = container_count || 1
 
     if desired_count == 0
-      return [0, 0]
+      return [0, 100]
     elsif desired_count == 1
       [100, 200]
     else

--- a/config/deploy/docker/show-workoff
+++ b/config/deploy/docker/show-workoff
@@ -1,0 +1,14 @@
+
+rm -f tasks.in*
+rm -f tasks
+
+aws-vault exec openpath -- aws ecs list-tasks --cluster=$CLUSTER | jq '.taskArns[]' -r > tasks
+
+# only 100 at a time possible
+split -d -l 100 tasks tasks.in.
+
+aws-vault exec openpath -- aws ecs describe-tasks --tasks $(cat tasks.in.00 | xargs) --cluster=$CLUSTER | jq '.tasks[]' > results.json
+aws-vault exec openpath -- aws ecs describe-tasks --tasks $(cat tasks.in.01 | xargs) --cluster=$CLUSTER | jq '.tasks[]' >> results.json
+
+# could do some fancy jq thing, but this works
+cat results.json | grep taskDefinitionArn | grep workoff

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
   git \
   bash \
   freetds-dev \
-  openssh \
+  openssh ctags zsh \
   icu icu-dev \
   curl libcurl curl-dev \
   imagemagick \


### PR DESCRIPTION
This does not cap workoff workers spun up entirely because of long jobs to 3. It caps it to three per arbiter run.

Let me know if you want me to change that. The logic will be a little more complicated.