### PR TITLE
fix issue with rack-attack session timeouts 185008282

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,6 +44,12 @@ class Rack::Attack
   end
 
   def self.warden_user_present?(request)
+    # Avoid calling warden for user status endpoints. Calling warden here bumps
+    # last_request_at, regardless of skip_trackable in the controller. This means
+    # sessions may not expire as expected
+    strip_path = request.path.split('.', 2)[0]
+    return false if strip_path == '/hmis/user' || strip_path == '/active'
+
     request.env['warden']&.user.present? || request.env['warden']&.user(:hmis_user).present?
   end
 


### PR DESCRIPTION
Avoid calling warden for user status endpoints in rack-attack. Calling warden bumps last_request_at, regardless of skip_trackable in the controller. This means sessions may not expire as expected. 

Notes:
* My fix is somewhat crude but shouldn't cause side effects.
* When I was working on extending our okta support, I hit a number of strange bugs that I couldn't explain. I suspect this call to warden from within rack-attack was the cause. I wonder if there's a way we could avoid this?