### PR TITLE
Disallow GET /hmis/login, limit HMIS session controller to only JSON requests

### DIFF
--- a/drivers/hmis/app/controllers/hmis/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/sessions_controller.rb
@@ -7,10 +7,20 @@
 class Hmis::SessionsController < Devise::SessionsController
   include Hmis::Concerns::JsonErrors
   include AuthenticatesWithTwoFactor
+
+  # Only respond to JSON requests
+  clear_respond_to
   respond_to :json
+
   skip_before_action :verify_signed_out_user
   before_action :authenticate_with_2fa, only: [:create], if: -> { two_factor_enabled? }
 
+  # GET /hmis/login
+  def new
+    raise ActionController::RoutingError, 'Not Found'
+  end
+
+  # POST /hmis/login
   def create
     self.resource = warden.authenticate!(auth_options)
     sign_in(:hmis_user, resource)
@@ -18,6 +28,7 @@ class Hmis::SessionsController < Devise::SessionsController
     render json: { name: resource.name, email: resource.email }
   end
 
+  # DELETE /hmis/logout
   def destroy
     sign_out(:hmis_user) # Only sign out of the HMIS, not the warehouse
     render json: { success: true }, status: 204

--- a/drivers/hmis/config/initializers/graphiql.rb
+++ b/drivers/hmis/config/initializers/graphiql.rb
@@ -1,9 +1,10 @@
-Rails.configuration.to_prepare do
-  # Add before_action to GraphiQL to sign the current user in as an HMIS user.
-  # This controller is only used in development.
-  GraphiQL::Rails::EditorsController.class_eval do
-    before_action do
-      sign_in(:hmis_user, current_user)
+if Rails.env.development?
+  Rails.configuration.to_prepare do
+    # For GraphiQL, sign the current user in as an HMIS user
+    GraphiQL::Rails::EditorsController.class_eval do
+      before_action do
+        sign_in(:hmis_user, current_user)
+      end
     end
   end
 end

--- a/drivers/hmis/config/initializers/graphiql.rb
+++ b/drivers/hmis/config/initializers/graphiql.rb
@@ -1,0 +1,9 @@
+Rails.configuration.to_prepare do
+  # Add before_action to GraphiQL to sign the current user in as an HMIS user.
+  # This controller is only used in development.
+  GraphiQL::Rails::EditorsController.class_eval do
+    before_action do
+      sign_in(:hmis_user, current_user)
+    end
+  end
+end

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -6,6 +6,7 @@ BostonHmis::Application.routes.draw do
     namespace :hmis, defaults: { format: :json } do
       devise_for :users, class_name: 'Hmis::User',
                          skip: [:registrations, :invitations, :passwords, :confirmations, :unlocks, :password_expired],
+                         controllers: { sessions: 'hmis/sessions' },
                          path: '', path_names: { sign_in: 'login', sign_out: 'logout' }
 
       resources :user, only: [:none] do


### PR DESCRIPTION
https://sentry.io/organizations/green-river/issues/3791355247/?referrer=assigned_activity-slack error occurs when `GET /hmis/login` is called, because it was falling back to the default devise controller.

This doesn't address the root cause (I don't know why that GET request is happening) but it does make it so it will result in a 404 instead of the template error.

In addition:
* limit all sessions endpoints to JSON format
* don't require extra login step for `/hmis/graphiql` (previously you had to log in "as an HMIS user" at `/hmis/login.html` before you could make graphql requests)