### PR TITLE
Only show projects in supported project types for PATH and Homeless Summary Report

### DIFF
--- a/app/assets/javascripts/filter_projects.js.es6
+++ b/app/assets/javascripts/filter_projects.js.es6
@@ -41,7 +41,8 @@ App.StimulusApp.register('filter-projects', class extends Stimulus.Controller {
       project_type_codes: $(this.projectTypesTarget).val(),
     }
     if (this.hasFunderIdsTarget) {
-      data.funder_ids = $(this.funderIdsTarget).val()
+      const val = $(this.funderIdsTarget).val();
+      if (val) data.funder_ids = Array.isArray(val) ? val : [val];
     }
     if (this.hasCocCodesTarget) {
       const val = $(this.cocCodesTarget).val();

--- a/app/controllers/api/hud_filters_controller.rb
+++ b/app/controllers/api/hud_filters_controller.rb
@@ -21,7 +21,7 @@ module Api
           joins(:organization).
           where(id: filter.effective_project_ids)
 
-        projects = projects.with_project_type(params[:supported_project_types].map(&:to_i)) if params[:supported_project_types].present?
+        projects = projects.with_hud_project_type(params[:supported_project_types].map(&:to_i)) if params[:supported_project_types].present?
 
         projects.pluck(
           :id,

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -855,7 +855,7 @@ module GrdaWarehouse::Hud
       @options = begin
         options = {}
         project_scope = viewable_by(user)
-        project_scope = project_scope.merge(scope) if scope.present?
+        project_scope = project_scope.merge(scope) unless scope.nil?
 
         project_scope.
           joins(:organization, :data_source).

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -43,6 +43,8 @@ module GrdaWarehouse::Hud
     end.freeze
 
     HOMELESS_PROJECT_TYPE_CODES = [:es, :so, :sh, :th].freeze
+    SPM_PROJECT_TYPE_CODES = [:es, :so, :sh, :th, :ph].freeze
+    PATH_PROJECT_TYPE_CODES = [:so, :services_only].freeze
 
     RESIDENTIAL_PROJECT_TYPE_IDS = RESIDENTIAL_PROJECT_TYPES.values.flatten.uniq.sort
 

--- a/app/views/hud_reports/_project_filter.haml
+++ b/app/views/hud_reports/_project_filter.haml
@@ -1,5 +1,5 @@
 - project_types_collection = local_assigns[:project_types_collection] || @filter.available_residential_project_types
-- projects_collection = local_assigns[:projects_collection] || @filter.project_options_for_select(user: current_user)
+- api_projects_parameters = local_assigns[:api_projects_parameters] || {}
 %h2 Projects to Include
 %p.alert.alert-info
   Please note, the following options are additive.  If you choose a single project and a project type, the report will run for all projects in the project type and the chosen project.  If you choose a data source and project type, the report will run for all projects in the chosen data source and chosen project type.
@@ -10,7 +10,7 @@
   .col-md-8
     .row
       .col-sm-6
-        = f.input :project_ids, collection: projects_collection, as: :grouped_select_two, group_method: :last, input_html: { multiple: true, placeholder: 'Choose Projects', data: { 'filter-projects-target' => 'projects', action: 'change->filter-projects#update' } }, label: 'Projects'
+        = f.input :project_ids, collection: [], as: :grouped_select_two, group_method: :last, input_html: { multiple: true, placeholder: 'Choose Projects', data: { 'filter-projects-target' => 'projects', action: 'change->filter-projects#update', 'collection-path' => api_projects_path(selected_project_ids: @filter.project_ids, **api_projects_parameters) } }, label: 'Projects'
       .col-sm-6
         = f.input :data_source_ids, collection: @filter.data_source_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose Data Sources', data: { 'filter-projects-target' => 'dataSources', action: 'change->filter-projects#update' }}, label: 'Data Sources'
     .row

--- a/app/views/hud_reports/_project_filter.haml
+++ b/app/views/hud_reports/_project_filter.haml
@@ -1,10 +1,11 @@
 - project_types_collection = local_assigns[:project_types_collection] || @filter.available_residential_project_types
 - projects_collection = local_assigns[:projects_collection] || @filter.project_options_for_select(user: current_user)
 %h2 Projects to Include
-- if local_assigns[:alert]
-  %p.alert.alert-info= local_assigns[:alert]
-- else
-  %p.alert.alert-info Please note, the following options are additive.  If you choose a single project and a project type, the report will run for all projects in the project type and the chosen project.  If you choose a data source and project type, the report will run for all projects in the chosen data source and chosen project type.
+%p.alert.alert-info
+  Please note, the following options are additive.  If you choose a single project and a project type, the report will run for all projects in the project type and the chosen project.  If you choose a data source and project type, the report will run for all projects in the chosen data source and chosen project type.
+  - if local_assigns[:alert].present?
+    %br
+    %br= local_assigns[:alert]
 .row
   .col-md-8
     .row

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -26,6 +26,8 @@ module HomelessSummaryReport
 
     after_initialize :filter
 
+    SPM_PROJECT_TYPES = [:es, :so, :sh, :th, :ph].freeze
+
     # NOTE: this differs from viewable_by which looks at the report definitions
     scope :visible_to, ->(user) do
       return all if user.can_view_all_reports?
@@ -111,11 +113,11 @@ module HomelessSummaryReport
     end
 
     def project_type_ids
-      [:es, :so, :sh, :th, :ph].map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
+      SPM_PROJECT_TYPES.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
     end
 
     def project_type_options_for_select
-      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:es, :so, :sh, :th, :ph]) }.freeze.invert
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(SPM_PROJECT_TYPES) }.freeze.invert
     end
 
     def project_options_for_select(user)

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -110,8 +110,18 @@ module HomelessSummaryReport
       true
     end
 
