### PR TITLE
Per-client YYA Export

### DIFF
--- a/app/controllers/warehouse_reports/youth_intake_export_controller.rb
+++ b/app/controllers/warehouse_reports/youth_intake_export_controller.rb
@@ -36,6 +36,11 @@ module WarehouseReports
         preload(:client, :youth_intakes).
         visible_by?(current_user).
         between(start_date: @filter.start, end_date: @filter.end)
+      @housing_resolution_plans = GrdaWarehouse::Youth::HousingResolutionPlan.ordered.
+        joins(:client).
+        preload(:client, :youth_intakes).
+        visible_by?(current_user).
+        between(start_date: @filter.start, end_date: @filter.end)
 
       commit = params[:commit]
       respond_to do |format|
@@ -52,6 +57,7 @@ module WarehouseReports
               dfas: @dfas,
               case_managements: @case_managements,
               follow_ups: @follow_ups,
+              housing_resolution_plans: @housing_resolution_plans,
               controller: self,
             )
             send_data(zip_exporter.export!, filename: zip_filename)

--- a/app/controllers/warehouse_reports/youth_intake_export_controller.rb
+++ b/app/controllers/warehouse_reports/youth_intake_export_controller.rb
@@ -36,10 +36,26 @@ module WarehouseReports
         preload(:client, :youth_intakes).
         visible_by?(current_user).
         between(start_date: @filter.start, end_date: @filter.end)
+
+      commit = params[:commit]
       respond_to do |format|
         format.xlsx do
-          filename = "Youth Intake Export #{Time.current.to_s.delete(',')}.xlsx"
-          render(xlsx: 'index', filename: filename)
+          case commit
+          when 'Download Data'
+            xlsx_filename = "Youth Intake Export #{Time.current.to_s.delete(',')}.xlsx"
+            render(xlsx: 'index', filename: xlsx_filename)
+          when 'Download Per-Client Data'
+            zip_filename = "Youth Intake Exports #{Time.current.to_s.delete(',')}.zip"
+            zip_exporter = GrdaWarehouse::Youth::ZipExporter.new(
+              intakes: @intakes,
+              referrals: @referrals,
+              dfas: @dfas,
+              case_managements: @case_managements,
+              follow_ups: @follow_ups,
+              controller: self,
+            )
+            send_data(zip_exporter.export!, filename: zip_filename)
+          end
         end
       end
     end

--- a/app/models/grda_warehouse/youth/housing_resolution_plan.rb
+++ b/app/models/grda_warehouse/youth/housing_resolution_plan.rb
@@ -6,9 +6,19 @@
 
 module GrdaWarehouse::Youth
   class HousingResolutionPlan < GrdaWarehouse::Youth::Base
+    include YouthExport
+
     belongs_to :client, class_name: 'GrdaWarehouse::Hud::Client', inverse_of: :housing_resolution_plans
     belongs_to :user, optional: true
     has_many :youth_intakes, through: :client
+    scope :ordered, -> do
+      order(planned_on: :desc)
+    end
+
+    scope :between, ->(start_date:, end_date:) do
+      at = arel_table
+      where(at[:planned_on].gteq(start_date).and(at[:planned_on].lteq(end_date)))
+    end
 
     def yes_no
       [

--- a/app/models/grda_warehouse/youth/zip_exporter.rb
+++ b/app/models/grda_warehouse/youth/zip_exporter.rb
@@ -31,7 +31,10 @@ module GrdaWarehouse::Youth
             housing_resolution_plans: @housing_resolution_plans.select { |hrp| hrp.client_id == intake.client_id },
           }
           contents = @controller.render_to_string(:per_client, locals: locals)
-          filename = File.join(@file_path, 'Client ' + intake.client_id.to_s + (intake.hmis_client? ? ' (HMIS)' : '') + '.xlsx')
+          name = "Client #{intake.client_id} - #{intake.id}"
+          name += ' (HMIS)' if intake.hmis_client?
+          name += '.xlsx'
+          filename = File.join(@file_path, name)
           File.open(filename, 'w') { |file| file.write(contents) }
         end
         file = create_zip_file

--- a/app/models/grda_warehouse/youth/zip_exporter.rb
+++ b/app/models/grda_warehouse/youth/zip_exporter.rb
@@ -7,12 +7,13 @@
 require 'zip'
 module GrdaWarehouse::Youth
   class ZipExporter
