### PR TITLE
184586495 remove editable by

### DIFF
--- a/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
@@ -28,6 +28,9 @@ module Mutations
       return { errors: errors } if errors.any?
 
       existing_enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(household_id: household_id)
+
+      return { household_id: nil, errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless current_user.permissions_for?(existing_enrollment, :can_edit_enrollments)
+
       lookup = Hmis::Hud::Client.where(id: household_members.map(&:id)).index_by(&:id)
       project_id = existing_enrollment.project.project_id
 

--- a/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
@@ -10,8 +10,8 @@ module Mutations
       errors = HmisErrors::Errors.new
       errors.add :start_date, :out_of_range, message: 'cannot be in the future', readable_attribute: 'Entry date' if Date.parse(start_date) > Date.today
 
-      has_enrollment = Hmis::Hud::Enrollment.editable_by(current_user).exists?(household_id: household_id)
-      has_hoh_enrollment = Hmis::Hud::Enrollment.editable_by(current_user).exists?(
+      has_enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).exists?(household_id: household_id)
+      has_hoh_enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).exists?(
         household_id: household_id,
         relationship_to_ho_h: 1,
       )
@@ -27,7 +27,7 @@ module Mutations
       errors = validate_input(household_id: household_id, start_date: start_date, household_members: household_members)
       return { errors: errors } if errors.any?
 
