### PR TITLE
Fix Homeless Summary Report bugs, add back Adult Only households

### DIFF
--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -455,6 +455,15 @@ module HomelessSummaryReport
       # Work through all the SPM report variants, building up the `report_clients` as we go.
       run_spm.each do |household_category, spec|
         report = spec[:base_variant]
+
+        # Create lists of client IDs in each demographic variant
+        demographic_variant_clients = {}
+        spec[:variants].each do |demographic_category, sub_spec|
+          detail_variant_name = "spm_#{household_category}__#{demographic_category}"
+          client_ids = client_ids_for_demographic_category(spec, sub_spec)
+          demographic_variant_clients[detail_variant_name] = client_ids
+        end
+
         spm_fields.each do |spm_field, parts|
           cells = parts[:cells]
           cells.each do |cell|
@@ -473,12 +482,10 @@ module HomelessSummaryReport
               report_clients[client_id] = report_client
 
               # Set demographic flags
-              spec[:variants].each do |demographic_category, sub_spec|
-                detail_variant_name = "spm_#{household_category}__#{demographic_category}"
-                client_ids_in_demographic_category = client_ids_for_demographic_category(spec, sub_spec)
-                next unless client_id.in?(client_ids_in_demographic_category)
+              demographic_variant_clients.each do |demographic_variant_name, client_ids|
+                next unless client_id.in?(client_ids)
 
-                report_client[detail_variant_name] = 1
+                report_client[demographic_variant_name] = 1
               end
             end
           end

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -460,8 +460,7 @@ module HomelessSummaryReport
         demographic_variant_clients = {}
         spec[:variants].each do |demographic_category, sub_spec|
           detail_variant_name = "spm_#{household_category}__#{demographic_category}"
-          client_ids = client_ids_for_demographic_category(spec, sub_spec)
-          demographic_variant_clients[detail_variant_name] = client_ids
+          demographic_variant_clients[detail_variant_name] = client_ids_for_demographic_category(spec, sub_spec)
         end
 
         spm_fields.each do |spm_field, parts|
@@ -518,9 +517,8 @@ module HomelessSummaryReport
     private def client_ids_for_demographic_category(spec, sub_spec)
       @filter = filter
 
-      # Force date range from measure 2 because it has the largest date range,
-      # and we only use this to check to see if someone existed in a demographic
-      # category, time is irrelevant for these
+      # Force date range from measure 2 because it has the largest date range, and we
+      # only use this to check to see if someone existed in a demographic category
       @filter.update(start: @filter.start - 2.years)
 
       # Update filter with demographic values

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -149,9 +149,6 @@ module HomelessSummaryReport
       scope = @filter.apply(report_scope_source)
       scope = filter_for_range(scope)
 
-      # force re-calculation of filter
-      @filter = nil
-      filter
       scope
     end
 
@@ -545,18 +542,16 @@ module HomelessSummaryReport
       @filter = filter
       base_variant = spec[:base_variant]
       extra_filters = base_variant[:extra_filters] || {}
-      demographic_filter_values = extra_filters.merge(sub_spec[:extra_filters] || {})
-      @filter.update(demographic_filter_values)
-
+      @filter.update(extra_filters.merge(sub_spec[:extra_filters] || {}))
       demographic_scope = report_scope(measure)
-      @filter.update(demographic_filter_values)
 
       # demographic_filter is a method known to filter_scopes
       sub_spec[:demographic_filters].each do |demographic_filter|
         demographic_scope = send(demographic_filter, demographic_scope)
       end
-      puts demographic_scope.select(:client_id).to_sql
+
       ids = demographic_scope.pluck(:client_id).uniq.to_set
+
       @filter = nil
       filter
       ids

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -545,8 +545,11 @@ module HomelessSummaryReport
       @filter = filter
       base_variant = spec[:base_variant]
       extra_filters = base_variant[:extra_filters] || {}
-      @filter.update(extra_filters.merge(sub_spec[:extra_filters] || {}))
+      demographic_filter_values = extra_filters.merge(sub_spec[:extra_filters] || {})
+      @filter.update(demographic_filter_values)
+
       demographic_scope = report_scope(measure)
+      @filter.update(demographic_filter_values)
 
       # demographic_filter is a method known to filter_scopes
       sub_spec[:demographic_filters].each do |demographic_filter|

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -131,27 +131,6 @@ module HomelessSummaryReport
       ]
     end
 
-    # @return filtered scope
-    def report_scope(measure)
-      @filter = filter
-      # Measure 2 needs a 2 year look-back
-      # Measure 7 needs to extend one day before the filter start to match the SPM
-      case measure
-      when 'Measure 2'
-        @filter.update(start: @filter.start - 2.years)
-      when 'Measure 7'
-        @filter.update(start: @filter.start - 1.days)
-      end
-
-      # Make sure we take advantage of the additive nature of HUD report filters
-      @filter.project_ids = @filter.effective_project_ids
-
-      scope = @filter.apply(report_scope_source)
-      scope = filter_for_range(scope)
-
-      scope
-    end
-
     def report_scope_source
       GrdaWarehouse::ServiceHistoryEnrollment.entry
     end