-    def initialize(intakes:, referrals:, dfas:, case_managements:, follow_ups:, controller:, file_path: 'var/yya_export')
+    def initialize(intakes:, referrals:, dfas:, case_managements:, follow_ups:, housing_resolution_plans:, controller:, file_path: 'var/yya_export')
       @intakes = intakes
       @referrals = referrals
       @dfas = dfas
       @case_managements = case_managements
       @follow_ups = follow_ups
+      @housing_resolution_plans = housing_resolution_plans
       @controller = controller
       @file_path = "#{file_path}/#{Process.pid}" # Usual Unixism -- create a unique path based on the PID
     end
@@ -27,6 +28,7 @@ module GrdaWarehouse::Youth
             client_dfas: @dfas.select { |dfa| dfa.client_id == intake.client_id },
             client_case_managements: @case_managements.select { |case_management| case_management.client_id == intake.client_id },
             client_follow_ups: @follow_ups.select { |follow_up| follow_up.client_id == intake.client_id },
+            housing_resolution_plans: @housing_resolution_plans.select { |hrp| hrp.client_id == intake.client_id },
           }
           contents = @controller.render_to_string(:per_client, locals: locals)
           filename = File.join(@file_path, 'Client ' + intake.client_id.to_s + (intake.hmis_client? ? ' (HMIS)' : '') + '.xlsx')

--- a/app/models/grda_warehouse/youth/zip_exporter.rb
+++ b/app/models/grda_warehouse/youth/zip_exporter.rb
@@ -1,0 +1,69 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'zip'
+module GrdaWarehouse::Youth
+  class ZipExporter
+    def initialize(intakes:, referrals:, dfas:, case_managements:, follow_ups:, controller:, file_path: 'var/yya_export')
+      @intakes = intakes
+      @referrals = referrals
+      @dfas = dfas
+      @case_managements = case_managements
+      @follow_ups = follow_ups
+      @controller = controller
+      @file_path = "#{file_path}/#{Process.pid}" # Usual Unixism -- create a unique path based on the PID
+    end
+
+    def export!
+      create_export_directory
+      begin
+        @intakes.each do |intake|
+          locals = {
+            client_intake: intake,
+            client_referrals: @referrals.select { |referral| referral.client_id == intake.client_id },
+            client_dfas: @dfas.select { |dfa| dfa.client_id == intake.client_id },
+            client_case_managements: @case_managements.select { |case_management| case_management.client_id == intake.client_id },
+            client_follow_ups: @follow_ups.select { |follow_up| follow_up.client_id == intake.client_id },
+          }
+          contents = @controller.render_to_string(:per_client, locals: locals)
+          filename = File.join(@file_path, 'Client ' + intake.client_id.to_s + (intake.hmis_client? ? ' (HMIS)' : '') + '.xlsx')
+          File.open(filename, 'w') { |file| file.write(contents) }
+        end
+        file = create_zip_file
+      ensure
+        remove_export_directory
+      end
+      file
+    end
+
+    def create_export_directory
+      # Remove any old export
+      FileUtils.rmtree(@file_path) if File.exist?(@file_path)
+      FileUtils.mkdir_p(@file_path)
+    end
+
+    def zip_path
+      File.join(@file_path, 'yya_export') + '.zip'
+    end
+
+    def create_zip_file
+      files = Dir.glob(File.join(@file_path, '*')).map { |path| File.basename(path) }
+      Zip::File.open(zip_path, Zip::File::CREATE) do |zip_file|
+        files.each do |file_name|
+          zip_file.add(
+            file_name,
+            File.join(@file_path, file_name),
+          )
+        end
+      end
+      File.open(zip_path, 'rb', &:read)
+    end
+
+    def remove_export_directory
+      FileUtils.rmtree(@file_path) if File.exist?(@file_path)
+    end
+  end
+end

--- a/app/models/grda_warehouse/youth_intake/base.rb
+++ b/app/models/grda_warehouse/youth_intake/base.rb
@@ -62,6 +62,11 @@ module GrdaWarehouse::YouthIntake
       end
     end
 
+    def hmis_client?
+      # If there is a client from a non-authoritative data source, it is from an HMIS upload
+      client.source_clients.any? { |client| ! client.data_source.authoritative? }
+    end
+
     scope :served, -> do
       where(turned_away: false)
     end

