### PR TITLE
Set @pdf to true so templates work correctly

### DIFF
--- a/app/controllers/concerns/health_careplan.rb
+++ b/app/controllers/concerns/health_careplan.rb
@@ -134,6 +134,7 @@ module HealthCareplan
 
     # The logic for creating the CarePlan PDF is fairly complicated and needs to be used in both the careplan controllers and the signable document controllers
     def careplan_combine_pdf_object
+      @pdf = true
       @goal = Health::Goal::Base.new
       @readonly = false
       # If we already have a document with a signature, use that to try and avoid massive duplication


### PR DESCRIPTION
I introduced a bug where an error is thrown when PDFs are generated using `careplan_combine_pdf_object` if it is being called from a controllers where `@pdf` was not set, because the templates now rely on it. It caused an error when trying to do the "have patient sign using this device" ,  "send signature request" , and anywhere else that we call careplan_combine_pdf_object.