### PR TITLE
Automated claims reporting sftp dropbox

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -153,7 +153,6 @@ Layout/DotPosition:
     - 'app/models/grda_warehouse/us_census_api/finder.rb'
     - 'app/models/health/patient.rb'
     - 'app/models/health/patient_referral.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/report_generators/lsa/fy2018/all.rb'
 
 # Offense count: 6
@@ -420,7 +419,6 @@ Layout/EmptyLines:
     - 'app/models/role.rb'
     - 'app/models/talentlms/config.rb'
     - 'app/models/user.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -912,7 +910,6 @@ Layout/FirstHashElementIndentation:
     - 'app/models/report_generators/system_performance/fy2018/measure_three.rb'
     - 'app/models/report_generators/system_performance/fy2019/measure_three.rb'
     - 'app/models/role.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
     - 'drivers/claims_reporting/app/models/hl7/value_set_code.rb'
 
 # Offense count: 264
@@ -1080,7 +1077,6 @@ Layout/LeadingCommentSpace:
     - 'app/models/reports/ahar/fy2017/base.rb'
     - 'bin/containers/list'
     - 'bin/containers/ssh'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
 
 # Offense count: 33
 # Cop supports --auto-correct.
@@ -1216,7 +1212,6 @@ Layout/SpaceAfterComma:
     - 'app/models/health/careplan.rb'
     - 'app/models/health/premium_payment.rb'
     - 'app/models/health/self_sufficiency_matrix_form.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/health/team/member.rb'
@@ -1445,7 +1440,6 @@ Layout/SpaceBeforeBlockBraces:
     - 'app/models/health/patient_referral.rb'
     - 'app/models/health/premium_payment.rb'
     - 'app/models/health/sdh_case_management_note.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/health/tasks/patient_client_matcher.rb'
@@ -1580,7 +1574,6 @@ Layout/SpaceInLambdaLiteral:
     - 'app/models/health/patient_referral.rb'
     - 'app/models/health/sdh_case_management_note.rb'
     - 'app/models/health/self_sufficiency_matrix_form.rb'
-    - 'app/models/health/status_date.rb'
     - 'app/models/message.rb'
     - 'app/models/nickname.rb'
     - 'app/models/report_generators/data_quality/fy2017/q6.rb'
@@ -1698,7 +1691,6 @@ Layout/SpaceInsideBlockBraces:
     - 'app/models/health/sdh_case_management_note.rb'
     - 'app/models/health/self_sufficiency_matrix_form.rb'
     - 'app/models/health/signable_document.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/health/tasks/patient_client_matcher.rb'
@@ -1945,7 +1937,6 @@ Layout/SpaceInsideParens:
     - 'app/models/similarity_metric/multinomial.rb'
     - 'app/models/similarity_metric/name_data_quality.rb'
     - 'app/models/similarity_metric/tasks/generate_candidates.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
 
 # Offense count: 4
 # Cop supports --auto-correct.
@@ -2163,7 +2154,6 @@ Lint/ShadowingOuterLocalVariable:
     - 'app/models/health/claim.rb'
     - 'app/models/health/patient.rb'
     - 'app/models/health/premium_payment.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/importers/hmis_six_one_one/base.rb'
     - 'app/models/importers/hmis_twenty_twenty/base.rb'
     - 'app/models/report_generators/data_quality/fy2017/base.rb'
@@ -2201,7 +2191,6 @@ Lint/UnreachableCode:
 # IgnoredPatterns: (?-mix:(exactly|at_least|at_most)\(\d+\)\.times)
 Lint/UnreachableLoop:
   Exclude:
-    - 'app/models/health/tasks/import_epic.rb'
 
 # Offense count: 93
 # Cop supports --auto-correct.
@@ -2312,7 +2301,6 @@ Lint/UnusedMethodArgument:
     - 'app/models/health/patient.rb'
     - 'app/models/health/problem.rb'
     - 'app/models/health/self_sufficiency_matrix_form.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/vaccination.rb'
     - 'app/models/health/visit.rb'
     - 'app/models/report.rb'
