### PR TITLE
Cancels queued background jobs if subscription is gone

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2259,7 +2259,6 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/rds_sql_server/hmis_sql_server.rb'
-    - 'app/jobs/background_render_job.rb'
     - 'app/models/cohort_columns/ongoing_es.rb'
     - 'app/models/cohort_columns/ongoing_psh.rb'
     - 'app/models/cohort_columns/ongoing_rrh.rb'
@@ -3570,7 +3569,6 @@ Style/StringLiterals:
   Exclude:
     - 'app/channels/application_cable/connection.rb'
     - 'app/channels/test_channel.rb'
-    - 'app/jobs/background_render_job.rb'
     - 'app/models/agency.rb'
     - 'app/models/auto_encoding_csv.rb'
     - 'app/models/cas/user.rb'

--- a/app/jobs/background_render_job.rb
+++ b/app/jobs/background_render_job.rb
@@ -3,6 +3,12 @@ class BackgroundRenderJob < BaseJob
   queue_as :short_running
 
   def perform(render_id, **options)
+    # Before we run this, let's make sure someone still wants it.
+    pubsub = ActionCable.server.pubsub
+    channels = pubsub.send(:redis_connection).pubsub('channels', '*')
+    found_stream = channels.detect { |stream| stream.include?(render_id) }
+    return unless found_stream
+
     html = render_html(**options)
     payload = cable_ready[BackgroundRenderChannel.stream_name(render_id)].
       outer_html(
@@ -14,13 +20,13 @@ class BackgroundRenderJob < BaseJob
     handle_error(render_id, e)
   end
 
-  private def render_html(**options)
-    raise "abstract method not implemented"
+  private def render_html(**_options)
+    raise 'abstract method not implemented'
   end
 
   private def handle_error(render_id, error)
     payload = cable_ready[BackgroundRenderChannel.stream_name(render_id)].
-      alert(message: "Sorry, an error occurred building the report.  Please refresh the page and try again.")
+      alert(message: 'Sorry, an error occurred building the report.  Please refresh the page and try again.')
 
     if Rails.env.development?
       message = (["Error in #{self.class}", error.message] + error.backtrace).join("\n")

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -20,7 +20,7 @@ class Rack::Attack
   end
 
   def self.rapid_paths(request)
-    request.path.include?('rollup') || request.path.include?('cohort') || asset_paths(request)
+    request.path.include?('rollup') || request.path.include?('cohort') || request.path.include?('core_demographics') || asset_paths(request)
   end
 
   def self.asset_paths(request)


### PR DESCRIPTION
I think this will do the job that we're looking for. Testing was difficult because the jobs run slowly, and about half the time the browser didn't pick up the data. That was true on pre-release as well as on this feature branch, so I don't think it's anything I've introduced, and it may have to do with my installation. At any rate, wanted to mention it.