### PR TITLE
Add literal demographics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (1.0.1)
-    hashie (4.1.0)
+    hashie (5.0.0)
     heapy (0.2.0)
       thor
     hellosign-ruby-sdk (3.7.7)
@@ -584,7 +584,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     oj (3.13.10)
-    omniauth (1.9.1)
+    omniauth (1.9.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
     omniauth-oauth2 (1.7.1)

--- a/app/models/eto_api/tasks/update_client_demographics.rb
+++ b/app/models/eto_api/tasks/update_client_demographics.rb
@@ -178,7 +178,7 @@ module EtoApi::Tasks
 
         if @custom_config.present?
           @custom_config.demographic_fields.each do |key, label|
-            hmis_client[key] = defined_value(client: client, response: api_response, label: label)
+            hmis_client[key] = literal_value(response: api_response, label: label) || defined_value(client: client, response: api_response, label: label)
           end
 
           # cm = entity(client: client, response: api_response, entity_label: 'Case Manager/Advocate')
@@ -419,6 +419,11 @@ module EtoApi::Tasks
         address << "#{k}: #{address_hash[k]}" if address_hash[k].present?
       end
       address.join(";\n")
+    end
+
+    private def literal_value(response:, label:)
+      as_hash = JSON.parse(response)
+      as_hash[label]
     end
 
     private def entity(client:, response:, entity_label:)


### PR DESCRIPTION
I think this will get the ZipCodes when combined with the config:

`demographic_fields: {"language_1"=>"Primary Language", "language_2"=>"Language", "youth_current_zip"=> "ZipCode"}`

There aren't any language_1/language_2 in the DB either -- but I don't know if they are in use. or if the config is wrong for them as well...