@@ -2321,7 +2309,6 @@ Lint/UnusedMethodArgument:
     - 'app/models/reporting/data_quality_reports/enrollment.rb'
     - 'app/models/similarity_metric/base.rb'
     - 'app/models/user_role.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
     - 'drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/importer/affiliation.rb'
     - 'drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/importer/client.rb'
     - 'drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/importer/export.rb'
@@ -2589,7 +2576,6 @@ Security/YAMLLoad:
   Exclude:
     - 'app/models/application_record.rb'
     - 'app/models/grda_warehouse_base.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/health_base.rb'
@@ -2657,7 +2643,6 @@ Style/ColonMethodCall:
     - 'app/models/grda_warehouse/warehouse_reports/dashboard/entered.rb'
     - 'app/models/grda_warehouse/warehouse_reports/dashboard/housed.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_three.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/importers/hmis_six_one_one/sftp.rb'
@@ -2794,7 +2779,6 @@ Style/GuardClause:
     - 'app/models/similarity_metric/multinomial.rb'
     - 'app/models/talentlms/config.rb'
     - 'app/models/user.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
 
 # Offense count: 6
 # Cop supports --auto-correct.
@@ -3107,7 +3091,6 @@ Style/MutableConstant:
     - 'app/models/similarity_metric/levenshtein.rb'
     - 'app/models/similarity_metric/multinomial.rb'
     - 'app/models/similarity_metric/social_security_number.rb'
-    - 'drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb'
 
 # Offense count: 20
 # Cop supports --auto-correct.
@@ -3124,7 +3107,6 @@ Style/NegatedIf:
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_two.rb'
     - 'app/models/health/cha_saver.rb'
     - 'app/models/health/signable_document.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/reporting/data_quality_reports/enrollment.rb'
@@ -3669,8 +3651,6 @@ Style/StringLiterals:
     - 'app/models/health/self_sufficiency_matrix_form.rb'
     - 'app/models/health/signable_document.rb'
     - 'app/models/health/ssm_export.rb'
-    - 'app/models/health/status_date.rb'
-    - 'app/models/health/tasks/import_epic.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
     - 'app/models/health/team.rb'

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -57,6 +57,7 @@ module Admin
         :health_emergency,
         :health_emergency_tracing,
         :health_priority_age,
+        :health_claims_data_path,
         :multi_coc_installation,
         :auto_de_duplication_accept_threshold,
         :auto_de_duplication_reject_threshold,

--- a/app/models/health/status_date.rb
+++ b/app/models/health/status_date.rb
@@ -47,7 +47,6 @@ module Health
               enrolled: enrolled,
             }
           end
-          puts "FOUND DATES"
           self.class.transaction do
             self.class.where(patient_id: patient_id).delete_all
             self.class.import(dates)

--- a/app/models/health/tasks/import_epic.rb
+++ b/app/models/health/tasks/import_epic.rb
@@ -32,21 +32,17 @@ module Health::Tasks
 
     def run!
       @configs ||= YAML::load(ERB.new(File.read(Rails.root.join("config","health_sftp.yml"))).result)[Rails.env]
-      @configs.map do |config_name, config|
-        if config['host'].present? && config['path'].present? &&  config['destination'].present?
-          @config = config
-          ds = Health::DataSource.find_by(name: config['data_source_name'])
-          @data_source_id = ds.id
-          fetch_files unless @load_locally
-          import_files
-          update_consent
-          sync_epic_pilot_patients
-          update_housing_statuses
-        else
-          notify "Warning: ImportEpic SFTP #{config_name} host, path, destination must all be set"
-        end
-        change_counts
-      end.first
+      @configs.each do |_, config|
+        @config = config
+        ds = Health::DataSource.find_by(name: config['data_source_name'])
+        @data_source_id = ds.id
+        fetch_files unless @load_locally
+        import_files
+        update_consent
+        sync_epic_pilot_patients
+        update_housing_statuses
+        return change_counts
+      end
     end
 
     def import(klass:, file:)
