### PR TITLE
Create demographic scope after setting extra filters

### DIFF
--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -541,12 +541,13 @@ module HomelessSummaryReport
       # Force measure 2 because it has the largest date range, and we only use this to check to see if
       # someone existed in a demographic category, time is irrelevant for these
       measure = 'Measure 2'
-      demographic_scope = report_scope(measure)
 
       @filter = filter
       base_variant = spec[:base_variant]
       extra_filters = base_variant[:extra_filters] || {}
       @filter.update(extra_filters.merge(sub_spec[:extra_filters] || {}))
+      demographic_scope = report_scope(measure)
+
       # demographic_filter is a method known to filter_scopes
       sub_spec[:demographic_filters].each do |demographic_filter|
         demographic_scope = send(demographic_filter, demographic_scope)


### PR DESCRIPTION
Fix inaccurate counts by calling `report_scope` _after_ updating `@filter` to include any extra filters are set before the scope is filtered down. This includes:
* `spec[:base_variant][:extra_filters]` includes `household_type` and sometimes `age_ranges` and `hoh_only`
* `sub_spec[:extra_filters]` includes demographic filter values such as race, ethnicity, veteran status, etc.