### PR TITLE
Pass validation errors from assessment processor up to the assessment detail

### DIFF
--- a/drivers/hmis/app/models/hmis/form/assessment_detail.rb
+++ b/drivers/hmis/app/models/hmis/form/assessment_detail.rb
@@ -10,10 +10,20 @@ class Hmis::Form::AssessmentDetail < ::GrdaWarehouseBase
   belongs_to :assessment, class_name: 'Hmis::Hud::Assessment'
   belongs_to :definition
   belongs_to :assessment_processor, dependent: :destroy
+  validate :assessment_processor_is_valid
 
   after_initialize :build_assessment_processor
 
   scope :with_role, ->(role) do
     where(role: Array.wrap(role))
+  end
+
+  # Pull up the errors from the assessment processor so we can see them (as opposed to validates_associated)
+  private def assessment_processor_is_valid
+    return if assessment_processor.valid?
+
+    assessment_processor.errors.each do |error|
+      errors.add(error.attribute, error.type, error.options)
+    end
   end
 end

--- a/drivers/hmis/spec/models/hmis/form/assessment_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/assessment_processor_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe Hmis::Form::AssessmentProcessor, type: :model do
     expect(disabilities.find_by(disability_type: 10).disability_response).to eq(3)
   end
 
+  it 'pulls validation errors up from HUD records' do
+    assessment = Hmis::Hud::Assessment.new_with_defaults(enrollment: e1, user: hmis_hud_user, form_definition: fd, assessment_date: Date.current)
+    assessment.assessment_detail.hud_values = {
+      'EnrollmentCoc.user_id' => nil,
+    }
+
+    assessment.assessment_detail.assessment_processor.run!
+    expect(assessment.assessment_detail.valid?).to be false
+    expect(assessment.assessment_detail.errors[:user]).to include('must exist')
+  end
+
   describe 'updating existing assessment' do
     it "doesn't touch an existing value, if it isn't listed (but applies the listed fields)" do
       assessment = Hmis::Hud::Assessment.new_with_defaults(enrollment: e1, user: hmis_hud_user, form_definition: fd, assessment_date: Date.current)


### PR DESCRIPTION
Not yet integrated into the GraphQL submit assessment controller.