### PR TITLE
Get Prior Living Situation logic correct; Add support for initial values

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -728,29 +728,46 @@ enum EnableBehavior {
 }
 
 enum EnableOperator {
+  """
+  Use with answerBoolean to specify is the item should be enabled or not.
+  """
+  ENABLED
   EQUAL
+
+  """
+  Use with answerBoolean to specify if an answer should exist or not.
+  """
   EXISTS
   GREATER_THAN
   GREATER_THAN_EQUAL
+
+  """
+  Whether the value is in the answerCodes array.
+  """
+  IN
   LESS_THAN
   LESS_THAN_EQUAL
   NOT_EQUAL
-  NOT_EXISTS
 }
 
 type EnableWhen {
   """
-  If question is BOOLEAN type, value for comparison
+  If question is boolean type, value for comparison
   """
   answerBoolean: Boolean
 
   """
-  If question is CHOICE type, value for comparison
+  If question is choice type, value for comparison
   """
   answerCode: String
 
   """
-  If question is CHOICE type and has grouped options, value for comparison
+  If question is choice type, and operator is IN, values for comparison
+  """
+  answerCodes: [String!]
+
+  """
+  If question is choice type and has grouped options, value for comparison
   """
   answerGroupCode: String
 
@@ -1024,6 +1041,11 @@ type FormItem {
   Whether the item should always be hidden
   """
   hidden: Boolean
+
+  """
+  Initial value(s) when item is first rendered
+  """
+  initial: [InitialValue!]
 
   """
   Nested items
@@ -1535,6 +1557,26 @@ scalar ISO8601Date
 An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
+
+"""
+Initial value when item is first rendered
+"""
+type InitialValue {
+  """
+  If question is boolean type, initial value
+  """
+  valueBoolean: Boolean
+
+  """
+  If question is choice type, initial value
+  """
+  valueCode: String
+
+  """
+  If question is numeric, initial value
+  """
+  valueNumber: Int
+}
 
 type InventoriesPaginated {
   hasMoreAfter: Boolean!

--- a/drivers/hmis/app/graphql/types/forms/enable_when.rb
+++ b/drivers/hmis/app/graphql/types/forms/enable_when.rb
@@ -10,9 +10,10 @@ module Types
   class Forms::EnableWhen < Types::BaseObject
     field :question, String, 'The linkId of question that determines whether item is enabled/disabled', null: false
     field :operator, Forms::Enums::EnableOperator, 'How to evaluate the question\'s answer', null: false
-    field :answer_code, String, 'If question is CHOICE type, value for comparison', null: true
-    field :answer_group_code, String, 'If question is CHOICE type and has grouped options, value for comparison', null: true
+    field :answer_code, String, 'If question is choice type, value for comparison', null: true
+    field :answer_codes, [String], 'If question is choice type, and operator is IN, values for comparison', null: true
+    field :answer_group_code, String, 'If question is choice type and has grouped options, value for comparison', null: true
     field :answer_number, Integer, 'If question is numeric, value for comparison', null: true
-    field :answer_boolean, Boolean, 'If question is BOOLEAN type, value for comparison', null: true
+    field :answer_boolean, Boolean, 'If question is boolean type, value for comparison', null: true
   end
 end

--- a/drivers/hmis/app/graphql/types/forms/enums/enable_operator.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/enable_operator.rb
@@ -10,8 +10,9 @@ module Types
   class Forms::Enums::EnableOperator < Types::BaseEnum
     graphql_name 'EnableOperator'
 
-    value 'EXISTS'
-    value 'NOT_EXISTS'
+    value 'ENABLED', 'Use with answerBoolean to specify is the item should be enabled or not.'
+    value 'EXISTS', 'Use with answerBoolean to specify if an answer should exist or not.'
+    value 'IN', 'Whether the value is in the answerCodes array.'
     value 'EQUAL'
     value 'NOT_EQUAL'
     value 'GREATER_THAN'

--- a/drivers/hmis/app/graphql/types/forms/form_item.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_item.rb
@@ -27,6 +27,7 @@ module Types
     field :pick_list_options, [Forms::PickListOption], 'Permitted answers, for choice items', null: true
     field :enable_behavior, Forms::Enums::EnableBehavior, null: true
     field :enable_when, [Forms::EnableWhen], null: true
+    field :initial, [Forms::InitialValue], 'Initial value(s) when item is first rendered', null: true
     field :item, ['Types::Forms::FormItem'], 'Nested items', null: true
     field :query_field, String, 'Name of the query input field that corresponds to this item. Only used for record creation/update forms, not for assessments.', null: true
   end

--- a/drivers/hmis/app/graphql/types/forms/initial_value.rb
+++ b/drivers/hmis/app/graphql/types/forms/initial_value.rb
@@ -1,0 +1,19 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class Forms::InitialValue < Types::BaseObject
+    description 'Initial value when item is first rendered'
+
+    field :value_code, String, 'If question is choice type, initial value', null: true
+    field :value_number, Integer, 'If question is numeric, initial value', null: true
+    field :value_boolean, Boolean, 'If question is boolean type, initial value', null: true
+
+    # Add date, datetime, etc as needed
+  end
+end

--- a/drivers/hmis/lib/form_data/assessments/dummy_intake_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/dummy_intake_assessment.json
@@ -107,6 +107,41 @@
           ]
         },
         {
+          "type": "DISPLAY",
+          "link_id": "3.917.C.message",
+          "text": "Stopping data collection for 3.917 Prior Living Situation.",
+          "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
+          "_comment": "FIXME: If 2.917 B or C were enabled, we shouldnt show this unless B/C have been answered?",
+          "enable_behavior": "ALL",
+          "enable_when": [
+            {
+              "question": "3.917.C",
+              "operator": "EQUAL",
+              "answer_boolean": false
+            },
+            {
+              "question": "3.917.1",
+              "operator": "EXISTS",
+              "answer_boolean": true
+            },
+            {
+              "question": "3.917.2",
+              "operator": "EXISTS",
+              "answer_boolean": true
+            },
+            {
+              "question": "3.917.A",
+              "operator": "ENABLED",
+              "answer_boolean": false
+            },
+            {
+              "question": "3.917.B",
+              "operator": "ENABLED",
+              "answer_boolean": false
+            }
+          ]
+        },
+        {
           "type": "DATE",
           "link_id": "3.917.3",
           "text": "Date homelessness started",
@@ -119,6 +154,11 @@
             },
             {
               "question": "3.917.B",
+              "operator": "ENABLED",
+              "answer_boolean": false
+            },
+            {
+              "question": "3.917.C.message",
               "operator": "ENABLED",
               "answer_boolean": false
             }
@@ -140,6 +180,11 @@
               "question": "3.917.B",
               "operator": "ENABLED",
               "answer_boolean": false
+            },
+            {
+              "question": "3.917.C.message",
+              "operator": "ENABLED",
+              "answer_boolean": false
             }
           ]
         },