--- a/app/models/grda_warehouse/youth_intake/base.rb
+++ b/app/models/grda_warehouse/youth_intake/base.rb
@@ -64,7 +64,7 @@ module GrdaWarehouse::YouthIntake
 
     def hmis_client?
       # If there is a client from a non-authoritative data source, it is from an HMIS upload
-      client.source_clients.any? { |client| ! client.data_source.authoritative? }
+      client&.source_clients&.any? { |client| ! client.data_source&.authoritative? }
     end
 
     scope :served, -> do

--- a/app/views/warehouse_reports/youth_intake_export/_filter.haml
+++ b/app/views/warehouse_reports/youth_intake_export/_filter.haml
@@ -6,6 +6,7 @@
 
   - content_for :filter_actions do
     = f.button :submit, value: 'Download Data'
+    = f.button :submit, value: 'Download Per-Client Data'
 
   = render 'warehouse_reports/filters', f:f, submit_button: nil
 = content_for :page_js do

--- a/app/views/warehouse_reports/youth_intake_export/per_client.xlsx.axlsx
+++ b/app/views/warehouse_reports/youth_intake_export/per_client.xlsx.axlsx
@@ -1,0 +1,145 @@
+wb = xlsx_package.workbook
+wb.add_worksheet(name: 'Youth Intakes') do |sheet|
+  intake_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :title,
+    :other_staff_completed_intake,
+    :first_name,
+    :last_name,
+    :ssn,
+    :client_dob,
+    :staff_name,
+    :staff_email,
+    :engagement_date,
+    :exit_date,
+    :unaccompanied,
+    :street_outreach_contact,
+    :housing_status,
+    :owns_cell_phone,
+    :secondary_education,
+    :attending_college,
+    :health_insurance,
+    :requesting_financial_assistance,
+    :staff_believes_youth_under_24,
+    :gender,
+    :client_lgbtq,
+    :race_array,
+    :ethnicity_description,
+    :client_primary_language,
+    :pregnant_or_parenting,
+    :disabilities,
+    :how_hear,
+    :needs_shelter,
+    :referred_to_shelter,
+    :in_stable_housing,
+    :stable_housing_zipcode,
+    :youth_experiencing_homelessness_at_start,
+    :turned_away,
+    :college_pilot,
+    :graduating_college,
+    :other_agency_involvements,
+    :client_id,
+  ]
+  bold = sheet.styles.add_style(sz: 12, b: true)
+  intake = GrdaWarehouse::YouthIntake::Base.export_headers.zip(client_intake.for_export).
+    select { |k, _v| intake_order.include?(k.to_sym) }.
+    sort_by { |k, _v| intake_order.find_index(k.to_sym) }
+  intake.each do |k, v|
+    sheet.add_row([k.titleize, v], style: [bold, nil])
+  end
+end
+
+wb.add_worksheet(name: 'Referrals') do |sheet|
+  referrals_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :referred_on,
+    :referred_to,
+    :notes,
+  ]
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  row = GrdaWarehouse::Youth::YouthReferral.export_headers.select { |k, _v| referrals_order.include?(k.to_sym) }.map(&:titleize)
+  sheet.add_row(row, style: title)
+
+  client_referrals.each do |record|
+    row = GrdaWarehouse::Youth::YouthReferral.export_headers.zip(record.for_export).
+      select { |k, _v| referrals_order.include?(k.to_sym) }.
+      sort_by { |k, _v| referrals_order.find_index(k.to_sym) }.
+      map { |_k, v| v }
+    sheet.add_row(row)
+  end
+end
+
+wb.add_worksheet(name: 'Case Management') do |sheet|
+  case_managements_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :engaged_on,
+    :activity,
+    :housing_status,
+    :other_housing_status,
+    :zip_code,
+  ]
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  row = GrdaWarehouse::Youth::YouthCaseManagement.export_headers.select { |k, _v| case_managements_order.include?(k.to_sym) }.map(&:titleize)
+  sheet.add_row(row, style: title)
+
+  client_case_managements.each do |record|
+    row = GrdaWarehouse::Youth::YouthCaseManagement.export_headers.zip(record.for_export).
+      select { |k, _v| case_managements_order.include?(k.to_sym) }.
+      sort_by { |k, _v| case_managements_order.find_index(k.to_sym) }.
+      map { |_k, v| v }
+    sheet.add_row(row)
+  end
+end
+
+wb.add_worksheet(name: 'Direct Financial Assistance') do |sheet|
+  dfas_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :provided_on,
+    :type_provided,
+    :amount,
+  ]
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  row = GrdaWarehouse::Youth::DirectFinancialAssistance.export_headers.select { |k, _v| dfas_order.include?(k.to_sym) }.map(&:titleize)
+  sheet.add_row(row, style: title)
+
+  client_dfas.each do |record|
+    row = GrdaWarehouse::Youth::DirectFinancialAssistance.export_headers.zip(record.for_export).
+      select { |k, _v| dfas_order.include?(k.to_sym) }.
+      sort_by { |k, _v| dfas_order.find_index(k.to_sym) }.
+      map { |_k, v| v }
+    sheet.add_row(row)
+  end
+end
+
+wb.add_worksheet(name: '3-Month Follow-ups') do |sheet|
+  follow_ups_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :contacted_on,
+    :housing_status,
+    :zip_code,
+    :action,
+    :action_on,
+    :required_on,
+  ]
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  row = GrdaWarehouse::Youth::YouthFollowUp.export_headers.select { |k, _v| follow_ups_order.include?(k.to_sym) }.map(&:titleize)
+  sheet.add_row(row, style: title)
+
+  client_follow_ups.each do |record|
+    row = GrdaWarehouse::Youth::YouthFollowUp.export_headers.zip(record.for_export).
+      select { |k, _v| follow_ups_order.include?(k.to_sym) }.
+      sort_by { |k, _v| follow_ups_order.find_index(k.to_sym) }.
+      map { |_k, v| v }
+    sheet.add_row(row)
+  end
+end

