### PR TITLE
Remove hardcoded date from start date dq report

### DIFF
--- a/drivers/start_date_dq/app/models/start_date_dq/report.rb
+++ b/drivers/start_date_dq/app/models/start_date_dq/report.rb
@@ -17,7 +17,7 @@ module StartDateDq
     end
 
     def default_filter(user_id)
-      Filters::FilterBase.new(user_id: user_id, start: '2018-01-01')
+      Filters::FilterBase.new(user_id: user_id)
     end
 
     def self.viewable_by(user)


### PR DESCRIPTION
This accidentally made its way into release branch. It has no effect because the default filter isn't used, it's just there to make development and debugging easier.