### PR TITLE
Remove Duplicate Re-activate User Button

### DIFF
--- a/app/controllers/admin/recreate_invitations_controller.rb
+++ b/app/controllers/admin/recreate_invitations_controller.rb
@@ -11,7 +11,7 @@ module Admin
     def create
       @user = User.find params[:user_id]
 
-      if User.inactive.find(@user.id).present?
+      if @user.inactive?
         @user.update(
           active: true,
           last_activity_at: Time.current,

--- a/app/controllers/admin/recreate_invitations_controller.rb
+++ b/app/controllers/admin/recreate_invitations_controller.rb
@@ -10,6 +10,15 @@ module Admin
 
     def create
       @user = User.find params[:user_id]
+
+      if User.inactive.find(@user.id).present?
+        @user.update(
+          active: true,
+          last_activity_at: Time.current,
+          expired_at: nil,
+        )
+      end
+
       @user.invite!
       flash[:notice] = "Account activation instructions resent to #{@user.email}"
       redirect_to admin_users_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,6 +307,11 @@ class User < ApplicationRecord
     email == 'noreply@greenriver.com'
   end
 
+  def inactive?
+    return true unless active?
+    expired?
+  end
+
   def data_sources
     viewable GrdaWarehouse::DataSource
   end

--- a/app/views/admin/inactive_users/index.haml
+++ b/app/views/admin/inactive_users/index.haml
@@ -39,7 +39,7 @@
                 = render 'admin/users/user_invitation_status', user: user
               %td
                 - if user.invitation_status == :invitation_expired || user.invitation_status == :pending_confirmation
-                  = simple_form_for(user, url: reactivate_admin_inactive_user_path(user)) do |f|
+                  = simple_form_for(user, url: admin_user_recreate_invitation_path(user), method: :post) do |f|
                     = f.button :button, data: { confirm: 'When re-inviting an user, the account will be re-activated and an email invitation will be sent to the address on file.' }, class: 'btn btn-primary' do
                       Re-invite
                 - else

--- a/app/views/admin/inactive_users/index.haml
+++ b/app/views/admin/inactive_users/index.haml
@@ -38,7 +38,7 @@
               %td
                 = render 'admin/users/user_invitation_status', user: user
               %td
-                - if user.invitation_status == :invitation_expired || user.invitation_status == :pending_confirmation
+                - if user.invitation_status.in?([:invitation_expired, :pending_confirmation])
                   = simple_form_for(user, url: admin_user_recreate_invitation_path(user), method: :post) do |f|
                     = f.button :button, data: { confirm: 'When re-inviting an user, the account will be re-activated and an email invitation will be sent to the address on file.' }, class: 'btn btn-primary' do
                       Re-invite

--- a/app/views/admin/inactive_users/index.haml
+++ b/app/views/admin/inactive_users/index.haml
@@ -38,8 +38,13 @@
               %td
                 = render 'admin/users/user_invitation_status', user: user
               %td
-                = simple_form_for(user, url: reactivate_admin_inactive_user_path(user)) do |f|
-                  = f.button :button, data: { confirm: 'When re-activating an account, the password will be set to something random and an email will be sent to the address on file with a link to pick a new password.' }, class: 'btn btn-primary' do
-                    Re-activate
+                - if user.invitation_status == :invitation_expired || user.invitation_status == :pending_confirmation
+                  = simple_form_for(user, url: reactivate_admin_inactive_user_path(user)) do |f|
+                    = f.button :button, data: { confirm: 'When re-inviting an user, the account will be re-activated and an email invitation will be sent to the address on file.' }, class: 'btn btn-primary' do
+                      Re-invite
+                - else
+                  = simple_form_for(user, url: reactivate_admin_inactive_user_path(user)) do |f|
+                    = f.button :button, data: { confirm: 'When re-activating an account, the password will be set to something random and an email will be sent to the address on file with a link to pick a new password.' }, class: 'btn btn-primary' do
+                      Re-activate
 
     %p= paginate @users

--- a/app/views/admin/users/_user_invitation_status.haml
+++ b/app/views/admin/users/_user_invitation_status.haml
@@ -1,11 +1,8 @@
 - if user.invitation_status == :active
   - if user.access_locked?
     Account locked.
-    = link_to 'Unlock', unlock_admin_user_path(user), method: :post, class: 'btn btn-secondary btn-sm mt-2'
   - elsif user.expired?
     Account Expired #{user.expired_at}
-    %br
-    = link_to 'Re-activate account', un_expire_admin_user_path(user), method: :post, class: 'btn btn-secondary btn-sm mt-2'
   - elsif user.future_expiration?
     Account will expire on #{user.expired_at.to_date}
   - else
@@ -14,8 +11,5 @@
   Pending Confirmation.
   %br
   Invitation will expire on #{user.invitation_due_at.strftime "%m/%d/%Y"}
-  %br
-  = link_to "Resend Invitation", admin_user_resend_invitation_path(user), method: :post, class: 'btn btn-secondary btn-sm mt-2'
 - elsif user.invitation_status == :invitation_expired
   %i Invitation Expired.
-  = link_to "Re-create Invitation", admin_user_recreate_invitation_path(user), method: :post, class: 'btn btn-secondary btn-sm mt-2'

--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -66,21 +66,21 @@
               %td
                 - if user.invitation_status != :active || user.access_locked?
                   .mb-6
-                    - if user.access_locked?
-                      .w-100
-                        = link_to unlock_admin_user_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
-                          %i.icon-unlocked
-                          Unlock
                     - if user.invitation_status == :pending_confirmation
                       .w-100
                         = link_to admin_user_resend_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
                           %i.icon-envelope-o
                           Resend Invitation
-                    - if user.invitation_status == :invitation_expired
+                    - elsif user.invitation_status == :invitation_expired
                       .w-100
                         = link_to admin_user_recreate_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
                           %i.icon-envelope-o
                           Re-create Invitation
+                    - elsif user.access_locked?
+                      .w-100
+                        = link_to unlock_admin_user_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                          %i.icon-unlocked
+                          Unlock
                 .w-100
                   = link_to(edit_admin_user_path(id: user), class: 'btn btn-sm btn-secondary mb-2 text-nowrap') do
                     %i.icon-pencil

--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -64,6 +64,23 @@
                   %div= "Sign-in provided by #{user.provider.upcase}"
                 = render 'user_invitation_status', user: user
               %td
+                - if user.invitation_status != :active or user.access_locked?
+                  .mb-6
+                    - if user.access_locked?
+                      .w-100
+                        = link_to unlock_admin_user_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                          %i.icon-unlocked
+                          Unlock
+                    - if user.invitation_status == :pending_confirmation
+                      .w-100
+                        = link_to admin_user_resend_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                          %i.icon-envelope-o
+                          Resend Invitation
+                    - if user.invitation_status == :invitation_expired
+                      .w-100
+                        = link_to admin_user_recreate_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                          %i.icon-envelope-o
+                          Re-create Invitation
                 .w-100
                   = link_to(edit_admin_user_path(id: user), class: 'btn btn-sm btn-secondary mb-2 text-nowrap') do
                     %i.icon-pencil
@@ -73,21 +90,6 @@
                     = link_to admin_user_audit_path(user), class: 'btn btn-sm btn-secondary mb-2' do
                       %i.icon-eye{data: {toggle: :tooltip, title: 'Audit'}}
                       Audit
-                - if user.access_locked?
-                  .w-100
-                    = link_to unlock_admin_user_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
-                      %i.icon-unlocked
-                      Unlock
-                - if user.invitation_status == :pending_confirmation
-                  .w-100
-                    = link_to admin_user_resend_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
-                      %i.icon-envelope-o
-                      Resend Invitation
-                - if user.invitation_status == :invitation_expired
-                  .w-100
-                    = link_to admin_user_recreate_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
-                      %i.icon-envelope-o
-                      Re-create Invitation
                 - if can_impersonate_users? && user.impersonateable_by?(true_user)
                   .w-100
                     = link_to impersonate_admin_user_path(true_user, become_id: user.id), method: :post, class: 'btn btn-sm btn-secondary mb-2' do

--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -73,6 +73,21 @@
                     = link_to admin_user_audit_path(user), class: 'btn btn-sm btn-secondary mb-2' do
                       %i.icon-eye{data: {toggle: :tooltip, title: 'Audit'}}
                       Audit
+                - if user.access_locked?
+                  .w-100
+                    = link_to unlock_admin_user_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                      %i.icon-unlocked
+                      Unlock
+                - if user.invitation_status == :pending_confirmation
+                  .w-100
+                    = link_to admin_user_resend_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                      %i.icon-envelope-o
+                      Resend Invitation
+                - if user.invitation_status == :invitation_expired
+                  .w-100
+                    = link_to admin_user_recreate_invitation_path(user), method: :post, class: 'btn btn-sm btn-secondary mb-2' do
+                      %i.icon-envelope-o
+                      Re-create Invitation
                 - if can_impersonate_users? && user.impersonateable_by?(true_user)
                   .w-100
                     = link_to impersonate_admin_user_path(true_user, become_id: user.id), method: :post, class: 'btn btn-sm btn-secondary mb-2' do

--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -64,7 +64,7 @@
                   %div= "Sign-in provided by #{user.provider.upcase}"
                 = render 'user_invitation_status', user: user
               %td
-                - if user.invitation_status != :active or user.access_locked?
+                - if user.invitation_status != :active || user.access_locked?
                   .mb-6
                     - if user.access_locked?
                       .w-100


### PR DESCRIPTION
Fix bug where there were duplicate "re-activate" buttons shown for inactive users.

---

The updated inactive user tab shows a single button per user, which either re-activates (sends password reset email) or re-creates an invitation. The "Re-invite" button is shown if (1) the user's invite expired and then the user account became inactive (either manually or by expiration), OR (2) the user was deactivated before they got a chance to accept the invitation.
Each button has a confirmation modal that explains what will happen.

<img width="808" alt="inactiveusertab" src="https://user-images.githubusercontent.com/5333982/160192722-668cd248-0147-41f0-a6f1-f0a02f139c44.png">

---

The updated Active User tab has status-related buttons in the rightmost action column:

<img width="1103" alt="Screen Shot 2022-03-25 at 3 53 56 PM" src="https://user-images.githubusercontent.com/5333982/160192704-d7f6c9ed-0a58-4ef5-b254-525a507a012d.png">


Closes 181538873.