### PR TITLE
Hide health tabs for disenrolled patients from non-health-admin users

### DIFF
--- a/app/controllers/concerns/health_patient.rb
+++ b/app/controllers/concerns/health_patient.rb
@@ -49,18 +49,8 @@ module HealthPatient
       @patient = Health::Patient.accessible_by_user(current_user).find_by(client_id: params[:client_id].to_i)
     end
 
-    # For now, all patients are visible to all health users
-    # BUT, all patients must have a referral
     protected def set_hpc_patient
-      # Allow admins to see confirmed rejected patients
-      if can_administer_health?
-        @patient = Health::Patient.joins(:patient_referral).
-          find_by(client_id: params[:client_id].to_i)
-      else
-        @patient = Health::Patient.joins(:patient_referral).
-          merge(Health::PatientReferral.not_confirmed_rejected).
-          find_by(client_id: params[:client_id].to_i)
-      end
+      @patient = Health::Patient.viewable_by_user(current_user).find_by(client_id: params[:client_id].to_i)
 
       not_authorized! unless @patient.present?
     end

--- a/app/controllers/concerns/health_patient.rb
+++ b/app/controllers/concerns/health_patient.rb
@@ -61,6 +61,8 @@ module HealthPatient
           merge(Health::PatientReferral.not_confirmed_rejected).
           find_by(client_id: params[:client_id].to_i)
       end
+
+      not_authorized! unless @patient.present?
     end
   end
 end

--- a/app/controllers/concerns/health_patient.rb
+++ b/app/controllers/concerns/health_patient.rb
@@ -43,6 +43,8 @@ module HealthPatient
       GrdaWarehouse::Hud::Client.destination
     end
 
+    # Note: use set_hpc_patient instead.
+    # This bypasses the filter for disenrolled patients. Only used by pilot program.
     protected def set_patient
       @patient = Health::Patient.accessible_by_user(current_user).find_by(client_id: params[:client_id].to_i)
     end

--- a/app/controllers/health/appointments_controller.rb
+++ b/app/controllers/health/appointments_controller.rb
@@ -15,7 +15,7 @@ module Health
 
     def index
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
       a_t = Health::Appointment.arel_table
       @appointments = @patient.appointments.order(appointment_time: :desc)
       @upcoming = @appointments.limited.where(a_t[:appointment_time].gt(Time.now)).order(appointment_time: :asc)
@@ -25,7 +25,7 @@ module Health
 
     def upcoming
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
       start_date = Date.current.to_time
       if params[:end_date].present?
         end_date = begin
@@ -45,8 +45,8 @@ module Health
 
     def calendar
       set_hpc_patient
-      set_patient if @patient.blank?
-      start_date = Date.current.beginning_of_week(start_day = :sunday)
+      # set_patient if @patient.blank?
+      start_date = Date.current.beginning_of_week(:sunday)
       end_date = Date.current + 2.weeks
 
       appointments = @patient.appointments.

--- a/app/controllers/health/contacts_controller.rb
+++ b/app/controllers/health/contacts_controller.rb
@@ -6,8 +6,9 @@
 
 module Health
   class ContactsController < IndividualPatientController
+    before_action :set_hpc_patient
+
     def index
-      @patient = Health::Patient.viewable_by_user(current_user).find_by(client_id: params[:client_id].to_i)
       @contacts = @patient.
         client_contacts.
         order(collected_on: :desc)

--- a/app/controllers/health/contacts_controller.rb
+++ b/app/controllers/health/contacts_controller.rb
@@ -7,7 +7,7 @@
 module Health
   class ContactsController < IndividualPatientController
     def index
-      @patient = Health::Patient.accessible_by_user(current_user).find_by(client_id: params[:client_id].to_i)
+      @patient = Health::Patient.viewable_by_user(current_user).find_by(client_id: params[:client_id].to_i)
       @contacts = @patient.
         client_contacts.
         order(collected_on: :desc)

--- a/app/controllers/health/ed_ip_visits_controller.rb
+++ b/app/controllers/health/ed_ip_visits_controller.rb
@@ -14,7 +14,7 @@ module Health
 
     def index
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
 
       respond_to do |format|
         format.json do

