### PR TITLE
Close related records when closing project; Confirmation warnings pattern

### DIFF
--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -52,10 +52,12 @@ module Mutations
     end
 
     # Default CRUD Update functionality
-    def default_update_record(record:, field_name:, input:, confirmed:)
+    def default_update_record(record:, field_name:, input:, confirmed: nil)
       return { field_name => nil, errors: [InputValidationError.new("#{field_name.to_s.humanize} record not found", attribute: 'id')] } unless record.present?
 
+      # If confirm is not specified, treat as confirmed (aka ignore warnings)
       confirmed = true if confirmed.nil?
+
       errors = []
       # Add custom warnings to error list
       errors += create_warnings(record, input) unless confirmed

--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -19,6 +19,20 @@ module Mutations
     end
   end
 
+  class InputConfirmationWarning
+    def initialize(message, attribute: nil, **kwargs)
+      {
+        message: message,
+        attribute: attribute,
+        full_message: message,
+        type: :confirm_warning,
+        **kwargs,
+      }.each do |key, value|
+        define_singleton_method(key) { value }
+      end
+    end
+  end
+
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
     argument_class Types::BaseArgument
     field_class Types::BaseField
@@ -38,23 +52,34 @@ module Mutations
     end
 
     # Default CRUD Update functionality
-    def default_update_record(record:, field_name:, input:)
-      errors = []
-      if record.present?
-        record.update(
-          **input.to_params,
-          user_id: hmis_user.user_id,
-          date_updated: DateTime.current,
-        )
-        errors += record.errors.errors unless record.valid?
-      else
-        errors << InputValidationError.new("#{field_name.to_s.humanize} record not found", attribute: 'id') unless record.present?
-      end
+    def default_update_record(record:, field_name:, input:, confirmed:)
+      return { field_name => nil, errors: [InputValidationError.new("#{field_name.to_s.humanize} record not found", attribute: 'id')] } unless record.present?
 
-      {
-        field_name => record&.valid? ? record : nil,
-        errors: errors,
-      }
+      confirmed = true if confirmed.nil?
+      errors = []
+      # Add custom warnings to error list
+      errors += create_warnings(record, input) unless confirmed
+
+      record.assign_attributes(
+        **input.to_params,
+        user_id: hmis_user.user_id,
+        date_updated: DateTime.current,
+      )
+
+      # Add validation errors to error list
+      errors += record.errors.errors unless record.valid?
+
+      if errors.empty?
+        record.save!
+        { field_name => record, errors: [] }
+      else
+        { field_name => nil, errors: errors }
+      end
+    end
+
+    # Override to create custom warnings
+    def create_warnings(_record, _input)
+      []
     end
 
     # Default CRUD Create functionality

--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -52,11 +52,9 @@ module Mutations
     end
 
     # Default CRUD Update functionality
-    def default_update_record(record:, field_name:, input:, confirmed: nil)
+    # If confirm is not specified, treat as confirmed (aka ignore warnings)
+    def default_update_record(record:, field_name:, input:, confirmed: true)
       return { field_name => nil, errors: [InputValidationError.new("#{field_name.to_s.humanize} record not found", attribute: 'id')] } unless record.present?
-
-      # If confirm is not specified, treat as confirmed (aka ignore warnings)
-      confirmed = true if confirmed.nil?
 
       errors = []
       # Add custom warnings to error list

--- a/drivers/hmis/app/graphql/mutations/update_project.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project.rb
@@ -2,17 +2,39 @@ module Mutations
   class UpdateProject < BaseMutation
     argument :id, ID, required: true
     argument :input, Types::HmisSchema::ProjectInput, required: true
+    argument :confirmed, Boolean, required: true
 
     field :project, Types::HmisSchema::Project, null: true
     field :errors, [Types::HmisSchema::ValidationError], null: false
 
-    def resolve(id:, input:)
+    def resolve(id:, input:, confirmed:)
       record = Hmis::Hud::Project.editable_by(current_user).find_by(id: id)
