### PR TITLE
[PVT-183478468] more stuff

### DIFF
--- a/app/jobs/check_job_queue.rb
+++ b/app/jobs/check_job_queue.rb
@@ -13,11 +13,10 @@ class CheckJobQueue
   end
 
   def notify_of_hung_jobs
-    return unless File.exist?('config/exception_notifier.yml')
-
-    setup_notifier('DelayedJobQueue')
-    msg = 'One or more jobs have been queued for more than 24 hours'
-    @notifier.ping(msg) if @send_notifications
+    Rails.logger.tagged('DelayedJobQueue') do
+      Rails.logger.info('One or more jobs have been queued for more than 24 hours')
+    end
+    # TODO: Prometheus metric
   end
 
   def hung_job

--- a/app/jobs/reporting_setup_job.rb
+++ b/app/jobs/reporting_setup_job.rb
@@ -8,16 +8,14 @@ class ReportingSetupJob < BaseJob
   include ActionView::Helpers::DateHelper
   queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
 
+  def start_message; 'Reporting database updating' end
+
+  def done_message(t); "Reporting database updated in #{t}" end
+
   def perform
-    setup_notifier('ReportingSetupJob')
-    started_at = Time.current
-    @notifier.ping('Reporting database updating') if @send_notifications
     Reporting::Housed.new.populate!
-    elapsed = distance_of_time_in_words(started_at, Time.current)
-    @notifier.ping("Reporting database Housed completed in #{elapsed}, starting Return") if @send_notifications
+    log_progress('Housed done, starting Return')
     Reporting::Return.new.populate!
-    elapsed = distance_of_time_in_words(started_at, Time.current)
-    @notifier.ping("Reporting database updated in #{elapsed}") if @send_notifications
   end
 
   def max_attempts

--- a/app/jobs/sync_synthetic_data_job.rb
+++ b/app/jobs/sync_synthetic_data_job.rb
@@ -17,14 +17,10 @@ class SyncSyntheticDataJob < BaseJob
   def perform
     return unless CasBase.db_exists?
 
-    @notifier.ping('Processing synthetic data') if @send_notifications
-
     # Find CAS Non HMIS clients that should be connected to warehouse clients
     Cas::NonHmisClient.find_exact_matches
     GrdaWarehouse::Synthetic::Assessment.hud_sync
     GrdaWarehouse::Synthetic::Event.hud_sync
     GrdaWarehouse::Synthetic::YouthEducationStatus.hud_sync
-
-    @notifier.ping('Updated synthetic data') if @send_notifications
   end
 end

--- a/app/jobs/system_cohorts_job.rb
+++ b/app/jobs/system_cohorts_job.rb
@@ -17,10 +17,6 @@ class SystemCohortsJob < BaseJob
   def perform
     return unless GrdaWarehouse::Config.get(:enable_system_cohorts)
 
-    @notifier.ping('Processing system cohorts') if @send_notifications
-
     GrdaWarehouse::SystemCohorts::Base.update_all_system_cohorts
-
-    @notifier.ping('Processed system cohorts') if @send_notifications
   end
 end

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -10,7 +10,7 @@ class TestJob < BaseJob
   def perform(length_in_seconds: 10, memory_bloat_per_second: 10_000_000)
     a = Time.now
 
-    log_progress("Testing!")
+    log_progress('Testing!')
 
     bloater = {}
 

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -8,9 +8,9 @@ class TestJob < BaseJob
   SLEEP_TIME = 5
 
   def perform(length_in_seconds: 10, memory_bloat_per_second: 10_000_000)
-    setup_notifier('TestJob')
-    @notifier.ping('Testing!') if @send_notifications
     a = Time.now
+
+    log_progress("Testing!")
 
     bloater = {}
 

--- a/app/jobs/youth_follow_ups_job.rb
+++ b/app/jobs/youth_follow_ups_job.rb
@@ -14,11 +14,7 @@ class YouthFollowUpsJob < BaseJob
   end
 
   def perform
-    @notifier.ping('Processing youth follow ups') if @send_notifications
-
     # Process all clients with a youth intake to update their follow up history for the last 90 days
     GrdaWarehouse::Youth::YouthFollowUp.recreate_follow_ups
-
-    @notifier.ping('Updated youth follow ups') if @send_notifications
   end
 end

--- a/app/models/grda_warehouse/hud/enrollment.rb
+++ b/app/models/grda_warehouse/hud/enrollment.rb
@@ -298,9 +298,12 @@ module GrdaWarehouse::Hud
         return { address: address, lat: result.lat, lon: result.lon, boundingbox: result.boundingbox } if result.present?
       rescue NominatimApiPaused
         # Ignore errors if we are paused
-      rescue StandardError
-        setup_notifier('NominatimWarning')
-        @notifier.ping("Error contacting the OSM Nominatim API. Looking address for enrollment id: #{id}") if @send_notifications
+      rescue StandardError => e
+        Sentry.with_scope do |scope|
+          scope.set_context('extra', { enrollment_id: id })
+          Sentry.capture_exception(e)
+          Sentry.capture_message("Error contacting the OSM Nominatim API. Looking address for enrollment id: #{id}")
+        end
       end
       return nil
     end

--- a/app/models/weather/noaa_service.rb
+++ b/app/models/weather/noaa_service.rb
@@ -72,11 +72,9 @@ class Weather::NoaaService
     url = "#{@endpoint}#{path}?#{query_args.to_param}"
     begin
       JSON.parse(RestClient.get(url, token: @token).body)
-    rescue StandardError => e
-      Sentry.with_scope do |scope|
-        scope.set_context('extra', { url: url })
-        Sentry.capture_exception(e)
-        Sentry.capture_message("Error contacting the weather API at #{url}")
+    rescue StandardError
+      Rails.logger.tagged('WeatherWarning') do
+        Rails.logger.info("Error contacting the weather API at #{url}")
       end
     end
   end


### PR DESCRIPTION
This is a bit of a mishmosh but I needed a place to try out code and document some questions we'll need to answer around the monitoring initiative as we move forward.

**Capture Message vs Capture Exception**

`Sentry.capture_exception` is what we want for capturing actual Exceptions, but it doesn't allow easy inclusion of a custom message -- that is, the title of the "issue" in Sentry will be the Exception type/class, rather than the custom message you get with `Sentry.capture_message`. So for example, if we have something like:

```
rescue StandardError => e
  msg = "Some specific thing with id #{id} has failed to do something"`
```

We can handle this two ways:
- Use `Sentry.capture_message(msg)` to basically replicate the Slack notification
  - Will not have direct info on the Exception object, and I don't see an easy way to attach it
- Use `Sentry.capture_error(e)` to get us more in-depth error info. We can also add extra info with `set_context`:
  - ```
      Sentry.with_scope do |scope|
      scope.set_context('extra', {
        id_of_the_thing: id,
      })
      Sentry.capture_exception
    end
    ```
  - But, this will show up as StandardError in the list of issues in the Sentry console, and it won't necessarily be obvious where that error is coming from until you dig in

**What sort of tagging do we want on logs?**

Todd implemented tagging for our structured logs. What standards do we have/want around Slack notifications that we're converting to logs? For example, in the code pushed here, you can see that I tagged Job status logs with `job={myActiveJob}` and `job_status={starting|in_progress|done}` and `elapsed_time={elapsed_time}` -- do we want to keep these, add more, change them, etc. And of course the same question applies to other non-exception notifications.