### PR TITLE
Chronic at Entry calculation table

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -161,6 +161,7 @@ jobs:
           MAX_FAILURES: 20
           LOG_LEVEL: INFO
         run: |
+          bundle exec rspec --fail-fast=$MAX_FAILURES --color --format p spec/models/grda_warehouse/hud/enrollment_spec.rb
           bundle exec rspec --fail-fast=$MAX_FAILURES --color --format p -P "{spec,drivers}/**/*_spec.rb"
           OKTA_DOMAIN=localhost OKTA_CLIENT_ID=x OKTA_CLIENT_SECRET=x bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/requests/omniauth_spec.rb # this one test needs a different ENV
 

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -161,7 +161,6 @@ jobs:
           MAX_FAILURES: 20
           LOG_LEVEL: INFO
         run: |
-          bundle exec rspec --fail-fast=$MAX_FAILURES --color --format p spec/models/grda_warehouse/hud/enrollment_spec.rb
           bundle exec rspec --fail-fast=$MAX_FAILURES --color --format p -P "{spec,drivers}/**/*_spec.rb"
           OKTA_DOMAIN=localhost OKTA_CLIENT_ID=x OKTA_CLIENT_SECRET=x bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/requests/omniauth_spec.rb # this one test needs a different ENV
 

--- a/app/controllers/clients/enrollments_controller.rb
+++ b/app/controllers/clients/enrollments_controller.rb
@@ -1,0 +1,34 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Clients
+  class EnrollmentsController < ApplicationController
+    include ClientController
+    include ClientPathGenerator
+    include ClientDependentControllers
+
+    # before_action :require_can_edit_clients!
+    before_action :set_enrollment
+
+    def show
+      # TODO create matrix of all the things
+      # get service history enrollment
+    end
+
+    private
+
+    def set_enrollment
+      @enrollment = GrdaWarehouse::Hud::Enrollment.visible_to(current_user).find(params[:id].to_i)
+      @service_history_enrollment = @enrollment.service_history_enrollment
+      @client = @enrollment.destination_client
+      raise ActiveRecord::RecordNotFound if @client.id != params[:client_id].to_i
+    end
+
+    def title_for_show
+      "#{@client.name} - Enrollment at X"
+    end
+  end
+end

--- a/app/controllers/clients/enrollments_controller.rb
+++ b/app/controllers/clients/enrollments_controller.rb
@@ -10,6 +10,7 @@ module Clients
     include ClientPathGenerator
     include ClientDependentControllers
 
+    before_action :require_can_view_enrollment_details_tab!
     before_action :set_enrollment
 
     def show

--- a/app/controllers/clients/enrollments_controller.rb
+++ b/app/controllers/clients/enrollments_controller.rb
@@ -16,6 +16,7 @@ module Clients
     def show
       # TODO create matrix of all the things
       # get service history enrollment
+      @chronic_at_entry_matrix = GrdaWarehouse::ChEnrollment.ch_at_entry_matrix(@enrollment)
     end
 
     private

--- a/app/controllers/clients/enrollments_controller.rb
+++ b/app/controllers/clients/enrollments_controller.rb
@@ -10,12 +10,9 @@ module Clients
     include ClientPathGenerator
     include ClientDependentControllers
 
-    # before_action :require_can_edit_clients!
     before_action :set_enrollment
 
     def show
-      # TODO create matrix of all the things
-      # get service history enrollment
       @chronic_at_entry_matrix = GrdaWarehouse::ChEnrollment.ch_at_entry_matrix(@enrollment)
     end
 
@@ -26,10 +23,6 @@ module Clients
       @service_history_enrollment = @enrollment.service_history_enrollment
       @client = @enrollment.destination_client
       raise ActiveRecord::RecordNotFound if @client.id != params[:client_id].to_i
-    end
-
-    def title_for_show
-      "#{@client.name} - Enrollment at X"
     end
   end
 end

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -276,7 +276,6 @@ module GrdaWarehouse
       { result: :continue, display_value: value - 100 }
     end
 
-    # TODO: test boundaries days/months for entry/exit, NbN, and SO
     def self.homeless_duration_sufficient(enrollment, date: enrollment.EntryDate)
       steps = [approximate_start_date(enrollment, date: date)]
       return steps if terminating?(steps.last[:result])

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -223,12 +223,14 @@ module GrdaWarehouse
       { result: result, display_value: "#{days} days" }
     end
 
+    THREE_OR_FEWER_TIMES_HOMELESS = [1, 2, 3].freeze
+    TWELVE_OR_MORE_MONTHS_HOMELESS = [112, 113].freeze # 112 = 12 months, 113 = 13+ months
+
     # Lines 5, 11, 18, and 25 (3.917.4)
     def self.num_times_homeless(enrollment)
-      @three_or_fewer_times_homeless ||= [1, 2, 3].freeze
       value = enrollment.TimesHomelessPastThreeYears
 
-      result = if @three_or_fewer_times_homeless.include?(value)
+      result = if THREE_OR_FEWER_TIMES_HOMELESS.include?(value)
         :no
       elsif dk_or_r_or_missing(value)
         dk_or_r_or_missing(value)
@@ -239,9 +241,8 @@ module GrdaWarehouse
 
     # Lines 6, 12, 19, and 26 (3.917.4)
     def self.total_months_homeless(enrollment, date: enrollment.EntryDate)
-      @twelve_or_more_months_homeless ||= [112, 113].freeze # 112 = 12 months, 113 = 13+ months
       value = enrollment.MonthsHomelessPastThreeYears
-      return { result: :yes, display_value: value - 100 } if @twelve_or_more_months_homeless.include?(value)
+      return { result: :yes, display_value: value - 100 } if TWELVE_OR_MORE_MONTHS_HOMELESS.include?(value)
 
       # If you don't have time prior to entry, day calculation above will catch any days during the enrollment
       # If you have time prior to entry and we are looking at an arbitrary date, we need to add
@@ -291,7 +292,7 @@ module GrdaWarehouse
     end
 
     def self.dates_in_enrollment_between(enrollment, start_date, end_date)
-      @dates_in_enrollment_between ||= enrollment.service_history_services.
+      enrollment.service_history_services.
         service_between(start_date: start_date, end_date: end_date).
         distinct.
         pluck(:date)

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -47,7 +47,7 @@ module GrdaWarehouse
             batch << {
               enrollment_id: enrollment.id,
               processed_as: enrollment.processed_as,
-              chronically_homeless_at_entry: enrollment.chronically_homeless_at_start?(date: Date.current),
+              chronically_homeless_at_entry: chronically_homeless_at_start?(enrollment, date: Date.current),
             }
           end
           import(batch)
@@ -62,7 +62,7 @@ module GrdaWarehouse
           batch << {
             id: ch_enrollment.id,
             processed_as: enrollment.processed_as,
-            chronically_homeless_at_entry: enrollment.chronically_homeless_at_start?(date: Date.current),
+            chronically_homeless_at_entry: chronically_homeless_at_start?(enrollment, date: Date.current),
           }
         end
         import(
@@ -73,6 +73,112 @@ module GrdaWarehouse
           },
         )
       end
