### PR TITLE
Enforce newlines on multiline arrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,8 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: new_line
 
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,8 @@ Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: new_line
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
 
 Style/OptionalBooleanParameter:
   Enabled: false


### PR DESCRIPTION
Enforce this style for multiline arrays:
```
[
  a,
  b,
]
```

https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/FirstArrayElementLineBreak
https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/MultilineArrayBraceLayout