-      default_update_record(
+      closes_project = record.present? && !record.operating_end_date.present? && input.operating_end_date.present?
+      response = default_update_record(
         record: record,
         field_name: :project,
         input: input,
+        confirmed: confirmed,
       )
+      close_related_records(record) if closes_project && response[:project].present?
+      response
+    end
+
+    def create_warnings(project, input)
+      return [] unless !project.operating_end_date && input.operating_end_date
+
+      funder_count = project.funders.where(end_date: nil).count
+      inventory_count = project.inventories.where(inventory_end_date: nil).count
+      warnings = []
+      # TODO add warning if there are open enrollments in project
+      warnings << InputConfirmationWarning.new("#{funder_count} open funders will be closed.", attribute: 'id') if funder_count.positive?
+      warnings << InputConfirmationWarning.new("#{inventory_count} open inventory records will be closed.", attribute: 'id') if inventory_count.positive?
+      warnings
+    end
+
+    def close_related_records(project)
+      project.funders.where(end_date: nil).update_all(end_date: project.operating_end_date)
+      project.inventories.where(inventory_end_date: nil).update_all(inventory_end_date: project.operating_end_date)
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/update_project.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project.rb
@@ -9,7 +9,7 @@ module Mutations
 
     def resolve(id:, input:, confirmed:)
       record = Hmis::Hud::Project.editable_by(current_user).find_by(id: id)
-      closes_project = record.present? && !record.operating_end_date.present? && input.operating_end_date.present?
+      closes_project = record.present? && record.operating_end_date.blank? && input.operating_end_date.present?
       response = default_update_record(
         record: record,
         field_name: :project,
@@ -21,7 +21,7 @@ module Mutations
     end
 
     def create_warnings(project, input)
-      return [] unless !project.operating_end_date && input.operating_end_date
+      return [] unless project.operating_end_date.blank? && input.operating_end_date.present?
 
       funder_count = project.funders.where(end_date: nil).count
       inventory_count = project.inventories.where(inventory_end_date: nil).count

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4322,6 +4322,7 @@ input UpdateProjectInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  confirmed: Boolean!
   id: ID!
   input: ProjectInput!
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -830,8 +830,7 @@ type DisabilityGroup {
   developmentalDisability: NoYesReasonsForMissingData
 
   """
-  Current disabling conditionn on the linked Enrollment. It may not matching up
-  with the disabilities specified in this group.
+  Current disabling conditionn on the linked Enrollment. It may not match up with the disabilities specified in this group.
   """
   disablingCondition: NoYesReasonsForMissingData!
   enrollment: Enrollment!

--- a/drivers/hmis/app/graphql/types/hmis_schema/disability_group.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/disability_group.rb
@@ -16,7 +16,7 @@ module Types
     field :information_date, GraphQL::Types::ISO8601Date, null: false
     field :data_collection_stage, HmisSchema::Enums::Hud::DataCollectionStage, null: false
 
-    field :disabling_condition, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, 'Current disabling conditionn on the linked Enrollment. It may not matching up with the disabilities specified in this group.', null: false
+    field :disabling_condition, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, 'Current disabling conditionn on the linked Enrollment. It may not match up with the disabilities specified in this group.', null: false
 
     # Disability Type 5
     field :physical_disability, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true

--- a/drivers/hmis/spec/requests/hmis/update_project_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_project_spec.rb
@@ -151,8 +151,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq 200
         project = result.dig('data', 'updateProject', 'project')
         errors = result.dig('data', 'updateProject', 'errors')
-        puts project
-        puts errors
         expect(project).to be_nil
         expect(p1.operating_end_date).to be_nil
         expect(errors.length).to eq(2)


### PR DESCRIPTION
Create pattern for backend "confirmation warnings" for mutations:

Instead of calling `updateProject(id: 1, input: {...})` the frontend calls `updateProject(id: 1, input: {...}, confirmed: false)` on initial submission. "Confirmed: false" indicates that the method should return warnings if there are any (and NOT perform the mutation). The frontend displays any errors of type `confirm_warning` in a dialog. If user confirms, frontend makes the request again but with `confirmed: true`, which will bypass the warnings and perform the mutation.

This PR adds warning about funders and inventories being closed when a project is closed. We needed a confirmation dialog pattern anyway, so I implemented it that way for now.

We can use this pattern for:
* Warn if there are open enrollments in a project
* Warn if fields will be filled with DNC
* Warn if name is missing (client form)
* etc.
