### PR TITLE
Use record ID as access type ID if present

### DIFF
--- a/drivers/hmis/app/graphql/types/base_access.rb
+++ b/drivers/hmis/app/graphql/types/base_access.rb
@@ -14,7 +14,7 @@ module Types
         field :id, ID, null: false
 
         def id
-          [object.respond_to?(:id) ? object.id : nil, current_user&.id].compact.join(':')
+          [object.respond_to?(:id) ? object.id : nil, current_user&.id].compact.first
         end
       end
     end


### PR DESCRIPTION
I don't think there's any need to throw `current_user.id` into the ID if the object already has an ID. Using the object ID allows us to read directly from the apollo cache (https://github.com/greenriver/hmis-frontend/pull/215)