### PR TITLE
Adventures in Latest Tagging Part 3(?): don't tag until the deployment is done

### DIFF
--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -84,6 +84,7 @@ class Deployer
 
     roll_out.run!
 
+    _add_latest_tags!
     _clean_up_old_local_images!
   end
 
@@ -212,11 +213,18 @@ class Deployer
         _tag_the_image!(authority: 'them')
       end
     end
-
-    _add_latest_tag!
   end
 
-  def _add_latest_tag!
+  def _add_latest_tags!
+    _add_latest_tag!('base')
+    _add_latest_tag!('web')
+    _add_latest_tag!('dj')
+  end
+
+  def _add_latest_tag!(variant)
+    self.variant = variant
+    _set_image_tag!
+
     puts "[INFO] Update latest tag for '#{image_tag}':"
     if image_tag_latest.nil?
       puts ">> Skipping, no latest tag set (this is the pre-cache image)."


### PR DESCRIPTION
@eanders We had talked about how doing the latest tags at the beginning of the process opened us up to the risk of desync between latest tag and deployed image if a deployment failed or was cancelled. This simply moves the latest tagging to the end of the deployment, which should prevent that risk.

I was prompted to submit this because I saw that `three-warehouse-staging` was desynced from its latest tag, and it looked to me like it might have been a case of a failed/cancelled deployment that was not taken into account by the previous latest tag functionality. I'd like to check in with you Monday/tomorrow to see if we can confirm that.