### PR TITLE
Standardize error responses for failed authentication

### DIFF
--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -8,10 +8,7 @@ class Hmis::BaseController < ApplicationController
   include Hmis::Concerns::JsonErrors
   respond_to :json
   before_action :set_csrf_cookie
-
-  rescue_from ActionController::InvalidAuthenticityToken do
-    render_json_error(401, :unauthenticated)
-  end
+  protect_from_forgery with: :reset_session
 
   private def set_csrf_cookie
     cookies['CSRF-Token'] = form_authenticity_token

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -5,6 +5,7 @@
 ###
 
 class Hmis::BaseController < ApplicationController
+  include Hmis::Concerns::JsonErrors
   respond_to :json
   before_action :set_csrf_cookie
 
@@ -20,5 +21,9 @@ class Hmis::BaseController < ApplicationController
     domain = URI.parse(request.origin).host
     data_source_id = GrdaWarehouse::DataSource.hmis.where(hmis: domain).pluck(:id).first
     current_hmis_user.hmis_data_source_id = data_source_id
+  end
+
+  def handle_unverified_request
+    render_json_error(401, :unauthenticated)
   end
 end

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -9,6 +9,10 @@ class Hmis::BaseController < ApplicationController
   respond_to :json
   before_action :set_csrf_cookie
 
+  rescue_from ActionController::InvalidAuthenticityToken do
+    render_json_error(401, :unauthenticated)
+  end
+
   private def set_csrf_cookie
     cookies['CSRF-Token'] = form_authenticity_token
   end
@@ -21,9 +25,5 @@ class Hmis::BaseController < ApplicationController
     domain = URI.parse(request.origin).host
     data_source_id = GrdaWarehouse::DataSource.hmis.where(hmis: domain).pluck(:id).first
     current_hmis_user.hmis_data_source_id = data_source_id
-  end
-
-  def handle_unverified_request
-    render_json_error(401, :unauthenticated)
   end
 end

--- a/drivers/hmis/app/controllers/hmis/concerns/json_errors.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/json_errors.rb
@@ -1,0 +1,11 @@
+module Hmis::Concerns::JsonErrors
+  extend ActiveSupport::Concern
+
+  def render_json_error(status, type, message: nil, backtrace: nil)
+    status = Rack::Utils::SYMBOL_TO_STATUS_CODE[status] if status.is_a? Symbol
+    error = { type: type }
+    error[:message] = message if message.present?
+    error[:backtrace] = backtrace if backtrace.present? && Rails.env.development?
+    render status: status, json: { error: error }
+  end
+end

--- a/drivers/hmis/app/controllers/hmis/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/sessions_controller.rb
@@ -5,6 +5,7 @@
 ###
 
 class Hmis::SessionsController < Devise::SessionsController
+  include Hmis::Concerns::JsonErrors
   include AuthenticatesWithTwoFactor
   respond_to :json
   skip_before_action :verify_signed_out_user
@@ -67,13 +68,6 @@ class Hmis::SessionsController < Devise::SessionsController
 
   private def set_csrf_cookie
     cookies['CSRF-Token'] = form_authenticity_token
-  end
-
-  private def render_json_error(status, type, message: nil)
-    status = Rack::Utils::SYMBOL_TO_STATUS_CODE[status] if status.is_a? Symbol
-    error = { type: type }
-    error[:message] = message if message.present?
-    render status: status, json: { error: error }
   end
 
   private def two_factor_resource_name

--- a/drivers/hmis/app/controllers/hmis/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/sessions_controller.rb
@@ -11,6 +11,10 @@ class Hmis::SessionsController < Devise::SessionsController
   skip_before_action :verify_signed_out_user
   before_action :authenticate_with_2fa, only: [:create], if: -> { two_factor_enabled? }
 
+  rescue_from ActionController::InvalidAuthenticityToken do
+    render_json_error(401, :unauthenticated)
+  end
+
   def create
     self.resource = warden.authenticate!(auth_options)
     sign_in(:hmis_user, resource)

--- a/drivers/hmis/app/controllers/hmis/user_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/user_controller.rb
@@ -8,8 +8,15 @@ class Hmis::UserController < Hmis::BaseController
   skip_before_action :verify_authenticity_token, only: [:index]
   skip_before_action :authenticate_user!, only: [:index]
 
+  # Endpoint to retrieve the currently logged-in user.
+  #
+  # This is called by the frontend on initial page load, to determine whether
+  # there is a currently active session.
+  #
+  # If there is no active session, warden will return a 401.
+  # We set a CSRF cookie *prior* to authentication, because the frontend
+  # needs a valid CSRF token to hit POST /hmis/login.
   def index
-    # Set CSRF cookie even if no user is logged in, so that the client can send it with the login request
     set_csrf_cookie
     authenticate_hmis_user!
     render json: {

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -50,6 +50,33 @@ RSpec.describe Hmis::SessionsController, type: :request do
     end
   end
 
+  describe 'Un-successful login due to missing CSRF token' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
+    after do
+      ActionController::Base.allow_forgery_protection = false
+    end
+    it 'has correct response code' do
+      post hmis_user_session_path(hmis_user: { email: user.email, password: user.password })
+      expect(response.status).to eq 401
+    end
+  end
+
+  describe 'Un-successful login due to inactive account' do
+    before do
+      user.update(active: false)
+    end
+    after do
+      user.update(active: false)
+    end
+    it 'has correct response' do
+      post hmis_user_session_path(hmis_user: { email: user.email, password: user.password })
+      expect(response.status).to eq 401
+      expect(response.body).to include 'inactive'
+    end
+  end
+
   describe 'Account locked after 9 un-successful logins' do
     before(:each) do
       # Devise.maximum_attempts is twice what it should be (see Devise 2FA bug above)

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hmis::SessionsController, type: :request do
       user.update(active: false)
     end
     after do
-      user.update(active: false)
+      user.update(active: true)
     end
     it 'has correct response' do
       post hmis_user_session_path(hmis_user: { email: user.email, password: user.password })

--- a/lib/devise/custom_auth_failure.rb
+++ b/lib/devise/custom_auth_failure.rb
@@ -16,6 +16,6 @@ class CustomAuthFailure < Devise::FailureApp
   def json_error_response
     self.status = 401
     self.content_type = 'application/json'
-    self.response_body = { error: { type: warden_message, message: i18n_message } }.to_json
+    self.response_body = { error: { type: warden_message || :unauthenticated, message: i18n_message } }.to_json
   end
 end

--- a/lib/devise/custom_auth_failure.rb
+++ b/lib/devise/custom_auth_failure.rb
@@ -6,7 +6,7 @@
 
 class CustomAuthFailure < Devise::FailureApp
   def respond
-    if warden_options[:scope] == :hmis_user && request.format == :json
+    if scope == :hmis_user && request.format == :json
       json_error_response
     else
       super
@@ -16,6 +16,6 @@ class CustomAuthFailure < Devise::FailureApp
   def json_error_response
     self.status = 401
     self.content_type = 'application/json'
-    self.response_body = { error: { type: 'authentication_failed', message: i18n_message } }.to_json
+    self.response_body = { error: { type: warden_message, message: i18n_message } }.to_json
   end
 end


### PR DESCRIPTION
When any of these endpoints are hit without authentication (ie cookie is missing or invalid, or CSRF token is missing or invalid), the server responds with a `401` with response body `{ error: { type: 'unauthenticated' } }` (at minimum).

This covers all the HMIS endpoints:
* /hmis/user
* /hmis/login
* /hmis/logout
* /hmis/hmis-gql