-    def default_project_types
-      [:ph, :es, :th, :sh, :so]
+    def project_type_ids
+      [:es, :so, :sh, :th, :ph].map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
+    end
+
+    def project_type_options_for_select
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:es, :so, :sh, :th, :ph]) }.freeze.invert
+    end
+
+    def project_options_for_select(user)
+      GrdaWarehouse::Hud::Project.viewable_by(user).
+        with_hud_project_type(project_type_ids).
+        options_for_select(user: user)
     end
 
     private def build_control_sections
@@ -568,11 +578,6 @@ module HomelessSummaryReport
         'Measure 7',
       ]
       options = filter.to_h
-      # NOTE: The returns to homeless calculation in the SPM won't work unless homeless types are included in the calculation.
-      # For now we've decided to let that slide, and require people to pick the right project types when running the report.
-      # The two lines commented below could potentially help with forcing that.
-      # options[:project_type_codes] ||= []
-      # options[:project_type_codes] += [:es, :so, :sh, :th]
       generator = HudSpmReport::Generators::Fy2020::Generator
       variants.each do |_, spec|
         base_variant = spec[:base_variant]

--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -26,8 +26,6 @@ module HomelessSummaryReport
 
     after_initialize :filter
 
-    SPM_PROJECT_TYPES = [:es, :so, :sh, :th, :ph].freeze
-
     # NOTE: this differs from viewable_by which looks at the report definitions
     scope :visible_to, ->(user) do
       return all if user.can_view_all_reports?
@@ -112,12 +110,16 @@ module HomelessSummaryReport
       true
     end
 
+    def spm_project_types
+      GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES
+    end
+
     def project_type_ids
-      SPM_PROJECT_TYPES.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
+      spm_project_types.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
     end
 
     def project_type_options_for_select
-      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(SPM_PROJECT_TYPES) }.freeze.invert
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(spm_project_types) }.freeze.invert
     end
 
     def project_options_for_select(user)

--- a/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
+++ b/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
@@ -12,7 +12,7 @@
         = f.input :end, as: :date_picker, label: 'End Date', required: true
       .col-sm-6
         = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose CoCs', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes'
-    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: HomelessSummaryReport::Report::SPM_PROJECT_TYPES }, alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES }, alert: alert
     %h2 Limits
     .row.mt-4
       - @sections.in_groups(2).each do |sections|

--- a/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
+++ b/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
@@ -1,8 +1,9 @@
 - url = polymorphic_path(@report.report_path_array)
+- alert = 'Included projects are limited by supported types (ES, SO, SH, TH, PH), selected CoCs, and selected Funding Sources.'
 
 %p.alert.alert-info Please note that, unless you include all homeless project types (ES, SO, SH, TH), returns to homelessness calculations may not work as expected.
 
-= simple_form_for @filter, as: :filters, url: url, data: { controller: 'filter-projects' } do |f|
+= simple_form_for @filter, as: :filters, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @report.project_type_ids } do |f|
   - content_for :filters_col_full do
     .row.mb-4
       .col-sm-3
@@ -11,7 +12,7 @@
         = f.input :end, as: :date_picker, label: 'End Date', required: true
       .col-sm-6
         = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose CoCs', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes'
