### PR TITLE
priority metric default

### DIFF
--- a/app/jobs/workoff_arbiter.rb
+++ b/app/jobs/workoff_arbiter.rb
@@ -94,6 +94,7 @@ class WorkoffArbiter
 
       # { -5 => 1, ... }
       raw_priorities.zip(normalized_priorities).to_h.tap do |p|
+        p.default = 0.5
         Rails.logger.debug "Queue attributes: #{Delayed::Worker.queue_attributes}"
         Rails.logger.debug "Normalized priority values (lower priority values are more important.): #{p.inspect}"
       end


### PR DESCRIPTION
We were assuming all jobs have a priority similar to how we were assuming all jobs had an explicit queue. This sets the priority in the computation to half way between the low and high values (0 and 1).

Feel like the real solution should involve always having a queue (which implies always having a priority), but that might be a big lift compared to this one-liner.