### PR TITLE
[PVT#178806766] Docker image non-root user

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -57,16 +57,22 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Delete pre-cache image?
+    - name: Prepare pre-cache image
+      id: prep
       env:
         ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       run: |
+        export RUBY_VERSION=`cat .ruby-version`
+        export PRE_CACHE_VERSION="2"
+        export PRE_CACHE_TAG="${RUBY_VERSION}-${PRE_CACHE_VERSION}--pre-cache"
+
         if git log -1 | fgrep '[gh:rebuild]' ;
         then
           echo 'Deleting pre-cache image...'
-          export RUBY_VERSION=`cat .ruby-version`
-          aws ecr batch-delete-image --repository-name ${ECR_REPOSITORY} --image-ids imageTag="${RUBY_VERSION}--pre-cache"
+          aws ecr batch-delete-image --repository-name ${ECR_REPOSITORY} --image-ids imageTag="${PRE_CACHE_TAG}"
         fi
+
+        echo "::set-output name=pre_cache_tag::$PRE_CACHE_TAG"
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
@@ -75,10 +81,10 @@ jobs:
         ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         DOCKER_ASSETS_PATH: config/deploy/docker/assets
         SHA: ${{ github.sha }}
+        PRE_CACHE_TAG: ${{ steps.prep.outputs.pre_cache_tag }}
       run: |
         export GITHASH="${SHA::9}"
         export IMAGE_TAG="githash-${GITHASH}"
-        export RUBY_VERSION=`cat .ruby-version`
 
         echo $SHA > $DOCKER_ASSETS_PATH/REVISION
         echo 'no tag generated' > image-tag.txt
@@ -88,13 +94,13 @@ jobs:
           # Pull the image that speeds up builds. Build it if we have to.
           # Delete from ECR to re-cache
           echo Pulling or building pre-cache image
-          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${RUBY_VERSION}--pre-cache || docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.pre-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:${RUBY_VERSION}--pre-cache .
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} || docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.pre-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} .
 
           echo Tagging pre-cache so local dockerfiles will work
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${RUBY_VERSION}--pre-cache ${ECR_REPOSITORY}:latest--pre-cache
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} ${ECR_REPOSITORY}:latest--pre-cache
 
           echo Pushing pre-cache
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${RUBY_VERSION}--pre-cache
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG}
         fi
 
         # the pre-cache image is like a stale version of the code. This builds the most recent things

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -63,7 +63,7 @@ jobs:
         ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
       run: |
         export RUBY_VERSION=`cat .ruby-version`
-        export PRE_CACHE_VERSION="2"
+        export PRE_CACHE_VERSION=`cat .pre-cache-version`
         export PRE_CACHE_TAG="${RUBY_VERSION}-${PRE_CACHE_VERSION}--pre-cache"
 
         if git log -1 | fgrep '[gh:rebuild]' ;

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -861,9 +861,9 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 376,
+      "line": 381,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`docker image ls -f 'reference=#{repo_name}' | grep #{_ruby_version}--pre-cache`",
+      "code": "`docker image ls -f 'reference=#{repo_name}' | grep "#{_ruby_version}-#{_pre_cache_version}--pre-cache"`",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -863,7 +863,7 @@
       "file": "config/deploy/docker/lib/deployer.rb",
       "line": 381,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`docker image ls -f 'reference=#{repo_name}' | grep "#{_ruby_version}-#{_pre_cache_version}--pre-cache`",
+      "code": "`docker image ls -f 'reference=#{repo_name}' | grep #{_ruby_version}-#{_pre_cache_version}--pre-cache`",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -261,37 +261,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "194ffcfbbfb5dad65d6c2cd5fc8e010479f66a6251142ec091dc5436f8205abe",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/imports/show.haml",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => import_scope.find(params.require(:id)), {})",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "ImportsController",
-          "method": "show",
-          "line": 29,
-          "file": "app/controllers/imports_controller.rb",
-          "rendered": {
-            "name": "imports/show",
-            "file": "app/views/imports/show.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "imports/show"
-      },
-      "user_input": "params.require(:id)",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "19b0be47dc59be902eb1e0500e9fba29ccf43752f0eb56a2180a222af552ceb0",
@@ -499,26 +468,6 @@
         "template": "account_two_factors/show"
       },
       "user_input": "current_user.generate_otp_backup_codes!.join(\"<br />\")",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "39fbe5b21264364680753579cfb9bbfa2a05b5af5e3646dbe3bdcd6c65579db5",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/data_quality_reports_controller.rb",
