### PR TITLE
Normalize stacked bar chart and trim destination detail length

### DIFF
--- a/app/assets/javascripts/warehouse_reports/homeless_summary_report/horizontal_stacked_bar.js.es6
+++ b/app/assets/javascripts/warehouse_reports/homeless_summary_report/horizontal_stacked_bar.js.es6
@@ -161,7 +161,7 @@ window.App.WarehouseReports.HomelessSummaryReport.HorizontalStackedBar = class H
 
       if (row != null) {
         const bg_color = color(row.id);
-        const box = `<td class='name' style='width: 200px;'><svg><rect style='fill:${bg_color}' width='10' height='10'></rect></svg>${row.name}</td>`;
+        const box = `<td class='name' style='width: 110px;'><svg><rect style='fill:${bg_color}' width='10' height='10'></rect></svg>${row.name.split(/[ ,]/)[0]}</td>`;
         const value = `<td style='width: 10%; white-space: nowrap;'>${row.value} (${parseFloat((row.ratio * 100.0).toFixed(1))}%)</td>`;
         const detailRows = support.all_detail_counts[tooltip_title][row.name].map(this.shortenDestinationDetail)
         const details = `<td class='text-left' style='white-space: nowrap;'>${detailRows.join('<br />')}</td>`;


### PR DESCRIPTION
### Chart
* Use [data.stack.normalize](https://naver.github.io/billboard.js/release/latest/doc/Options.html#.data%25E2%2580%25A4stack%25E2%2580%25A4normalize) to show percentages instead of counts
* Remove numeric labels from stacked bars

### Tooltip readability
* Increase z-index so its not covered by the footer
* Opacity 1
* Prevent wrapping of details
* Reduce width of first 2 columns
* Shortening length of [destination details](https://github.com/greenriver/hmis-warehouse/blob/e04e4c31b380d624319e9d65604bf39b88c4c660/app/models/concerns/hud_reports/destinations.rb#L20) by cutting out parenthesized text if the string is over 30 chars long. I'm not sure if missing that text will cause confusion, please check me on that.
* Special case to shorten `Emergency shelter, including hotel or motel paid for with emergency shelter voucher, or RHY-funded Host Home shelter` to `Emergency shelter`


---

![Screen Shot 2022-05-05 at 10 47 45 AM](https://user-images.githubusercontent.com/5333982/166949985-5ae11fb9-77c3-40c9-a9bb-7854297f184c.png)

 
![Screen Shot 2022-05-05 at 10 47 07 AM](https://user-images.githubusercontent.com/5333982/166949843-12c82bf0-139a-4365-a2e3-9f9d3e544611.png)
