### PR TITLE
Change default file watcher to FileUpdateChecker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  if ENV['DISABLE_EVENT_FS_CHECKER'] == '1'
+  if ENV['ENABLE_EVENT_FS_CHECKER'] == '1'
     config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  if ENV['DISABLE_EVENT_FS_CHECKER'] != '1'
+  if ENV['DISABLE_EVENT_FS_CHECKER'] == '1'
     config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   end
 


### PR DESCRIPTION
Change default behavior to using `FileUpdateChecker`, which is [the default](https://github.com/rails/rails/blob/cfa728478935dc48d9d6e2463dc500ffafee802b/railties/lib/rails/application/configuration.rb#L57). I renamed the env variable so it shouldn't affect your environments @awisema @eanders since you're both using FileUpdatedChecker already.

EventedFileUpdateChecker doesn't work for me on Docker/Vagrant/Parallels setup, maybe related to https://github.com/rails/rails/issues/25186.
