### PR TITLE
Require file upload for Release of Information

### DIFF
--- a/app/models/health/release_form.rb
+++ b/app/models/health/release_form.rb
@@ -36,7 +36,6 @@ module Health
     scope :valid, -> do
       parent_ids = Health::ReleaseFormFile.where.not(parent_id: nil).pluck(:parent_id)
       where.not(file_location: [nil, '']).
-        or(where(verbal_approval: true)).
         or(where(id: parent_ids))
     end
 
@@ -95,8 +94,6 @@ module Health
     end
 
     def file_or_location
-      return if verbal_approval?
-
       errors.add :file_location, 'Please upload a release of information form.' if health_file.blank? && file_location.blank?
       errors.add :health_file, health_file.errors.messages.try(:[], :file)&.uniq&.join('; ') if health_file.present? && health_file.invalid?
     end

--- a/app/views/health/release_forms/_form.haml
+++ b/app/views/health/release_forms/_form.haml
@@ -1,7 +1,11 @@
 = simple_form_for @release_form, url: form_url, as: :form, remote: true, html: {multipart: true} do |f|
 
-  = f.error_notification
-
+  - if @release_form.errors.any?
+    .alert.alert-danger.flex-column.align-items-start
+      %p Please review the errors below:
+      %ul.error_list
+        - @release_form.errors.messages.values.first.each do |msg|
+          %li= msg
   .row
     .col-sm-6
       = f.input :signature_on, as: :date_picker
@@ -17,10 +21,7 @@
           %i.icon-download2
           Blank Release Form
 
-  - highlights = ''
-  - if @release_form.errors.messages[:file_location].present?
-    - highlights = 'alert alert-danger'
-  %div{class: highlights}
+  %div
     .row
       .col-sm-6.j-file-upload
         = render 'upload_fields', f: f


### PR DESCRIPTION
Require ROI upload, and show error if file upload missing.

If you get errors after uploading a file (e.g. uploading the wrong format) then you're popped out of the modal onto a new page (because [you can't do remote forms with file uploads](https://stackoverflow.com/questions/7376304/remote-true-not-working-when-a-file-uploader-is-used-in-form)). I think we should probably fix that, but at least it shows the errors listed out now.
