### PR TITLE
Support query assessments by multiple roles

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -247,7 +247,7 @@ enum BoundType {
 HUD Client
 """
 type Client {
-  assessments(limit: Int, offset: Int, role: AssessmentRole, sortOrder: AssessmentSortOption): AssessmentsPaginated!
+  assessments(inProgress: Boolean, limit: Int, offset: Int, roles: [AssessmentRole!], sortOrder: AssessmentSortOption): AssessmentsPaginated!
   dateCreated: ISO8601DateTime!
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime!
@@ -1260,7 +1260,7 @@ type EnableWhen {
 HUD Enrollment
 """
 type Enrollment {
-  assessments(limit: Int, offset: Int, role: AssessmentRole, sortOrder: AssessmentSortOption): AssessmentsPaginated!
+  assessments(inProgress: Boolean, limit: Int, offset: Int, roles: [AssessmentRole!], sortOrder: AssessmentSortOption): AssessmentsPaginated!
   client: Client!
   dateCreated: ISO8601DateTime!
   dateDeleted: ISO8601DateTime

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
@@ -17,7 +17,8 @@ module Types
           field_options = default_field_options.merge(override_options)
           field(name, **field_options) do
             argument :sort_order, Types::HmisSchema::AssessmentSortOption, required: false
-            argument :role, HmisSchema::Enums::AssessmentRole, required: false
+            argument :roles, [HmisSchema::Enums::AssessmentRole], required: false
+            argument :in_progress, GraphQL::Types::Boolean, required: false
             instance_eval(&block) if block_given?
           end
         end
@@ -37,10 +38,12 @@ module Types
 
       private
 
-      def scoped_assessments(scope, sort_order: nil, role: nil)
+      def scoped_assessments(scope, sort_order: nil, roles: nil, in_progress: nil)
         scope = scope.viewable_by(current_user)
         scope = scope.sort_by_option(sort_order) if sort_order.present?
-        scope = scope.with_role(role) if role.present?
+        scope = scope.with_role(roles) if roles.present?
+        scope = scope.in_progress if in_progress == true
+        scope = scope.not_in_progress if in_progress == false
         scope
       end
     end

--- a/drivers/hmis/app/models/hmis/form/assessment_detail.rb
+++ b/drivers/hmis/app/models/hmis/form/assessment_detail.rb
@@ -11,6 +11,6 @@ class Hmis::Form::AssessmentDetail < ::GrdaWarehouseBase
   belongs_to :definition
 
   scope :with_role, ->(role) do
-    where(role: role)
+    where(role: Array.wrap(role))
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -27,6 +27,7 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
   validates_with Hmis::Hud::Validators::AssessmentValidator
 
   scope :in_progress, -> { where(enrollment_id: WIP_ID) }
+  scope :not_in_progress, -> { where.not(enrollment_id: WIP_ID) }
 
   # hide previous declaration of :viewable_by, we'll use this one
   replace_scope :viewable_by, ->(user) do


### PR DESCRIPTION
This query supports the updated logic for the "Action Button" on the HoH's row of the household member table, which is:
* if no intake assessment exists AND the enrollment is WIP: prompt to begin new intake
* else if WIP intake exists: prompt to complete it
* else if WIP exit exists: prompt to complete it
* else if WIP annual exists: prompt to complete it
* else if enrollment is non-WIP AND enrollment is non-Exited AND no Exit assessment exists: show exit button
* else no action to take