--- a/app/controllers/health/epic_chas_controller.rb
+++ b/app/controllers/health/epic_chas_controller.rb
@@ -17,7 +17,7 @@ module Health
 
     def show
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
     end
 
     def set_form

--- a/app/controllers/health/epic_ssms_controller.rb
+++ b/app/controllers/health/epic_ssms_controller.rb
@@ -17,7 +17,7 @@ module Health
 
     def show
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
     end
 
     def set_form

--- a/app/controllers/health/medications_controller.rb
+++ b/app/controllers/health/medications_controller.rb
@@ -15,7 +15,7 @@ module Health
 
     def index
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
       @medications = @patient.medications.order(start_date: :desc, ordered_date: :desc)
 
       render layout: !request.xhr?

--- a/app/controllers/health/metrics_controller.rb
+++ b/app/controllers/health/metrics_controller.rb
@@ -13,7 +13,7 @@ module Health
     helper HealthOverviewHelper
 
     before_action :set_client, only: [:index]
-    before_action :set_patient, only: [:index]
+    before_action :set_hpc_patient, only: [:index]
 
     def index
       load_patient_metrics

--- a/app/controllers/health/problems_controller.rb
+++ b/app/controllers/health/problems_controller.rb
@@ -15,7 +15,7 @@ module Health
 
     def index
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
       @problems = @patient.problems.order(onset_date: :desc)
 
       render layout: !request.xhr?

--- a/app/controllers/health/signable_documents_controller.rb
+++ b/app/controllers/health/signable_documents_controller.rb
@@ -12,7 +12,7 @@ module Health
     helper ChaHelper
 
     before_action :set_client, except: [:signature, :signed]
-    before_action :set_patient, except: [:signature, :signed]
+    before_action :set_hpc_patient, except: [:signature, :signed]
     before_action :set_careplan, except: [:signature, :signed]
     before_action :set_medications, except: [:signature, :signed]
     before_action :set_problems, except: [:signature, :signed]

--- a/app/controllers/health/utilization_controller.rb
+++ b/app/controllers/health/utilization_controller.rb
@@ -14,7 +14,7 @@ module Health
 
     def index
       set_hpc_patient
-      set_patient if @patient.blank?
+      # set_patient if @patient.blank?
       @visits = @patient.visits.order(date_of_service: :desc)
 
       render layout: !request.xhr?

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -332,6 +332,16 @@ module Health
         having(nf('count', [h_sd_t[:patient_id]]).between(range)).select(:patient_id))
     end
 
+    # For now, all patients are visible to all health users
+    # BUT, all patients must have a referral
+    scope :viewable_by_user, ->(user) do
+      if user.can_administer_health?
+        joins(:patient_referral)
+      else
+        joins(:patient_referral).merge(Health::PatientReferral.not_confirmed_rejected)
+      end
+    end
+
     delegate :effective_date, to: :patient_referral
     delegate :enrollment_start_date, to: :patient_referral
     delegate :aco, to: :patient_referral

--- a/app/views/menus/_client_tab_navigation.haml
+++ b/app/views/menus/_client_tab_navigation.haml
@@ -2,6 +2,8 @@
   can_see_always_visible = always_visible.map{|_,details| details[:permission]}.any?
   can_see_hmis = hmis.map{|_,details| details[:permission]}.any?
   can_see_health = health.map{|_,details| details[:permission]}.any?
+  can_see_health_for_client = Health::Patient.viewable_by_user(current_user).where(client_id: @client.id).exists?
+  can_see_health = can_see_health && can_see_health_for_client
   can_see_tabs = can_see_always_visible || can_see_hmis || can_see_health
   on_health = health.keys.include?(current) || @on_health
   on_hmis = ! on_hmis


### PR DESCRIPTION
- [x] Comment out all `set_patient if @patient.blank?` usages
- [x] Don't show health tabs on the dashboard if the current user cannot access the patient (because they are disenrolled)
- [x] Redirect to 401 page from health controllers if user cannot access patient