### PR TITLE
Resolve all related record types directly on the Assessment

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -60,9 +60,13 @@ type Assessment {
   dateCreated: ISO8601DateTime!
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime!
+  disabilityGroup: DisabilityGroup
   enrollment: Enrollment!
+  exit: Exit
+  healthAndDv: HealthAndDv
   id: ID!
   inProgress: Boolean!
+  incomeBenefit: IncomeBenefit
   user: User
 }
 
@@ -1108,6 +1112,207 @@ type DeleteUnitsPayload {
 }
 
 """
+3.12.1
+"""
+enum Destination {
+  """
+  (8) Client doesn't know
+  """
+  CLIENT_DOESN_T_KNOW
+
+  """
+  (9) Client refused
+  """
+  CLIENT_REFUSED
+
+  """
+  (99) Data not collected
+  """
+  DATA_NOT_COLLECTED
+
+  """
+  (24) Deceased
+  """
+  DECEASED
+
+  """
+  (1) Emergency shelter, including hotel or motel paid for with emergency shelter voucher, or RHY-funded Host Home shelter
+  """
+  EMERGENCY_SHELTER_INCLUDING_HOTEL_OR_MOTEL_PAID_FOR_WITH_EMERGENCY_SHELTER_VOUCHER_OR_RHY_FUNDED_HOST_HOME_SHELTER
+
+  """
+  (15) Foster care home or foster care group home
+  """
+  FOSTER_CARE_HOME_OR_FOSTER_CARE_GROUP_HOME
+
+  """
+  (6) Hospital or other residential non-psychiatric medical facility
+  """
+  HOSPITAL_OR_OTHER_RESIDENTIAL_NON_PSYCHIATRIC_MEDICAL_FACILITY
+
+  """
+  (32) Host Home (non-crisis)
+  """
+  HOST_HOME_NON_CRISIS
+
+  """
+  (14) Hotel or motel paid for without emergency shelter voucher
+  """
+  HOTEL_OR_MOTEL_PAID_FOR_WITHOUT_EMERGENCY_SHELTER_VOUCHER
+
+  """
+  Invalid Value
+  """
+  INVALID
+
+  """
+  (7) Jail, prison or juvenile detention facility
+  """
+  JAIL_PRISON_OR_JUVENILE_DETENTION_FACILITY
+
+  """
+  (25) Long-term care facility or nursing home
+  """
+  LONG_TERM_CARE_FACILITY_OR_NURSING_HOME
+
+  """
+  (26) Moved from one HOPWA funded project to HOPWA PH
+  """
+  MOVED_FROM_ONE_HOPWA_FUNDED_PROJECT_TO_HOPWA_PH
+
+  """
+  (27) Moved from one HOPWA funded project to HOPWA TH
+  """
+  MOVED_FROM_ONE_HOPWA_FUNDED_PROJECT_TO_HOPWA_TH
+
+  """
+  (30) No exit interview completed
+  """
+  NO_EXIT_INTERVIEW_COMPLETED
+
+  """
+  (17) Other
+  """
+  OTHER
+
+  """
+  (11) Owned by client, no ongoing housing subsidy
+  """
+  OWNED_BY_CLIENT_NO_ONGOING_HOUSING_SUBSIDY
+
+  """
+  (21) Owned by client, with ongoing housing subsidy
+  """
+  OWNED_BY_CLIENT_WITH_ONGOING_HOUSING_SUBSIDY
+
+  """
+  (3) Permanent housing (other than RRH) for formerly homeless persons
+  """
+  PERMANENT_HOUSING_OTHER_THAN_RRH_FOR_FORMERLY_HOMELESS_PERSONS
+
+  """
+  (16) Place not meant for habitation (e.g., a vehicle, an abandoned building,
+  bus/train/subway station/airport or anywhere outside)
+  """
+  PLACE_NOT_MEANT_FOR_HABITATION_E_G_A_VEHICLE_AN_ABANDONED_BUILDING_BUS_TRAIN_SUBWAY_STATION_AIRPORT_OR_ANYWHERE_OUTSIDE
+
+  """
+  (4) Psychiatric hospital or other psychiatric facility
+  """
+  PSYCHIATRIC_HOSPITAL_OR_OTHER_PSYCHIATRIC_FACILITY
+
+  """
+  (34) Rental by client in a public housing unit
+  """
+  RENTAL_BY_CLIENT_IN_A_PUBLIC_HOUSING_UNIT
+
+  """
+  (10) Rental by client, no ongoing housing subsidy
+  """
+  RENTAL_BY_CLIENT_NO_ONGOING_HOUSING_SUBSIDY
+
+  """
+  (28) Rental by client, with GPD TIP housing subsidy
+  """
+  RENTAL_BY_CLIENT_WITH_GPD_TIP_HOUSING_SUBSIDY
+
+  """
+  (33) Rental by client, with HCV voucher (tenant or project based)
+  """
+  RENTAL_BY_CLIENT_WITH_HCV_VOUCHER_TENANT_OR_PROJECT_BASED
+
+  """
+  (20) Rental by client, with other ongoing housing subsidy
+  """
+  RENTAL_BY_CLIENT_WITH_OTHER_ONGOING_HOUSING_SUBSIDY
+
+  """
+  (31) Rental by client, with RRH or equivalent subsidy
+  """
+  RENTAL_BY_CLIENT_WITH_RRH_OR_EQUIVALENT_SUBSIDY
+
+  """
+  (19) Rental by client, with VASH housing subsidy
+  """
+  RENTAL_BY_CLIENT_WITH_VASH_HOUSING_SUBSIDY
+
+  """
+  (29) Residential project or halfway house with no homeless criteria
+  """
+  RESIDENTIAL_PROJECT_OR_HALFWAY_HOUSE_WITH_NO_HOMELESS_CRITERIA
+
+  """
+  (18) Safe Haven
+  """
+  SAFE_HAVEN
+
+  """
+  (35) Staying or living in a family member's room, apartment or house
+  """
+  STAYING_OR_LIVING_IN_A_FAMILY_MEMBER_S_ROOM_APARTMENT_OR_HOUSE
+
+  """
+  (36) Staying or living in a friend's room, apartment or house
+  """
+  STAYING_OR_LIVING_IN_A_FRIEND_S_ROOM_APARTMENT_OR_HOUSE
+
+  """
+  (22) Staying or living with family, permanent tenure
+  """
+  STAYING_OR_LIVING_WITH_FAMILY_PERMANENT_TENURE
+
+  """
+  (12) Staying or living with family, temporary tenure (e.g. room, apartment or house)
+  """
+  STAYING_OR_LIVING_WITH_FAMILY_TEMPORARY_TENURE_E_G_ROOM_APARTMENT_OR_HOUSE
+
+  """
+  (23) Staying or living with friends, permanent tenure
+  """
+  STAYING_OR_LIVING_WITH_FRIENDS_PERMANENT_TENURE
+
+  """
+  (13) Staying or living with friends, temporary tenure (e.g. room apartment or house)
+  """
+  STAYING_OR_LIVING_WITH_FRIENDS_TEMPORARY_TENURE_E_G_ROOM_APARTMENT_OR_HOUSE
+
+  """
+  (5) Substance abuse treatment facility or detox center
+  """
+  SUBSTANCE_ABUSE_TREATMENT_FACILITY_OR_DETOX_CENTER
+
+  """
+  (2) Transitional housing for homeless persons (including homeless youth)
+  """
+  TRANSITIONAL_HOUSING_FOR_HOMELESS_PERSONS_INCLUDING_HOMELESS_YOUTH
+
+  """
+  (37) Worker unable to determine
+  """
+  WORKER_UNABLE_TO_DETERMINE
+}
+
+"""
 Represents direct upload credentials
 """
 type DirectUpload {
@@ -1387,16 +1592,20 @@ type Enrollment {
   dateDeleted: ISO8601DateTime
   dateToStreetEssh: ISO8601Date
   dateUpdated: ISO8601DateTime!
+  disabilities(limit: Int, offset: Int): DisabilitiesPaginated!
+  disabilityGroups: [DisabilityGroup!]!
   disablingCondition: NoYesReasonsForMissingData
   entryDate: ISO8601Date!
   events(limit: Int, offset: Int, sortOrder: EventSortOption): EventsPaginated!
   exitAssessment: Assessment
   exitDate: ISO8601Date
   files(limit: Int, offset: Int, sortOrder: FileSortOption): FilesPaginated!
+  healthAndDvs(limit: Int, offset: Int): HealthAndDvsPaginated!
   household: Household!
   householdSize: Int!
   id: ID!
   inProgress: Boolean!
+  incomeBenefits(limit: Int, offset: Int): IncomeBenefitsPaginated!
   intakeAssessment: Assessment
   lengthOfStay: ResidencePriorLengthOfStay
   livingSituation: LivingSituation
@@ -1653,6 +1862,19 @@ type EventsPaginated {
   nodesCount: Int!
   offset: Int!
   pagesCount: Int!
+}
+
+type Exit {
+  client: Client!
+  dateCreated: ISO8601DateTime!
+  dateDeleted: ISO8601DateTime
+  dateUpdated: ISO8601DateTime!
+  destination: Destination!
+  enrollment: Enrollment!
+  exitDate: ISO8601Date!
+  id: ID!
+  otherDestination: String
+  user: User
 }
 
 """

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -13,6 +13,10 @@ module Types
     include Types::HmisSchema::HasAssessments
     include Types::HmisSchema::HasCeAssessments
     include Types::HmisSchema::HasFiles
+    include Types::HmisSchema::HasIncomeBenefits
+    include Types::HmisSchema::HasDisabilities
+    include Types::HmisSchema::HasDisabilityGroups
+    include Types::HmisSchema::HasHealthAndDvs
 
     def self.configuration
       Hmis::Hud::Enrollment.hmis_configuration(version: '2022')
@@ -29,6 +33,10 @@ module Types
     services_field
     files_field
     ce_assessments_field
+    income_benefits_field
+    disabilities_field
+    disability_groups_field
+    health_and_dvs_field
     field :household, HmisSchema::Household, null: false
     field :household_size, Integer, null: false
     field :client, HmisSchema::Client, null: false
@@ -105,6 +113,22 @@ module Types
 
     def files(**args)
       resolve_files(**args)
+    end
+
+    def income_benefits(**args)
+      resolve_income_benefits(**args)
+    end
+
+    def disabilities(**args)
+      resolve_disabilities(**args)
+    end
+
+    def disability_groups(**args)
+      resolve_disability_groups(**args)
+    end
+
+    def health_and_dvs(**args)
+      resolve_health_and_dvs(**args)
     end
 
     def user

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -114,6 +114,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               #{scalar_fields(Types::HmisSchema::Service)}
             }
           }
+          incomeBenefits {
+            nodesCount
+            nodes {
+              #{scalar_fields(Types::HmisSchema::IncomeBenefit)}
+            }
+          }
+          healthAndDvs {
+            nodesCount
+            nodes {
+              #{scalar_fields(Types::HmisSchema::HealthAndDv)}
+            }
+          }
+          disabilities {
+            nodesCount
+            nodes {
+              #{scalar_fields(Types::HmisSchema::Disability)}
+            }
+          }
+          disabilityGroups {
+            #{scalar_fields(Types::HmisSchema::DisabilityGroup)}
+          }
         }
       }
     GRAPHQL
@@ -169,6 +190,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(enrollment['services']['nodesCount']).to eq(2)
       expect(enrollment['events']['nodesCount']).to eq(1)
       expect(enrollment['assessments']['nodesCount']).to eq(1)
+      expect(enrollment['incomeBenefits']['nodesCount']).to eq(1)
+      expect(enrollment['disabilities']['nodesCount']).to eq(1)
+      expect(enrollment['healthAndDvs']['nodesCount']).to eq(1)
+      expect(enrollment['disabilityGroups'].size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Resolve related records on the Assessment, so that they can be used to construct the initial form state (https://www.pivotaltracker.com/n/projects/2591838/stories/185008164)