### PR TITLE
182548234/client search

### DIFF
--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -5267,8 +5267,7 @@ CREATE TABLE public.configs (
     system_cohort_processing_date date,
     system_cohort_date_window integer DEFAULT 1,
     roi_model character varying DEFAULT 'explicit'::character varying,
-    client_dashboard character varying DEFAULT 'default'::character varying NOT NULL,
-    require_service_for_reporting_default boolean DEFAULT true NOT NULL
+    client_dashboard character varying DEFAULT 'default'::character varying NOT NULL
 );
 
 
@@ -48893,9 +48892,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220617180748'),
 ('20220628162723'),
 ('20220712164926'),
-('20220713150217'),
 ('20220714190911'),
-('20220715194241'),
 ('20220718185442');
 
 

--- a/drivers/hmis/app/graphql/types/base_field.rb
+++ b/drivers/hmis/app/graphql/types/base_field.rb
@@ -13,10 +13,10 @@ module Types
       return_type = kwargs[:type]
       return unless return_type.is_a?(Class) && return_type < BasePaginated
 
-      extension(PaginagtionWrapperExtension)
+      extension(PaginationWrapperExtension)
     end
 
-    class PaginagtionWrapperExtension < GraphQL::Schema::FieldExtension
+    class PaginationWrapperExtension < GraphQL::Schema::FieldExtension
       def apply
         field.argument(:offset, Integer, required: false)
         field.argument(:limit, Integer, required: false)

--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -13,5 +13,9 @@ module Types
     def current_user
       context[:current_user]
     end
+
+    def self.page_type
+      @page_type ||= BasePaginated.create(self)
+    end
   end
 end

--- a/drivers/hmis/app/graphql/types/base_paginated.rb
+++ b/drivers/hmis/app/graphql/types/base_paginated.rb
@@ -1,0 +1,21 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Types
+  class BasePaginated < BaseObject
+    def self.create(node_class)
+      Class.new(self) do
+        graphql_name("#{node_class.graphql_name.pluralize}Paginated")
+        field :nodes, [node_class], null: false
+      end
+    end
+
+    field :has_more_before, Boolean, null: false
+    field :has_more_after, Boolean, null: false
+    field :pages_count, Integer, null: false
+    field :nodes_count, Integer, null: false
+  end
+end

--- a/drivers/hmis/app/graphql/types/date.rb
+++ b/drivers/hmis/app/graphql/types/date.rb
@@ -1,0 +1,19 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Types
+  class Date < BaseScalar
+    description 'A Date object, transporated as a string'
+
+    def self.coerce_input(input_value)
+      Date.parse(input_value)
+    end
+
+    def self.coerce_result(ruby_value)
+      ruby_value.to_s(:db)
+    end
+  end
+end

--- a/drivers/hmis/app/graphql/types/date.rb
+++ b/drivers/hmis/app/graphql/types/date.rb
@@ -8,11 +8,11 @@ module Types
   class Date < BaseScalar
     description 'A Date object, transporated as a string'
 
-    def self.coerce_input(input_value)
+    def self.coerce_input(input_value, _context)
       Date.parse(input_value)
     end
 
-    def self.coerce_result(ruby_value)
+    def self.coerce_result(ruby_value, _context)
       ruby_value.to_s(:db)
     end
   end

--- a/drivers/hmis/app/graphql/types/date_time.rb
+++ b/drivers/hmis/app/graphql/types/date_time.rb
@@ -1,0 +1,19 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Types
+  class DateTime < BaseScalar
+    description 'A DateTime object, transporated as a string'
+
+    def self.coerce_input(input_value)
+      DateTime.parse(input_value)
+    end
+
+    def self.coerce_result(ruby_value)
+      ruby_value.to_s
+    end
+  end
+end

--- a/drivers/hmis/app/graphql/types/date_time.rb
+++ b/drivers/hmis/app/graphql/types/date_time.rb
@@ -8,11 +8,11 @@ module Types
   class DateTime < BaseScalar
     description 'A DateTime object, transporated as a string'
 
-    def self.coerce_input(input_value)
+    def self.coerce_input(input_value, _context)
       DateTime.parse(input_value)
     end
 
-    def self.coerce_result(ruby_value)
+    def self.coerce_result(ruby_value, _context)
       ruby_value.to_s
     end
   end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -1,0 +1,31 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::Client < Types::BaseObject
