### PR TITLE
Enable specifying virtual processing dates for system cohorts

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -99,6 +99,8 @@ module Admin
         :service_register_visible,
         :enable_youth_unstably_housed,
         :cas_sync_project_group_id,
+        :system_cohort_processing_date,
+        :system_cohort_date_window,
         client_details: [],
       )
     end

--- a/app/models/grda_warehouse/system_cohorts/base.rb
+++ b/app/models/grda_warehouse/system_cohorts/base.rb
@@ -7,7 +7,9 @@
 module GrdaWarehouse::SystemCohorts
   class Base < GrdaWarehouse::Cohort
     # Factory
-    def self.update_system_cohorts(processing_date: Date.current, date_window: 1.day)
+    def self.update_system_cohorts(processing_date: nil, date_window: nil)
+      processing_date ||= ::GrdaWarehouse::Config.get(:system_cohort_processing_date) || Date.current
+      date_window ||= ::GrdaWarehouse::Config.get(:system_cohort_date_window) || 1.day
       cohort_classes.each do |config_key, klass|
         next unless GrdaWarehouse::Config.get(config_key)
 

--- a/app/models/grda_warehouse/system_cohorts/base.rb
+++ b/app/models/grda_warehouse/system_cohorts/base.rb
@@ -7,7 +7,7 @@
 module GrdaWarehouse::SystemCohorts
   class Base < GrdaWarehouse::Cohort
     # Factory
-    def self.update_system_cohorts
+    def self.update_system_cohorts(processing_date: Date.current, date_window: 1.day)
       cohort_classes.each do |config_key, klass|
         next unless GrdaWarehouse::Config.get(config_key)
 
@@ -17,7 +17,7 @@ module GrdaWarehouse::SystemCohorts
           cohort.days_of_inactivity = 90
         end
         system_cohort.update(name: system_cohort.cohort_name)
-        system_cohort.sync
+        system_cohort.sync(processing_date: processing_date, date_window: date_window)
       end
     end
 

--- a/app/models/grda_warehouse/system_cohorts/currently_homeless.rb
+++ b/app/models/grda_warehouse/system_cohorts/currently_homeless.rb
@@ -43,7 +43,7 @@ module GrdaWarehouse::SystemCohorts
         homeless.
         ongoing.
         with_service_between(start_date: inactive_date, end_date: @processing_date).
-        where.not(client_id: service_history_source.where(date: @processing_date - @date_window, homeless: false).select(:client_id)).
+        where.not(client_id: service_history_source.where(date: (@processing_date - @date_window .. @processing_date - 1.day), homeless: false).select(:client_id)).
         where.not(client_id: moved_in_ph).
         where.not(client_id: cohort_clients.select(:client_id)).
         group(:client_id).minimum(:first_date_in_program)

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -34,7 +34,8 @@
           = f.input :chronic_cohort, label: 'Chronic', hint: 'The chronic cohort includes all clients who are currently chronically homeless with open enrollment in ES, SO, TH, SH and no move-in date in a current PH project.'
           = f.input :adult_and_child_cohort, label: 'Adult and Child', hint: 'The adult and child cohort includes all clients in an adult and child household with open enrollment in ES, SO, TH, SH and no move-in date in a current PH project.'
           = f.input :adult_only_cohort, label: 'Adult Only', hint: 'The adult only cohort includes all clients in a household with only adults with open enrollment in ES, SO, TH, SH and no move-in date in a current PH project.'