-    = render 'hud_reports/project_filter', f: f
+    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, projects_collection: @report.project_options_for_select(current_user), alert: alert
     %h2 Limits
     .row.mt-4
       - @sections.in_groups(2).each do |sections|

--- a/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
+++ b/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
@@ -1,5 +1,8 @@
 - url = polymorphic_path(@report.report_path_array)
-- alert = 'Included projects are limited by supported types (ES, SO, SH, TH, PH), selected CoCs, and selected Funding Sources.'
+- alert = 'Included projects are limited by those in the SPM (ES, SO, SH, TH, PH), selected CoCs, and selected Funding Sources.'
+- project_types_collection = @report.project_type_options_for_select
+-# Limit project list by supported project types
+- api_projects_parameters = { project_types: project_types_collection.values }
 
 %p.alert.alert-info Please note that, unless you include all homeless project types (ES, SO, SH, TH), returns to homelessness calculations may not work as expected.
 
@@ -12,7 +15,7 @@
         = f.input :end, as: :date_picker, label: 'End Date', required: true
       .col-sm-6
         = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose CoCs', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes'
-    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, projects_collection: @report.project_options_for_select(current_user), alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
     %h2 Limits
     .row.mt-4
       - @sections.in_groups(2).each do |sections|

--- a/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
+++ b/drivers/homeless_summary_report/app/views/homeless_summary_report/warehouse_reports/reports/_form.haml
@@ -1,8 +1,5 @@
 - url = polymorphic_path(@report.report_path_array)
 - alert = 'Included projects are limited by those in the SPM (ES, SO, SH, TH, PH), selected CoCs, and selected Funding Sources.'
-- project_types_collection = @report.project_type_options_for_select
--# Limit project list by supported project types
-- api_projects_parameters = { project_types: project_types_collection.values }
 
 %p.alert.alert-info Please note that, unless you include all homeless project types (ES, SO, SH, TH), returns to homelessness calculations may not work as expected.
 
@@ -15,7 +12,7 @@
         = f.input :end, as: :date_picker, label: 'End Date', required: true
       .col-sm-6
         = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose CoCs', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes'
-    = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: HomelessSummaryReport::Report::SPM_PROJECT_TYPES }, alert: alert
     %h2 Limits
     .row.mt-4
       - @sections.in_groups(2).each do |sections|

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -7,15 +7,19 @@
 module HudPathReport::Filters
   class PathFilter < ::Filters::HudFilterBase
     def default_project_type_codes
-      [:so, :services_only]
+      path_project_types
     end
 
     def path_project_types_for_select
-      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:so, :services_only]) }.invert.freeze
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(path_project_types) }.invert.freeze
     end
 
     def path_project_type_ids
-      [:so, :services_only].map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s] }.flatten
+      path_project_types.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s] }.flatten
+    end
+
+    def path_project_types
+      GrdaWarehouse::Hud::Project::PATH_PROJECT_TYPE_CODES
     end
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -12,11 +12,17 @@ module HudPathReport::Filters
 
     def project_options_for_select(user:)
       path_funded = ::GrdaWarehouse::Hud::Funder.funding_source(funder_code: 21)
-      all_project_scope.joins(:funders).options_for_select(user: user, scope: path_funded)
+      all_project_scope.with_hud_project_type(path_project_type_ids)
+        .joins(:funders)
+        .options_for_select(user: user, scope: path_funded)
     end
 
     def path_project_types_for_select
       GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:so, :services_only]) }.invert.freeze
+    end
+
+    def path_project_type_ids
+      [:so, :services_only].map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s] }.flatten
     end
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -10,13 +10,6 @@ module HudPathReport::Filters
       [:so, :services_only]
     end
 
-    def project_options_for_select(user:)
-      path_funded = ::GrdaWarehouse::Hud::Funder.funding_source(funder_code: 21)
-      all_project_scope.with_hud_project_type(path_project_type_ids)
-        .joins(:funders)
-        .options_for_select(user: user, scope: path_funded)
-    end
-
     def path_project_types_for_select
       GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:so, :services_only]) }.invert.freeze
     end

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2020/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2020/base.rb
@@ -11,6 +11,8 @@ module HudPathReport::Generators::Fy2020
     include HudPathReport::CommonQueries
     include HudReports::Incomes
 
+    PATH_FUNDER_CODE = 21
+
     def initialize(generator = nil, report = nil, options: {})
       super
       options = report.options.with_indifferent_access.merge(user_id: report.user_id) if options.blank?
