### PR TITLE
Dont throw if exception notifier config is missing

### DIFF
--- a/app/models/concerns/notifier_config.rb
+++ b/app/models/concerns/notifier_config.rb
@@ -11,7 +11,7 @@ module NotifierConfig
     attr_accessor :notifier_config
 
     def setup_notifier(username)
-      @notifier_config = Rails.application.config_for(:exception_notifier).fetch(:slack, nil)
+      @notifier_config = Rails.application.config_for(:exception_notifier)&.fetch(:slack, nil)
       @send_notifications = notifier_config.present? && notifier_config[:webhook_url].present? && (Rails.env.development? || Rails.env.production? || ENV['FORCE_EXCEPTION_NOTIFIER'] == 'true')
       # return unless @send_notifications
       if @send_notifications


### PR DESCRIPTION
small follow-up to https://github.com/greenriver/hmis-warehouse/pull/2363