### PR TITLE
Rework My Patients visibility.

### DIFF
--- a/app/controllers/health/my_patients_controller.rb
+++ b/app/controllers/health/my_patients_controller.rb
@@ -77,12 +77,14 @@ module Health
     end
 
     def patient_scope
-      population = if current_user.can_manage_care_coordinators?
+      population = if current_user.can_administer_health?
+        patient_source # Can see all clients
+      elsif current_user.can_manage_care_coordinators? # Can see clients and those of team mates
         ids = [current_user.id] + current_user.team_mates.pluck(:id)
         patient_source.
           where(care_coordinator_id: ids).
           or(patient_source.where(nurse_care_manager_id: ids))
-      else
+      else # Can see your own clients
         patient_source.
           where(care_coordinator_id: current_user.id).
           or(patient_source.where(nurse_care_manager_id: current_user.id))

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -106,6 +106,11 @@ module UserConcern
       )
     end
 
+    scope :care_coordinators, -> do
+      care_coordinator_ids = Health::Patient.pluck(:care_coordinator_id)
+      where(id: care_coordinator_ids)
+    end
+
     scope :nurse_care_managers, -> do
       joins(:roles).merge(Role.nurse_care_manager)
     end

--- a/app/views/health/patients/_filter.haml
+++ b/app/views/health/patients/_filter.haml
@@ -40,7 +40,7 @@
           Engagement Period Ending
 
       - unassigned_selector = OpenStruct.new(name: 'Only Unassigned', id: 'unassigned')
-      - selection_candidates = [unassigned_selector, current_user] + current_user.team_mates
+      - selection_candidates = [unassigned_selector, current_user] + User.care_coordinators.to_a
       - options = options_from_collection_for_select(selection_candidates.uniq, :id, :name, params.dig(:filter, :user))
       = render 'inputs/select', field_name: 'filter[user]', label: 'Care Coordinator', options: options, html_options: { include_blank: 'All', style: 'width: 100%;' }
 


### PR DESCRIPTION
Show all patients, for admins, patients of team mates for care coordinator managers, and assigned patients otherwise.

Filter list shows all care coordinator names.