### PR TITLE
Fix url obfuscation error

### DIFF
--- a/config/initializers/protected_id.rb
+++ b/config/initializers/protected_id.rb
@@ -12,7 +12,6 @@ module ProtectedId
 
   module Encoder
     def encode(id)
-      return if id.nil?
       return id.to_s unless PROTECT_IDS
 
       day_stamp = Date.today.to_time.to_i / (60 * 60 * 24) # Seconds in a day
@@ -74,6 +73,8 @@ module ProtectedId
     include Encoder
 
     def to_param
+      return '' if id.nil?
+
       encode(id)
     end
   end

--- a/config/initializers/protected_id.rb
+++ b/config/initializers/protected_id.rb
@@ -13,6 +13,7 @@ module ProtectedId
   module Encoder
     def encode(id)
       return id.to_s unless PROTECT_IDS
+      return if id.nil?
 
       day_stamp = Date.today.to_time.to_i / (60 * 60 * 24) # Seconds in a day
       obfuscate(id, day_stamp)

--- a/config/initializers/protected_id.rb
+++ b/config/initializers/protected_id.rb
@@ -12,8 +12,8 @@ module ProtectedId
 
   module Encoder
     def encode(id)
-      return id.to_s unless PROTECT_IDS
       return if id.nil?
+      return id.to_s unless PROTECT_IDS
 
       day_stamp = Date.today.to_time.to_i / (60 * 60 * 24) # Seconds in a day
       obfuscate(id, day_stamp)

--- a/config/initializers/protected_id.rb
+++ b/config/initializers/protected_id.rb
@@ -73,7 +73,7 @@ module ProtectedId
     include Encoder
 
     def to_param
-      return '' if id.nil?
+      return super unless id.is_a?(Integer)
 
       encode(id)
     end

--- a/drivers/hmis/app/views/hmis_admin/roles/new.haml
+++ b/drivers/hmis/app/views/hmis_admin/roles/new.haml
@@ -3,5 +3,5 @@
   .col-sm-12
     %h1 New Role
   .col-sm-8
-    = simple_form_for @role, as: :role, url: hmis_admin_role_path(@role) do |f|
+    = simple_form_for @role, as: :role, url: hmis_admin_roles_path(@role) do |f|
       = render 'admin/roles/new_form', f: f, submit_text: 'Create Role'


### PR DESCRIPTION
These are both needed to fix https://green-river.sentry.io/issues/3966465699. I couldn't figure out why it is trying to encode the path `hmis_admin/roles/new`. 