### PR TITLE
Bug fix in Involvement API; Check for uniqueness of referral identifiers

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_referral_posting_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_referral_posting_job.rb
@@ -6,6 +6,20 @@
 
 # An HMIS User changes the status of a Posting, for example accepting/rejecting/denying
 # a household into a program/project
+
+# The following "new statuses" are allowed to be sent.
+# For example, a posting that was in Assigned status
+# is allowed to be changed to "AcceptedPending" OR "DeniedPending"
+#
+# ---------------------------------------------------
+# New Status             | Old Status
+# ---------------------------------------------------
+# Closed(13)             | Accepted(20), Denied(21)
+# AcceptedPending(18)    | Assigned(12)
+# DeniedPending(19)      | Assigned(12), AcceptedPending(18)
+# Accepted(20)           | AcceptedPending(18)
+# Denied(21)             | DeniedPending(19)
+
 module HmisExternalApis::AcHmis
   class UpdateReferralPostingJob < ApplicationJob
     include HmisExternalApis::AcHmis::ReferralJobMixin
@@ -15,6 +29,8 @@ module HmisExternalApis::AcHmis
     # @param referral_result [Integer] Only for denials. Value from HUD list 4.20.D.
     # @param url [String]
     def perform(identifier:, status:, url:, referral_result: nil)
+      raise 'Invalid status. Expected one of: [Closed(13), AcceptedPending(18), DeniedPending(19), Accepted(20), Denied(21)]' unless [13, 18, 19, 20, 21].include?(status)
+
       payload = {
         posting_id: identifier,
         posting_status: status,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/program_involvement.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/program_involvement.rb
@@ -41,7 +41,7 @@ module HmisExternalApis::AcHmis
         message << 'end_date was not formatted correctly.'
       end
 
-      self.project = Hmis::Hud::Project.find_by(project_id: program_id)
+      self.project = Hmis::Hud::Project.find_by(project_id: program_id, data_source_id: data_source.id)
       message << 'program not found.' if project.blank?
 
       if message.present?

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/program_involvement_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/program_involvement_spec.rb
@@ -8,6 +8,7 @@ require 'rails_helper'
 
 RSpec.describe HmisExternalApis::AcHmis::ProgramInvolvement, type: :model do
   describe 'basics' do
+    let!(:ds) { create(:hmis_data_source) }
     let(:involvement) { HmisExternalApis::AcHmis::ProgramInvolvement.new({}) }
 
     before { involvement.validate_request! }

--- a/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
+++ b/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request 
     end
   end
 
-  before { create(:hmis_data_source) }
+  let!(:ds) { create(:hmis_data_source) }
+  let!(:org) { create(:hmis_hud_organization, data_source: ds) }
+  let!(:project) { create(:hmis_hud_project, data_source: ds, organization: org) }
 
   describe 'client involvement' do
     it 'works minimally' do
@@ -35,12 +37,6 @@ RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request 
   end
 
   describe 'program involvement' do
-    let(:project) do
-      ds = create(:source_data_source, id: 1)
-      org = create(:hud_organization, data_source_id: ds.id)
-      create(:hud_project, data_source_id: ds.id, OrganizationID: org.OrganizationID)
-    end
-
     it 'works minimally' do
       api_get(:program, { start_date: '2000-01-01', end_date: '2000-01-10', program_id: project.project_id })
 


### PR DESCRIPTION
Fixing an issue I saw in QA and adding a couple more errors