### PR TITLE
Do inventory date range validation on the backend

### DIFF
--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -56,7 +56,8 @@ module Mutations
     def default_update_record(record:, field_name:, input:, confirmed: true)
       return { field_name => nil, errors: [InputValidationError.new("#{field_name.to_s.humanize} record not found", attribute: 'id')] } unless record.present?
 
-      errors = []
+      errors = create_errors(record, input)
+
       # Add custom warnings to error list
       errors += create_warnings(record, input) unless confirmed
 
@@ -79,6 +80,11 @@ module Mutations
 
     # Override to create custom warnings
     def create_warnings(_record, _input)
+      []
+    end
+
+    # Override to create custom errors
+    def create_errors(_record, _input)
       []
     end
 

--- a/drivers/hmis/app/graphql/mutations/update_inventory.rb
+++ b/drivers/hmis/app/graphql/mutations/update_inventory.rb
@@ -14,5 +14,28 @@ module Mutations
         input: input,
       )
     end
+
+    def create_errors(inventory, input)
+      errors = []
+
+      project_start = inventory.project.operating_start_date
+      project_end = inventory.project.operating_end_date
+
+      # validate start date
+      if project_start && project_end && input.inventory_start_date && !input.inventory_start_date.between?(project_start, project_end)
+        errors << InputValidationError.new("Inventory start date must be within project operating period (#{project_start.strftime('%m/%d/%Y')}-#{project_end.strftime('%m/%d/%Y')})", attribute: 'inventory_start_date')
+      elsif project_start && input.inventory_start_date && input.inventory_start_date.before?(project_start)
+        errors << InputValidationError.new("Inventory start date must be on or after project start date (#{project_start.strftime('%m/%d/%Y')})", attribute: 'inventory_start_date')
+      end
+
+      # validate end date
+      if project_start && project_end && input.inventory_end_date && !input.inventory_end_date.between?(project_start, project_end)
+        errors << InputValidationError.new("Inventory end date must be within project operating period (#{project_start.strftime('%m/%d/%Y')}-#{project_end.strftime('%m/%d/%Y')})", attribute: 'inventory_end_date')
+      elsif project_start && input.inventory_end_date && input.inventory_end_date.before?(project_start)
+        errors << InputValidationError.new("Inventory end date must be after project start date (#{project_start.strftime('%m/%d/%Y')})", attribute: 'inventory_end_date')
+      end
+
+      errors
+    end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
@@ -123,7 +123,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
-    it 'validates start date against project operating period' do
+    it 'validates start date against project operating period (start date too early)' do
+      p1.update(operating_start_date: '2019-01-01')
       response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2010-01-01' }) { mutation }
 
       record = result.dig('data', 'updateInventory', 'inventory')
@@ -139,7 +140,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
-    it 'validates end date against project operating period' do
+    it 'validates end date against project operating period (end date too late)' do
+      p1.update(operating_start_date: '2019-01-01')
       p1.update(operating_end_date: '2019-02-01')
       response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2019-01-01', inventory_end_date: '2019-03-01' }) { mutation }
 
@@ -156,7 +158,26 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
-    it 'validates both dates against project operating period' do
+    it 'validates both dates against project operating period (start date too early, with end date)' do
+      p1.update(operating_start_date: '2019-01-01')
+      p1.update(operating_end_date: '2019-02-01')
+      response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2018-01-01', inventory_end_date: '2019-01-15' }) { mutation }
+
+      record = result.dig('data', 'updateInventory', 'inventory')
+      errors = result.dig('data', 'updateInventory', 'errors')
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        expect(errors).to be_present
+        expect(record).to be_nil
+        expect(errors.length).to eq(1)
+        expect(errors[0]['attribute']).to eq 'inventoryStartDate'
+        expect(errors[0]['type']).to eq 'invalid'
+      end
+    end
+
+    it 'validates both dates against project operating period (fully outside range)' do
+      p1.update(operating_start_date: '2019-01-01')
       p1.update(operating_end_date: '2019-02-01')
       response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2020-01-01', inventory_end_date: '2020-03-01' }) { mutation }
 
@@ -172,6 +193,41 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(errors[0]['type']).to eq 'invalid'
         expect(errors[1]['attribute']).to eq 'inventoryEndDate'
         expect(errors[1]['type']).to eq 'invalid'
+      end
+    end
+
+    it 'validates both dates against project operating period (fully outside range in other direction)' do
+      p1.update(operating_start_date: '2019-01-01')
+      p1.update(operating_end_date: '2019-02-01')
+      response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2010-01-01', inventory_end_date: '2010-03-01' }) { mutation }
+
+      record = result.dig('data', 'updateInventory', 'inventory')
+      errors = result.dig('data', 'updateInventory', 'errors')
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        expect(errors).to be_present
+        expect(record).to be_nil
+        expect(errors.length).to eq(2)
+        expect(errors[0]['attribute']).to eq 'inventoryStartDate'
+        expect(errors[0]['type']).to eq 'invalid'
+        expect(errors[1]['attribute']).to eq 'inventoryEndDate'
+        expect(errors[1]['type']).to eq 'invalid'
+      end
+    end
+
+    it 'passes validation if dates match project operating period' do
+      p1.update(operating_start_date: '2019-01-01')
+      p1.update(operating_end_date: '2019-02-01')
+      response, result = post_graphql(id: i1.id, input: { **valid_input, inventory_start_date: '2019-01-01', inventory_end_date: '2019-02-01' }) { mutation }
+
+      record = result.dig('data', 'updateInventory', 'inventory')
+      errors = result.dig('data', 'updateInventory', 'errors')
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        expect(errors).to be_empty
+        expect(record).to be_present
       end
     end
   end


### PR DESCRIPTION
We soft-validate this on the frontend (aka show warnings if outside min/max), but we should validate it on the backend too.

We could also/instead make the frontend do a hard validation, and not allow submitting if date is outside of bounds. that would require some reconfiguring of form state (doable, just more effort than this).