### PR TITLE
Read LOG_LEVEL in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['FQDN'], port: ENV['PORT'] }
 
   config.force_ssl = false
+
+  config.log_level = ENV.fetch('LOG_LEVEL') { 'debug' }.to_sym
 end


### PR DESCRIPTION
* Makes this change work: https://github.com/greenriver/hmis-warehouse/pull/2309/commits/be0e20efba05d9d38616c6b1c5933af4b9125991
* Can also set log level when running rspec locally: `LOG_LEVEL=INFO rspec ... `