### PR TITLE
Update form JSON to pass all income source booleans, update disabling condition fill logic

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1896,8 +1896,10 @@ scalar ISO8601DateTime
 
 type IncomeBenefit {
   adap: NoYesReasonsForMissingData
+  alimony: Boolean
   alimonyAmount: Float
   benefitsFromAnySource: NoYesReasonsForMissingData
+  childSupport: Boolean
   childSupportAmount: Float
   client: Client!
   cobra: Boolean
@@ -1906,9 +1908,11 @@ type IncomeBenefit {
   dateCreated: ISO8601DateTime!
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime!
+  earned: Boolean
   earnedAmount: Float
   employerProvided: Boolean
   enrollment: Enrollment!
+  ga: Boolean
   gaAmount: Float
   hivaidsAssistance: NoYesReasonsForMissingData
   id: ID!
@@ -1933,30 +1937,41 @@ type IncomeBenefit {
   otherBenefitsSource: Boolean
   otherBenefitsSourceIdentify: String
   otherIncomeAmount: Float
+  otherIncomeSource: Boolean
   otherIncomeSourceIdentify: String
   otherInsurance: Boolean
   otherInsuranceIdentify: String
   otherTanf: Boolean
+  pension: Boolean
   pensionAmount: Float
+  privateDisability: Boolean
   privateDisabilityAmount: Float
   privatePay: Boolean
   ryanWhiteMedDent: NoYesReasonsForMissingData
   schip: Boolean
   snap: Boolean
+  socSecRetirement: Boolean
   socSecRetirementAmount: Float
+  ssdi: Boolean
   ssdiAmount: Float
+  ssi: Boolean
   ssiAmount: Float
   stateHealthIns: Boolean
+  tanf: Boolean
   tanfAmount: Float
   tanfChildCare: Boolean
   tanfTransportation: Boolean
   totalMonthlyIncome: String
+  unemployment: Boolean
   unemploymentAmount: Float
   user: User
+  vaDisabilityNonService: Boolean
   vaDisabilityNonServiceAmount: Float
+  vaDisabilityService: Boolean
   vaDisabilityServiceAmount: Float
   vaMedicalServices: Boolean
   wic: Boolean
+  workersComp: Boolean
   workersCompAmount: Float
 }
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/income_benefit.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/income_benefit.rb
@@ -21,36 +21,39 @@ module Types
     # Income
     hud_field :income_from_any_source, HmisSchema::Enums::Hud::NoYesReasonsForMissingData
     hud_field :total_monthly_income
-    # TODO add all these
-    # hud_field :earned
+
+    # Income Booleans
+    yes_no_missing_field :earned
+    yes_no_missing_field :unemployment
+    yes_no_missing_field :ssi
+    yes_no_missing_field :ssdi
+    yes_no_missing_field :va_disability_service
+    yes_no_missing_field :va_disability_non_service
+    yes_no_missing_field :private_disability
+    yes_no_missing_field :workers_comp
+    yes_no_missing_field :tanf
+    yes_no_missing_field :ga
+    yes_no_missing_field :soc_sec_retirement
+    yes_no_missing_field :pension
+    yes_no_missing_field :child_support
+    yes_no_missing_field :alimony
+    yes_no_missing_field :other_income_source
+
+    # Income Amounts
     hud_field :earned_amount
-    # hud_field :unemployment
     hud_field :unemployment_amount
-    # hud_field :ssi
     hud_field :ssi_amount
-    # hud_field :ssdi
     hud_field :ssdi_amount
-    # hud_field :va_disability_service
     hud_field :va_disability_service_amount
-    # hud_field :va_disability_non_service
     hud_field :va_disability_non_service_amount
-    # hud_field :private_disability
     hud_field :private_disability_amount
-    # hud_field :workers_comp
     hud_field :workers_comp_amount
-    # hud_field :tanf
     hud_field :tanf_amount
-    # hud_field :ga
     hud_field :ga_amount
-    # hud_field :soc_sec_retirement
     hud_field :soc_sec_retirement_amount
-    # hud_field :pension
     hud_field :pension_amount
-    # hud_field :child_support
     hud_field :child_support_amount
-    # hud_field :alimony
     hud_field :alimony_amount
-    # hud_field :other_income_source
     hud_field :other_income_amount
     hud_field :other_income_source_identify
 

--- a/drivers/hmis/lib/form_data/assessments/base_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/base_assessment.json
@@ -390,10 +390,48 @@
           ],
           "item": [
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.3",
+              "hidden": true,
+              "field_name": "earned",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.A",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.A",
               "text": "Earned Income (i.e., employment income)",
               "field_name": "earnedAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.4",
+              "hidden": true,
+              "field_name": "unemployment",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.B",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -403,7 +441,7 @@
             },
             {
               "type": "BOOLEAN",
-              "link_id": "mis",
+              "link_id": "4.02.5",
               "hidden": true,
               "field_name": "ssi",
               "autofill_values": [
@@ -427,10 +465,48 @@
               "field_name": "ssiAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.6",
+              "hidden": true,
+              "field_name": "ssdi",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.D",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.D",
               "text": "Social Security Disability Insurance (SSDI)",
               "field_name": "ssdiAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.7",
+              "hidden": true,
+              "field_name": "vaDisabilityService",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.E",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -439,10 +515,48 @@
               "field_name": "vaDisabilityServiceAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.8",
+              "hidden": true,
+              "field_name": "vaDisabilityNonService",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.F",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.F",
               "text": "VA Non-Service-Connected Disability Pension",
               "field_name": "vaDisabilityNonServiceAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.9",
+              "hidden": true,
+              "field_name": "privateDisability",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.G",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -451,10 +565,48 @@
               "field_name": "privateDisabilityAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.10",
+              "hidden": true,
+              "field_name": "workersComp",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.H",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.H",
               "text": "Worker's Compensation",
               "field_name": "workersCompAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.11",
+              "hidden": true,
+              "field_name": "tanf",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.I",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -463,10 +615,48 @@
               "field_name": "tanfAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.12",
+              "hidden": true,
+              "field_name": "ga",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.J",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.J",
               "text": "General Assistance (GA)",
               "field_name": "gaAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.13",
+              "hidden": true,
+              "field_name": "socSecRetirement",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.K",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -475,10 +665,48 @@
               "field_name": "socSecRetirementAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.14",
+              "hidden": true,
+              "field_name": "pension",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.L",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.L",
               "text": "Pension or retirement income from a former job",
               "field_name": "pensionAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.15",
+              "hidden": true,
+              "field_name": "childSupport",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.M",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -487,10 +715,48 @@
               "field_name": "childSupportAmount"
             },
             {
+              "type": "BOOLEAN",
+              "link_id": "4.02.16",
+              "hidden": true,
+              "field_name": "alimony",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.N",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "type": "CURRENCY",
               "link_id": "4.02.N",
               "text": "Alimony and other spousal support",
               "field_name": "alimonyAmount"
+            },
+            {
+              "type": "BOOLEAN",
+              "link_id": "4.02.17",
+              "hidden": true,
+              "field_name": "otherIncomeSource",
+              "autofill_values": [
+                {
+                  "value_boolean": true,
+                  "autofill_behavior": "ALL",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.O",
+                      "operator": "GREATER_THAN",
+                      "answer_number": 0
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "CURRENCY",
@@ -970,11 +1236,6 @@
           "text": "Disabling Condition",
           "field_name": "disablingCondition",
           "pick_list_reference": "NoYesReasonsForMissingData",
-          "initial": [
-            {
-              "value_code": "NO"
-            }
-          ],
           "autofill_values": [
             {
               "value_code": "YES",

--- a/drivers/hmis/lib/form_data/assessments/base_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/base_assessment.json
@@ -405,6 +405,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.A",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.A",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -428,6 +444,22 @@
                       "question": "4.02.B",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.B",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.B",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -455,6 +487,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.C",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.C",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -478,6 +526,22 @@
                       "question": "4.02.D",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.D",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.D",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -505,6 +569,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.E",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.E",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -528,6 +608,22 @@
                       "question": "4.02.F",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.F",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.F",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -555,6 +651,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.G",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.G",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -578,6 +690,22 @@
                       "question": "4.02.H",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.H",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.H",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -605,6 +733,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.I",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.I",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -628,6 +772,22 @@
                       "question": "4.02.J",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.J",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.J",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -655,6 +815,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.K",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.K",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -678,6 +854,22 @@
                       "question": "4.02.L",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.L",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.L",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }
@@ -705,6 +897,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.M",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.M",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -730,6 +938,22 @@
                       "answer_number": 0
                     }
                   ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.N",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.N",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
+                    }
+                  ]
                 }
               ]
             },
