### PR TITLE
Add global feature flags; resolve MCI ID even if missing

### DIFF
--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -28,6 +28,12 @@ class Hmis::AppSettingsController < Hmis::BaseController
       unlockAccountUrl: "https://#{hostname}/users/unlock/new",
       manageAccountUrl: "https://#{hostname}/account/edit",
       casUrl: GrdaWarehouse::Config.get(:cas_url),
+      globalFeatureFlags: {
+        # Whether to show MCI ID in client search results
+        mciId: GrdaWarehouse::RemoteCredentials::Oauth.where(slug: 'mci').exists?,
+        # Whether to show Referral and Denial screens
+        externalReferrals: GrdaWarehouse::RemoteCredential.where(slug: 'mper').exists?,
+      },
     }
   end
 end

--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -30,9 +30,9 @@ class Hmis::AppSettingsController < Hmis::BaseController
       casUrl: GrdaWarehouse::Config.get(:cas_url),
       globalFeatureFlags: {
         # Whether to show MCI ID in client search results
-        mciId: GrdaWarehouse::RemoteCredentials::Oauth.where(slug: 'mci').exists?,
+        mciId: HmisExternalApis::Mci.enabled?,
         # Whether to show Referral and Denial screens
-        externalReferrals: GrdaWarehouse::RemoteCredential.where(slug: 'mper').exists?,
+        externalReferrals: GrdaWarehouse::RemoteCredential.active.where(slug: 'mper').exists?,
       },
     }
   end

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1623,7 +1623,7 @@ type ExternalIdentifier {
   """
   The identifier value
   """
-  identifier: ID!
+  identifier: ID
   label: String!
   url: String
 }

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -106,7 +106,6 @@ module Types
 
     def external_ids
       object.external_identifiers(current_user).
-        reject { |_k, vals| vals[:id].nil? }.
         map do |key, vals|
           {
             id: [key, object.id].join(':'),

--- a/drivers/hmis/app/graphql/types/hmis_schema/external_identifier.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/external_identifier.rb
@@ -10,7 +10,7 @@ module Types
   class HmisSchema::ExternalIdentifier < Types::BaseObject
     description 'External Identifier'
     field :id, ID, 'API ID, not the actual identifier value', null: false
-    field :identifier, ID, 'The identifier value', null: false
+    field :identifier, ID, 'The identifier value', null: true
     field :url, String, null: true
     field :label, String, null: false
 

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -120,7 +120,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   def external_identifiers(user = nil)
-    {
+    external_identifiers = {
       client_id: {
         id: id,
         label: 'HMIS ID',
@@ -134,12 +134,17 @@ class Hmis::Hud::Client < Hmis::Hud::Base
         url: warehouse_url,
         label: 'Warehouse ID',
       },
-      mci_id: {
+    }
+
+    if GrdaWarehouse::RemoteCredentials::Oauth.where(slug: 'mci').exists?
+      external_identifiers[:mci_id] = {
         id: mci_id,
         url: mci_url(user),
         label: 'MCI ID',
-      },
-    }
+      }
+    end
+
+    external_identifiers
   end
 
   SORT_OPTIONS = [

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -136,7 +136,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
       },
     }
 
-    if GrdaWarehouse::RemoteCredentials::Oauth.where(slug: 'mci').exists?
+    if HmisExternalApis::Mci.enabled?
       external_identifiers[:mci_id] = {
         id: mci_id,
         url: mci_url(user),

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/mci.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/mci.rb
@@ -143,6 +143,10 @@ module HmisExternalApis
     #   conn.get('clients/v1/api/Lookup/logicalTables')
     # end
 
+    def self.enabled?
+      ::GrdaWarehouse::RemoteCredentials::Oauth.active.where(slug: 'mci').exists?
+    end
+
     private
 
     def save_log!(result, payload)
@@ -169,7 +173,7 @@ module HmisExternalApis
     end
 
     def creds
-      @creds ||= ::GrdaWarehouse::RemoteCredentials::Oauth.find_by(slug: 'mci')
+      @creds ||= ::GrdaWarehouse::RemoteCredentials::Oauth.active.find_by(slug: 'mci')
     end
 
     def conn


### PR DESCRIPTION
Add global feature flag for mci and referrals. Later, we will probably want to set up a system for feature flags that can be toggled at the user-level, but this isn't that.

Also shows MCI ID on profile even if it's missing, so it's clear to the user that the client is "uncleared."

Frontend PR that relies on this: https://github.com/greenriver/hmis-frontend/pull/237