### PR TITLE
Support filtering CoC list by project

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2366,7 +2366,7 @@ type Query {
   """
   Get list of options for pick list
   """
-  pickList(pickListType: PickListType!): [PickListOption!]!
+  pickList(pickListType: PickListType!, projectId: ID): [PickListOption!]!
 
   """
   Project lookup

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -124,9 +124,10 @@ module Types
 
     field :pick_list, [Types::Forms::PickListOption], 'Get list of options for pick list', null: false do
       argument :pick_list_type, Types::Forms::Enums::PickListType, required: true
+      argument :project_id, ID, required: false
     end
-    def pick_list(pick_list_type:)
-      Types::Forms::PickListOption.options_for_type(pick_list_type, user: current_user)
+    def pick_list(pick_list_type:, project_id: nil)
+      Types::Forms::PickListOption.options_for_type(pick_list_type, user: current_user, project_id: project_id)
     end
   end
 end


### PR DESCRIPTION
We'll need this in at least two places:
1) CoC picker on the Inventory Create/Edit page should only allow CoCs that the project operates in
2) CoC picker for 3.16 Client Location should only allow CoCs that the project operates in