### PR TITLE
Avoid nils in patient_aco_changes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,6 @@ Layout/ClosingParenthesisIndentation:
     - 'app/models/grda_warehouse/warehouse_reports/cas/ce_assessment.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_one.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_three.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/importers/hmis_auto_detect/local.rb'
     - 'app/models/importers/hmis_auto_detect/s3.rb'
     - 'app/models/report_generators/data_quality/fy2017/base.rb'
@@ -665,7 +664,6 @@ Layout/FirstArgumentIndentation:
   Exclude:
     - 'app/models/grda_warehouse/warehouse_reports/cas/ce_assessment.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_three.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/report_generators/system_performance/fy2018/measure_one.rb'
     - 'app/models/report_generators/system_performance/fy2018/measure_six.rb'
     - 'app/models/report_generators/system_performance/fy2018/measure_two.rb'
@@ -720,7 +718,6 @@ Layout/HashAlignment:
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_two.rb'
     - 'app/models/health/accountable_care_organization.rb'
     - 'app/models/health/claim.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/tasks/notify_care_coordinators_of_patient_eligibility_problems.rb'
     - 'app/models/report_generators/data_quality/fy2017/base.rb'
     - 'app/models/report_generators/data_quality/fy2017/q1.rb'
@@ -868,7 +865,6 @@ Layout/MultilineMethodCallIndentation:
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_one.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_three.rb'
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_two.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/expiring_item_report.rb'
     - 'app/models/health/signature_request.rb'
     - 'app/models/health/transaction_acknowledgement.rb'
@@ -1724,7 +1720,6 @@ Lint/UselessAssignment:
     - 'app/models/health/careplan_saver.rb'
     - 'app/models/health/claim.rb'
     - 'app/models/health/claims/view_model.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/participation_saver.rb'
     - 'app/models/health/premium_payment.rb'
     - 'app/models/health/tasks/patient_client_matcher.rb'
@@ -1983,7 +1978,6 @@ Style/EmptyElse:
 # Cop supports --auto-correct.
 Style/EmptyLambdaParameter:
   Exclude:
-    - 'app/models/health/eligibility_inquiry.rb'
 
 # Offense count: 16
 # Cop supports --auto-correct.
@@ -2165,7 +2159,6 @@ Style/MethodCallWithoutArgsParentheses:
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_one.rb'
     - 'app/models/health/claim.rb'
     - 'app/models/health/claims/view_model.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/exporter/health_exporter.rb'
     - 'app/models/health/tasks/import_patient_referral_refreshes.rb'
     - 'app/models/health/tasks/import_patient_referrals.rb'
@@ -2280,7 +2273,6 @@ Style/NegatedIf:
 Style/NestedParenthesizedCalls:
   Exclude:
     - 'app/models/grda_warehouse/tasks/test_data.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/similarity_metric/base.rb'
 
 # Offense count: 55
@@ -2550,7 +2542,6 @@ Style/SafeNavigation:
 Style/SelfAssignment:
   Exclude:
     - 'app/models/grda_warehouse/warehouse_reports/project/data_quality/version_three.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/report_generators/system_performance/fy2019/measure_one.rb'
 
 # Offense count: 13
@@ -2630,7 +2621,6 @@ Style/StringLiterals:
     - 'app/models/health/claims/top_providers.rb'
     - 'app/models/health/cp_members/file_base.rb'
     - 'app/models/health/cp_members/roster.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/encounter_record.rb'
     - 'app/models/health/encounter_report.rb'
     - 'app/models/health/enrollment_reasons.rb'
@@ -2740,7 +2730,6 @@ Style/TrailingCommaInArguments:
     - 'app/models/health/cha_saver.rb'
     - 'app/models/health/claim.rb'
     - 'app/models/health/dme_saver.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
     - 'app/models/health/expiring_item_report.rb'
     - 'app/models/health/exporter/health_exporter.rb'
     - 'app/models/health/participation_saver.rb'
@@ -2883,7 +2872,6 @@ Style/WhileUntilDo:
 Style/WhileUntilModifier:
   Exclude:
     - 'app/models/health/claim.rb'
-    - 'app/models/health/eligibility_inquiry.rb'
 
 # Offense count: 8
 # Cop supports --auto-correct.

--- a/app/models/health/eligibility_inquiry.rb
+++ b/app/models/health/eligibility_inquiry.rb
@@ -8,22 +8,22 @@
 # Risk: Describes an insurance eligibility inquiry and contains PHI
 # Control: PHI attributes documented
 
