### PR TITLE
Include yarn lockfile in images

### DIFF
--- a/.github/workflows/asset_compilation.yml
+++ b/.github/workflows/asset_compilation.yml
@@ -94,7 +94,7 @@ jobs:
         echo "postgres:5432:*:postgres:postgres" > ~/.pgpass
         chmod 600 ~/.pgpass
 
-        yarn install
+        yarn install --frozen-lockfile
         gem install bundler --version=2.3.8
 
     # According to https://www.jessesquires.com/blog/2021/08/23/caching-bundler-on-github-actions/

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -116,7 +116,7 @@ jobs:
           echo "postgres:5432:*:postgres:postgres" > ~/.pgpass
           chmod 600 ~/.pgpass
 
-          yarn install
+          yarn install --frozen-lockfile
           gem install bundler --version=2.3.8
 
       - name: Install gems

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,7 @@ Dir.chdir APP_ROOT do
   system 'bundle check || bundle install --without seven_zip'
 
   puts '== Installing NPM dependencies =='
-  system 'yarn install'
+  system 'yarn install --frozen-lockfile'
 
   ymls = [
     'secrets.yml',

--- a/bin/update
+++ b/bin/update
@@ -22,7 +22,7 @@ chdir APP_ROOT do
   system! 'bundle exec rake db:migrate'
 
   puts "\n== Updating NPM dependencies =="
-  system! 'yarn install'
+  system! 'yarn install --frozen-lockfile'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bundle exec rake log:clear tmp:clear'

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
@@ -68,7 +68,7 @@ RUN chmod +x /usr/bin/entrypoint.sh \
   && rm -rf tmp/* \
   && rm .env \
   && mkdir tmp/pids \
-  && yarn
+  && yarn install --frozen-lockfile
 
 RUN touch /etc/timezone
 RUN ln -sf /app/etc-localtime /etc/localtime

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.base
@@ -11,7 +11,7 @@ RUN mkdir -p /app /app/shape_files/CoC /etc/ssl/certs \
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock Rakefile config.ru package.json ./
+COPY Gemfile Gemfile.lock Rakefile config.ru package.json yarn.lock ./
 COPY bin ./bin
 COPY public ./public
 COPY config/deploy/docker/lib ./bin

--- a/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
+++ b/config/deploy/docker/assets/Dockerfile.open-path-warehouse.pre-cache
@@ -26,7 +26,7 @@ RUN mkdir -p /app \
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock Rakefile config.ru package.json ./
+COPY Gemfile Gemfile.lock Rakefile config.ru package.json yarn.lock ./
 COPY bin ./bin
 COPY public ./public
 COPY lib ./lib

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,7 @@ rm -f /app/tmp/pids/server.pid
 cd /app
 bundle config --global set build.sassc --disable-march-tune-native
 bundle install --quiet
-yarn install --silent
+yarn install --silent --frozen-lockfile
 
 if [ ! -e /bundle/ruby/2.7.0/gems/seven_zip_ruby-1.3.0/lib/seven_zip_ruby/7z.so ]
 then


### PR DESCRIPTION
It defeats the purpose of having a yarn lock file if we don't use it!
Add [frozen-lockfile](https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile) everywhere to ensure it is present.

I noticed this because I saw `No lockfile found.` being logged in git runs.