### PR TITLE
[PVT-183478468] Sentry fix login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,10 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   protect_from_forgery with: :exception
 
-  before_action :authenticate_user!, :set_sentry_user
+  before_action :authenticate_user!
   auto_session_timeout User.timeout_in
+
+  before_action :set_sentry_user
 
   before_action :set_paper_trail_whodunnit
   before_action :set_notification
@@ -285,6 +287,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_sentry_user
-    Sentry.configure_scope { |scope| scope.set_user(id: current_user.id, email: current_user.email) } if ENV['WAREHOUSE_SENTRY_DSN'].present? && defined?(current_user) && current_user.present?
+    Sentry.configure_scope { |scope| scope.set_user(id: current_user.id, email: current_user.email) } if Sentry.initialized? && defined?(current_user) && current_user.is_a?(User)
   end
 end


### PR DESCRIPTION
@eanders reported that logins with the new Sentry code were not working, and that `before_action :set_sentry_user` was the source of the issue.

After some digging, I determined that moving `:set_sentry_user` below `auto_session_timeout User.timeout_in` instead of directly after `:authenticate_user!` resolved the issue.