### PR TITLE
Only validate CoC code on Inventory if it is present

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/validators/inventory_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/inventory_validator.rb
@@ -10,7 +10,7 @@ class Hmis::Hud::Validators::InventoryValidator < Hmis::Hud::Validators::BaseVal
   def validate(record)
     super(record) do
       # CoC code must be valid for project
-      record.errors.add :coc_code, :invalid, message: 'is invalid' unless ::HUD.valid_coc?(record.coc_code) && Hmis::Hud::ProjectCoc.where(coc_code: record.coc_code, project_id: record.project_id).exists?
+      record.errors.add :coc_code, :invalid, message: 'is invalid' if record.coc_code.present? && (!::HUD.valid_coc?(record.coc_code) || !Hmis::Hud::ProjectCoc.where(coc_code: record.coc_code, project_id: record.project_id).exists?)
 
       # Unit and bed counts must be non-negative
       [


### PR DESCRIPTION
Fix bug where backend would respond with both "CoC Code must exist" and "CoC Code is invalid" if the coc code was missing.