### PR TITLE
Fix bad line ending recovery

### DIFF
--- a/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/loader/loader.rb
+++ b/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/loader/loader.rb
@@ -170,6 +170,7 @@ module HmisCsvTwentyTwenty::Loader
           if bad_line_endings?(file)
             copy_length = file.stat.size - 2
             begin
+              logger.debug "Correcting bad line ending in #{source_file_path}"
               tmp_file = ::Tempfile.new(file_name)
               File.copy_stream(file, tmp_file, copy_length, 0)
               tmp_file.write("\n")

--- a/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/loader/loader.rb
+++ b/drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/loader/loader.rb
@@ -164,14 +164,16 @@ module HmisCsvTwentyTwenty::Loader
         source_file_path = File.join(@file_path, file_name)
         next unless File.file?(source_file_path)
 
-        File.open(source_file_path, 'r', encoding: AutoEncodingCsv.detect_encoding(source_file_path)) do |file|
+        encoding = AutoEncodingCsv.detect_encoding(source_file_path)
+
+        File.open(source_file_path, 'r', encoding: encoding) do |file|
           if bad_line_endings?(file)
             copy_length = file.stat.size - 2
             begin
               tmp_file = ::Tempfile.new(file_name)
               File.copy_stream(file, tmp_file, copy_length, 0)
               tmp_file.write("\n")
-              File.open(tmp_file.path, file_mode) do |tmp_file_io|
+              File.open(tmp_file.path, 'r', encoding: encoding) do |tmp_file_io|
                 load_source_file_pg(read_from: tmp_file_io, klass: klass, original_file_path: source_file_path)
               end
             ensure

--- a/drivers/hmis_csv_twenty_twenty/spec/fixtures/files/bad_ending/source/Export.csv
+++ b/drivers/hmis_csv_twenty_twenty/spec/fixtures/files/bad_ending/source/Export.csv
@@ -1,0 +1,2 @@
+﻿"ExportID","SourceType","SourceID","SourceName","SourceContactFirst","SourceContactLast","SourceContactPhone","SourceContactExtension","SourceContactEmail","ExportDate","ExportStartDate","ExportEndDate","SoftwareName","SoftwareVersion","ExportPeriodType","ExportDirective","HashStatus"
+"31a77b417911747e41ef9936f9a4b657","3","","Boston DND Warehouse","Automated","Export","","","","2017-10-03 00:00:00","2017-09-01","2017-10-03","Boston HMIS Warehouse","1","3","3","1"

--- a/drivers/hmis_csv_twenty_twenty/spec/fixtures/files/bad_ending/source/Project.csv
+++ b/drivers/hmis_csv_twenty_twenty/spec/fixtures/files/bad_ending/source/Project.csv
@@ -1,0 +1,2 @@
+﻿ProjectID,OrganizationID,ProjectName,ProjectCommonName,OperatingStartDate,OperatingEndDate,ContinuumProject,ProjectType,HousingType,ResidentialAffiliation,TrackingMethod,HMISParticipatingProject,TargetPopulation,PITCount,DateCreated,DateUpdated,UserID,DateDeleted,ExportID
+751,109,Furious Whistle Hill,"",,,0,1,,,3,,4,3589,2015-11-30 00:00:00,2015-11-30 08:50:40,francis,,31a77b417911747e41ef9936f9a4b657


### PR DESCRIPTION
Recently merged code to handle unexpected file encodings in the CSV import interacted badly with an existing workaround to handle strange final line endings. This PR fixes that with minimal code changes and adds test coverage.  it would likely be more efficient and clearer if both fixups could happen in the same place but that would involve more disruptive changes