-      "line": 27,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => report_scope.where(:project_id => params[:project_id].to_i).find(params[:id].to_i).model_name.element.to_sym, {})",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "DataQualityReportsController",
-        "method": "show"
-      },
-      "user_input": "params[:id]",
       "confidence": "Weak",
       "note": ""
     },
@@ -764,37 +713,6 @@
       "note": "Injection from internal sources"
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "6012356b03eb94bac6208d03adf39acd1db517d644ec8c52e503b7efef462571",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/health/goals/edit.haml",
-      "line": 4,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => ::Health::Goal::Hpc.find(params[:id].to_i), { :readonly => false })",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Health::GoalsController",
-          "method": "edit",
-          "line": 34,
-          "file": "app/controllers/concerns/health_goal.rb",
-          "rendered": {
-            "name": "health/goals/edit",
-            "file": "app/views/health/goals/edit.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "health/goals/edit"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "615f7900b129c22f4d71c443ead85e0694fc30435dfdc15e52ec03a94d2a3057",
@@ -855,26 +773,6 @@
       "note": ""
     },
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "6939d235d9f32e7a2694b926a5cf73222ec7b924323cb268a68c11d2a20ea082",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 381,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`docker image ls -f 'reference=#{repo_name}' | grep #{_ruby_version}-#{_pre_cache_version}--pre-cache`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Deployer",
-        "method": "_pre_cache_image_exists?"
-      },
-      "user_input": "repo_name",
-      "confidence": "Medium",
-      "note": "This is all internal code."
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "6c494e98b87c08b7dd22f8718f9fe58a980cffd1cb7c492ae79486f8f534914f",
@@ -901,7 +799,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 157,
+      "line": 159,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`git rev-parse #{`git rev-parse --abbrev-ref HEAD`.chomp}`",
       "render_path": null,
@@ -1417,6 +1315,26 @@
       "note": ""
     },
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "8a29ddebc189081add6710e179967e490ad042f12df9fdfaac8211e87e8d97db",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "config/deploy/docker/lib/deployer.rb",
+      "line": 381,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`docker image ls -f 'reference=#{repo_name}' | grep \"#{_ruby_version}-#{_pre_cache_version}--pre-cache\"`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Deployer",
+        "method": "_pre_cache_image_exists?"
+      },
+      "user_input": "repo_name",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "90ff2d536c66b271d5f9e428f8f430887e06ca4bf3031ede5a3846d9f7c12294",
@@ -1734,7 +1652,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 156,
+      "line": 158,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`git ls-remote origin | grep #{`git rev-parse --abbrev-ref HEAD`.chomp}`",
       "render_path": null,
@@ -1754,7 +1672,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb",
-      "line": 919,
+      "line": 920,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "clients.send(variant).send(\"spm_#{field}\").average(\"spm_#{field}\")",
       "render_path": null,
@@ -1794,7 +1712,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 151,
+      "line": 153,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`git rev-parse HEAD > #{_assets_path}/REVISION`",
       "render_path": null,
@@ -1805,47 +1723,6 @@
       },
       "user_input": "_assets_path",
       "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "b943aeb098e1d298b0a93b87df96a6d51af156941a6a8263d4dd96b2add2a5c4",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/admin/health/scheduled_documents/_form.haml",
