### PR TITLE
Use same data source for frontend and GraphiQL

### DIFF
--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -18,6 +18,10 @@ class Hmis::BaseController < ApplicationController
 
   def attach_data_source_id
     domain = URI.parse(request.origin).host
+
+    # In development: treat requests from GraphiQL as if they are coming from the local frontend
+    domain = ENV['HMIS_HOSTNAME'] if Rails.env.development? && domain == ENV['HOSTNAME'] && ENV['HMIS_HOSTNAME'].present?
+
     data_source_id = GrdaWarehouse::DataSource.hmis.where(hmis: domain).pluck(:id).first
     current_hmis_user.hmis_data_source_id = data_source_id
   end

--- a/sample.env
+++ b/sample.env
@@ -186,7 +186,9 @@ S3_PUBLIC_URL=
 # override the default with:
 
 # OKTA_AUTH_SERVER=some_id_string
-
-# ENABLE_HMIS_API=true
-
 # For users to self-register we require given_name, family_name and email to be present and mapped in the settings.
+
+
+# Optional: Enable API endpoints for the HMIS frontend
+# ENABLE_HMIS_API=true
+# HMIS_HOSTNAME=hmis.dev.test


### PR DESCRIPTION
For local development, requests from GrahiQL (https://hmis-warehouse.dev.test/hmis/graphiql) and requests from the frontend (hmis.dev.test) should hit the same data source. This is just for a better developer experience. Currently they are going to different data sources because they have different origins.