@@ -119,7 +121,7 @@ module HudPathReport::Generators::Fy2020
       scope = client.source_enrollments.
         joins(project: :funders).
         open_during_range(@report.start_date..@report.end_date).
-        merge(::GrdaWarehouse::Hud::Funder.funding_source(funder_code: 21)). # PATH projects are PATH funded
+        merge(::GrdaWarehouse::Hud::Funder.funding_source(funder_code: PATH_FUNDER_CODE)). # PATH projects are PATH funded
         order(EntryDate: :desc)
       scope = scope.with_project_type(@filter.project_type_ids) if @filter.project_type_ids.present?
       scope = scope.in_project(@report.project_ids) if @report.project_ids.present? # for consistency with client_scope

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/base.rb
@@ -11,6 +11,8 @@ module HudPathReport::Generators::Fy2021
     include HudPathReport::CommonQueries
     include HudReports::Incomes
 
+    PATH_FUNDER_CODE = 21
+
     def initialize(generator = nil, report = nil, options: {})
       super
       options = report.options.with_indifferent_access.merge(user_id: report.user_id) if options.blank?
@@ -119,7 +121,7 @@ module HudPathReport::Generators::Fy2021
       scope = client.source_enrollments.
         joins(project: :funders).
         open_during_range(@report.start_date..@report.end_date).
-        merge(::GrdaWarehouse::Hud::Funder.funding_source(funder_code: 21)). # PATH projects are PATH funded
+        merge(::GrdaWarehouse::Hud::Funder.funding_source(funder_code: PATH_FUNDER_CODE)). # PATH projects are PATH funded
         order(EntryDate: :desc)
       scope = scope.with_project_type(@filter.project_type_ids) if @filter.project_type_ids.present?
       scope = scope.in_project(@report.project_ids) if @report.project_ids.present? # for consistency with client_scope

--- a/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
+++ b/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
@@ -1,10 +1,7 @@
 - coc_cols = if active_report_versions.count > 1 then 'col-sm-3' else 'col-sm-6' end
 - default_coc_code = GrdaWarehouse::Config.get(:site_coc_codes)
 - alert = 'Included projects are limited by supported types (Street Outreach and Services Only) and selected CoCs.'
-- project_types_collection = @filter.path_project_types_for_select
--# Limit project list by supported project types and Funder ID
 - path_funder_code = HudPathReport::Generators::Fy2020::Base::PATH_FUNDER_CODE
-- api_projects_parameters = { project_types: project_types_collection.values, funder_codes: [path_funder_code] }
 = simple_form_for @filter, as: :filter, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @filter.path_project_type_ids } do |f|
   - content_for :filters_col_full do
     .hud-report-options
@@ -23,7 +20,7 @@
         %div{ class: coc_cols }
           = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes', hint: default_coc_code
         = f.input :funder_ids, as: :hidden, input_html: { value: [path_funder_code], data: {'filter-projects-target' => 'funderIds'} }
-      = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
+      = render 'hud_reports/project_filter', f: f, project_types_collection: @filter.path_project_types_for_select, api_projects_parameters: { project_types: @filter.default_project_type_codes, funder_codes: [path_funder_code] }, alert: alert
 
   - content_for :filter_actions do
     = f.button :submit, value: 'Queue Report', data: { 'filter-projects-target' => 'submitButton' }

--- a/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
+++ b/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
@@ -1,7 +1,7 @@
 - coc_cols = if active_report_versions.count > 1 then 'col-sm-3' else 'col-sm-6' end
-
 - default_coc_code = GrdaWarehouse::Config.get(:site_coc_codes)
-= simple_form_for @filter, as: :filter, url: url, data: { controller: 'filter-projects' } do |f|
+- alert = 'Included projects are limited by supported types (Street Outreach and Services Only) and selected CoCs.'
+= simple_form_for @filter, as: :filter, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @filter.path_project_type_ids } do |f|
   - content_for :filters_col_full do
     .hud-report-options
       %h2 Required Options
@@ -18,7 +18,8 @@
           = f.input :report_version, as: :hidden, input_html: { value: active_report_versions.map(&:last)}
         %div{ class: coc_cols }
           = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes', hint: default_coc_code
-      = render 'hud_reports/project_filter', f: f, project_types_collection: @filter.path_project_types_for_select
+      = render 'hud_reports/project_filter', f: f, project_types_collection: @filter.path_project_types_for_select, alert: alert
+
   - content_for :filter_actions do
     = f.button :submit, value: 'Queue Report', data: { 'filter-projects-target' => 'submitButton' }
 