-      "line": 25,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => scheduled_document_source.find(params[:id]), { :f => f })",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::Health::ScheduledDocumentsController",
-          "method": "edit",
-          "line": 40,
-          "file": "app/controllers/admin/health/scheduled_documents_controller.rb",
-          "rendered": {
-            "name": "admin/health/scheduled_documents/edit",
-            "file": "app/views/admin/health/scheduled_documents/edit.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "admin/health/scheduled_documents/edit",
-          "line": 6,
-          "file": "app/views/admin/health/scheduled_documents/edit.haml",
-          "rendered": {
-            "name": "admin/health/scheduled_documents/_form",
-            "file": "app/views/admin/health/scheduled_documents/_form.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "admin/health/scheduled_documents/_form"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
       "note": ""
     },
     {
@@ -1926,25 +1803,6 @@
       },
       "user_input": "Talentlms::Facade.new.course_url(current_user, Talentlms::Config.first.courseid, (clients_url or root_url), logout_talentlms_url)",
       "confidence": "High",
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "c0005570a238c0588abb23ceeeca1435585d73471894496817a57ba389867107",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/dashboards/base/section.html.haml",
-      "line": 2,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => (\"dashboards/base/\" + params[:partial]), {})",
-      "render_path": null,
-      "location": {
-        "type": "template",
-        "template": "dashboards/base/section"
-      },
-      "user_input": "params[:partial]",
-      "confidence": "Weak",
       "note": ""
     },
     {
@@ -2178,47 +2036,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "d49a5a59466bec717d9e77ab489b4ff1143141484211fd10b9919e04d8192423",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "drivers/public_reports/app/views/public_reports/warehouse_reports/state_level_homelessness/_need_map.haml",
-      "line": 25,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => report_scope.find(params[:id].to_i).map_type, {})",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PublicReports::WarehouseReports::StateLevelHomelessnessController",
-          "method": "map",
-          "line": 22,
-          "file": "drivers/public_reports/app/controllers/public_reports/warehouse_reports/state_level_homelessness_controller.rb",
-          "rendered": {
-            "name": "public_reports/warehouse_reports/state_level_homelessness/map",
-            "file": "drivers/public_reports/app/views/public_reports/warehouse_reports/state_level_homelessness/map.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "public_reports/warehouse_reports/state_level_homelessness/map",
-          "line": 6,
-          "file": "drivers/public_reports/app/views/public_reports/warehouse_reports/state_level_homelessness/map.haml",
-          "rendered": {
-            "name": "public_reports/warehouse_reports/state_level_homelessness/_need_map",
-            "file": "drivers/public_reports/app/views/public_reports/warehouse_reports/state_level_homelessness/_need_map.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "public_reports/warehouse_reports/state_level_homelessness/_need_map"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "d4bbc6a863c585c27cc2ff014bdd8c031677fc6f2054e782a5b49dd14e7998d8",
@@ -2245,7 +2062,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called with model attribute",
       "file": "app/models/filters/filter_base.rb",
-      "line": 810,
+      "line": 815,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Reporting::MonthlyReports::Base.available_types[sub_population].constantize",
       "render_path": null,
@@ -2559,25 +2376,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "fde02e1709a167801d237e080ec6ee9c281c0a4aaaef4e81a09c70c01613e32d",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/clients/rollup.haml",
-      "line": 2,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => (\"clients/rollup/\" + params[:partial]), {})",
-      "render_path": null,
-      "location": {
-        "type": "template",
-        "template": "clients/rollup"
-      },
-      "user_input": "params[:partial]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "fe7de455d82a4e3fef770c1272e861fb8f1d73042b2f82f1b417753f2d17bec7",
@@ -2598,6 +2396,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-01-01 19:03:22 -0500",
+  "updated": "2022-01-13 15:36:20 +0000",
   "brakeman_version": "5.0.4"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -863,7 +863,7 @@
       "file": "config/deploy/docker/lib/deployer.rb",
       "line": 381,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`docker image ls -f 'reference=#{repo_name}' | grep "#{_ruby_version}-#{_pre_cache_version}--pre-cache"`",
+      "code": "`docker image ls -f 'reference=#{repo_name}' | grep "#{_ruby_version}-#{_pre_cache_version}--pre-cache`",
       "render_path": null,
       "location": {
         "type": "method",

--- a/config/deploy/docker/assets/Dockerfile.open-path-cas.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-cas.base
@@ -57,7 +57,7 @@ COPY lib ./lib
 COPY config ./config
 COPY spec ./spec
 COPY db ./db
-COPY --chown app:app app ./app
+COPY --chown=app:app app ./app
 COPY vendor ./vendor
 COPY locale ./locale
 

--- a/config/deploy/docker/assets/Dockerfile.open-path-cas.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-cas.base
@@ -57,7 +57,7 @@ COPY lib ./lib
 COPY config ./config
 COPY spec ./spec
 COPY db ./db
-COPY app ./app
+COPY --chown app:app app ./app
 COPY vendor ./vendor
 COPY locale ./locale
 
@@ -72,6 +72,8 @@ COPY config/deploy/docker/assets/REVISION ./
 
 COPY config/deploy/docker/assets/entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
+
+USER app
 
 # Expose the GITHASH to entrypoint.sh for downloading precompiled assets.
 ENV GITHASH=${GITHASH}

--- a/config/deploy/docker/assets/Dockerfile.open-path-cas.pre-cache
+++ b/config/deploy/docker/assets/Dockerfile.open-path-cas.pre-cache
@@ -18,6 +18,9 @@ RUN apk add --no-cache \
 
 WORKDIR /app
 
+RUN addgroup -g 1001 app \
+  && adduser -u 1001 -G app -h /app -D app
+
 RUN gem install bundler --version=1.17.3 && \
   mkdir -p app/assets tmp/pids lib/assets vendor/assets public locale var
 

--- a/config/deploy/docker/assets/Dockerfile.open-path-cas.web
+++ b/config/deploy/docker/assets/Dockerfile.open-path-cas.web
@@ -3,9 +3,9 @@ FROM open-path-cas:latest--base
 LABEL "role"=web
 
 HEALTHCHECK --start-period=15s --interval=5m --timeout=10s \
-  CMD curl -k -f https://localhost:443/system_status/operational || exit 1
+  CMD curl -k -f https://localhost:3000/system_status/operational || exit 1
 
-EXPOSE 443
+EXPOSE 3000
 
 # Start the main process.
-CMD [ "puma", "-b", "ssl://0.0.0.0:443?key=/app/config/key.pem&cert=/app/config/cert.pem&verify_mode=none" ]
+CMD [ "puma", "-b", "ssl://0.0.0.0:3000?key=/app/config/key.pem&cert=/app/config/cert.pem&verify_mode=none" ]

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
@@ -70,7 +70,10 @@ RUN chmod +x /usr/bin/entrypoint.sh \
   && rm -rf tmp/* \
   && rm .env \
   && mkdir tmp/pids
+
 RUN chown -R app:app tmp
+RUN touch /etc/timezone /etc/localtime
+RUN chown app:app /etc/timezone /etc/localtime
 
 USER app
 

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
@@ -59,7 +59,7 @@ LABEL "app"=open-path-warehouse
 LABEL "ruby-version"=2.7.4
 
 COPY config/deploy/docker/assets/entrypoint.sh /usr/bin/
-COPY --from=code /app /app/
+COPY --from=code --chown=app:app /app /app/
 
 RUN chmod +x /usr/bin/entrypoint.sh \
   && bundle config without development test doc \
@@ -70,6 +70,9 @@ RUN chmod +x /usr/bin/entrypoint.sh \
   && rm -rf tmp/* \
   && rm .env \
   && mkdir tmp/pids
+RUN chown -R app:app tmp
+
+USER app
 
 # Expose the GITHASH to entrypoint.sh for downloading precompiled assets.
 ENV GITHASH=${GITHASH}

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
@@ -72,8 +72,9 @@ RUN chmod +x /usr/bin/entrypoint.sh \
   && mkdir tmp/pids
 
 RUN chown -R app:app tmp
-RUN touch /etc/timezone /etc/localtime
-RUN chown app:app /etc/timezone /etc/localtime
+RUN touch /etc/timezone
+RUN ln -sf /app/etc-localtime /etc/localtime
+RUN chown app:app /etc/timezone
 
 USER app
 

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.deploy
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.deploy
@@ -1,4 +1,7 @@
 FROM open-path-warehouse:latest--base
 
+USER root
 RUN apk add py3-pip
+USER app
+
 RUN pip3 install awscli

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.deploy
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.deploy
@@ -2,6 +2,5 @@ FROM open-path-warehouse:latest--base
 
 USER root
 RUN apk add py3-pip
-USER app
-
 RUN pip3 install awscli
+USER app

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
@@ -25,6 +25,9 @@ RUN mkdir -p /app \
     /app/shape_files/CoC /app/shape_files/zip_codes.census.2018 \
     /app/shape_files/block_groups /app/shape_files/states /app/shape_files/counties
 
+RUN addgroup -g 1001 app \
+  && adduser -u 1001 -G app -h /app -D app
+
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock Rakefile config.ru package.json ./
@@ -71,7 +74,7 @@ ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native \
 # allow tls connection to database with verification
 COPY config/deploy/docker/assets/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
-COPY --from=code /app /app/
+COPY --from=code --chown=app:app /app /app/
 
 # wkhtmltopdf line
 # https://beuke.org/docker-alpine-wkhtmltopdf/

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
@@ -74,7 +74,7 @@ ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native \
 # allow tls connection to database with verification
 COPY config/deploy/docker/assets/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
-COPY --from=code --chown=app:app /app /app/
+COPY --from=code /app /app/
 
 # wkhtmltopdf line
 # https://beuke.org/docker-alpine-wkhtmltopdf/

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
@@ -25,9 +25,6 @@ RUN mkdir -p /app \
     /app/shape_files/CoC /app/shape_files/zip_codes.census.2018 \
     /app/shape_files/block_groups /app/shape_files/states /app/shape_files/counties
 
-RUN addgroup -g 1001 app \
-  && adduser -u 1001 -G app -h /app -D app
-
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock Rakefile config.ru package.json ./
@@ -74,7 +71,10 @@ ENV BUNDLE_BUILD__SASSC=--disable-march-tune-native \
 # allow tls connection to database with verification
 COPY config/deploy/docker/assets/rds-combined-ca-bundle.pem /etc/ssl/certs/rds-combined-ca-bundle.pem
 
-COPY --from=code /app /app/
+RUN addgroup -g 1001 app \
+  && adduser -u 1001 -G app -h /app -D app
+
+COPY --from=code --chown=app:app /app /app/
 
 # wkhtmltopdf line
 # https://beuke.org/docker-alpine-wkhtmltopdf/

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.web
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.web
@@ -3,9 +3,9 @@ FROM open-path-warehouse:latest--base
 LABEL "role"=web
 
 HEALTHCHECK --start-period=15s --interval=5m --timeout=10s \
-  CMD curl -k -f https://localhost:443/system_status/operational || exit 1
+  CMD curl -k -f https://localhost:3000/system_status/operational || exit 1
 
-EXPOSE 443
+EXPOSE 3000
 
 # Start the main process.
-CMD [ "puma", "-b", "ssl://0.0.0.0:443?key=/app/config/key.pem&cert=/app/config/cert.pem&verify_mode=none" ]
+CMD [ "puma", "-b", "ssl://0.0.0.0:3000?key=/app/config/key.pem&cert=/app/config/cert.pem&verify_mode=none" ]

--- a/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
+++ b/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
@@ -20,7 +20,7 @@ echo "Syncing to s3://openpath-precompiled-assets/$ASSETS_PREFIX/$GITHASH"
 aws s3 sync ./public/assets s3://openpath-precompiled-assets/$ASSETS_PREFIX/$GITHASH
 
 echo Storing Themed Maintenance Page
-# bundle exec rake maintenance:create
+bundle exec rake maintenance:create
 
 echo Migrating with individual rake tasks
 

--- a/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
+++ b/config/deploy/docker/assets/deploy_tasks.open-path-warehouse.sh
@@ -20,7 +20,7 @@ echo "Syncing to s3://openpath-precompiled-assets/$ASSETS_PREFIX/$GITHASH"
 aws s3 sync ./public/assets s3://openpath-precompiled-assets/$ASSETS_PREFIX/$GITHASH
 
 echo Storing Themed Maintenance Page
-bundle exec rake maintenance:create
+# bundle exec rake maintenance:create
 
 echo Migrating with individual rake tasks
 

--- a/config/deploy/docker/assets/entrypoint.sh
+++ b/config/deploy/docker/assets/entrypoint.sh
@@ -18,7 +18,7 @@ echo Sourcing environment
 . .env
 
 echo Setting Timezone
-echo $(cat /usr/share/zoneinfo/$TIMEZONE) > /etc/localtime
+\cp /usr/share/zoneinfo/$TIMEZONE /etc/localtime
 echo $TIMEZONE > /etc/timezone
 
 echo Syncing the assets from s3

--- a/config/deploy/docker/assets/entrypoint.sh
+++ b/config/deploy/docker/assets/entrypoint.sh
@@ -18,7 +18,7 @@ echo Sourcing environment
 . .env
 
 echo Setting Timezone
-cp /usr/share/zoneinfo/$TIMEZONE /etc/localtime
+echo $(cat /usr/share/zoneinfo/$TIMEZONE) > /etc/localtime
 echo $TIMEZONE > /etc/timezone
 
 echo Syncing the assets from s3

--- a/config/deploy/docker/assets/entrypoint.sh
+++ b/config/deploy/docker/assets/entrypoint.sh
@@ -24,10 +24,6 @@ echo $TIMEZONE > /etc/timezone
 echo Syncing the assets from s3
 ./bin/sync_app_assets.rb
 
-echo Setting PGPass
-echo "$DATABASE_HOST:*:*:$DATABASE_USER:$DATABASE_PASS" > /root/.pgpass
-chmod 600 /root/.pgpass
-
 echo Pulling down assets from S3
 bundle exec rake assets:clobber && mkdir -p ./public/assets
 cd ./public/assets

--- a/config/deploy/docker/assets/entrypoint.sh
+++ b/config/deploy/docker/assets/entrypoint.sh
@@ -18,7 +18,7 @@ echo Sourcing environment
 . .env
 
 echo Setting Timezone
-\cp /usr/share/zoneinfo/$TIMEZONE /etc/localtime
+cp /usr/share/zoneinfo/$TIMEZONE /app/etc-localtime
 echo $TIMEZONE > /etc/timezone
 
 echo Syncing the assets from s3

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -286,6 +286,10 @@ class Deployer
     @_ruby_version ||= File.read('.ruby-version').chomp
   end
 
+  def _pre_cache_version
+    @_pre_cache_version ||= File.read('.pre-cache-version').chomp
+  end
+
   def _set_image_tag!
     if variant == 'pre-cache'
       self.image_tag = "#{_ruby_version}--pre-cache"

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -292,7 +292,7 @@ class Deployer
 
   def _set_image_tag!
     if variant == 'pre-cache'
-      self.image_tag = "#{_ruby_version}--pre-cache"
+      self.image_tag = "#{_ruby_version}-#{_pre_cache_version}--pre-cache"
     elsif ENV['IMAGE_TAG']
       self.image_tag = ENV['IMAGE_TAG'] + "--#{variant}"
       self.image_tag_latest = "latest-" + ENV['IMAGE_TAG'] + "--#{variant}"
@@ -378,7 +378,7 @@ class Deployer
   end
 
   def _pre_cache_image_exists?
-    result = `docker image ls -f 'reference=#{repo_name}' | grep #{_ruby_version}--pre-cache`
+    result = `docker image ls -f 'reference=#{repo_name}' | grep "#{_ruby_version}-#{_pre_cache_version}--pre-cache"`
 
     !result.match?(/^\s*$/)
   end

--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -213,7 +213,7 @@ class RollOut
       image: image_base + '--web',
       environment: environment,
       ports: [{
-        "container_port" => 443,
+        "container_port" => 3000,
         "host_port" => 0,
         "protocol" => "tcp"
       }],

--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -238,7 +238,7 @@ class RollOut
     end
     _start_service!(
       capacity_provider: capacity_provider_name,
-      name: name,
+      name: name + '-2', # version bump for change from port 443 -> 3000
       load_balancers: lb,
       desired_count: web_options['container_count'] || 1,
       minimum_healthy_percent: minimum,

--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -225,7 +225,7 @@ class RollOut
     lb = [{
       target_group_arn: target_group_arn,
       container_name: name,
-      container_port: 443,
+      container_port: 3000,
     }]
 
     minimum, maximum = _get_min_max_from_desired(web_options['container_count'])


### PR DESCRIPTION
This is very similar to the same functionality in HNMI: https://github.com/greenriver/hnmi/pull/1192

- Update Docker image to use `app` instead of `root` user
- Expose port 3000 instead of 443 because non-root can't bind to 443
- Bump ECS service name to allow port modification, will manually clean up old services post-deployment

This is currently deployed to QA. I want to make sure we test this on at least one non-QA client before merging and rolling out everywhere.