-
+          = f.input :system_cohort_processing_date, as: :date_picker, label: 'Date to calculate system cohorts from', hint: 'Should be left blank except in test environments'
+          = f.input :system_cohort_date_window, label: 'Number of days to consider when determining newly homeless'
       %section.o-section-card
         %h3 Client Calculations
         .c-card.c-card--flush.c-card--padded.flex-wrap

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -85,18 +85,6 @@ CREATE TYPE public.census_levels AS ENUM (
 
 
 --
--- Name: record_action; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.record_action AS ENUM (
-    'added',
-    'updated',
-    'unchanged',
-    'removed'
-);
-
-
---
 -- Name: record_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -2164,1215 +2152,6 @@ ALTER SEQUENCE public.available_file_tags_id_seq OWNED BY public.available_file_
 
 
 --
--- Name: bi_Affiliation; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Affiliation" AS
- SELECT "Affiliation".id AS "AffiliationID",
-    "Project".id AS "ProjectID",
-    "Affiliation"."ResProjectID",
-    "Affiliation"."DateCreated",
-    "Affiliation"."DateUpdated",
-    "Affiliation"."UserID",
-    "Affiliation"."DateDeleted",
-    "Affiliation"."ExportID",
-    "Affiliation".data_source_id
-   FROM (public."Affiliation"
-     JOIN public."Project" ON ((("Affiliation".data_source_id = "Project".data_source_id) AND (("Affiliation"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-  WHERE ("Affiliation"."DateDeleted" IS NULL);
-
-
---
--- Name: warehouse_clients; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.warehouse_clients (
-    id integer NOT NULL,
-    id_in_source character varying NOT NULL,
-    data_source_id integer,
-    proposed_at timestamp without time zone,
-    reviewed_at timestamp without time zone,
-    reviewd_by character varying,
-    approved_at timestamp without time zone,
-    rejected_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    deleted_at timestamp without time zone,
-    source_id integer,
-    destination_id integer,
-    client_match_id integer
-);
-
-
---
--- Name: bi_Assessment; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Assessment" AS
- SELECT "Assessment".id AS "AssessmentID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "Assessment"."AssessmentDate",
-    "Assessment"."AssessmentLocation",
-    "Assessment"."AssessmentType",
-    "Assessment"."AssessmentLevel",
-    "Assessment"."PrioritizationStatus",
-    "Assessment"."DateCreated",
-    "Assessment"."DateUpdated",
-    "Assessment"."UserID",
-    "Assessment"."DateDeleted",
-    "Assessment"."ExportID",
-    "Assessment".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."Assessment"
-     JOIN public."Enrollment" ON ((("Assessment".data_source_id = "Enrollment".data_source_id) AND (("Assessment"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Assessment".data_source_id = source_clients.data_source_id) AND (("Assessment"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Assessment"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_AssessmentQuestions; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_AssessmentQuestions" AS
- SELECT "AssessmentQuestions".id AS "AssessmentQuestionID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Assessment".id AS "AssessmentID",
-    "Enrollment".id AS "EnrollmentID",
-    "AssessmentQuestions"."AssessmentQuestionGroup",
-    "AssessmentQuestions"."AssessmentQuestionOrder",
-    "AssessmentQuestions"."AssessmentQuestion",
-    "AssessmentQuestions"."AssessmentAnswer",
-    "AssessmentQuestions"."DateCreated",
-    "AssessmentQuestions"."DateUpdated",
-    "AssessmentQuestions"."UserID",
-    "AssessmentQuestions"."DateDeleted",
-    "AssessmentQuestions"."ExportID",
-    "AssessmentQuestions".data_source_id,
-    source_clients.id AS demographic_id
-   FROM ((((((public."AssessmentQuestions"
-     JOIN public."Enrollment" ON ((("AssessmentQuestions".data_source_id = "Enrollment".data_source_id) AND (("AssessmentQuestions"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("AssessmentQuestions".data_source_id = source_clients.data_source_id) AND (("AssessmentQuestions"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-     JOIN public."Assessment" ON ((("AssessmentQuestions".data_source_id = "Assessment".data_source_id) AND (("AssessmentQuestions"."AssessmentID")::text = ("Assessment"."AssessmentID")::text) AND ("Assessment"."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("AssessmentQuestions"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_AssessmentResults; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_AssessmentResults" AS
- SELECT "AssessmentResults".id AS "AssessmentResultID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Assessment".id AS "AssessmentID",
-    "Enrollment".id AS "EnrollmentID",
-    "AssessmentResults"."AssessmentResultType",
-    "AssessmentResults"."AssessmentResult",
-    "AssessmentResults"."DateCreated",
-    "AssessmentResults"."DateUpdated",
-    "AssessmentResults"."UserID",
-    "AssessmentResults"."DateDeleted",
-    "AssessmentResults"."ExportID",
-    "AssessmentResults".data_source_id,
-    source_clients.id AS demographic_id
-   FROM ((((((public."AssessmentResults"
-     JOIN public."Enrollment" ON ((("AssessmentResults".data_source_id = "Enrollment".data_source_id) AND (("AssessmentResults"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("AssessmentResults".data_source_id = source_clients.data_source_id) AND (("AssessmentResults"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-     JOIN public."Assessment" ON ((("AssessmentResults".data_source_id = "Assessment".data_source_id) AND (("AssessmentResults"."AssessmentID")::text = ("Assessment"."AssessmentID")::text) AND ("Assessment"."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("AssessmentResults"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Client; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Client" AS
- SELECT "Client".id AS personalid,
-    4 AS "HashStatus",
-    encode(sha256((public.soundex(upper(btrim(("Client"."FirstName")::text))))::bytea), 'hex'::text) AS "FirstName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."MiddleName")::text))))::bytea), 'hex'::text) AS "MiddleName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."LastName")::text))))::bytea), 'hex'::text) AS "LastName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."NameSuffix")::text))))::bytea), 'hex'::text) AS "NameSuffix",
-    "Client"."NameDataQuality",
-    concat("right"(("Client"."SSN")::text, 4), encode(sha256((lpad(("Client"."SSN")::text, 9, 'x'::text))::bytea), 'hex'::text)) AS "SSN",
-    "Client"."SSNDataQuality",
-    "Client"."DOB",
-    "Client"."DOBDataQuality",
-    "Client"."AmIndAKNative",
-    "Client"."Asian",
-    "Client"."BlackAfAmerican",
-    "Client"."NativeHIOtherPacific",
-    "Client"."White",
-    "Client"."RaceNone",
-    "Client"."Ethnicity",
-    "Client"."Gender",
-    "Client"."VeteranStatus",
-    "Client"."YearEnteredService",
-    "Client"."YearSeparated",
-    "Client"."WorldWarII",
-    "Client"."KoreanWar",
-    "Client"."VietnamWar",
-    "Client"."DesertStorm",
-    "Client"."AfghanistanOEF",
-    "Client"."IraqOIF",
-    "Client"."IraqOND",
-    "Client"."OtherTheater",
-    "Client"."MilitaryBranch",
-    "Client"."DischargeStatus",
-    "Client"."DateCreated",
-    "Client"."DateUpdated",
-    "Client"."UserID",
-    "Client"."DateDeleted",
-    "Client"."ExportID"
-   FROM public."Client"
-  WHERE (("Client"."DateDeleted" IS NULL) AND ("Client".data_source_id = 85));
-
-
---
--- Name: bi_CurrentLivingSituation; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_CurrentLivingSituation" AS
- SELECT "CurrentLivingSituation".id AS "CurrentLivingSitID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "CurrentLivingSituation"."InformationDate",
-    "CurrentLivingSituation"."CurrentLivingSituation",
-    "CurrentLivingSituation"."VerifiedBy",
-    "CurrentLivingSituation"."LeaveSituation14Days",
-    "CurrentLivingSituation"."SubsequentResidence",
-    "CurrentLivingSituation"."ResourcesToObtain",
-    "CurrentLivingSituation"."LeaseOwn60Day",
-    "CurrentLivingSituation"."MovedTwoOrMore",
-    "CurrentLivingSituation"."LocationDetails",
-    "CurrentLivingSituation"."DateCreated",
-    "CurrentLivingSituation"."DateUpdated",
-    "CurrentLivingSituation"."UserID",
-    "CurrentLivingSituation"."DateDeleted",
-    "CurrentLivingSituation"."ExportID",
-    "CurrentLivingSituation".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."CurrentLivingSituation"
-     JOIN public."Enrollment" ON ((("CurrentLivingSituation".data_source_id = "Enrollment".data_source_id) AND (("CurrentLivingSituation"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("CurrentLivingSituation".data_source_id = source_clients.data_source_id) AND (("CurrentLivingSituation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("CurrentLivingSituation"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Demographics; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Demographics" AS
- SELECT "Client".id AS personalid,
-    4 AS "HashStatus",
-    encode(sha256((public.soundex(upper(btrim(("Client"."FirstName")::text))))::bytea), 'hex'::text) AS "FirstName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."MiddleName")::text))))::bytea), 'hex'::text) AS "MiddleName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."LastName")::text))))::bytea), 'hex'::text) AS "LastName",
-    encode(sha256((public.soundex(upper(btrim(("Client"."NameSuffix")::text))))::bytea), 'hex'::text) AS "NameSuffix",
-    "Client"."NameDataQuality",
-    concat("right"(("Client"."SSN")::text, 4), encode(sha256((lpad(("Client"."SSN")::text, 9, 'x'::text))::bytea), 'hex'::text)) AS "SSN",
-    "Client"."SSNDataQuality",
-    "Client"."DOB",
-    "Client"."DOBDataQuality",
-    "Client"."AmIndAKNative",
-    "Client"."Asian",
-    "Client"."BlackAfAmerican",
-    "Client"."NativeHIOtherPacific",
-    "Client"."White",
-    "Client"."RaceNone",
-    "Client"."Ethnicity",
-    "Client"."Gender",
-    "Client"."VeteranStatus",
-    "Client"."YearEnteredService",
-    "Client"."YearSeparated",
-    "Client"."WorldWarII",
-    "Client"."KoreanWar",
-    "Client"."VietnamWar",
-    "Client"."DesertStorm",
-    "Client"."AfghanistanOEF",
-    "Client"."IraqOIF",
-    "Client"."IraqOND",
-    "Client"."OtherTheater",
-    "Client"."MilitaryBranch",
-    "Client"."DischargeStatus",
-    "Client"."DateCreated",
-    "Client"."DateUpdated",
-    "Client"."UserID",
-    "Client"."DateDeleted",
-    "Client"."ExportID",
-    warehouse_clients.destination_id AS client_id,
-    "Client".data_source_id
-   FROM (public."Client"
-     JOIN public.warehouse_clients ON ((warehouse_clients.source_id = "Client".id)))
-  WHERE (("Client"."DateDeleted" IS NULL) AND ("Client".data_source_id = ANY (ARRAY[87, 88, 98, 91, 107, 80, 106, 105, 99, 108, 102, 110, 103, 82, 109, 112, 111, 81, 86, 113])));
-
-
---
--- Name: bi_Disabilities; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Disabilities" AS
- SELECT "Disabilities".id AS "DisabilitiesID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "Disabilities"."InformationDate",
-    "Disabilities"."DisabilityType",
-    "Disabilities"."DisabilityResponse",
-    "Disabilities"."IndefiniteAndImpairs",
-    "Disabilities"."TCellCountAvailable",
-    "Disabilities"."TCellCount",
-    "Disabilities"."TCellSource",
-    "Disabilities"."ViralLoadAvailable",
-    "Disabilities"."ViralLoad",
-    "Disabilities"."ViralLoadSource",
-    "Disabilities"."DataCollectionStage",
-    "Disabilities"."DateCreated",
-    "Disabilities"."DateUpdated",
-    "Disabilities"."UserID",
-    "Disabilities"."DateDeleted",
-    "Disabilities"."ExportID",
-    "Disabilities".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."Disabilities"
-     JOIN public."Enrollment" ON ((("Disabilities".data_source_id = "Enrollment".data_source_id) AND (("Disabilities"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Disabilities".data_source_id = source_clients.data_source_id) AND (("Disabilities"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Disabilities"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_EmploymentEducation; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_EmploymentEducation" AS
- SELECT "EmploymentEducation".id AS "EmploymentEducationID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "EmploymentEducation"."InformationDate",
-    "EmploymentEducation"."LastGradeCompleted",
-    "EmploymentEducation"."SchoolStatus",
-    "EmploymentEducation"."Employed",
-    "EmploymentEducation"."EmploymentType",
-    "EmploymentEducation"."NotEmployedReason",
-    "EmploymentEducation"."DataCollectionStage",
-    "EmploymentEducation"."DateCreated",
-    "EmploymentEducation"."DateUpdated",
-    "EmploymentEducation"."UserID",
-    "EmploymentEducation"."DateDeleted",
-    "EmploymentEducation"."ExportID",
-    "EmploymentEducation".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."EmploymentEducation"
-     JOIN public."Enrollment" ON ((("EmploymentEducation".data_source_id = "Enrollment".data_source_id) AND (("EmploymentEducation"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("EmploymentEducation".data_source_id = source_clients.data_source_id) AND (("EmploymentEducation"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("EmploymentEducation"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Enrollment; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Enrollment" AS
- SELECT "Enrollment".id AS "EnrollmentID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Project".id AS "ProjectID",
-    "Enrollment"."EntryDate",
-    "Enrollment"."HouseholdID",
-    "Enrollment"."RelationshipToHoH",
-    "Enrollment"."LivingSituation",
-    "Enrollment"."LengthOfStay",
-    "Enrollment"."LOSUnderThreshold",
-    "Enrollment"."PreviousStreetESSH",
-    "Enrollment"."DateToStreetESSH",
-    "Enrollment"."TimesHomelessPastThreeYears",
-    "Enrollment"."MonthsHomelessPastThreeYears",
-    "Enrollment"."DisablingCondition",
-    "Enrollment"."DateOfEngagement",
-    "Enrollment"."MoveInDate",
-    "Enrollment"."DateOfPATHStatus",
-    "Enrollment"."ClientEnrolledInPATH",
-    "Enrollment"."ReasonNotEnrolled",
-    "Enrollment"."WorstHousingSituation",
-    "Enrollment"."PercentAMI",
-    "Enrollment"."LastPermanentStreet",
-    "Enrollment"."LastPermanentCity",
-    "Enrollment"."LastPermanentState",
-    "Enrollment"."LastPermanentZIP",
-    "Enrollment"."AddressDataQuality",
-    "Enrollment"."DateOfBCPStatus",
-    "Enrollment"."EligibleForRHY",
-    "Enrollment"."ReasonNoServices",
-    "Enrollment"."RunawayYouth",
-    "Enrollment"."SexualOrientation",
-    "Enrollment"."SexualOrientationOther",
-    "Enrollment"."FormerWardChildWelfare",
-    "Enrollment"."ChildWelfareYears",
-    "Enrollment"."ChildWelfareMonths",
-    "Enrollment"."FormerWardJuvenileJustice",
-    "Enrollment"."JuvenileJusticeYears",
-    "Enrollment"."JuvenileJusticeMonths",
-    "Enrollment"."UnemploymentFam",
-    "Enrollment"."MentalHealthIssuesFam",
-    "Enrollment"."PhysicalDisabilityFam",
-    "Enrollment"."AlcoholDrugAbuseFam",
-    "Enrollment"."InsufficientIncome",
-    "Enrollment"."IncarceratedParent",
-    "Enrollment"."ReferralSource",
-    "Enrollment"."CountOutreachReferralApproaches",
-    "Enrollment"."UrgentReferral",
-    "Enrollment"."TimeToHousingLoss",
-    "Enrollment"."ZeroIncome",
-    "Enrollment"."AnnualPercentAMI",
-    "Enrollment"."FinancialChange",
-    "Enrollment"."HouseholdChange",
-    "Enrollment"."EvictionHistory",
-    "Enrollment"."SubsidyAtRisk",
-    "Enrollment"."LiteralHomelessHistory",
-    "Enrollment"."DisabledHoH",
-    "Enrollment"."CriminalRecord",
-    "Enrollment"."SexOffender",
-    "Enrollment"."DependentUnder6",
-    "Enrollment"."SingleParent",
-    "Enrollment"."HH5Plus",
-    "Enrollment"."IraqAfghanistan",
-    "Enrollment"."FemVet",
-    "Enrollment"."HPScreeningScore",
-    "Enrollment"."ThresholdScore",
-    "Enrollment"."VAMCStation",
-    "Enrollment"."DateCreated",
-    "Enrollment"."DateUpdated",
-    "Enrollment"."UserID",
-    "Enrollment"."DateDeleted",
-    "Enrollment"."ExportID",
-    "Enrollment".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."Enrollment"
-     JOIN public."Project" ON ((("Enrollment".data_source_id = "Project".data_source_id) AND (("Enrollment"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-     JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Enrollment".data_source_id = source_clients.data_source_id) AND (("Enrollment"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Enrollment"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_EnrollmentCoC; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_EnrollmentCoC" AS
- SELECT "EnrollmentCoC".id AS "EnrollmentCoCID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Project".id AS "ProjectID",
-    "Enrollment".id AS "EnrollmentID",
-    "EnrollmentCoC"."HouseholdID",
-    "EnrollmentCoC"."InformationDate",
-    "EnrollmentCoC"."CoCCode",
-    "EnrollmentCoC"."DataCollectionStage",
-    "EnrollmentCoC"."DateCreated",
-    "EnrollmentCoC"."DateUpdated",
-    "EnrollmentCoC"."UserID",
-    "EnrollmentCoC"."DateDeleted",
-    "EnrollmentCoC"."ExportID",
-    "EnrollmentCoC".data_source_id,
-    source_clients.id AS demographic_id
-   FROM ((((((public."EnrollmentCoC"
-     JOIN public."Project" ON ((("EnrollmentCoC".data_source_id = "Project".data_source_id) AND (("EnrollmentCoC"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-     JOIN public."Enrollment" ON ((("EnrollmentCoC".data_source_id = "Enrollment".data_source_id) AND (("EnrollmentCoC"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("EnrollmentCoC".data_source_id = source_clients.data_source_id) AND (("EnrollmentCoC"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("EnrollmentCoC"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Event; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Event" AS
- SELECT "Event".id AS "EventID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "Event"."EventDate",
-    "Event"."Event",
-    "Event"."ProbSolDivRRResult",
-    "Event"."ReferralCaseManageAfter",
-    "Event"."LocationCrisisOrPHHousing",
-    "Event"."ReferralResult",
-    "Event"."ResultDate",
-    "Event"."DateCreated",
-    "Event"."DateUpdated",
-    "Event"."UserID",
-    "Event"."DateDeleted",
-    "Event"."ExportID",
-    "Event".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."Event"
-     JOIN public."Enrollment" ON ((("Event".data_source_id = "Enrollment".data_source_id) AND (("Event"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Event".data_source_id = source_clients.data_source_id) AND (("Event"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Event"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Exit; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Exit" AS
- SELECT "Exit".id AS "ExitID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "Exit"."ExitDate",
-    "Exit"."Destination",
-    "Exit"."OtherDestination",
-    "Exit"."HousingAssessment",
-    "Exit"."SubsidyInformation",
-    "Exit"."ProjectCompletionStatus",
-    "Exit"."EarlyExitReason",
-    "Exit"."ExchangeForSex",
-    "Exit"."ExchangeForSexPastThreeMonths",
-    "Exit"."CountOfExchangeForSex",
-    "Exit"."AskedOrForcedToExchangeForSex",
-    "Exit"."AskedOrForcedToExchangeForSexPastThreeMonths",
-    "Exit"."WorkPlaceViolenceThreats",
-    "Exit"."WorkplacePromiseDifference",
-    "Exit"."CoercedToContinueWork",
-    "Exit"."LaborExploitPastThreeMonths",
-    "Exit"."CounselingReceived",
-    "Exit"."IndividualCounseling",
-    "Exit"."FamilyCounseling",
-    "Exit"."GroupCounseling",
-    "Exit"."SessionCountAtExit",
-    "Exit"."PostExitCounselingPlan",
-    "Exit"."SessionsInPlan",
-    "Exit"."DestinationSafeClient",
-    "Exit"."DestinationSafeWorker",
-    "Exit"."PosAdultConnections",
-    "Exit"."PosPeerConnections",
-    "Exit"."PosCommunityConnections",
-    "Exit"."AftercareDate",
-    "Exit"."AftercareProvided",
-    "Exit"."EmailSocialMedia",
-    "Exit"."Telephone",
-    "Exit"."InPersonIndividual",
-    "Exit"."InPersonGroup",
-    "Exit"."CMExitReason",
-    "Exit"."DateCreated",
-    "Exit"."DateUpdated",
-    "Exit"."UserID",
-    "Exit"."DateDeleted",
-    "Exit"."ExportID",
-    "Exit".data_source_id,
-    source_clients.id AS demographic_id
-   FROM ((((public."Exit"
-     JOIN public."Enrollment" ON ((("Exit".data_source_id = "Enrollment".data_source_id) AND (("Exit"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Exit".data_source_id = source_clients.data_source_id) AND (("Exit"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Exit"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Export; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Export" AS
- SELECT "Export".id AS "ExportID",
-    "Export"."SourceType",
-    "Export"."SourceID",
-    "Export"."SourceName",
-    "Export"."SourceContactFirst",
-    "Export"."SourceContactLast",
-    "Export"."SourceContactPhone",
-    "Export"."SourceContactExtension",
-    "Export"."SourceContactEmail",
-    "Export"."ExportDate",
-    "Export"."ExportStartDate",
-    "Export"."ExportEndDate",
-    "Export"."SoftwareName",
-    "Export"."SoftwareVersion",
-    "Export"."ExportPeriodType",
-    "Export"."ExportDirective",
-    "Export"."HashStatus",
-    "Export".data_source_id
-   FROM public."Export";
-
-
---
--- Name: bi_Funder; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Funder" AS
- SELECT "Funder".id AS "FunderID",
-    "Project".id AS "ProjectID",
-    "Funder"."Funder",
-    "Funder"."OtherFunder",
-    "Funder"."GrantID",
-    "Funder"."StartDate",
-    "Funder"."EndDate",
-    "Funder"."DateCreated",
-    "Funder"."DateUpdated",
-    "Funder"."UserID",
-    "Funder"."DateDeleted",
-    "Funder"."ExportID",
-    "Funder".data_source_id
-   FROM (public."Funder"
-     JOIN public."Project" ON ((("Funder".data_source_id = "Project".data_source_id) AND (("Funder"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-  WHERE ("Funder"."DateDeleted" IS NULL);
-
-
---
--- Name: bi_HealthAndDV; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_HealthAndDV" AS
- SELECT "HealthAndDV".id AS "HealthAndDVID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "HealthAndDV"."InformationDate",
-    "HealthAndDV"."DomesticViolenceVictim",
-    "HealthAndDV"."WhenOccurred",
-    "HealthAndDV"."CurrentlyFleeing",
-    "HealthAndDV"."GeneralHealthStatus",
-    "HealthAndDV"."DentalHealthStatus",
-    "HealthAndDV"."MentalHealthStatus",
-    "HealthAndDV"."PregnancyStatus",
-    "HealthAndDV"."DueDate",
-    "HealthAndDV"."DataCollectionStage",
-    "HealthAndDV"."DateCreated",
-    "HealthAndDV"."DateUpdated",
-    "HealthAndDV"."UserID",
-    "HealthAndDV"."DateDeleted",
-    "HealthAndDV"."ExportID",
-    "HealthAndDV".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."HealthAndDV"
-     JOIN public."Enrollment" ON ((("HealthAndDV".data_source_id = "Enrollment".data_source_id) AND (("HealthAndDV"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("HealthAndDV".data_source_id = source_clients.data_source_id) AND (("HealthAndDV"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("HealthAndDV"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_IncomeBenefits; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_IncomeBenefits" AS
- SELECT "IncomeBenefits".id AS "IncomeBenefitsID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "IncomeBenefits"."InformationDate",
-    "IncomeBenefits"."IncomeFromAnySource",
-    "IncomeBenefits"."TotalMonthlyIncome",
-    "IncomeBenefits"."Earned",
-    "IncomeBenefits"."EarnedAmount",
-    "IncomeBenefits"."Unemployment",
-    "IncomeBenefits"."UnemploymentAmount",
-    "IncomeBenefits"."SSI",
-    "IncomeBenefits"."SSIAmount",
-    "IncomeBenefits"."SSDI",
-    "IncomeBenefits"."SSDIAmount",
-    "IncomeBenefits"."VADisabilityService",
-    "IncomeBenefits"."VADisabilityServiceAmount",
-    "IncomeBenefits"."VADisabilityNonService",
-    "IncomeBenefits"."VADisabilityNonServiceAmount",
-    "IncomeBenefits"."PrivateDisability",
-    "IncomeBenefits"."PrivateDisabilityAmount",
-    "IncomeBenefits"."WorkersComp",
-    "IncomeBenefits"."WorkersCompAmount",
-    "IncomeBenefits"."TANF",
-    "IncomeBenefits"."TANFAmount",
-    "IncomeBenefits"."GA",
-    "IncomeBenefits"."GAAmount",
-    "IncomeBenefits"."SocSecRetirement",
-    "IncomeBenefits"."SocSecRetirementAmount",
-    "IncomeBenefits"."Pension",
-    "IncomeBenefits"."PensionAmount",
-    "IncomeBenefits"."ChildSupport",
-    "IncomeBenefits"."ChildSupportAmount",
-    "IncomeBenefits"."Alimony",
-    "IncomeBenefits"."AlimonyAmount",
-    "IncomeBenefits"."OtherIncomeSource",
-    "IncomeBenefits"."OtherIncomeAmount",
-    "IncomeBenefits"."OtherIncomeSourceIdentify",
-    "IncomeBenefits"."BenefitsFromAnySource",
-    "IncomeBenefits"."SNAP",
-    "IncomeBenefits"."WIC",
-    "IncomeBenefits"."TANFChildCare",
-    "IncomeBenefits"."TANFTransportation",
-    "IncomeBenefits"."OtherTANF",
-    "IncomeBenefits"."OtherBenefitsSource",
-    "IncomeBenefits"."OtherBenefitsSourceIdentify",
-    "IncomeBenefits"."InsuranceFromAnySource",
-    "IncomeBenefits"."Medicaid",
-    "IncomeBenefits"."NoMedicaidReason",
-    "IncomeBenefits"."Medicare",
-    "IncomeBenefits"."NoMedicareReason",
-    "IncomeBenefits"."SCHIP",
-    "IncomeBenefits"."NoSCHIPReason",
-    "IncomeBenefits"."VAMedicalServices",
-    "IncomeBenefits"."NoVAMedReason",
-    "IncomeBenefits"."EmployerProvided",
-    "IncomeBenefits"."NoEmployerProvidedReason",
-    "IncomeBenefits"."COBRA",
-    "IncomeBenefits"."NoCOBRAReason",
-    "IncomeBenefits"."PrivatePay",
-    "IncomeBenefits"."NoPrivatePayReason",
-    "IncomeBenefits"."StateHealthIns",
-    "IncomeBenefits"."NoStateHealthInsReason",
-    "IncomeBenefits"."IndianHealthServices",
-    "IncomeBenefits"."NoIndianHealthServicesReason",
-    "IncomeBenefits"."OtherInsurance",
-    "IncomeBenefits"."OtherInsuranceIdentify",
-    "IncomeBenefits"."HIVAIDSAssistance",
-    "IncomeBenefits"."NoHIVAIDSAssistanceReason",
-    "IncomeBenefits"."ADAP",
-    "IncomeBenefits"."NoADAPReason",
-    "IncomeBenefits"."ConnectionWithSOAR",
-    "IncomeBenefits"."DataCollectionStage",
-    "IncomeBenefits"."DateCreated",
-    "IncomeBenefits"."DateUpdated",
-    "IncomeBenefits"."UserID",
-    "IncomeBenefits"."DateDeleted",
-    "IncomeBenefits"."ExportID",
-    "IncomeBenefits".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."IncomeBenefits"
-     JOIN public."Enrollment" ON ((("IncomeBenefits".data_source_id = "Enrollment".data_source_id) AND (("IncomeBenefits"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("IncomeBenefits".data_source_id = source_clients.data_source_id) AND (("IncomeBenefits"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("IncomeBenefits"."DateDeleted" IS NULL)));
-
-
---
--- Name: bi_Inventory; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Inventory" AS
- SELECT "Inventory".id AS "InventoryID",
-    "Project".id AS "ProjectID",
-    "Inventory"."CoCCode",
-    "Inventory"."HouseholdType",
-    "Inventory"."Availability",
-    "Inventory"."UnitInventory",
-    "Inventory"."BedInventory",
-    "Inventory"."CHVetBedInventory",
-    "Inventory"."YouthVetBedInventory",
-    "Inventory"."VetBedInventory",
-    "Inventory"."CHYouthBedInventory",
-    "Inventory"."YouthBedInventory",
-    "Inventory"."CHBedInventory",
-    "Inventory"."OtherBedInventory",
-    "Inventory"."ESBedType",
-    "Inventory"."InventoryStartDate",
-    "Inventory"."InventoryEndDate",
-    "Inventory"."DateCreated",
-    "Inventory"."DateUpdated",
-    "Inventory"."UserID",
-    "Inventory"."DateDeleted",
-    "Inventory"."ExportID",
-    "Inventory".data_source_id
-   FROM (public."Inventory"
-     JOIN public."Project" ON ((("Inventory".data_source_id = "Project".data_source_id) AND (("Inventory"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-  WHERE ("Inventory"."DateDeleted" IS NULL);
-
-
---
--- Name: bi_Organization; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Organization" AS
- SELECT "Organization".id AS "OrganizationID",
-    "Organization"."OrganizationName",
-    "Organization"."VictimServicesProvider",
-    "Organization"."OrganizationCommonName",
-    "Organization"."DateCreated",
-    "Organization"."DateUpdated",
-    "Organization"."UserID",
-    "Organization"."DateDeleted",
-    "Organization"."ExportID",
-    "Organization".data_source_id
-   FROM public."Organization"
-  WHERE ("Organization"."DateDeleted" IS NULL);
-
-
---
--- Name: bi_Project; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Project" AS
- SELECT "Project".id AS "ProjectID",
-    "Organization".id AS "OrganizationID",
-    "Project"."ProjectName",
-    "Project"."ProjectCommonName",
-    "Project"."OperatingStartDate",
-    "Project"."OperatingEndDate",
-    "Project"."ContinuumProject",
-    "Project"."ProjectType",
-    "Project"."HousingType",
-    "Project"."ResidentialAffiliation",
-    "Project"."TrackingMethod",
-    "Project"."HMISParticipatingProject",
-    "Project"."TargetPopulation",
-    "Project"."PITCount",
-    "Project"."DateCreated",
-    "Project"."DateUpdated",
-    "Project"."UserID",
-    "Project"."DateDeleted",
-    "Project"."ExportID",
-    "Project".data_source_id
-   FROM (public."Project"
-     JOIN public."Organization" ON ((("Project".data_source_id = "Organization".data_source_id) AND (("Project"."OrganizationID")::text = ("Organization"."OrganizationID")::text) AND ("Organization"."DateDeleted" IS NULL))))
-  WHERE ("Project"."DateDeleted" IS NULL);
-
-
---
--- Name: bi_ProjectCoC; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_ProjectCoC" AS
- SELECT "ProjectCoC".id AS "ProjectCoCID",
-    "Project".id AS "ProjectID",
-    "ProjectCoC"."CoCCode",
-    "ProjectCoC"."Geocode",
-    "ProjectCoC"."Address1",
-    "ProjectCoC"."Address2",
-    "ProjectCoC"."City",
-    "ProjectCoC"."State",
-    "ProjectCoC"."Zip",
-    "ProjectCoC"."GeographyType",
-    "ProjectCoC"."DateCreated",
-    "ProjectCoC"."DateUpdated",
-    "ProjectCoC"."UserID",
-    "ProjectCoC"."DateDeleted",
-    "ProjectCoC"."ExportID",
-    "ProjectCoC".data_source_id
-   FROM (public."ProjectCoC"
-     JOIN public."Project" ON ((("ProjectCoC".data_source_id = "Project".data_source_id) AND (("ProjectCoC"."ProjectID")::text = ("Project"."ProjectID")::text) AND ("Project"."DateDeleted" IS NULL))))
-  WHERE ("ProjectCoC"."DateDeleted" IS NULL);
-
-
---
--- Name: bi_Services; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public."bi_Services" AS
- SELECT "Services".id AS "ServicesID",
-    warehouse_clients.destination_id AS "PersonalID",
-    "Enrollment".id AS "EnrollmentID",
-    "Services"."DateProvided",
-    "Services"."RecordType",
-    "Services"."TypeProvided",
-    "Services"."OtherTypeProvided",
-    "Services"."SubTypeProvided",
-    "Services"."FAAmount",
-    "Services"."ReferralOutcome",
-    "Services"."DateCreated",
-    "Services"."DateUpdated",
-    "Services"."UserID",
-    "Services"."DateDeleted",
-    "Services"."ExportID",
-    "Services".data_source_id,
-    source_clients.id AS demographic_id
-   FROM (((((public."Services"
-     JOIN public."Enrollment" ON ((("Services".data_source_id = "Enrollment".data_source_id) AND (("Services"."EnrollmentID")::text = ("Enrollment"."EnrollmentID")::text) AND ("Enrollment"."DateDeleted" IS NULL))))
-     LEFT JOIN public."Exit" ON ((("Enrollment".data_source_id = "Exit".data_source_id) AND (("Enrollment"."EnrollmentID")::text = ("Exit"."EnrollmentID")::text) AND ("Exit"."DateDeleted" IS NULL))))
-     JOIN public."Client" source_clients ON ((("Services".data_source_id = source_clients.data_source_id) AND (("Services"."PersonalID")::text = (source_clients."PersonalID")::text) AND (source_clients."DateDeleted" IS NULL))))
-     JOIN public.warehouse_clients ON ((source_clients.id = warehouse_clients.source_id)))
-     JOIN public."Client" destination_clients ON (((destination_clients.id = warehouse_clients.destination_id) AND (destination_clients."DateDeleted" IS NULL))))
-  WHERE (("Exit"."ExitDate" IS NULL) OR (("Exit"."ExitDate" >= (CURRENT_DATE - '5 years'::interval)) AND ("Services"."DateProvided" >= (CURRENT_DATE - '5 years'::interval)) AND ("Services"."DateDeleted" IS NULL)));
-
-
---
--- Name: data_sources; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.data_sources (
-    id integer NOT NULL,
-    name character varying,
-    file_path character varying,
-    last_imported_at timestamp without time zone,
-    newest_updated_at date,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    source_type character varying,
-    munged_personal_id boolean DEFAULT false NOT NULL,
-    short_name character varying,
-    visible_in_window boolean DEFAULT false NOT NULL,
-    authoritative boolean DEFAULT false,
-    after_create_path character varying,
-    import_paused boolean DEFAULT false NOT NULL,
-    authoritative_type character varying,
-    source_id character varying,
-    deleted_at timestamp without time zone,
-    service_scannable boolean DEFAULT false NOT NULL,
-    import_aggregators jsonb DEFAULT '{}'::jsonb,
-    import_cleanups jsonb DEFAULT '{}'::jsonb,
-    refuse_imports_with_errors boolean DEFAULT false
-);
-
-
---
--- Name: bi_data_sources; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_data_sources AS
- SELECT data_sources.id,
-    data_sources.name,
-    data_sources.short_name
-   FROM public.data_sources
-  WHERE ((data_sources.deleted_at IS NULL) AND (data_sources.deleted_at IS NULL));
-
-
---
--- Name: lookups_ethnicities; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_ethnicities (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_ethnicities; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_ethnicities AS
- SELECT lookups_ethnicities.id,
-    lookups_ethnicities.value,
-    lookups_ethnicities.text
-   FROM public.lookups_ethnicities;
-
-
---
--- Name: lookups_funding_sources; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_funding_sources (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_funding_sources; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_funding_sources AS
- SELECT lookups_funding_sources.id,
-    lookups_funding_sources.value,
-    lookups_funding_sources.text
-   FROM public.lookups_funding_sources;
-
-
---
--- Name: lookups_genders; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_genders (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_genders; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_genders AS
- SELECT lookups_genders.id,
-    lookups_genders.value,
-    lookups_genders.text
-   FROM public.lookups_genders;
-
-
---
--- Name: lookups_living_situations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_living_situations (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_living_situations; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_living_situations AS
- SELECT lookups_living_situations.id,
-    lookups_living_situations.value,
-    lookups_living_situations.text
-   FROM public.lookups_living_situations;
-
-
---
--- Name: lookups_project_types; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_project_types (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_project_types; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_project_types AS
- SELECT lookups_project_types.id,
-    lookups_project_types.value,
-    lookups_project_types.text
-   FROM public.lookups_project_types;
-
-
---
--- Name: lookups_relationships; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_relationships (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_relationships; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_relationships AS
- SELECT lookups_relationships.id,
-    lookups_relationships.value,
-    lookups_relationships.text
-   FROM public.lookups_relationships;
-
-
---
--- Name: lookups_tracking_methods; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_tracking_methods (
-    id bigint NOT NULL,
-    value integer,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_tracking_methods; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_tracking_methods AS
- SELECT lookups_tracking_methods.id,
-    lookups_tracking_methods.value,
-    lookups_tracking_methods.text
-   FROM public.lookups_tracking_methods;
-
-
---
--- Name: lookups_yes_no_etcs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.lookups_yes_no_etcs (
-    id bigint NOT NULL,
-    value integer NOT NULL,
-    text character varying NOT NULL
-);
-
-
---
--- Name: bi_lookups_yes_no_etcs; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_lookups_yes_no_etcs AS
- SELECT lookups_yes_no_etcs.id,
-    lookups_yes_no_etcs.value,
-    lookups_yes_no_etcs.text
-   FROM public.lookups_yes_no_etcs;
-
-
---
--- Name: nightly_census_by_projects; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.nightly_census_by_projects (
-    id integer NOT NULL,
-    date date NOT NULL,
-    project_id integer NOT NULL,
-    veterans integer DEFAULT 0,
-    non_veterans integer DEFAULT 0,
-    children integer DEFAULT 0,
-    adults integer DEFAULT 0,
-    youth integer DEFAULT 0,
-    families integer DEFAULT 0,
-    individuals integer DEFAULT 0,
-    parenting_youth integer DEFAULT 0,
-    parenting_juveniles integer DEFAULT 0,
-    all_clients integer DEFAULT 0,
-    beds integer DEFAULT 0,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    juveniles integer DEFAULT 0,
-    unaccompanied_minors integer DEFAULT 0,
-    youth_families integer DEFAULT 0,
-    family_parents integer DEFAULT 0
-);
-
-
---
--- Name: bi_nightly_census_by_projects; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_nightly_census_by_projects AS
- SELECT nightly_census_by_projects.id,
-    nightly_census_by_projects.date,
-    nightly_census_by_projects.project_id,
-    nightly_census_by_projects.veterans,
-    nightly_census_by_projects.non_veterans,
-    nightly_census_by_projects.children,
-    nightly_census_by_projects.adults,
-    nightly_census_by_projects.all_clients,
-    nightly_census_by_projects.beds
-   FROM public.nightly_census_by_projects;
-
-
---
--- Name: service_history_enrollments; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.service_history_enrollments (
-    id bigint NOT NULL,
-    client_id integer NOT NULL,
-    data_source_id integer,
-    date date NOT NULL,
-    first_date_in_program date NOT NULL,
-    last_date_in_program date,
-    enrollment_group_id character varying(50),
-    project_id character varying(50),
-    age smallint,
-    destination integer,
-    head_of_household_id character varying(50),
-    household_id character varying(50),
-    project_name character varying(150),
-    project_type smallint,
-    project_tracking_method integer,
-    organization_id character varying(50),
-    record_type character varying(50) NOT NULL,
-    housing_status_at_entry integer,
-    housing_status_at_exit integer,
-    service_type smallint,
-    computed_project_type smallint,
-    presented_as_individual boolean,
-    other_clients_over_25 smallint DEFAULT 0 NOT NULL,
-    other_clients_under_18 smallint DEFAULT 0 NOT NULL,
-    other_clients_between_18_and_25 smallint DEFAULT 0 NOT NULL,
-    unaccompanied_youth boolean DEFAULT false NOT NULL,
-    parenting_youth boolean DEFAULT false NOT NULL,
-    parenting_juvenile boolean DEFAULT false NOT NULL,
-    children_only boolean DEFAULT false NOT NULL,
-    individual_adult boolean DEFAULT false NOT NULL,
-    individual_elder boolean DEFAULT false NOT NULL,
-    head_of_household boolean DEFAULT false NOT NULL,
-    move_in_date date,
-    unaccompanied_minor boolean DEFAULT false
-);
-
-
---
--- Name: bi_service_history_enrollments; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_service_history_enrollments AS
- SELECT service_history_enrollments.id,
-    service_history_enrollments.client_id,
-    service_history_enrollments.data_source_id,
-    service_history_enrollments.first_date_in_program,
-    service_history_enrollments.last_date_in_program,
-    service_history_enrollments.age,
-    service_history_enrollments.destination,
-    service_history_enrollments.head_of_household_id,
-    service_history_enrollments.household_id,
-    service_history_enrollments.project_name,
-    service_history_enrollments.project_tracking_method,
-    service_history_enrollments.computed_project_type,
-    service_history_enrollments.move_in_date,
-    "Project".id AS project_id,
-    "Enrollment".id AS enrollment_id
-   FROM (((public.service_history_enrollments
-     JOIN public."Client" ON ((("Client"."DateDeleted" IS NULL) AND ("Client".id = service_history_enrollments.client_id))))
-     JOIN public."Project" ON ((("Project"."DateDeleted" IS NULL) AND ("Project".data_source_id = service_history_enrollments.data_source_id) AND (("Project"."ProjectID")::text = (service_history_enrollments.project_id)::text) AND (("Project"."OrganizationID")::text = (service_history_enrollments.organization_id)::text))))
-     JOIN public."Enrollment" ON ((("Enrollment"."DateDeleted" IS NULL) AND ("Enrollment".data_source_id = service_history_enrollments.data_source_id) AND (("Enrollment"."EnrollmentID")::text = (service_history_enrollments.enrollment_group_id)::text) AND (("Enrollment"."ProjectID")::text = (service_history_enrollments.project_id)::text))))
-  WHERE (((service_history_enrollments.record_type)::text = 'entry'::text) AND ((service_history_enrollments.last_date_in_program IS NULL) OR (service_history_enrollments.last_date_in_program >= (CURRENT_DATE - '5 years'::interval))));
-
-
---
--- Name: service_history_services; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.service_history_services (
-    id bigint NOT NULL,
-    service_history_enrollment_id integer NOT NULL,
-    record_type character varying(50) NOT NULL,
-    date date NOT NULL,
-    age smallint,
-    service_type smallint,
-    client_id integer,
-    project_type smallint,
-    homeless boolean,
-    literally_homeless boolean
-);
-
-
---
--- Name: bi_service_history_services; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.bi_service_history_services AS
- SELECT service_history_services.id,
-    service_history_services.service_history_enrollment_id,
-    service_history_services.record_type,
-    service_history_services.date,
-    service_history_services.age,
-    service_history_services.client_id,
-    service_history_services.project_type
-   FROM (public.service_history_services
-     JOIN public."Client" ON ((("Client"."DateDeleted" IS NULL) AND ("Client".id = service_history_services.client_id))))
-  WHERE (service_history_services.date >= (CURRENT_DATE - '5 years'::interval));
-
-
---
 -- Name: bo_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3946,200 +2725,6 @@ CREATE TABLE public.census_values (
 
 
 --
--- Name: census_variables; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.census_variables (
-    id bigint NOT NULL,
-    year integer NOT NULL,
-    downloaded boolean DEFAULT false NOT NULL,
-    dataset character varying NOT NULL,
-    name character varying NOT NULL,
-    label text NOT NULL,
-    concept text NOT NULL,
-    census_group character varying NOT NULL,
-    census_attributes character varying NOT NULL,
-    internal_name character varying,
-    created_on date NOT NULL
-);
-
-
---
--- Name: shape_cocs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.shape_cocs (
-    id bigint NOT NULL,
-    st character varying,
-    state_name character varying,
-    cocnum character varying,
-    cocname character varying,
-    ard numeric,
-    pprn numeric,
-    fprn numeric,
-    fprn_statu character varying,
-    es_c_hwac numeric,
-    es_c_hwoa_ numeric,
-    es_c_hwoc numeric,
-    es_vso_tot numeric,
-    th_c_hwac_ numeric,
-    th_c_hwoa numeric,
-    th_c_hwoc numeric,
-    th_c_vet numeric,
-    rrh_c_hwac numeric,
-    rrh_c_hwoa numeric,
-    rrh_c_hwoc numeric,
-    rrh_c_vet numeric,
-    psh_c_hwac numeric,
-    psh_c_hwoa numeric,
-    psh_c_hwoc numeric,
-    psh_c_vet numeric,
-    psh_c_ch numeric,
-    psh_u_hwac character varying,
-    psh_u_hwoa character varying,
-    psh_u_hwoc character varying,
-    psh_u_vet character varying,
-    psh_u_ch character varying,
-    sh_c_hwoa numeric,
-    sh_c_vet numeric,
-    sh_pers_hw numeric,
-    unsh_pers_ numeric,
-    sh_pers__1 numeric,
-    unsh_pers1 numeric,
-    sh_pers__2 numeric,
-    unsh_per_1 numeric,
-    sh_ch numeric,
-    unsh_ch numeric,
-    sh_youth_u numeric,
-    unsh_youth numeric,
-    sh_vets numeric,
-    unsh_vets numeric,
-    shape_leng numeric,
-    shape_area numeric,
-    geom public.geometry(MultiPolygon,4326),
-    simplified_geom public.geometry(MultiPolygon,4326),
-    full_geoid character varying
-);
-
-
---
--- Name: shape_counties; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.shape_counties (
-    id bigint NOT NULL,
-    statefp character varying,
-    countyfp character varying,
-    countyns character varying,
-    full_geoid character varying,
-    geoid character varying,
-    name character varying,
-    namelsad character varying,
-    lsad character varying,
-    classfp character varying,
-    mtfcc character varying,
-    csafp character varying,
-    cbsafp character varying,
-    metdivfp character varying,
-    funcstat character varying,
-    aland double precision,
-    awater double precision,
-    intptlat character varying,
-    intptlon character varying,
-    simplified_geom public.geometry(MultiPolygon,4326),
-    geom public.geometry(MultiPolygon,4326)
-);
-
-
---
--- Name: shape_states; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.shape_states (
-    id bigint NOT NULL,
-    region character varying,
-    division character varying,
-    statefp character varying,
-    statens character varying,
-    full_geoid character varying,
-    geoid character varying,
-    stusps character varying,
-    name character varying,
-    lsad character varying,
-    mtfcc character varying,
-    funcstat character varying,
-    aland double precision,
-    awater double precision,
-    intptlat character varying,
-    intptlon character varying,
-    simplified_geom public.geometry(MultiPolygon,4326),
-    geom public.geometry(MultiPolygon,4326)
-);
-
-
---
--- Name: shape_zip_codes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.shape_zip_codes (
-    id bigint NOT NULL,
-    zcta5ce10 character varying(5),
-    geoid10 character varying(5),
-    classfp10 character varying(2),
-    mtfcc10 character varying(5),
-    funcstat10 character varying(1),
-    aland10 double precision,
-    awater10 double precision,
-    intptlat10 character varying(11),
-    intptlon10 character varying(12),
-    geom public.geometry(MultiPolygon,4326),
-    simplified_geom public.geometry(MultiPolygon,4326),
-    full_geoid character varying,
-    st_geoid character varying,
-    county_name_lower character varying
-);
-
-
---
--- Name: census_reviews; Type: VIEW; Schema: public; Owner: -
---
-
-CREATE VIEW public.census_reviews AS
- WITH locs AS (
-         SELECT shape_cocs.cocname AS name,
-            shape_cocs.full_geoid
-           FROM public.shape_cocs
-        UNION ALL
-         SELECT shape_zip_codes.zcta5ce10 AS name,
-            shape_zip_codes.full_geoid
-           FROM public.shape_zip_codes
-        UNION ALL
-         SELECT shape_counties.name,
-            shape_counties.full_geoid
-           FROM public.shape_counties
-        UNION ALL
-         SELECT shape_states.name,
-            shape_states.full_geoid
-           FROM public.shape_states
-        )
- SELECT locs.name AS geometry_name,
-    vals.census_level,
-    vars.internal_name,
-    vals.value,
-    vars.year,
-    vars.dataset,
-    vars.name AS variable,
-    vars.census_group,
-    g.description AS group_description,
-    vals.id,
-    locs.full_geoid
-   FROM (((locs
-     LEFT JOIN public.census_values vals ON (((locs.full_geoid)::text = (vals.full_geoid)::text)))
-     LEFT JOIN public.census_variables vars ON (((vals.census_variable_id = vars.id) AND (vars.internal_name IS NOT NULL))))
-     LEFT JOIN public.census_groups g ON ((((vars.census_group)::text = (g.name)::text) AND (vars.year = g.year) AND ((vars.dataset)::text = (g.dataset)::text))));
-
-
---
 -- Name: census_values_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -4156,6 +2741,25 @@ CREATE SEQUENCE public.census_values_id_seq
 --
 
 ALTER SEQUENCE public.census_values_id_seq OWNED BY public.census_values.id;
+
+
+--
+-- Name: census_variables; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.census_variables (
+    id bigint NOT NULL,
+    year integer NOT NULL,
+    downloaded boolean DEFAULT false NOT NULL,
+    dataset character varying NOT NULL,
+    name character varying NOT NULL,
+    label text NOT NULL,
+    concept text NOT NULL,
+    census_group character varying NOT NULL,
+    census_attributes character varying NOT NULL,
+    internal_name character varying,
+    created_on date NOT NULL
+);
 
 
 --
@@ -5098,10 +3702,10 @@ CREATE TABLE public.configs (
     cas_sync_months integer DEFAULT 3,
     send_sms_for_covid_reminders boolean DEFAULT false NOT NULL,
     bypass_2fa_duration integer DEFAULT 0 NOT NULL,
-    health_claims_data_path character varying,
-    enable_youth_hrp boolean DEFAULT true NOT NULL,
     enable_system_cohorts boolean DEFAULT false,
     currently_homeless_cohort boolean DEFAULT false,
+    health_claims_data_path character varying,
+    enable_youth_hrp boolean DEFAULT true NOT NULL,
     show_client_last_seen_info_in_client_details boolean DEFAULT true,
     ineligible_uses_extrapolated_days boolean DEFAULT true NOT NULL,
     warehouse_client_name_order character varying DEFAULT 'earliest'::character varying NOT NULL,
@@ -5116,7 +3720,8 @@ CREATE TABLE public.configs (
     youth_no_child_cohort boolean DEFAULT false NOT NULL,
     youth_and_child_cohort boolean DEFAULT false NOT NULL,
     cas_sync_project_group_id integer,
-    majority_sheltered_calculation character varying DEFAULT 'current_living_situation'::character varying
+    system_cohort_processing_date date,
+    system_cohort_date_window integer DEFAULT 1
 );
 
 
@@ -5458,6 +4063,35 @@ CREATE SEQUENCE public.data_monitorings_id_seq
 --
 
 ALTER SEQUENCE public.data_monitorings_id_seq OWNED BY public.data_monitorings.id;
+
+
+--
+-- Name: data_sources; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.data_sources (
+    id integer NOT NULL,
+    name character varying,
+    file_path character varying,
+    last_imported_at timestamp without time zone,
+    newest_updated_at date,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    source_type character varying,
+    munged_personal_id boolean DEFAULT false NOT NULL,
+    short_name character varying,
+    visible_in_window boolean DEFAULT false NOT NULL,
+    authoritative boolean DEFAULT false,
+    after_create_path character varying,
+    import_paused boolean DEFAULT false NOT NULL,
+    authoritative_type character varying,
+    source_id character varying,
+    deleted_at timestamp without time zone,
+    service_scannable boolean DEFAULT false NOT NULL,
+    import_aggregators jsonb DEFAULT '{}'::jsonb,
+    import_cleanups jsonb DEFAULT '{}'::jsonb,
+    refuse_imports_with_errors boolean DEFAULT false
+);
 
 
 --
@@ -6853,7 +5487,16 @@ CREATE TABLE public.hmis_2020_aggregated_enrollments (
     source_id integer NOT NULL,
     source_type character varying NOT NULL,
     dirty_at timestamp without time zone,
-    clean_at timestamp without time zone
+    clean_at timestamp without time zone,
+    "MentalHealthDisorderFam" integer,
+    "AlcoholDrugUseDisorderFam" integer,
+    "ClientLeaseholder" integer,
+    "HOHLeasesholder" integer,
+    "IncarceratedAdult" integer,
+    "PrisonDischarge" integer,
+    "CurrentPregnant" integer,
+    "CoCPrioritized" integer,
+    "TargetScreenReqd" integer
 );
 
 
@@ -9634,11 +8277,12 @@ CREATE TABLE public.hmis_aggregated_enrollments (
     "IncarceratedParent" integer,
     "VAMCStation" character varying,
     "TargetScreenReqd" integer,
+    "UrgentReferral" integer,
     "TimeToHousingLoss" integer,
     "AnnualPercentAMI" integer,
     "LiteralHomelessHistory" integer,
     "ClientLeaseholder" integer,
-    "HOHLeaseholder" integer,
+    "HOHLeasesholder" integer,
     "SubsidyAtRisk" integer,
     "EvictionHistory" integer,
     "CriminalRecord" integer,
@@ -9665,7 +8309,8 @@ CREATE TABLE public.hmis_aggregated_enrollments (
     source_id integer NOT NULL,
     source_type character varying NOT NULL,
     dirty_at timestamp without time zone,
-    clean_at timestamp without time zone
+    clean_at timestamp without time zone,
+    "HOHLeaseholder" integer
 );
 
 
@@ -14400,39 +13045,6 @@ CREATE VIEW public.index_stats AS
 
 
 --
--- Name: involved_in_imports; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.involved_in_imports (
-    id bigint NOT NULL,
-    importer_log_id bigint,
-    record_type character varying NOT NULL,
-    record_id bigint NOT NULL,
-    hud_key character varying NOT NULL,
-    record_action public.record_action
-);
-
-
---
--- Name: involved_in_imports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.involved_in_imports_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: involved_in_imports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.involved_in_imports_id_seq OWNED BY public.involved_in_imports.id;
-
-
---
 -- Name: lftp_s3_syncs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -14470,6 +13082,17 @@ ALTER SEQUENCE public.lftp_s3_syncs_id_seq OWNED BY public.lftp_s3_syncs.id;
 
 
 --
+-- Name: lookups_ethnicities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_ethnicities (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
+
+
+--
 -- Name: lookups_ethnicities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -14486,6 +13109,17 @@ CREATE SEQUENCE public.lookups_ethnicities_id_seq
 --
 
 ALTER SEQUENCE public.lookups_ethnicities_id_seq OWNED BY public.lookups_ethnicities.id;
+
+
+--
+-- Name: lookups_funding_sources; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_funding_sources (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
 
 
 --
@@ -14508,6 +13142,17 @@ ALTER SEQUENCE public.lookups_funding_sources_id_seq OWNED BY public.lookups_fun
 
 
 --
+-- Name: lookups_genders; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_genders (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
+
+
+--
 -- Name: lookups_genders_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -14524,6 +13169,17 @@ CREATE SEQUENCE public.lookups_genders_id_seq
 --
 
 ALTER SEQUENCE public.lookups_genders_id_seq OWNED BY public.lookups_genders.id;
+
+
+--
+-- Name: lookups_living_situations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_living_situations (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
 
 
 --
@@ -14546,6 +13202,17 @@ ALTER SEQUENCE public.lookups_living_situations_id_seq OWNED BY public.lookups_l
 
 
 --
+-- Name: lookups_project_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_project_types (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
+
+
+--
 -- Name: lookups_project_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -14562,6 +13229,17 @@ CREATE SEQUENCE public.lookups_project_types_id_seq
 --
 
 ALTER SEQUENCE public.lookups_project_types_id_seq OWNED BY public.lookups_project_types.id;
+
+
+--
+-- Name: lookups_relationships; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_relationships (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
 
 
 --
@@ -14584,6 +13262,17 @@ ALTER SEQUENCE public.lookups_relationships_id_seq OWNED BY public.lookups_relat
 
 
 --
+-- Name: lookups_tracking_methods; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_tracking_methods (
+    id bigint NOT NULL,
+    value integer,
+    text character varying NOT NULL
+);
+
+
+--
 -- Name: lookups_tracking_methods_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -14600,6 +13289,17 @@ CREATE SEQUENCE public.lookups_tracking_methods_id_seq
 --
 
 ALTER SEQUENCE public.lookups_tracking_methods_id_seq OWNED BY public.lookups_tracking_methods.id;
+
+
+--
+-- Name: lookups_yes_no_etcs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lookups_yes_no_etcs (
+    id bigint NOT NULL,
+    value integer NOT NULL,
+    text character varying NOT NULL
+);
 
 
 --
@@ -15046,6 +13746,34 @@ CREATE SEQUENCE public.nightly_census_by_project_types_id_seq
 --
 
 ALTER SEQUENCE public.nightly_census_by_project_types_id_seq OWNED BY public.nightly_census_by_project_types.id;
+
+
+--
+-- Name: nightly_census_by_projects; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.nightly_census_by_projects (
+    id integer NOT NULL,
+    date date NOT NULL,
+    project_id integer NOT NULL,
+    veterans integer DEFAULT 0,
+    non_veterans integer DEFAULT 0,
+    children integer DEFAULT 0,
+    adults integer DEFAULT 0,
+    youth integer DEFAULT 0,
+    families integer DEFAULT 0,
+    individuals integer DEFAULT 0,
+    parenting_youth integer DEFAULT 0,
+    parenting_juveniles integer DEFAULT 0,
+    all_clients integer DEFAULT 0,
+    beds integer DEFAULT 0,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    juveniles integer DEFAULT 0,
+    unaccompanied_minors integer DEFAULT 0,
+    youth_families integer DEFAULT 0,
+    family_parents integer DEFAULT 0
+);
 
 
 --
@@ -16415,6 +15143,28 @@ ALTER SEQUENCE public.report_definitions_id_seq OWNED BY public.report_definitio
 
 
 --
+-- Name: warehouse_clients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.warehouse_clients (
+    id integer NOT NULL,
+    id_in_source character varying NOT NULL,
+    data_source_id integer,
+    proposed_at timestamp without time zone,
+    reviewed_at timestamp without time zone,
+    reviewd_by character varying,
+    approved_at timestamp without time zone,
+    rejected_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    deleted_at timestamp without time zone,
+    source_id integer,
+    destination_id integer,
+    client_match_id integer
+);
+
+
+--
 -- Name: report_disabilities; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -16936,6 +15686,66 @@ ALTER SEQUENCE public.secure_files_id_seq OWNED BY public.secure_files.id;
 
 
 --
+-- Name: service_history_enrollments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.service_history_enrollments (
+    id integer NOT NULL,
+    client_id integer NOT NULL,
+    data_source_id integer,
+    date date NOT NULL,
+    first_date_in_program date NOT NULL,
+    last_date_in_program date,
+    enrollment_group_id character varying(50),
+    project_id character varying(50),
+    age smallint,
+    destination integer,
+    head_of_household_id character varying(50),
+    household_id character varying(50),
+    project_name character varying(150),
+    project_type smallint,
+    project_tracking_method integer,
+    organization_id character varying(50),
+    record_type character varying(50) NOT NULL,
+    housing_status_at_entry integer,
+    housing_status_at_exit integer,
+    service_type smallint,
+    computed_project_type smallint,
+    presented_as_individual boolean,
+    other_clients_over_25 smallint DEFAULT 0 NOT NULL,
+    other_clients_under_18 smallint DEFAULT 0 NOT NULL,
+    other_clients_between_18_and_25 smallint DEFAULT 0 NOT NULL,
+    unaccompanied_youth boolean DEFAULT false NOT NULL,
+    parenting_youth boolean DEFAULT false NOT NULL,
+    parenting_juvenile boolean DEFAULT false NOT NULL,
+    children_only boolean DEFAULT false NOT NULL,
+    individual_adult boolean DEFAULT false NOT NULL,
+    individual_elder boolean DEFAULT false NOT NULL,
+    head_of_household boolean DEFAULT false NOT NULL,
+    move_in_date date,
+    unaccompanied_minor boolean DEFAULT false
+);
+
+
+--
+-- Name: service_history_services; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.service_history_services (
+    id bigint NOT NULL,
+    service_history_enrollment_id integer NOT NULL,
+    record_type character varying(50) NOT NULL,
+    date date NOT NULL,
+    age smallint,
+    service_type smallint,
+    client_id integer,
+    project_type smallint,
+    homeless boolean,
+    literally_homeless boolean
+);
+
+
+--
 -- Name: service_history; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -17274,16 +16084,6 @@ INHERITS (public.service_history_services);
 
 CREATE TABLE public.service_history_services_2021 (
     CONSTRAINT service_history_services_2021_date_check CHECK (((date >= '2021-01-01'::date) AND (date <= '2021-12-31'::date)))
-)
-INHERITS (public.service_history_services);
-
-
---
--- Name: service_history_services_2022; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.service_history_services_2022 (
-    CONSTRAINT service_history_services_2022_date_check CHECK (((date >= '2022-01-01'::date) AND (date <= '2022-12-31'::date)))
 )
 INHERITS (public.service_history_services);
 
@@ -17713,6 +16513,64 @@ ALTER SEQUENCE public.shape_block_groups_id_seq OWNED BY public.shape_block_grou
 
 
 --
+-- Name: shape_cocs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shape_cocs (
+    id bigint NOT NULL,
+    st character varying,
+    state_name character varying,
+    cocnum character varying,
+    cocname character varying,
+    ard numeric,
+    pprn numeric,
+    fprn numeric,
+    fprn_statu character varying,
+    es_c_hwac numeric,
+    es_c_hwoa_ numeric,
+    es_c_hwoc numeric,
+    es_vso_tot numeric,
+    th_c_hwac_ numeric,
+    th_c_hwoa numeric,
+    th_c_hwoc numeric,
+    th_c_vet numeric,
+    rrh_c_hwac numeric,
+    rrh_c_hwoa numeric,
+    rrh_c_hwoc numeric,
+    rrh_c_vet numeric,
+    psh_c_hwac numeric,
+    psh_c_hwoa numeric,
+    psh_c_hwoc numeric,
+    psh_c_vet numeric,
+    psh_c_ch numeric,
+    psh_u_hwac character varying,
+    psh_u_hwoa character varying,
+    psh_u_hwoc character varying,
+    psh_u_vet character varying,
+    psh_u_ch character varying,
+    sh_c_hwoa numeric,
+    sh_c_vet numeric,
+    sh_pers_hw numeric,
+    unsh_pers_ numeric,
+    sh_pers__1 numeric,
+    unsh_pers1 numeric,
+    sh_pers__2 numeric,
+    unsh_per_1 numeric,
+    sh_ch numeric,
+    unsh_ch numeric,
+    sh_youth_u numeric,
+    unsh_youth numeric,
+    sh_vets numeric,
+    unsh_vets numeric,
+    shape_leng numeric,
+    shape_area numeric,
+    geom public.geometry(MultiPolygon,4326),
+    simplified_geom public.geometry(MultiPolygon,4326),
+    full_geoid character varying
+);
+
+
+--
 -- Name: shape_cocs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -17729,6 +16587,35 @@ CREATE SEQUENCE public.shape_cocs_id_seq
 --
 
 ALTER SEQUENCE public.shape_cocs_id_seq OWNED BY public.shape_cocs.id;
+
+
+--
+-- Name: shape_counties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shape_counties (
+    id bigint NOT NULL,
+    statefp character varying,
+    countyfp character varying,
+    countyns character varying,
+    full_geoid character varying,
+    geoid character varying,
+    name character varying,
+    namelsad character varying,
+    lsad character varying,
+    classfp character varying,
+    mtfcc character varying,
+    csafp character varying,
+    cbsafp character varying,
+    metdivfp character varying,
+    funcstat character varying,
+    aland double precision,
+    awater double precision,
+    intptlat character varying,
+    intptlon character varying,
+    simplified_geom public.geometry(MultiPolygon,4326),
+    geom public.geometry(MultiPolygon,4326)
+);
 
 
 --
@@ -17798,6 +16685,32 @@ ALTER SEQUENCE public.shape_places_id_seq OWNED BY public.shape_places.id;
 
 
 --
+-- Name: shape_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shape_states (
+    id bigint NOT NULL,
+    region character varying,
+    division character varying,
+    statefp character varying,
+    statens character varying,
+    full_geoid character varying,
+    geoid character varying,
+    stusps character varying,
+    name character varying,
+    lsad character varying,
+    mtfcc character varying,
+    funcstat character varying,
+    aland double precision,
+    awater double precision,
+    intptlat character varying,
+    intptlon character varying,
+    simplified_geom public.geometry(MultiPolygon,4326),
+    geom public.geometry(MultiPolygon,4326)
+);
+
+
+--
 -- Name: shape_states_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -17852,6 +16765,29 @@ CREATE SEQUENCE public.shape_towns_id_seq
 --
 
 ALTER SEQUENCE public.shape_towns_id_seq OWNED BY public.shape_towns.id;
+
+
+--
+-- Name: shape_zip_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shape_zip_codes (
+    id bigint NOT NULL,
+    zcta5ce10 character varying(5),
+    geoid10 character varying(5),
+    classfp10 character varying(2),
+    mtfcc10 character varying(5),
+    funcstat10 character varying(1),
+    aland10 double precision,
+    awater10 double precision,
+    intptlat10 character varying(11),
+    intptlon10 character varying(12),
+    geom public.geometry(MultiPolygon,4326),
+    simplified_geom public.geometry(MultiPolygon,4326),
+    full_geoid character varying,
+    st_geoid character varying,
+    county_name_lower character varying
+);
 
 
 --
@@ -20198,13 +19134,6 @@ ALTER TABLE ONLY public.hmis_aggregated_exits ALTER COLUMN id SET DEFAULT nextva
 
 
 --
--- Name: hmis_assessments id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_assessments ALTER COLUMN id SET DEFAULT nextval('public.hmis_assessments_id_seq'::regclass);
-
-
---
 -- Name: hmis_client_attributes_defined_text id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -20786,13 +19715,6 @@ ALTER TABLE ONLY public.income_benefits_reports ALTER COLUMN id SET DEFAULT next
 
 
 --
--- Name: involved_in_imports id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.involved_in_imports ALTER COLUMN id SET DEFAULT nextval('public.involved_in_imports_id_seq'::regclass);
-
-
---
 -- Name: lftp_s3_syncs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -21210,13 +20132,6 @@ ALTER TABLE ONLY public.service_history_services_2019 ALTER COLUMN id SET DEFAUL
 --
 
 ALTER TABLE ONLY public.service_history_services_2021 ALTER COLUMN id SET DEFAULT nextval('public.service_history_services_id_seq'::regclass);
-
-
---
--- Name: service_history_services_2022 id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.service_history_services_2022 ALTER COLUMN id SET DEFAULT nextval('public.service_history_services_id_seq'::regclass);
 
 
 --
@@ -22937,14 +21852,6 @@ ALTER TABLE ONLY public.hmis_aggregated_exits
 
 
 --
--- Name: hmis_assessments hmis_assessments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_assessments
-    ADD CONSTRAINT hmis_assessments_pkey PRIMARY KEY (id);
-
-
---
 -- Name: hmis_client_attributes_defined_text hmis_client_attributes_defined_text_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -23606,14 +22513,6 @@ ALTER TABLE ONLY public.income_benefits_report_incomes
 
 ALTER TABLE ONLY public.income_benefits_reports
     ADD CONSTRAINT income_benefits_reports_pkey PRIMARY KEY (id);
-
-
---
--- Name: involved_in_imports involved_in_imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.involved_in_imports
-    ADD CONSTRAINT involved_in_imports_pkey PRIMARY KEY (id);
 
 
 --
@@ -24730,4623 +23629,7570 @@ CREATE INDEX health_and_dv_export_id ON public."HealthAndDV" USING btree ("Expor
 
 
 --
--- Name: hmis2022affiliations_9Tjd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_5iM4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022affiliations_9Tjd" ON public.hmis_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_5iM4" ON public.hmis_2020_aggregated_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022affiliations_MCe3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_D3A6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022affiliations_MCe3" ON public.hmis_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_D3A6" ON public.hmis_2020_aggregated_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022affiliations_lc0a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_MaIx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022affiliations_lc0a ON public.hmis_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_MaIx" ON public.hmis_2020_aggregated_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022affiliations_lt6c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_N4sj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022affiliations_lt6c ON public.hmis_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_N4sj" ON public.hmis_2020_aggregated_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022affiliations_otVM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_QB8m; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022affiliations_otVM" ON public.hmis_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_QB8m" ON public.hmis_2020_aggregated_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022assessmentquestions_66AG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_TRUK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_66AG" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_TRUK" ON public.hmis_2020_aggregated_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessmentquestions_67BE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_V4sO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_67BE" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_V4sO" ON public.hmis_2020_aggregated_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022assessmentquestions_8Qlc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_VhbC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_8Qlc" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_VhbC" ON public.hmis_2020_aggregated_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022assessmentquestions_FW3S; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_W1q1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_FW3S" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_W1q1" ON public.hmis_2020_aggregated_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022assessmentquestions_NcX9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_kb9y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_NcX9" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX hmis2020aggregatedenrollments_kb9y ON public.hmis_2020_aggregated_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022assessmentquestions_U4bM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_lS6g; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_U4bM" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_lS6g" ON public.hmis_2020_aggregated_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022assessmentquestions_Y8GY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_qFAU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_Y8GY" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_qFAU" ON public.hmis_2020_aggregated_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022assessmentquestions_cKeo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_qJO4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_cKeo" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_qJO4" ON public.hmis_2020_aggregated_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022assessmentquestions_jsNW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_r7Pu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_jsNW" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_r7Pu" ON public.hmis_2020_aggregated_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022assessmentquestions_mNPM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_vnEt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentquestions_mNPM" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedenrollments_vnEt" ON public.hmis_2020_aggregated_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022assessmentresults_4YlO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_yLsJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_4YlO" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_yLsJ" ON public.hmis_2020_aggregated_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022assessmentresults_A8se; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedenrollments_yMM0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_A8se" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedenrollments_yMM0" ON public.hmis_2020_aggregated_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022assessmentresults_BRi6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_1iPA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_BRi6" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedexits_1iPA" ON public.hmis_2020_aggregated_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022assessmentresults_BgP9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_Bm25; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_BgP9" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedexits_Bm25" ON public.hmis_2020_aggregated_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022assessmentresults_QszM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_QrrN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_QszM" ON public.hmis_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedexits_QrrN" ON public.hmis_2020_aggregated_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022assessmentresults_j7wN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_ZxQa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_j7wN" ON public.hmis_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedexits_ZxQa" ON public.hmis_2020_aggregated_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022assessmentresults_l8P3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_cQ7Y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_l8P3" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmis2020aggregatedexits_cQ7Y" ON public.hmis_2020_aggregated_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessmentresults_pBh1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_mPsr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_pBh1" ON public.hmis_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedexits_mPsr" ON public.hmis_2020_aggregated_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022assessmentresults_qwBT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_vUc5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_qwBT" ON public.hmis_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedexits_vUc5" ON public.hmis_2020_aggregated_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022assessmentresults_wvgD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2020aggregatedexits_xGyj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessmentresults_wvgD" ON public.hmis_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmis2020aggregatedexits_xGyj" ON public.hmis_2020_aggregated_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022assessments_1WRE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_14fN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_1WRE" ON public.hmis_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmis2022affiliations_14fN" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_1xkk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_31gM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022assessments_1xkk ON public.hmis_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022affiliations_31gM" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_8G4O; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_3JRL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_8G4O" ON public.hmis_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmis2022affiliations_3JRL" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_A3yK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_AuTZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_A3yK" ON public.hmis_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmis2022affiliations_AuTZ" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_ACmg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_HCaK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_ACmg" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022affiliations_HCaK" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_AlYO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_IKRH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_AlYO" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022affiliations_IKRH" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_BXpI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_lYOl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_BXpI" ON public.hmis_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmis2022affiliations_lYOl" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_ByZf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022affiliations_prEc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_ByZf" ON public.hmis_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmis2022affiliations_prEc" ON public.hmis_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_D5nN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_04ox; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_D5nN" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX hmis2022assessmentquestions_04ox ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_KR2P; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_0skc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_KR2P" ON public.hmis_2022_assessments USING btree ("PersonalID");
+CREATE INDEX hmis2022assessmentquestions_0skc ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_LJiY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_3qiB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_LJiY" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmis2022assessmentquestions_3qiB" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_PDLH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_9OKc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_PDLH" ON public.hmis_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmis2022assessmentquestions_9OKc" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_PKqe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_Ei5Q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_PKqe" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmis2022assessmentquestions_Ei5Q" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_W410; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_PbcE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_W410" ON public.hmis_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentquestions_PbcE" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_bjSD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_bqtp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_bjSD" ON public.hmis_2022_assessments USING btree ("PersonalID");
+CREATE INDEX hmis2022assessmentquestions_bqtp ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_fvZW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_crPf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_fvZW" ON public.hmis_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentquestions_crPf" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_je8c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_dVVU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022assessments_je8c ON public.hmis_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmis2022assessmentquestions_dVVU" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_lRgj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_foru; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_lRgj" ON public.hmis_2022_assessments USING btree ("PersonalID");
+CREATE INDEX hmis2022assessmentquestions_foru ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_lWWv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_jw6G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_lWWv" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmis2022assessmentquestions_jw6G" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_qLFb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_nxim; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_qLFb" ON public.hmis_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX hmis2022assessmentquestions_nxim ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_r7np; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_t4e9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022assessments_r7np ON public.hmis_2022_assessments USING btree ("ExportID");
+CREATE INDEX hmis2022assessmentquestions_t4e9 ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_sqjV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_tqlv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_sqjV" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX hmis2022assessmentquestions_tqlv ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_t8k1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_xrfT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022assessments_t8k1 ON public.hmis_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmis2022assessmentquestions_xrfT" ON public.hmis_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmis2022assessments_vHPu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentquestions_y3Qq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_vHPu" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmis2022assessmentquestions_y3Qq" ON public.hmis_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022assessments_vTjw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_4Cuu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022assessments_vTjw" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022assessmentresults_4Cuu" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_0K2Q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_5Orn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_0K2Q" ON public.hmis_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentresults_5Orn" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_0nAI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_7oP8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_0nAI" ON public.hmis_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmis2022assessmentresults_7oP8" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_1ZkA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_BDns; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_1ZkA" ON public.hmis_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmis2022assessmentresults_BDns" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_5PV0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_I0uZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_5PV0" ON public.hmis_2022_clients USING btree ("DOB");
+CREATE INDEX "hmis2022assessmentresults_I0uZ" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_8dIx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_MzDc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_8dIx" ON public.hmis_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmis2022assessmentresults_MzDc" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_E1Fj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_XpYc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_E1Fj" ON public.hmis_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmis2022assessmentresults_XpYc" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_EuyH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_dDtS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_EuyH" ON public.hmis_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmis2022assessmentresults_dDtS" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_G2Er; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_jlW3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_G2Er" ON public.hmis_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmis2022assessmentresults_jlW3" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_H9sW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_lKyN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_H9sW" ON public.hmis_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentresults_lKyN" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_HLPo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_lwrC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_HLPo" ON public.hmis_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmis2022assessmentresults_lwrC" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_I9Fk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_pfUR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_I9Fk" ON public.hmis_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmis2022assessmentresults_pfUR" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_I9Hf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_tmrX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_I9Hf" ON public.hmis_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentresults_tmrX" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_IHZO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_uLld; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_IHZO" ON public.hmis_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmis2022assessmentresults_uLld" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_JCgD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_uoOY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_JCgD" ON public.hmis_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessmentresults_uoOY" ON public.hmis_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_Lowh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessmentresults_zymK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_Lowh" ON public.hmis_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmis2022assessmentresults_zymK" ON public.hmis_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_NBVb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_0j5C; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_NBVb" ON public.hmis_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmis2022assessments_0j5C" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022clients_O4VV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_1VPu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_O4VV" ON public.hmis_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmis2022assessments_1VPu" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_V6Ey; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_1wwO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_V6Ey" ON public.hmis_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmis2022assessments_1wwO" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022clients_WRGs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_26Ek; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_WRGs" ON public.hmis_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmis2022assessments_26Ek" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_YO8w; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_2YFL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_YO8w" ON public.hmis_2022_clients USING btree ("LastName");
+CREATE INDEX "hmis2022assessments_2YFL" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_bgBr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_2egR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_bgBr" ON public.hmis_2022_clients USING btree ("DOB");
+CREATE INDEX "hmis2022assessments_2egR" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_cWzB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_3rlJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_cWzB" ON public.hmis_2022_clients USING btree ("DOB");
+CREATE INDEX "hmis2022assessments_3rlJ" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_ctEI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_4tQD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_ctEI" ON public.hmis_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmis2022assessments_4tQD" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_fT7G; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_5Xg6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_fT7G" ON public.hmis_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmis2022assessments_5Xg6" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_fuco; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_6ocU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022clients_fuco ON public.hmis_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmis2022assessments_6ocU" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022clients_kDCg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_6sgu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_kDCg" ON public.hmis_2022_clients USING btree ("DateUpdated");
+CREATE INDEX hmis2022assessments_6sgu ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_kPEm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_9etT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_kPEm" ON public.hmis_2022_clients USING btree ("DOB");
+CREATE INDEX "hmis2022assessments_9etT" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_kXnX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_CHOY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_kXnX" ON public.hmis_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmis2022assessments_CHOY" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022clients_lDTO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_Diqu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_lDTO" ON public.hmis_2022_clients USING btree ("LastName");
+CREATE INDEX "hmis2022assessments_Diqu" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_lUID; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_Ezx7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_lUID" ON public.hmis_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmis2022assessments_Ezx7" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_mwtf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_IP8f; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022clients_mwtf ON public.hmis_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmis2022assessments_IP8f" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022clients_nPqP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_JjgZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_nPqP" ON public.hmis_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmis2022assessments_JjgZ" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022clients_o1zL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_K9di; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_o1zL" ON public.hmis_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmis2022assessments_K9di" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_rhmD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_PAHh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_rhmD" ON public.hmis_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmis2022assessments_PAHh" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_sjHR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_PLiY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_sjHR" ON public.hmis_2022_clients USING btree ("DOB");
+CREATE INDEX "hmis2022assessments_PLiY" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022clients_smwv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_Qq2t; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022clients_smwv ON public.hmis_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessments_Qq2t" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022clients_tAtk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_Rmt8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_tAtk" ON public.hmis_2022_clients USING btree ("LastName");
+CREATE INDEX "hmis2022assessments_Rmt8" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022clients_vm2H; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_SjIV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_vm2H" ON public.hmis_2022_clients USING btree ("LastName");
+CREATE INDEX "hmis2022assessments_SjIV" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022clients_wPM4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_TR5Y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_wPM4" ON public.hmis_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmis2022assessments_TR5Y" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022clients_xavS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_Zfo1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022clients_xavS" ON public.hmis_2022_clients USING btree ("LastName");
+CREATE INDEX "hmis2022assessments_Zfo1" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022currentlivingsituations_1i8x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_cPEX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022currentlivingsituations_1i8x ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessments_cPEX" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_4lpH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_cpIe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_4lpH" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmis2022assessments_cpIe" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022currentlivingsituations_5TrW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_dGf7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_5TrW" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmis2022assessments_dGf7" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022currentlivingsituations_D7JX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_fnDj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_D7JX" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmis2022assessments_fnDj" ON public.hmis_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022currentlivingsituations_Dihe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_j3FJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_Dihe" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessments_j3FJ" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_ELrQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_jWpu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_ELrQ" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmis2022assessments_jWpu" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_Jc9G; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_ljDf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_Jc9G" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmis2022assessments_ljDf" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_No3V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_nMgX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_No3V" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmis2022assessments_nMgX" ON public.hmis_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmis2022currentlivingsituations_OUiJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_qFI3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_OUiJ" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022assessments_qFI3" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022currentlivingsituations_P7xE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_roKh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_P7xE" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmis2022assessments_roKh" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022currentlivingsituations_Q6ST; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_s7op; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_Q6ST" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX hmis2022assessments_s7op ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022currentlivingsituations_Q9cW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_u3Mg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_Q9cW" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmis2022assessments_u3Mg" ON public.hmis_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmis2022currentlivingsituations_QXw2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_vBtT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_QXw2" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmis2022assessments_vBtT" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022currentlivingsituations_S2Pz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_vcmI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_S2Pz" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmis2022assessments_vcmI" ON public.hmis_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_S7CL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022assessments_wu4S; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_S7CL" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022assessments_wu4S" ON public.hmis_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022currentlivingsituations_TGSd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_1hhC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_TGSd" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmis2022clients_1hhC" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022currentlivingsituations_XjUe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_448Z; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_XjUe" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_448Z" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022currentlivingsituations_YN5f; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_4Quz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_YN5f" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmis2022clients_4Quz" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022currentlivingsituations_ZUJw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_4WQL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_ZUJw" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_4WQL" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022currentlivingsituations_aP5P; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_4yOs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_aP5P" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_4yOs" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022currentlivingsituations_bdhj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_5L3d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022currentlivingsituations_bdhj ON public.hmis_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_5L3d" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022currentlivingsituations_cf01; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_60OC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022currentlivingsituations_cf01 ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmis2022clients_60OC" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022currentlivingsituations_dREG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_706U; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_dREG" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmis2022clients_706U" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022currentlivingsituations_dhqx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_8GSL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022currentlivingsituations_dhqx ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmis2022clients_8GSL" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022currentlivingsituations_fcmV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_8JmR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_fcmV" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmis2022clients_8JmR" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022currentlivingsituations_g26S; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_8Nc4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_g26S" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmis2022clients_8Nc4" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022currentlivingsituations_jaT0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_8jAx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_jaT0" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_8jAx" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022currentlivingsituations_ktGp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_94F8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_ktGp" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_94F8" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022currentlivingsituations_nYeO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_ARdr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_nYeO" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmis2022clients_ARdr" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022currentlivingsituations_sxaI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_Ct42; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022currentlivingsituations_sxaI" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_Ct42" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022disabilities_2fdh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_Dttb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022disabilities_2fdh ON public.hmis_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_Dttb" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022disabilities_8STr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_GyUL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_8STr" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_GyUL" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022disabilities_Clxr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_HeEQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_Clxr" ON public.hmis_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_HeEQ" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022disabilities_DcsA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_HfEb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_DcsA" ON public.hmis_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_HfEb" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022disabilities_EnAl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_JcFu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_EnAl" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_JcFu" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022disabilities_Fc3v; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_K3k2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_Fc3v" ON public.hmis_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_K3k2" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022disabilities_GajH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_L8Kh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_GajH" ON public.hmis_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_L8Kh" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_GjW5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_LO5g; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_GjW5" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_LO5g" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_HxEV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_Ldsn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_HxEV" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_Ldsn" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022disabilities_JZgU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_RQ0G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_JZgU" ON public.hmis_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_RQ0G" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022disabilities_KpIn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_RWg4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_KpIn" ON public.hmis_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_RWg4" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022disabilities_Ku2m; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_RhT3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_Ku2m" ON public.hmis_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_RhT3" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022disabilities_QvrC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_S5iX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_QvrC" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_S5iX" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022disabilities_RCMq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_SD4h; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_RCMq" ON public.hmis_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_SD4h" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_RKMq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_St4O; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_RKMq" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_St4O" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022disabilities_UzGK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_T7QV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_UzGK" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmis2022clients_T7QV" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022disabilities_VCx7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_TZ0D; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_VCx7" ON public.hmis_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_TZ0D" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_XiFD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_VwfZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_XiFD" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmis2022clients_VwfZ" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_XtPr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_W0jd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_XtPr" ON public.hmis_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_W0jd" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022disabilities_YfE6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_X6j5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_YfE6" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_X6j5" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022disabilities_Yqqw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_XdUk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_Yqqw" ON public.hmis_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_XdUk" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022disabilities_e39G; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_YeAL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_e39G" ON public.hmis_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_YeAL" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022disabilities_f6dj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_aD1k; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022disabilities_f6dj ON public.hmis_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_aD1k" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022disabilities_mMjd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_b9L1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_mMjd" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmis2022clients_b9L1" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022disabilities_mwGB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_cVEq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_mwGB" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_cVEq" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022disabilities_sUB4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_ch01; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_sUB4" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX hmis2022clients_ch01 ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022disabilities_sWeo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_d5wm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_sWeo" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX hmis2022clients_d5wm ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022disabilities_trSP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_dqMt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_trSP" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_dqMt" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022disabilities_v0nQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_ejkW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_v0nQ" ON public.hmis_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_ejkW" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022disabilities_yEVb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_fEBa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022disabilities_yEVb" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_fEBa" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022employmenteducations_01I4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_giRs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_01I4" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmis2022clients_giRs" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022employmenteducations_0QcH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_hJGQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_0QcH" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_hJGQ" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022employmenteducations_0bvE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_jCQm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_0bvE" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_jCQm" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022employmenteducations_0mfY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_mKdi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_0mfY" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_mKdi" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022employmenteducations_10CJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_mPTC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_10CJ" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmis2022clients_mPTC" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022employmenteducations_1Y1K; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_mR5K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_1Y1K" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmis2022clients_mR5K" ON public.hmis_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022employmenteducations_1uKW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_pAOw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_1uKW" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_pAOw" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022employmenteducations_2YQq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_pIaL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_2YQq" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_pIaL" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022employmenteducations_4vda; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_pKg1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022employmenteducations_4vda ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_pKg1" ON public.hmis_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmis2022employmenteducations_6zwy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_qNfs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022employmenteducations_6zwy ON public.hmis_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_qNfs" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022employmenteducations_8RGj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_qRVO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_8RGj" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_qRVO" ON public.hmis_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmis2022employmenteducations_BpmW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_qZoG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_BpmW" ON public.hmis_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_qZoG" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022employmenteducations_D2yI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_tAb8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_D2yI" ON public.hmis_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_tAb8" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022employmenteducations_Dnln; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_uSUk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_Dnln" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022clients_uSUk" ON public.hmis_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022employmenteducations_Fj6e; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_uxMn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_Fj6e" ON public.hmis_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_uxMn" ON public.hmis_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmis2022employmenteducations_LanN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_vFH6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_LanN" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_vFH6" ON public.hmis_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmis2022employmenteducations_TEaN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_vjEw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_TEaN" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmis2022clients_vjEw" ON public.hmis_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022employmenteducations_VQ2U; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_ygHu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_VQ2U" ON public.hmis_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmis2022clients_ygHu" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022employmenteducations_a5yU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022clients_ystU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_a5yU" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmis2022clients_ystU" ON public.hmis_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmis2022employmenteducations_dg9r; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_0xKw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022employmenteducations_dg9r ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmis2022currentlivingsituations_0xKw" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022employmenteducations_e8J8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_2xjS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_e8J8" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022currentlivingsituations_2xjS" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022employmenteducations_g4D9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_5RN3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_g4D9" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_5RN3" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022employmenteducations_kcTC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_5wiZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_kcTC" ON public.hmis_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_5wiZ" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022employmenteducations_m0aK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_6plB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_m0aK" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_6plB" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022employmenteducations_nQzF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_9rpJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_nQzF" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_9rpJ" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022employmenteducations_njVL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_AMSS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_njVL" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_AMSS" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022employmenteducations_piba; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Ar00; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022employmenteducations_piba ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_Ar00" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022employmenteducations_rUdW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_CFRH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_rUdW" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmis2022currentlivingsituations_CFRH" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022employmenteducations_telE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_CzIv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_telE" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmis2022currentlivingsituations_CzIv" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022employmenteducations_vFzw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_DXrp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022employmenteducations_vFzw" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022currentlivingsituations_DXrp" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_00w1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Hhjf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_00w1 ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmis2022currentlivingsituations_Hhjf" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_0w9c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_HsNI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_0w9c ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_HsNI" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_1cHr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_JXqC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_1cHr" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022currentlivingsituations_JXqC" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_4x91; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_N2K2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_4x91 ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_N2K2" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_5zjF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_NAEX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_5zjF" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_NAEX" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022enrollmentcocs_6tJM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_O0Li; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_6tJM" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_O0Li" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_AwFj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_OBTk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_AwFj" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmis2022currentlivingsituations_OBTk" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_BpYl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_QNOG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_BpYl" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmis2022currentlivingsituations_QNOG" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022enrollmentcocs_CPqr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Qff6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_CPqr" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_Qff6" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_DDdl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_T9BG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_DDdl" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmis2022currentlivingsituations_T9BG" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_DPzf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_TyNo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_DPzf" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmis2022currentlivingsituations_TyNo" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022enrollmentcocs_DssF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_VC6w; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_DssF" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_VC6w" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_ErL4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_WdxL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_ErL4" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmis2022currentlivingsituations_WdxL" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_Gu7W; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Y5Dl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_Gu7W" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022currentlivingsituations_Y5Dl" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_IMgq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Z8ms; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_IMgq" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022currentlivingsituations_Z8ms" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_JPql; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_ZRfC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_JPql" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_ZRfC" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_JhHT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_Zw1x; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_JhHT" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022currentlivingsituations_Zw1x" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_NW2c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_am5d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_NW2c" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX hmis2022currentlivingsituations_am5d ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_Oj66; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_dGLU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_Oj66" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmis2022currentlivingsituations_dGLU" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022enrollmentcocs_RDDm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_eUkP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_RDDm" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022currentlivingsituations_eUkP" ON public.hmis_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_SLq3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_eyxL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_SLq3" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_eyxL" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_TBBA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_g3wI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_TBBA" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022currentlivingsituations_g3wI" ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_XK0J; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_iSoV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_XK0J" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022currentlivingsituations_iSoV" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_Xq7j; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_kmQc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_Xq7j" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_kmQc" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_bKTB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_l6to; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_bKTB" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX hmis2022currentlivingsituations_l6to ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmis2022enrollmentcocs_ce8t; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_lOJo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_ce8t ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_lOJo" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_d0Ax; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_nzlq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_d0Ax" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX hmis2022currentlivingsituations_nzlq ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_e6x1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_pQCD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_e6x1 ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmis2022currentlivingsituations_pQCD" ON public.hmis_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmis2022enrollmentcocs_emfv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_pmno; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_emfv ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX hmis2022currentlivingsituations_pmno ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_goeT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_pzdR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_goeT" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022currentlivingsituations_pzdR" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_gtAC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_roKO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_gtAC" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmis2022currentlivingsituations_roKO" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_kTmm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_s2fn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_kTmm" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX hmis2022currentlivingsituations_s2fn ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_ltSs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_sTi9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_ltSs" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmis2022currentlivingsituations_sTi9" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_nLeg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_uKLZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_nLeg" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_uKLZ" ON public.hmis_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollmentcocs_ptxT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_uvcS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_ptxT" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmis2022currentlivingsituations_uvcS" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_qb26; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_w3FT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_qb26 ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022currentlivingsituations_w3FT" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmis2022enrollmentcocs_rftp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022currentlivingsituations_ylkt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollmentcocs_rftp ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX hmis2022currentlivingsituations_ylkt ON public.hmis_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollmentcocs_tZAm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_0qxe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_tZAm" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX hmis2022disabilities_0qxe ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollmentcocs_vL8z; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_1gbs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_vL8z" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX hmis2022disabilities_1gbs ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollmentcocs_yNaH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_2j4X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollmentcocs_yNaH" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmis2022disabilities_2j4X" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_0jfu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_51XV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_0jfu ON public.hmis_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmis2022disabilities_51XV" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_20lu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_7Yr3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_20lu ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmis2022disabilities_7Yr3" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_2j3v; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_9NqB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_2j3v ON public.hmis_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmis2022disabilities_9NqB" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_37TX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_9k3I; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_37TX" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmis2022disabilities_9k3I" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_3RmC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_Bnwo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_3RmC" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022disabilities_Bnwo" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_3Y3B; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_DxUZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_3Y3B" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmis2022disabilities_DxUZ" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_3qUb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_FAoP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_3qUb" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmis2022disabilities_FAoP" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_3vdn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_FImk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_3vdn ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmis2022disabilities_FImk" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_4AvS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_G6wm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_4AvS" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmis2022disabilities_G6wm" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_4EjQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_JV0x; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_4EjQ" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmis2022disabilities_JV0x" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_4KrJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_Kwom; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_4KrJ" ON public.hmis_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmis2022disabilities_Kwom" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_5mgY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_L5t4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_5mgY" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmis2022disabilities_L5t4" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_6aWK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_O3VV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_6aWK" ON public.hmis_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmis2022disabilities_O3VV" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_6d0L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_O8Ol; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_6d0L" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022disabilities_O8Ol" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_7LRJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_OaYd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_7LRJ" ON public.hmis_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmis2022disabilities_OaYd" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_7SGc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_QbPU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_7SGc" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmis2022disabilities_QbPU" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_7WTk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_RRTT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_7WTk" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmis2022disabilities_RRTT" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_8n5u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_T38Q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_8n5u ON public.hmis_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmis2022disabilities_T38Q" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_8p3b; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_UONW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_8p3b ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmis2022disabilities_UONW" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_9HQ9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_V3eC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_9HQ9" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmis2022disabilities_V3eC" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_AUyr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_Vcra; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_AUyr" ON public.hmis_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmis2022disabilities_Vcra" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_B6MA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_VxXo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_B6MA" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmis2022disabilities_VxXo" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_BDpp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_WPal; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_BDpp" ON public.hmis_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmis2022disabilities_WPal" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_BTri; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_Y6Bu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_BTri" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmis2022disabilities_Y6Bu" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_ClYG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_ZtKP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_ClYG" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmis2022disabilities_ZtKP" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_DCEF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_cOOI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_DCEF" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmis2022disabilities_cOOI" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_Dclz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_cj5j; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_Dclz" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX hmis2022disabilities_cj5j ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_EC9L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_dCua; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_EC9L" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmis2022disabilities_dCua" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_ELY8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_edEh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_ELY8" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmis2022disabilities_edEh" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_F7ci; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_hOBl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_F7ci" ON public.hmis_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmis2022disabilities_hOBl" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_G9GI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_iTOY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_G9GI" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmis2022disabilities_iTOY" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_HQ8T; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_lEwf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_HQ8T" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022disabilities_lEwf" ON public.hmis_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_HTOM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_mZKV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_HTOM" ON public.hmis_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmis2022disabilities_mZKV" ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_HULG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_nFUW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_HULG" ON public.hmis_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmis2022disabilities_nFUW" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_J8cl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_nNrV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_J8cl" ON public.hmis_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmis2022disabilities_nNrV" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_LElu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_nz6q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_LElu" ON public.hmis_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX hmis2022disabilities_nz6q ON public.hmis_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_LiYM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_pv4G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_LiYM" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmis2022disabilities_pv4G" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_Mjsu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_r2uL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_Mjsu" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmis2022disabilities_r2uL" ON public.hmis_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_Mz76; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_rKc5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_Mz76" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022disabilities_rKc5" ON public.hmis_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_MzHk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_s9Gr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_MzHk" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmis2022disabilities_s9Gr" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_N8KZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_viMw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_N8KZ" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmis2022disabilities_viMw" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_NCDd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_w0vZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_NCDd" ON public.hmis_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmis2022disabilities_w0vZ" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_NsV4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_yInH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_NsV4" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmis2022disabilities_yInH" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_PFBl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_yf6F; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_PFBl" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmis2022disabilities_yf6F" ON public.hmis_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_QC4k; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022disabilities_zV1y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_QC4k" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022disabilities_zV1y" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmis2022enrollments_SjW2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_0Guy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_SjW2" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmis2022employmenteducations_0Guy" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_SvKn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_0NGh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_SvKn" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmis2022employmenteducations_0NGh" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_SyID; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_2LcH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_SyID" ON public.hmis_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmis2022employmenteducations_2LcH" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_TMSu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_2ZyY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_TMSu" ON public.hmis_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmis2022employmenteducations_2ZyY" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_TSRY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_5Nqm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_TSRY" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmis2022employmenteducations_5Nqm" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_V3qz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_CYKY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_V3qz" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmis2022employmenteducations_CYKY" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_Xexy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_CiCt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_Xexy" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmis2022employmenteducations_CiCt" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_aTDs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_DpuK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_aTDs" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmis2022employmenteducations_DpuK" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_bIh3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_F49o; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_bIh3" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmis2022employmenteducations_F49o" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_bbpQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_G5fa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_bbpQ" ON public.hmis_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmis2022employmenteducations_G5fa" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_c5yw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_HXcy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_c5yw ON public.hmis_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmis2022employmenteducations_HXcy" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_dl2L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_HZXi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_dl2L" ON public.hmis_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmis2022employmenteducations_HZXi" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_eyPk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_IlM6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_eyPk" ON public.hmis_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmis2022employmenteducations_IlM6" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_gSa1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_Iwdi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_gSa1" ON public.hmis_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmis2022employmenteducations_Iwdi" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_geFN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_JDX6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_geFN" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022employmenteducations_JDX6" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_gz2q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_Pl75; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_gz2q ON public.hmis_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmis2022employmenteducations_Pl75" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_hDxL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_PlGR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_hDxL" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmis2022employmenteducations_PlGR" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_hHFu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_QY98; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_hHFu" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmis2022employmenteducations_QY98" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_icgG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_SYm4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_icgG" ON public.hmis_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmis2022employmenteducations_SYm4" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_inZc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_T8xi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_inZc" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmis2022employmenteducations_T8xi" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_k0nD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_UodA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_k0nD" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmis2022employmenteducations_UodA" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_mM9g; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_VzF0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_mM9g" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmis2022employmenteducations_VzF0" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_nrVw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_ZbEC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_nrVw" ON public.hmis_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmis2022employmenteducations_ZbEC" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_oD3L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_a1lJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_oD3L" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmis2022employmenteducations_a1lJ" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_oO3x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_a3ja; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_oO3x" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX hmis2022employmenteducations_a3ja ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_oSGW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_bw42; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_oSGW" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX hmis2022employmenteducations_bw42 ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022enrollments_pPK5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_c57X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_pPK5" ON public.hmis_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmis2022employmenteducations_c57X" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_pWJS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_dKd3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_pWJS" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022employmenteducations_dKd3" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_q5xg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_eltF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_q5xg ON public.hmis_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmis2022employmenteducations_eltF" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_qHpP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_gcFe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_qHpP" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmis2022employmenteducations_gcFe" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_rcM8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_gcW2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_rcM8" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022employmenteducations_gcW2" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022enrollments_seem; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_hD4J; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_seem ON public.hmis_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmis2022employmenteducations_hD4J" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_t4ln; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_ijzn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022enrollments_t4ln ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX hmis2022employmenteducations_ijzn ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022enrollments_tVoY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_knOm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_tVoY" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmis2022employmenteducations_knOm" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_uaMe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_lecH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_uaMe" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022employmenteducations_lecH" ON public.hmis_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022enrollments_vRaD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_mkMA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_vRaD" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmis2022employmenteducations_mkMA" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_y3F2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_n2dd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_y3F2" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX hmis2022employmenteducations_n2dd ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_ynuX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_rTm2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_ynuX" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmis2022employmenteducations_rTm2" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022enrollments_zmTQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_rssW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_zmTQ" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmis2022employmenteducations_rssW" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022enrollments_zo2X; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_syjn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022enrollments_zo2X" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX hmis2022employmenteducations_syjn ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_2XYp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_tKyR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_2XYp" ON public.hmis_2022_events USING btree ("EventDate");
+CREATE INDEX "hmis2022employmenteducations_tKyR" ON public.hmis_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022events_3GeP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_te5M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_3GeP" ON public.hmis_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022employmenteducations_te5M" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_Evth; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_v89T; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_Evth" ON public.hmis_2022_events USING btree ("ExportID");
+CREATE INDEX "hmis2022employmenteducations_v89T" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022events_EwgP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_vCWI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_EwgP" ON public.hmis_2022_events USING btree ("EventDate");
+CREATE INDEX "hmis2022employmenteducations_vCWI" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmis2022events_Exri; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_vp0T; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_Exri" ON public.hmis_2022_events USING btree ("EventID");
+CREATE INDEX "hmis2022employmenteducations_vp0T" ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022events_GNsx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_vrFg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_GNsx" ON public.hmis_2022_events USING btree ("EventDate");
+CREATE INDEX "hmis2022employmenteducations_vrFg" ON public.hmis_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_HaIL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_xHRP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_HaIL" ON public.hmis_2022_events USING btree ("ExportID");
+CREATE INDEX "hmis2022employmenteducations_xHRP" ON public.hmis_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022events_JK9C; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022employmenteducations_xjai; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_JK9C" ON public.hmis_2022_events USING btree ("EnrollmentID");
+CREATE INDEX hmis2022employmenteducations_xjai ON public.hmis_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022events_LCxa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_0luF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_LCxa" ON public.hmis_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_0luF" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022events_LXwo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_1LWp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_LXwo" ON public.hmis_2022_events USING btree ("EventDate");
+CREATE INDEX "hmis2022enrollmentcocs_1LWp" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022events_OBnR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_1Qo7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_OBnR" ON public.hmis_2022_events USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_1Qo7" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022events_SLKf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_1T5Y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_SLKf" ON public.hmis_2022_events USING btree ("EventID");
+CREATE INDEX "hmis2022enrollmentcocs_1T5Y" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_T5lV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_2Sgn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_T5lV" ON public.hmis_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_2Sgn" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022events_TcFv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_36d4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_TcFv" ON public.hmis_2022_events USING btree ("EnrollmentID");
+CREATE INDEX hmis2022enrollmentcocs_36d4 ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022events_Uk3l; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_5Dvp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_Uk3l" ON public.hmis_2022_events USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_5Dvp" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_ZWfu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_5y9X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_ZWfu" ON public.hmis_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_5y9X" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_fsBr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_67Uq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_fsBr" ON public.hmis_2022_events USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_67Uq" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022events_jTpi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_6osh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_jTpi" ON public.hmis_2022_events USING btree ("PersonalID");
+CREATE INDEX hmis2022enrollmentcocs_6osh ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022events_jZh3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_6yrp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_jZh3" ON public.hmis_2022_events USING btree ("EnrollmentID");
+CREATE INDEX hmis2022enrollmentcocs_6yrp ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022events_lU5Z; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_7MPR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_lU5Z" ON public.hmis_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_7MPR" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022events_oHnT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_7aGw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_oHnT" ON public.hmis_2022_events USING btree ("EventID");
+CREATE INDEX "hmis2022enrollmentcocs_7aGw" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022events_pGIP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_95sr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_pGIP" ON public.hmis_2022_events USING btree ("EventID");
+CREATE INDEX hmis2022enrollmentcocs_95sr ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022events_pf5U; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_BG6a; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_pf5U" ON public.hmis_2022_events USING btree ("EventID");
+CREATE INDEX "hmis2022enrollmentcocs_BG6a" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022events_uIUg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_C7cw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_uIUg" ON public.hmis_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_C7cw" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022events_unUI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_DWhg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022events_unUI" ON public.hmis_2022_events USING btree ("EventDate");
+CREATE INDEX "hmis2022enrollmentcocs_DWhg" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022exits_0mCE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_EBxI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_0mCE" ON public.hmis_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmis2022enrollmentcocs_EBxI" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022exits_2fAC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_EUrA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_2fAC" ON public.hmis_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmis2022enrollmentcocs_EUrA" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022exits_3ric; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_FF8H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_3ric ON public.hmis_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmis2022enrollmentcocs_FF8H" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022exits_4AWu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Ig84; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_4AWu" ON public.hmis_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_Ig84" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022exits_4FaP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_J3WG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_4FaP" ON public.hmis_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollmentcocs_J3WG" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exits_9U2x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_J4Cb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_9U2x" ON public.hmis_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_J4Cb" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022exits_Af3i; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_JGe0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_Af3i" ON public.hmis_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_JGe0" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_AuYr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_K9XW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_AuYr" ON public.hmis_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmis2022enrollmentcocs_K9XW" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022exits_Cl49; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Lq4v; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_Cl49" ON public.hmis_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_Lq4v" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022exits_E5ii; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_MM8g; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_E5ii" ON public.hmis_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollmentcocs_MM8g" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exits_EVIM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_N6IN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_EVIM" ON public.hmis_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_N6IN" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022exits_IuDI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_NYE8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_IuDI" ON public.hmis_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmis2022enrollmentcocs_NYE8" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_KKNd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_OAbx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_KKNd" ON public.hmis_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmis2022enrollmentcocs_OAbx" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022exits_L2iM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_OCNN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_L2iM" ON public.hmis_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmis2022enrollmentcocs_OCNN" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exits_LBAD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_PFMf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_LBAD" ON public.hmis_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_PFMf" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exits_MqXv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Qdam; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_MqXv" ON public.hmis_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmis2022enrollmentcocs_Qdam" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exits_Pdxz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Rbri; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_Pdxz" ON public.hmis_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_Rbri" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exits_R91g; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_RpsF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_R91g" ON public.hmis_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmis2022enrollmentcocs_RpsF" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022exits_Rbol; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Tl0X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_Rbol" ON public.hmis_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_Tl0X" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exits_Tldv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_UX9G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_Tldv" ON public.hmis_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollmentcocs_UX9G" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_VVBK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_UznC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_VVBK" ON public.hmis_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_UznC" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_XAoJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_X4AH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_XAoJ" ON public.hmis_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_X4AH" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022exits_ZNEH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_XZvw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_ZNEH" ON public.hmis_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollmentcocs_XZvw" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_cyno; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_Zx91; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_cyno ON public.hmis_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_Zx91" ON public.hmis_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmis2022exits_d4hu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_bak6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_d4hu ON public.hmis_2022_exits USING btree ("ExitDate");
+CREATE INDEX hmis2022enrollmentcocs_bak6 ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_dFpc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_bg6y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_dFpc" ON public.hmis_2022_exits USING btree ("DateDeleted");
+CREATE INDEX hmis2022enrollmentcocs_bg6y ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022exits_fTOL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_bwt9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_fTOL" ON public.hmis_2022_exits USING btree ("ExportID");
+CREATE INDEX hmis2022enrollmentcocs_bwt9 ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exits_ksT2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_cJhe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_ksT2" ON public.hmis_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmis2022enrollmentcocs_cJhe" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022exits_lzvt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_cKo5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_lzvt ON public.hmis_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmis2022enrollmentcocs_cKo5" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exits_msZd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_ciLc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_msZd" ON public.hmis_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_ciLc" ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022exits_noAP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_dADN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_noAP" ON public.hmis_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_dADN" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exits_oWLc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_dwFR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_oWLc" ON public.hmis_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmis2022enrollmentcocs_dwFR" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exits_p6Jb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_fGJY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_p6Jb" ON public.hmis_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollmentcocs_fGJY" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exits_r50N; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_haAi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_r50N" ON public.hmis_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_haAi" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022exits_sMXZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_hysq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_sMXZ" ON public.hmis_2022_exits USING btree ("ExitID");
+CREATE INDEX hmis2022enrollmentcocs_hysq ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exits_ssZQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_jEh5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_ssZQ" ON public.hmis_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollmentcocs_jEh5" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exits_uttT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_nihn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_uttT" ON public.hmis_2022_exits USING btree ("PersonalID");
+CREATE INDEX hmis2022enrollmentcocs_nihn ON public.hmis_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmis2022exits_vL1k; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_ofMh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exits_vL1k" ON public.hmis_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_ofMh" ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022exits_vktj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_p5MT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_vktj ON public.hmis_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_p5MT" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022exits_x3r7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_p9K9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022exits_x3r7 ON public.hmis_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollmentcocs_p9K9" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exports_0o3Y; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_pIFZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exports_0o3Y" ON public.hmis_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_pIFZ" ON public.hmis_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022exports_Vb9V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_pXd5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exports_Vb9V" ON public.hmis_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_pXd5" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exports_kbyY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_qGoC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exports_kbyY" ON public.hmis_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_qGoC" ON public.hmis_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022exports_r5Vj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_qOgX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exports_r5Vj" ON public.hmis_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_qOgX" ON public.hmis_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022exports_vVa8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_tfnB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022exports_vVa8" ON public.hmis_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollmentcocs_tfnB" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022funders_26bc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_x24f; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_26bc ON public.hmis_2022_funders USING btree ("ExportID");
+CREATE INDEX hmis2022enrollmentcocs_x24f ON public.hmis_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022funders_46DZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollmentcocs_ysPE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_46DZ" ON public.hmis_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollmentcocs_ysPE" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmis2022funders_4uvj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_0b36; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_4uvj ON public.hmis_2022_funders USING btree ("DateUpdated");
+CREATE INDEX hmis2022enrollments_0b36 ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022funders_ABi2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_0bR6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_ABi2" ON public.hmis_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmis2022enrollments_0bR6" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022funders_CM44; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_1SyE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_CM44" ON public.hmis_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_1SyE" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022funders_DmBq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_1qWo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_DmBq" ON public.hmis_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_1qWo" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022funders_La2t; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_2k9X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_La2t" ON public.hmis_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_2k9X" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022funders_OTDJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_2lkK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_OTDJ" ON public.hmis_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_2lkK" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022funders_SshV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_4pPT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_SshV" ON public.hmis_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_4pPT" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022funders_ahFB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_57og; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_ahFB" ON public.hmis_2022_funders USING btree ("FunderID");
+CREATE INDEX hmis2022enrollments_57og ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022funders_aqqv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_5BoK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_aqqv ON public.hmis_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_5BoK" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022funders_e42h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_5ddO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_e42h ON public.hmis_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_5ddO" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022funders_hjB3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_5mxf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_hjB3" ON public.hmis_2022_funders USING btree ("DateCreated");
+CREATE INDEX hmis2022enrollments_5mxf ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022funders_ml9I; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_62NG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_ml9I" ON public.hmis_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_62NG" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022funders_p7Md; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_6Aun; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_p7Md" ON public.hmis_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_6Aun" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022funders_pYDL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_6JQX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_pYDL" ON public.hmis_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmis2022enrollments_6JQX" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022funders_rbeh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_6rgr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_rbeh ON public.hmis_2022_funders USING btree ("DateCreated");
+CREATE INDEX hmis2022enrollments_6rgr ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022funders_tO3b; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7Iuz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_tO3b" ON public.hmis_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmis2022enrollments_7Iuz" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022funders_wrmf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7QnM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022funders_wrmf ON public.hmis_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmis2022enrollments_7QnM" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022funders_zCs4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7Si6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022funders_zCs4" ON public.hmis_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_7Si6" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022healthanddvs_39pa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7vbI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022healthanddvs_39pa ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_7vbI" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022healthanddvs_81Ip; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7zT3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_81Ip" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_7zT3" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022healthanddvs_9xtv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_7zny; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022healthanddvs_9xtv ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX hmis2022enrollments_7zny ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022healthanddvs_B3cK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_90oE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_B3cK" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmis2022enrollments_90oE" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022healthanddvs_C3P0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_923i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_C3P0" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX hmis2022enrollments_923i ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022healthanddvs_CqjD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_AvKg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_CqjD" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_AvKg" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022healthanddvs_EmeI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_CJAp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_EmeI" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_CJAp" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022healthanddvs_GwLc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_CtVZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_GwLc" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_CtVZ" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022healthanddvs_IGDp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_DiMO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_IGDp" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_DiMO" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022healthanddvs_J2k9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_DlSi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_J2k9" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_DlSi" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022healthanddvs_JnNy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Dora; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_JnNy" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_Dora" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022healthanddvs_L20r; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_FLFC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_L20r" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_FLFC" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022healthanddvs_LYST; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Fi0S; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_LYST" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_Fi0S" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022healthanddvs_MM9C; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Fnr3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_MM9C" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_Fnr3" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022healthanddvs_PTMk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_G9us; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_PTMk" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_G9us" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022healthanddvs_RZLE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_GQhD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_RZLE" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_GQhD" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022healthanddvs_Vitu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Gjmo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_Vitu" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_Gjmo" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022healthanddvs_Zsjv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_H323; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_Zsjv" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_H323" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022healthanddvs_bSYK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_IMEE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_bSYK" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmis2022enrollments_IMEE" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022healthanddvs_d4Mp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_J2kg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_d4Mp" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_J2kg" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022healthanddvs_eFRE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_J6VD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_eFRE" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmis2022enrollments_J6VD" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022healthanddvs_jsVe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_K2q6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_jsVe" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_K2q6" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022healthanddvs_kG26; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_KKeu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_kG26" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_KKeu" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022healthanddvs_lrk9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_KQkV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022healthanddvs_lrk9 ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_KQkV" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022healthanddvs_mxKc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Ki3X; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_mxKc" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmis2022enrollments_Ki3X" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022healthanddvs_nCmK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Lp92; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_nCmK" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_Lp92" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022healthanddvs_oE33; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_NJ4u; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_oE33" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_NJ4u" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022healthanddvs_qQGt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_NVKj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_qQGt" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmis2022enrollments_NVKj" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022healthanddvs_rKKo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_NY3k; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_rKKo" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_NY3k" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022healthanddvs_sSdO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_NZXn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022healthanddvs_sSdO" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_NZXn" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022incomebenefits_0x7T; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Ncf4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_0x7T" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_Ncf4" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022incomebenefits_1iTb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_NvqE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_1iTb" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_NvqE" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022incomebenefits_84A2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_O2hO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_84A2" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_O2hO" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022incomebenefits_8YX1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_OX9H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_8YX1" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmis2022enrollments_OX9H" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022incomebenefits_9VUZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_OapS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_9VUZ" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_OapS" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022incomebenefits_AOIn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Pana; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_AOIn" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_Pana" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022incomebenefits_AhcR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_QD5y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_AhcR" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_QD5y" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022incomebenefits_CqV2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_QXdz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_CqV2" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_QXdz" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_DEc8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_RIml; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_DEc8" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_RIml" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022incomebenefits_DHfs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Sg21; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_DHfs" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_Sg21" ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022incomebenefits_FKM8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Sjw1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_FKM8" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX "hmis2022enrollments_Sjw1" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022incomebenefits_G13K; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_T4jp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_G13K" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmis2022enrollments_T4jp" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022incomebenefits_GZEz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_TDMt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_GZEz" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX "hmis2022enrollments_TDMt" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022incomebenefits_GskQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Td0y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_GskQ" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_Td0y" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022incomebenefits_HA2R; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_TqEM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_HA2R" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_TqEM" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022incomebenefits_Hrr8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_UJEE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_Hrr8" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_UJEE" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022incomebenefits_JHkd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_UgEw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_JHkd" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_UgEw" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022incomebenefits_JHq0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_UqS0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_JHq0" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_UqS0" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022incomebenefits_JwMD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VEQv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_JwMD" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_VEQv" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022incomebenefits_JzOv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VKYe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_JzOv" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_VKYe" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022incomebenefits_PI60; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VSX5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_PI60" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmis2022enrollments_VSX5" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022incomebenefits_Sy6R; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VWau; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_Sy6R" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_VWau" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022incomebenefits_TMFo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VhhJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_TMFo" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_VhhJ" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_UERs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_VwbU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_UERs" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_VwbU" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_Vn6L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_W2FC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_Vn6L" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_W2FC" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022incomebenefits_VnlT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_XEXc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_VnlT" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmis2022enrollments_XEXc" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022incomebenefits_Zgub; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_XllL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_Zgub" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_XllL" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_azJ6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Xm8a; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_azJ6" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_Xm8a" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022incomebenefits_bPyx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_Zuq3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_bPyx" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_Zuq3" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_ciWw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_a1hw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_ciWw" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX hmis2022enrollments_a1hw ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_dRwA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_aQHy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_dRwA" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_aQHy" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022incomebenefits_ek1a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_aj56; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022incomebenefits_ek1a ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX hmis2022enrollments_aj56 ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022incomebenefits_fD7y; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_b08Y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_fD7y" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_b08Y" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022incomebenefits_haCV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_bU6v; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_haCV" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_bU6v" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022incomebenefits_is5G; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_bjwo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_is5G" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX hmis2022enrollments_bjwo ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022incomebenefits_lvsq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_d8cO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022incomebenefits_lvsq ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_d8cO" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022incomebenefits_mvDZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_dXnn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_mvDZ" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmis2022enrollments_dXnn" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022incomebenefits_n8pL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_db1N; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_n8pL" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmis2022enrollments_db1N" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022incomebenefits_qGS5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_dcNL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_qGS5" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_dcNL" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022incomebenefits_sQmz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_djwC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_sQmz" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmis2022enrollments_djwC" ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022incomebenefits_tIGj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_dpjd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_tIGj" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX hmis2022enrollments_dpjd ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022incomebenefits_ts9d; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_duYW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022incomebenefits_ts9d ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_duYW" ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022incomebenefits_uWiD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_ecUe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022incomebenefits_uWiD" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX "hmis2022enrollments_ecUe" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022incomebenefits_vzlx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_fLNm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022incomebenefits_vzlx ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022enrollments_fLNm" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022incomebenefits_x9tg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_fyon; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022incomebenefits_x9tg ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX hmis2022enrollments_fyon ON public.hmis_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022inventories_3i1a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_g1X7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022inventories_3i1a ON public.hmis_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_g1X7" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022inventories_6jdY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_gWta; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_6jdY" ON public.hmis_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_gWta" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022inventories_8BiB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_hQXa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_8BiB" ON public.hmis_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmis2022enrollments_hQXa" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022inventories_9WW6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_iQtc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_9WW6" ON public.hmis_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmis2022enrollments_iQtc" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022inventories_AYgL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_ix64; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_AYgL" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX hmis2022enrollments_ix64 ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022inventories_Arn3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_jq7r; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_Arn3" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX hmis2022enrollments_jq7r ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022inventories_C1bt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_kYhP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_C1bt" ON public.hmis_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_kYhP" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_IstJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_kaLs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_IstJ" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022enrollments_kaLs" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_KB9n; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_lNhF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_KB9n" ON public.hmis_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_lNhF" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_LdMP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_mUZM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_LdMP" ON public.hmis_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmis2022enrollments_mUZM" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022inventories_M3Ha; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_nsYk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_M3Ha" ON public.hmis_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_nsYk" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_PsW9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_oGiq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_PsW9" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_oGiq" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022inventories_Qelf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_opeo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_Qelf" ON public.hmis_2022_inventories USING btree ("DateCreated");
+CREATE INDEX hmis2022enrollments_opeo ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022inventories_SWlE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_os0q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_SWlE" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX hmis2022enrollments_os0q ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022inventories_bofb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_pKZ7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022inventories_bofb ON public.hmis_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_pKZ7" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022inventories_cXOY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_plLo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_cXOY" ON public.hmis_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmis2022enrollments_plLo" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022inventories_eLHl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_qPO8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_eLHl" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_qPO8" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022inventories_eXpd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_qeUy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_eXpd" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022enrollments_qeUy" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmis2022inventories_iP6i; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_rPuN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_iP6i" ON public.hmis_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_rPuN" ON public.hmis_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmis2022inventories_kR2K; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_sCqv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_kR2K" ON public.hmis_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_sCqv" ON public.hmis_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmis2022inventories_ovgT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_sb8y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_ovgT" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX hmis2022enrollments_sb8y ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_rLxn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_tXw0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_rLxn" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022enrollments_tXw0" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022inventories_sm3T; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_tZXb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_sm3T" ON public.hmis_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmis2022enrollments_tZXb" ON public.hmis_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmis2022inventories_wLQS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_twrd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_wLQS" ON public.hmis_2022_inventories USING btree ("ExportID");
+CREATE INDEX hmis2022enrollments_twrd ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022inventories_yY0M; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_u1yO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022inventories_yY0M" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_u1yO" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022organizations_011s; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_uGOF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022organizations_011s ON public.hmis_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmis2022enrollments_uGOF" ON public.hmis_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022organizations_LOzw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_uLcf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_LOzw" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmis2022enrollments_uLcf" ON public.hmis_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmis2022organizations_Psl1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_uQJZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_Psl1" ON public.hmis_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_uQJZ" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022organizations_TLP5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_uusY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_TLP5" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmis2022enrollments_uusY" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022organizations_TdT2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_v6jk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_TdT2" ON public.hmis_2022_organizations USING btree ("ExportID");
+CREATE INDEX hmis2022enrollments_v6jk ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022organizations_UwWr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_v9Y0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_UwWr" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmis2022enrollments_v9Y0" ON public.hmis_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmis2022organizations_XsGg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_vOv3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_XsGg" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmis2022enrollments_vOv3" ON public.hmis_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmis2022organizations_mjhZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_vm6d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_mjhZ" ON public.hmis_2022_organizations USING btree ("ExportID");
+CREATE INDEX hmis2022enrollments_vm6d ON public.hmis_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmis2022organizations_rt9t; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_vsAA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022organizations_rt9t ON public.hmis_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_vsAA" ON public.hmis_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmis2022organizations_sCgG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_xD0R; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022organizations_sCgG" ON public.hmis_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_xD0R" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_0Now; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_xF4J; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_0Now" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmis2022enrollments_xF4J" ON public.hmis_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022projectcocs_1ike; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_xTUm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projectcocs_1ike ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022enrollments_xTUm" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_3ED0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_xUIq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_3ED0" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022enrollments_xUIq" ON public.hmis_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_3zNV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_y24j; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_3zNV" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX hmis2022enrollments_y24j ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022projectcocs_4M5C; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_y3Ze; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_4M5C" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmis2022enrollments_y3Ze" ON public.hmis_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022projectcocs_4qjb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_yOBE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projectcocs_4qjb ON public.hmis_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022enrollments_yOBE" ON public.hmis_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmis2022projectcocs_5LwF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_ySNH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_5LwF" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022enrollments_ySNH" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_5tqd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022enrollments_yeyp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projectcocs_5tqd ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX hmis2022enrollments_yeyp ON public.hmis_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmis2022projectcocs_6Ygh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_0GGW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_6Ygh" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022events_0GGW" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projectcocs_9Yoi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_11dU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_9Yoi" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022events_11dU" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_CcFO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_3mvj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_CcFO" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX hmis2022events_3mvj ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projectcocs_Mi4u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_4wxb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_Mi4u" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX hmis2022events_4wxb ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projectcocs_PKtl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_6CqB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_PKtl" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmis2022events_6CqB" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projectcocs_TNSX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_7VDm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_TNSX" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022events_7VDm" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projectcocs_Vz5V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_8HWZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_Vz5V" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmis2022events_8HWZ" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projectcocs_X9kf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_9a58; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_X9kf" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX hmis2022events_9a58 ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projectcocs_XYpN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_A0sR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_XYpN" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_A0sR" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projectcocs_b6rB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_B3Ia; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_b6rB" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022events_B3Ia" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_ef8C; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_C6Cq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_ef8C" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022events_C6Cq" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projectcocs_kX0x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_DJam; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_kX0x" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_DJam" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projectcocs_lrLY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Dh0R; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_lrLY" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_Dh0R" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projectcocs_lty3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_EnTk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projectcocs_lty3 ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_EnTk" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projectcocs_oD4E; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_FL4Y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_oD4E" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmis2022events_FL4Y" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projectcocs_sQfd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Ice3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_sQfd" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmis2022events_Ice3" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projectcocs_yEto; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Nctv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projectcocs_yEto" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_Nctv" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projects_2k9I; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Nw7b; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_2k9I" ON public.hmis_2022_projects USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_Nw7b" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_784w; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_PRho; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projects_784w ON public.hmis_2022_projects USING btree ("ProjectID");
+CREATE INDEX "hmis2022events_PRho" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projects_9qGh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Rn8G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_9qGh" ON public.hmis_2022_projects USING btree ("ProjectID");
+CREATE INDEX "hmis2022events_Rn8G" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projects_ADJi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_TFfI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_ADJi" ON public.hmis_2022_projects USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_TFfI" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projects_AnNo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_U6e6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_AnNo" ON public.hmis_2022_projects USING btree ("ExportID");
+CREATE INDEX "hmis2022events_U6e6" ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projects_CYGj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_V0FC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_CYGj" ON public.hmis_2022_projects USING btree ("ProjectType");
+CREATE INDEX "hmis2022events_V0FC" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projects_DMpm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_WEGY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_DMpm" ON public.hmis_2022_projects USING btree ("ProjectID");
+CREATE INDEX "hmis2022events_WEGY" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_F8tr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_WL3K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_F8tr" ON public.hmis_2022_projects USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_WL3K" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projects_GF0h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_ZH9F; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_GF0h" ON public.hmis_2022_projects USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_ZH9F" ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projects_GbSc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_Zpmj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_GbSc" ON public.hmis_2022_projects USING btree ("ProjectType");
+CREATE INDEX "hmis2022events_Zpmj" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projects_Gu3H; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_ZwRJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_Gu3H" ON public.hmis_2022_projects USING btree ("ExportID");
+CREATE INDEX "hmis2022events_ZwRJ" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_JSje; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_abPj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_JSje" ON public.hmis_2022_projects USING btree ("ProjectID");
+CREATE INDEX "hmis2022events_abPj" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projects_K13K; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_cBir; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_K13K" ON public.hmis_2022_projects USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_cBir" ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projects_OT6u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_e2ek; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_OT6u" ON public.hmis_2022_projects USING btree ("ExportID");
+CREATE INDEX hmis2022events_e2ek ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projects_Pwue; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_lLWh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_Pwue" ON public.hmis_2022_projects USING btree ("ProjectType");
+CREATE INDEX "hmis2022events_lLWh" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_dQCA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_lWFk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_dQCA" ON public.hmis_2022_projects USING btree ("ExportID");
+CREATE INDEX "hmis2022events_lWFk" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projects_eOC7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_m02H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_eOC7" ON public.hmis_2022_projects USING btree ("DateCreated");
+CREATE INDEX "hmis2022events_m02H" ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projects_eUQm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_pZnd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_eUQm" ON public.hmis_2022_projects USING btree ("ExportID");
+CREATE INDEX "hmis2022events_pZnd" ON public.hmis_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022projects_fcQR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_palV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_fcQR" ON public.hmis_2022_projects USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_palV" ON public.hmis_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmis2022projects_own3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_tBTi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022projects_own3 ON public.hmis_2022_projects USING btree ("ProjectType");
+CREATE INDEX "hmis2022events_tBTi" ON public.hmis_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmis2022projects_qlW7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_ulmZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_qlW7" ON public.hmis_2022_projects USING btree ("ProjectType");
+CREATE INDEX "hmis2022events_ulmZ" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_snHq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_wzG3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_snHq" ON public.hmis_2022_projects USING btree ("ProjectID");
+CREATE INDEX "hmis2022events_wzG3" ON public.hmis_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmis2022projects_v8Tc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022events_yLsQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_v8Tc" ON public.hmis_2022_projects USING btree ("DateUpdated");
+CREATE INDEX "hmis2022events_yLsQ" ON public.hmis_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022projects_vOpf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_19Ep; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_vOpf" ON public.hmis_2022_projects USING btree ("DateCreated");
+CREATE INDEX "hmis2022exits_19Ep" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022projects_wkvZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_1Wc2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022projects_wkvZ" ON public.hmis_2022_projects USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_1Wc2" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_1VpJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_1oIq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_1VpJ" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022exits_1oIq" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_2Pi6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_1uqz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_2Pi6" ON public.hmis_2022_services USING btree ("DateProvided");
+CREATE INDEX hmis2022exits_1uqz ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_3F1O; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_2fCD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_3F1O" ON public.hmis_2022_services USING btree ("RecordType");
+CREATE INDEX "hmis2022exits_2fCD" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_4Fxe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_353V; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_4Fxe" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+CREATE INDEX "hmis2022exits_353V" ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_4IqJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_3d2Q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_4IqJ" ON public.hmis_2022_services USING btree ("DateDeleted");
+CREATE INDEX "hmis2022exits_3d2Q" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_5tYV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_3zun; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_5tYV" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+CREATE INDEX hmis2022exits_3zun ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_68qY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_5O6C; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_68qY" ON public.hmis_2022_services USING btree ("RecordType");
+CREATE INDEX "hmis2022exits_5O6C" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_7WwG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_6USs; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_7WwG" ON public.hmis_2022_services USING btree ("ExportID");
+CREATE INDEX "hmis2022exits_6USs" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_80Zv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_7gVq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_80Zv" ON public.hmis_2022_services USING btree ("ExportID");
+CREATE INDEX "hmis2022exits_7gVq" ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_8Bt5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_7ynG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_8Bt5" ON public.hmis_2022_services USING btree ("DateProvided");
+CREATE INDEX "hmis2022exits_7ynG" ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_8XXq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_8NlR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_8XXq" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+CREATE INDEX "hmis2022exits_8NlR" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_8evh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_8OXR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022services_8evh ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022exits_8OXR" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_93jP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_8bVG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_93jP" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+CREATE INDEX "hmis2022exits_8bVG" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_9eiT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_Ag54; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_9eiT" ON public.hmis_2022_services USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022exits_Ag54" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_BCCk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_BuJg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_BCCk" ON public.hmis_2022_services USING btree ("DateProvided");
+CREATE INDEX "hmis2022exits_BuJg" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_CsGp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_BxTm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_CsGp" ON public.hmis_2022_services USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_BxTm" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_D1jd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_CmRb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_D1jd" ON public.hmis_2022_services USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_CmRb" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_Ek53; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_DB6t; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Ek53" ON public.hmis_2022_services USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_DB6t" ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_FSBY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_E21N; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_FSBY" ON public.hmis_2022_services USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_E21N" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_FcVG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_EDyk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_FcVG" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+CREATE INDEX "hmis2022exits_EDyk" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_Fd80; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_EfnJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Fd80" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+CREATE INDEX "hmis2022exits_EfnJ" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_HEJX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_FLBt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_HEJX" ON public.hmis_2022_services USING btree ("ServicesID");
+CREATE INDEX "hmis2022exits_FLBt" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_JfRQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_FMk5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_JfRQ" ON public.hmis_2022_services USING btree ("ExportID");
+CREATE INDEX "hmis2022exits_FMk5" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_LA4D; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_G2R6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_LA4D" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+CREATE INDEX "hmis2022exits_G2R6" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_LTfU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_H40M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_LTfU" ON public.hmis_2022_services USING btree ("DateCreated");
+CREATE INDEX "hmis2022exits_H40M" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_MR5w; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_HEfn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_MR5w" ON public.hmis_2022_services USING btree ("ServicesID");
+CREATE INDEX "hmis2022exits_HEfn" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_OuBj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_HeOn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_OuBj" ON public.hmis_2022_services USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022exits_HeOn" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_PgzK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_HoQo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_PgzK" ON public.hmis_2022_services USING btree ("PersonalID");
+CREATE INDEX "hmis2022exits_HoQo" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_Q64k; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_I0lG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Q64k" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+CREATE INDEX "hmis2022exits_I0lG" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_QM5r; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_IlLd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_QM5r" ON public.hmis_2022_services USING btree ("PersonalID");
+CREATE INDEX "hmis2022exits_IlLd" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_QVc8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_M1UW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_QVc8" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+CREATE INDEX "hmis2022exits_M1UW" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_QsED; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_MMBp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_QsED" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+CREATE INDEX "hmis2022exits_MMBp" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_Qscs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_OXqe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Qscs" ON public.hmis_2022_services USING btree ("DateDeleted");
+CREATE INDEX "hmis2022exits_OXqe" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_Qxai; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_P29L; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Qxai" ON public.hmis_2022_services USING btree ("ExportID");
+CREATE INDEX "hmis2022exits_P29L" ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_R4Ug; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_PhoM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_R4Ug" ON public.hmis_2022_services USING btree ("DateCreated");
+CREATE INDEX "hmis2022exits_PhoM" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_Rgn7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_WsdD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Rgn7" ON public.hmis_2022_services USING btree ("RecordType");
+CREATE INDEX "hmis2022exits_WsdD" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_TR6P; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_X4fU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_TR6P" ON public.hmis_2022_services USING btree ("ServicesID");
+CREATE INDEX "hmis2022exits_X4fU" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_TeiS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_YJAc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_TeiS" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+CREATE INDEX "hmis2022exits_YJAc" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_UdjB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_aFIo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_UdjB" ON public.hmis_2022_services USING btree ("ExportID");
+CREATE INDEX "hmis2022exits_aFIo" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_UhG8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_bWXi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_UhG8" ON public.hmis_2022_services USING btree ("DateDeleted");
+CREATE INDEX "hmis2022exits_bWXi" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_WzIZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_ekW7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_WzIZ" ON public.hmis_2022_services USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022exits_ekW7" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_Xp4E; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_enyn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Xp4E" ON public.hmis_2022_services USING btree ("DateDeleted");
+CREATE INDEX hmis2022exits_enyn ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_Y9OY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_hiFQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_Y9OY" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+CREATE INDEX "hmis2022exits_hiFQ" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_YlM0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_jaEf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_YlM0" ON public.hmis_2022_services USING btree ("DateUpdated");
+CREATE INDEX "hmis2022exits_jaEf" ON public.hmis_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmis2022services_ZeNL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_jniW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_ZeNL" ON public.hmis_2022_services USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022exits_jniW" ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_aZ1P; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_kP2u; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_aZ1P" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+CREATE INDEX "hmis2022exits_kP2u" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_dkaE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_kYBE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_dkaE" ON public.hmis_2022_services USING btree ("DateProvided");
+CREATE INDEX "hmis2022exits_kYBE" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_evj6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_lFjr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022services_evj6 ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+CREATE INDEX "hmis2022exits_lFjr" ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_fS9c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_o46o; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_fS9c" ON public.hmis_2022_services USING btree ("PersonalID");
+CREATE INDEX hmis2022exits_o46o ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_gLfJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_p6xu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_gLfJ" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+CREATE INDEX hmis2022exits_p6xu ON public.hmis_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmis2022services_hp6g; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_pM7r; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022services_hp6g ON public.hmis_2022_services USING btree ("RecordType");
+CREATE INDEX "hmis2022exits_pM7r" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_i3Fn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_pygG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_i3Fn" ON public.hmis_2022_services USING btree ("PersonalID");
+CREATE INDEX "hmis2022exits_pygG" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_jK9O; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_q6st; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_jK9O" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+CREATE INDEX hmis2022exits_q6st ON public.hmis_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmis2022services_jPzY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_tUk7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_jPzY" ON public.hmis_2022_services USING btree ("PersonalID");
+CREATE INDEX "hmis2022exits_tUk7" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_jnER; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_thz3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_jnER" ON public.hmis_2022_services USING btree ("DateCreated");
+CREATE INDEX hmis2022exits_thz3 ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_kMoh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_unSU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_kMoh" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022exits_unSU" ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_l83Q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_uwq0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_l83Q" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+CREATE INDEX hmis2022exits_uwq0 ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_n6xL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_vfd7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_n6xL" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX hmis2022exits_vfd7 ON public.hmis_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmis2022services_pQHA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_w29k; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_pQHA" ON public.hmis_2022_services USING btree ("DateCreated");
+CREATE INDEX hmis2022exits_w29k ON public.hmis_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmis2022services_rKMA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_wpnB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_rKMA" ON public.hmis_2022_services USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022exits_wpnB" ON public.hmis_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_rwkF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_xWOu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_rwkF" ON public.hmis_2022_services USING btree ("RecordType");
+CREATE INDEX "hmis2022exits_xWOu" ON public.hmis_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022services_s8In; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exits_zNv0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_s8In" ON public.hmis_2022_services USING btree ("DateProvided");
+CREATE INDEX "hmis2022exits_zNv0" ON public.hmis_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022services_tYIb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_1I5N; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_tYIb" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmis2022exports_1I5N" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_taNN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_70sB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_taNN" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+CREATE INDEX "hmis2022exports_70sB" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_u0nP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_NNAg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_u0nP" ON public.hmis_2022_services USING btree ("ServicesID");
+CREATE INDEX "hmis2022exports_NNAg" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_vfjk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_Y7T7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022services_vfjk ON public.hmis_2022_services USING btree ("DateDeleted");
+CREATE INDEX "hmis2022exports_Y7T7" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_vsKi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_iTlW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_vsKi" ON public.hmis_2022_services USING btree ("ServicesID");
+CREATE INDEX "hmis2022exports_iTlW" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_w0lh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_nj7S; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022services_w0lh ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+CREATE INDEX "hmis2022exports_nj7S" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_z7LQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_oNnU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_z7LQ" ON public.hmis_2022_services USING btree ("DateCreated");
+CREATE INDEX "hmis2022exports_oNnU" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022services_zbEp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022exports_uUNS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022services_zbEp" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+CREATE INDEX "hmis2022exports_uUNS" ON public.hmis_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmis2022users_6bs3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_38Dk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022users_6bs3 ON public.hmis_2022_users USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_38Dk" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022users_9tte; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_49pp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022users_9tte ON public.hmis_2022_users USING btree ("UserID");
+CREATE INDEX hmis2022funders_49pp ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022users_Bb37; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_6g4a; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_Bb37" ON public.hmis_2022_users USING btree ("ExportID");
+CREATE INDEX hmis2022funders_6g4a ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022users_I56Y; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_9vZT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_I56Y" ON public.hmis_2022_users USING btree ("UserID");
+CREATE INDEX "hmis2022funders_9vZT" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022users_L8dm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_CGBW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_L8dm" ON public.hmis_2022_users USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_CGBW" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022users_cfDN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_E50S; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_cfDN" ON public.hmis_2022_users USING btree ("UserID");
+CREATE INDEX "hmis2022funders_E50S" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022users_iRM6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_EtfL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_iRM6" ON public.hmis_2022_users USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_EtfL" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022users_ixDP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_IDZn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_ixDP" ON public.hmis_2022_users USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_IDZn" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022users_jC3x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_MAXz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_jC3x" ON public.hmis_2022_users USING btree ("UserID");
+CREATE INDEX "hmis2022funders_MAXz" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022users_n0RN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_SD49; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022users_n0RN" ON public.hmis_2022_users USING btree ("UserID");
+CREATE INDEX "hmis2022funders_SD49" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_2ePH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_TKRa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_2ePH" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX "hmis2022funders_TKRa" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_3nPV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_UXnF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_3nPV" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022funders_UXnF" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_5Amx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_V44h; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_5Amx" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+CREATE INDEX "hmis2022funders_V44h" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_6acJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_Xagz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_6acJ" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_Xagz" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_9lDW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_YASu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_9lDW" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_YASu" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_CPRH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_Ynco; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_CPRH" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+CREATE INDEX "hmis2022funders_Ynco" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_Cl2V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_Yzh1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_Cl2V" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX "hmis2022funders_Yzh1" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_E26n; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_bRUS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_E26n" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_bRUS" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_EioI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_cR20; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_EioI" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX "hmis2022funders_cR20" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_GqWc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_cwU7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_GqWc" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+CREATE INDEX "hmis2022funders_cwU7" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_Jb6k; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_dRNW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_Jb6k" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022funders_dRNW" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_KWZP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_fDwy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_KWZP" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX "hmis2022funders_fDwy" ON public.hmis_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_MXhY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_gsct; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_MXhY" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+CREATE INDEX hmis2022funders_gsct ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_V5KQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_iJrG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_V5KQ" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+CREATE INDEX "hmis2022funders_iJrG" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_Xvwe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_jMmA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_Xvwe" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+CREATE INDEX "hmis2022funders_jMmA" ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_bmwi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_m22c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022youtheducationstatuses_bmwi ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX hmis2022funders_m22c ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_oUUw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_oW4L; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_oUUw" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_oW4L" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_pIqT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_pBdF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_pIqT" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+CREATE INDEX "hmis2022funders_pBdF" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_qY17; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_q1ra; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_qY17" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+CREATE INDEX hmis2022funders_q1ra ON public.hmis_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_r4i7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_r6HF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmis2022youtheducationstatuses_r4i7 ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+CREATE INDEX "hmis2022funders_r6HF" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_rWnz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_tmjA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_rWnz" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+CREATE INDEX "hmis2022funders_tmjA" ON public.hmis_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_tADn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022funders_yqgM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_tADn" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022funders_yqgM" ON public.hmis_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_u4Ae; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022healthanddvs_1V1Q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_u4Ae" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+CREATE INDEX "hmis2022healthanddvs_1V1Q" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
 
 
 --
--- Name: hmis2022youtheducationstatuses_xQUJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022healthanddvs_6uGQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_xQUJ" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+CREATE INDEX "hmis2022healthanddvs_6uGQ" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
 
 
 --
--- Name: hmis2022youtheducationstatuses_yBQz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis2022healthanddvs_7sRz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis2022youtheducationstatuses_yBQz" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+CREATE INDEX "hmis2022healthanddvs_7sRz" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_CCUJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_CCUJ" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_E3G9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_E3G9" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_ExGt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_ExGt" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_GIcO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_GIcO" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_Huiw; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_Huiw" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_ICZI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_ICZI" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_IWCm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_IWCm" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_J7vE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_J7vE" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_Ofog; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_Ofog" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_QmUP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_QmUP" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_SPMU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_SPMU" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_SdUP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_SdUP" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_UXY5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_UXY5" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_Ux07; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_Ux07" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_WEho; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_WEho" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_Wckb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_Wckb" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_boZW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_boZW" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_cO71; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_cO71" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_dJJ2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_dJJ2" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_dOub; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_dOub" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_dqsj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_dqsj ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_i8BW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_i8BW" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_jHVZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_jHVZ" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_k0iY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_k0iY" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_kXPT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_kXPT" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_kuYV; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_kuYV" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_mBES; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_mBES" ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_mbaW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_mbaW" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_mikD; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_mikD" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_mqdn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_mqdn ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_nKLq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_nKLq" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_nxiH; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_nxiH" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022healthanddvs_okh8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_okh8 ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_owVv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_owVv" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_qTVT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_qTVT" ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_qz7I; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_qz7I" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_r56y; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_r56y ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_rDNg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_rDNg" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_rjyc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_rjyc ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_twIW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_twIW" ON public.hmis_2022_health_and_dvs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022healthanddvs_uQyT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_uQyT" ON public.hmis_2022_health_and_dvs USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022healthanddvs_vYZn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_vYZn" ON public.hmis_2022_health_and_dvs USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022healthanddvs_vb5y; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_vb5y ON public.hmis_2022_health_and_dvs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022healthanddvs_wffs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022healthanddvs_wffs ON public.hmis_2022_health_and_dvs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022healthanddvs_yEYU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022healthanddvs_yEYU" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID");
+
+
+--
+-- Name: hmis2022incomebenefits_0TG2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_0TG2" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_0kea; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022incomebenefits_0kea ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_2CyE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_2CyE" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_2LpU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_2LpU" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_2hgI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_2hgI" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_3DFM; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_3DFM" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_4Y8c; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_4Y8c" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_8Xla; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_8Xla" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_9b05; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022incomebenefits_9b05 ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_BHim; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_BHim" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_F3ni; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_F3ni" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_F9mK; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_F9mK" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_FMUo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_FMUo" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_Fvtm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Fvtm" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_Gydp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Gydp" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_HhM5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_HhM5" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_HvRj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_HvRj" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_I3XE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_I3XE" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_ITKs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ITKs" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_IelJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_IelJ" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_IsGp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_IsGp" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_JJEo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_JJEo" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_LL9I; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_LL9I" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_LjPa; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_LjPa" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_Mgyr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Mgyr" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_MkXp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_MkXp" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_N0GD; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_N0GD" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_NqKj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_NqKj" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_OiR8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_OiR8" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_RvnQ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_RvnQ" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_Smem; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Smem" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_TIGB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_TIGB" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_TMJK; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_TMJK" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_TYqn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_TYqn" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_UNL6; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_UNL6" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_Vp3C; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Vp3C" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_Xp6p; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Xp6p" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_Y1HN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Y1HN" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_YV0F; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_YV0F" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_YyZH; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_YyZH" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_Z2s5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_Z2s5" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_ZK7E; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ZK7E" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_ZWSg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ZWSg" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID");
+
+
+--
+-- Name: hmis2022incomebenefits_ZdKr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ZdKr" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_ZeD3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ZeD3" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_ZwmE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ZwmE" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_a00X; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_a00X" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_d1xw; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022incomebenefits_d1xw ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_dbDo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_dbDo" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_e5Ut; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_e5Ut" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_eBrU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_eBrU" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_eQDS; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_eQDS" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_f8RL; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_f8RL" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_fM9M; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_fM9M" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_gMxn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_gMxn" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_hDyB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_hDyB" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_hGmh; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_hGmh" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_ionY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_ionY" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_kt8s; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022incomebenefits_kt8s ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_lFvO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_lFvO" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_nHRg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_nHRg" ON public.hmis_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_odRk; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_odRk" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_orAS; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_orAS" ON public.hmis_2022_income_benefits USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022incomebenefits_rdxU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_rdxU" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_riGJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_riGJ" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_tldA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_tldA" ON public.hmis_2022_income_benefits USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022incomebenefits_urCl; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_urCl" ON public.hmis_2022_income_benefits USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022incomebenefits_vTSd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_vTSd" ON public.hmis_2022_income_benefits USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022incomebenefits_vWqC; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_vWqC" ON public.hmis_2022_income_benefits USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022incomebenefits_vbAb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_vbAb" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022incomebenefits_xZGS; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_xZGS" ON public.hmis_2022_income_benefits USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022incomebenefits_xd9M; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022incomebenefits_xd9M" ON public.hmis_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+
+
+--
+-- Name: hmis2022inventories_0QM7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_0QM7" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_2j6O; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_2j6O" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_5VeD; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_5VeD" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_5gWy; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_5gWy" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_5sV5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_5sV5" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_5wgW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_5wgW" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_7Ie4; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_7Ie4" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_Bif3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_Bif3" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_CmSI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_CmSI" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_DloM; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_DloM" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_DmN6; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_DmN6" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_DwW3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_DwW3" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_GWIK; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_GWIK" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_I2pu; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_I2pu" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_LEjl; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_LEjl" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_NI6i; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_NI6i" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_Nftj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_Nftj" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_O5Rf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_O5Rf" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_OevE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_OevE" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_P6FI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_P6FI" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_Ryqp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_Ryqp" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_SIN3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_SIN3" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_SQ9q; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_SQ9q" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_SwGR; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_SwGR" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_XWQj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_XWQj" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_aAnN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_aAnN" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_cebA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_cebA" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_crXT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_crXT" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_eC4y; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_eC4y" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_edvf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022inventories_edvf ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_egTn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_egTn" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_fMPP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_fMPP" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_fSbj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_fSbj" ON public.hmis_2022_inventories USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022inventories_rdy6; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022inventories_rdy6 ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_sNDg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_sNDg" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_sv0U; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_sv0U" ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022inventories_uP3O; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_uP3O" ON public.hmis_2022_inventories USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022inventories_wiH9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_wiH9" ON public.hmis_2022_inventories USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022inventories_wtGz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022inventories_wtGz" ON public.hmis_2022_inventories USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022inventories_x74n; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022inventories_x74n ON public.hmis_2022_inventories USING btree ("InventoryID");
+
+
+--
+-- Name: hmis2022organizations_3Hul; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_3Hul" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_8IZj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_8IZj" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_AaSf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_AaSf" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_NIes; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_NIes" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_NSVn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_NSVn" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_U8Fn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_U8Fn" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_VIKX; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_VIKX" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_VeT4; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_VeT4" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_YhxL; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_YhxL" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_beNO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_beNO" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_d5D3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_d5D3" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_f6IA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_f6IA" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_lJGs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_lJGs" ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_m4p8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022organizations_m4p8 ON public.hmis_2022_organizations USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022organizations_pZth; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022organizations_pZth" ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022organizations_xt8r; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022organizations_xt8r ON public.hmis_2022_organizations USING btree ("OrganizationID");
+
+
+--
+-- Name: hmis2022projectcocs_3yMs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_3yMs" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_5S15; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_5S15" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_7VWV; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_7VWV" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_8Yz8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_8Yz8" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_9HZE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_9HZE" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_BRS3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_BRS3" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_Etzu; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_Etzu" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_G9DZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_G9DZ" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_JdKy; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_JdKy" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_KnQJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_KnQJ" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_L1Fo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_L1Fo" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_LRWr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_LRWr" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_O5zb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_O5zb" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_Qj6P; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_Qj6P" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_QsU7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_QsU7" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_RJEW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_RJEW" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_SU2k; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_SU2k" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_TleW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_TleW" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_VYqk; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_VYqk" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_XaR9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_XaR9" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_Y08J; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_Y08J" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_YYrq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_YYrq" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_ZdBf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_ZdBf" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_bEgU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_bEgU" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_bnhP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_bnhP" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_d1hW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_d1hW" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_e2BR; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_e2BR" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_eGIc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_eGIc" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_eY7R; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_eY7R" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_fVly; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_fVly" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_jJRX; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_jJRX" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_k5jA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_k5jA" ON public.hmis_2022_project_cocs USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projectcocs_mFf3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_mFf3" ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projectcocs_mZpF; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_mZpF" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_myWS; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_myWS" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID");
+
+
+--
+-- Name: hmis2022projectcocs_pLbv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_pLbv" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_sQIm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_sQIm" ON public.hmis_2022_project_cocs USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projectcocs_tN6h; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_tN6h" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_wZrF; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projectcocs_wZrF" ON public.hmis_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+
+
+--
+-- Name: hmis2022projectcocs_ynck; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projectcocs_ynck ON public.hmis_2022_project_cocs USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_2CVL; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_2CVL" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_3x2K; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_3x2K" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_4Ptc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_4Ptc" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_5nxb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_5nxb ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_5rLy; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_5rLy" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_8Qon; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_8Qon" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_8hpl; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_8hpl ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_9Bn5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_9Bn5" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_F5Mb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_F5Mb" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_FNb8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_FNb8" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_Ha6s; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_Ha6s" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_JUVN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_JUVN" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_LnZe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_LnZe" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_MBZZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_MBZZ" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_NDxg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_NDxg" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_NIcP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_NIcP" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_NjFe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_NjFe" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_RCCu; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_RCCu" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_SDsR; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_SDsR" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_VRli; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_VRli" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_VnlR; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_VnlR" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_X5FY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_X5FY" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_XXRC; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_XXRC" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_dVQn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_dVQn" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_ensN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_ensN" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_fEG2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_fEG2" ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_fWqZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_fWqZ" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_frsc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_frsc ON public.hmis_2022_projects USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022projects_gC3W; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_gC3W" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_hmJh; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_hmJh" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_iidi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_iidi ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_l42E; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_l42E" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_lAcz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_lAcz" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_mKIb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_mKIb" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_pEbo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_pEbo" ON public.hmis_2022_projects USING btree ("ProjectID");
+
+
+--
+-- Name: hmis2022projects_t7rd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_t7rd ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_uAeN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_uAeN" ON public.hmis_2022_projects USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022projects_uXwg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_uXwg" ON public.hmis_2022_projects USING btree ("ProjectType");
+
+
+--
+-- Name: hmis2022projects_vaz3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022projects_vaz3 ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022projects_w8V7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022projects_w8V7" ON public.hmis_2022_projects USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_0SM9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_0SM9" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_1qz3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_1qz3 ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_39yU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_39yU" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_3w75; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_3w75 ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_4FMl; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_4FMl" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_4MEG; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_4MEG" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_4klF; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_4klF" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_4tBz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_4tBz" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_5Zue; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_5Zue" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_6dyr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_6dyr ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_7Ghg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_7Ghg" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_7ba0; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_7ba0 ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_8RcC; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_8RcC" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_8ZO8; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_8ZO8" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_95yI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_95yI" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_AAXF; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_AAXF" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_AHqT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_AHqT" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_AXjc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_AXjc" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_AZkB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_AZkB" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_Ab7O; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Ab7O" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_B4SM; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_B4SM" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_BBU3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_BBU3" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_BkDi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_BkDi" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_BzkI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_BzkI" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_Ciqq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Ciqq" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_ClpV; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_ClpV" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_Cmfn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Cmfn" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_DPZn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_DPZn" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_EiJi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_EiJi" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_ErLK; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_ErLK" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_FKP1; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_FKP1" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_Fl3w; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Fl3w" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_IvhT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_IvhT" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_JQb3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_JQb3" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_L75s; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_L75s" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_LBpv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_LBpv" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_LbnU; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_LbnU" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_MOSB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_MOSB" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_MWer; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_MWer" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_MjkD; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_MjkD" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_Mmsi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Mmsi" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_NYDq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_NYDq" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_OHJa; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_OHJa" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_PRh2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_PRh2" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_PUtT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_PUtT" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_PcIQ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_PcIQ" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_QaWP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_QaWP" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_QcME; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_QcME" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_Qr8G; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Qr8G" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_R3l2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_R3l2" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_SrM6; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_SrM6" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_TiE2; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_TiE2" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_U2wI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_U2wI" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_UMzW; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_UMzW" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_UgzJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_UgzJ" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_Uhqj; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Uhqj" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_Uynz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Uynz" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_VUFE; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_VUFE" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_VjfZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_VjfZ" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_VuO9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_VuO9" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_XgFx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_XgFx" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_Xk5U; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_Xk5U" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_bWVe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_bWVe" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_cFZs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_cFZs" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_cnzI; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_cnzI" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_dWKu; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_dWKu" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_dhJp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_dhJp" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_efaG; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_efaG" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_gBH0; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_gBH0" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_gOcz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_gOcz" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_gRxC; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_gRxC" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_gT9w; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_gT9w" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_gyNi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_gyNi" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_hpZa; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_hpZa" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_hsIv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_hsIv" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_jHYB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_jHYB" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_jxVm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_jxVm" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_jzQX; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_jzQX" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_k4qf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_k4qf ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_k8vX; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_k8vX" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_ksMf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_ksMf" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_lMqV; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_lMqV" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_lQ9h; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_lQ9h" ON public.hmis_2022_services USING btree ("RecordType");
+
+
+--
+-- Name: hmis2022services_lgZx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_lgZx" ON public.hmis_2022_services USING btree ("EnrollmentID", "PersonalID");
+
+
+--
+-- Name: hmis2022services_m2Qb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_m2Qb" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_nHc5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_nHc5" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_nMUY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_nMUY" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_p1Iu; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_p1Iu" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_pHlz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_pHlz" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_pqUn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_pqUn" ON public.hmis_2022_services USING btree ("DateProvided");
+
+
+--
+-- Name: hmis2022services_psgx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_psgx ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022services_rKLY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_rKLY" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_s05R; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_s05R" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_s5V1; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_s5V1" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_swC9; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_swC9" ON public.hmis_2022_services USING btree ("RecordType", "DateProvided");
+
+
+--
+-- Name: hmis2022services_tgoe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022services_tgoe ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_u9IP; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_u9IP" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_uIvq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_uIvq" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_uayM; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_uayM" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_ueHT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_ueHT" ON public.hmis_2022_services USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022services_upMm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_upMm" ON public.hmis_2022_services USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022services_uuxJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_uuxJ" ON public.hmis_2022_services USING btree ("DateCreated");
+
+
+--
+-- Name: hmis2022services_wCb1; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_wCb1" ON public.hmis_2022_services USING btree ("DateUpdated");
+
+
+--
+-- Name: hmis2022services_wE0v; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_wE0v" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_wqCz; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_wqCz" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_x9VA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_x9VA" ON public.hmis_2022_services USING btree ("RecordType", "DateDeleted");
+
+
+--
+-- Name: hmis2022services_xCjX; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_xCjX" ON public.hmis_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
+
+
+--
+-- Name: hmis2022services_xbJf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_xbJf" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_xd0G; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_xd0G" ON public.hmis_2022_services USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022services_yBz3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_yBz3" ON public.hmis_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
+
+
+--
+-- Name: hmis2022services_yHn3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_yHn3" ON public.hmis_2022_services USING btree ("DateDeleted");
+
+
+--
+-- Name: hmis2022services_zPB7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022services_zPB7" ON public.hmis_2022_services USING btree ("ServicesID");
+
+
+--
+-- Name: hmis2022users_104P; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_104P" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_B2Xm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_B2Xm" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_KHN1; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_KHN1" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_L2VL; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_L2VL" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_M64h; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_M64h" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_Opqv; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_Opqv" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_Vz2T; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_Vz2T" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_XDa7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_XDa7" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_YEAt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_YEAt" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_ZSr3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_ZSr3" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_dB8n; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_dB8n" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_m8ps; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022users_m8ps ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_mTri; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_mTri" ON public.hmis_2022_users USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022users_pf7p; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022users_pf7p ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_zGnR; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_zGnR" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022users_zI2O; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022users_zI2O" ON public.hmis_2022_users USING btree ("UserID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_1rz0; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022youtheducationstatuses_1rz0 ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_3YEo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_3YEo" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_3ipf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022youtheducationstatuses_3ipf ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_4KNS; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_4KNS" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_6W3c; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_6W3c" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_6zpH; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_6zpH" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_CKlO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_CKlO" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_G9HA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_G9HA" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_GhGf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_GhGf" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_Goeg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_Goeg" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_IGit; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_IGit" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_JSVi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_JSVi" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_KBPJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_KBPJ" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_KOW5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_KOW5" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_Khh7; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_Khh7" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_KiKJ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_KiKJ" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_N49X; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_N49X" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_OBJm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_OBJm" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_Prpt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_Prpt" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_SfNs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_SfNs" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_SpUF; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_SpUF" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_U5wx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_U5wx" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_V0A0; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_V0A0" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_VcFO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_VcFO" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_WbhB; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_WbhB" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_YIZO; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_YIZO" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_g52y; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022youtheducationstatuses_g52y ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_glKw; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_glKw" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_iWyN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_iWyN" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_kKgw; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_kKgw" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_lN2T; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_lN2T" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_md2g; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022youtheducationstatuses_md2g ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_nAyi; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_nAyi" ON public.hmis_2022_youth_education_statuses USING btree ("PersonalID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_nPGd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_nPGd" ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_pBYf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_pBYf" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_rYjN; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_rYjN" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_tUaf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_tUaf" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_tnDr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_tnDr" ON public.hmis_2022_youth_education_statuses USING btree ("ExportID");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_uSRK; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis2022youtheducationstatuses_uSRK" ON public.hmis_2022_youth_education_statuses USING btree ("InformationDate");
+
+
+--
+-- Name: hmis2022youtheducationstatuses_v72w; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX hmis2022youtheducationstatuses_v72w ON public.hmis_2022_youth_education_statuses USING btree ("EnrollmentID");
 
 
 --
@@ -30736,325 +32582,325 @@ CREATE INDEX "hmis_2020_users-ZfY6" ON public.hmis_2020_users USING btree (sourc
 
 
 --
--- Name: hmis_2022_affiliations-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_affiliations-1Xu3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_affiliations-48bf" ON public.hmis_2022_affiliations USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_affiliations-1Xu3" ON public.hmis_2022_affiliations USING btree ("AffiliationID", data_source_id);
 
 
 --
--- Name: hmis_2022_affiliations-6457; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_affiliations-Zd5i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_affiliations-6457" ON public.hmis_2022_affiliations USING btree ("AffiliationID", data_source_id);
+CREATE INDEX "hmis_2022_affiliations-Zd5i" ON public.hmis_2022_affiliations USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_assessment_questions-0cd3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessment_questions-P5uB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessment_questions-0cd3" ON public.hmis_2022_assessment_questions USING btree ("AssessmentQuestionID", data_source_id);
+CREATE INDEX "hmis_2022_assessment_questions-P5uB" ON public.hmis_2022_assessment_questions USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_assessment_questions-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessment_questions-hEXE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessment_questions-48bf" ON public.hmis_2022_assessment_questions USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_assessment_questions-hEXE" ON public.hmis_2022_assessment_questions USING btree ("AssessmentQuestionID", data_source_id);
 
 
 --
--- Name: hmis_2022_assessment_results-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessment_results-aqKh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessment_results-48bf" ON public.hmis_2022_assessment_results USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_assessment_results-aqKh" ON public.hmis_2022_assessment_results USING btree ("AssessmentResultID", data_source_id);
 
 
 --
--- Name: hmis_2022_assessment_results-d6c9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessment_results-i4kH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessment_results-d6c9" ON public.hmis_2022_assessment_results USING btree ("AssessmentResultID", data_source_id);
+CREATE INDEX "hmis_2022_assessment_results-i4kH" ON public.hmis_2022_assessment_results USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_assessments-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessments-3hHI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessments-48bf" ON public.hmis_2022_assessments USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_assessments-3hHI" ON public.hmis_2022_assessments USING btree ("AssessmentID", data_source_id);
 
 
 --
--- Name: hmis_2022_assessments-df76; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_assessments-uQI7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_assessments-df76" ON public.hmis_2022_assessments USING btree ("AssessmentID", data_source_id);
+CREATE INDEX "hmis_2022_assessments-uQI7" ON public.hmis_2022_assessments USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_clients-230f; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_clients-e9GF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_clients-230f" ON public.hmis_2022_clients USING btree ("PersonalID", data_source_id);
+CREATE INDEX "hmis_2022_clients-e9GF" ON public.hmis_2022_clients USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_clients-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_clients-hBaA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_clients-48bf" ON public.hmis_2022_clients USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_clients-hBaA" ON public.hmis_2022_clients USING btree ("PersonalID", data_source_id);
 
 
 --
--- Name: hmis_2022_current_living_situations-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_current_living_situations-YsY8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_current_living_situations-48bf" ON public.hmis_2022_current_living_situations USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_current_living_situations-YsY8" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID", data_source_id);
 
 
 --
--- Name: hmis_2022_current_living_situations-cf31; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_current_living_situations-anIf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_current_living_situations-cf31" ON public.hmis_2022_current_living_situations USING btree ("CurrentLivingSitID", data_source_id);
+CREATE INDEX "hmis_2022_current_living_situations-anIf" ON public.hmis_2022_current_living_situations USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_disabilities-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_disabilities-0ss8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_disabilities-48bf" ON public.hmis_2022_disabilities USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_disabilities-0ss8" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID", data_source_id);
 
 
 --
--- Name: hmis_2022_disabilities-7712; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_disabilities-ClBv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_disabilities-7712" ON public.hmis_2022_disabilities USING btree ("DisabilitiesID", data_source_id);
+CREATE INDEX "hmis_2022_disabilities-ClBv" ON public.hmis_2022_disabilities USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_employment_educations-3032; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_employment_educations-Fq3T; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_employment_educations-3032" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID", data_source_id);
+CREATE INDEX "hmis_2022_employment_educations-Fq3T" ON public.hmis_2022_employment_educations USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_employment_educations-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_employment_educations-ZpJE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_employment_educations-48bf" ON public.hmis_2022_employment_educations USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_employment_educations-ZpJE" ON public.hmis_2022_employment_educations USING btree ("EmploymentEducationID", data_source_id);
 
 
 --
--- Name: hmis_2022_enrollment_cocs-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_enrollment_cocs-7yDO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_enrollment_cocs-48bf" ON public.hmis_2022_enrollment_cocs USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_enrollment_cocs-7yDO" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID", data_source_id);
 
 
 --
--- Name: hmis_2022_enrollment_cocs-d4b8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_enrollment_cocs-FvQc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_enrollment_cocs-d4b8" ON public.hmis_2022_enrollment_cocs USING btree ("EnrollmentCoCID", data_source_id);
+CREATE INDEX "hmis_2022_enrollment_cocs-FvQc" ON public.hmis_2022_enrollment_cocs USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_enrollments-0a46; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_enrollments-ZLrC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_enrollments-0a46" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", data_source_id);
+CREATE INDEX "hmis_2022_enrollments-ZLrC" ON public.hmis_2022_enrollments USING btree ("EnrollmentID", data_source_id);
 
 
 --
--- Name: hmis_2022_enrollments-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_enrollments-tQjx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_enrollments-48bf" ON public.hmis_2022_enrollments USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_enrollments-tQjx" ON public.hmis_2022_enrollments USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_events-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_events-ZbIw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_events-48bf" ON public.hmis_2022_events USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_events-ZbIw" ON public.hmis_2022_events USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_events-9f9c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_events-nuXD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_events-9f9c" ON public.hmis_2022_events USING btree ("EventID", data_source_id);
+CREATE INDEX "hmis_2022_events-nuXD" ON public.hmis_2022_events USING btree ("EventID", data_source_id);
 
 
 --
--- Name: hmis_2022_exits-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_exits-EWB7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_exits-48bf" ON public.hmis_2022_exits USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_exits-EWB7" ON public.hmis_2022_exits USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_exits-cfdd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_exits-ievA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_exits-cfdd" ON public.hmis_2022_exits USING btree ("ExitID", data_source_id);
+CREATE INDEX "hmis_2022_exits-ievA" ON public.hmis_2022_exits USING btree ("ExitID", data_source_id);
 
 
 --
--- Name: hmis_2022_exports-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_exports-FtVP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_exports-48bf" ON public.hmis_2022_exports USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_exports-FtVP" ON public.hmis_2022_exports USING btree ("ExportID", data_source_id);
 
 
 --
--- Name: hmis_2022_exports-86be; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_exports-VA0U; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_exports-86be" ON public.hmis_2022_exports USING btree ("ExportID", data_source_id);
+CREATE INDEX "hmis_2022_exports-VA0U" ON public.hmis_2022_exports USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_funders-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_funders-Hnq2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_funders-48bf" ON public.hmis_2022_funders USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_funders-Hnq2" ON public.hmis_2022_funders USING btree ("FunderID", data_source_id);
 
 
 --
--- Name: hmis_2022_funders-4ad5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_funders-oI8n; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_funders-4ad5" ON public.hmis_2022_funders USING btree ("FunderID", data_source_id);
+CREATE INDEX "hmis_2022_funders-oI8n" ON public.hmis_2022_funders USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_health_and_dvs-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_health_and_dvs-a5xh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_health_and_dvs-48bf" ON public.hmis_2022_health_and_dvs USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_health_and_dvs-a5xh" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID", data_source_id);
 
 
 --
--- Name: hmis_2022_health_and_dvs-e384; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_health_and_dvs-i6aV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_health_and_dvs-e384" ON public.hmis_2022_health_and_dvs USING btree ("HealthAndDVID", data_source_id);
+CREATE INDEX "hmis_2022_health_and_dvs-i6aV" ON public.hmis_2022_health_and_dvs USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_income_benefits-200d; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_income_benefits-qiTt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_income_benefits-200d" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID", data_source_id);
+CREATE INDEX "hmis_2022_income_benefits-qiTt" ON public.hmis_2022_income_benefits USING btree ("IncomeBenefitsID", data_source_id);
 
 
 --
--- Name: hmis_2022_income_benefits-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_income_benefits-xJKB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_income_benefits-48bf" ON public.hmis_2022_income_benefits USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_income_benefits-xJKB" ON public.hmis_2022_income_benefits USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_inventories-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_inventories-ADPv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_inventories-48bf" ON public.hmis_2022_inventories USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_inventories-ADPv" ON public.hmis_2022_inventories USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_inventories-86c0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_inventories-fzE8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_inventories-86c0" ON public.hmis_2022_inventories USING btree ("InventoryID", data_source_id);
+CREATE INDEX "hmis_2022_inventories-fzE8" ON public.hmis_2022_inventories USING btree ("InventoryID", data_source_id);
 
 
 --
--- Name: hmis_2022_organizations-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_organizations-BxR1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_organizations-48bf" ON public.hmis_2022_organizations USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_organizations-BxR1" ON public.hmis_2022_organizations USING btree ("OrganizationID", data_source_id);
 
 
 --
--- Name: hmis_2022_organizations-7580; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_organizations-sQqm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_organizations-7580" ON public.hmis_2022_organizations USING btree ("OrganizationID", data_source_id);
+CREATE INDEX "hmis_2022_organizations-sQqm" ON public.hmis_2022_organizations USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_project_cocs-3966; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_project_cocs-mweX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_project_cocs-3966" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID", data_source_id);
+CREATE INDEX "hmis_2022_project_cocs-mweX" ON public.hmis_2022_project_cocs USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_project_cocs-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_project_cocs-pVay; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_project_cocs-48bf" ON public.hmis_2022_project_cocs USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_project_cocs-pVay" ON public.hmis_2022_project_cocs USING btree ("ProjectCoCID", data_source_id);
 
 
 --
--- Name: hmis_2022_projects-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_projects-Y3m1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_projects-48bf" ON public.hmis_2022_projects USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_projects-Y3m1" ON public.hmis_2022_projects USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_projects-92c5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_projects-YEud; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_projects-92c5" ON public.hmis_2022_projects USING btree ("ProjectID", data_source_id);
+CREATE INDEX "hmis_2022_projects-YEud" ON public.hmis_2022_projects USING btree ("ProjectID", data_source_id);
 
 
 --
--- Name: hmis_2022_services-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_services-foCr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_services-48bf" ON public.hmis_2022_services USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_services-foCr" ON public.hmis_2022_services USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_services-7a57; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_services-pqX5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_services-7a57" ON public.hmis_2022_services USING btree ("ServicesID", data_source_id);
+CREATE INDEX "hmis_2022_services-pqX5" ON public.hmis_2022_services USING btree ("ServicesID", data_source_id);
 
 
 --
--- Name: hmis_2022_users-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_users-Z7jb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_users-48bf" ON public.hmis_2022_users USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_users-Z7jb" ON public.hmis_2022_users USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_users-b749; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_users-itNW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_users-b749" ON public.hmis_2022_users USING btree ("UserID", data_source_id);
+CREATE INDEX "hmis_2022_users-itNW" ON public.hmis_2022_users USING btree ("UserID", data_source_id);
 
 
 --
--- Name: hmis_2022_youth_education_statuses-48bf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_youth_education_statuses-6AQe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_youth_education_statuses-48bf" ON public.hmis_2022_youth_education_statuses USING btree (source_type, source_id);
+CREATE INDEX "hmis_2022_youth_education_statuses-6AQe" ON public.hmis_2022_youth_education_statuses USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_2022_youth_education_statuses-a32f; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_2022_youth_education_statuses-JZFL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_2022_youth_education_statuses-a32f" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID", data_source_id);
+CREATE INDEX "hmis_2022_youth_education_statuses-JZFL" ON public.hmis_2022_youth_education_statuses USING btree ("YouthEducationStatusID", data_source_id);
 
 
 --
@@ -31072,31 +32918,31 @@ CREATE INDEX hmis_agg_enrollments_p_id_p_id_ds_id ON public.hmis_aggregated_enro
 
 
 --
--- Name: hmis_aggregated_enrollments-aTmv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_aggregated_enrollments-quLn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "hmis_aggregated_enrollments-aTmv" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "PersonalID", data_source_id);
-
-
---
--- Name: hmis_aggregated_enrollments-qHbn; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_aggregated_enrollments-qHbn" ON public.hmis_aggregated_enrollments USING btree (source_type, source_id);
+CREATE UNIQUE INDEX "hmis_aggregated_enrollments-quLn" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "PersonalID", data_source_id);
 
 
 --
--- Name: hmis_aggregated_exits-FiCn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_aggregated_enrollments-vWhn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX "hmis_aggregated_exits-FiCn" ON public.hmis_aggregated_exits USING btree ("ExitID", data_source_id);
+CREATE INDEX "hmis_aggregated_enrollments-vWhn" ON public.hmis_aggregated_enrollments USING btree (source_type, source_id);
 
 
 --
--- Name: hmis_aggregated_exits-Nmym; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_aggregated_exits-CKc1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_aggregated_exits-Nmym" ON public.hmis_aggregated_exits USING btree (source_type, source_id);
+CREATE UNIQUE INDEX "hmis_aggregated_exits-CKc1" ON public.hmis_aggregated_exits USING btree ("ExitID", data_source_id);
+
+
+--
+-- Name: hmis_aggregated_exits-LxzY; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_aggregated_exits-LxzY" ON public.hmis_aggregated_exits USING btree (source_type, source_id);
 
 
 --
@@ -32108,164 +33954,164 @@ CREATE INDEX "hmis_csv_2020_users-Y4OW" ON public.hmis_csv_2020_users USING btre
 
 
 --
--- Name: hmis_csv_2022_affiliations-6457; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_affiliations-yZj0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_affiliations-6457" ON public.hmis_csv_2022_affiliations USING btree ("AffiliationID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_assessment_questions-0cd3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_assessment_questions-0cd3" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentQuestionID", data_source_id);
+CREATE INDEX "hmis_csv_2022_affiliations-yZj0" ON public.hmis_csv_2022_affiliations USING btree ("AffiliationID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_assessment_results-d6c9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_assessment_questions-Lm4v; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_assessment_results-d6c9" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentResultID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_assessments-df76; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_assessments-df76" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID", data_source_id);
+CREATE INDEX "hmis_csv_2022_assessment_questions-Lm4v" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentQuestionID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_clients-230f; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_assessment_results-Pjh3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_clients-230f" ON public.hmis_csv_2022_clients USING btree ("PersonalID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_current_living_situations-cf31; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_current_living_situations-cf31" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID", data_source_id);
+CREATE INDEX "hmis_csv_2022_assessment_results-Pjh3" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentResultID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_disabilities-7712; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_assessments-2IK5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_disabilities-7712" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_employment_educations-3032; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_employment_educations-3032" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID", data_source_id);
+CREATE INDEX "hmis_csv_2022_assessments-2IK5" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_enrollment_cocs-d4b8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_clients-EXKY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_enrollment_cocs-d4b8" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_enrollments-0a46; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_enrollments-0a46" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", data_source_id);
+CREATE INDEX "hmis_csv_2022_clients-EXKY" ON public.hmis_csv_2022_clients USING btree ("PersonalID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_events-9f9c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_current_living_situations-eCJZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_events-9f9c" ON public.hmis_csv_2022_events USING btree ("EventID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_exits-cfdd; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_exits-cfdd" ON public.hmis_csv_2022_exits USING btree ("ExitID", data_source_id);
+CREATE INDEX "hmis_csv_2022_current_living_situations-eCJZ" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_exports-86be; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_disabilities-Fla5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_exports-86be" ON public.hmis_csv_2022_exports USING btree ("ExportID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_funders-4ad5; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_funders-4ad5" ON public.hmis_csv_2022_funders USING btree ("FunderID", data_source_id);
+CREATE INDEX "hmis_csv_2022_disabilities-Fla5" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_health_and_dvs-e384; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_employment_educations-Y7Gt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_health_and_dvs-e384" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_income_benefits-200d; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_income_benefits-200d" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID", data_source_id);
+CREATE INDEX "hmis_csv_2022_employment_educations-Y7Gt" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_inventories-86c0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_enrollment_cocs-Uwmr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_inventories-86c0" ON public.hmis_csv_2022_inventories USING btree ("InventoryID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_organizations-7580; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_organizations-7580" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID", data_source_id);
+CREATE INDEX "hmis_csv_2022_enrollment_cocs-Uwmr" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_project_cocs-3966; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_enrollments-txfr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_project_cocs-3966" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_projects-92c5; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_projects-92c5" ON public.hmis_csv_2022_projects USING btree ("ProjectID", data_source_id);
+CREATE INDEX "hmis_csv_2022_enrollments-txfr" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_services-7a57; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_events-VVGy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_services-7a57" ON public.hmis_csv_2022_services USING btree ("ServicesID", data_source_id);
-
-
---
--- Name: hmis_csv_2022_users-b749; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmis_csv_2022_users-b749" ON public.hmis_csv_2022_users USING btree ("UserID", data_source_id);
+CREATE INDEX "hmis_csv_2022_events-VVGy" ON public.hmis_csv_2022_events USING btree ("EventID", data_source_id);
 
 
 --
--- Name: hmis_csv_2022_youth_education_statuses-a32f; Type: INDEX; Schema: public; Owner: -
+-- Name: hmis_csv_2022_exits-DVBe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmis_csv_2022_youth_education_statuses-a32f" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID", data_source_id);
+CREATE INDEX "hmis_csv_2022_exits-DVBe" ON public.hmis_csv_2022_exits USING btree ("ExitID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_exports-YeUC; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_exports-YeUC" ON public.hmis_csv_2022_exports USING btree ("ExportID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_funders-wdDT; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_funders-wdDT" ON public.hmis_csv_2022_funders USING btree ("FunderID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_health_and_dvs-Si3A; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_health_and_dvs-Si3A" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_income_benefits-WgJx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_income_benefits-WgJx" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_inventories-iTQg; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_inventories-iTQg" ON public.hmis_csv_2022_inventories USING btree ("InventoryID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_organizations-Pgis; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_organizations-Pgis" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_project_cocs-maeA; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_project_cocs-maeA" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_projects-9NSZ; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_projects-9NSZ" ON public.hmis_csv_2022_projects USING btree ("ProjectID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_services-XAuh; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_services-XAuh" ON public.hmis_csv_2022_services USING btree ("ServicesID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_users-Q4Qa; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_users-Q4Qa" ON public.hmis_csv_2022_users USING btree ("UserID", data_source_id);
+
+
+--
+-- Name: hmis_csv_2022_youth_education_statuses-FSD5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "hmis_csv_2022_youth_education_statuses-FSD5" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID", data_source_id);
 
 
 --
@@ -32283,4798 +34129,3874 @@ CREATE INDEX "hmis_csv_validations-ONiu" ON public.hmis_csv_import_validations U
 
 
 --
--- Name: hmisaggregatedenrollments_1KEG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_0XsD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_1KEG" ON public.hmis_aggregated_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmisaggregatedenrollments_0XsD" ON public.hmis_aggregated_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmisaggregatedenrollments_A5GJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_CJm8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_A5GJ" ON public.hmis_aggregated_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmisaggregatedenrollments_CJm8" ON public.hmis_aggregated_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmisaggregatedenrollments_FHjE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_EGDJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_FHjE" ON public.hmis_aggregated_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmisaggregatedenrollments_EGDJ" ON public.hmis_aggregated_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmisaggregatedenrollments_NHNS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_HIJy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_NHNS" ON public.hmis_aggregated_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmisaggregatedenrollments_HIJy" ON public.hmis_aggregated_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmisaggregatedenrollments_QCCR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_IzKV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_QCCR" ON public.hmis_aggregated_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmisaggregatedenrollments_IzKV" ON public.hmis_aggregated_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmisaggregatedenrollments_Uv3q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_Ourx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_Uv3q" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmisaggregatedenrollments_Ourx" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmisaggregatedenrollments_V6EX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_Qpy4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_V6EX" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmisaggregatedenrollments_Qpy4" ON public.hmis_aggregated_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmisaggregatedenrollments_VpLz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_R6Nr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_VpLz" ON public.hmis_aggregated_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmisaggregatedenrollments_R6Nr" ON public.hmis_aggregated_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmisaggregatedenrollments_bGvX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_W1n5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_bGvX" ON public.hmis_aggregated_enrollments USING btree ("ExportID");
+CREATE INDEX "hmisaggregatedenrollments_W1n5" ON public.hmis_aggregated_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmisaggregatedenrollments_bHWN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_WGGC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_bHWN" ON public.hmis_aggregated_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmisaggregatedenrollments_WGGC" ON public.hmis_aggregated_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmisaggregatedenrollments_c08h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_ZXD1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmisaggregatedenrollments_c08h ON public.hmis_aggregated_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmisaggregatedenrollments_ZXD1" ON public.hmis_aggregated_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmisaggregatedenrollments_eq3c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_cJhP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmisaggregatedenrollments_eq3c ON public.hmis_aggregated_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmisaggregatedenrollments_cJhP" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmisaggregatedenrollments_kHZg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_eAWX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_kHZg" ON public.hmis_aggregated_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmisaggregatedenrollments_eAWX" ON public.hmis_aggregated_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmisaggregatedenrollments_kQyq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_gnFl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_kQyq" ON public.hmis_aggregated_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmisaggregatedenrollments_gnFl" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmisaggregatedenrollments_naBW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_h1EK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_naBW" ON public.hmis_aggregated_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmisaggregatedenrollments_h1EK" ON public.hmis_aggregated_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmisaggregatedenrollments_oNYR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_krj2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_oNYR" ON public.hmis_aggregated_enrollments USING btree ("EntryDate");
+CREATE INDEX hmisaggregatedenrollments_krj2 ON public.hmis_aggregated_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmisaggregatedenrollments_uy6S; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedenrollments_vv2K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedenrollments_uy6S" ON public.hmis_aggregated_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmisaggregatedenrollments_vv2K" ON public.hmis_aggregated_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmisaggregatedexits_3LO0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_8XAf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_3LO0" ON public.hmis_aggregated_exits USING btree ("ExportID");
+CREATE INDEX "hmisaggregatedexits_8XAf" ON public.hmis_aggregated_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmisaggregatedexits_IHNR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_93wt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_IHNR" ON public.hmis_aggregated_exits USING btree ("DateDeleted");
+CREATE INDEX hmisaggregatedexits_93wt ON public.hmis_aggregated_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmisaggregatedexits_IKVS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_AWPj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_IKVS" ON public.hmis_aggregated_exits USING btree ("DateCreated");
+CREATE INDEX "hmisaggregatedexits_AWPj" ON public.hmis_aggregated_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmisaggregatedexits_XuIA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_NVov; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_XuIA" ON public.hmis_aggregated_exits USING btree ("ExitID");
+CREATE INDEX "hmisaggregatedexits_NVov" ON public.hmis_aggregated_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmisaggregatedexits_YcRf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_RgPV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_YcRf" ON public.hmis_aggregated_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmisaggregatedexits_RgPV" ON public.hmis_aggregated_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmisaggregatedexits_bSNd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_VhMe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_bSNd" ON public.hmis_aggregated_exits USING btree ("PersonalID");
+CREATE INDEX "hmisaggregatedexits_VhMe" ON public.hmis_aggregated_exits USING btree ("ExportID");
 
 
 --
--- Name: hmisaggregatedexits_rDFN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_Y7My; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_rDFN" ON public.hmis_aggregated_exits USING btree ("ExitDate");
+CREATE INDEX "hmisaggregatedexits_Y7My" ON public.hmis_aggregated_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmisaggregatedexits_tmOV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmisaggregatedexits_lFrL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmisaggregatedexits_tmOV" ON public.hmis_aggregated_exits USING btree ("DateUpdated");
+CREATE INDEX "hmisaggregatedexits_lFrL" ON public.hmis_aggregated_exits USING btree ("ExitID");
 
 
 --
--- Name: hmiscsv2022affiliations_6QZN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022affiliations_A80f; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022affiliations_6QZN" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022affiliations_A80f" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022affiliations_IYWP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022affiliations_Ap65; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022affiliations_IYWP" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022affiliations_Ap65" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022affiliations_K0pm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022affiliations_XIXF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022affiliations_K0pm" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022affiliations_XIXF" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022affiliations_ZrIt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022affiliations_n1uq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022affiliations_ZrIt" ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
+CREATE INDEX hmiscsv2022affiliations_n1uq ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022affiliations_ayf6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_1gU0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022affiliations_ayf6 ON public.hmis_csv_2022_affiliations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentquestions_1gU0" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_0Hnw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_6Bfn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_0Hnw" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentquestions_6Bfn" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_9OKb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_8ZkR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_9OKb" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessmentquestions_8ZkR" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_BYOc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_E6nI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_BYOc" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentquestions_E6nI" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_Ce5I; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_EdS6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_Ce5I" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessmentquestions_EdS6" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_Wboq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_HwrR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_Wboq" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessmentquestions_HwrR" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_YiRf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_eB1i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_YiRf" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentquestions_eB1i" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_b7du; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentquestions_zfhQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022assessmentquestions_b7du ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessmentquestions_zfhQ" ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_f92d; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_3yhu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022assessmentquestions_f92d ON public.hmis_csv_2022_assessment_questions USING btree ("AssessmentID");
+CREATE INDEX hmiscsv2022assessmentresults_3yhu ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_tkC5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_DE9M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_tkC5" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentresults_DE9M" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentquestions_zaOr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_Df0i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentquestions_zaOr" ON public.hmis_csv_2022_assessment_questions USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentresults_Df0i" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_FEyR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_b1ii; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_FEyR" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX hmiscsv2022assessmentresults_b1ii ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_HXI3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_izyI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_HXI3" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentresults_izyI" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_IHby; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_odLf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_IHby" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentresults_odLf" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_Kx2Z; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_uwAj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_Kx2Z" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessmentresults_uwAj" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_WyDM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessmentresults_xuPu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_WyDM" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessmentresults_xuPu" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_deg4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_0mtA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022assessmentresults_deg4 ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessments_0mtA" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmiscsv2022assessmentresults_fmqe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_1uad; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022assessmentresults_fmqe ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX hmiscsv2022assessments_1uad ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_jF3M; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_4CUp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_jF3M" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessments_4CUp" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmiscsv2022assessmentresults_mcU2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_FOx0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_mcU2" ON public.hmis_csv_2022_assessment_results USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessments_FOx0" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessmentresults_tz9L; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_J9a7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessmentresults_tz9L" ON public.hmis_csv_2022_assessment_results USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessments_J9a7" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022assessments_2PIZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_KFAj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_2PIZ" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmiscsv2022assessments_KFAj" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022assessments_53fu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_M4Gh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022assessments_53fu ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmiscsv2022assessments_M4Gh" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022assessments_7pXC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_PtzT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_7pXC" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessments_PtzT" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022assessments_9pYi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_QqyU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_9pYi" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022assessments_QqyU" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessments_BR24; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_TkNk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_BR24" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessments_TkNk" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessments_C04R; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_V7aT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_C04R" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022assessments_V7aT" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022assessments_NGHw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_cHwX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_NGHw" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022assessments_cHwX" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmiscsv2022assessments_NaP9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_eHvi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_NaP9" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022assessments_eHvi" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022assessments_OGHC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_opK8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_OGHC" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022assessments_opK8" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessments_Pd8t; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_q30o; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_Pd8t" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
+CREATE INDEX hmiscsv2022assessments_q30o ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022assessments_Rg8h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_qp6C; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_Rg8h" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmiscsv2022assessments_qp6C" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessments_Rthi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_sqxb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_Rthi" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022assessments_sqxb ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
 
 
 --
--- Name: hmiscsv2022assessments_UlUg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_tx7y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_UlUg" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
+CREATE INDEX hmiscsv2022assessments_tx7y ON public.hmis_csv_2022_assessments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessments_UsZf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_wJAy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_UsZf" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX "hmiscsv2022assessments_wJAy" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
 
 
 --
--- Name: hmiscsv2022assessments_V72H; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022assessments_zyr4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_V72H" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX hmiscsv2022assessments_zyr4 ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022assessments_X4D5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_0KKm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_X4D5" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022clients_0KKm" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022assessments_ZFcY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_0zvv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_ZFcY" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022clients_0zvv ON public.hmis_csv_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmiscsv2022assessments_bNif; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_2nNz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_bNif" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022clients_2nNz" ON public.hmis_csv_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmiscsv2022assessments_iP36; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_57gv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_iP36" ON public.hmis_csv_2022_assessments USING btree ("AssessmentDate");
+CREATE INDEX hmiscsv2022clients_57gv ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022assessments_mO4c; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_B2cr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_mO4c" ON public.hmis_csv_2022_assessments USING btree ("AssessmentID");
+CREATE INDEX "hmiscsv2022clients_B2cr" ON public.hmis_csv_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmiscsv2022assessments_peUV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_CrgQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_peUV" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022clients_CrgQ" ON public.hmis_csv_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022assessments_rDxW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_DgQk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_rDxW" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022clients_DgQk" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022assessments_rylL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_F2zq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_rylL" ON public.hmis_csv_2022_assessments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022clients_F2zq" ON public.hmis_csv_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmiscsv2022assessments_tGj7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Fwlr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_tGj7" ON public.hmis_csv_2022_assessments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022clients_Fwlr" ON public.hmis_csv_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmiscsv2022assessments_vgMX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_IVCg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022assessments_vgMX" ON public.hmis_csv_2022_assessments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022clients_IVCg" ON public.hmis_csv_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_1B2M; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Idqk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_1B2M" ON public.hmis_csv_2022_clients USING btree ("DOB");
+CREATE INDEX "hmiscsv2022clients_Idqk" ON public.hmis_csv_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmiscsv2022clients_2g9p; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_JsGY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022clients_2g9p ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022clients_JsGY" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_4Erz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_OGq8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_4Erz" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmiscsv2022clients_OGq8" ON public.hmis_csv_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmiscsv2022clients_9y96; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Ofmf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022clients_9y96 ON public.hmis_csv_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022clients_Ofmf" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022clients_ANF3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Pw84; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_ANF3" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022clients_Pw84" ON public.hmis_csv_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmiscsv2022clients_ATux; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_QOlp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_ATux" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022clients_QOlp" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022clients_AblB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_QUpS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_AblB" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022clients_QUpS" ON public.hmis_csv_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmiscsv2022clients_CftS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_SPYV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_CftS" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmiscsv2022clients_SPYV" ON public.hmis_csv_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_DFQP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_TLxj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_DFQP" ON public.hmis_csv_2022_clients USING btree ("LastName");
+CREATE INDEX "hmiscsv2022clients_TLxj" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmiscsv2022clients_DlZc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_TQ32; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_DlZc" ON public.hmis_csv_2022_clients USING btree ("DOB");
+CREATE INDEX "hmiscsv2022clients_TQ32" ON public.hmis_csv_2022_clients USING btree ("DOB");
 
 
 --
--- Name: hmiscsv2022clients_Go11; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_VmWg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_Go11" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmiscsv2022clients_VmWg" ON public.hmis_csv_2022_clients USING btree ("LastName");
 
 
 --
--- Name: hmiscsv2022clients_HMAT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_XiEI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_HMAT" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022clients_XiEI" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022clients_HyWK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Yect; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_HyWK" ON public.hmis_csv_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022clients_Yect" ON public.hmis_csv_2022_clients USING btree ("FirstName");
 
 
 --
--- Name: hmiscsv2022clients_Ipa3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_Zpws; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_Ipa3" ON public.hmis_csv_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmiscsv2022clients_Zpws" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_SPth; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_ai3k; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_SPth" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022clients_ai3k ON public.hmis_csv_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022clients_Tyfa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_fb0i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_Tyfa" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022clients_fb0i ON public.hmis_csv_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022clients_UOq6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_hHj3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_UOq6" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmiscsv2022clients_hHj3" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022clients_Ue7r; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_hkl2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_Ue7r" ON public.hmis_csv_2022_clients USING btree ("LastName");
+CREATE INDEX hmiscsv2022clients_hkl2 ON public.hmis_csv_2022_clients USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_XjIr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_iHs5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_XjIr" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022clients_iHs5" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmiscsv2022clients_ZIZI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_jhdy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_ZIZI" ON public.hmis_csv_2022_clients USING btree ("DOB");
+CREATE INDEX hmiscsv2022clients_jhdy ON public.hmis_csv_2022_clients USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_ZbiK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_plWM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_ZbiK" ON public.hmis_csv_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022clients_plWM" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmiscsv2022clients_bTWy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022clients_rNUg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_bTWy" ON public.hmis_csv_2022_clients USING btree ("DOB");
+CREATE INDEX "hmiscsv2022clients_rNUg" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
 
 
 --
--- Name: hmiscsv2022clients_dpoO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_2475; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_dpoO" ON public.hmis_csv_2022_clients USING btree ("FirstName");
+CREATE INDEX hmiscsv2022currentlivingsituations_2475 ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_dxgO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_3YmW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_dxgO" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022currentlivingsituations_3YmW" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022clients_hLhh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_4Fch; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_hLhh" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022currentlivingsituations_4Fch" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_ilET; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_8FAq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_ilET" ON public.hmis_csv_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_8FAq" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022clients_jtrl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_DlZD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022clients_jtrl ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022currentlivingsituations_DlZD" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022clients_lhQG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_GHK6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_lhQG" ON public.hmis_csv_2022_clients USING btree ("LastName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_GHK6" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022clients_nEPb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_IZ3u; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_nEPb" ON public.hmis_csv_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_IZ3u" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_nuV1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_P3s7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_nuV1" ON public.hmis_csv_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_P3s7" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022clients_oEBV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_Q31M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_oEBV" ON public.hmis_csv_2022_clients USING btree ("LastName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_Q31M" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmiscsv2022clients_preE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_QJQT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_preE" ON public.hmis_csv_2022_clients USING btree ("DOB");
+CREATE INDEX "hmiscsv2022currentlivingsituations_QJQT" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmiscsv2022clients_qxVi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_QP9G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_qxVi" ON public.hmis_csv_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_QP9G" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022clients_tVth; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_Szav; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_tVth" ON public.hmis_csv_2022_clients USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_Szav" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_tWOM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_WhCB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_tWOM" ON public.hmis_csv_2022_clients USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022currentlivingsituations_WhCB" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022clients_u5Dy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_WmDq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_u5Dy" ON public.hmis_csv_2022_clients USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022currentlivingsituations_WmDq" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022clients_vJDq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_Wug1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_vJDq" ON public.hmis_csv_2022_clients USING btree ("VeteranStatus");
+CREATE INDEX "hmiscsv2022currentlivingsituations_Wug1" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmiscsv2022clients_xYa1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_X2am; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_xYa1" ON public.hmis_csv_2022_clients USING btree ("LastName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_X2am" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_yj7O; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_awcW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_yj7O" ON public.hmis_csv_2022_clients USING btree ("FirstName");
+CREATE INDEX "hmiscsv2022currentlivingsituations_awcW" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022clients_zrAC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_dBOx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022clients_zrAC" ON public.hmis_csv_2022_clients USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_dBOx" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_0QjY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_hX53; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_0QjY" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_hX53" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_0whq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_iM8O; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022currentlivingsituations_0whq ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmiscsv2022currentlivingsituations_iM8O" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_2ix3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_jc5g; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022currentlivingsituations_2ix3 ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022currentlivingsituations_jc5g ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_79om; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_w3BB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022currentlivingsituations_79om ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022currentlivingsituations_w3BB" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_G53q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_yVda; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_G53q" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_yVda" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_IbRS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022currentlivingsituations_yaUa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_IbRS" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022currentlivingsituations_yaUa" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_L04m; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_22JK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_L04m" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmiscsv2022disabilities_22JK" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_L44P; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_3vPj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_L44P" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022disabilities_3vPj" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_Lu7u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_4syY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_Lu7u" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022disabilities_4syY" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_MBRO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_7V5r; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_MBRO" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022disabilities_7V5r" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_OoDu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_8UgZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_OoDu" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmiscsv2022disabilities_8UgZ" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_Rgzv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_8z8G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_Rgzv" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmiscsv2022disabilities_8z8G" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_Rq1z; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_BxgA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_Rq1z" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmiscsv2022disabilities_BxgA" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_Wec8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_EBkK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_Wec8" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022disabilities_EBkK" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_Zwl1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_FPEJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_Zwl1" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022disabilities_FPEJ" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_beIg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_I87W; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_beIg" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022disabilities_I87W" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_c7Fg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_KnXJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_c7Fg" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmiscsv2022disabilities_KnXJ" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_dUT6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_LRoI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_dUT6" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022disabilities_LRoI" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_hxGV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_LdNK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_hxGV" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022disabilities_LdNK" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_iNeW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_MZLK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_iNeW" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022disabilities_MZLK" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_lc17; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_UpY0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022currentlivingsituations_lc17 ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmiscsv2022disabilities_UpY0" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_oN7a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_WJxK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_oN7a" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSituation");
+CREATE INDEX "hmiscsv2022disabilities_WJxK" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_prGC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_WLmb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_prGC" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022disabilities_WLmb" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_qJOi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_a6i6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_qJOi" ON public.hmis_csv_2022_current_living_situations USING btree ("ExportID");
+CREATE INDEX hmiscsv2022disabilities_a6i6 ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_ttmJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_lbKX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_ttmJ" ON public.hmis_csv_2022_current_living_situations USING btree ("CurrentLivingSitID");
+CREATE INDEX "hmiscsv2022disabilities_lbKX" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_xWxO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_mPmU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_xWxO" ON public.hmis_csv_2022_current_living_situations USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022disabilities_mPmU" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_y4vM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_q2sw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_y4vM" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022disabilities_q2sw ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_yXYJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_vV1G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_yXYJ" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022disabilities_vV1G" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_z0XS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_vkkq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_z0XS" ON public.hmis_csv_2022_current_living_situations USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022disabilities_vkkq ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022currentlivingsituations_zYGE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022disabilities_wKOS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022currentlivingsituations_zYGE" ON public.hmis_csv_2022_current_living_situations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022disabilities_wKOS" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022disabilities_0FAj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_0p38; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_0FAj" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022employmenteducations_0p38 ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmiscsv2022disabilities_14pD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_22WO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_14pD" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmiscsv2022employmenteducations_22WO" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022disabilities_3jSy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_5N02; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_3jSy" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022employmenteducations_5N02" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022disabilities_6NwA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_5t10; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_6NwA" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022employmenteducations_5t10 ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022disabilities_6PJV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_AR0V; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_6PJV" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022employmenteducations_AR0V" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022disabilities_ARC4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_Csvn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_ARC4" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022employmenteducations_Csvn" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_BfOC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_DIxZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_BfOC" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmiscsv2022employmenteducations_DIxZ" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022disabilities_DUOj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_HI3F; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_DUOj" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022employmenteducations_HI3F" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_Gwg7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_MK0K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_Gwg7" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022employmenteducations_MK0K" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022disabilities_HfAi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_PT4W; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_HfAi" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022employmenteducations_PT4W" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_Ia96; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_QAmv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_Ia96" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022employmenteducations_QAmv" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022disabilities_JS03; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_X99g; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_JS03" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmiscsv2022employmenteducations_X99g" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022disabilities_JlIz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_ZUio; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_JlIz" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022employmenteducations_ZUio" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmiscsv2022disabilities_MLpw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_ahrN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_MLpw" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022employmenteducations_ahrN" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022disabilities_NAn7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_arDA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_NAn7" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022employmenteducations_arDA" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022disabilities_OFo6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_bpAy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_OFo6" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022employmenteducations_bpAy" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_OMdy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_do8K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_OMdy" ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022employmenteducations_do8K" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022disabilities_Olzq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_kmMU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_Olzq" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022employmenteducations_kmMU" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmiscsv2022disabilities_Tf5p; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_pHPm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_Tf5p" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmiscsv2022employmenteducations_pHPm" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022disabilities_TwHW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_rOxF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_TwHW" ON public.hmis_csv_2022_disabilities USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022employmenteducations_rOxF" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022disabilities_VMgh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_s15F; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_VMgh" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022employmenteducations_s15F" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022disabilities_bckS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_ue6K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_bckS" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022employmenteducations_ue6K" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
 
 
 --
--- Name: hmiscsv2022disabilities_dHHy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_yCD4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_dHHy" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022employmenteducations_yCD4" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022disabilities_eK81; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022employmenteducations_yh2H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_eK81" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022employmenteducations_yh2H" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022disabilities_fd6N; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_6vNM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_fd6N" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_6vNM" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_jDA7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_8HfO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_jDA7" ON public.hmis_csv_2022_disabilities USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_8HfO" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmiscsv2022disabilities_jabB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_8lDf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_jabB" ON public.hmis_csv_2022_disabilities USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_8lDf" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022disabilities_kUs4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_Aedi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_kUs4" ON public.hmis_csv_2022_disabilities USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_Aedi" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022disabilities_xTGY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_HMrt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022disabilities_xTGY" ON public.hmis_csv_2022_disabilities USING btree ("DisabilitiesID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_HMrt" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022disabilities_y3fv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_HZH0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022disabilities_y3fv ON public.hmis_csv_2022_disabilities USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_HZH0" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_6eDi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_KHtZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_6eDi" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_KHtZ" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmiscsv2022employmenteducations_78id; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_LfnC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022employmenteducations_78id ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_LfnC" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmiscsv2022employmenteducations_8Z2N; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_MUEh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_8Z2N" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_MUEh" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022employmenteducations_A6mw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_QuHy; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_A6mw" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_QuHy" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_AiJX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_R5g6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_AiJX" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_R5g6" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_EVib; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_Rnec; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_EVib" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_Rnec" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_F0mG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_SCRw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_F0mG" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_SCRw" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_FiLV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_SZte; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_FiLV" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_SZte" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_LI7n; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_UAPz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_LI7n" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_UAPz" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022employmenteducations_MSFC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_WXsj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_MSFC" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_WXsj" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_NAxg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_bEk1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_NAxg" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_bEk1" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_NbWu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_bpQ2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_NbWu" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_bpQ2" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmiscsv2022employmenteducations_R9hB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_cRm1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_R9hB" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_cRm1" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_Ysak; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_edtx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_Ysak" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022enrollmentcocs_edtx ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_Yxep; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_gUXq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_Yxep" ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_gUXq" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_ZbXO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_iWNQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_ZbXO" ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_iWNQ" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_bJWx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_nmt7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_bJWx" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022enrollmentcocs_nmt7 ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
 
 
 --
--- Name: hmiscsv2022employmenteducations_cugU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_oRxx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_cugU" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_oRxx" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_dRqv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_p8Rm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_dRqv" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_p8Rm" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_fmAi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_qBwA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_fmAi" ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_qBwA" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_iobe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_qT6H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022employmenteducations_iobe ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_qT6H" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022employmenteducations_j9oN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_qmMX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_j9oN" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_qmMX" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_lIAh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_retN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_lIAh" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollmentcocs_retN" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_mmce; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_sq0r; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022employmenteducations_mmce ON public.hmis_csv_2022_employment_educations USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022enrollmentcocs_sq0r ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_ocww; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_u6a6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022employmenteducations_ocww ON public.hmis_csv_2022_employment_educations USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022enrollmentcocs_u6a6 ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_oprT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollmentcocs_yPSw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_oprT" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollmentcocs_yPSw" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_ozcJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_1SYw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_ozcJ" ON public.hmis_csv_2022_employment_educations USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_1SYw" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022employmenteducations_skDR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_1pbA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_skDR" ON public.hmis_csv_2022_employment_educations USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_1pbA" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022employmenteducations_wddn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_1tQi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022employmenteducations_wddn ON public.hmis_csv_2022_employment_educations USING btree ("EmploymentEducationID");
+CREATE INDEX "hmiscsv2022enrollments_1tQi" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmiscsv2022employmenteducations_zwTX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_2X9m; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022employmenteducations_zwTX" ON public.hmis_csv_2022_employment_educations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_2X9m" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_0IAL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_3CGm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_0IAL" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022enrollments_3CGm" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_1Xm2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_6TLU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_1Xm2" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022enrollments_6TLU" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_1dHp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_8Cm4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_1dHp" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollments_8Cm4" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_8MhC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_8jXw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_8MhC" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_8jXw" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_CkJU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_9V5n; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_CkJU" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_9V5n" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_DOSa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_9tKq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_DOSa" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmiscsv2022enrollments_9tKq" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_EYBf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_9wWd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_EYBf" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_9wWd" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_FwbF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_9xYn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_FwbF" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022enrollments_9xYn" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_GQqO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_AZom; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_GQqO" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_AZom" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_GuqN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_DEvw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_GuqN" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_DEvw" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_MbjI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_Dwbx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_MbjI" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_Dwbx" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_RAnO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_GL9N; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_RAnO" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_GL9N" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_RFoA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_Gqtf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_RFoA" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_Gqtf" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_RWu2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_H9Um; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_RWu2" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_H9Um" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_SbfY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_JIyi; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_SbfY" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmiscsv2022enrollments_JIyi" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_Uzo4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_LkfK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_Uzo4" ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_LkfK" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_VVbQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_LlZW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_VVbQ" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmiscsv2022enrollments_LlZW" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_WRnl; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_M2D9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_WRnl" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmiscsv2022enrollments_M2D9" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_XgoM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_NELQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_XgoM" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollments_NELQ" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_Yhrm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_NgcN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_Yhrm" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollments_NgcN" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_ZMp3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_NiZa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_ZMp3" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022enrollments_NiZa" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_aC6n; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_NoKe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_aC6n" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_NoKe" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_axDz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_OADB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_axDz" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmiscsv2022enrollments_OADB" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_caGj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_OfYH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_caGj" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022enrollments_OfYH" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_cezi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_OscW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollmentcocs_cezi ON public.hmis_csv_2022_enrollment_cocs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_OscW" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_emcB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_PGYl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_emcB" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmiscsv2022enrollments_PGYl" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_g5J5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_Q1YG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_g5J5" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_Q1YG" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_gXcN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_R1Sx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_gXcN" ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_R1Sx" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_iz8D; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_RDyb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_iz8D" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022enrollments_RDyb" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_mKux; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_RXy6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_mKux" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_RXy6" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_nt0O; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_S2hr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_nt0O" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmiscsv2022enrollments_S2hr" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_oCoG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_T7Z8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_oCoG" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_T7Z8" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_p3i5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_TArd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollmentcocs_p3i5 ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmiscsv2022enrollments_TArd" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_pfEL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_U7AO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_pfEL" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentCoCID");
+CREATE INDEX "hmiscsv2022enrollments_U7AO" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_pmSf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_WXDQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_pmSf" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_WXDQ" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_qsT9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_Wyog; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_qsT9" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_Wyog" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_wcbV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_Yp53; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_wcbV" ON public.hmis_csv_2022_enrollment_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022enrollments_Yp53" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_wiac; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_aKx6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollmentcocs_wiac ON public.hmis_csv_2022_enrollment_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_aKx6" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_ybyR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_arHZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_ybyR" ON public.hmis_csv_2022_enrollment_cocs USING btree ("CoCCode");
+CREATE INDEX "hmiscsv2022enrollments_arHZ" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollmentcocs_zIJt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_d14d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollmentcocs_zIJt" ON public.hmis_csv_2022_enrollment_cocs USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022enrollments_d14d ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_000u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_dHhP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_000u ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmiscsv2022enrollments_dHhP" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollments_02Gq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_eH6t; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_02Gq" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_eH6t" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_04uI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_f4Sd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_04uI" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmiscsv2022enrollments_f4Sd" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollments_0CSP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_fTfT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_0CSP" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmiscsv2022enrollments_fTfT" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_0HUb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_h5Es; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_0HUb" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmiscsv2022enrollments_h5Es" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollments_0x3v; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_im4n; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_0x3v ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX hmiscsv2022enrollments_im4n ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollments_1O7e; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_ju3y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_1O7e" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
+CREATE INDEX hmiscsv2022enrollments_ju3y ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollments_1jXQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_lTXE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_1jXQ" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmiscsv2022enrollments_lTXE" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmiscsv2022enrollments_2KUN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_mHJL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_2KUN" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmiscsv2022enrollments_mHJL" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollments_2Uh6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_mo3v; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_2Uh6" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX hmiscsv2022enrollments_mo3v ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
 
 
 --
--- Name: hmiscsv2022enrollments_2W2h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_n53y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_2W2h" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX hmiscsv2022enrollments_n53y ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022enrollments_5Od1; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_pWbu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_5Od1" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_pWbu" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
 
 
 --
--- Name: hmiscsv2022enrollments_6RGw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_rLbm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_6RGw" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022enrollments_rLbm" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollments_6xDx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_sQV3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_6xDx" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmiscsv2022enrollments_sQV3" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmiscsv2022enrollments_9KtN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_stPv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_9KtN" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022enrollments_stPv" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
 
 
 --
--- Name: hmiscsv2022enrollments_COSj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_taDR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_COSj" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmiscsv2022enrollments_taDR" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_DEbx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_tlAI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_DEbx" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmiscsv2022enrollments_tlAI" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
 
 
 --
--- Name: hmiscsv2022enrollments_G41a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_v4ap; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_G41a" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022enrollments_v4ap ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_G6mN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_vvPP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_G6mN" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022enrollments_vvPP" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
 
 
 --
--- Name: hmiscsv2022enrollments_HAgm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_wFkt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_HAgm" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmiscsv2022enrollments_wFkt" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_INhf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_wxZJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_INhf" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmiscsv2022enrollments_wxZJ" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
 
 
 --
--- Name: hmiscsv2022enrollments_Jfc4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_x61e; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Jfc4" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022enrollments_x61e ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollments_Kbfs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_xmRM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Kbfs" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmiscsv2022enrollments_xmRM" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_Knt6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022enrollments_yt2K; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Knt6" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmiscsv2022enrollments_yt2K" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_LOT5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_3RTU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_LOT5" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022events_3RTU" ON public.hmis_csv_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_LVhZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_6KWu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_LVhZ" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmiscsv2022events_6KWu" ON public.hmis_csv_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_Lr7G; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_761p; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Lr7G" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX hmiscsv2022events_761p ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_N5Wd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_CkrU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_N5Wd" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022events_CkrU" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_NGvh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_EmtY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_NGvh" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmiscsv2022events_EmtY" ON public.hmis_csv_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmiscsv2022enrollments_OvVn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_FURv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_OvVn" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmiscsv2022events_FURv" ON public.hmis_csv_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmiscsv2022enrollments_PKib; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_HncU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_PKib" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmiscsv2022events_HncU" ON public.hmis_csv_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_PZWA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_JroF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_PZWA" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmiscsv2022events_JroF" ON public.hmis_csv_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_QE4p; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_NJuB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_QE4p" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022events_NJuB" ON public.hmis_csv_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmiscsv2022enrollments_QJf5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_RsQR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_QJf5" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmiscsv2022events_RsQR" ON public.hmis_csv_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_QqES; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_SKqh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_QqES" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022events_SKqh" ON public.hmis_csv_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmiscsv2022enrollments_S95a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_WAif; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_S95a" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmiscsv2022events_WAif" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_SIaS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_bQjX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_SIaS" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022events_bQjX" ON public.hmis_csv_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_TUkM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_cnjU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_TUkM" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022events_cnjU" ON public.hmis_csv_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmiscsv2022enrollments_Vf7B; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_gtmS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Vf7B" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmiscsv2022events_gtmS" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_WODv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_i7AK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_WODv" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmiscsv2022events_i7AK" ON public.hmis_csv_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmiscsv2022enrollments_XcDq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_ofqu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_XcDq" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX hmiscsv2022events_ofqu ON public.hmis_csv_2022_events USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_Xlha; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_swJX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_Xlha" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmiscsv2022events_swJX" ON public.hmis_csv_2022_events USING btree ("EventDate");
 
 
 --
--- Name: hmiscsv2022enrollments_YQva; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_tVMW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_YQva" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX "hmiscsv2022events_tVMW" ON public.hmis_csv_2022_events USING btree ("EventID");
 
 
 --
--- Name: hmiscsv2022enrollments_YiGw; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022events_xLrR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_YiGw" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmiscsv2022events_xLrR" ON public.hmis_csv_2022_events USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_YwGX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_0gNP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_YwGX" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022exits_0gNP" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_ZJOW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_1JVD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_ZJOW" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022exits_1JVD" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_b4C4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_2RTk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_b4C4" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022exits_2RTk" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_bItG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_2bUK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_bItG" ON public.hmis_csv_2022_enrollments USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022exits_2bUK" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_cCys; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_2fAq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_cCys" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022exits_2fAq" ON public.hmis_csv_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmiscsv2022enrollments_dJ9X; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_3N2W; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_dJ9X" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmiscsv2022exits_3N2W" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollments_dc9H; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_57Sn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_dc9H" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmiscsv2022exits_57Sn" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_eMPH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_8l1d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_eMPH" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX hmiscsv2022exits_8l1d ON public.hmis_csv_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmiscsv2022enrollments_fYTX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_8xO4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_fYTX" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmiscsv2022exits_8xO4" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_fkcM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_F2mD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_fkcM" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmiscsv2022exits_F2mD" ON public.hmis_csv_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_gn6K; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_FM8e; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_gn6K" ON public.hmis_csv_2022_enrollments USING btree ("LivingSituation");
+CREATE INDEX "hmiscsv2022exits_FM8e" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_goII; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_PiX5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_goII" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmiscsv2022exits_PiX5" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_hYxd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_R6UE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_hYxd" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmiscsv2022exits_R6UE" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_hdwb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_TeXX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_hdwb ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmiscsv2022exits_TeXX" ON public.hmis_csv_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_iWHQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_VP7c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_iWHQ" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022exits_VP7c" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmiscsv2022enrollments_jJjY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_Vkm6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_jJjY" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022exits_Vkm6" ON public.hmis_csv_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_jiTz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_Y5pA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_jiTz" ON public.hmis_csv_2022_enrollments USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022exits_Y5pA" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollments_kdcK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_Z2WS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_kdcK" ON public.hmis_csv_2022_enrollments USING btree ("EntryDate");
+CREATE INDEX "hmiscsv2022exits_Z2WS" ON public.hmis_csv_2022_exits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_kfHu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_a5kE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_kfHu" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmiscsv2022exits_a5kE" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_lCDv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_drZO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_lCDv" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022exits_drZO" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_mGyY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_gZtv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_mGyY" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmiscsv2022exits_gZtv" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollments_nhXb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_kjHd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_nhXb" ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022exits_kjHd" ON public.hmis_csv_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmiscsv2022enrollments_oC1q; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_l0dh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_oC1q" ON public.hmis_csv_2022_enrollments USING btree ("RelationshipToHoH");
+CREATE INDEX hmiscsv2022exits_l0dh ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_oOOv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_lEEJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_oOOv" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmiscsv2022exits_lEEJ" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_pYk7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_lIdj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_pYk7" ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmiscsv2022exits_lIdj" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_pksT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_nQva; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_pksT" ON public.hmis_csv_2022_enrollments USING btree ("HouseholdID");
+CREATE INDEX "hmiscsv2022exits_nQva" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmiscsv2022enrollments_py9x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_qBcx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_py9x ON public.hmis_csv_2022_enrollments USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022exits_qBcx" ON public.hmis_csv_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmiscsv2022enrollments_qhAg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_v0mD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_qhAg" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmiscsv2022exits_v0mD" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022enrollments_rgZ9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_wcOb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_rgZ9" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "HouseholdID");
+CREATE INDEX "hmiscsv2022exits_wcOb" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022enrollments_rmZr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_wzRX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_rmZr" ON public.hmis_csv_2022_enrollments USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022exits_wzRX" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
 
 
 --
--- Name: hmiscsv2022enrollments_rufY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_yT36; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_rufY" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022exits_yT36" ON public.hmis_csv_2022_exits USING btree ("ExitID");
 
 
 --
--- Name: hmiscsv2022enrollments_sD3N; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exits_z4mY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_sD3N" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmiscsv2022exits_z4mY" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022enrollments_upFd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exports_85wI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_upFd" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022exports_85wI" ON public.hmis_csv_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_vfUq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exports_BnDb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_vfUq" ON public.hmis_csv_2022_enrollments USING btree ("TimesHomelessPastThreeYears", "MonthsHomelessPastThreeYears");
+CREATE INDEX "hmiscsv2022exports_BnDb" ON public.hmis_csv_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_wCi5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exports_GT1p; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_wCi5" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "PersonalID");
+CREATE INDEX "hmiscsv2022exports_GT1p" ON public.hmis_csv_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_xYjO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022exports_KuWB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_xYjO" ON public.hmis_csv_2022_enrollments USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022exports_KuWB" ON public.hmis_csv_2022_exports USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_xkHU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_1gUo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_xkHU" ON public.hmis_csv_2022_enrollments USING btree ("EnrollmentID", "ProjectID", "EntryDate");
+CREATE INDEX "hmiscsv2022funders_1gUo" ON public.hmis_csv_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022enrollments_xwum; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_2JHN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_xwum ON public.hmis_csv_2022_enrollments USING btree ("PreviousStreetESSH", "LengthOfStay");
+CREATE INDEX "hmiscsv2022funders_2JHN" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_yiWK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_7Nez; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_yiWK" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID");
+CREATE INDEX "hmiscsv2022funders_7Nez" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022enrollments_z9WI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_D5mG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022enrollments_z9WI" ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmiscsv2022funders_D5mG" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022enrollments_zumz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_F0To; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022enrollments_zumz ON public.hmis_csv_2022_enrollments USING btree ("ProjectID", "RelationshipToHoH");
+CREATE INDEX "hmiscsv2022funders_F0To" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022events_6eMI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_GNqh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_6eMI" ON public.hmis_csv_2022_events USING btree ("EventDate");
+CREATE INDEX "hmiscsv2022funders_GNqh" ON public.hmis_csv_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmiscsv2022events_70cK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_H3cI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_70cK" ON public.hmis_csv_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022funders_H3cI" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_9PUb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_I9hx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_9PUb" ON public.hmis_csv_2022_events USING btree ("EventID");
+CREATE INDEX "hmiscsv2022funders_I9hx" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_9r3x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_NaTx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022events_9r3x ON public.hmis_csv_2022_events USING btree ("EventDate");
+CREATE INDEX "hmiscsv2022funders_NaTx" ON public.hmis_csv_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022events_9rNL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_UJCh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_9rNL" ON public.hmis_csv_2022_events USING btree ("EventID");
+CREATE INDEX "hmiscsv2022funders_UJCh" ON public.hmis_csv_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmiscsv2022events_A0Re; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_WOm9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_A0Re" ON public.hmis_csv_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022funders_WOm9" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022events_AFoC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_YbVa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_AFoC" ON public.hmis_csv_2022_events USING btree ("EventDate");
+CREATE INDEX "hmiscsv2022funders_YbVa" ON public.hmis_csv_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022events_EF2x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_dMfg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_EF2x" ON public.hmis_csv_2022_events USING btree ("EventID");
+CREATE INDEX "hmiscsv2022funders_dMfg" ON public.hmis_csv_2022_funders USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022events_HWMU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_jULh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_HWMU" ON public.hmis_csv_2022_events USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022funders_jULh" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_MpdL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_pbOr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_MpdL" ON public.hmis_csv_2022_events USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022funders_pbOr" ON public.hmis_csv_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmiscsv2022events_PVi4; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022funders_qO5n; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_PVi4" ON public.hmis_csv_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022funders_qO5n" ON public.hmis_csv_2022_funders USING btree ("FunderID");
 
 
 --
--- Name: hmiscsv2022events_RGSg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_2LCH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_RGSg" ON public.hmis_csv_2022_events USING btree ("EventDate");
+CREATE INDEX "hmiscsv2022healthanddvs_2LCH" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022events_RRPj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_ElUS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_RRPj" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022healthanddvs_ElUS" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022events_SEgq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_Eo8h; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_SEgq" ON public.hmis_csv_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022healthanddvs_Eo8h" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022events_TrwM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_FGBd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_TrwM" ON public.hmis_csv_2022_events USING btree ("EventID");
+CREATE INDEX "hmiscsv2022healthanddvs_FGBd" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_UMEc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_G5Jf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_UMEc" ON public.hmis_csv_2022_events USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_G5Jf" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022events_b0HY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_NYgG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_b0HY" ON public.hmis_csv_2022_events USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_NYgG" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
 
 
 --
--- Name: hmiscsv2022events_f8eV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_PUcW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_f8eV" ON public.hmis_csv_2022_events USING btree ("EventID");
+CREATE INDEX "hmiscsv2022healthanddvs_PUcW" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_fVxv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_R7wH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_fVxv" ON public.hmis_csv_2022_events USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022healthanddvs_R7wH" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022events_gFxo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_SPe7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_gFxo" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022healthanddvs_SPe7" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022events_jBzv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_SoHY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_jBzv" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022healthanddvs_SoHY" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022events_k3Vz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_UEfD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_k3Vz" ON public.hmis_csv_2022_events USING btree ("EventDate");
+CREATE INDEX "hmiscsv2022healthanddvs_UEfD" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_wPoI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_UXW4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_wPoI" ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022healthanddvs_UXW4" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022events_wiJI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_Ui7C; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022events_wiJI" ON public.hmis_csv_2022_events USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_Ui7C" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022events_yhpj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_VGDw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022events_yhpj ON public.hmis_csv_2022_events USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022healthanddvs_VGDw" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exits_0oqJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_YPOv; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_0oqJ" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022healthanddvs_YPOv" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022exits_2IJt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_b8zb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_2IJt" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022healthanddvs_b8zb ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_3hM6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_eIeq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_3hM6" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmiscsv2022healthanddvs_eIeq" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exits_6mEQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_gOIl; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_6mEQ" ON public.hmis_csv_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_gOIl" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
 
 
 --
--- Name: hmiscsv2022exits_7XJm; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_hGd9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_7XJm" ON public.hmis_csv_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_hGd9" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
 
 
 --
--- Name: hmiscsv2022exits_7kNM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_mgkL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_7kNM" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022healthanddvs_mgkL" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_97kE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_pCz7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_97kE" ON public.hmis_csv_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_pCz7" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022exits_9wKe; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_trK1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_9wKe" ON public.hmis_csv_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022healthanddvs_trK1" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_AJQd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_wfxQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_AJQd" ON public.hmis_csv_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmiscsv2022healthanddvs_wfxQ" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_BugK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022healthanddvs_zfaQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_BugK" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022healthanddvs_zfaQ" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
 
 
 --
--- Name: hmiscsv2022exits_CFOy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_2CTm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_CFOy" ON public.hmis_csv_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmiscsv2022incomebenefits_2CTm" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022exits_FaOP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_7p65; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_FaOP" ON public.hmis_csv_2022_exits USING btree ("ExitID");
+CREATE INDEX hmiscsv2022incomebenefits_7p65 ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
 
 
 --
--- Name: hmiscsv2022exits_GVqN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_8JB4; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_GVqN" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022incomebenefits_8JB4" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022exits_H1wM; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_9EgQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_H1wM" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022incomebenefits_9EgQ" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022exits_HEXL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_AZRb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_HEXL" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022incomebenefits_AZRb" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
 
 
 --
--- Name: hmiscsv2022exits_JFIj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_CRnh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_JFIj" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmiscsv2022incomebenefits_CRnh" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_QIyW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_DX5F; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_QIyW" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022incomebenefits_DX5F" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_QQgW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_FPGT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_QQgW" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmiscsv2022incomebenefits_FPGT" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022exits_Sweu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_Jlmw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_Sweu" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022incomebenefits_Jlmw" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_UpXI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_MaND; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_UpXI" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022incomebenefits_MaND" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022exits_V4hG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_NWif; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_V4hG" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022incomebenefits_NWif" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exits_YPuW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_OWDD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_YPuW" ON public.hmis_csv_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022incomebenefits_OWDD" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
 
 
 --
--- Name: hmiscsv2022exits_ZLAK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_OX57; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_ZLAK" ON public.hmis_csv_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmiscsv2022incomebenefits_OX57" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022exits_b9Iz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_Q4OK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_b9Iz" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022incomebenefits_Q4OK" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_jid6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_Qa6T; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_jid6 ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022incomebenefits_Qa6T" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_lR9a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_SCGf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_lR9a" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022incomebenefits_SCGf" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022exits_nNms; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_ShR7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_nNms" ON public.hmis_csv_2022_exits USING btree ("ExitID");
+CREATE INDEX "hmiscsv2022incomebenefits_ShR7" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_nix9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_UKo8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_nix9 ON public.hmis_csv_2022_exits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_UKo8" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_othX; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_WIgH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_othX" ON public.hmis_csv_2022_exits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022incomebenefits_WIgH" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exits_pVQh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_WoFO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_pVQh" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022incomebenefits_WoFO" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_s2TS; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_XQXS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_s2TS" ON public.hmis_csv_2022_exits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022incomebenefits_XQXS" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022exits_sL74; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_Y1Uo; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_sL74" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022incomebenefits_Y1Uo" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022exits_sUuv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_c45G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_sUuv" ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
+CREATE INDEX "hmiscsv2022incomebenefits_c45G" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
 
 
 --
--- Name: hmiscsv2022exits_t4xs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_cE32; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_t4xs ON public.hmis_csv_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022incomebenefits_cE32" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022exits_vZPo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_dcuD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_vZPo" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022incomebenefits_dcuD" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022exits_vtCz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_dgOe; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_vtCz" ON public.hmis_csv_2022_exits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022incomebenefits_dgOe" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exits_w7ex; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_eeXk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_w7ex ON public.hmis_csv_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmiscsv2022incomebenefits_eeXk" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022exits_xila; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_g4CO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_xila ON public.hmis_csv_2022_exits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022incomebenefits_g4CO" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022exits_xm89; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_gth6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exits_xm89 ON public.hmis_csv_2022_exits USING btree ("DateDeleted");
+CREATE INDEX hmiscsv2022incomebenefits_gth6 ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exits_yCw0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_iEOg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exits_yCw0" ON public.hmis_csv_2022_exits USING btree ("ExitDate");
+CREATE INDEX "hmiscsv2022incomebenefits_iEOg" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022exports_4A4m; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_mHfx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exports_4A4m" ON public.hmis_csv_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_mHfx" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022exports_786V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_n21G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exports_786V" ON public.hmis_csv_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_n21G" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022exports_7cpb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_oklW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022exports_7cpb ON public.hmis_csv_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_oklW" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022exports_Gf6i; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_rVvF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exports_Gf6i" ON public.hmis_csv_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_rVvF" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022exports_qkPK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_uLjI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022exports_qkPK" ON public.hmis_csv_2022_exports USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022incomebenefits_uLjI" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022funders_EBQd; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022incomebenefits_yHqN; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_EBQd" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022incomebenefits_yHqN" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
 
 
 --
--- Name: hmiscsv2022funders_EeF8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_0i2M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_EeF8" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022inventories_0i2M" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022funders_FasV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_EEKC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_FasV" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022inventories_EEKC" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022funders_I59Y; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_Gt8M; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_I59Y" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022inventories_Gt8M" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022funders_KCdj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_HQXE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_KCdj" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022inventories_HQXE" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
 
 
 --
--- Name: hmiscsv2022funders_Q8i7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_HgeH; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_Q8i7" ON public.hmis_csv_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmiscsv2022inventories_HgeH" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022funders_U23e; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_J2Gb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_U23e" ON public.hmis_csv_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022inventories_J2Gb" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022funders_W9nA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_JunS; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_W9nA" ON public.hmis_csv_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022inventories_JunS" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022funders_Zyir; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_Lq2c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_Zyir" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022inventories_Lq2c" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022funders_aEqh; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_MCku; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_aEqh" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022inventories_MCku" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022funders_acMZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_Qys1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_acMZ" ON public.hmis_csv_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022inventories_Qys1" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022funders_gFjD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_gdUF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_gFjD" ON public.hmis_csv_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022inventories_gdUF" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022funders_hsxT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_iC1n; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_hsxT" ON public.hmis_csv_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmiscsv2022inventories_iC1n" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022funders_trtP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_kenp; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_trtP" ON public.hmis_csv_2022_funders USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022inventories_kenp ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022funders_vp8u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_mvpt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022funders_vp8u ON public.hmis_csv_2022_funders USING btree ("FunderID");
+CREATE INDEX hmiscsv2022inventories_mvpt ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
 
 
 --
--- Name: hmiscsv2022funders_wAAz; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_n4BJ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_wAAz" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022inventories_n4BJ" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022funders_wkTK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_nDVb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_wkTK" ON public.hmis_csv_2022_funders USING btree ("FunderID");
+CREATE INDEX "hmiscsv2022inventories_nDVb" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
 
 
 --
--- Name: hmiscsv2022funders_y0jT; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_oCKn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_y0jT" ON public.hmis_csv_2022_funders USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022inventories_oCKn" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022funders_yNBZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_p16i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_yNBZ" ON public.hmis_csv_2022_funders USING btree ("FunderID");
+CREATE INDEX hmiscsv2022inventories_p16i ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022funders_zZPu; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_qXes; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022funders_zZPu" ON public.hmis_csv_2022_funders USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022inventories_qXes" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_3s5V; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022inventories_vp2v; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_3s5V" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022inventories_vp2v ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_8V6w; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_Fdvh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_8V6w" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmiscsv2022organizations_Fdvh" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_9xZf; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_OZ18; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_9xZf" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022organizations_OZ18" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_BRTj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_Wt9c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_BRTj" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022organizations_Wt9c" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_CRfc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_iuEj; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_CRfc" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022organizations_iuEj" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_DBWO; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_s14D; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_DBWO" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022organizations_s14D" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_HnGC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_sQW8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_HnGC" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022organizations_sQW8" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_I9SQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_wmJL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_I9SQ" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022organizations_wmJL" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_JFxv; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022organizations_zLx5; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_JFxv" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022organizations_zLx5" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_PVQH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_4y3l; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_PVQH" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022projectcocs_4y3l ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_TMQt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_91j1; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_TMQt" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX hmiscsv2022projectcocs_91j1 ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_Vsks; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_BUMA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_Vsks" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022projectcocs_BUMA" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_Xory; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_BnbR; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_Xory" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022projectcocs_BnbR" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022healthanddvs_Y01x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_DP9O; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_Y01x" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmiscsv2022projectcocs_DP9O" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_elHq; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_Hikz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_elHq" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projectcocs_Hikz" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_fkYA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_MDPf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_fkYA" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmiscsv2022projectcocs_MDPf" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_h8HB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_RyUC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_h8HB" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projectcocs_RyUC" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_i9dN; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_cZcV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_i9dN" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projectcocs_cZcV" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_lDba; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_e7nb; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_lDba" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX hmiscsv2022projectcocs_e7nb ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_lP0u; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_f8xT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_lP0u" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022projectcocs_f8xT" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022healthanddvs_n8lZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_jpfz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_n8lZ" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022projectcocs_jpfz ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_nNgi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_jzS2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_nNgi" ON public.hmis_csv_2022_health_and_dvs USING btree ("HealthAndDVID");
+CREATE INDEX "hmiscsv2022projectcocs_jzS2" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_pyNn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_kvtz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_pyNn" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022projectcocs_kvtz ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_q5XV; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_kzeM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_q5XV" ON public.hmis_csv_2022_health_and_dvs USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projectcocs_kzeM" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_qUR2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_lCfd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_qUR2" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022projectcocs_lCfd" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_r4Lx; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_lwd8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_r4Lx" ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022projectcocs_lwd8 ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022healthanddvs_sdZG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_mMpM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_sdZG" ON public.hmis_csv_2022_health_and_dvs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022projectcocs_mMpM" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
 
 
 --
--- Name: hmiscsv2022healthanddvs_xsrk; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_pjB3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022healthanddvs_xsrk ON public.hmis_csv_2022_health_and_dvs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022projectcocs_pjB3" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022healthanddvs_yG7j; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projectcocs_wxHM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022healthanddvs_yG7j" ON public.hmis_csv_2022_health_and_dvs USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022projectcocs_wxHM" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022healthanddvs_zf1v; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_0h8Q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022healthanddvs_zf1v ON public.hmis_csv_2022_health_and_dvs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022projects_0h8Q" ON public.hmis_csv_2022_projects USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_1RQb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_2ZKP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_1RQb" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022projects_2ZKP" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_1XAs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_3q00; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_1XAs" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX hmiscsv2022projects_3q00 ON public.hmis_csv_2022_projects USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_1tdi; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_7ecc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022incomebenefits_1tdi ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX hmiscsv2022projects_7ecc ON public.hmis_csv_2022_projects USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_2tUP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_7m7h; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_2tUP" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX hmiscsv2022projects_7m7h ON public.hmis_csv_2022_projects USING btree ("ProjectType");
 
 
 --
--- Name: hmiscsv2022incomebenefits_6HiZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_AQol; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_6HiZ" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022projects_AQol" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_6g8h; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_CROV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022incomebenefits_6g8h ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022projects_CROV" ON public.hmis_csv_2022_projects USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_7IcJ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_CX72; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_7IcJ" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022projects_CX72" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_7obR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_CgZO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_7obR" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022projects_CgZO" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Aw1x; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_Doig; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Aw1x" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022projects_Doig" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_BPxA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_Lw6W; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_BPxA" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022projects_Lw6W" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_EJv6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_QKei; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_EJv6" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projects_QKei" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
 
 
 --
--- Name: hmiscsv2022incomebenefits_EOkg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_UgEE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_EOkg" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projects_UgEE" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_EY8v; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_Y1UZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_EY8v" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022projects_Y1UZ" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
 
 
 --
--- Name: hmiscsv2022incomebenefits_F7Yo; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_ZK7R; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_F7Yo" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022projects_ZK7R" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Fget; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_ZplM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Fget" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmiscsv2022projects_ZplM" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_FnDI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_aea3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_FnDI" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX hmiscsv2022projects_aea3 ON public.hmis_csv_2022_projects USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_GD5Y; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_fkyK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_GD5Y" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022projects_fkyK" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_GRRK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_nHuI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_GRRK" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022projects_nHuI" ON public.hmis_csv_2022_projects USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Gcc7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022projects_qehC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Gcc7" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022projects_qehC" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
 
 
 --
--- Name: hmiscsv2022incomebenefits_HQxa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_1XqX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_HQxa" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022services_1XqX" ON public.hmis_csv_2022_services USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_HeoF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_1nyD; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_HeoF" ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022services_1nyD" ON public.hmis_csv_2022_services USING btree ("DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Hzxy; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_21dn; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Hzxy" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX hmiscsv2022services_21dn ON public.hmis_csv_2022_services USING btree ("ServicesID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_KDpF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_2FbI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_KDpF" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_2FbI" ON public.hmis_csv_2022_services USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Myd9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_2W8H; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Myd9" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmiscsv2022services_2W8H" ON public.hmis_csv_2022_services USING btree ("ServicesID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_OVW3; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_42Vz; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_OVW3" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_42Vz" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_QURQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_5pZd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_QURQ" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_5pZd" ON public.hmis_csv_2022_services USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022incomebenefits_RlAP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_6w02; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_RlAP" ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX hmiscsv2022services_6w02 ON public.hmis_csv_2022_services USING btree ("DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_SyN5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_7DdL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_SyN5" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_7DdL" ON public.hmis_csv_2022_services USING btree ("ServicesID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_VKKY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_7IHf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_VKKY" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_7IHf" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_W8mA; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_AYV8; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_W8mA" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmiscsv2022services_AYV8" ON public.hmis_csv_2022_services USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_WpiB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_AfzK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_WpiB" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_AfzK" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_Yjz6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_BHcP; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_Yjz6" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_BHcP" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
 
 
 --
--- Name: hmiscsv2022incomebenefits_ZRt9; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_CgcQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_ZRt9" ON public.hmis_csv_2022_income_benefits USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_CgcQ" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_ZW68; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_DU3k; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_ZW68" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmiscsv2022services_DU3k" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_cE9a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_EAWt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_cE9a" ON public.hmis_csv_2022_income_benefits USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_EAWt" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_irza; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_EhIW; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022incomebenefits_irza ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_EhIW" ON public.hmis_csv_2022_services USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_jnNE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_GSE7; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_jnNE" ON public.hmis_csv_2022_income_benefits USING btree ("Earned", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_GSE7" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
 
 
 --
--- Name: hmiscsv2022incomebenefits_mM7W; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_I3gC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_mM7W" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_I3gC" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
 
 
 --
--- Name: hmiscsv2022incomebenefits_nLIb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_JE59; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_nLIb" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_JE59" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022incomebenefits_pgB6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_JFhE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_pgB6" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeBenefitsID");
+CREATE INDEX "hmiscsv2022services_JFhE" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022incomebenefits_rV97; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_JHa6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_rV97" ON public.hmis_csv_2022_income_benefits USING btree ("EnrollmentID");
+CREATE INDEX "hmiscsv2022services_JHa6" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_t2OW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_M1bq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_t2OW" ON public.hmis_csv_2022_income_benefits USING btree ("IncomeFromAnySource", "DataCollectionStage");
+CREATE INDEX "hmiscsv2022services_M1bq" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_vuok; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_Nz2I; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022incomebenefits_vuok ON public.hmis_csv_2022_income_benefits USING btree ("PersonalID");
+CREATE INDEX "hmiscsv2022services_Nz2I" ON public.hmis_csv_2022_services USING btree ("DateProvided");
 
 
 --
--- Name: hmiscsv2022incomebenefits_w5M0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_QT28; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022incomebenefits_w5M0" ON public.hmis_csv_2022_income_benefits USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_QT28" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022incomebenefits_z5mn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_QddI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022incomebenefits_z5mn ON public.hmis_csv_2022_income_benefits USING btree ("InformationDate");
+CREATE INDEX "hmiscsv2022services_QddI" ON public.hmis_csv_2022_services USING btree ("RecordType");
 
 
 --
--- Name: hmiscsv2022inventories_0hc8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_R1S0; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022inventories_0hc8 ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmiscsv2022services_R1S0" ON public.hmis_csv_2022_services USING btree ("ServicesID");
 
 
 --
--- Name: hmiscsv2022inventories_2JYH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_SyRQ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_2JYH" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_SyRQ" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
 
 
 --
--- Name: hmiscsv2022inventories_5blG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_Uo0y; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_5blG" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_Uo0y" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
 
 
 --
--- Name: hmiscsv2022inventories_7XPQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_W2b6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_7XPQ" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_W2b6" ON public.hmis_csv_2022_services USING btree ("RecordType");
 
 
 --
--- Name: hmiscsv2022inventories_FcjB; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_Wgpm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_FcjB" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmiscsv2022services_Wgpm" ON public.hmis_csv_2022_services USING btree ("RecordType");
 
 
 --
--- Name: hmiscsv2022inventories_HoVQ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_aG9q; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_HoVQ" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_aG9q" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
 
 
 --
--- Name: hmiscsv2022inventories_MaX0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_axDa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_MaX0" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022services_axDa" ON public.hmis_csv_2022_services USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022inventories_Mam6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_dndU; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_Mam6" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_dndU" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022inventories_O4mI; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_fmlm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_O4mI" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022services_fmlm ON public.hmis_csv_2022_services USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022inventories_TTYE; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_hD5A; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_TTYE" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_hD5A" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022inventories_UVsK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_hFhA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_UVsK" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_hFhA" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022inventories_Xkhg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_hv2B; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_Xkhg" ON public.hmis_csv_2022_inventories USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_hv2B" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022inventories_bqiF; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_i1JL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_bqiF" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022services_i1JL" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
 
 
 --
--- Name: hmiscsv2022inventories_ctyg; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_iXlI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022inventories_ctyg ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022services_iXlI" ON public.hmis_csv_2022_services USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022inventories_f8rb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_lgtY; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022inventories_f8rb ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmiscsv2022services_lgtY" ON public.hmis_csv_2022_services USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022inventories_h8H6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_lhpK; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_h8H6" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_lhpK" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022inventories_hcBa; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_oRmd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_hcBa" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_oRmd" ON public.hmis_csv_2022_services USING btree ("RecordType");
 
 
 --
--- Name: hmiscsv2022inventories_hpp8; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_q06O; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022inventories_hpp8 ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_q06O" ON public.hmis_csv_2022_services USING btree ("DateCreated");
 
 
 --
--- Name: hmiscsv2022inventories_hu1F; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_qzvZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_hu1F" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmiscsv2022services_qzvZ" ON public.hmis_csv_2022_services USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022inventories_nYsR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_rFtw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_nYsR" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022services_rFtw" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
 
 
 --
--- Name: hmiscsv2022inventories_pqsZ; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_sMEu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_pqsZ" ON public.hmis_csv_2022_inventories USING btree ("InventoryID");
+CREATE INDEX "hmiscsv2022services_sMEu" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
 
 
 --
--- Name: hmiscsv2022inventories_vHpP; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_sYN6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_vHpP" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_sYN6" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022inventories_wNmp; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_tz9J; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_wNmp" ON public.hmis_csv_2022_inventories USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022services_tz9J" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022inventories_yEox; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_v9XL; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_yEox" ON public.hmis_csv_2022_inventories USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022services_v9XL" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
 
 
 --
--- Name: hmiscsv2022inventories_yqNs; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_vGmG; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022inventories_yqNs" ON public.hmis_csv_2022_inventories USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022services_vGmG" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
 
 
 --
--- Name: hmiscsv2022organizations_FjV6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_vIhC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_FjV6" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_vIhC" ON public.hmis_csv_2022_services USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022organizations_LnYR; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_vxeB; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_LnYR" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmiscsv2022services_vxeB" ON public.hmis_csv_2022_services USING btree ("DateProvided");
 
 
 --
--- Name: hmiscsv2022organizations_P9WD; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_x0ZE; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_P9WD" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmiscsv2022services_x0ZE" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
 
 
 --
--- Name: hmiscsv2022organizations_PW7F; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_yjqX; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_PW7F" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_yjqX" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
 
 
 --
--- Name: hmiscsv2022organizations_Q2CY; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022services_z0nM; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_Q2CY" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022services_z0nM" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
 
 
 --
--- Name: hmiscsv2022organizations_SBB6; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_4kRq; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_SBB6" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022users_4kRq" ON public.hmis_csv_2022_users USING btree ("UserID");
 
 
 --
--- Name: hmiscsv2022organizations_eKN2; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_C0xg; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_eKN2" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmiscsv2022users_C0xg" ON public.hmis_csv_2022_users USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022organizations_gmSL; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_GZae; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_gmSL" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmiscsv2022users_GZae" ON public.hmis_csv_2022_users USING btree ("UserID");
 
 
 --
--- Name: hmiscsv2022organizations_qR0a; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_Lhuw; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_qR0a" ON public.hmis_csv_2022_organizations USING btree ("OrganizationID");
+CREATE INDEX "hmiscsv2022users_Lhuw" ON public.hmis_csv_2022_users USING btree ("UserID");
 
 
 --
--- Name: hmiscsv2022organizations_uD5T; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_NXSV; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022organizations_uD5T" ON public.hmis_csv_2022_organizations USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022users_NXSV" ON public.hmis_csv_2022_users USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_0mWW; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_htT6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_0mWW" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022users_htT6" ON public.hmis_csv_2022_users USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_7QwC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_jqKO; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_7QwC" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022users_jqKO" ON public.hmis_csv_2022_users USING btree ("UserID");
 
 
 --
--- Name: hmiscsv2022projectcocs_7coH; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022users_xSm9; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_7coH" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022users_xSm9" ON public.hmis_csv_2022_users USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_F3r0; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_4FZ2; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_F3r0" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_4FZ2" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022projectcocs_Jfub; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_6A73; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_Jfub" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_6A73" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_KMu5; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_8cDc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_KMu5" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_8cDc" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022projectcocs_KccU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_Ci6d; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_KccU" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_Ci6d" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
 
 
 --
--- Name: hmiscsv2022projectcocs_QHMr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_EAab; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_QHMr" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_EAab" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_R2Yn; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_I3XC; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_R2Yn" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_I3XC" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
 
 
 --
--- Name: hmiscsv2022projectcocs_XKYG; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_LtA3; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_XKYG" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_LtA3" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022projectcocs_ZaMC; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_TDtu; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_ZaMC" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_TDtu" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
 
 
 --
--- Name: hmiscsv2022projectcocs_Zv8Z; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_X31W; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_Zv8Z" ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_X31W" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022projectcocs_ZwP7; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_YjxT; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_ZwP7" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_YjxT" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
 
 
 --
--- Name: hmiscsv2022projectcocs_fHPb; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_f2lr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_fHPb" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX hmiscsv2022youtheducationstatuses_f2lr ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022projectcocs_gMun; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_lUm6; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_gMun" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_lUm6" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
 
 
 --
--- Name: hmiscsv2022projectcocs_haHj; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_nIkF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_haHj" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_nIkF" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_hhqc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_nJ1G; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022projectcocs_hhqc ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_nJ1G" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022projectcocs_jWiU; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_oddF; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_jWiU" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_oddF" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022projectcocs_lfWt; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_ojKI; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_lfWt" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_ojKI" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
 
 
 --
--- Name: hmiscsv2022projectcocs_mLOc; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_teWr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_mLOc" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectID", "CoCCode");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_teWr" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022projectcocs_rI43; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_ufJa; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_rI43" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_ufJa" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
 
 
 --
--- Name: hmiscsv2022projectcocs_snwr; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_vWgA; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX hmiscsv2022projectcocs_snwr ON public.hmis_csv_2022_project_cocs USING btree ("ExportID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_vWgA" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
 
 
 --
--- Name: hmiscsv2022projectcocs_toVK; Type: INDEX; Schema: public; Owner: -
+-- Name: hmiscsv2022youtheducationstatuses_wTMZ; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX "hmiscsv2022projectcocs_toVK" ON public.hmis_csv_2022_project_cocs USING btree ("ProjectCoCID");
-
-
---
--- Name: hmiscsv2022projectcocs_uGEA; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projectcocs_uGEA" ON public.hmis_csv_2022_project_cocs USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projectcocs_xNgm; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projectcocs_xNgm" ON public.hmis_csv_2022_project_cocs USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_6pjf; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022projects_6pjf ON public.hmis_csv_2022_projects USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022projects_AZRv; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_AZRv" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
-
-
---
--- Name: hmiscsv2022projects_BNpw; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_BNpw" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projects_BcGz; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_BcGz" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projects_CR7E; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_CR7E" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_CrgU; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_CrgU" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projects_EFMI; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_EFMI" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
-
-
---
--- Name: hmiscsv2022projects_EHcK; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_EHcK" ON public.hmis_csv_2022_projects USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022projects_FH4m; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_FH4m" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
-
-
---
--- Name: hmiscsv2022projects_K1UM; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_K1UM" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
-
-
---
--- Name: hmiscsv2022projects_K1g9; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_K1g9" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_LGTq; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_LGTq" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
-
-
---
--- Name: hmiscsv2022projects_Oc0U; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_Oc0U" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
-
-
---
--- Name: hmiscsv2022projects_Oj9G; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_Oj9G" ON public.hmis_csv_2022_projects USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022projects_OtF6; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_OtF6" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
-
-
---
--- Name: hmiscsv2022projects_QkSr; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_QkSr" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
-
-
---
--- Name: hmiscsv2022projects_VzMf; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_VzMf" ON public.hmis_csv_2022_projects USING btree ("ProjectType");
-
-
---
--- Name: hmiscsv2022projects_fGby; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_fGby" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_ftTe; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_ftTe" ON public.hmis_csv_2022_projects USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projects_jgtt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022projects_jgtt ON public.hmis_csv_2022_projects USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022projects_oatJ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_oatJ" ON public.hmis_csv_2022_projects USING btree ("ProjectID");
-
-
---
--- Name: hmiscsv2022projects_ouoy; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022projects_ouoy ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_qPVR; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_qPVR" ON public.hmis_csv_2022_projects USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022projects_uN6c; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_uN6c" ON public.hmis_csv_2022_projects USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022projects_yGw1; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022projects_yGw1" ON public.hmis_csv_2022_projects USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_1kzC; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_1kzC" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
-
-
---
--- Name: hmiscsv2022services_3gBa; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_3gBa" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_3wwH; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_3wwH" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022services_4qG7; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_4qG7" ON public.hmis_csv_2022_services USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_53sL; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_53sL" ON public.hmis_csv_2022_services USING btree ("ServicesID");
-
-
---
--- Name: hmiscsv2022services_68n9; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022services_68n9 ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_732S; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_732S" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_78KE; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_78KE" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: hmiscsv2022services_9Ain; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_9Ain" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_AGvJ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_AGvJ" ON public.hmis_csv_2022_services USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022services_AMYt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_AMYt" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_BZI2; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_BZI2" ON public.hmis_csv_2022_services USING btree ("DateProvided");
-
-
---
--- Name: hmiscsv2022services_BbIE; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_BbIE" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_Bo1g; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Bo1g" ON public.hmis_csv_2022_services USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022services_D39O; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_D39O" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_E4Js; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_E4Js" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_EtU3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_EtU3" ON public.hmis_csv_2022_services USING btree ("DateProvided");
-
-
---
--- Name: hmiscsv2022services_FnGv; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_FnGv" ON public.hmis_csv_2022_services USING btree ("RecordType");
-
-
---
--- Name: hmiscsv2022services_G0rQ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_G0rQ" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
-
-
---
--- Name: hmiscsv2022services_HfxJ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_HfxJ" ON public.hmis_csv_2022_services USING btree ("RecordType");
-
-
---
--- Name: hmiscsv2022services_IyZM; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_IyZM" ON public.hmis_csv_2022_services USING btree ("ServicesID");
-
-
---
--- Name: hmiscsv2022services_JOKs; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_JOKs" ON public.hmis_csv_2022_services USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_JiC3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_JiC3" ON public.hmis_csv_2022_services USING btree ("ServicesID");
-
-
---
--- Name: hmiscsv2022services_K7Zt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_K7Zt" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_Ke4l; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Ke4l" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022services_LD3i; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_LD3i" ON public.hmis_csv_2022_services USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022services_LJSD; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_LJSD" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022services_Lk4w; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Lk4w" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
-
-
---
--- Name: hmiscsv2022services_MBfF; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_MBfF" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_NI7r; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_NI7r" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022services_OCo1; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_OCo1" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
-
-
---
--- Name: hmiscsv2022services_Owsi; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Owsi" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022services_PZaU; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_PZaU" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_QQPx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_QQPx" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: hmiscsv2022services_RLdg; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_RLdg" ON public.hmis_csv_2022_services USING btree ("RecordType");
-
-
---
--- Name: hmiscsv2022services_U2RZ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_U2RZ" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022services_WkLH; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_WkLH" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
-
-
---
--- Name: hmiscsv2022services_WxH1; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_WxH1" ON public.hmis_csv_2022_services USING btree ("DateProvided");
-
-
---
--- Name: hmiscsv2022services_Xjc3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Xjc3" ON public.hmis_csv_2022_services USING btree ("DateDeleted");
-
-
---
--- Name: hmiscsv2022services_Xt15; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Xt15" ON public.hmis_csv_2022_services USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022services_Zeox; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_Zeox" ON public.hmis_csv_2022_services USING btree ("RecordType");
-
-
---
--- Name: hmiscsv2022services_ZsCG; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_ZsCG" ON public.hmis_csv_2022_services USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_aK50; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_aK50" ON public.hmis_csv_2022_services USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022services_cK9O; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_cK9O" ON public.hmis_csv_2022_services USING btree ("PersonalID", "RecordType", "EnrollmentID", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_cOsh; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_cOsh" ON public.hmis_csv_2022_services USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022services_dQSt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_dQSt" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "RecordType", "DateDeleted", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_enQH; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_enQH" ON public.hmis_csv_2022_services USING btree ("DateProvided");
-
-
---
--- Name: hmiscsv2022services_f0qq; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022services_f0qq ON public.hmis_csv_2022_services USING btree ("DateUpdated");
-
-
---
--- Name: hmiscsv2022services_f8LM; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_f8LM" ON public.hmis_csv_2022_services USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022services_fGnF; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_fGnF" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_gUHS; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_gUHS" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
-
-
---
--- Name: hmiscsv2022services_iILP; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_iILP" ON public.hmis_csv_2022_services USING btree ("ServicesID");
-
-
---
--- Name: hmiscsv2022services_ipWR; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_ipWR" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
-
-
---
--- Name: hmiscsv2022services_kUi3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_kUi3" ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: hmiscsv2022services_lCd2; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_lCd2" ON public.hmis_csv_2022_services USING btree ("DateProvided");
-
-
---
--- Name: hmiscsv2022services_lbEG; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_lbEG" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
-
-
---
--- Name: hmiscsv2022services_mIWt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_mIWt" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateDeleted");
-
-
---
--- Name: hmiscsv2022services_mSwA; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_mSwA" ON public.hmis_csv_2022_services USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022services_n0Bz; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_n0Bz" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022services_qYm3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_qYm3" ON public.hmis_csv_2022_services USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022services_s7W3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_s7W3" ON public.hmis_csv_2022_services USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_t2qL; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_t2qL" ON public.hmis_csv_2022_services USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022services_tUIX; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_tUIX" ON public.hmis_csv_2022_services USING btree ("RecordType");
-
-
---
--- Name: hmiscsv2022services_thj9; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022services_thj9 ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: hmiscsv2022services_ut9w; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022services_ut9w ON public.hmis_csv_2022_services USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: hmiscsv2022services_wl51; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022services_wl51 ON public.hmis_csv_2022_services USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022services_x0QA; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_x0QA" ON public.hmis_csv_2022_services USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022services_x32D; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_x32D" ON public.hmis_csv_2022_services USING btree ("RecordType", "DateProvided");
-
-
---
--- Name: hmiscsv2022services_ytLZ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_ytLZ" ON public.hmis_csv_2022_services USING btree ("DateCreated");
-
-
---
--- Name: hmiscsv2022services_zkJ3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022services_zkJ3" ON public.hmis_csv_2022_services USING btree ("ServicesID");
-
-
---
--- Name: hmiscsv2022users_7hAX; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_7hAX" ON public.hmis_csv_2022_users USING btree ("UserID");
-
-
---
--- Name: hmiscsv2022users_8RTX; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_8RTX" ON public.hmis_csv_2022_users USING btree ("UserID");
-
-
---
--- Name: hmiscsv2022users_9lCp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_9lCp" ON public.hmis_csv_2022_users USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022users_FSU8; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_FSU8" ON public.hmis_csv_2022_users USING btree ("UserID");
-
-
---
--- Name: hmiscsv2022users_MWOa; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_MWOa" ON public.hmis_csv_2022_users USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022users_T7HY; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_T7HY" ON public.hmis_csv_2022_users USING btree ("UserID");
-
-
---
--- Name: hmiscsv2022users_ZsWm; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_ZsWm" ON public.hmis_csv_2022_users USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022users_ut6h; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022users_ut6h ON public.hmis_csv_2022_users USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022users_wBZo; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_wBZo" ON public.hmis_csv_2022_users USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022users_xDzZ; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022users_xDzZ" ON public.hmis_csv_2022_users USING btree ("UserID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_22GP; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_22GP" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_27QU; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_27QU" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_3wUp; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_3wUp" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_6Gvz; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_6Gvz" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_9UF7; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_9UF7" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_9dk3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022youtheducationstatuses_9dk3 ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_IQMw; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_IQMw" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_LLFz; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_LLFz" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_LsJX; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_LsJX" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_Msvb; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_Msvb" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_O5XN; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_O5XN" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_P7pk; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_P7pk" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_PBWg; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_PBWg" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_PMHG; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_PMHG" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_Tv5M; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_Tv5M" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_WARO; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_WARO" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_eWaV; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_eWaV" ON public.hmis_csv_2022_youth_education_statuses USING btree ("PersonalID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_fsBL; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_fsBL" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_g8wl; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022youtheducationstatuses_g8wl ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_hkeS; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_hkeS" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_nb9y; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX hmiscsv2022youtheducationstatuses_nb9y ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_u98C; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_u98C" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_uegS; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_uegS" ON public.hmis_csv_2022_youth_education_statuses USING btree ("EnrollmentID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_vPI4; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_vPI4" ON public.hmis_csv_2022_youth_education_statuses USING btree ("ExportID");
-
-
---
--- Name: hmiscsv2022youtheducationstatuses_xGU1; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "hmiscsv2022youtheducationstatuses_xGU1" ON public.hmis_csv_2022_youth_education_statuses USING btree ("YouthEducationStatusID");
+CREATE INDEX "hmiscsv2022youtheducationstatuses_wTMZ" ON public.hmis_csv_2022_youth_education_statuses USING btree ("InformationDate");
 
 
 --
@@ -39591,31 +40513,10 @@ CREATE INDEX index_hmis_2022_youth_education_statuses_on_importer_log_id ON publ
 
 
 --
--- Name: index_hmis_assessments_on_assessment_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_assessments_on_assessment_id ON public.hmis_assessments USING btree (assessment_id);
-
-
---
--- Name: index_hmis_assessments_on_data_source_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_assessments_on_data_source_id ON public.hmis_assessments USING btree (data_source_id);
-
-
---
 -- Name: index_hmis_assessments_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_hmis_assessments_on_name ON public.hmis_assessments USING btree (name);
-
-
---
--- Name: index_hmis_assessments_on_site_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_assessments_on_site_id ON public.hmis_assessments USING btree (site_id);
 
 
 --
@@ -40515,13 +41416,6 @@ CREATE INDEX index_income_benefits_reports_on_user_id ON public.income_benefits_
 
 
 --
--- Name: index_involved_in_imports_on_importer_log_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_involved_in_imports_on_importer_log_id ON public.involved_in_imports USING btree (importer_log_id);
-
-
---
 -- Name: index_lftp_s3_syncs_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -41135,13 +42029,6 @@ CREATE UNIQUE INDEX index_service_history_services_2020_on_id ON public.service_
 --
 
 CREATE UNIQUE INDEX index_service_history_services_2021_on_id ON public.service_history_services_2021 USING btree (id);
-
-
---
--- Name: index_service_history_services_2022_on_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_service_history_services_2022_on_id ON public.service_history_services_2022 USING btree (id);
 
 
 --
@@ -42899,55 +43786,6 @@ CREATE INDEX index_shs_2021_date_project_type ON public.service_history_services
 --
 
 CREATE INDEX index_shs_2021_en_id_only ON public.service_history_services_2021 USING btree (service_history_enrollment_id);
-
-
---
--- Name: index_shs_2022_c_id_en_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_c_id_en_id ON public.service_history_services_2022 USING btree (client_id, service_history_enrollment_id);
-
-
---
--- Name: index_shs_2022_client_id_only; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_client_id_only ON public.service_history_services_2022 USING btree (client_id);
-
-
---
--- Name: index_shs_2022_date_brin; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_date_brin ON public.service_history_services_2022 USING brin (date);
-
-
---
--- Name: index_shs_2022_date_client_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_date_client_id ON public.service_history_services_2022 USING btree (client_id, date, record_type);
-
-
---
--- Name: index_shs_2022_date_en_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_shs_2022_date_en_id ON public.service_history_services_2022 USING btree (date, service_history_enrollment_id);
-
-
---
--- Name: index_shs_2022_date_project_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_date_project_type ON public.service_history_services_2022 USING btree (project_type, date, record_type);
-
-
---
--- Name: index_shs_2022_en_id_only; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_shs_2022_en_id_only ON public.service_history_services_2022 USING btree (service_history_enrollment_id);
 
 
 --
@@ -44848,27 +45686,6 @@ CREATE INDEX inventory_export_id ON public."Inventory" USING btree ("ExportID");
 
 
 --
--- Name: involved_in_imports_by_hud_key; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX involved_in_imports_by_hud_key ON public.involved_in_imports USING btree (hud_key, importer_log_id, record_type, record_action);
-
-
---
--- Name: involved_in_imports_by_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX involved_in_imports_by_id ON public.involved_in_imports USING btree (record_id, importer_log_id, record_type, record_action);
-
-
---
--- Name: involved_in_imports_by_importer_log; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX involved_in_imports_by_importer_log ON public.involved_in_imports USING btree (importer_log_id, record_type, record_action);
-
-
---
 -- Name: one_entity_per_type_per_group; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -45076,13 +45893,6 @@ CREATE UNIQUE INDEX taggings_idx ON public.taggings USING btree (tag_id, taggabl
 --
 
 CREATE INDEX taggings_idy ON public.taggings USING btree (taggable_id, taggable_type, tagger_id, context);
-
-
---
--- Name: test_shs; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX test_shs ON public.service_history_services_2000 USING btree (service_history_enrollment_id, date);
 
 
 --
@@ -45608,27 +46418,6 @@ CREATE STATISTICS public.stats_shs_2021_age_literally_homeless ON age, literally
 --
 
 CREATE STATISTICS public.stats_shs_2021_homeless ON homeless, literally_homeless FROM public.service_history_services_2021;
-
-
---
--- Name: stats_shs_2022_age_homeless; Type: STATISTICS; Schema: public; Owner: -
---
-
-CREATE STATISTICS public.stats_shs_2022_age_homeless ON age, homeless FROM public.service_history_services_2022;
-
-
---
--- Name: stats_shs_2022_age_literally_homeless; Type: STATISTICS; Schema: public; Owner: -
---
-
-CREATE STATISTICS public.stats_shs_2022_age_literally_homeless ON age, literally_homeless FROM public.service_history_services_2022;
-
-
---
--- Name: stats_shs_2022_homeless; Type: STATISTICS; Schema: public; Owner: -
---
-
-CREATE STATISTICS public.stats_shs_2022_homeless ON homeless, literally_homeless FROM public.service_history_services_2022;
 
 
 --
@@ -46584,14 +47373,6 @@ ALTER TABLE ONLY public.project_pass_fails_projects
 
 ALTER TABLE ONLY public.project_pass_fails_clients
     ADD CONSTRAINT fk_rails_8455b3472c FOREIGN KEY (project_pass_fail_id) REFERENCES public.project_pass_fails(id) ON DELETE CASCADE;
-
-
---
--- Name: service_history_services_2022 fk_rails_85cc8de3dc; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.service_history_services_2022
-    ADD CONSTRAINT fk_rails_85cc8de3dc FOREIGN KEY (service_history_enrollment_id) REFERENCES public.service_history_enrollments(id) ON DELETE CASCADE;
 
 
 --
@@ -47592,7 +48373,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210708192452'),
 ('20210714131449'),
 ('20210716144139'),
-('20210717154701'),
 ('20210722155210'),
 ('20210723161722'),
 ('20210726155740'),
@@ -47663,6 +48443,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211220204231'),
 ('20211221151552'),
 ('20211223134654'),
+('20211223150223'),
 ('20211229164804'),
 ('20211230201245'),
 ('20220101180956'),
@@ -47693,7 +48474,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220331180748'),
 ('20220411150736'),
 ('20220413144557'),
-('20220415192223'),
-('20220427144200');
+('20220427144200'),
+('20220511171233');
 
 


### PR DESCRIPTION
This allows specifying a date other than `Date.current` for the system cohorts to create test data:
`GrdaWarehouse::SystemCohorts::Base.update_system_cohorts(processing_date: GrdaWarehouse::ServiceHistoryService.maximum(:date))`
It also allows specifying a different housing lookback window (`date_window:`), but maybe there is a better way to handle identifying previously housed.