### PR TITLE
Limit veteran counts to leavers; use unknown household type when age …

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
@@ -135,7 +135,7 @@ module HudApr::Generators::Shared::Fy2020
             developmental_disability: disabilities.detect(&:developmental?).present?,
             disabling_condition: enrollment.DisablingCondition,
             dob_quality: source_client.DOBDataQuality,
-            dob: dob,
+            dob: source_client.DOB,
             domestic_violence: health_and_dv&.DomesticViolenceVictim,
             drug_abuse_entry: [2, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             drug_abuse_exit: [2, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
@@ -95,6 +95,13 @@ module HudApr::Generators::Shared::Fy2020
             next
           end
 
+          age = source_client.age_on(client_start_date)
+          household_type = if age.blank? || age.negative?
+            :unknown
+          else
+            household_types[get_hh_id(last_service_history_enrollment)]
+          end
+
           processed_source_clients << source_client.id
           pending_associations[client] = report_client_universe.new(
             client_id: source_client.id,
@@ -102,7 +109,7 @@ module HudApr::Generators::Shared::Fy2020
             data_source_id: source_client.data_source_id,
             report_instance_id: @report.id,
 
-            age: source_client.age_on(client_start_date),
+            age: age,
             alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
@@ -128,7 +135,7 @@ module HudApr::Generators::Shared::Fy2020
             developmental_disability: disabilities.detect(&:developmental?).present?,
             disabling_condition: enrollment.DisablingCondition,
             dob_quality: source_client.DOBDataQuality,
-            dob: source_client.DOB,
+            dob: dob,
             domestic_violence: health_and_dv&.DomesticViolenceVictim,
             drug_abuse_entry: [2, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             drug_abuse_exit: [2, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
@@ -148,7 +155,7 @@ module HudApr::Generators::Shared::Fy2020
             hiv_aids: disabilities.detect(&:hiv?).present?,
             household_id: get_hh_id(last_service_history_enrollment),
             household_members: household_member_data(last_service_history_enrollment),
-            household_type: household_types[get_hh_id(last_service_history_enrollment)],
+            household_type: household_type,
             housing_assessment: last_service_history_enrollment.enrollment.exit&.HousingAssessment,
             income_date_at_annual_assessment: income_at_annual_assessment&.InformationDate,
             income_date_at_exit: income_at_exit&.InformationDate,

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/question_five.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/question_five.rb
@@ -65,17 +65,17 @@ module HudApr::Generators::Shared::Fy2020
         # Number of leavers
         {
           cell: 'B5',
-          clause: a_t[:last_date_in_program].lteq(@report.end_date),
+          clause: leavers_clause,
         },
         # Number of adult leavers
         {
           cell: 'B6',
-          clause: a_t[:last_date_in_program].lteq(@report.end_date).and(adult_clause),
+          clause: leavers_clause.and(adult_clause),
         },
         # Number of adult and HoH leavers
         {
           cell: 'B7',
-          clause: a_t[:last_date_in_program].lteq(@report.end_date).
+          clause: leavers_clause.
             and(adult_clause.
               or(a_t[:head_of_household].eq(true))),
         },

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/question_twenty_five.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/question_twenty_five.rb
@@ -368,7 +368,7 @@ module HudApr::Generators::Shared::Fy2020
 
       cols = (metadata[:first_column]..metadata[:last_column]).to_a
       rows = (metadata[:first_row]..metadata[:last_row]).to_a
-      veterans = universe.members.where(veteran_clause)
+      veterans_leavers = universe.members.where(veteran_clause.and(leavers_clause))
       q25i_populations.values.each_with_index do |population_clause, col_index|
         q25i_destinations.values.each_with_index do |destination_clause, row_index|
           cell = "#{cols[col_index]}#{rows[row_index]}"
@@ -380,14 +380,14 @@ module HudApr::Generators::Shared::Fy2020
             case destination_clause
             when :percentage
               value = percentage(0.0)
-              members = veterans.where(population_clause)
+              members = veterans_leavers.where(population_clause)
               positive = members.where(q25i_destinations['Total persons exiting to positive housing destinations']).count
               total = members.where(q25i_destinations['Total']).count
               excluded = members.where(q25i_destinations['Total persons whose destinations excluded them from the calculation']).count
               value = percentage(positive.to_f / (total - excluded)) if total.positive? && excluded != total
             end
           else
-            members = veterans.where(population_clause).where(destination_clause)
+            members = veterans_leavers.where(population_clause).where(destination_clause)
             value = members.count
           end
           answer.add_members(members)

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/base.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/base.rb
@@ -88,6 +88,13 @@ module HudDataQualityReport::Generators::Fy2020
             next
           end
 
+          age = source_client.age_on(client_start_date)
+          household_type = if age.blank? || age.negative?
+            :unknown
+          else
+            household_types[get_hh_id(last_service_history_enrollment)]
+          end
+
           processed_source_clients << source_client.id
           pending_associations[client] = report_client_universe.new(
             client_id: source_client.id,
@@ -95,7 +102,7 @@ module HudDataQualityReport::Generators::Fy2020
             data_source_id: source_client.data_source_id,
             report_instance_id: @report.id,
 
-            age: source_client.age_on(client_start_date),
+            age: age,
             alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
@@ -140,7 +147,7 @@ module HudDataQualityReport::Generators::Fy2020
             hiv_aids: disabilities.detect(&:hiv?).present?,
             household_id: get_hh_id(last_service_history_enrollment),
             household_members: household_member_data(last_service_history_enrollment),
-            household_type: household_types[get_hh_id(last_service_history_enrollment)],
+            household_type: household_type,
             housing_assessment: last_service_history_enrollment.enrollment.exit&.HousingAssessment,
             income_date_at_annual_assessment: income_at_annual_assessment&.InformationDate,
             income_date_at_exit: income_at_exit&.InformationDate,


### PR DESCRIPTION
…is blank even if you know the household type