@@ -753,6 +977,22 @@
                       "question": "4.02.O",
                       "operator": "GREATER_THAN",
                       "answer_number": 0
+                    }
+                  ]
+                },
+                {
+                  "value_boolean": false,
+                  "autofill_behavior": "ANY",
+                  "autofill_when": [
+                    {
+                      "question": "4.02.O",
+                      "operator": "LESS_THAN_EQUAL",
+                      "answer_number": 0
+                    },
+                    {
+                      "question": "4.02.O",
+                      "operator": "EXISTS",
+                      "answer_boolean": false
                     }
                   ]
                 }

--- a/drivers/hmis/lib/form_data/assessments/base_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/base_assessment.json
@@ -1555,6 +1555,11 @@
               "_comment": "It should autofull when ANY element is interacted with, so add these as dependencies even though they do not determine disabling condition status. This autofill will only occur if none of the above rules matcheed.",
               "autofill_when": [
                 {
+                  "question": "4.05.2",
+                  "operator": "EXISTS",
+                  "answer_boolean": true
+                },
+                {
                   "question": "4.07.2",
                   "operator": "EXISTS",
                   "answer_boolean": true

--- a/drivers/hmis/lib/form_data/assessments/base_assessment.json
+++ b/drivers/hmis/lib/form_data/assessments/base_assessment.json
@@ -1548,6 +1548,28 @@
                   "answer_code": "YES"
                 }
               ]
+            },
+            {
+              "value_code": "NO",
+              "autofill_behavior": "ALL",
+              "_comment": "It should autofull when ANY element is interacted with, so add these as dependencies even though they do not determine disabling condition status. This autofill will only occur if none of the above rules matcheed.",
+              "autofill_when": [
+                {
+                  "question": "4.07.2",
+                  "operator": "EXISTS",
+                  "answer_boolean": true
+                },
+                {
+                  "question": "4.09.2",
+                  "operator": "EXISTS",
+                  "answer_boolean": true
+                },
+                {
+                  "question": "4.10.2",
+                  "operator": "EXISTS",
+                  "answer_boolean": true
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
1) Only fill disabling condition if anything in that group is touched. don't fill initially.
2) Add hidden fields for boolean income sources, so we can send them back as `hudValues`. Example:

<img width="702" alt="Screen Shot 2022-12-08 at 10 59 20 AM" src="https://user-images.githubusercontent.com/5333982/206496925-f45a46d6-9e37-46ed-beb7-d521eb08e5d0.png">
