### PR TITLE
New Capacity Provider

### DIFF
--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -399,14 +399,14 @@ class RollOut
   end
 
   def _on_demand_capacity_provider_name
-    _capacity_providers.find { |cp| cp.match(/on-demand/) }
+    _capacity_providers.find { |cp| cp.match(/ondemand-v2/) }
   end
 
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html
   def _placement_strategy
     [
       {
-        # distribute across zones first
+        # Distribute across zones first
         "field": "attribute:ecs.availability-zone",
         "type": "spread"
       },
@@ -414,12 +414,6 @@ class RollOut
         # Then try to maximize utilization (minimize number of EC2 instances)
         "field": "memory",
         "type": "binpack"
-      },
-      {
-        # Tie-breaker is to put tasks on difference instances, but I don't know
-        # if we ever would get to this choice
-        "field": "instanceId",
-        "type": "spread"
       }
     ]
   end


### PR DESCRIPTION
As we deploy with this commit, we transition to the new capacity provider

* It has only 4xlarge instances, each weighted as "1"
* This gets us in sync with recomendations and hopefully makes the capacity provider better able to not over-provision.
* existing one is very confused about capacity after modifing the auto-scaling group parameters and instances manually. The docs allude to this not always working, but it just basically doesn't work right at all. Replacement is the way to modify it.