### PR TITLE
Add PaperTrail to HMIS models

### DIFF
--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -34,4 +34,9 @@ class Hmis::BaseController < ApplicationController
     data_source_id = GrdaWarehouse::DataSource.hmis.find_by(hmis: domain).id
     current_hmis_user.hmis_data_source_id = data_source_id
   end
+
+  # PaperTrail whodunnit (set in ApplicationController) uses this method to determine the label to be stored
+  def user_for_paper_trail
+    current_hmis_user&.id
+  end
 end

--- a/drivers/hmis/app/models/hmis/active_range.rb
+++ b/drivers/hmis/app/models/hmis/active_range.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::ActiveRange < ::GrdaWarehouseBase
+class Hmis::ActiveRange < HmisBase
   self.table_name = :hmis_active_ranges
   belongs_to :entity, polymorphic: true, optional: true
 

--- a/drivers/hmis/app/models/hmis/active_range.rb
+++ b/drivers/hmis/app/models/hmis/active_range.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::ActiveRange < HmisBase
+class Hmis::ActiveRange < Hmis::HmisBase
   self.table_name = :hmis_active_ranges
   belongs_to :entity, polymorphic: true, optional: true
 

--- a/drivers/hmis/app/models/hmis/bed.rb
+++ b/drivers/hmis/app/models/hmis/bed.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Bed < HmisBase
+class Hmis::Bed < Hmis::HmisBase
   include Hmis::Hud::Concerns::HasEnums
   include ArelHelper
   self.table_name = :hmis_beds

--- a/drivers/hmis/app/models/hmis/bed.rb
+++ b/drivers/hmis/app/models/hmis/bed.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Bed < ::GrdaWarehouseBase
+class Hmis::Bed < HmisBase
   include Hmis::Hud::Concerns::HasEnums
   include ArelHelper
   self.table_name = :hmis_beds

--- a/drivers/hmis/app/models/hmis/hmis_base.rb
+++ b/drivers/hmis/app/models/hmis/hmis_base.rb
@@ -1,0 +1,11 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class Hmis::HmisBase < GrdaWarehouseBase
+  self.abstract_class = true
+
+  has_paper_trail
+end

--- a/drivers/hmis/app/models/hmis/hud/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/base.rb
@@ -8,6 +8,7 @@ class Hmis::Hud::Base < ::GrdaWarehouseBase
   self.abstract_class = true
 
   acts_as_paranoid(column: :DateDeleted)
+  has_paper_trail # Track changes made to HUD objects via PaperTrail
 
   attr_writer :skip_validations
   attr_writer :required_fields

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -6,6 +6,8 @@
 
 class Hmis::Role < ::ApplicationRecord
   self.table_name = :hmis_roles
+  # Warehouse roles do not have a paper trail, so neither do these
+
   has_many :user_hmis_data_source_roles, class_name: '::Hmis::UserHmisDataSourceRole'
   has_many :users, through: :user_hmis_data_source_roles, source: :user
 

--- a/drivers/hmis/app/models/hmis/unit.rb
+++ b/drivers/hmis/app/models/hmis/unit.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Unit < HmisBase
+class Hmis::Unit < Hmis::HmisBase
   include ArelHelper
   self.table_name = :hmis_units
 

--- a/drivers/hmis/app/models/hmis/unit.rb
+++ b/drivers/hmis/app/models/hmis/unit.rb
@@ -4,9 +4,10 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Unit < ::GrdaWarehouseBase
+class Hmis::Unit < HmisBase
   include ArelHelper
   self.table_name = :hmis_units
+
   belongs_to :inventory, class_name: 'Hmis::Hud::Inventory'
   has_many :beds
   has_many :active_ranges, class_name: 'Hmis::ActiveRange', as: :entity

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -14,6 +14,7 @@ class Hmis::User < ApplicationRecord
   include UserConcern
   include HasRecentItems
   self.table_name = :users
+
   has_many :user_hmis_data_sources_roles, class_name: '::Hmis::UserHmisDataSourceRole', dependent: :destroy, inverse_of: :user # join table with user_id, data_source_id, role_id
   has_many :roles, through: :user_hmis_data_sources_roles, source: :role
   has_many :hmis_data_sources, through: :user_hmis_data_sources_roles, source: :data_source

--- a/drivers/hmis/app/models/hmis/user_hmis_data_source_role.rb
+++ b/drivers/hmis/app/models/hmis/user_hmis_data_source_role.rb
@@ -6,7 +6,30 @@
 
 class Hmis::UserHmisDataSourceRole < ::ApplicationRecord
   self.table_name = :user_hmis_data_source_roles
+  has_paper_trail(
+    meta: {
+      referenced_user_id: :referenced_user_id,
+      referenced_entity_name: :referenced_entity_name,
+    },
+  )
+
   belongs_to :user
   belongs_to :role
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
+  def referenced_user_id
+    user.id
+  end
+
+  def referenced_entity_name
+    role.name
+  end
+
+  def self.describe_changes(version, _changes)
+    if version.event == 'create'
+      ["Added role #{version.referenced_entity_name}"]
+    else
+      ["Removed role #{version.referenced_entity_name}"]
+    end
+  end
 end

--- a/drivers/hmis/app/models/hmis/wip.rb
+++ b/drivers/hmis/app/models/hmis/wip.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Wip < HmisBase
+class Hmis::Wip < Hmis::HmisBase
   belongs_to :source, polymorphic: true
   belongs_to :client, class_name: '::Hmis::Hud::Client'
   belongs_to :enrollment, class_name: '::Hmis::Hud::Enrollment', optional: true

--- a/drivers/hmis/app/models/hmis/wip.rb
+++ b/drivers/hmis/app/models/hmis/wip.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::Wip < GrdaWarehouseBase
+class Hmis::Wip < HmisBase
   belongs_to :source, polymorphic: true
   belongs_to :client, class_name: '::Hmis::Hud::Client'
   belongs_to :enrollment, class_name: '::Hmis::Hud::Enrollment', optional: true


### PR DESCRIPTION
Form definitions are not included as they already have a versioning mechanism. If this is incorrect (e.g., maybe we want auditing on how the definitions are developed?) this can be changed as part of of creating a form builder...