--- a/app/views/warehouse_reports/youth_intake_export/per_client.xlsx.axlsx
+++ b/app/views/warehouse_reports/youth_intake_export/per_client.xlsx.axlsx
@@ -143,3 +143,44 @@ wb.add_worksheet(name: '3-Month Follow-ups') do |sheet|
     sheet.add_row(row)
   end
 end
+
+wb.add_worksheet(name: 'Housing Resolution Plans') do |sheet|
+  housing_resolution_plans_order = [
+    :entered_by_user,
+    :user_email,
+    :user_agency,
+    :pronouns,
+    :planned_on,
+    :staff_name,
+    :location,
+    :chosen_resolution,
+    :temporary_resolution,
+    :plan_description, :action_steps,
+    :backup_plan,
+    :next_checkin,
+    :how_to_contact,
+    :psc_attempted,
+    :psc_why_not,
+    :resolution_achieved,
+    :resolution_why_not,
+    :problem_solving_point,
+    :housing_crisis_causes,
+    :housing_crisis_cause_other,
+    :factor_employment_income,
+    :factor_family_supports,
+    :factor_social_supports,
+    :factor_life_skills,
+  ]
+
+  title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
+  row = GrdaWarehouse::Youth::HousingResolutionPlan.export_headers.select { |k, _v| housing_resolution_plans_order.include?(k.to_sym) }.map(&:titleize)
+  sheet.add_row(row, style: title)
+
+  housing_resolution_plans.each do |record|
+    row = GrdaWarehouse::Youth::HousingResolutionPlan.export_headers.zip(record.for_export).
+      select { |k, _v| housing_resolution_plans_order.include?(k.to_sym) }.
+      sort_by { |k, _v| housing_resolution_plans_order.find_index(k.to_sym) }.
+      map { |_k, v| v }
+    sheet.add_row(row)
+  end
+end


### PR DESCRIPTION
Added 'Download Per-Client Data' to https://hmis-warehouse.dev.test/warehouse_reports/youth_intake_export

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/33072305/171894153-45a4f03f-6749-4f83-8875-ccdff5865ed6.png">

Which selects the set of clients with an open YYA Intake in the specified range, and downloads a Zip file containing a spreadsheet for each client. The files are named with the Warehouse ID, and if there is a non-authoritative datasource (one that allows uploads) associated with the client, it is flagged as '(HMIS')'

Each file contains tabs that correspond to the Intake, and any Referrals, Case Management Notes, Direct Financial Assistance, 3-Month Follow Ups, and Housing Resolution Plans that were performed in the report range.

I took a guess on which fields were useful and minimally ordered the data, but that is easily updated as needed.