### PR TITLE
Fix failing submit_assessment_spec

### DIFF
--- a/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   include_context 'hmis base setup'
   let(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
-  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1 }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: '2022-01-01' }
   let!(:fd1) { create :hmis_form_definition }
   let!(:fi1) { create :hmis_form_instance, definition: fd1, entity: p1 }
 


### PR DESCRIPTION
It was failing because of new warnings about the information date being after the entry date