### PR TITLE
Explicitly remove placement_constraints

### DIFF
--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -555,6 +555,7 @@ class RollOut
           },
         ],
         placement_strategy: _placement_strategy,
+        placement_constraints: [],
         deployment_configuration: {
           maximum_percent: maximum_percent,
           minimum_healthy_percent: minimum_healthy_percent,


### PR DESCRIPTION
@eanders @joe4123 This cleans up the placement constraints. We should merge and deploy this everywhere, and then we can proceed with the capacity provider switch over (🤞 ). Elliot feel free to change base, shouldn't be any conflicts.