### PR TITLE
Resolve entry and exit assessments directly on Enrollment

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1309,11 +1309,13 @@ type Enrollment {
   disablingCondition: NoYesReasonsForMissingData
   entryDate: ISO8601Date!
   events(limit: Int, offset: Int, sortOrder: EventSortOption): EventsPaginated!
+  exitAssessment: Assessment
   exitDate: ISO8601Date
   household: Household!
   householdSize: Int!
   id: ID!
   inProgress: Boolean!
+  intakeAssessment: Assessment
   lengthOfStay: ResidencePriorLengthOfStay
   livingSituation: LivingSituation
   losUnderThreshold: NoYesMissing

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -41,6 +41,8 @@ module Types
     hud_field :date_created
     hud_field :date_deleted
     field :user, HmisSchema::User, null: true
+    field :intake_assessment, HmisSchema::Assessment, null: true
+    field :exit_assessment, HmisSchema::Assessment, null: true
 
     def project
       load_ar_association(object.in_progress? ? object.wip : object, :project)

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -129,4 +129,18 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     @in_progress = project_id.nil? if @in_progress.nil?
     @in_progress
   end
+
+  def intake_assessment
+    assessments_including_wip.
+      joins(:assessment_detail).
+      where(assessment_detail: { data_collection_stage: 1 }). # Project entry
+      first
+  end
+
+  def exit_assessment
+    assessments_including_wip.
+      joins(:assessment_detail).
+      where(assessment_detail: { data_collection_stage: 3 }). # Project exit
+      first
+  end
 end


### PR DESCRIPTION
Add `intake_assessment` and `exit_assessment` convenience fields to the Enrollment type. These assessment types are special because there can only be 1 assessment of each type per Enrollment. (The same may be true for post-exit).