### PR TITLE
Check for existing latest-* tag

### DIFF
--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -235,17 +235,17 @@ class Deployer
       puts "[INFO] Skipping latest tag. This image has already been pushed with a latest tag for this environment."
       return
     elsif images.count > 2
-      puts "[ERROR] More than two images found during latest-* check, something is wrong."
+      raise "More than two images found during latest-* check, something is wrong."
       return
     elsif images.count < 1
-      puts "[ERROR] No images matching tag #{image_tag} found during latest-* check, something is wrong."
+      raise "No images matching tag #{image_tag} found during latest-* check, something is wrong."
     end
 
     image = images.find { |image| image.image_id.image_tag == image_tag }
     manifest = image.image_manifest
 
     if manifest.nil?
-      puts "[ERROR] No manifest matching tag #{image_tag} found during latest-* check, something is wrong."
+      raise "No manifest matching tag #{image_tag} found during latest-* check, something is wrong."
     end
 
     putparams = {

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -218,7 +218,8 @@ class Deployer
 
   def _add_latest_tag!
     if image_tag_latest.nil?
-      return # No latest tag set.
+      puts "[INFO] Skipping latest tag. No latest tag set (probably this is the pre-cache image)."
+      return
     end
 
     getparams = {
@@ -231,7 +232,8 @@ class Deployer
     images = ecr.batch_get_image(getparams).images
 
     if images.count > 1
-      return # Image with latest-* tag already exists.
+      puts "[INFO] Skipping latest tag. This image has already been pushed with a latest tag for this environment."
+      return
     end
     manifest = images.image_manifest
 

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -218,16 +218,22 @@ class Deployer
 
   def _add_latest_tag!
     if image_tag_latest.nil?
-      return
+      return # No latest tag set.
     end
 
     getparams = {
       repository_name: repo_name,
       image_ids: [{
         image_tag: image_tag,
+        image_tag: image_tag_latest
       }]
     }
-    manifest = ecr.batch_get_image(getparams).images[0].image_manifest
+    images = ecr.batch_get_image(getparams).images
+
+    if images.count > 1
+      return # Image with latest-* tag already exists.
+    end
+    manifest = images.image_manifest
 
     putparams = {
       repository_name: repo_name,

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -231,21 +231,21 @@ class Deployer
     }
     images = ecr.batch_get_image(getparams).images
 
-    byebug
     if images.count == 2 && images[0].image_id.image_digest == images[1].image_id.image_digest
       puts "[INFO] Skipping latest tag. This image has already been pushed with a latest tag for this environment."
       return
     elsif images.count > 2
-      puts "[ERROR] More than two images found, something is wrong."
+      puts "[ERROR] More than two images found during latest-* check, something is wrong."
       return
     elsif images.count < 1
-      puts "[ERROR] No images found, something is wrong."
+      puts "[ERROR] No images matching tag #{image_tag} found during latest-* check, something is wrong."
     end
 
-    manifest = images.find { |image| image.image_id.image_tag == image_tag }
+    image = images.find { |image| image.image_id.image_tag == image_tag }
+    manifest = image.image_manifest
 
     if manifest.nil?
-      puts "[ERROR] No manifest found, something is wrong."
+      puts "[ERROR] No manifest matching tag #{image_tag} found during latest-* check, something is wrong."
     end
 
     putparams = {


### PR DESCRIPTION
This checks that the `latest-*` tag for the given variant & environment doesn't already exist on an identical image digest (that is, it checks if we've already tagged this image in this environment as latest). I tested this by deploying to QA twice and observed no errors.