### PR TITLE
Dont require user_id for ChronicVerificationJob

### DIFF
--- a/app/jobs/service_history/chronic_verification_job.rb
+++ b/app/jobs/service_history/chronic_verification_job.rb
@@ -10,7 +10,7 @@ module ServiceHistory
     include Rails.application.routes.url_helpers
     queue_as ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)
 
-    def perform(client_id:, years:, user_id:)
+    def perform(client_id:, years:, user_id: nil)
       @client_id = client_id
       @years = years
       @user_id = user_id


### PR DESCRIPTION
This is throwing an error: https://github.com/greenriver/hmis-warehouse/blob/275e9c6d0692222560679f40671df1802d2fce98/lib/tasks/grda_warehouse.rake#L286-L289