### PR TITLE
Stop skipping verify_authenticity_token on GET user endpoint

### DIFF
--- a/drivers/hmis/app/controllers/hmis/user_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/user_controller.rb
@@ -17,8 +17,7 @@ class Hmis::UserController < Hmis::BaseController
   # The frontend also polls this method to determine if the session is still valid.
   #
   # If there is no active session, warden will return a 401.
-  # We set a CSRF cookie *prior* to authentication, because the frontend
-  # needs a valid CSRF token to hit POST /hmis/login.
+  # We set a CSRF cookie here because the frontend needs it for authentication (POST /hmis/login)
   def index
     set_csrf_cookie
     authenticate_hmis_user!

--- a/drivers/hmis/app/controllers/hmis/user_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/user_controller.rb
@@ -5,7 +5,6 @@
 ###
 
 class Hmis::UserController < Hmis::BaseController
-  skip_before_action :verify_authenticity_token, only: [:index]
   skip_before_action :authenticate_user!, only: [:index]
   prepend_before_action :skip_timeout, only: [:index]
   before_action :clear_etag, only: [:index]


### PR DESCRIPTION
I think I remember why I added this in the beginning, but we don't need it! CSRF tokens are not verified on GET requests.