+    end
+
+    def self.dk_or_r_or_missing(value)
+      return :dk_or_r if [8, 9].include?(value)
+      return :missing if [nil, 99].include?(value)
+    end
+
+    def self.is_no?(value) # rubocop:disable Naming/PredicateName
+      return :no if value&.zero?
+    end
+
+    # TODO mini functions for each line
+    # TODO function returning matrix for table
+
+    # Accept an optional date which will be used for extending the homeless
+    # range if the project is a homeless project
+    def self.chronically_homeless_at_start?(enrollment, date: enrollment.EntryDate)
+      chronically_homeless_at_start(enrollment, date: date) == :yes
+    end
+
+    # Was the client chronically homeless at the start of this enrollment?
+    #
+    # @return [Symbol] :yes, :no, :dk_or_r, or :missing
+    def self.chronically_homeless_at_start(enrollment, date: enrollment.EntryDate)
+      # Line 1
+      return :no if is_no?(enrollment.DisablingCondition)
+      return dk_or_r_or_missing(enrollment.DisablingCondition) if dk_or_r_or_missing(enrollment.DisablingCondition)
+
+      # Line 3
+      if GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES.include?(enrollment.project.computed_project_type)
+        # Lines 4 - 6
+        result = homeless_duration_sufficient(enrollment, date: date)
+        return result if result
+      end
+
+      # Line 9
+      if HUD.homeless_situations(as: :prior).include?(enrollment.LivingSituation)
+        # Lines 10 - 12
+        result = homeless_duration_sufficient(enrollment)
+        return result if result
+      end
+
+      # Line 14
+      if HUD.institutional_situations(as: :prior).include?(enrollment.LivingSituation)
+        # Line 15
+        return :no if is_no?(enrollment.LOSUnderThreshold)
+        # Line 16
+        return :no if is_no?(enrollment.PreviousStreetESSH)
+
+        # Lines 17 - 19
+        result = homeless_duration_sufficient(enrollment)
+        return result if result
+      end
+
+      # Line 21
+      if (HUD.temporary_and_permanent_housing_situations(as: :prior) + HUD.other_situations(as: :prior)).include?(enrollment.LivingSituation)
+        # Line 22
+        return :no if is_no?(enrollment.LOSUnderThreshold)
+        # Line 23
+        return :no if is_no?(enrollment.PreviousStreetESSH)
+
+        # Lines 24 - 26
+        result = homeless_duration_sufficient(enrollment)
+        return result if result
+      end
+
+      return :no # Not included in flow -- added as fail safe
+    end
+
+    # TODO: test boundaries days/months for entry/exit, NbN, and SO
+    def self.homeless_duration_sufficient(enrollment, date: enrollment.EntryDate)
+      ch_start_date = [enrollment.DateToStreetESSH, enrollment.EntryDate].compact.min
+      project = enrollment.project
+      days = if date != enrollment.EntryDate && (project.so? || project.es? && project.bed_night_tracking?)
+        dates_in_enrollment_between(enrollment.EntryDate, date).count + (enrollment.EntryDate - ch_start_date).to_i
+      else
+        (date - ch_start_date).to_i
+      end
+      return :yes if days > 365
+
+      @three_or_fewer_times_homeless ||= [1, 2, 3].freeze
+      return :no if @three_or_fewer_times_homeless.include?(enrollment.TimesHomelessPastThreeYears)
+      return dk_or_r_or_missing(enrollment.TimesHomelessPastThreeYears) if dk_or_r_or_missing(enrollment.TimesHomelessPastThreeYears)
+
+      @twelve_or_more_months_homeless ||= [112, 113].freeze # 112 = 12 months, 113 = 13+ months
+      return :yes if @twelve_or_more_months_homeless.include?(enrollment.MonthsHomelessPastThreeYears)
+
+      # If you don't have time prior to entry, day calculation above will catch any days during the enrollment
+      # If you have time prior to entry and we are looking at an arbitrary date, we need to add
+      # the months served
+      if date != enrollment.EntryDate && enrollment.MonthsHomelessPastThreeYears.present? && enrollment.MonthsHomelessPastThreeYears > 100
+        months_in_enrollment = if project.so? || project.es? && project.bed_night_tracking?
+          dates_in_enrollment_between(enrollment.EntryDate, date).map do |d|
+            [d.month, d.year]
+          end.uniq.count
+        else
+          month_count = (date.year * 12 + date.month) - (enrollment.EntryDate.year * 12 + enrollment.EntryDate.month)
+          # Subtract 1 from this number if the [project start date] does not fall on the first of the month.
+          month_count -= 1 if month_count.positive? && enrollment.EntryDate.day != 1
+          month_count
+        end
+        months_prior_to_enrollment = enrollment.MonthsHomelessPastThreeYears - 100
+        return :yes if (months_prior_to_enrollment + months_in_enrollment) > 11
+      end
+
+      return dk_or_r_or_missing(enrollment.MonthsHomelessPastThreeYears) if dk_or_r_or_missing(enrollment.MonthsHomelessPastThreeYears)
     end
   end
 end

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -75,34 +75,85 @@ module GrdaWarehouse
       end
     end
 
-    def self.dk_or_r_or_missing(value)
-      return :dk_or_r if [8, 9].include?(value)
-      return :missing if [nil, 99].include?(value)
+    # Line 1
+    def self.disabling_condition(enrollment)
+      result = if is_no?(enrollment.DisablingCondition)
+        :no
+      elsif dk_or_r_or_missing(enrollment.DisablingCondition)
+        dk_or_r_or_missing(enrollment.DisablingCondition)
+      end
+
+      [result, enrollment.DisablingCondition]
     end
 
-    def self.is_no?(value) # rubocop:disable Naming/PredicateName
-      return :no if value&.zero?
+    # Line 3
+    def self.project_type(enrollment)
+      ptype = enrollment.project.computed_project_type
+      result = GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES.include?(ptype)
+      [result, ::HUD.project_type_brief(ptype)]
     end
 
