### PR TITLE
Dont lighten light colors so much

### DIFF
--- a/app/assets/stylesheets/application/_settings/_colors.scss
+++ b/app/assets/stylesheets/application/_settings/_colors.scss
@@ -30,7 +30,7 @@ $brand-secondary:       #7D5226 !default;
 $brand-secondary-l:     lighten($brand-secondary, 25%) !default;
 $brand-success:         #009f44 !default;
 $brand-success-l:       #B1F2C4 !default;
-$brand-success-ll:      lighten($brand-success-l, 25%) !default;
+$brand-success-ll:      lighten($brand-success-l, 5%) !default;
 $brand-success-d:       #68c27f !default;
 $brand-positive:        $brand-success !default;
 $brand-positive-l:      $brand-success-l !default;
@@ -76,9 +76,9 @@ $vi-spdat: rgb(147, 12, 0) !default;
 
 // Tables
 $table-border-color: #DDDDDD !default;
-$table-cell-bg-positive: lighten($brand-success-l, 25%);
-$table-cell-bg-warning: lighten($brand-warning-l, 25%);
-$table-cell-bg-danger: lighten($brand-danger-l, 25%);
+$table-cell-bg-positive: lighten($brand-success-l, 5%);
+$table-cell-bg-warning: lighten($brand-warning-l, 5%);
+$table-cell-bg-danger: lighten($brand-danger-l, 5%);
 
 // Tabs
 $tab-bg: #88A6C9 !default; // Primary in HMIS

--- a/app/assets/stylesheets/application/components/_card.scss
+++ b/app/assets/stylesheets/application/components/_card.scss
@@ -277,7 +277,7 @@
 }
 
 .c-card__content-block--danger {
-  background-color: lighten($brand-danger-l, 10%);
+  background-color: lighten($brand-danger-l, 5%);
   padding: space(4);
 }
 

--- a/app/assets/stylesheets/application/modules/_health_emergency.scss
+++ b/app/assets/stylesheets/application/modules/_health_emergency.scss
@@ -2,7 +2,7 @@
 
 .client-tabs__health-emergency
 {
-  background-color: lighten($brand-danger-l, 10%);
+  background-color: lighten($brand-danger-l, 5%);
   margin-bottom: - space(4);
   margin-left: -30px;
   margin-right: -30px;


### PR DESCRIPTION
follow-up to https://github.com/greenriver/hmis-warehouse/pull/2302 which lightened the `-l` colors, so we don't need to lighten them so much. this was resulting in a white background for some.