### PR TITLE
Don't show checkbox for selecting all of a project group.

### DIFF
--- a/drivers/boston_project_scorecard/app/views/boston_project_scorecard/warehouse_reports/scorecards/_project_groups.haml
+++ b/drivers/boston_project_scorecard/app/views/boston_project_scorecard/warehouse_reports/scorecards/_project_groups.haml
@@ -4,9 +4,9 @@
     .mb-5
       .c-card.c-card--linked.c-card--row.j-parent
         .c-card__content.d-flex.align-items-center
-          .c-checkbox.c-checkbox.mr-4
-            = check_box_tag("organization-toggle[project_groups]", 1, false, {class: 'j-select-children'})
-            %label{for: "organization-toggle_project_groups", data: {toggle: 'tooltip'}, title: 'Select/Deselect all projects in group'}
+          -#.c-checkbox.c-checkbox.mr-4
+          -#  = check_box_tag("organization-toggle[project_groups]", 1, false, {class: 'j-select-children'})
+          -#  %label{for: "organization-toggle_project_groups", data: {toggle: 'tooltip'}, title: 'Select/Deselect all projects in group'}
           %h3.mb-0.mt-0 Project Groups
       %table.table.c-table.j-children.d-none
         %thead


### PR DESCRIPTION
Selecting all the project groups didn't seem worth the level of effort it was taking to get everything working.