### PR TITLE
[PVT#181020089] More deployment improvements

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -45,10 +45,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    #- name: Install postgres
-    #  uses: harmon758/postgresql-action@v1
-    #  with:
-    #    postgresql version: '11'  # See https://hub.docker.com/_/postgres for available versions
     - name: Install aws cli
       id: install-aws-cli
       uses: unfor19/install-aws-cli-action@v1.0.3
@@ -67,75 +63,80 @@ jobs:
     - name: Prepare
       id: prep
       env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         SHA: ${{ github.sha }}
+        DOCKER_ASSETS_PATH: config/deploy/docker/assets
       run: |
+        export GITHASH="${SHA::9}"
+        export IMAGE_TAG="githash-${GITHASH}"
         export RUBY_VERSION=`cat .ruby-version`
         export PRE_CACHE_VERSION=`cat .pre-cache-version`
         export PRE_CACHE_TAG="${RUBY_VERSION}-${PRE_CACHE_VERSION}--pre-cache"
-        echo "::set-output name=pre_cache_tag::$PRE_CACHE_TAG"
 
-        export GITHASH="${SHA::9}"
+        echo $SHA > $DOCKER_ASSETS_PATH/REVISION
+
+        echo "::set-output name=pre_cache_tag::$PRE_CACHE_TAG"
+        echo "::set-output name=githash::$GITHASH"
+        echo "::set-output name=ruby_version::$RUBY_VERSION"
+        echo "::set-output name=docker_assets_path::$DOCKER_ASSETS_PATH"
+        echo "::set-output name=image_tag::$IMAGE_TAG"
+
         GITHASH=${GITHASH} VARIANT='base' bin/error_if_githash_is_latest
         GITHASH=${GITHASH} VARIANT='web' bin/error_if_githash_is_latest
         GITHASH=${GITHASH} VARIANT='dj' bin/error_if_githash_is_latest
+        GITHASH=${GITHASH} VARIANT='deploy' bin/error_if_githash_is_latest
+
+    # git commit --allow-empty -m "[gh:rebuild]"
+    - name: (Maybe) Rebuild pre-cache image
+      id: pre-cache
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        DOCKER_ASSETS_PATH: ${{ steps.prep.outputs.docker_assets_path }}
+        ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        RUBY_VERSION: ${{ steps.prep.outputs.ruby_version }}
+        PRE_CACHE_TAG: ${{ steps.prep.outputs.pre_cache_tag }}
+      run: |
+        if git log -1 | fgrep '[gh:rebuild]' ;
+        then
+          echo Building pre-cache image
+          docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.pre-cache --build-arg RUBY_VERSION=${RUBY_VERSION} -t $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} ${ECR_REPOSITORY}:latest--pre-cache
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG}
+        else
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG}
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} ${ECR_REPOSITORY}:latest--pre-cache
+        fi
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-        DOCKER_ASSETS_PATH: config/deploy/docker/assets
-        SHA: ${{ github.sha }}
+        DOCKER_ASSETS_PATH: ${{ steps.prep.outputs.docker_assets_path }}
+        GITHASH: ${{ steps.prep.outputs.githash }}
         PRE_CACHE_TAG: ${{ steps.prep.outputs.pre_cache_tag }}
+        IMAGE_TAG: ${{ steps.prep.outputs.image_tag }}
+        RUBY_VERSION: ${{ steps.prep.outputs.ruby_version }}
       run: |
-        export GITHASH="${SHA::9}"
-        export IMAGE_TAG="githash-${GITHASH}"
-        export RUBY_VERSION=`cat .ruby-version`
-
         echo $SHA > $DOCKER_ASSETS_PATH/REVISION
         echo 'no tag generated' > image-tag.txt
 
-        # git commit --allow-empty -m "[gh:rebuild]"
-        if git log -1 | fgrep '[gh:rebuild]' ;
-        then
-          echo Building pre-cache image
-          docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.pre-cache --build-arg RUBY_VERSION=${RUBY_VERSION} -t $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} .
-
-          echo Tagging pre-cache so local dockerfiles will work
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} ${ECR_REPOSITORY}:latest--pre-cache
-
-          echo Pushing pre-cache
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG}
-        else
-          echo Pulling pre-cache image
-          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG}
-
-          echo Tagging pre-cache so local dockerfiles will work
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${PRE_CACHE_TAG} ${ECR_REPOSITORY}:latest--pre-cache
-        fi
-
-        # the pre-cache image is like a stale version of the code. This builds the most recent things
         echo Building base
         docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.base --build-arg GITHASH=${GITHASH} --build-arg RUBY_VERSION=${RUBY_VERSION} -t ${ECR_REPOSITORY}:latest--base .
-
-        # tag it so we can push it remotely
-        echo Tagging base
         docker tag ${ECR_REPOSITORY}:latest--base $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--base
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--base
 
         echo Building web
         docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.web -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--web .
-
-        echo Building deploy
-        docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.deploy -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--deploy .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--web
 
         echo Building dj
         docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.dj -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--dj .
-
-        echo Pushing base/web/deploy
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--base
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--web
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--dj
+
+        echo Building deploy
+        docker build --file=$DOCKER_ASSETS_PATH/Dockerfile.${ECR_REPOSITORY}.deploy -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--deploy .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG--deploy
 
         echo $IMAGE_TAG--base > image-tag.txt

--- a/config/deploy/docker/lib/ecs_tools.rb
+++ b/config/deploy/docker/lib/ecs_tools.rb
@@ -39,6 +39,8 @@ class EcsTools
   end
 
   def poll_state_until_stable!(cluster, failures: true, max_unfinished: 0)
+    return if ENV.fetch('DISABLE_POLL_UNTIL_STABLE', false)
+
     puts 'These are only services, not tasks (e.g. migrations won\'t appear here)'
     puts 'PRIMARY: The most recently pushed task definition. These are the desired things we want or are deployed'
     puts 'ACTIVE: This is what\'s currently running and will show up when we have not yet transferred all the containers to be primary'


### PR DESCRIPTION
This includes:
- General cleanup to ECR GitHub Workflow (I did test using a matrix, we don't get any time back from it)
- Deploy will retry spinning up the deploy task if it takes too long to start
  - See line 483 of `roll_out.rb`, adjust `max_attemps` and `delay` if you're running into issues
  - `ecs.wait_until(:tasks_running, { cluster: cluster, tasks: [task_arn] }, { max_attempts: 25, delay: 10 })`
- You can now supply `DISABLE_POLL_UNTIL_STABLE=true` in your env file to disable polling until stable (the tabular view of running/upcoming tasks that pops up at the end of an individual deployment). We had discussed that this probably isn't needed anymore to prevent cluster churn, and that it makes the deployments take longer. 