### PR TITLE
Meaningful errors from form processor; change losUnderThreshold type

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1318,7 +1318,7 @@ type Enrollment {
   intakeAssessment: Assessment
   lengthOfStay: ResidencePriorLengthOfStay
   livingSituation: LivingSituation
-  losUnderThreshold: NoYesMissing
+  losUnderThreshold: Boolean
   monthsHomelessPastThreeYears: MonthsHomelessPastThreeYears
   previousStreetEssh: Boolean
   project: Project!
@@ -3118,31 +3118,6 @@ enum NoAssistanceReason {
   Invalid Value
   """
   INVALID
-}
-
-"""
-1.7
-"""
-enum NoYesMissing {
-  """
-  (99) Data not collected
-  """
-  DATA_NOT_COLLECTED
-
-  """
-  Invalid Value
-  """
-  INVALID
-
-  """
-  (0) No
-  """
-  NO
-
-  """
-  (1) Yes
-  """
-  YES
 }
 
 """

--- a/drivers/hmis/app/graphql/types/base_enum.rb
+++ b/drivers/hmis/app/graphql/types/base_enum.rb
@@ -55,6 +55,8 @@ module Types
     end
 
     def self.value_for(key)
+      raise "Unrecognized key '#{key}' for enum #{name}" unless values[key].present?
+
       values[key].value
     end
   end

--- a/drivers/hmis/app/graphql/types/base_enum.rb
+++ b/drivers/hmis/app/graphql/types/base_enum.rb
@@ -55,7 +55,7 @@ module Types
     end
 
     def self.value_for(key)
-      raise "Unrecognized key '#{key}' for enum #{name}" unless values[key].present?
+      raise "Unrecognized key '#{key}' for enum #{name}" unless values.key?(key)
 
       values[key].value
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -30,7 +30,7 @@ module Types
     hud_field :relationship_to_ho_h, HmisSchema::Enums::Hud::RelationshipToHoH, null: false
     field :living_situation, HmisSchema::Enums::Hud::LivingSituation
     hud_field :length_of_stay, HmisSchema::Enums::Hud::ResidencePriorLengthOfStay
-    hud_field :los_under_threshold, HmisSchema::Enums::Hud::NoYesMissing
+    yes_no_missing_field :los_under_threshold
     yes_no_missing_field :previous_street_essh
     hud_field :date_to_street_essh
     hud_field :times_homeless_past_three_years, HmisSchema::Enums::Hud::TimesHomelessPastThreeYears

--- a/drivers/hmis/app/models/hmis/form/assessment_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/assessment_processor.rb
@@ -30,7 +30,11 @@ class Hmis::Form::AssessmentProcessor < ::GrdaWarehouseBase
 
       container, field = match[1..2]
 
-      container_processor(container)&.process(field, value)
+      begin
+        container_processor(container)&.process(field, value)
+      rescue StandardError => e
+        raise e.class, "Error processing field '#{field}': #{e.message}"
+      end
     end
 
     valid_containers.values.each do |processor|


### PR DESCRIPTION
Fix issue where frontend was sending a boolean for Los Under Threshold, and the processor was expecting an enum. The exact error took a while to track down, so I also added some error handling to provide more context.