+    include Types::HmisSchema::HasEnrollments
+
+    description 'HUD Client'
+    field :id, ID, null: false
+    field :personal_id, String, null: false
+    field :first_name, String, null: false
+    field :last_name, String, null: false
+    field :preferred_name, String, null: true
+    field :ssn_serial, String, null: true
+    field :dob, Types::Date, 'Date of birth as format yyyy-mm-dd', null: true
+    field :pronouns, String, null: true
+    field :date_updated, Types::DateTime, null: false
+    enrollments_field :enrollments
+    field :start_date, Types::DateTime, null: true
+    field :end_date, Types::DateTime, null: true
+
+    def enrollments
+      resolve_enrollments
+    end
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client_search_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client_search_input.rb
@@ -1,0 +1,21 @@
+module Types
+  class HmisSchema::ClientSearchInput < BaseInputObject
+    description 'HMIS Client search input'
+
+    argument :id, ID, 'Client primary key', required: false
+    argument :text_search, String, 'Omnisearch string', required: false
+    argument :personal_id, String, required: false
+    argument :warehouse_id, String, required: false
+    argument :first_name, String, required: false
+    argument :last_name, String, required: false
+    argument :preferred_name, String, required: false
+    argument :ssn_serial, String, 'Last 4 digits of SSN', required: false
+    argument :dob, String, 'Date of birth as format yyyy-mm-dd', required: false
+    argument :projects, [ID], required: false
+    argument :organizations, [ID], required: false
+
+    def to_params
+      to_h
+    end
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client_sort_option.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client_sort_option.rb
@@ -1,0 +1,18 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::ClientSortOption < Types::BaseEnum
+    description 'HUD Client Sorting Options'
+    graphql_name 'ClientSortOption'
+
+    value 'LAST_NAME', 'Client Last Name', value: 'LastName'
+
+    # TODO: Add more sorting options if needed
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::Enrollment < Types::BaseObject
+    description 'HUD Enrollment'
+    field :id, ID, null: false
+    field :project, Types::HmisSchema::Project, null: true
+    field :entry_date, DateTime, null: true
+    field :exit_date, DateTime, null: true
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
@@ -1,0 +1,33 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  module HmisSchema
+    module HasClients
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def clients_field(name = :clients, description = nil, type: [Types::HmisSchema::Client], **override_options, &block)
+          default_field_options = { type: type, null: false, description: description }
+          field_options = default_field_options.merge(override_options)
+          field(name, **field_options) do
+            argument :sort_field, Types::HmisSchema::ClientSortOption, required: false
+            argument :sort_direction, Types::HmisSchema::SortDirection, required: false
+            instance_eval(&block) if block_given?
+          end
+        end
+      end
+
+      def resolve_clients(scope = object.clients, sort_field: :LastName, sort_direction: :asc, _user: current_user, no_sort: false)
+        clients_scope = scope
+        clients_scope = clients_scope.order(sort_field => sort_direction) unless no_sort
+        clients_scope
+      end
+    end
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
@@ -8,12 +8,12 @@
 
 module Types
   module HmisSchema
-    module HasOrganizations
+    module HasEnrollments
       extend ActiveSupport::Concern
 
       class_methods do
-        def organizations_field(name = :organizations, description = nil, **override_options, &block)
-          default_field_options = { type: [Types::HmisSchema::Organization], null: false, description: description }
+        def enrollments_field(name = :enrollments, description = nil, type: [Types::HmisSchema::Enrollment], **override_options, &block)
+          default_field_options = { type: type, null: false, description: description }
           field_options = default_field_options.merge(override_options)
           field(name, **field_options) do
             instance_eval(&block) if block_given?
@@ -21,9 +21,8 @@ module Types
         end
       end
 
-      def resolve_organizations(scope = object.organizations, user: current_user)
-        organizations_scope = scope.viewable_by(user)
-        organizations_scope
+      def resolve_enrollments(scope = object.enrollments, _user: current_user)
+        scope
       end
     end
   end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_projects.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_projects.rb
@@ -1,3 +1,11 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
 module Types
   module HmisSchema
     module HasProjects

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -14,6 +14,7 @@ module Types
     include GraphQL::Types::Relay::HasNodesField
     include Types::HmisSchema::HasProjects
     include Types::HmisSchema::HasOrganizations
+    include Types::HmisSchema::HasClients
 
     projects_field :projects, description: 'Get a list of projects'
 
