### PR TITLE
Move waiting for compiled assets to entrypoint

### DIFF
--- a/bin/wait_for_compiled_assets.rb
+++ b/bin/wait_for_compiled_assets.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+require_relative '../config/deploy/docker/lib/asset_compiler.rb'
+
+target_group_name = ENV.fetch('TARGET_GROUP_NAME', false)
+checksum = ENV.fetch('ASSET_CHECKSUM', false)
+
+raise 'Waiting for compiled assets error: TARGET_GROUP_NAME not defined' unless target_group_name
+raise 'Waiting for compiled assets error: ASSET_CHECKSUM not defined' unless checksum
+
+compiled_assets_s3_path = AssetCompiler.compiled_assets_s3_path(target_group_name, checksum)
+while `aws s3 ls #{compiled_assets_s3_path.shellescape}`.strip.empty?
+  puts "[INFO] Assets for hash [#{checksum}] not compiled yet, waiting 60 seconds..."
+  sleep 60
+end
+puts "[INFO] Assets for hash [#{checksum}] are compiled, proceeding..."

--- a/config/deploy/docker/assets/entrypoint.sh
+++ b/config/deploy/docker/assets/entrypoint.sh
@@ -50,6 +50,7 @@ echo "Using ASSET_CHECKSUM [${ASSET_CHECKSUM}]"
 
 cd ./public/assets
 # Pull down the compiled assets. Using ASSETS_PREFIX from .env and ASSET_CHECKSUM from above.
+bundle exec ../../bin/wait_for_compiled_assets.rb
 T1=`date +%s`
 ASSETS_PREFIX="${ASSETS_PREFIX}/${ASSET_CHECKSUM}" ASSETS_BUCKET_NAME=openpath-precompiled-assets UPDATE_ONLY=true ../../bin/sync_app_assets.rb
 T2=`date +%s`

--- a/config/deploy/docker/lib/asset_compiler.rb
+++ b/config/deploy/docker/lib/asset_compiler.rb
@@ -1,5 +1,4 @@
 require_relative 'aws_sdk_helpers'
-require 'byebug'
 require 'dotenv'
 
 class AssetCompiler

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -127,7 +127,7 @@ class Deployer
     _docker_login!
     _build_and_push_all!
     _check_secrets!
-    _check_compiled_assets!
+    # _check_compiled_assets! # Moved to entrypoint.
   end
 
   def roll_out


### PR DESCRIPTION
This avoids several bugs related to running the asset checksumming locally