-    # TODO mini functions for each line
-    # TODO function returning matrix for table
+    def self.ch_at_entry_matrix(enrollment)
+      steps = [
+        {
+          line: 1,
+          title: 'Disabling Condition',
+          descriptions: ['If 1 (yes), CONTINUE processing using 3.917A (line 3) or B (line 8) as appropriate.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+          method: :disabling_condition,
+        },
+        {
+          line: 3,
+          title: 'Project Type',
+          descriptions: ['If 1, 4 or 8 (street outreach, shelter, or safe haven), CONTINUE processing on line 4.'],
+          method: :project_type,
+        },
+        {
+          line: 4,
+          title: 'Days since approximate start date',
+          descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 5.'],
+          method: :approximate_start_date,
+        },
+        {
+          line: 5,
+          title: 'Number of times homeless',
+          descriptions: ['If four or more times, CONTINUE processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+          method: :num_times_homeless,
+        },
+        {
+          line: 6,
+          title: 'Total months homeless',
+          descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+          method: :total_months_homeless,
+        },
+      ]
+      rows = []
+      steps.each do |step|
+        # some functions accept optional date, but we don't need it here because we're only using this for chronic-at-entry (not chronic-at-PIT)
+        result, value = send(step[:method], enrollment)
 
-    # Accept an optional date which will be used for extending the homeless
-    # range if the project is a homeless project
-    def self.chronically_homeless_at_start?(enrollment, date: enrollment.EntryDate)
-      chronically_homeless_at_start(enrollment, date: date) == :yes
+        # sometimes result returns a boolean used by 'chronically_homeless_at_start' fn. ignore the value unless it is a final decision.
+        result = nil unless result.in?([:yes, :no, :dk_or_r, :missing])
+        rows.push([step[:line], step[:title], result, value, step[:descriptions]])
+
+        # break if decision was reached
+        # break if result
+      end
+
+      rows
     end
 
     # Was the client chronically homeless at the start of this enrollment?
+    # Optionally accepts a date to use for "CH at a point-in-time" calculation.
     #
     # @return [Symbol] :yes, :no, :dk_or_r, or :missing
     def self.chronically_homeless_at_start(enrollment, date: enrollment.EntryDate)
       # Line 1
-      return :no if is_no?(enrollment.DisablingCondition)
-      return dk_or_r_or_missing(enrollment.DisablingCondition) if dk_or_r_or_missing(enrollment.DisablingCondition)
+      result_1 = disabling_condition(enrollment)[0]
+      return result_1 if result_1
 
       # Line 3
-      if GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES.include?(enrollment.project.computed_project_type)
+      result_3 = project_type(enrollment)[0]
+      if result_3
         # Lines 4 - 6
         result = homeless_duration_sufficient(enrollment, date: date)
         return result if result
@@ -142,8 +193,24 @@ module GrdaWarehouse
       return :no # Not included in flow -- added as fail safe
     end
 
-    # TODO: test boundaries days/months for entry/exit, NbN, and SO
-    def self.homeless_duration_sufficient(enrollment, date: enrollment.EntryDate)
+    # Accept an optional date which will be used for extending the homeless
+    # range if the project is a homeless project
+    def self.chronically_homeless_at_start?(enrollment, date: enrollment.EntryDate)
+      chronically_homeless_at_start(enrollment, date: date) == :yes
+    end
+
+    def self.dk_or_r_or_missing(value)
+      return :dk_or_r if [8, 9].include?(value)
+      return :missing if [nil, 99].include?(value)
+    end
+
+    def self.is_no?(value) # rubocop:disable Naming/PredicateName
+      return :no if value&.zero?
+    end
+
+    # Lines 4, 10, 17, and 24
+    # 3.917.3
+    def self.approximate_start_date(enrollment, date: enrollment.EntryDate)
       ch_start_date = [enrollment.DateToStreetESSH, enrollment.EntryDate].compact.min
       project = enrollment.project
       days = if date != enrollment.EntryDate && (project.so? || project.es? && project.bed_night_tracking?)
@@ -151,19 +218,33 @@ module GrdaWarehouse
       else
         (date - ch_start_date).to_i
       end
-      return :yes if days > 365
+      result = days > 365 ? :yes : nil
+      [result, days]
+    end
 
+    # Lines 5, 11, 18, and 25 (3.917.4)
+    def self.num_times_homeless(enrollment)
       @three_or_fewer_times_homeless ||= [1, 2, 3].freeze
-      return :no if @three_or_fewer_times_homeless.include?(enrollment.TimesHomelessPastThreeYears)
-      return dk_or_r_or_missing(enrollment.TimesHomelessPastThreeYears) if dk_or_r_or_missing(enrollment.TimesHomelessPastThreeYears)
+      value = enrollment.TimesHomelessPastThreeYears
 
+      return [:no, value] if @three_or_fewer_times_homeless.include?(value)
+
+      return [dk_or_r_or_missing(value), value] if dk_or_r_or_missing(value)
+
+      [nil, value]
+    end
+
+    # Lines 6, 12, 19, and 26 (3.917.4)
+    def self.total_months_homeless(enrollment, date: enrollment.EntryDate)
       @twelve_or_more_months_homeless ||= [112, 113].freeze # 112 = 12 months, 113 = 13+ months
-      return :yes if @twelve_or_more_months_homeless.include?(enrollment.MonthsHomelessPastThreeYears)
+      value = enrollment.MonthsHomelessPastThreeYears
+      return [:yes, value - 100] if @twelve_or_more_months_homeless.include?(value)
 
       # If you don't have time prior to entry, day calculation above will catch any days during the enrollment
       # If you have time prior to entry and we are looking at an arbitrary date, we need to add
-      # the months served
+      # the months served. (This is only used for Chronic-at-PIT calculation, not Chronic-at-Entry).
       if date != enrollment.EntryDate && enrollment.MonthsHomelessPastThreeYears.present? && enrollment.MonthsHomelessPastThreeYears > 100
+        project = enrollment.project
         months_in_enrollment = if project.so? || project.es? && project.bed_night_tracking?
           dates_in_enrollment_between(enrollment.EntryDate, date).map do |d|
             [d.month, d.year]
@@ -175,10 +256,24 @@ module GrdaWarehouse
           month_count
         end
         months_prior_to_enrollment = enrollment.MonthsHomelessPastThreeYears - 100
-        return :yes if (months_prior_to_enrollment + months_in_enrollment) > 11
+        sum = months_prior_to_enrollment + months_in_enrollment
+        return [:yes, sum] if sum > 11
       end
 
-      return dk_or_r_or_missing(enrollment.MonthsHomelessPastThreeYears) if dk_or_r_or_missing(enrollment.MonthsHomelessPastThreeYears)
+      return [dk_or_r_or_missing(value), value] if dk_or_r_or_missing(value)
+
+      [nil, value - 100]
+    end
+
+    # TODO: test boundaries days/months for entry/exit, NbN, and SO
+    def self.homeless_duration_sufficient(enrollment, date: enrollment.EntryDate)
+      result = approximate_start_date(enrollment, date: date)[0]
+      return result if result
+
+      result = num_times_homeless(enrollment)[0]
+      return result if result
+
+      total_months_homeless(enrollment, date: date)[0]
     end
   end
 end

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -75,7 +75,7 @@ module GrdaWarehouse
       end
     end
 
-    # Line 1
+    # Line 1 (3.08)
     def self.disabling_condition(enrollment)
       result = if is_no?(enrollment.DisablingCondition)
         :no
@@ -83,57 +83,142 @@ module GrdaWarehouse
         dk_or_r_or_missing(enrollment.DisablingCondition)
       end
 
-      [result, enrollment.DisablingCondition]
+      { result: result, display_value: enrollment.DisablingCondition, line: 1 }
     end
 
-    # Line 3
+    # Line 3 (2.02.6)
     def self.project_type(enrollment)
       ptype = enrollment.project.computed_project_type
       result = GrdaWarehouse::Hud::Project::CHRONIC_PROJECT_TYPES.include?(ptype)
-      [result, ::HUD.project_type_brief(ptype)]
+      { result: result, display_value: "#{ptype} (#{::HUD.project_type_brief(ptype)})", line: 3 }
     end
 
+    # Line 9  (3.917.1)
+    def self.prior_living_sitation_homeless(enrollment)
+      value = enrollment.LivingSituation
+      result = HUD.homeless_situations(as: :prior).include?(value)
+      { result: result, display_value: "#{value} (#{::HUD.living_situation(value)})", line: 9 }
+    end
+
+    # Line 14 (3.917.1)
+    def self.prior_living_sitation_institutional(enrollment)
+      value = enrollment.LivingSituation
+      result = HUD.institutional_situations(as: :prior).include?(value)
+      { result: result, display_value: "#{value} (#{::HUD.living_situation(value)})", line: 14 }
+    end
+
+    # Line 21 (3.917.1)
+    def self.prior_living_sitation_other(enrollment)
+      value = enrollment.LivingSituation
+      result = (HUD.temporary_and_permanent_housing_situations(as: :prior) + HUD.other_situations(as: :prior)).include?(value)
+      { result: result, display_value: "#{value} (#{::HUD.living_situation(value)})", line: 21 }
+    end
+
+    CH_AT_DATE_STEP_DESCRIPTIONS = {
+      1 => {
+        title: 'Disabling Condition',
+        descriptions: ['If 1 (yes), CONTINUE processing using 3.917A (line 3) or B (line 8) as appropriate.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      3 => {
+        title: 'Project Type',
+        descriptions: ['If 1, 4 or 8, CONTINUE processing on line 4.'],
+      },
+      4 => {
+        title: 'Days since approximate start date',
+        descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 5.'],
+      },
+      5 => {
+        title: 'Number of times homeless',
+        descriptions: ['If four or more times, CONTINUE processing on line 6.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      6 => {
+        title: 'Total months homeless',
+        descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      9 => {
+        title: 'Prior Living Situation (3.917B Homeless Situation)',
+        descriptions: ['If 16, 1, 18, CONTINUE processing on line 10.'],
+      },
+      10 => {
+        title: 'Days since approximate start date',
+        descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 11.'],
+      },
+      11 => {
+        title: 'Number of times homeless',
+        descriptions: ['If four or more times, CONTINUE processing on line 12.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      12 => {
+        title: 'Total months homeless',
+        descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      14 => {
+        title: 'Prior Living Situation (3.917B Institutional Situation)',
+        descriptions: ['If 15, 6, 7, 25, 4, 5, CONTINUE processing on line 15.'],
+      },
+      15 => {
+        title: 'Did you stay longer than 90 days?',
+        descriptions: ['If 1 (yes), CONTINUE processing on line 16.', 'If 0 (no), CH = NO. STOP processing.'],
+      },
+      16 => {
+        title: 'On the night before did you stay on the streets, ES or SH',
+        descriptions: ['If 1 (yes), CONTINUE processing on line 17.', 'If 0 (no), CH = NO. STOP processing.'],
+      },
+      17 => {
+        title: 'Days since approximate start date',
+        descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 18.'],
+      },
+      18 => {
+        title: 'Number of times homeless',
+        descriptions: ['If four or more times, CONTINUE processing on line 19.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      19 => {
+        title: 'Total months homeless',
+        descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      21 => {
+        title: 'Prior Living Situation (3.917B Temporary, Permanent, and other Situations:)',
+        descriptions: ['If 29, 14, 2, 32, 36, 35, 28, 19, 3, 31, 33, 34, 10, 20, 21, 11, 8, 9, 99, CONTINUE processing on line 22.'],
+      },
+      22 => {
+        title: 'Did you stay less than 7 nights?',
+        descriptions: ['If 1 (yes), CONTINUE processing on line 23.', 'If 0 (no), CH = NO. STOP processing.'],
+      },
+      23 => {
+        title: 'On the night before did you stay on the streets, ES or SH',
+        descriptions: ['If 1 (yes), CONTINUE processing on line 24.', 'If 0 (no), CH = NO. STOP processing.'],
+      },
+      24 => {
+        title: 'Days since approximate start date',
+        descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 25.'],
+      },
+      25 => {
+        title: 'Number of times homeless',
+        descriptions: ['If four or more times, CONTINUE processing on line 26.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+      26 => {
+        title: 'Total months homeless',
+        descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1 to 11 months, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
+      },
+
+    }.freeze
+
     def self.ch_at_entry_matrix(enrollment)
-      steps = [
-        {
-          line: 1,
-          title: 'Disabling Condition',
-          descriptions: ['If 1 (yes), CONTINUE processing using 3.917A (line 3) or B (line 8) as appropriate.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
-          method: :disabling_condition,
-        },
-        {
-          line: 3,
-          title: 'Project Type',
-          descriptions: ['If 1, 4 or 8 (street outreach, shelter, or safe haven), CONTINUE processing on line 4.'],
-          method: :project_type,
-        },
-        {
-          line: 4,
-          title: 'Days since approximate start date',
-          descriptions: ['If > 365 days, CH = YES. STOP processing.', 'If missing or less than 365 days before [project start date], CONTINUE processing on line 5.'],
-          method: :approximate_start_date,
-        },
-        {
-          line: 5,
-          title: 'Number of times homeless',
-          descriptions: ['If four or more times, CONTINUE processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
-          method: :num_times_homeless,
-        },
-        {
-          line: 6,
-          title: 'Total months homeless',
-          descriptions: ['If >= 12, CH = YES. STOP processing.', 'If 1, 2, or 3 times, CH = NO. STOP processing.', 'If 8 or 9 then CH = DK/R. STOP processing', 'If 99 then CH = missing. STOP processing'],
-          method: :total_months_homeless,
-        },
-      ]
       rows = []
-      steps.each do |step|
+
+      result_steps = chronically_homeless_at_start_steps(enrollment)
+      result_steps.each do |s|
+        result = s[:result]
+        value = s[:display_value]
         # some functions accept optional date, but we don't need it here because we're only using this for chronic-at-entry (not chronic-at-PIT)
-        result, value = send(step[:method], enrollment)
+        # result, value = send(step[:method], enrollment)
+        line_number = s[:line]
+        step = CH_AT_DATE_STEP_DESCRIPTIONS[line_number]
+        next unless step.present?
 
         # sometimes result returns a boolean used by 'chronically_homeless_at_start' fn. ignore the value unless it is a final decision.
-        result = nil unless result.in?([:yes, :no, :dk_or_r, :missing])
-        rows.push([step[:line], step[:title], result, value, step[:descriptions]])
+        # result = nil unless result.in?([:yes, :no, :dk_or_r, :missing])
+        # rows.push([step[:line], step[:title], result, value, step[:descriptions]])
+        rows.push([line_number, step[:title], result, value, step[:descriptions]])
 
         # break if decision was reached
         # break if result
@@ -147,50 +232,69 @@ module GrdaWarehouse
     #
     # @return [Symbol] :yes, :no, :dk_or_r, or :missing
     def self.chronically_homeless_at_start(enrollment, date: enrollment.EntryDate)
+      chronically_homeless_at_start_steps(enrollment, date: date).last[:result]
+    end
+
+    # Was the client chronically homeless at the start of this enrollment?
+    # Optionally accepts a date to use for "CH at a point-in-time" calculation.
+    #
+    # @return [Symbol] :yes, :no, :dk_or_r, or :missing
+    # @return [Array] all steps evaluated
+    def self.chronically_homeless_at_start_steps(enrollment, date: enrollment.EntryDate)
+      steps = []
       # Line 1
-      result_1 = disabling_condition(enrollment)[0]
-      return result_1 if result_1
+      steps.push(disabling_condition(enrollment))
+      return steps if steps.last[:result]
 
       # Line 3
-      result_3 = project_type(enrollment)[0]
-      if result_3
+      steps.push(project_type(enrollment))
+      if steps.last[:result]
         # Lines 4 - 6
-        result = homeless_duration_sufficient(enrollment, date: date)
-        return result if result
+        time_steps = homeless_duration_sufficient(enrollment, date: date)
+        steps.push(*time_steps.each_with_index { |s, i| s[:line] = 4 + i })
+        return steps if steps.last[:result]
       end
 
       # Line 9
-      if HUD.homeless_situations(as: :prior).include?(enrollment.LivingSituation)
+      steps.push(prior_living_sitation_homeless(enrollment))
+      if steps.last[:result]
         # Lines 10 - 12
-        result = homeless_duration_sufficient(enrollment)
-        return result if result
+        time_steps = homeless_duration_sufficient(enrollment)
+        steps.push(*time_steps.each_with_index { |s, i| s[:line] = 10 + i })
+        return steps if steps.last[:result]
       end
 
       # Line 14
-      if HUD.institutional_situations(as: :prior).include?(enrollment.LivingSituation)
-        # Line 15
-        return :no if is_no?(enrollment.LOSUnderThreshold)
-        # Line 16
-        return :no if is_no?(enrollment.PreviousStreetESSH)
+      steps.push(prior_living_sitation_institutional(enrollment))
+      if steps.last[:result]
+        # Lines 15-16
+        los_steps = length_of_stay_previous_sufficient(enrollment)
+        steps.push(*los_steps.each_with_index { |s, i| s[:line] = 15 + i })
+        return steps if steps.last[:result]
 
         # Lines 17 - 19
-        result = homeless_duration_sufficient(enrollment)
-        return result if result
+        time_steps = homeless_duration_sufficient(enrollment)
+        steps.push(*time_steps.each_with_index { |s, i| s[:line] = 17 + i })
+        return steps if steps.last[:result]
       end
 
       # Line 21
-      if (HUD.temporary_and_permanent_housing_situations(as: :prior) + HUD.other_situations(as: :prior)).include?(enrollment.LivingSituation)
-        # Line 22
-        return :no if is_no?(enrollment.LOSUnderThreshold)
-        # Line 23
-        return :no if is_no?(enrollment.PreviousStreetESSH)
+      steps.push(prior_living_sitation_other(enrollment))
+      if steps.last[:result]
+        # Lines 22-23
+        los_steps = length_of_stay_previous_sufficient(enrollment)
+        steps.push(*los_steps.each_with_index { |s, i| s[:line] = 22 + i })
+        return steps if steps.last[:result]
 
         # Lines 24 - 26
-        result = homeless_duration_sufficient(enrollment)
-        return result if result
+        time_steps = homeless_duration_sufficient(enrollment)
+        steps.push(*time_steps.each_with_index { |s, i| s[:line] = 24 + i })
+        return steps if steps.last[:result]
       end
 
-      return :no # Not included in flow -- added as fail safe
+      # This matches the last step (26) for clients who were homeless 4-11 months, since 'homeless_duration_sufficient' doesn't check for that
+      steps.last[:result] = :no
+      steps
     end
 
     # Accept an optional date which will be used for extending the homeless
@@ -219,7 +323,7 @@ module GrdaWarehouse
         (date - ch_start_date).to_i
       end
       result = days > 365 ? :yes : nil
-      [result, days]
+      { result: result, display_value: "#{days} days" }
     end
 
     # Lines 5, 11, 18, and 25 (3.917.4)
@@ -227,18 +331,20 @@ module GrdaWarehouse
       @three_or_fewer_times_homeless ||= [1, 2, 3].freeze
       value = enrollment.TimesHomelessPastThreeYears
 
-      return [:no, value] if @three_or_fewer_times_homeless.include?(value)
+      result = if @three_or_fewer_times_homeless.include?(value)
+        :no
+      elsif dk_or_r_or_missing(value)
+        dk_or_r_or_missing(value)
+      end
 
-      return [dk_or_r_or_missing(value), value] if dk_or_r_or_missing(value)
-
-      [nil, value]
+      { result: result, display_value: value }
     end
 
     # Lines 6, 12, 19, and 26 (3.917.4)
     def self.total_months_homeless(enrollment, date: enrollment.EntryDate)
       @twelve_or_more_months_homeless ||= [112, 113].freeze # 112 = 12 months, 113 = 13+ months
       value = enrollment.MonthsHomelessPastThreeYears
-      return [:yes, value - 100] if @twelve_or_more_months_homeless.include?(value)
+      return { result: :yes, display_value: value - 100 } if @twelve_or_more_months_homeless.include?(value)
 
       # If you don't have time prior to entry, day calculation above will catch any days during the enrollment
       # If you have time prior to entry and we are looking at an arbitrary date, we need to add
@@ -257,23 +363,34 @@ module GrdaWarehouse
         end
         months_prior_to_enrollment = enrollment.MonthsHomelessPastThreeYears - 100
         sum = months_prior_to_enrollment + months_in_enrollment
-        return [:yes, sum] if sum > 11
+        return { result: :yes, display_value: sum } if sum > 11
       end
 
-      return [dk_or_r_or_missing(value), value] if dk_or_r_or_missing(value)
+      return { result: dk_or_r_or_missing(value), display_value: value } if dk_or_r_or_missing(value)
 
-      [nil, value - 100]
+      { result: nil, display_value: value - 100 }
     end
 
     # TODO: test boundaries days/months for entry/exit, NbN, and SO
     def self.homeless_duration_sufficient(enrollment, date: enrollment.EntryDate)
-      result = approximate_start_date(enrollment, date: date)[0]
-      return result if result
+      steps = [approximate_start_date(enrollment, date: date)]
+      return steps if steps.last[:result]
 
-      result = num_times_homeless(enrollment)[0]
-      return result if result
+      steps.push(num_times_homeless(enrollment))
+      return steps if steps.last[:result]
 
-      total_months_homeless(enrollment, date: date)[0]
+      steps.push(total_months_homeless(enrollment, date: date))
+      steps
+    end
+
+    # Add steps for lines 15-16 and lines 22-23
+    def self.length_of_stay_previous_sufficient(enrollment)
+      steps = []
+      steps.push({ result: is_no?(enrollment.LOSUnderThreshold), display_value: enrollment.LOSUnderThreshold })
+      return steps if steps.last[:result]
+
+      steps.push({ result: is_no?(enrollment.PreviousStreetESSH), display_value: enrollment.PreviousStreetESSH })
+      steps
     end
   end
 end

--- a/app/models/grda_warehouse/hud/enrollment.rb
+++ b/app/models/grda_warehouse/hud/enrollment.rb
@@ -393,13 +393,6 @@ module GrdaWarehouse::Hud
       GrdaWarehouse::ChEnrollment.chronically_homeless_at_start(self, date: date)
     end
 
-    private def dates_in_enrollment_between(start_date, end_date)
-      @dates_in_enrollment_between ||= service_history_services.
-        service_between(start_date: start_date, end_date: end_date).
-        distinct.
-        pluck(:date)
-    end
-
     # NOTE: this must be included at the end of the class so that scopes can override correctly
     include RailsDrivers::Extensions
   end # End Enrollment

--- a/app/models/grda_warehouse/hud/enrollment.rb
+++ b/app/models/grda_warehouse/hud/enrollment.rb
@@ -383,97 +383,14 @@ module GrdaWarehouse::Hud
     # Accept an optional date which will be used for extending the homeless
     # range if the project is a homeless project
     def chronically_homeless_at_start?(date: self.EntryDate)
-      chronically_homeless_at_start(date: date) == :yes
+      GrdaWarehouse::ChEnrollment.chronically_homeless_at_start?(self, date: date)
     end
 
     # Was the client chronically homeless at the start of this enrollment?
     #
     # @return [Symbol] :yes, :no, :dk_or_r, or :missing
     def chronically_homeless_at_start(date: self.EntryDate)
-      # Line 1
-      return :no if is_no?(self.DisablingCondition)
-      return dk_or_r_or_missing(self.DisablingCondition) if dk_or_r_or_missing(self.DisablingCondition)
-
-      # Line 3
-      if Project::CHRONIC_PROJECT_TYPES.include?(project.computed_project_type)
-        # Lines 4 - 6
-        return homeless_duration_sufficient(date: date) if homeless_duration_sufficient(date: date)
-      end
-
-      # Line 9
-      if HUD.homeless_situations(as: :prior).include?(self.LivingSituation)
-        # Lines 10 - 12
-        return homeless_duration_sufficient if homeless_duration_sufficient
-      end
-
-      # Line 14
-      if HUD.institutional_situations(as: :prior).include?(self.LivingSituation)
-        # Line 15
-        return :no if is_no?(self.LOSUnderThreshold)
-        # Line 16
-        return :no if is_no?(self.PreviousStreetESSH)
-        # Lines 17 - 19
-        return homeless_duration_sufficient if homeless_duration_sufficient
-      end
-
-      # Line 21
-      if (HUD.temporary_and_permanent_housing_situations(as: :prior) + HUD.other_situations(as: :prior)).include?(self.LivingSituation)
-        # Line 22
-        return :no if is_no?(self.LOSUnderThreshold)
-        # Line 23
-        return :no if is_no?(self.PreviousStreetESSH)
-        # Lines 24 - 26
-        return homeless_duration_sufficient if homeless_duration_sufficient
-      end
-
-      return :no # Not included in flow -- added as fail safe
-    end
-
-    def is_no?(value) # rubocop:disable Naming/PredicateName
-      return :no if value&.zero?
-    end
-
-    def dk_or_r_or_missing(value)
-      return :dk_or_r if [8, 9].include?(value)
-      return :missing if [nil, 99].include?(value)
-    end
-
-    # TODO: test boundaries days/months for entry/exit, NbN, and SO
-    def homeless_duration_sufficient(date: self.EntryDate)
-      ch_start_date = [self.DateToStreetESSH, self.EntryDate].compact.min
-      days = if date != self.EntryDate && (project.so? || project.es? && project.bed_night_tracking?)
-        dates_in_enrollment_between(self.EntryDate, date).count + (self.EntryDate - ch_start_date).to_i
-      else
-        (date - ch_start_date).to_i
-      end
-      return :yes if days > 365
-
-      @three_or_fewer_times_homeless ||= [1, 2, 3].freeze
-      return :no if @three_or_fewer_times_homeless.include?(self.TimesHomelessPastThreeYears)
-      return dk_or_r_or_missing(self.TimesHomelessPastThreeYears) if dk_or_r_or_missing(self.TimesHomelessPastThreeYears)
-
-      @twelve_or_more_months_homeless ||= [112, 113].freeze # 112 = 12 months, 113 = 13+ months
-      return :yes if @twelve_or_more_months_homeless.include?(self.MonthsHomelessPastThreeYears)
-
-      # If you don't have time prior to entry, day calculation above will catch any days during the enrollment
-      # If you have time prior to entry and we are looking at an arbitrary date, we need to add
-      # the months served
-      if date != self.EntryDate && self.MonthsHomelessPastThreeYears.present? && self.MonthsHomelessPastThreeYears > 100
-        months_in_enrollment = if project.so? || project.es? && project.bed_night_tracking?
-          dates_in_enrollment_between(self.EntryDate, date).map do |d|
-            [d.month, d.year]
-          end.uniq.count
-        else
-          month_count = (date.year * 12 + date.month) - (self.EntryDate.year * 12 + self.EntryDate.month)
-          # Subtract 1 from this number if the [project start date] does not fall on the first of the month.
-          month_count -= 1 if month_count.positive? && self.EntryDate.day != 1
-          month_count
-        end
-        months_prior_to_enrollment = self.MonthsHomelessPastThreeYears - 100
-        return :yes if (months_prior_to_enrollment + months_in_enrollment) > 11
-      end
-
-      return dk_or_r_or_missing(self.MonthsHomelessPastThreeYears) if dk_or_r_or_missing(self.MonthsHomelessPastThreeYears)
+      GrdaWarehouse::ChEnrollment.chronically_homeless_at_start(self, date: date)
     end
 
     private def dates_in_enrollment_between(start_date, end_date)

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -77,7 +77,7 @@
           - elsif e[:project_type_id].in?(GrdaWarehouse::Hud::Project::WITH_MOVE_IN_DATES)
             - title += ";<br /><b>Move-in Date:</b> No move-in date"
           %span{data: { toggle: :tooltip, title: title.html_safe, html: 'true' }}
-            - if current_user.can_view_enrollment_details_tab?
+            - if e[:residential] && current_user.can_view_enrollment_details_tab?
               = link_to e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
             - else
               = e[:entry_date]

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -77,10 +77,8 @@
           - elsif e[:project_type_id].in?(GrdaWarehouse::Hud::Project::WITH_MOVE_IN_DATES)
             - title += ";<br /><b>Move-in Date:</b> No move-in date"
           %span{data: { toggle: :tooltip, title: title.html_safe, html: 'true' }}
-            - if e[:residential] && current_user.can_view_enrollment_details_tab?
-              = link_to e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
-            - else
-              = e[:entry_date]
+            - include_link = e[:residential] && current_user.can_view_enrollment_details_tab?
+            = link_to_if include_link, e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
           - if e[:residential] && e[:chronically_homeless_at_start]
             %i.icon-passport{data: {toggle: :tooltip, title: 'Chronic at entry'}}
           - if move_in_date.present?

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -77,7 +77,10 @@
           - elsif e[:project_type_id].in?(GrdaWarehouse::Hud::Project::WITH_MOVE_IN_DATES)
             - title += ";<br /><b>Move-in Date:</b> No move-in date"
           %span{data: { toggle: :tooltip, title: title.html_safe, html: 'true' }}
-            = link_to e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
+            - if current_user.can_view_enrollment_details_tab?
+              = link_to e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
+            - else
+              = e[:entry_date]
           - if e[:residential] && e[:chronically_homeless_at_start]
             %i.icon-passport{data: {toggle: :tooltip, title: 'Chronic at entry'}}
           - if move_in_date.present?

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -77,10 +77,9 @@
           - elsif e[:project_type_id].in?(GrdaWarehouse::Hud::Project::WITH_MOVE_IN_DATES)
             - title += ";<br /><b>Move-in Date:</b> No move-in date"
           %span{data: { toggle: :tooltip, title: title.html_safe, html: 'true' }}
-            = e[:entry_date]
+            = link_to e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
           - if e[:residential] && e[:chronically_homeless_at_start]
-            %div
-              %i.icon-passport{data: {toggle: :tooltip, title: 'Chronically homeless at entry'}}
+            %i.icon-passport{data: {toggle: :tooltip, title: 'Chronic at entry'}}
           - if move_in_date.present?
             - title = "<b>Move-in Date:</b> #{move_in_date}"
             - if e[:move_in_date_inherited]
@@ -140,7 +139,6 @@
                 Created: #{e[:created_at]}
               .text-nowrap
                 Updated: #{e[:updated_at]}
-          = link_to 'Chronic at Entry Info', client_enrollment_path(@client.id, e[:hmis_id]), class: 'mb-2 text-teeny'
 - else
   %p.ml-3.mt-3
     No enrollments on file

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -39,8 +39,8 @@
           - else
             = total_adjusted_days
         %th.num-cell= total_months
-        -# - if @client.hmis_source_visible_by?(current_user)
-        %th
+        - if @client.hmis_source_visible_by?(current_user)
+          %th
     %tbody
     - enrollments.each do |e|
       - episode_class = ''
@@ -123,9 +123,8 @@
                     Age:
                     = c['age']
                 %br
-        
-        %td
-          - if @client.hmis_source_visible_by?(current_user)
+        - if @client.hmis_source_visible_by?(current_user)
+          %td
             - if e[:hmis_id]
               - title = 'HMIS'
               - if e[:hmis_exit_id]

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -39,8 +39,8 @@
           - else
             = total_adjusted_days
         %th.num-cell= total_months
-        - if @client.hmis_source_visible_by?(current_user)
-          %th
+        -# - if @client.hmis_source_visible_by?(current_user)
+        %th
     %tbody
     - enrollments.each do |e|
       - episode_class = ''
@@ -124,8 +124,9 @@
                     Age:
                     = c['age']
                 %br
-        - if @client.hmis_source_visible_by?(current_user)
-          %td
+        
+        %td
+          - if @client.hmis_source_visible_by?(current_user)
             - if e[:hmis_id]
               - title = 'HMIS'
               - if e[:hmis_exit_id]
@@ -139,6 +140,7 @@
                 Created: #{e[:created_at]}
               .text-nowrap
                 Updated: #{e[:updated_at]}
+          = link_to 'Chronic at Entry Info', client_enrollment_path(@client.id, e[:hmis_id]), class: 'mb-2 text-teeny'
 - else
   %p.ml-3.mt-3
     No enrollments on file

--- a/app/views/clients/enrollments/_chronic_at_entry.haml
+++ b/app/views/clients/enrollments/_chronic_at_entry.haml
@@ -17,12 +17,10 @@
           %td{style: 'max-width: 300px;'}= title
           %td{style: 'max-width: 300px;'}= value
           %td
-            - if result.in? [true, false]
-              %em.text-muted= result ? 'continue' : 'skip'
-            - elsif result.nil?
-              %em.text-muted continue
+            - if result&.in? [:continue, :skip]
+              %em.text-muted= result
             - else
-              %strong= result.upcase
+              %strong= result&.upcase
           %td
             - descriptions.each do |s|
               .mb-1= s

--- a/app/views/clients/enrollments/_chronic_at_entry.haml
+++ b/app/views/clients/enrollments/_chronic_at_entry.haml
@@ -1,0 +1,28 @@
+%h2 Chronic at Entry
+.mb-4
+  Calculation used to determine whether the client was chronic at entry.
+.table-responsive
+  %table.table.table-striped
+    %thead
+      %tr
+        %th Line
+        %th Field / Condition
+        %th Value
+        %th Result
+        %th HUD Decision Logic
+    %tbody
+      - @chronic_at_entry_matrix.each do |number, title, value, result, descriptions|
+        %tr
+          %td= number
+          %td{style: 'max-width: 300px;'}= title
+          %td{style: 'max-width: 300px;'}= value
+          %td
+            - if result.in? [true, false]
+              %em.text-muted= result ? 'continue' : 'skip'
+            - elsif result.nil?
+              %em.text-muted continue
+            - else
+              %strong= result.upcase
+          %td
+            - descriptions.each do |s|
+              .mb-1= s

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -33,31 +33,4 @@
               %td Move-in Date
               %td= "#{@service_history_enrollment.move_in_date || '-'} #{move_in_date_inherited ? '(inherited from HoH)' : ''}"
 
-%h2 Chronic at Entry
-.mb-4
-  Calculation used to determine whether the client was chronic at entry.
-.table-responsive
-  %table.table.table-striped
-    %thead
-      %tr
-        %th Line
-        %th Field / Condition
-        %th Value
-        %th Result
-        %th HUD Decision Logic
-    %tbody
-      - @chronic_at_entry_matrix.each do |number, title, value, result, descriptions|
-        %tr
-          %td= number
-          %td{style: 'max-width: 300px;'}= title
-          %td{style: 'max-width: 300px;'}= value
-          %td
-            - if result.in? [true, false]
-              %em.text-muted= result ? 'continue' : 'skip'
-            - elsif result.nil?
-              %em.text-muted continue
-            - else
-              %strong= result.upcase
-          %td
-            - descriptions.each do |s|
-              .mb-1= s
+= render 'chronic_at_entry' if @service_history_enrollment.computed_project_type.in?(::GrdaWarehouse::Hud::Project::RESIDENTIAL_PROJECT_TYPE_IDS)

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -1,4 +1,4 @@
-- title = "#{@client.name} enrollment at #{@enrollment.project&.name(current_user)}"
+- title = "Enrollment at #{@enrollment.project&.name(current_user)} for #{@client.name} "
 - content_for :title, title
 = render 'clients/anomalies/breadcrumbs'
 %h1= title

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -1,4 +1,4 @@
-- title = "Enrollment for #{@client.name} at #{@enrollment.project&.name(current_user)}"
+- title = "#{@client.name} enrollment at #{@enrollment.project&.name(current_user)}"
 - content_for :title, title
 = render 'clients/anomalies/breadcrumbs'
 %h1= title
@@ -46,7 +46,7 @@
         %th Result
         %th HUD Decision Logic
     %tbody
-      - @chronic_at_entry_matrix.each do |number, title, result, value, descriptions|
+      - @chronic_at_entry_matrix.each do |number, title, value, result, descriptions|
         %tr
           %td= number
           %td{style: 'max-width: 300px;'}= title

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -1,0 +1,23 @@
+- title = "Enrollment #{@client.name} at X"
+- content_for :title, title
+%h4= title
+.mb-1
+  %em.text-muted
+    Client ID:
+    %strong= @client.id
+.mb-1
+  %em.text-muted
+    Enrollment ID:
+    %strong= @enrollment.id
+.mb-1
+  prior living situation:
+  = @enrollment.LivingSituation
+.mb-1
+  entry date:
+  = @service_history_enrollment.first_date_in_program
+  = @service_history_enrollment.last_date_in_program
+  = @service_history_enrollment.move_in_date
+.mb-1
+  chronic at entry:
+  = @enrollment.chronically_homeless_at_start
+  = @enrollment.chronically_homeless_at_start?

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -1,6 +1,6 @@
 - title = "Enrollment #{@client.name} at X"
 - content_for :title, title
-%h4= title
+%h1= title
 .mb-1
   %em.text-muted
     Client ID:
@@ -21,3 +21,28 @@
   chronic at entry:
   = @enrollment.chronically_homeless_at_start
   = @enrollment.chronically_homeless_at_start?
+
+- @chronic_at_entry_matrix
+.table-responsive
+  %table.table.table-striped
+    %thead
+      %tr
+        %th Line
+        %th Field
+        %th Value
+        %th Result
+        %th HUD Decision Logic
+    %tbody
+      - @chronic_at_entry_matrix.each do |number, title, result, value, descriptions|
+        %tr
+          %td= number
+          %td= title
+          %td= value
+          %td
+            - if result
+              %strong= result
+            - else
+              %em.text-muted continue
+          %td
+            - descriptions.each do |s|
+              .mb-1= s

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -1,34 +1,47 @@
-- title = "Enrollment #{@client.name} at X"
+- title = "Enrollment for #{@client.name} at #{@enrollment.project&.name(current_user)}"
 - content_for :title, title
+= render 'clients/anomalies/breadcrumbs'
 %h1= title
-.mb-1
-  %em.text-muted
-    Client ID:
-    %strong= @client.id
 .mb-1
   %em.text-muted
     Enrollment ID:
     %strong= @enrollment.id
-.mb-1
-  prior living situation:
-  = @enrollment.LivingSituation
-.mb-1
-  entry date:
-  = @service_history_enrollment.first_date_in_program
-  = @service_history_enrollment.last_date_in_program
-  = @service_history_enrollment.move_in_date
-.mb-1
-  chronic at entry:
-  = @enrollment.chronically_homeless_at_start
-  = @enrollment.chronically_homeless_at_start?
 
-- @chronic_at_entry_matrix
+.row.mb-6.mt-4
+  .col-6
+    .table-responsive
+      %table.table.table-striped.table-sm
+        %tbody
+          %tr
+            %td Project Type
+            %td= ::HUD.project_type_brief(@service_history_enrollment.computed_project_type)
+          %tr
+            %td Entry Date
+            %td= @enrollment.EntryDate || '-'
+          %tr
+            %td Chronic at Entry
+            %td= yes_no(@enrollment.chronically_homeless_at_start?)
+          %tr
+            %td Prior Living Situation
+            %td= ::HUD.living_situation(@enrollment.LivingSituation) || '-'
+          %tr
+            %td Exit Date
+            %td= @service_history_enrollment.last_date_in_program || '-'
+          - if @service_history_enrollment.move_in_date.present? || @service_history_enrollment.computed_project_type.in?(GrdaWarehouse::Hud::Project::WITH_MOVE_IN_DATES)
+            - move_in_date_inherited = @enrollment.MoveInDate.blank? && @service_history_enrollment.move_in_date.present?
+            %tr
+              %td Move-in Date
+              %td= "#{@service_history_enrollment.move_in_date || '-'} #{move_in_date_inherited ? '(inherited from HoH)' : ''}"
+
+%h2 Chronic at Entry
+.mb-4
+  Calculation used to determine whether the client was chronic at entry.
 .table-responsive
   %table.table.table-striped
     %thead
       %tr
         %th Line
-        %th Field
+        %th Field / Condition
         %th Value
         %th Result
         %th HUD Decision Logic
@@ -36,13 +49,15 @@
       - @chronic_at_entry_matrix.each do |number, title, result, value, descriptions|
         %tr
           %td= number
-          %td= title
-          %td= value
+          %td{style: 'max-width: 300px;'}= title
+          %td{style: 'max-width: 300px;'}= value
           %td
-            - if result
-              %strong= result
-            - else
+            - if result.in? [true, false]
+              %em.text-muted= result ? 'continue' : 'skip'
+            - elsif result.nil?
               %em.text-muted continue
+            - else
+              %strong= result.upcase
           %td
             - descriptions.each do |s|
               .mb-1= s

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -524,6 +524,7 @@ Rails.application.routes.draw do
     resources :notes, only: [:index, :destroy, :create], controller: 'clients/notes' do
       get :alerts, on: :collection
     end
+    resources :enrollments, only: [:show], controller: 'clients/enrollments'
     resource :eto_api, only: [:show, :update], controller: 'clients/eto_api'
     resources :users, only: [:index, :create, :update, :destroy], controller: 'clients/users'
     resources :anomalies, except: [:show], controller: 'clients/anomalies'

--- a/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
@@ -161,7 +161,7 @@ module ClientAccessControl::GrdaWarehouse::Hud
               confidential_project: project.confidential,
               entry_date: entry.first_date_in_program,
               living_situation: entry.enrollment.LivingSituation,
-              chronically_homeless_at_start: entry.enrollment.ch_enrollment&.chronically_homeless_at_entry,
+              chronically_homeless_at_start: entry.enrollment.chronically_homeless_at_start?,
               exit_date: entry.last_date_in_program,
               destination: entry.destination,
               move_in_date_inherited: entry.enrollment.MoveInDate.blank? && entry.move_in_date.present?,


### PR DESCRIPTION
- [x] Link to new enrollment page from entry date on client dashboard
- [x] Render table showing each evaluated step of CH-at-entry calculation and it's result
- [x] Update the chronic-at-entry icon to show _chronic at entry_ not the most recent ChEnrollment value (which is a _chronic-at-point-in-time_)
- [x] All tests pass
- [x] Ensure correct permissions required for the enrollment page! <--