### PR TITLE
(179927362) GitHub Actions: pre-cache image expiry

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -57,6 +57,17 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
+    - name: Delete pre-cache image?
+      env:
+        ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+      run: |
+        if git log -1 | fgrep '[gh:rebuild]' ;
+        then
+          echo 'Deleting pre-cache image...'
+          export RUBY_VERSION=`cat .ruby-version`
+          aws ecr batch-delete-image --repository-name ${ECR_REPOSITORY} --image-ids imageTag="${RUBY_VERSION}--pre-cache"
+        fi
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:


### PR DESCRIPTION
The ecs workflow deletes the pre-cache image from ECR and rebuilds it if the string `[gh:rebuild]` is in the commit message.