### PR TITLE
Symlink latest version to libproj.so.25

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
   tar xz \
   python3 py3-pip \
   && git config --global --add safe.directory /app \
-  && ln -s libproj.so.21.1.2 /usr/lib/libproj.so.20
+  && ln -s $(ls -1r /usr/lib/libproj.so.* | head -1) /usr/lib/libproj.so.25
 
 RUN pip3 install awscliv2
 


### PR DESCRIPTION
It's possible this will break things for other people? I don't know if there is a way to determine whether we need 25 or some other version.