-      existing_enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(household_id: household_id)
+      existing_enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(household_id: household_id)
 
       return { household_id: nil, errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless current_user.permissions_for?(existing_enrollment, :can_edit_enrollments)
 
@@ -36,7 +36,7 @@ module Mutations
 
       enrollments = household_members.map do |household_member|
         client = lookup[household_member.id.to_i]
-        enrollment = client.enrollments.editable_by(current_user).find_by(household_id: household_id)
+        enrollment = client.enrollments.viewable_by(current_user).find_by(household_id: household_id)
 
         next enrollment if enrollment.present?
 

--- a/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/add_household_members_to_enrollment.rb
@@ -29,7 +29,7 @@ module Mutations
 
       existing_enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(household_id: household_id)
 
-      return { household_id: nil, errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless current_user.permissions_for?(existing_enrollment, :can_edit_enrollments)
+      return { errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless current_user.permissions_for?(existing_enrollment, :can_edit_enrollments)
 
       lookup = Hmis::Hud::Client.where(id: household_members.map(&:id)).index_by(&:id)
       project_id = existing_enrollment.project.project_id

--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -56,7 +56,9 @@ module Mutations
     end
 
     # Default CRUD Create functionality
-    def default_create_record(cls, field_name:, id_field_name:, input:, _permissions: nil)
+    def default_create_record(cls, field_name:, id_field_name:, input:, permissions: nil)
+      return { field_name => nil, errors: [HmisErrors::Error.new(field_name, :not_allowed)] } if permissions.present? && !current_user.permissions?(*permissions)
+
       record = cls.new(
         **input.to_params,
         id_field_name => Hmis::Hud::Base.generate_uuid,

--- a/drivers/hmis/app/graphql/mutations/create_beds.rb
+++ b/drivers/hmis/app/graphql/mutations/create_beds.rb
@@ -8,7 +8,8 @@ module Mutations
       inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: input.inventory_id)
       errors = HmisErrors::Errors.new
       errors.add :inventory_id, :not_found unless inventory.present?
-      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
+      errors.add :inventory_id, :not_allowed if inventory.present? && !current_user.permissions_for?(inventory, :can_edit_project_details)
+      return { errors: errors.errors } if errors.any?
 
       unit = Hmis::Unit.find_by(id: input.unit_id)
       errors.add :unit_id, :not_found unless unit.present?
@@ -19,7 +20,7 @@ module Mutations
         errors.add bed_type, :out_of_range, message: 'must be positive' if num&.negative?
       end
 
-      return { inventory: nil, errors: errors.errors } if errors.any?
+      return { errors: errors.errors } if errors.any?
 
       # Create Beds
       bed_args = []

--- a/drivers/hmis/app/graphql/mutations/create_beds.rb
+++ b/drivers/hmis/app/graphql/mutations/create_beds.rb
@@ -5,9 +5,10 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(input:)
-      inventory = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: input.inventory_id)
+      inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: input.inventory_id)
       errors = HmisErrors::Errors.new
       errors.add :inventory_id, :not_found unless inventory.present?
+      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       unit = Hmis::Unit.find_by(id: input.unit_id)
       errors.add :unit_id, :not_found unless unit.present?

--- a/drivers/hmis/app/graphql/mutations/create_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/create_enrollment.rb
@@ -19,7 +19,8 @@ module Mutations
       result = []
       household_id = Hmis::Hud::Enrollment.generate_household_id
       lookup = Hmis::Hud::Client.where(id: household_members.map(&:id)).pluck(:id, :personal_id).to_h
-      project = Hmis::Hud::Project.editable_by(context[:current_user]).find_by(id: project_id)
+      project = Hmis::Hud::Project.viewable_by(context[:current_user]).find_by(id: project_id)
+      return { enrollments: [], errors: [HmisErrors::Error.new(:project_id, :not_allowed)] } unless current_user.permissions_for?(project, :can_edit_enrollments)
 
       household_members.each do |household_member|
         result << {

--- a/drivers/hmis/app/graphql/mutations/create_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/create_enrollment.rb
@@ -11,7 +11,7 @@ module Mutations
       errors = HmisErrors::Errors.new
       errors.add :relationship_to_ho_h, full_message: 'Exactly one client must be head of household' if household_members.select { |hm| hm.relationship_to_ho_h == 1 }.size != 1
       errors.add :start_date, :out_of_range, message: 'cannot be in the future', readable_attribute: 'Entry date' if Date.parse(start_date) > Date.today
-      errors.add :project_id, :not_found unless Hmis::Hud::Project.editable_by(current_user).exists?(id: project_id)
+      errors.add :project_id, :not_found unless Hmis::Hud::Project.viewable_by(current_user).exists?(id: project_id)
       errors.errors
     end
 

--- a/drivers/hmis/app/graphql/mutations/create_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/create_enrollment.rb
@@ -20,7 +20,6 @@ module Mutations
       household_id = Hmis::Hud::Enrollment.generate_household_id
       lookup = Hmis::Hud::Client.where(id: household_members.map(&:id)).pluck(:id, :personal_id).to_h
       project = Hmis::Hud::Project.viewable_by(context[:current_user]).find_by(id: project_id)
-      return { enrollments: [], errors: [HmisErrors::Error.new(:project_id, :not_allowed)] } unless current_user.permissions_for?(project, :can_edit_enrollments)
 
       household_members.each do |household_member|
         result << {
@@ -41,6 +40,9 @@ module Mutations
       user = hmis_user
       errors = validate_input(project_id: project_id, start_date: start_date, household_members: household_members)
       return { enrollments: [], errors: errors } if errors.any?
+
+      project = Hmis::Hud::Project.viewable_by(context[:current_user]).find_by(id: project_id)
+      return { enrollments: [], errors: [HmisErrors::Error.new(:project_id, :not_allowed)] } unless current_user.permissions_for?(project, :can_edit_enrollments)
 
       enrollments = to_enrollments_params(project_id: project_id, start_date: start_date, household_members: household_members, in_progress: in_progress).map do |attrs|
         enrollment = Hmis::Hud::Enrollment.new(

--- a/drivers/hmis/app/graphql/mutations/create_funder.rb
+++ b/drivers/hmis/app/graphql/mutations/create_funder.rb
@@ -10,6 +10,7 @@ module Mutations
         field_name: :funder,
         id_field_name: :funder_id,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_inventory.rb
+++ b/drivers/hmis/app/graphql/mutations/create_inventory.rb
@@ -10,6 +10,7 @@ module Mutations
         field_name: :inventory,
         id_field_name: :inventory_id,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_organization.rb
+++ b/drivers/hmis/app/graphql/mutations/create_organization.rb
@@ -10,6 +10,7 @@ module Mutations
         field_name: :organization,
         id_field_name: :organization_id,
         input: input,
+        permissions: [:can_edit_organization],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_project.rb
+++ b/drivers/hmis/app/graphql/mutations/create_project.rb
@@ -10,6 +10,7 @@ module Mutations
         field_name: :project,
         id_field_name: :project_id,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_project_coc.rb
+++ b/drivers/hmis/app/graphql/mutations/create_project_coc.rb
@@ -10,6 +10,7 @@ module Mutations
         field_name: :project_coc,
         id_field_name: :project_coc_id,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_service.rb
+++ b/drivers/hmis/app/graphql/mutations/create_service.rb
@@ -13,13 +13,14 @@ module Mutations
 
     def resolve(input:)
       errors = validate_input(input)
-      return { service: nil, errors: errors } if errors.present?
+      return { errors: errors } if errors.any?
 
       default_create_record(
         Hmis::Hud::Service,
         field_name: :service,
         id_field_name: :services_id,
         input: input,
+        permissions: [:can_edit_enrollments],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -6,13 +6,13 @@ module Mutations
 
     def resolve(input:)
       inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: input.inventory_id)
-      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
+      return { errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
 
       errors = HmisErrors::Errors.new
       errors.add :inventory_id, :not_found unless inventory.present?
       errors.add :count, :required unless input.count.present?
       errors.add :count, :out_of_range, message: 'must be positive' if input.count&.negative?
-      return { inventory: nil, errors: errors.errors } if errors.any?
+      return { errors: errors.errors } if errors.any?
 
       # Create Units
       common = { user_id: hmis_user.user_id, created_at: Time.now, updated_at: Time.now }

--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -5,7 +5,9 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(input:)
-      inventory = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: input.inventory_id)
+      inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: input.inventory_id)
+      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
+
       errors = HmisErrors::Errors.new
       errors.add :inventory_id, :not_found unless inventory.present?
       errors.add :count, :required unless input.count.present?

--- a/drivers/hmis/app/graphql/mutations/delete_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_assessment.rb
@@ -5,8 +5,8 @@ module Mutations
     field :assessment, Types::HmisSchema::Assessment, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Assessment.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :assessment)
+      record = Hmis::Hud::Assessment.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :assessment, permissions: [:can_edit_enrollments])
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_beds.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_beds.rb
@@ -6,8 +6,9 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(inventory_id:, bed_ids:)
-      inventory = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: inventory_id)
-      return { inventory => nil, errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
+      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       return { inventory => inventory, errors: [] } unless bed_ids.any?
 

--- a/drivers/hmis/app/graphql/mutations/delete_beds.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_beds.rb
@@ -7,8 +7,8 @@ module Mutations
 
     def resolve(inventory_id:, bed_ids:)
       inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
-      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
-      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
+      return { errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       return { inventory => inventory, errors: [] } unless bed_ids.any?
 

--- a/drivers/hmis/app/graphql/mutations/delete_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client_image.rb
@@ -6,18 +6,18 @@ module Mutations
 
     def resolve(client_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
-      errors = []
 
-      errors << HmisErrors::Error.new(:client_id, :not_found) unless client.present?
+      errors = HmisErrors::Errors.new
+      errors.add :client_id, :not_found unless client.present?
+      errors.add :client_id, :not_allowed if client.present? && !current_user.permission?(:can_edit_clients)
+      return { errors: errors } if errors.any?
 
-      if client.present?
-        client.delete_image
-        client = client.reload
-      end
+      client.delete_image
+      client = client.reload
 
-      return {
+      {
         client: client,
-        errors: errors,
+        errors: [],
       }
     end
   end

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -9,7 +9,7 @@ module Mutations
       enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
 
       if enrollment.present?
-        return { enrollment: nil, errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
+        return { enrollment: nil, errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
 
         if enrollment.in_progress?
           enrollment.destroy

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -6,9 +6,11 @@ module Mutations
 
     def resolve(id:)
       errors = []
-      enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(id: id)
+      enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
 
       if enrollment.present?
+        return { enrollment: nil, errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
+
         if enrollment.in_progress?
           enrollment.destroy
         else

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -8,7 +8,7 @@ module Mutations
       enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
 
       return { errors: [HmisErrors::Error.new(:enrollment, :not_found)] } unless enrollment.present?
-      return { errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_enrollments)
+      return { errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
 
       errors = []
       if enrollment.in_progress?

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -5,22 +5,19 @@ module Mutations
     field :enrollment, Types::HmisSchema::Enrollment, null: true
 
     def resolve(id:)
-      errors = []
       enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
 
-      if enrollment.present?
-        return { enrollment: nil, errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
+      return { errors: [HmisErrors::Error.new(:enrollment, :not_found)] } unless enrollment.present?
+      return { errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_enrollments)
 
-        if enrollment.in_progress?
-          enrollment.destroy
-        else
-          errors << HmisErrors::Error.new(:base, full_message: 'Completed enrollments can not be deleted. Please exit the client instead.')
-        end
-
-        errors << enrollment.errors.errors unless enrollment.valid?
+      errors = []
+      if enrollment.in_progress?
+        enrollment.destroy
       else
-        errors << HmisErrors::Error.new(:enrollment, :not_found)
+        errors << HmisErrors::Error.new(:base, full_message: 'Completed enrollments can not be deleted. Please exit the client instead.')
       end
+
+      errors << enrollment.errors.errors unless enrollment.valid?
 
       {
         enrollment: enrollment,

--- a/drivers/hmis/app/graphql/mutations/delete_funder.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_funder.rb
@@ -5,8 +5,8 @@ module Mutations
     field :funder, Types::HmisSchema::Funder, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Funder.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :funder)
+      record = Hmis::Hud::Funder.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :funder, permissions: [:can_edit_project_details])
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_inventory.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_inventory.rb
@@ -5,8 +5,8 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :inventory)
+      record = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :inventory, permissions: [:can_edit_project_details])
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_organization.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_organization.rb
@@ -5,7 +5,7 @@ module Mutations
     field :organization, Types::HmisSchema::Organization, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Organization.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Organization.viewable_by(current_user).find_by(id: id)
       default_delete_record(record: record, field_name: :organization, permissions: [:can_delete_organization])
     end
   end

--- a/drivers/hmis/app/graphql/mutations/delete_organization.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_organization.rb
@@ -6,7 +6,7 @@ module Mutations
 
     def resolve(id:)
       record = Hmis::Hud::Organization.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :organization)
+      default_delete_record(record: record, field_name: :organization, permissions: [:can_delete_organization])
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_project.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project.rb
@@ -5,8 +5,8 @@ module Mutations
     field :project, Types::HmisSchema::Project, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Project.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :project)
+      record = Hmis::Hud::Project.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :project, permissions: :can_delete_project)
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_project_coc.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project_coc.rb
@@ -5,8 +5,8 @@ module Mutations
     field :project_coc, Types::HmisSchema::ProjectCoc, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::ProjectCoc.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :project_coc)
+      record = Hmis::Hud::ProjectCoc.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :project_coc, permissions: [:can_edit_project_details])
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_service.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_service.rb
@@ -5,8 +5,8 @@ module Mutations
     field :service, Types::HmisSchema::Service, null: true
 
     def resolve(id:)
-      record = Hmis::Hud::Service.editable_by(current_user).find_by(id: id)
-      default_delete_record(record: record, field_name: :service)
+      record = Hmis::Hud::Service.viewable_by(current_user).find_by(id: id)
+      default_delete_record(record: record, field_name: :service, permissions: :can_edit_enrollments)
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_units.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_units.rb
@@ -7,8 +7,8 @@ module Mutations
 
     def resolve(inventory_id:, unit_ids:)
       inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
-      return { inventory => nil, errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
-      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
+      return { errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
 
       return { inventory => inventory, errors: [] } unless unit_ids.any?
 

--- a/drivers/hmis/app/graphql/mutations/delete_units.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_units.rb
@@ -6,8 +6,9 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(inventory_id:, unit_ids:)
-      inventory = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: inventory_id)
+      inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
       return { inventory => nil, errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { inventory: nil, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_edit_project_details)
 
       return { inventory => inventory, errors: [] } unless unit_ids.any?
 

--- a/drivers/hmis/app/graphql/mutations/save_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/save_assessment.rb
@@ -8,7 +8,7 @@ module Mutations
 
     def resolve(input:)
       assessment, errors = input.find_or_create_assessment
-      return { assessment: nil, errors: errors } if errors.any?
+      return { errors: errors } if errors.any?
 
       definition = assessment.assessment_detail.definition
       enrollment = assessment.enrollment
@@ -19,7 +19,7 @@ module Mutations
         entry_date: enrollment.entry_date,
         exit_date: enrollment.exit_date,
       )
-      return { assessment: nil, errors: errors } if errors.any?
+      return { errors: errors } if errors.any?
 
       # Update values
       assessment.assessment_detail.assign_attributes(

--- a/drivers/hmis/app/graphql/mutations/set_ho_h_for_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/set_ho_h_for_enrollment.rb
@@ -13,7 +13,7 @@ module Mutations
 
       if client
         household_enrollments = Hmis::Hud::Enrollment.viewable_by(current_user).where(household_id: household_id)
-        return { enrollment: nil, errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless household_enrollments.all? { |e| current_user.permissions_for?(e, :can_edit_enrollments) }
+        return { errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless household_enrollments.all? { |e| current_user.permissions_for?(e, :can_edit_enrollments) }
 
         new_hoh_enrollment = household_enrollments.find_by(personal_id: client&.personal_id)
         if new_hoh_enrollment

--- a/drivers/hmis/app/graphql/mutations/set_ho_h_for_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/set_ho_h_for_enrollment.rb
@@ -12,7 +12,9 @@ module Mutations
       client = Hmis::Hud::Client.find_by(id: client_id)
 
       if client
-        household_enrollments = Hmis::Hud::Enrollment.editable_by(current_user).where(household_id: household_id)
+        household_enrollments = Hmis::Hud::Enrollment.viewable_by(current_user).where(household_id: household_id)
+        return { enrollment: nil, errors: [HmisErrors::Error.new(:household_id, :not_allowed)] } unless household_enrollments.all? { |e| current_user.permissions_for?(e, :can_edit_enrollments) }
+
         new_hoh_enrollment = household_enrollments.find_by(personal_id: client&.personal_id)
         if new_hoh_enrollment
           update_params = { user_id: hmis_user.user_id }

--- a/drivers/hmis/app/graphql/mutations/submit_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_assessment.rb
@@ -69,7 +69,7 @@ module Mutations
         assessment.touch
       end
 
-      return { assessment: nil, errors: errors } if errors.any?
+      return { errors: errors } if errors.any?
 
       # Run processor to create/update related records
       assessment.assessment_detail.assessment_processor.run!

--- a/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
@@ -8,13 +8,16 @@ module Mutations
     field :assessments, [Types::HmisSchema::Assessment], null: true
 
     def resolve(assessment_ids:, confirmed:)
-      errors = HmisErrors::Errors.new
-
       assessments = Hmis::Hud::Assessment.viewable_by(current_user).
         where(id: assessment_ids).
         preload(:enrollment, :assessment_detail)
 
       enrollments = assessments.map(&:enrollment)
+
+      errors = HmisErrors::Errors.new
+      # Error: insufficient permissions
+      errors.add :assessment, :not_allowed if enrollments.first.present? && !current_user.permissions_for?(enrollments.first, :can_edit_enrollments)
+      return { errors: errors } if errors.any?
 
       # Error: not all assessments found
       errors.add :assessment, :not_found if assessments.count != assessment_ids.size

--- a/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
@@ -10,7 +10,7 @@ module Mutations
     def resolve(assessment_ids:, confirmed:)
       errors = HmisErrors::Errors.new
 
-      assessments = Hmis::Hud::Assessment.editable_by(current_user).
+      assessments = Hmis::Hud::Assessment.viewable_by(current_user).
         where(id: assessment_ids).
         preload(:enrollment, :assessment_detail)
 

--- a/drivers/hmis/app/graphql/mutations/update_beds.rb
+++ b/drivers/hmis/app/graphql/mutations/update_beds.rb
@@ -11,9 +11,9 @@ module Mutations
     def resolve(inventory_id:, bed_ids:, name: nil, gender: nil, unit: nil)
       inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
       return { beds: [], errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { beds: [], errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       beds = inventory.beds.where(id: bed_ids)
-      return { beds: beds, errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       common = { user_id: hmis_user.user_id, updated_at: Time.now }
       beds.update_all(gender: gender, name: name, **common)

--- a/drivers/hmis/app/graphql/mutations/update_client.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client.rb
@@ -11,6 +11,7 @@ module Mutations
         record: record,
         field_name: :client,
         input: input,
+        permissions: [:can_edit_clients],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client_image.rb
@@ -7,19 +7,19 @@ module Mutations
 
     def resolve(client_id:, image_blob_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
-      errors = []
 
-      errors << HmisErrors::Error.new(:client_id, :not_found) unless client.present?
+      errors = HmisErrors::Errors.new
+      errors.add :client_id, :not_found unless client.present?
+      errors.add :client_id, :not_allowed if client.present? && !current_user.permission?(:can_edit_clients)
+      return { errors: errors } if errors.any?
 
-      if client.present?
-        client.image_blob_id = image_blob_id
-        client.save!
-        client = client.reload
-      end
+      client.image_blob_id = image_blob_id
+      client.save!
+      client = client.reload
 
-      return {
+      {
         client: client,
-        errors: errors,
+        errors: [],
       }
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/update_enrollment.rb
@@ -8,16 +8,21 @@ module Mutations
 
     def resolve(id:, entry_date: nil, relationship_to_ho_h: nil)
       errors = []
-      enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(id: id)
+      enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
 
       if enrollment
-        enrollment.entry_date = entry_date if entry_date.present?
-        enrollment.relationship_to_ho_h = relationship_to_ho_h if relationship_to_ho_h.present?
-        enrollment.date_updated = DateTime.current
-        enrollment.user_id = hmis_user.user_id
-        enrollment.save!
+        if current_user.permissions_for?(enrollment, :can_edit_enrollments)
+          enrollment.entry_date = entry_date if entry_date.present?
+          enrollment.relationship_to_ho_h = relationship_to_ho_h if relationship_to_ho_h.present?
+          enrollment.date_updated = DateTime.current
+          enrollment.user_id = hmis_user.user_id
+          enrollment.save!
 
-        errors << enrollment.errors.errors unless enrollment.valid?
+          errors << enrollment.errors.errors unless enrollment.valid?
+        else
+          enrollment = nil
+          errors << HmisErrors::Error.new(:enrollment, :not_allowed)
+        end
       else
         errors << HmisErrors::Error.new(:enrollment, :not_found)
       end

--- a/drivers/hmis/app/graphql/mutations/update_funder.rb
+++ b/drivers/hmis/app/graphql/mutations/update_funder.rb
@@ -6,11 +6,12 @@ module Mutations
     field :funder, Types::HmisSchema::Funder, null: true
 
     def resolve(id:, input:)
-      record = Hmis::Hud::Funder.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Funder.viewable_by(current_user).find_by(id: id)
       default_update_record(
         record: record,
         field_name: :funder,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_inventory.rb
+++ b/drivers/hmis/app/graphql/mutations/update_inventory.rb
@@ -6,11 +6,12 @@ module Mutations
     field :inventory, Types::HmisSchema::Inventory, null: true
 
     def resolve(id:, input:)
-      record = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: id)
       default_update_record(
         record: record,
         field_name: :inventory,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_organization.rb
+++ b/drivers/hmis/app/graphql/mutations/update_organization.rb
@@ -6,11 +6,12 @@ module Mutations
     field :organization, Types::HmisSchema::Organization, null: true
 
     def resolve(id:, input:)
-      record = Hmis::Hud::Organization.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Organization.viewable_by(current_user).find_by(id: id)
       default_update_record(
         record: record,
         field_name: :organization,
         input: input,
+        permissions: [:can_edit_organization],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_project.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project.rb
@@ -7,13 +7,14 @@ module Mutations
     field :project, Types::HmisSchema::Project, null: true
 
     def resolve(id:, input:, confirmed:)
-      record = Hmis::Hud::Project.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Project.viewable_by(current_user).find_by(id: id)
       closes_project = record.present? && record.operating_end_date.blank? && input.operating_end_date.present?
       response = default_update_record(
         record: record,
         field_name: :project,
         input: input,
         confirmed: confirmed,
+        permissions: [:can_edit_project_details],
       )
       close_related_records(record) if closes_project && response[:project].present?
       response

--- a/drivers/hmis/app/graphql/mutations/update_project_coc.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_coc.rb
@@ -6,11 +6,12 @@ module Mutations
     field :project_coc, Types::HmisSchema::ProjectCoc, null: true
 
     def resolve(id:, input:)
-      record = Hmis::Hud::ProjectCoc.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::ProjectCoc.viewable_by(current_user).find_by(id: id)
       default_update_record(
         record: record,
         field_name: :project_coc,
         input: input,
+        permissions: [:can_edit_project_details],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_service.rb
+++ b/drivers/hmis/app/graphql/mutations/update_service.rb
@@ -6,11 +6,12 @@ module Mutations
     field :service, Types::HmisSchema::Service, null: true
 
     def resolve(id:, input:)
-      record = Hmis::Hud::Service.editable_by(current_user).find_by(id: id)
+      record = Hmis::Hud::Service.viewable_by(current_user).find_by(id: id)
       default_update_record(
         record: record,
         field_name: :service,
         input: input,
+        permissions: [:can_edit_enrollments],
       )
     end
   end

--- a/drivers/hmis/app/graphql/mutations/update_units.rb
+++ b/drivers/hmis/app/graphql/mutations/update_units.rb
@@ -7,8 +7,9 @@ module Mutations
     field :units, [Types::HmisSchema::Unit], null: false
 
     def resolve(inventory_id:, unit_ids:, name:)
-      inventory = Hmis::Hud::Inventory.editable_by(current_user).find_by(id: inventory_id)
+      inventory = Hmis::Hud::Inventory.viewable_by(current_user).find_by(id: inventory_id)
       return { units: [], errors: [HmisErrors::Error.new(:inventory_id, :not_found)] } unless inventory.present?
+      return { units: [], errors: [HmisErrors::Error.new(:inventory_id, :not_allowed)] } unless current_user.permissions_for?(inventory, :can_edit_project_details)
 
       units = inventory.units.where(id: unit_ids)
       units.update_all(name: name, user_id: hmis_user.user_id, updated_at: Time.now)

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5375,6 +5375,7 @@ enum ValidationType {
   data_not_collected
   information
   invalid
+  not_allowed
   not_found
   out_of_range
   required

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -95,7 +95,7 @@ module Types
         living_situation_options(as: :destination)
 
       when 'PROJECT'
-        Hmis::Hud::Project.editable_by(user).
+        Hmis::Hud::Project.viewable_by(user).
           joins(:organization).
           sort_by_option(:organization_and_name).
           map do |project|
@@ -109,7 +109,7 @@ module Types
         end
 
       when 'ORGANIZATION'
-        Hmis::Hud::Organization.editable_by(user).
+        Hmis::Hud::Organization.viewable_by(user).
           sort_by_option(:name).
           map do |organization|
           {

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
@@ -20,11 +20,11 @@ module Types
 
       if assessment_id.present?
         # Updating an existing assessment
-        assessment = Hmis::Hud::Assessment.editable_by(current_user).find_by(id: assessment_id)
+        assessment = Hmis::Hud::Assessment.viewable_by(current_user).find_by(id: assessment_id)
         errors.add :assessment, :required unless assessment.present?
       elsif enrollment_id.present? && form_definition_id.present?
         # Creating a new assessment
-        enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(id: enrollment_id)
+        enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: enrollment_id)
         form_definition = Hmis::Form::Definition.find_by(id: form_definition_id)
         errors.add :enrollment, :required unless enrollment.present?
         errors.add :form_definition, :required unless form_definition.present?

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
@@ -34,6 +34,10 @@ module Types
 
       return [nil, errors.errors] if errors.any?
 
+      enrollment ||= assessment&.enrollment
+      errors.add :assessment, :not_allowed unless current_user.permissions_for?(enrollment, :can_edit_enrollments)
+      return [nil, errors.errors] if errors.any?
+
       # Create new Assessment (and AssessmentDetail) if one doesn't exist already
       assessment ||= Hmis::Hud::Assessment.new_with_defaults(
         enrollment: enrollment,

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/validation_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/validation_type.rb
@@ -14,6 +14,7 @@ module Types
     value 'invalid'
     value 'information'
     value 'not_found'
+    value 'not_allowed'
     value 'out_of_range'
     value 'server_error'
     value 'data_not_collected'

--- a/drivers/hmis/app/graphql/types/hmis_schema/funder_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/funder_input.rb
@@ -13,7 +13,7 @@ module Types
 
     def to_params
       result = to_h
-      result[:project_id] = Hmis::Hud::Project.editable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
+      result[:project_id] = Hmis::Hud::Project.viewable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
 
       result
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/inventory_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/inventory_input.rb
@@ -23,7 +23,7 @@ module Types
 
     def to_params
       result = to_h
-      result[:project_id] = Hmis::Hud::Project.editable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
+      result[:project_id] = Hmis::Hud::Project.viewable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
 
       result
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project_coc_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project_coc_input.rb
@@ -16,7 +16,7 @@ module Types
 
     def to_params
       result = to_h
-      result[:project_id] = Hmis::Hud::Project.editable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
+      result[:project_id] = Hmis::Hud::Project.viewable_by(current_user).find_by(id: project_id)&.project_id if project_id.present?
 
       result
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project_input.rb
@@ -22,7 +22,7 @@ module Types
     def to_params
       result = to_h.except(:organization_id)
 
-      result[:organization_id] = Hmis::Hud::Organization.editable_by(current_user).find_by(id: organization_id)&.organization_id if organization_id.present?
+      result[:organization_id] = Hmis::Hud::Organization.viewable_by(current_user).find_by(id: organization_id)&.organization_id if organization_id.present?
 
       result
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/service_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/service_input.rb
@@ -27,7 +27,7 @@ module Types
       result[:sub_type_provided] = sub_type_provided.split(':').last&.to_i if sub_type_provided.present?
 
       if enrollment_id.present?
-        enrollment = Hmis::Hud::Enrollment.editable_by(current_user).find_by(id: enrollment_id)
+        enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: enrollment_id)
 
         result[:enrollment_id] = enrollment&.enrollment_id
         result[:personal_id] = enrollment&.personal_id

--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -23,6 +23,7 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
   has_one :wip, class_name: 'Hmis::Wip', as: :source, dependent: :destroy
   has_many :assessment_questions, **hmis_relation(:AssessmentID, 'AssessmentQuestion'), dependent: :destroy
   has_many :assessment_results, **hmis_relation(:AssessmentID, 'AssessmentResult'), dependent: :destroy
+  has_one :project, through: :enrollment
 
   attr_accessor :in_progress
 

--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -41,15 +41,6 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
     left_outer_joins(:wip).where(viewable_wip.or(viewable_completed))
   end
 
-  # hide previous declaration of :editable_by, we'll use this one
-  replace_scope :editable_by, ->(user) do
-    enrollment_ids = Hmis::Hud::Enrollment.editable_by(user).pluck(:id, :EnrollmentID)
-    editable_wip = wip_t[:enrollment_id].in(enrollment_ids.map(&:first))
-    editable_completed = as_t[:EnrollmentID].in(enrollment_ids.map(&:second))
-
-    left_outer_joins(:wip).where(editable_wip.or(editable_completed))
-  end
-
   scope :with_role, ->(role) do
     joins(:assessment_detail).merge(Hmis::Form::AssessmentDetail.with_role(role))
   end

--- a/drivers/hmis/app/models/hmis/hud/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/base.rb
@@ -19,10 +19,6 @@ class Hmis::Hud::Base < ::GrdaWarehouseBase
     none
   end
 
-  scope :editable_by, ->(_) do
-    none
-  end
-
   def self.hmis_relation(col, model_name = nil)
     h = {
       primary_key: [

--- a/drivers/hmis/app/models/hmis/hud/concerns/enrollment_related.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/enrollment_related.rb
@@ -12,10 +12,5 @@ module Hmis::Hud::Concerns::EnrollmentRelated
     replace_scope :viewable_by, ->(user) do
       joins(:enrollment).merge(Hmis::Hud::Enrollment.viewable_by(user))
     end
-
-    # hide previous declaration of :editable_by, we'll use this one
-    replace_scope :editable_by, ->(user) do
-      joins(:enrollment).merge(Hmis::Hud::Enrollment.editable_by(user))
-    end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/concerns/project_related.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/project_related.rb
@@ -12,10 +12,5 @@ module Hmis::Hud::Concerns::ProjectRelated
     replace_scope :viewable_by, ->(user) do
       joins(:project).merge(Hmis::Hud::Project.viewable_by(user))
     end
-
-    # hide previous declaration of :editable_by, we'll use this one
-    replace_scope :editable_by, ->(user) do
-      joins(:project).merge(Hmis::Hud::Project.editable_by(user))
-    end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -49,15 +49,6 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     left_outer_joins(:wip).where(viewable_wip.or(viewable_enrollment))
   end
 
-  # hide previous declaration of :editable_by, we'll use this one
-  replace_scope :editable_by, ->(user) do
-    project_ids = Hmis::Hud::Project.editable_by(user).pluck(:id, :ProjectID)
-    editable_wip = wip_t[:project_id].in(project_ids.map(&:first))
-    editable_enrollment = e_t[:ProjectID].in(project_ids.map(&:second))
-
-    left_outer_joins(:wip).where(editable_wip.or(editable_enrollment))
-  end
-
   scope :in_project_including_wip, ->(ids, project_ids) do
     wip_enrollments = wip_t[:project_id].in(Array.wrap(ids))
     actual_enrollments = e_t[:ProjectID].in(Array.wrap(project_ids))

--- a/drivers/hmis/app/models/hmis/hud/organization.rb
+++ b/drivers/hmis/app/models/hmis/hud/organization.rb
@@ -26,13 +26,6 @@ class Hmis::Hud::Organization < Hmis::Hud::Base
     where(id: ids, data_source_id: user.hmis_data_source_id)
   end
 
-  # hide previous declaration of :editable_by, we'll use this one
-  replace_scope :editable_by, ->(user) do
-    ids = user.editable_organizations.pluck(:id)
-    ids += user.editable_data_sources.joins(:organizations).pluck(o_t[:id])
-    where(id: ids, data_source_id: user.hmis_data_source_id)
-  end
-
   SORT_OPTIONS = [:name].freeze
 
   def self.sort_by_option(option)

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -37,16 +37,6 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     where(id: ids, data_source_id: user.hmis_data_source_id)
   end
 
-  # hide previous declaration of :editable_by, we'll use this one
-  replace_scope :editable_by, ->(user) do
-    ids = user.editable_projects.pluck(:id)
-    ids += user.editable_organizations.joins(:projects).pluck(p_t[:id])
-    ids += user.editable_data_sources.joins(:projects).pluck(p_t[:id])
-    ids += user.editable_project_access_groups.joins(:projects).pluck(p_t[:id])
-
-    where(id: ids, data_source_id: user.hmis_data_source_id)
-  end
-
   # Always use ProjectType, we shouldn't need overrides since we can change the source data
   scope :with_project_type, ->(project_types) do
     where(ProjectType: project_types)

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -15,6 +15,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+  has_one :project, through: :enrollment
 
   validates_with Hmis::Hud::Validators::ServiceValidator
 

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -60,7 +60,7 @@ class Hmis::User < ApplicationRecord
     define_method("#{permission}_for?") do |entity|
       return false unless send("#{permission}?")
 
-      access_group_ids = Hmis::GroupViewableEntity.includes_entity(entity).pluck(:access_group_id)
+      access_group_ids = Hmis::GroupViewableEntity.includes_entity(permissions_base_for_entity(entity)).pluck(:access_group_id)
 
       raise "Invalid entity '#{entity.class.name}'" if access_group_ids.nil?
 
@@ -81,17 +81,38 @@ class Hmis::User < ApplicationRecord
     super opts.merge({ send_instructions: false })
   end
 
-  # private def access_group_ids_for_entity(entity)
-  #   access_group_ids = nil
+  private def permissions_base_for_entity(entity)
+    case entity.class.name
+    when Hmis::Hud::Service.name
+      entity.enrollment.project
+    when Hmis::Hud::Enrollment.name
+      entity.project
+    else
+      entity
+    end
+  end
 
-  #   if entity.is_a?(Hmis::Hud::Project)
-  #     access_group_ids = Hmis::GroupViewableEntity.includes_entity(entity).pluck(:access_group_id)
-  #   elsif entity.is_a?(Hmis::Hud::Organization)
-  #     access_group_ids = Hmis::GroupViewableEntity.includes_organization(entity).pluck(:access_group_id)
-  #   end
+  private def check_permissions_with_mode(*permissions, mode: :any)
+    method_name = mode == :all ? :all? : :any?
+    permissions.send(method_name) { |perm| yield(perm) }
+  end
 
-  #   access_group_ids
-  # end
+  def permission?(permission)
+    respond_to?(permission) ? send(permission) : false
+  end
+
+  def permission_for?(entity, permission)
+    method_name = "#{permission}_for?".to_sym
+    respond_to?(method_name) ? send(method_name, entity) : false
+  end
+
+  def permissions?(*permissions, mode: :any)
+    check_permissions_with_mode(*permissions, mode: mode) { |perm| permission?(perm) }
+  end
+
+  def permissions_for?(entity, *permissions, mode: :any)
+    check_permissions_with_mode(*permissions, mode: mode) { |perm| permission_for?(entity, perm) }
+  end
 
   private def viewable(model)
     model.where(

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -173,6 +173,6 @@ class Hmis::User < ApplicationRecord
   end
 
   def editable_project_ids
-    @editable_project_ids ||= Hmis::Hud::Project.editable_by(self).pluck(:id)
+    @editable_project_ids ||= Hmis::Hud::Project.viewable_by(self).pluck(:id)
   end
 end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -82,14 +82,10 @@ class Hmis::User < ApplicationRecord
   end
 
   private def permissions_base_for_entity(entity)
-    case entity.class.name
-    when Hmis::Hud::Service.name
-      entity.enrollment.project
-    when Hmis::Hud::Enrollment.name
-      entity.project
-    else
-      entity
-    end
+    return entity if entity.is_a? Hmis::Hud::Organization
+    return entity.project if entity.respond_to? :project
+
+    entity
   end
 
   private def check_permissions_with_mode(*permissions, mode: :any)

--- a/drivers/hmis/lib/hmis_errors/error.rb
+++ b/drivers/hmis/lib/hmis_errors/error.rb
@@ -16,7 +16,7 @@ module HmisErrors
 
       # Set default message and full message
       message ||= self.class.default_message_for_type(type)
-      full_message ||= "#{readable_attribute} #{message}"
+      full_message ||= self.class.default_full_message_for_type(readable_attribute, message, type)
 
       {
         attribute: attribute,
@@ -64,12 +64,23 @@ module HmisErrors
       attribute.to_s.underscore.humanize
     end
 
+    def self.default_full_message_for_type(attribute, message, err_type)
+      case err_type.to_sym
+      when :not_allowed
+        "Unauthorized operation on #{attribute}"
+      else
+        "#{attribute} #{message}"
+      end
+    end
+
     def self.default_message_for_type(err_type)
       case err_type.to_sym
       when :data_not_collected
         'is empty'
       when :not_found
         'not found'
+      when :not_allowed
+        'not allowed'
       else
         I18n.t("errors.messages.#{err_type}", default: 'is invalid')
       end

--- a/drivers/hmis/lib/hmis_errors/error.rb
+++ b/drivers/hmis/lib/hmis_errors/error.rb
@@ -16,7 +16,7 @@ module HmisErrors
 
       # Set default message and full message
       message ||= self.class.default_message_for_type(type)
-      full_message ||= self.class.default_full_message_for_type(readable_attribute, message, type)
+      full_message ||= "#{readable_attribute} #{message}"
 
       {
         attribute: attribute,
@@ -64,15 +64,6 @@ module HmisErrors
       attribute.to_s.underscore.humanize
     end
 
-    def self.default_full_message_for_type(attribute, message, err_type)
-      case err_type.to_sym
-      when :not_allowed
-        "Unauthorized operation on #{attribute}"
-      else
-        "#{attribute} #{message}"
-      end
-    end
-
     def self.default_message_for_type(err_type)
       case err_type.to_sym
       when :data_not_collected
@@ -80,7 +71,7 @@ module HmisErrors
       when :not_found
         'not found'
       when :not_allowed
-        'not allowed'
+        'operation not allowed'
       else
         I18n.t("errors.messages.#{err_type}", default: 'is invalid')
       end

--- a/drivers/hmis/spec/factories/hmis/access_groups.rb
+++ b/drivers/hmis/spec/factories/hmis/access_groups.rb
@@ -1,13 +1,9 @@
 FactoryBot.define do
   factory :hmis_role, class: 'Hmis::Role' do
     name { 'Test Role' }
-    can_view_full_ssn { true }
-    can_view_clients { true }
-    can_administer_hmis { true }
-    can_delete_assigned_project_data { true }
-    can_delete_enrollments { true }
-    can_delete_project { true }
-    can_edit_project_details { true }
+    Hmis::Role.permissions_with_descriptions.keys.each do |perm|
+      send(perm) { true }
+    end
   end
 
   factory :hmis_role_with_no_permissions, class: 'Hmis::Role' do

--- a/drivers/hmis/spec/requests/hmis/add_household_members_to_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/add_household_members_to_enrollment_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    it 'should throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_enrollments)
+      response, result = post_graphql(input: test_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        enrollments = result.dig('data', 'addHouseholdMembersToEnrollment', 'enrollments')
+        errors = result.dig('data', 'addHouseholdMembersToEnrollment', 'errors')
+        expect(enrollments).to be_nil
+        expect(errors).to be_present
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(Hmis::Hud::Enrollment.count).to eq(1)
+      end
+    end
+
     it 'should add members to an in-progress enrollment correctly' do
       enrollment.save_in_progress
 

--- a/drivers/hmis/spec/requests/hmis/add_household_members_to_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/add_household_members_to_enrollment_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'addHouseholdMembersToEnrollment', 'errors')
         expect(enrollments).to be_nil
         expect(errors).to be_present
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         expect(Hmis::Hud::Enrollment.count).to eq(1)
       end
     end

--- a/drivers/hmis/spec/requests/hmis/create_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_enrollment_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'createEnrollment', 'errors')
         expect(enrollments).to be_empty
         expect(errors).to be_present
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         expect(Hmis::Hud::Enrollment.count).to eq(0)
       end
     end

--- a/drivers/hmis/spec/requests/hmis/create_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_enrollment_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    it 'should throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_enrollments)
+      response, result = post_graphql(input: test_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        enrollments = result.dig('data', 'createEnrollment', 'enrollments')
+        errors = result.dig('data', 'createEnrollment', 'errors')
+        expect(enrollments).to be_empty
+        expect(errors).to be_present
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(Hmis::Hud::Enrollment.count).to eq(0)
+      end
+    end
+
     describe 'In progress tests' do
       it 'should create WIP enrollment' do
         response, result = post_graphql(input: test_input.merge(in_progress: true)) { mutation }

--- a/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'createOrganization', 'errors')
         expect(organization).to be_nil
         expect(errors).to be_present
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
@@ -58,9 +58,23 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq 200
         organization = result.dig('data', 'createOrganization', 'organization')
         errors = result.dig('data', 'createOrganization', 'errors')
-        # byebug
         expect(organization['id']).to be_present
         expect(errors).to be_empty
+      end
+    end
+
+    it 'throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_organization)
+      mutation_input = test_input
+      response, result = post_graphql(input: mutation_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        organization = result.dig('data', 'createOrganization', 'organization')
+        errors = result.dig('data', 'createOrganization', 'errors')
+        expect(organization).to be_nil
+        expect(errors).to be_present
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_organization_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   after(:all) do
     cleanup_test_environment
   end
+  include_context 'hmis base setup'
 
   describe 'organization creation tests' do
-    let!(:ds1) { create :hmis_data_source }
-    let!(:user) { create(:user).tap { |u| u.add_viewable(ds1) } }
+    # let!(:ds1) { create :hmis_data_source }
+    # let!(:user) { create(:user).tap { |u| u.add_viewable(ds1) } }
     before(:each) do
       hmis_login(user)
+      assign_viewable(edit_access_group, ds1, hmis_user)
     end
 
     let(:mutation) do
@@ -56,6 +58,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq 200
         organization = result.dig('data', 'createOrganization', 'organization')
         errors = result.dig('data', 'createOrganization', 'errors')
+        # byebug
         expect(organization['id']).to be_present
         expect(errors).to be_empty
       end

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
 
+  it 'should throw error if unauthorized' do
+    remove_permissions(hmis_user, :can_delete_enrollments)
+    response, result = post_graphql(input: { id: e1.id }) { mutation }
+
+    aggregate_failures 'checking response' do
+      expect(response.status).to eq 200
+      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
+      errors = result.dig('data', 'deleteEnrollment', 'errors')
+      expect(enrollment).to be_nil
+      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
+        have_attributes(id: e1.id),
+        have_attributes(id: e2.id),
+      )
+    end
+  end
+
   it 'should delete an enrollment that is in progress' do
     response, result = post_graphql(input: { id: e2.id }) { mutation }
 

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -53,23 +53,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
 
-  it 'should throw error if unauthorized' do
-    remove_permissions(hmis_user, :can_delete_enrollments)
-    response, result = post_graphql(input: { id: e1.id }) { mutation }
-
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
-      errors = result.dig('data', 'deleteEnrollment', 'errors')
-      expect(enrollment).to be_nil
-      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
-      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
-        have_attributes(id: e1.id),
-        have_attributes(id: e2.id),
-      )
-    end
-  end
-
   it 'should delete an enrollment that is in progress' do
     response, result = post_graphql(input: { id: e2.id }) { mutation }
 
@@ -81,6 +64,23 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(errors).to be_empty
       expect(Hmis::Hud::Enrollment.all).to contain_exactly(
         have_attributes(id: e1.id),
+      )
+    end
+  end
+
+  it 'should throw error if unauthorized' do
+    remove_permissions(hmis_user, :can_delete_enrollments)
+    response, result = post_graphql(input: { id: e2.id }) { mutation }
+
+    aggregate_failures 'checking response' do
+      expect(response.status).to eq 200
+      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
+      errors = result.dig('data', 'deleteEnrollment', 'errors')
+      expect(enrollment).to be_nil
+      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
+      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
+        have_attributes(id: e1.id),
+        have_attributes(id: e2.id),
       )
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(response.status).to eq 200
       service = result.dig('data', 'deleteService', 'service')
       errors = result.dig('data', 'deleteService', 'errors')
-      expect(service).to be_present
-      expect(errors).to contain_exactly(include('message' => 'not allowed'))
+      expect(service).to be_nil
+      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
       expect(Hmis::Hud::Service.count).to eq(1)
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       service = result.dig('data', 'deleteService', 'service')
       errors = result.dig('data', 'deleteService', 'errors')
       expect(service).to be_nil
-      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
       expect(Hmis::Hud::Service.count).to eq(1)
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(errors).to contain_exactly(include('fullMessage' => 'Service not found'))
     end
   end
+
+  it 'should error if not allowed to delete a service' do
+    remove_permissions(hmis_user, :can_edit_enrollments)
+    response, result = post_graphql(id: s1.id) { mutation }
+
+    aggregate_failures 'checking response' do
+      expect(response.status).to eq 200
+      service = result.dig('data', 'deleteService', 'service')
+      errors = result.dig('data', 'deleteService', 'errors')
+      expect(service).to be_present
+      expect(errors).to contain_exactly(include('message' => 'not allowed'))
+      expect(Hmis::Hud::Service.count).to eq(1)
+    end
+  end
 end
 
 RSpec.configure do |c|

--- a/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
+++ b/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
@@ -21,3 +21,15 @@ def remove_viewable(access_group, viewable, user)
   access_group.remove_viewable(viewable)
   access_group.access_controls&.first&.remove(user)
 end
+
+def set_permissions(user, value, *permissions)
+  user.roles.update_all(**permissions.map { |p| [p, value] }.to_h)
+end
+
+def add_permissions(user, *permissions)
+  set_permissions(user, true, *permissions)
+end
+
+def remove_permissions(user, *permissions)
+  set_permissions(user, false, *permissions)
+end

--- a/drivers/hmis/spec/requests/hmis/set_hoh_for_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/set_hoh_for_enrollment_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
 
+  it 'should throw error if unauthorized' do
+    remove_permissions(hmis_user, :can_edit_enrollments)
+    response, result = post_graphql(input: { household_id: '1', client_id: c3.id }) { mutation }
+
+    aggregate_failures 'checking response' do
+      expect(response.status).to eq 200
+      enrollment = result.dig('data', 'setHoHForEnrollment', 'enrollment')
+      errors = result.dig('data', 'setHoHForEnrollment', 'errors')
+      expect(enrollment).to be_nil
+      expect(errors).to be_present
+      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+    end
+  end
+
   describe 'Validity tests' do
     [
       [

--- a/drivers/hmis/spec/requests/hmis/set_hoh_for_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/set_hoh_for_enrollment_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       errors = result.dig('data', 'setHoHForEnrollment', 'errors')
       expect(enrollment).to be_nil
       expect(errors).to be_present
-      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/update_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_enrollment_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   describe 'with view access' do
     before(:each) do
       hmis_login(user)
+      remove_permissions(hmis_user, :can_edit_enrollments)
       assign_viewable(view_access_group, p1.as_warehouse, hmis_user)
     end
     it 'should not update enrollment' do

--- a/drivers/hmis/spec/requests/hmis/update_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_enrollment_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'updateEnrollment', 'errors')
         expect(e2.reload.date_updated > prev_date_updated).to eq(false)
         expect(e2.reload.user_id).to eq(u2.user_id)
-        expect(enrollment).to be_blank
+        expect(enrollment).to be_nil
         expect(errors).to be_present
 
         expect(Hmis::Hud::Enrollment.all).to contain_exactly(

--- a/drivers/hmis/spec/requests/hmis/update_funder_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_funder_spec.rb
@@ -58,6 +58,24 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    it 'should throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_project_details)
+      response, result = post_graphql(id: f1.id, input: valid_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        record = result.dig('data', 'updateFunder', 'funder')
+        errors = result.dig('data', 'updateFunder', 'errors')
+        expect(errors).to be_present
+        expect(record).to be_nil
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        record = Hmis::Hud::Funder.find(f1.id)
+        expect(record.funder).to eq 20
+        expect(record.date_created).to eq(f1.date_created)
+        expect(record.date_updated).to eq(f1.date_updated)
+      end
+    end
+
     it 'fails if grant id is null' do
       response, result = post_graphql(id: f1.id, input: { **valid_input, grant_id: nil }) { mutation }
 

--- a/drivers/hmis/spec/requests/hmis/update_funder_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_funder_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'updateFunder', 'errors')
         expect(errors).to be_present
         expect(record).to be_nil
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         record = Hmis::Hud::Funder.find(f1.id)
         expect(record.funder).to eq 20
         expect(record.date_created).to eq(f1.date_created)

--- a/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
@@ -60,6 +60,22 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    it 'should throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_project_details)
+      response, result = post_graphql(id: i1.id, input: valid_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        record = result.dig('data', 'updateInventory', 'inventory')
+        errors = result.dig('data', 'updateInventory', 'errors')
+        expect(errors).to be_present
+        expect(record).to be_nil
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        inventory = Hmis::Hud::Inventory.find(i1.id)
+        expect(inventory.coc_code).to eq pc1.coc_code
+      end
+    end
+
     it 'fails if coc code is invalid' do
       response, result = post_graphql(id: i1.id, input: { **valid_input, coc_code: 'FL-512' }) { mutation }
 

--- a/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_inventory_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'updateInventory', 'errors')
         expect(errors).to be_present
         expect(record).to be_nil
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         inventory = Hmis::Hud::Inventory.find(i1.id)
         expect(inventory.coc_code).to eq pc1.coc_code
       end

--- a/drivers/hmis/spec/requests/hmis/update_organization_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_organization_spec.rb
@@ -78,6 +78,24 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(errors).to be_empty
       end
     end
+
+    it 'should throw error if unauthorized' do
+      prev_date_updated = o1.date_updated
+      remove_permissions(hmis_user, :can_edit_organization)
+      aggregate_failures 'checking response' do
+        expect(o1.user_id).to eq(u2.user_id)
+
+        response, result = post_graphql(id: o1.id, input: test_input) { mutation }
+
+        expect(response.status).to eq 200
+        organization = result.dig('data', 'updateOrganization', 'organization')
+        errors = result.dig('data', 'updateOrganization', 'errors')
+        expect(organization).to be_nil
+        expect(errors).to be_present
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(o1.reload.date_updated == prev_date_updated).to eq(true)
+      end
+    end
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/update_organization_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_organization_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'updateOrganization', 'errors')
         expect(organization).to be_nil
         expect(errors).to be_present
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         expect(o1.reload.date_updated == prev_date_updated).to eq(true)
       end
     end

--- a/drivers/hmis/spec/requests/hmis/update_project_coc_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_project_coc_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         errors = result.dig('data', 'updateProjectCoc', 'errors')
         expect(errors).to be_present
         expect(record).to be_nil
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         record = Hmis::Hud::ProjectCoc.find(pc1.id)
         expect(record.coc_code).to eq(pc1.coc_code)
       end

--- a/drivers/hmis/spec/requests/hmis/update_project_coc_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_project_coc_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    it 'should throw error if unauthorized' do
+      remove_permissions(hmis_user, :can_edit_project_details)
+      response, result = post_graphql(id: pc1.id, input: valid_input) { mutation }
+
+      aggregate_failures 'checking response' do
+        expect(response.status).to eq 200
+        record = result.dig('data', 'updateProjectCoc', 'projectCoc')
+        errors = result.dig('data', 'updateProjectCoc', 'errors')
+        expect(errors).to be_present
+        expect(record).to be_nil
+        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        record = Hmis::Hud::ProjectCoc.find(pc1.id)
+        expect(record.coc_code).to eq(pc1.coc_code)
+      end
+    end
+
     it 'fails if coc code is null' do
       response, result = post_graphql(id: pc1.id, input: { **valid_input, coc_code: nil }) { mutation }
 

--- a/drivers/hmis/spec/requests/hmis/update_project_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_project_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         project = result.dig('data', 'updateProject', 'project')
         errors = result.dig('data', 'updateProject', 'errors')
         expect(errors).to be_present
-        expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
         expect(project).to be_nil
 
         project = Hmis::Hud::Project.find(p1.id)

--- a/drivers/hmis/spec/requests/hmis/update_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       service = result.dig('data', 'updateService', 'service')
       errors = result.dig('data', 'updateService', 'errors')
       expect(errors).to be_present
-      expect(errors).to contain_exactly(include('message' => 'operation not allowed'))
+      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
       expect(service).to be_nil
 
       service = Hmis::Hud::Service.find(s1.id)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184586495

@gigxz This PR should handle all of the mutations you listed in the issue. However, there were a number of `create_x` mutations that were not mentioned in the issue, so I have not implemented permissions for those. Since the `editable_by` scope is now gone, it may well mean that those mutations are no longer properly protected if they were using `editable_by`.

Is it correct to leave those un-implemented, or should implement them now? If so, what permissions would you like me to use?