--- a/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
+++ b/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
@@ -1,6 +1,10 @@
 - coc_cols = if active_report_versions.count > 1 then 'col-sm-3' else 'col-sm-6' end
 - default_coc_code = GrdaWarehouse::Config.get(:site_coc_codes)
 - alert = 'Included projects are limited by supported types (Street Outreach and Services Only) and selected CoCs.'
+- project_types_collection = @filter.path_project_types_for_select
+-# Limit project list by supported project types and Funder ID
+- path_funder_code = HudPathReport::Generators::Fy2020::Base::PATH_FUNDER_CODE
+- api_projects_parameters = { project_types: project_types_collection.values, funder_codes: [path_funder_code] }
 = simple_form_for @filter, as: :filter, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @filter.path_project_type_ids } do |f|
   - content_for :filters_col_full do
     .hud-report-options
@@ -18,7 +22,8 @@
           = f.input :report_version, as: :hidden, input_html: { value: active_report_versions.map(&:last)}
         %div{ class: coc_cols }
           = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes', hint: default_coc_code
-      = render 'hud_reports/project_filter', f: f, project_types_collection: @filter.path_project_types_for_select, alert: alert
+        = f.input :funder_ids, as: :hidden, input_html: { value: [path_funder_code], data: {'filter-projects-target' => 'funderIds'} }
+      = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
 
   - content_for :filter_actions do
     = f.button :submit, value: 'Queue Report', data: { 'filter-projects-target' => 'submitButton' }

--- a/drivers/performance_measurement/app/models/performance_measurement/report.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/report.rb
@@ -28,8 +28,6 @@ module PerformanceMeasurement
 
     after_initialize :filter
 
-    SPM_PROJECT_TYPES = [:es, :so, :sh, :th, :ph].freeze
-
     # NOTE: this differs from viewable_by which looks at the report definitions
     scope :visible_to, ->(user) do
       return all if user.can_view_all_reports?
@@ -115,12 +113,16 @@ module PerformanceMeasurement
       'performance_measurement/warehouse_reports/reports'
     end
 
+    def spm_project_types
+      GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES
+    end
+
     def project_type_ids
-      SPM_PROJECT_TYPES.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
+      spm_project_types.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
     end
 
     def project_type_options_for_select
-      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(SPM_PROJECT_TYPES) }.freeze.invert
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(spm_project_types) }.freeze.invert
     end
 
     def project_options_for_select(user)
@@ -142,7 +144,7 @@ module PerformanceMeasurement
     end
 
     def default_project_types
-      SPM_PROJECT_TYPES
+      GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES
     end
 
     def report_path_array

--- a/drivers/performance_measurement/app/models/performance_measurement/report.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/report.rb
@@ -28,6 +28,8 @@ module PerformanceMeasurement
 
     after_initialize :filter
 
+    SPM_PROJECT_TYPES = [:es, :so, :sh, :th, :ph].freeze
+
     # NOTE: this differs from viewable_by which looks at the report definitions
     scope :visible_to, ->(user) do
       return all if user.can_view_all_reports?
@@ -114,11 +116,11 @@ module PerformanceMeasurement
     end
 
     def project_type_ids
-      [:es, :so, :sh, :th, :ph].map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
+      SPM_PROJECT_TYPES.map { |s| GrdaWarehouse::Hud::Project::PERFORMANCE_REPORTING[s.to_sym] }.flatten
     end
 
     def project_type_options_for_select
-      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?([:es, :so, :sh, :th, :ph]) }.freeze.invert
+      GrdaWarehouse::Hud::Project::PROJECT_GROUP_TITLES.select { |k, _| k.in?(SPM_PROJECT_TYPES) }.freeze.invert
     end
 
     def project_options_for_select(user)
@@ -140,7 +142,7 @@ module PerformanceMeasurement
     end
 
     def default_project_types
-      [:ph, :es, :th, :sh, :so]
+      SPM_PROJECT_TYPES
     end
 
     def report_path_array

--- a/drivers/performance_measurement/app/models/performance_measurement/report.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/report.rb
@@ -123,7 +123,7 @@ module PerformanceMeasurement
 
     def project_options_for_select(user)
       GrdaWarehouse::Hud::Project.viewable_by(user).
-        where(ProjectType: project_type_ids).
+        with_hud_project_type(project_type_ids).
         options_for_select(user: user)
     end
 

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
@@ -1,5 +1,9 @@
 - url = polymorphic_path(@report.report_path_array)
