### PR TITLE
Allow capacity provider override per target group

### DIFF
--- a/app/jobs/workoff_arbiter.rb
+++ b/app/jobs/workoff_arbiter.rb
@@ -56,7 +56,7 @@ class WorkoffArbiter
       task_definition: _task_definition,
       capacity_provider_strategy: [
         {
-          capacity_provider: _on_demand_capacity_provider_name,
+          capacity_provider: _on_demand_capacity_provider_name(target_group_name),
           weight: 1,
           base: 1,
         },

--- a/config/deploy/docker/lib/cron_installer.rb
+++ b/config/deploy/docker/lib/cron_installer.rb
@@ -59,7 +59,7 @@ class CronInstaller
   def _spot_capacity_provider_strategy
     [
       {
-        capacity_provider: _spot_capacity_provider_name,
+        capacity_provider: _spot_capacity_provider_name(target_group_name),
         weight: 1,
         base: 1,
       },
@@ -69,7 +69,7 @@ class CronInstaller
   def _on_demand_capacity_provider_strategy
     [
       {
-        capacity_provider: _on_demand_capacity_provider_name,
+        capacity_provider: _on_demand_capacity_provider_name(target_group_name),
         weight: 1,
         base: 1,
       },


### PR DESCRIPTION
Create an SSM parameter like `/#{target_group_name}/CapacityProviders/#{which}`, e.g. `/qa-warehouse-staging-ecs/CapacityProviders/Spot`