### PR TITLE
Include buttons for other questions when viewing HUD report results

### DIFF
--- a/app/views/hud_reports/_inline_parameters.haml
+++ b/app/views/hud_reports/_inline_parameters.haml
@@ -1,7 +1,18 @@
-.mb-2.reports.warehouse-reports__completed.d-flex
-  - # NOTE: this is not ideal, we need to figure out which filter type we're actually using
-  - # but for displaying the items chosen, it's probably fine
-  - filter = Filters::FilterBase.new(user_id: report.user_id).update(report.options.with_indifferent_access)
-  = filter.describe_filter_as_html(@generator.allowed_options)
-.d-flex
-  .ml-auto= link_to 'View universe details', filter_path(filter: filter.to_h, selected_keys: @generator.allowed_options), data: { loads_in_ajax_modal: true }
+.row
+  .col-sm-8
+    %h3 Universe
+    .mb-2.reports.warehouse-reports__completed
+      - # NOTE: this is not ideal, we need to figure out which filter type we're actually using
+      - # but for displaying the items chosen, it's probably fine
+      - filter = Filters::FilterBase.new(user_id: report.user_id).update(report.options.with_indifferent_access)
+      = filter.describe_filter_as_html(@generator.allowed_options)
+    .d-flex
+      .ml-auto= link_to 'View universe details', filter_path(filter: filter.to_h, selected_keys: @generator.allowed_options), data: { loads_in_ajax_modal: true }
+
+  .col-sm-4.border-left
+    - if @report&.completed_questions && @report.completed_questions.count > 1
+      %h3 Jump to
+      - @generator.questions.keys.each do |item|
+        - if item != @question && @report&.completed_questions.include?(item)
+          = link_to path_for_question_result(item, report: @report), class: 'btn btn-sm btn-secondary mb-2 ml-2' do
+            = item


### PR DESCRIPTION
This adds buttons to the HUD report drill-downs so you can jump directly from Question 5 to Question 26, etc.

<img width="1314" alt="Screen Shot 2022-09-19 at 8 51 21 AM" src="https://user-images.githubusercontent.com/1346876/191021391-22982bbb-75e3-4eef-9420-9f410a94980c.png">