@@ -95,7 +91,6 @@ module Health::Tasks
     end
 
     def import_files
-      logger.info 'ImportEpic: import_files'
       Health.models_by_health_filename.each do |file, klass|
         import(klass: klass, file: file)
       end
@@ -154,7 +149,6 @@ module Health::Tasks
     end
 
     def fetch_files
-      logger.info 'ImportEpic: fetch_files'
       sftp = Net::SFTP.start(
         @config['host'],
         @config['username'],

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -78,6 +78,8 @@
           = f.input :health_emergency, collection: GrdaWarehouse::Config.available_health_emergencies, label: 'Ongoing health emergency?', include_blank: 'No current emergency', as: :select_two
           = f.input :health_emergency_tracing, collection: GrdaWarehouse::Config.available_health_emergency_tracings, label: 'Tracing contacts for', include_blank: 'No current emergency', as: :select_two
           = f.input :send_sms_for_covid_reminders, label: 'Send SMS reminders for 2nd dose of COVID-19 Vaccine?'
+          - if RailsDrivers.loaded.include?(:claims_reporting) && ClaimsReporting::Importer.default_credentials[:host].present?
+            = f.input :health_claims_data_path, label: _('Health SFTP incoming claims data folder'), hint: "If provided, any new claims data files detected will be imported automatically. #{link_to 'Details & Logs', claims_reporting_imports_path}".html_safe
 
       %section.o-section-card
         %h3 CAS

--- a/db/warehouse/migrate/20210707172124_add_health_claims_data_path_to_config.rb
+++ b/db/warehouse/migrate/20210707172124_add_health_claims_data_path_to_config.rb
@@ -1,0 +1,5 @@
+class AddHealthClaimsDataPathToConfig < ActiveRecord::Migration[5.2]
+  def change
+    add_column :configs, :health_claims_data_path, :string
+  end
+end

--- a/drivers/claims_reporting/app/models/claims_reporting/importer.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/importer.rb
@@ -118,7 +118,7 @@ module ClaimsReporting
       # and then sync over any content we cant find. Ugly
       # race conditions exist if these are interleaved
       HealthBase.with_advisory_lock('import_all_from_health_sftp') do
-        logger.info { "ClaimsReporting::Importer#import_all_from_health_sftp" }
+        logger.info { 'ClaimsReporting::Importer#import_all_from_health_sftp' }
         results = check_sftp(
           naming_convention: naming_convention,
           root_path: root_path,
@@ -248,6 +248,14 @@ module ClaimsReporting
     rescue StandardError => e
       record_complete(successful: false, status_message: e.message)
       raise
+    end
+
+    def pending
+      check_sftp.reject do |r|
+        r[:last_successful_import_id].present?
+      end.map do |info|
+        File.basename(info[:path])
+      end
     end
 
     private def run_post_import_hook(file_filter)

--- a/drivers/claims_reporting/app/models/claims_reporting/importer.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/importer.rb
@@ -9,13 +9,27 @@ module ClaimsReporting
     attr_accessor :logger
 
     def self.default_credentials
-      YAML.safe_load(ERB.new(File.read(Rails.root.join('config/health_sftp.yml'))).result)[Rails.env]['ONE']
+      YAML.safe_load(ERB.new(File.read(Rails.root.join('config/health_sftp.yml'))).result)[Rails.env]['ONE'].with_indifferent_access
+    end
+
+    def self.default_path
+      GrdaWarehouse::Config.get(:health_claims_data_path)
+    end
+
+    def self.polling_enabled?
+      default_credentials[:host].present? && default_path.present?
+    end
+
+    def self.nightly!
+      return unless polling_enabled?
+
+      new.import_all_from_health_sftp
     end
 
     def self.clear!
       raise 'Disabled' unless Rails.env.development? || Rails.env.test?
 
-      HealthBase.logger.warn { "#{self}.clear! truncating/clearing all tables" }
+      Rails.logger.warn { "#{self}.clear! truncating/clearing all tables" }
       [MemberRoster, MemberEnrollmentRoster, MedicalClaim, RxClaim].each do |klass|
         klass.connection.truncate(klass.table_name)
       end
@@ -23,15 +37,16 @@ module ClaimsReporting
     end
 
     def initialize
-      @logger = HealthBase.logger
+      @logger = Rails.logger
     end
 
     DEFAULT_NAMING_CONVENTION = /(?<prefix>.*)_?(?<m>[a-z]{3})_(?<y>\d{4})\.zip\Z/i.freeze
 
     private def using_sftp(credentials)
       credentials ||= self.class.default_credentials
+      host = credentials.fetch('host').presence or raise "'host:' must be provided or set via ENV['HEALTH_SFTP_HOST']"
       Net::SFTP.start(
-        credentials['host'],
+        host,
         credentials['username'],
         password: credentials['password'],
         auth_methods: ['publickey', 'password'],
@@ -47,10 +62,11 @@ module ClaimsReporting
     # in the file name. See naming_convention
     def check_sftp(
       naming_convention: DEFAULT_NAMING_CONVENTION,
-      root_path: '',
+      root_path: nil,
       show_import_status: true,
       credentials: self.class.default_credentials
     )
+      root_path ||= self.class.default_path
       results = []
       using_sftp(credentials) do |sftp|
         sftp.dir.glob(root_path, '*.zip').each do |remote_file|
@@ -58,7 +74,7 @@ module ClaimsReporting
           next unless md
 
           results << {
-            path: root_path + '/' + remote_file.name,
+            path: File.join(root_path, remote_file.name),
             prefix: md[:prefix],
             month: md[:m],
             year: md[:y],
@@ -77,7 +93,7 @@ module ClaimsReporting
           zip_path = r[:path]
           r[:last_successful_import_id] = ClaimsReporting::Import.where(
             source_url: sftp_url(credentials['host'], zip_path),
-            successful: [true, nil],
+            successful: true,
           ).order(updated_at: :desc).limit(1).pluck(:id).first
         end
       end
@@ -87,30 +103,35 @@ module ClaimsReporting
       end
     end
 
+    # check_sftp and find any files we haven't successfully imported
+    # in the past. Currently matches on the sftp url of the file
+    # to save on downloads but could also check #content_hash if
+    # files being changed is a problem
     def import_all_from_health_sftp(
-      root_path: '',
+      root_path: nil,
       naming_convention: DEFAULT_NAMING_CONVENTION,
       credentials: self.class.default_credentials,
       redo_past_imports: false
     )
       # Allow only one in progress call per DB.
-      # We will be read from our db, then an external SFTP
+      # We will be reading from our db, then an external SFTP
       # and then sync over any content we cant find. Ugly
       # race conditions exist if these are interleaved
       HealthBase.with_advisory_lock('import_all_from_health_sftp') do
+        logger.info { "ClaimsReporting::Importer#import_all_from_health_sftp" }
         results = check_sftp(
           naming_convention: naming_convention,
           root_path: root_path,
           show_import_status: true,
           credentials: credentials,
         )
-        results.map do |r|
-          if r[:last_successful_import_id].present? && redo_past_imports
-            logger.debug { "Skipping #{r}" }
-            r
-          else
-            @import = nil
+        results.select do |r|
+          if redo_past_imports || r[:last_successful_import_id].blank?
+            @import = nil # paranoia, reset this since we are looping
             import_from_health_sftp(r[:path], credentials: credentials)
+          else
+            logger.debug { "Skipping #{r}" }
+            false
           end
         end
       end

--- a/drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/quality_measures_report.rb
@@ -1744,7 +1744,7 @@ module ClaimsReporting
       )
     end
 
-    private def trace_set_match!(vs_name, claim, code_type)
+    private def trace_set_match!(vs_name, claim, code_type) # rubocop:disable Lint/UnusedMethodArgument
       # puts "in_set? #{vs_name} matched #{code_type} for Claim#id=#{claim.id}"
       true
     end

--- a/drivers/claims_reporting/app/views/claims_reporting/imports/index.html.haml
+++ b/drivers/claims_reporting/app/views/claims_reporting/imports/index.html.haml
@@ -18,12 +18,7 @@
         %tr
           %th Pending files
           %td
-            :ruby
-              pending = ClaimsReporting::Importer.new.check_sftp(
-                root_path: '/prod/MassHealth Claims Data'
-              ).reject do |r|
-                r[:last_successful_import_id].present?
-              end.map{ |info| File.basename(info[:path]) }
+            - pending = ClaimsReporting::Importer.new.pending
             - if pending.none?
               %em None found
             - else

--- a/drivers/claims_reporting/app/views/claims_reporting/imports/index.html.haml
+++ b/drivers/claims_reporting/app/views/claims_reporting/imports/index.html.haml
@@ -1,5 +1,35 @@
 %h1= "Claims Reporting Imports"
-/ debug ClaimsReporting::Importer.new.check_sftp(root_path: '/prod/MassHealth Claims Data')
+- sftp_host = ClaimsReporting::Importer.default_credentials[:host]
+- if sftp_host.present?
+  - path = GrdaWarehouse::Config.get(:health_claims_data_path)
+  %h4 Health SFTP Status
+  %table.table.table-bordered.table-sm.table-striped
+    %tr
+      %th Host
+      %td= sftp_host
+    %tr
+      %th= _('Health SFTP incoming claims data folder')
+      %td
+        - if path.present?
+          = path
+        - else
+          %em Not set. Automatic import disabled.
+      - if path
+        %tr
+          %th Pending files
+          %td
+            :ruby
+              pending = ClaimsReporting::Importer.new.check_sftp(
+                root_path: '/prod/MassHealth Claims Data'
+              ).reject do |r|
+                r[:last_successful_import_id].present?
+              end.map{ |info| File.basename(info[:path]) }
+            - if pending.none?
+              %em None found
+            - else
+              = pending.to_sentence
+  %p Configure in #{link_to 'Site Admin', admin_configs_path(anchor: 'grda_warehouse_config_health_claims_data_path')}.
+%h4 Past imports
 .table-responsive
   %table.table.table-bordered.table-sm.table-striped
     %thead

--- a/lib/tasks/health.rake
+++ b/lib/tasks/health.rake
@@ -7,6 +7,7 @@ namespace :health do
 
   desc "Import and match health data"
   task daily: [:environment, "log:info_to_stdout"] do
+    ClaimsReporting::Importer.nightly! if RailsDrivers.loaded.include?(:claims_reporting)
     Importing::RunHealthImportJob.new.perform
     Health::Tasks::NotifyCareCoordinatorsOfPatientEligibilityProblems.new.notify!
     Health::Tasks::CalculateValidUnpayableQas.new.run!


### PR DESCRIPTION
Add automatic claims reporting imports to health:daily...
- The path to pull from is configurable in site admin (our current convention)
- The job only runs if the driver is enabled and the SFTP credentials and path to check are configured
- Nearby code made more tolerant of partial config now that HEALTH_SFTP
  is used for more than one thing

Site config has a new setting (visible if the claims_reporting driver and health SFTP credentails are enabled)
![image](https://user-images.githubusercontent.com/563046/124816770-e5b4ee00-df36-11eb-9701-56222ba5d25e.png)

Details and Logs links to UI that has been updated to show the SFTP status including any pending files found when the page loads.
![image](https://user-images.githubusercontent.com/563046/124816510-979fea80-df36-11eb-879f-4541a10fe5dd.png)