-- alert = 'Included projects are limited by supported types (ES, SO, SH, TH, PH) and selected CoC.'
+- alert = 'Included projects are limited by those in the SPM (ES, SO, SH, TH, PH) and the selected CoC.'
+- project_types_collection = @report.project_type_options_for_select
+-# Limit project list by supported project types
+- api_projects_parameters = { project_types: project_types_collection.values }
+
 = simple_form_for @filter, as: :filters, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @report.project_type_ids } do |f|
   - content_for :filters_col_full do
     %p Please note, the report will cover the year prior to the date chosen, and provide a comparison to the year before that.
@@ -8,7 +12,7 @@
         = f.input :end, as: :date_picker, label: 'End date of period', required: true
       .col-sm-3
         = f.input :coc_code, collection: @filter.coc_code_options_for_select(user: current_user), required: false, input_html: { class: ['select2-id-when-selected'], placeholder: 'Please Choose', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'} }, label: 'CoC Code', as: :select_two, placeholder: 'Please Choose', required: true
-    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, projects_collection: @report.project_options_for_select(current_user), alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
   - content_for :filter_actions do
     = f.submit 'Queue Report', class: ['btn', 'btn-primary'], data: { 'filter-projects-target' => 'submitButton' }
 

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
@@ -1,5 +1,5 @@
 - url = polymorphic_path(@report.report_path_array)
-- alert = 'Please note, the following options are additive.  If you choose a single project and a project type, the report will run for all projects in the project type and the chosen project.  If you choose a data source and project type, the report will run for all projects in the chosen data source and chosen project type. Projects are limited by supported Project Types (PH, ES, TH, SH, SO) and selected CoC.'
+- alert = 'Included projects are limited by supported types (ES, SO, SH, TH, PH) and selected CoC.'
 = simple_form_for @filter, as: :filters, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @report.project_type_ids } do |f|
   - content_for :filters_col_full do
     %p Please note, the report will cover the year prior to the date chosen, and provide a comparison to the year before that.

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
@@ -1,8 +1,5 @@
 - url = polymorphic_path(@report.report_path_array)
 - alert = 'Included projects are limited by those in the SPM (ES, SO, SH, TH, PH) and the selected CoC.'
-- project_types_collection = @report.project_type_options_for_select
--# Limit project list by supported project types
-- api_projects_parameters = { project_types: project_types_collection.values }
 
 = simple_form_for @filter, as: :filters, url: url, data: { controller: 'filter-projects', 'filter-projects-supported-project-types-value': @report.project_type_ids } do |f|
   - content_for :filters_col_full do
@@ -12,7 +9,7 @@
         = f.input :end, as: :date_picker, label: 'End date of period', required: true
       .col-sm-3
         = f.input :coc_code, collection: @filter.coc_code_options_for_select(user: current_user), required: false, input_html: { class: ['select2-id-when-selected'], placeholder: 'Please Choose', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'} }, label: 'CoC Code', as: :select_two, placeholder: 'Please Choose', required: true
-    = render 'hud_reports/project_filter', f: f, project_types_collection: project_types_collection, api_projects_parameters: api_projects_parameters, alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: PerformanceMeasurement::Report::SPM_PROJECT_TYPES }, alert: alert
   - content_for :filter_actions do
     = f.submit 'Queue Report', class: ['btn', 'btn-primary'], data: { 'filter-projects-target' => 'submitButton' }
 

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
@@ -9,7 +9,7 @@
         = f.input :end, as: :date_picker, label: 'End date of period', required: true
       .col-sm-3
         = f.input :coc_code, collection: @filter.coc_code_options_for_select(user: current_user), required: false, input_html: { class: ['select2-id-when-selected'], placeholder: 'Please Choose', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'} }, label: 'CoC Code', as: :select_two, placeholder: 'Please Choose', required: true
-    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: PerformanceMeasurement::Report::SPM_PROJECT_TYPES }, alert: alert
+    = render 'hud_reports/project_filter', f: f, project_types_collection: @report.project_type_options_for_select, api_projects_parameters: { project_types: GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES }, alert: alert
   - content_for :filter_actions do
     = f.submit 'Queue Report', class: ['btn', 'btn-primary'], data: { 'filter-projects-target' => 'submitButton' }
 


### PR DESCRIPTION
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/2187

1. Switch to `with_hud_project_type` everywhere
2. Update PATH to limit included project list (and project dropdown) by supported types
3. Update Homeless Summary Report to limit included project list (and project dropdown) by supported types
4. Update alert messages for clarity