### PR TITLE
CoC performance measurement limits

### DIFF
--- a/app/assets/stylesheets/application/overrides/bootstrap/buttons.scss
+++ b/app/assets/stylesheets/application/overrides/bootstrap/buttons.scss
@@ -17,10 +17,13 @@ button.close {
   }
 }
 
-.btn-sm {
+.btn-sm, input[type=submit].btn-sm {
   padding: $input-btn-sm-padding-y $input-btn-sm-padding-x;
   min-height: auto;
   font-weight: 600;
+}
+input[type=submit].btn-sm {
+  font-size: 0.875rem;
 }
 
 .btn-xs {

--- a/app/views/style_guides/_buttons.haml
+++ b/app/views/style_guides/_buttons.haml
@@ -63,3 +63,69 @@
   .btn-group
     %button.btn.btn-light.disabled
       Light (BS 4)
+
+.buttons.mb-6
+  .btn-group.client__filter-active
+    %button.btn.btn-sm.btn-default
+      Default (Client Filter Active)
+
+  .btn-group
+    %button.btn.btn-sm.btn-default
+      Default
+
+  .btn-group
+    %button.btn.btn-sm.btn-primary
+      Primary
+
+  .btn-group
+    %button.btn.btn-sm.btn-secondary
+      Secondary
+
+  .btn-group
+    %button.btn.btn-sm.btn-success
+      Success
+
+  .btn-group
+    %button.btn.btn-sm.btn-warning
+      Warning
+
+  .btn-group
+    %button.btn.btn-sm.btn-danger
+      Danger
+
+  .btn-group
+    %button.btn.btn-sm.btn-light
+      Light (BS 4)
+
+.buttons.mb-6
+  .btn-group.client__filter-active
+    %button.btn.btn-sm.btn-default.disabled
+      Default (Client Filter Active)
+
+  .btn-group
+    %button.btn.btn-sm.btn-default.disabled
+      Default
+
+  .btn-group
+    %button.btn.btn-sm.btn-primary.disabled
+      Primary
+
+  .btn-group
+    %button.btn.btn-sm.btn-secondary.disabled
+      Secondary
+
+  .btn-group
+    %button.btn.btn-sm.btn-success.disabled
+      Success
+
+  .btn-group
+    %button.btn.btn-sm.btn-warning.disabled
+      Warning
+
+  .btn-group
+    %button.btn.btn-sm.btn-danger.disabled
+      Danger
+
+  .btn-group
+    %button.btn.btn-sm.btn-light.disabled
+      Light (BS 4)

--- a/db/warehouse/migrate/20221209131957_add_coc_config_to_coc_performance.rb
+++ b/db/warehouse/migrate/20221209131957_add_coc_config_to_coc_performance.rb
@@ -1,0 +1,5 @@
+class AddCoCConfigToCoCPerformance < ActiveRecord::Migration[6.1]
+  def change
+    add_column :performance_measurement_goals, :always_run_for_coc, :boolean, default: false
+  end
+end

--- a/drivers/performance_measurement/app/controllers/performance_measurement/warehouse_reports/goal_configs_controller.rb
+++ b/drivers/performance_measurement/app/controllers/performance_measurement/warehouse_reports/goal_configs_controller.rb
@@ -12,7 +12,7 @@ module PerformanceMeasurement::WarehouseReports
     before_action :set_goal, only: [:edit, :update, :destroy]
 
     def index
-      goal_source.ensure_default
+      @default_goal = goal_source.ensure_default
       @goals = goal_source.default_first
     end
 
@@ -55,6 +55,7 @@ module PerformanceMeasurement::WarehouseReports
         :recidivism_6_months,
         :recidivism_24_months,
         :income,
+        :always_run_for_coc,
       )
       p[:coc_code] = :default if p[:coc_code].blank?
       p

--- a/drivers/performance_measurement/app/models/performance_measurement/goal.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/goal.rb
@@ -32,6 +32,10 @@ module PerformanceMeasurement
       default_goal
     end
 
+    def self.include_project_options?
+      ! default_goal.always_run_for_coc
+    end
+
     def self.default_first
       goals = [default_goal]
       goals += coc.to_a

--- a/drivers/performance_measurement/app/models/performance_measurement/report.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/report.rb
@@ -106,11 +106,18 @@ module PerformanceMeasurement
 
     def filter
       @filter ||= begin
-        f = ::Filters::HudFilterBase.new(user_id: user_id)
+        f = ::Filters::HudFilterBase.new(user_id: filter_user_id)
         f.update((options || {}).merge(comparison_pattern: :prior_year).with_indifferent_access)
         f.update(start: f.end - 1.years + 1.days)
         f
       end
+    end
+
+    # The filter user is dependent on the configuration
+    private def filter_user_id
+      return user_id if PerformanceMeasurement::Goal.include_project_options?
+
+      User.system_user.id
     end
 
     def coc_code

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/goal_configs/index.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/goal_configs/index.haml
@@ -4,14 +4,26 @@
 
 = render '/warehouse_reports/breadcrumbs', tab: 'performance'
 %h1.mb-5= title
+= simple_form_for @default_goal, url: performance_measurement_warehouse_reports_goal_config_path(@default_goal), as: :goal do |f|
+  .well
+    %p The #{_('CoC Performance Measurement Dashboard')} can be run limited to the projects a user can see, or can be run for the entire CoC with detailed comparisons for all projects. Turning "Always run for full CoC" off is the safer choice.
+    .row
+      .col-sm-3
+        = f.input :always_run_for_coc, label: 'Always run for full CoC'
+      .col-sm-2
+        = f.submit 'Set CoC Config', class: 'btn-secondary btn-sm ml-4'
 .row.mb-4
   .col-sm-8
-    %p Goals can be adjusted on a per-CoC basis.  If a particular CoC does not have a goal configuration, the following will be used.
+    %p Goals can be adjusted on a per-CoC basis.  If a particular CoC does not have a goal configuration, the default goal will be used.
+
+
+
   .col-sm-4.d-flex
     .ml-auto
       = link_to performance_measurement_warehouse_reports_goal_configs_path(), method: :post, class: 'btn btn-primary' do
         %i.icon-plus
         Add CoC Specific Goal
+
 .card
   %table.table.table-striped
     %thead

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_details_row.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_details_row.haml
@@ -1,6 +1,7 @@
 - denominator_label = @report.detail_denominator_label_for(key)
 - numerator_label = @report.detail_numerator_label_for(key)
 - pit_count_types = @report.detail_pit_types(key)
+- project_id = if defined?(project_id) then project_id else nil end
 %h3.mb-6= @report.detail_title_for(key)
 .row
   .col-6
@@ -25,7 +26,12 @@
           .performance-measurement__result-number.font-weight-bold.mt-4= "#{median.secondary_value} #{median.secondary_unit}"
           .text-capitalize= sanitize(median.value_label)
       .col-sm-4
-        .performance-measurement__result-number.font-weight-bold= primary_value
+        .performance-measurement__result-number.font-weight-bold
+          - if project_id.present?
+            = link_to performance_measurement_warehouse_reports_report_clients_path(@report.id, key, project_id) do
+              = primary_value
+          - else
+            = primary_value
         .text-capitalize= primary_unit
         - if @report.result_includes_median?(result.field)
           .performance-measurement__result-number.font-weight-bold.mt-4= median.primary_value.to_s

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_form.haml
@@ -9,7 +9,8 @@
         = f.input :end, as: :date_picker, label: 'End date of period', required: true
       .col-sm-3
         = f.input :coc_code, collection: @filter.coc_code_options_for_select(user: current_user), required: false, input_html: { class: ['select2-id-when-selected'], placeholder: 'Please Choose', data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'} }, label: 'CoC Code', as: :select_two, placeholder: 'Please Choose', required: true
-    = render 'hud_reports/project_filter', f: f, api_projects_parameters: { project_types: GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES }, alert: alert
+    - if PerformanceMeasurement::Goal.include_project_options?
+      = render 'hud_reports/project_filter', f: f, api_projects_parameters: { project_types: GrdaWarehouse::Hud::Project::SPM_PROJECT_TYPE_CODES }, alert: alert
   - content_for :filter_actions do
     = f.submit 'Queue Report', class: ['btn', 'btn-primary'], data: { 'filter-projects-target' => 'submitButton' }
 

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_projects.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_projects.haml
@@ -15,7 +15,7 @@
 
       .page-break-avoid
         %h3.mb-4= result.hud_project.name(current_user, include_project_type: true)
-        = render 'performance_measurement/warehouse_reports/reports/details_row', key: key, result: result, class_name: "jProjectLevelPerformance_#{key}_#{project_id}", show_label_detail: result.percentage?
+        = render 'performance_measurement/warehouse_reports/reports/details_row', key: key, result: result, class_name: "jProjectLevelPerformance_#{key}_#{project_id}", show_label_detail: result.percentage?, project_id: project_id
 - other_projects = @report.other_projects(current_user, key)
 - if other_projects.present?
   .well.no-break


### PR DESCRIPTION
This sets up a config to choose if you want the CoC performance dashboard to run for only the scope of projects you can see or for the entire CoC on each run.  If run by CoC you can only get client-level details for the projects assigned to you, but can see the metrics for any project included in the report scope.