### PR TITLE
Ignore deleted "recent items"

### DIFF
--- a/app/models/concerns/has_recent_items.rb
+++ b/app/models/concerns/has_recent_items.rb
@@ -14,7 +14,7 @@ module HasRecentItems
     end
 
     def recent_items
-      sorted_recent_item_links.preload(:item).map(&:item)
+      sorted_recent_item_links.preload(:item).map(&:item).compact
     end
 
     def add_recent_item(item)


### PR DESCRIPTION
Fixes a bug where GraphQL request would fail if any of a users "recent items" (clients or projects) have been deleted.