### PR TITLE
Add open_on_date filter to enrollments; always warn about enrollment open on project end date

### DIFF
--- a/drivers/hmis/app/graphql/mutations/update_project.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project.rb
@@ -26,9 +26,9 @@ module Mutations
 
       funder_count = project.funders.where(end_date: nil).count
       inventory_count = project.inventories.where(inventory_end_date: nil).count
-      open_enrollments = Hmis::Hud::Enrollment.open_on_date.in_project_including_wip(project.id, project.project_id)
+      open_enrollments = Hmis::Hud::Enrollment.open_on_date(input.operating_end_date).in_project_including_wip(project.id, project.project_id)
 
-      errors.add :base, :information, severity: :warning, full_message: "Project has #{open_enrollments.count} open #{'enrollment'.pluralize(open_enrollments.count)}." if open_enrollments.present?
+      errors.add :base, :information, severity: :warning, full_message: "Project has #{open_enrollments.count} open #{'enrollment'.pluralize(open_enrollments.count)} on specified end date." if open_enrollments.present?
       errors.add :base, :information, severity: :warning, full_message: "#{funder_count} open #{'funder'.pluralize(funder_count)} will be closed." if funder_count.positive?
       errors.add :base, :information, severity: :warning, full_message: "#{inventory_count} open inventory #{'record'.pluralize(inventory_count)} will be closed." if inventory_count.positive?
 

--- a/drivers/hmis/app/graphql/mutations/update_project.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project.rb
@@ -20,17 +20,21 @@ module Mutations
     end
 
     def create_errors(project, input)
-      return [] unless project.operating_end_date.blank? && input.operating_end_date.present?
-
       errors = HmisErrors::Errors.new
 
-      funder_count = project.funders.where(end_date: nil).count
-      inventory_count = project.inventories.where(inventory_end_date: nil).count
-      open_enrollments = Hmis::Hud::Enrollment.open_on_date(input.operating_end_date).in_project_including_wip(project.id, project.project_id)
+      # If project end date is changing
+      if input.operating_end_date.present? && project.operating_end_date != input.operating_end_date
+        open_enrollments = Hmis::Hud::Enrollment.open_on_date(input.operating_end_date).in_project_including_wip(project.id, project.project_id)
+        errors.add :base, :information, severity: :warning, full_message: "Project has #{open_enrollments.count} open #{'enrollment'.pluralize(open_enrollments.count)} on the selected end date." if open_enrollments.present?
+      end
 
-      errors.add :base, :information, severity: :warning, full_message: "Project has #{open_enrollments.count} open #{'enrollment'.pluralize(open_enrollments.count)} on specified end date." if open_enrollments.present?
-      errors.add :base, :information, severity: :warning, full_message: "#{funder_count} open #{'funder'.pluralize(funder_count)} will be closed." if funder_count.positive?
-      errors.add :base, :information, severity: :warning, full_message: "#{inventory_count} open inventory #{'record'.pluralize(inventory_count)} will be closed." if inventory_count.positive?
+      # If project is being "closed" for the first time
+      if project.operating_end_date.blank? && input.operating_end_date.present?
+        funder_count = project.funders.where(end_date: nil).count
+        inventory_count = project.inventories.where(inventory_end_date: nil).count
+        errors.add :base, :information, severity: :warning, full_message: "#{funder_count} open #{'funder'.pluralize(funder_count)} will be closed." if funder_count.positive?
+        errors.add :base, :information, severity: :warning, full_message: "#{inventory_count} open inventory #{'record'.pluralize(inventory_count)} will be closed." if inventory_count.positive?
+      end
 
       errors.errors
     end

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -347,7 +347,7 @@ type Client {
   disabilityGroups: [DisabilityGroup!]!
   dob: ISO8601Date
   dobDataQuality: DOBDataQuality!
-  enrollments(includeInProgress: Boolean, limit: Int, offset: Int, projectTypes: [ProjectType!], sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
+  enrollments(includeInProgress: Boolean, limit: Int, offset: Int, openOnDate: ISO8601Date, projectTypes: [ProjectType!], sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
   ethnicity: Ethnicity!
   firstName: String
   gender: [Gender!]!
@@ -3433,7 +3433,7 @@ type Project {
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime!
   description: String
-  enrollments(clientSearchTerm: String, includeInProgress: Boolean, limit: Int, offset: Int, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
+  enrollments(clientSearchTerm: String, includeInProgress: Boolean, limit: Int, offset: Int, openOnDate: ISO8601Date, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
   funders(limit: Int, offset: Int, sortOrder: FunderSortOption): FundersPaginated!
   housingType: HousingType
   id: ID!

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
@@ -18,6 +18,7 @@ module Types
           field(name, **field_options) do
             argument :sort_order, HmisSchema::EnrollmentSortOption, required: false
             argument :include_in_progress, GraphQL::Types::Boolean, required: false
+            argument :open_on_date, GraphQL::Types::ISO8601Date, required: false
             argument :project_types, [Types::HmisSchema::Enums::ProjectType], required: false  unless without_args.include? :project_types
             argument :client_search_term, String, required: false unless without_args.include? :client_search_term
             instance_eval(&block) if block_given?
@@ -35,9 +36,10 @@ module Types
 
       private
 
-      def scoped_enrollments(scope, sort_order: :most_recent, include_in_progress: false, project_types: nil, client_search_term: nil)
+      def scoped_enrollments(scope, sort_order: :most_recent, include_in_progress: false, open_on_date: nil, project_types: nil, client_search_term: nil)
         scope = scope.viewable_by(current_user)
         scope = scope.where.not(project_id: nil) unless include_in_progress
+        scope = scope.open_on_date(open_on_date) if open_on_date.present?
         scope = scope.with_project_type(project_types) if project_types.present?
         scope = scope.joins(:client).merge(Hmis::Hud::Client.matching_search_term(client_search_term)) if client_search_term.present?
         scope = scope.sort_by_option(sort_order) if sort_order.present?


### PR DESCRIPTION
1. Addressing feedback on project update mutation https://github.com/greenriver/hmis-warehouse/pull/2788#discussion_r1100643201
2. Add `open_on_date` filter to enrollments query