@@ -26,5 +27,18 @@ module Types
     def organizations(**args)
       resolve_organizations(Hmis::Hud::Organization.all, **args)
     end
+
+    clients_field :client_search, 'Search for clients', type: Types::HmisSchema::Client.page_type, null: false do |field|
+      field.argument :input, Types::HmisSchema::ClientSearchInput, required: true
+    end
+
+    # Need to keep "input" stated as an argument. Un-ignore once we're actually using it
+    # rubocop:disable Lint/UnusedMethodArgument
+    def client_search(input:, **args)
+      # TODO <SANDY>: Apply client search here, input shape is defined in Types::HmisSchema::ClientSearchInput
+      search_scope = Hmis::Hud::Client.all
+      resolve_clients(search_scope, **args)
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/sort_direction.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/sort_direction.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::SortDirection < Types::BaseEnum
+    description 'Sorting Direction'
+    graphql_name 'SortDirection'
+
+    value 'ASC', 'Ascending', value: :asc
+    value 'DESC', 'Descending', value: :desc
+  end
+end

--- a/drivers/hmis/app/graphql/types/paginated_scope.rb
+++ b/drivers/hmis/app/graphql/types/paginated_scope.rb
@@ -1,0 +1,38 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Types
+  class PaginatedScope
+    def initialize(all_nodes, offset: 0, limit:)
+      @all_nodes = all_nodes
+      @offset = offset
+      @limit = limit
+    end
+
+    def nodes
+      @all_nodes.offset(@offset).limit(@limit)
+    end
+
+    def nodes_count
+      @all_nodes.count
+    end
+
+    def pages_count
+      (nodes_count / @limit.to_f).ceil
+    end
+
+    # Ignoring rubocop because the method names need to match the API field names, which use "has_*"
+    # rubocop:disable Naming/PredicateName
+    def has_more_after
+      @offset + @limit < nodes_count
+    end
+
+    def has_more_before
+      @offset.positive?
+    end
+    # rubocop:enable Naming/PredicateName
+  end
+end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -10,14 +10,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   self.table_name = :Client
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
-  def preferred_name
-    # TODO: Implement this
-  end
-
-  def pronouns
-    # TODO: Implement this
-  end
-
   def ssn_serial
     self.SSN&.[](-4..-1)
   end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -10,6 +10,18 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   self.table_name = :Client
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
-  has_many :enrollments, **hmis_relation(:EnrollmentID, 'Enrollment')
+  def preferred_name
+    # TODO: Implement this
+  end
+
+  def pronouns
+    # TODO: Implement this
+  end
+
+  def ssn_serial
+    self.SSN&.[](-4..-1)
+  end
+
+  has_many :enrollments, **hmis_relation(:PersonalID, 'Enrollment')
   has_many :projects, through: :enrollments
 end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -10,5 +10,9 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   self.table_name = :Enrollment
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
+  delegate :exit_date, to: :exit, allow_nil: true
+
+  belongs_to :project, **hmis_relation(:ProjectID, 'Project')
+  has_one :exit, **hmis_relation(:EnrollmentID, 'Exit')
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
 end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -22,6 +22,11 @@ class Hmis::User < ApplicationRecord
     true
   end
 
+  def can_report_on_confidential_projects
+    # TODO: Make this role present on the HMIS user model or Hmis::Hud::Project.viewable_by will error out
+    true
+  end
+
   # load a hash of permission names (e.g. 'can_view_all_reports')
   # to a boolean true if the user has the permission through one
   # of their roles

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -22,11 +22,6 @@ class Hmis::User < ApplicationRecord
     true
   end
 
-  def can_report_on_confidential_projects
-    # TODO: Make this role present on the HMIS user model or Hmis::Hud::Project.viewable_by will error out
-    true
-  end
-
   # load a hash of permission names (e.g. 'can_view_all_reports')
   # to a boolean true if the user has the permission through one
   # of their roles


### PR DESCRIPTION
@awisema @eanders This is ready from the GraphQL side, but I need you all to plug in the client search logic. I've added comment with `TODO <SANDY>` where this needs to be done. You should adjust `search_scope` so that it contains the scope of filtered clients before it's passed into `resolve_clients`. That method handles the ordering. Pagination happens elsewhere in the process, so no need to worry about that piece here. Let me know if you have any questions or need a hand.