### PR TITLE
Adjust form field names to match Filters::FilterBase

### DIFF
--- a/app/controllers/warehouse_reports/client_lookups_controller.rb
+++ b/app/controllers/warehouse_reports/client_lookups_controller.rb
@@ -10,7 +10,8 @@ module WarehouseReports
     include ArelHelper
 
     def index
-      @filter = ::Filters::FilterBase.new(user_id: current_user.id, enforce_one_year_range: false).update(report_params)
+      @filter = ::Filters::FilterBase.new(user_id: current_user.id, enforce_one_year_range: false)
+      @filter.update(report_params)
       respond_to do |format|
         format.html {}
         format.xlsx do

--- a/app/controllers/warehouse_reports/client_lookups_controller.rb
+++ b/app/controllers/warehouse_reports/client_lookups_controller.rb
@@ -35,8 +35,8 @@ module WarehouseReports
 
       params.require(:report).
         permit(
-          :start_date,
-          :end_date,
+          :start,
+          :end,
           project_ids: [],
           organization_ids: [],
           data_source_ids: [],

--- a/app/controllers/warehouse_reports/client_lookups_controller.rb
+++ b/app/controllers/warehouse_reports/client_lookups_controller.rb
@@ -33,14 +33,7 @@ module WarehouseReports
     private def report_params
       return nil unless params[:report].present?
 
-      params.require(:report).
-        permit(
-          :start,
-          :end,
-          project_ids: [],
-          organization_ids: [],
-          data_source_ids: [],
-        )
+      params.require(:report).permit(@filter.known_params)
     end
 
     private def client_source

--- a/app/views/warehouse_reports/client_lookups/index.haml
+++ b/app/views/warehouse_reports/client_lookups/index.haml
@@ -11,9 +11,9 @@
   - content_for :filters_col_full do
     .row
       .col-sm-3
-        = f.input :start_date, as: :date_picker
+        = f.input :start, as: :date_picker
       .col-sm-3
-        = f.input :end_date, as: :date_picker
+        = f.input :end, as: :date_picker
     .row
       .col-sm-4
         = f.input :project_ids, label: 'Project', collection: [], as: :select_two, input_html: {multiple: true, data: {'collection-path' => api_projects_path}}, include_blank: false


### PR DESCRIPTION
The names of the report parameters for the date range did not match the ones used in `Filters::FilterBase#update`. A quick search didn't uncover any other places we might have made this error, but either a more careful inspection, or perhaps adding `start_date` and `end_date` as aliases in `update` would be a good idea.