### PR TITLE
Add attributes for language_1, language_2

### DIFF
--- a/app/models/eto_api/tasks/update_client_demographics.rb
+++ b/app/models/eto_api/tasks/update_client_demographics.rb
@@ -197,7 +197,7 @@ module EtoApi::Tasks
             data = entity(client: client, response: api_response, entity_label: details['entity_label'])
             if data.present?
               hmis_client[key] = data.try(:[], 'EntityName')
-              hmis_client[details['attributes']] = data if hmis_client[key].present? # rubocop:disable Metrics/BlockNesting
+              hmis_client[details['attributes']] = data if hmis_client[key].present?
             end
           end
 
@@ -242,6 +242,8 @@ module EtoApi::Tasks
           sexual_orientation: hmis_client&.sexual_orientation,
           phone: hmis_client&.phone,
           email: hmis_client&.email,
+          language_1: hmis_client&.language_1,
+          language_2: hmis_client&.language_2,
         }
         hmis_client.eto_last_updated = @api.parse_date(api_response['AuditDate'])
         if hmis_client.changed?

--- a/app/models/grda_warehouse/hmis_client.rb
+++ b/app/models/grda_warehouse/hmis_client.rb
@@ -13,7 +13,7 @@ class GrdaWarehouse::HmisClient < GrdaWarehouseBase
   serialize :assigned_staff_attributes, Hash
   serialize :counselor_attributes, Hash
   serialize :outreach_counselor_attributes, Hash
-  attr_accessor :phone, :email
+  attr_accessor :phone, :email, :language_1, :language_2
 
   scope :consent_active, -> do
     where(


### PR DESCRIPTION
Once deployed, we should be able to enable these via
```
config = GrdaWarehouse::EtoApiConfig.first
config.update(demographic_fields: {language_1: 'Primary Language', language_2: 'Language'}, additional_fields: {hud_last_permanent_zip: 1030})
```