@@ -476,12 +455,12 @@ module HomelessSummaryReport
       # Work through all the SPM report variants, building up the `report_clients` as we go.
       run_spm.each do |household_category, spec|
         report = spec[:base_variant]
-        detail_variant_name = "spm_#{household_category}__all"
         spm_fields.each do |spm_field, parts|
           cells = parts[:cells]
           cells.each do |cell|
             spm_clients = answer_clients(report[:report], *cell)
             spm_clients.each do |spm_client|
+              detail_variant_name = "spm_#{household_category}__all"
               client_id = spm_client[:client_id]
               report_client = report_clients[client_id] || Client.new_with_default_values
               report_client[:client_id] = client_id
@@ -492,6 +471,15 @@ module HomelessSummaryReport
               report_client[field_name(cell)] = true if field_measure(spm_field) == 7
               report_client[detail_variant_name] = report[:report].id # SPM ID for future reference
               report_clients[client_id] = report_client
+
+              # Set demographic flags
+              spec[:variants].each do |demographic_category, sub_spec|
+                detail_variant_name = "spm_#{household_category}__#{demographic_category}"
+                client_ids_in_demographic_category = client_ids_for_demographic_category(spec, sub_spec)
+                next unless client_id.in?(client_ids_in_demographic_category)
+
+                report_client[detail_variant_name] = 1
+              end
             end
           end
         end
@@ -505,20 +493,6 @@ module HomelessSummaryReport
             client.spm_m7b1_c3
           ) && !client.spm_m7b2_c3
         client
-      end
-
-      # Set demographic flags
-      variants.each do |household_category, spec|
-        spec[:variants].each do |demographic_category, sub_spec|
-          detail_variant_name = "spm_#{household_category}__#{demographic_category}"
-          client_ids_in_demographic_category = client_ids_for_demographic_category(spec, sub_spec)
-          report_clients.each do |client_id, report_client|
-            next unless client_id.in?(client_ids_in_demographic_category)
-
-            # This previously inserted 0, now we just need to make it > 0
-            report_client[detail_variant_name] = 1
-          end
-        end
       end
 
       Client.import(
@@ -535,22 +509,34 @@ module HomelessSummaryReport
     # filter set.  When it's done, it can just clear it as calling `filter` will reset it from
     # the chosen options
     private def client_ids_for_demographic_category(spec, sub_spec)
-      # Force measure 2 because it has the largest date range, and we only use this to check to see if
-      # someone existed in a demographic category, time is irrelevant for these
-      measure = 'Measure 2'
-
       @filter = filter
-      base_variant = spec[:base_variant]
-      extra_filters = base_variant[:extra_filters] || {}
-      @filter.update(extra_filters.merge(sub_spec[:extra_filters] || {}))
-      demographic_scope = report_scope(measure)
 
-      # demographic_filter is a method known to filter_scopes
+      # Force date range from measure 2 because it has the largest date range,
+      # and we only use this to check to see if someone existed in a demographic
+      # category, time is irrelevant for these
+      @filter.update(start: @filter.start - 2.years)
+
+      # Update filter with demographic values
+      base_variant = spec[:base_variant] # household type and age ranges
+      extra_filters = base_variant[:extra_filters] || {} # demographics
+      @filter.update(extra_filters.merge(sub_spec[:extra_filters] || {}))
+
+      # Make sure we take advantage of the additive nature of HUD report filters
+      @filter.project_ids = @filter.effective_project_ids
+
+      # Apply HUD filters
+      scope = @filter.apply(report_scope_source)
+
+      # Filter for range
+      scope = filter_for_range(scope)
+
+      # Filter for demographics, to catch any demo filters that aren't applied with HudFilterBase.apply
       sub_spec[:demographic_filters].each do |demographic_filter|
-        demographic_scope = send(demographic_filter, demographic_scope)
+        # demographic_filter is a method known to filter_scopes
+        scope = send(demographic_filter, scope)
       end
 
-      ids = demographic_scope.pluck(:client_id).uniq.to_set
+      ids = scope.pluck(:client_id).uniq.to_set
 
       @filter = nil
       filter
@@ -777,6 +763,15 @@ module HomelessSummaryReport
             name: 'All Clients',
             extra_filters: {
               household_type: :all,
+            },
+          },
+          variants: {},
+        },
+        without_children: {
+          base_variant: {
+            name: 'Clients in Adult Only Households',
+            extra_filters: {
+              household_type: :without_children,
             },
           },
           variants: {},


### PR DESCRIPTION
1. Fix issue where not all demographic filters were being applied (bug introduced recently, in release-34), by inlining `report_scope` which previously reset the filters
2. Fix issue where clients from different SPMs were being counted in demographic categories where they shouldn't be, by setting demographics flags within the `spm_clients.each` loop
3. Add Adult-Only household category back (removed in https://github.com/greenriver/hmis-warehouse/pull/1854/files#diff-8ef874511af8250dbf77a2b2a5958b2f247078275c1cc013848d2546a8d667ebL388)