### PR TITLE
Use effective_project_ids to filter report_scope for demographics

### DIFF
--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -142,7 +142,10 @@ module HomelessSummaryReport
       when 'Measure 7'
         @filter.update(start: @filter.start - 1.days)
       end
-      # puts measure
+
+      # Make sure we take advantage of the additive nature of HUD report filters
+      @filter.project_ids = @filter.effective_project_ids
+
       scope = @filter.apply(report_scope_source)
       scope = filter_for_range(scope)
 


### PR DESCRIPTION
Fix bug introduced in https://github.com/greenriver/hmis-warehouse/pull/2162 where the `report_scope` would be filtered down to zero because it switched to using `HudFilterBase.apply`, which uses `filter_for_projects_hud` which filters on `@filter.project_ids`. As a result, enrollments were only included if a specific project was selected, rather than including enrollments in all effective projects.