### PR TITLE
Minimal monkey-patch fix for a Docker/overlay fs bug we are hitting o…

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,6 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
+require_relative '../lib/docker_fs_fix'
+
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/lib/docker_fs_fix.rb
+++ b/lib/docker_fs_fix.rb
@@ -1,0 +1,15 @@
+# https://github.com/docker/for-linux/issues/1015
+
+puts "Patching https://github.com/docker/for-linux/issues/1015"
+module FileUtilsPatch
+  def copy_file(dest)
+    FileUtils.touch(path())
+    super
+  end
+end
+
+module FileUtils
+  class Entry_
+    prepend FileUtilsPatch
+  end
+end

--- a/spec/factories/grda_warehouse/secure_files.rb
+++ b/spec/factories/grda_warehouse/secure_files.rb
@@ -1,9 +1,7 @@
-# include ActionDispatch::TestProcess
 FactoryBot.define do
   factory :secure_file, class: 'GrdaWarehouse::SecureFile' do
     name { 'test file' }
-    content { File.open('spec/fixtures/files/images/test_photo.jpg', 'r') }
-
     file { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/images/test_photo.jpg'), 'image/jpeg') }
+    content { file.read }
   end
 end


### PR DESCRIPTION
Monkey-patch `FileUtils.copy_file` to hack around https://github.com/docker/for-linux/issues/1015


The slow process of tracking this down and finding a minimal fix are in 
https://github.com/greenriver/hmis-warehouse/commit/fbebf41e27ef3094c3c8359d8243da3cbb74722f and https://github.com/greenriver/hmis-warehouse/commit/52ca6b69f57d8a6d28673ecb5e2037a7e74bd97a
