### PR TITLE
Only count unique enrollments, don't multiply by funding sources

### DIFF
--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/base.rb
@@ -122,6 +122,7 @@ module HudPathReport::Generators::Fy2021
         joins(project: :funders).
         open_during_range(@report.start_date..@report.end_date).
         merge(::GrdaWarehouse::Hud::Funder.funding_source(funder_code: PATH_FUNDER_CODE)). # PATH projects are PATH funded
+        distinct. # sometimes projects have multiple funding sources all PATH, only include the project once
         order(EntryDate: :desc)
       scope = scope.with_project_type(@filter.project_type_ids) if @filter.project_type_ids.present?
       scope = scope.in_project(@report.project_ids) if @report.project_ids.present? # for consistency with client_scope


### PR DESCRIPTION
Sometimes projects get multiple PATH funding sources and we were returning enrollments multiplied by funding sources.  This gets distinct enrollments.