-require "stupidedi"
+require 'stupidedi'
 module Health
   class EligibilityInquiry < HealthBase
     before_create :assign_control_numbers
     after_initialize :set_batch
 
-    phi_attr :inquiry, Phi::Bulk, "Description of inquiry" # contains EDI serialized PHI
-    phi_attr :result, Phi::Bulk, "Result of inquiry" # contains EDI serialized PHI
+    phi_attr :inquiry, Phi::Bulk, 'Description of inquiry' # contains EDI serialized PHI
+    phi_attr :result, Phi::Bulk, 'Result of inquiry' # contains EDI serialized PHI
     attr_accessor :batch
 
     has_one :eligibility_response, dependent: :destroy
     has_many :batches, class_name: 'Health::EligibilityInquiry', foreign_key: :batch_id, dependent: :destroy
 
-    scope :pending, -> () do
+    scope :pending, -> do
       where.not(inquiry: nil).
-      where.not(id: Health::EligibilityResponse.select(:eligibility_inquiry_id))
+        where.not(id: Health::EligibilityResponse.select(:eligibility_inquiry_id))
     end
 
     scope :patients, -> do
@@ -38,7 +38,7 @@ module Health
       @eligible_ids ||= begin
         ids = []
         batch_responses.each do |response|
-          ids = ids + response.eligible_ids
+          ids += response.eligible_ids
         end
         ids.uniq
       end
@@ -50,7 +50,7 @@ module Health
       @ineligible_ids ||= begin
         ids = []
         batch_responses.each do |response|
-          ids = ids + response.ineligible_ids
+          ids += response.ineligible_ids
         end
         ids.uniq
       end
@@ -62,7 +62,7 @@ module Health
       @managed_care_ids ||= begin
         ids = []
         batch_responses.each do |response|
-          ids = ids + response.managed_care_ids
+          ids += response.managed_care_ids
         end
         ids.uniq
       end
@@ -86,7 +86,7 @@ module Health
       @patient_aco_changes ||= begin
         changes = {}
         batch_responses.each do |response|
-          changes.merge!(response.patient_aco_changes)
+          changes.merge!(response.patient_aco_changes || {})
         end
         changes
       end
@@ -134,16 +134,12 @@ module Health
         b.NM1 'IL', '1', patient.last_name, patient.first_name, patient.middle_name, b.blank, b.blank, 'MI', patient.medicaid_id
         b.DMG 'D8', patient.birthdate&.strftime('%Y%m%d'), edi_gender(patient.gender)
         b.DTP '291', 'D8', service_date.strftime('%Y%m%d')
-        b.EQ(
-            b.repeated '30'
-        )
+        b.EQ(b.repeated('30'))
       end
 
       m = b.machine
       st = m
-      while st.segment.fetch.node.id != :ST
-        st = st.parent.fetch
-      end
+      st = st.parent.fetch while st.segment.fetch.node.id != :ST
 
       b.SE 2 + m.distance(st).fetch, transaction_control_number
       b.GE '1', group_control_number
@@ -156,13 +152,13 @@ module Health
       file = ''
       @edi_builder.machine.zipper.tap do |z|
         separators = Stupidedi::Reader::Separators.build(
-            segment: "~\n",
-            element: "*",
-            component: ">",
-            repetition:  "^"
+          segment: "~\n",
+          element: '*',
+          component: '>',
+          repetition: '^',
         )
         w = Stupidedi::Writer::Default.new(z.root, separators)
-        file = w.write().upcase
+        file = w.write.upcase
       end
       file
     end
@@ -189,17 +185,17 @@ module Health
 
     def self.next_isa_control_number
       isa_control_number = maximum(:isa_control_number) || 10
-      isa_control_number += 1
+      isa_control_number + 1
     end
 
     def self.next_group_control_number
       group_control_number = maximum(:group_control_number) || 1010
-      group_control_number += 1
+      group_control_number + 1
     end
 
     def self.next_transaction_control_number
       transaction_control_number = maximum(:transaction_control_number) || 1010
-      transaction_control_number += 1
+      transaction_control_number + 1
     end
   end
 end


### PR DESCRIPTION
The bug fix is line 89: `changes.merge!(response.patient_aco_changes || {})`
The rest are making RuboCop happy.