@@ -157,6 +202,11 @@
             },
             {
               "question": "3.917.B",
+              "operator": "ENABLED",
+              "answer_boolean": false
+            },
+            {
+              "question": "3.917.C.message",
               "operator": "ENABLED",
               "answer_boolean": false
             }

--- a/drivers/hmis/lib/form_data/assessments/dummy_intake_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/dummy_intake_assessment.json
@@ -41,55 +41,68 @@
           "pick_list_reference": "LengthOfStay"
         },
         {
-          "type": "GROUP",
-          "link_id": "pls-conditionals",
-          "item": [
+          "type": "DISPLAY",
+          "link_id": "3.917.A",
+          "read_only": true,
+          "text": "Client stayed 90+ days in an institutional setting. This is considered a \"break\" according to the HUD definition of chronic homelessness. Stopping data collection for 3.917 Prior Living Situation.",
+          "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
+          "enable_behavior": "ALL",
+          "enable_when": [
             {
-              "type": "BOOLEAN",
-              "link_id": "3.917.A",
-              "text": "Did the client stay less than 90 days?",
-              "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
-              "enable_behavior": "ALL",
-              "enable_when": [
-                {
-                  "question": "3.917.1",
-                  "operator": "EQUAL",
-                  "answer_group_code": "INSTITUTIONAL"
-                }
-              ]
+              "question": "3.917.1",
+              "operator": "EQUAL",
+              "answer_group_code": "INSTITUTIONAL"
             },
             {
-              "type": "BOOLEAN",
-              "link_id": "3.917.B",
-              "text": "Did the client stay less than 7 nights?",
-              "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
-              "enable_behavior": "ALL",
-              "enable_when": [
-                {
-                  "question": "3.917.1",
-                  "operator": "EQUAL",
-                  "answer_group_code": "TEMPORARY_PERMANENT_OTHER"
-                }
+              "question": "3.917.2",
+              "operator": "IN",
+              "answer_codes": [
+                "LOS_90_DAYS_OR_MORE_BUT_LESS_THAN_ONE_YEAR",
+                "LOS_ONE_YEAR_OR_LONGER"
               ]
+            }
+          ]
+        },
+        {
+          "type": "DISPLAY",
+          "link_id": "3.917.B",
+          "text": "Client stayed 7+ days in a transitional or permanent housing situation. This is considered a \"break\" according to the HUD definition of chronic homelessness. Stopping data collection for 3.917 Prior Living Situation.",
+          "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
+          "enable_behavior": "ALL",
+          "enable_when": [
+            {
+              "question": "3.917.1",
+              "operator": "EQUAL",
+              "answer_group_code": "TEMPORARY_PERMANENT_OTHER"
             },
             {
-              "type": "BOOLEAN",
-              "link_id": "3.917.C",
-              "text": "On the night before, did the client stay on the streets, ES or SH?",
-              "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
-              "enable_behavior": "ANY",
-              "enable_when": [
-                {
-                  "question": "3.917.A",
-                  "operator": "EQUAL",
-                  "answer_boolean": true
-                },
-                {
-                  "question": "3.917.B",
-                  "operator": "EQUAL",
-                  "answer_boolean": true
-                }
+              "question": "3.917.2",
+              "operator": "IN",
+              "answer_codes": [
+                "LOS_ONE_WEEK_OR_MORE_BUT_LESS_THAN_ONE_MONTH",
+                "LOS_ONE_MONTH_OR_MORE_BUT_LESS_THAN_90_DAYS",
+                "LOS_90_DAYS_OR_MORE_BUT_LESS_THAN_ONE_YEAR",
+                "LOS_ONE_YEAR_OR_LONGER"
               ]
+            }
+          ]
+        },
+        {
+          "type": "BOOLEAN",
+          "link_id": "3.917.C",
+          "text": "On the night before, did the client stay on the streets, ES or SH?",
+          "project_types_excluded": ["ES", "SERVICES_ONLY", "SH"],
+          "enable_behavior": "ALL",
+          "enable_when": [
+            {
+              "question": "3.917.A",
+              "operator": "ENABLED",
+              "answer_boolean": false
+            },
+            {
+              "question": "3.917.B",
+              "operator": "ENABLED",
+              "answer_boolean": false
             }
           ]
         },
@@ -101,21 +114,13 @@
           "enable_when": [
             {
               "question": "3.917.A",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             },
             {
               "question": "3.917.B",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
-            },
-            {
-              "question": "3.917.C",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             }
           ]
         },
@@ -128,21 +133,13 @@
           "enable_when": [
             {
               "question": "3.917.A",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             },
             {
               "question": "3.917.B",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
-            },
-            {
-              "question": "3.917.C",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             }
           ]
         },
@@ -155,21 +152,13 @@
           "enable_when": [
             {
               "question": "3.917.A",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             },
             {
               "question": "3.917.B",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
-            },
-            {
-              "question": "3.917.C",
-              "operator": "NOT_EQUAL",
-              "answer_boolean": false,
-              "_comment": "Stop data collection if false"
+              "operator": "ENABLED",
+              "answer_boolean": false
             }
           ]
         }
@@ -325,7 +314,8 @@
             },
             {
               "question": "4.04.2",
-              "operator": "NOT_EXISTS"
+              "operator": "EXISTS",
+              "answer_boolean": false
             }
           ],
           "item": [


### PR DESCRIPTION
* Remove `NOT_EXISTS` operator in favor of `EXISTS` with `answerBoolean` value (like FHIR)
* Add `IN` operator and `answerCodes` value. This lets us do something like `the answer to question A is in list [A,B,C], AND some other thing is true` which previously wouldn't be possible within the `ANY`/`ALL` enable-behavior framework.
* Add `ENABLED` operator. **EXISTS** means that the item should have a non-null _answer_, **ENABLED** just means that the item should be enabled. This is slightly more work at eval time, because we are evaluating the same enableWhen repeatedly, but we can optimize that later. I think this pattern will make it easier to write these definitions. One bad thing is that it could cause and infinite loop at eval time if there is a dependency cycle, but we could add a check for that when validating the definition.
* Add `initial` type (matching FHIR again here). Not used yet.
* Corresponding PR https://github.com/greenriver/hmis-frontend/pull/65 has evaluation tests!