### PR TITLE
Stop resolving duplicate households; include WIP households

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -99,7 +99,7 @@ module Types
     end
 
     def households(**args)
-      resolve_households(**args)
+      resolve_households(object.households_including_wip, **args)
     end
 
     def referral_requests(**args)

--- a/drivers/hmis/app/models/hmis/hud/household.rb
+++ b/drivers/hmis/app/models/hmis/hud/household.rb
@@ -15,11 +15,19 @@ class Hmis::Hud::Household < Hmis::Hud::Base
   has_many :clients, through: :enrollments
 
   replace_scope :viewable_by, ->(user) do
-    joins(:enrollments).merge(Hmis::Hud::Enrollment.viewable_by(user))
+    viewable_households = joins(:enrollments).
+      merge(Hmis::Hud::Enrollment.viewable_by(user)). # does Data Source filter
+      pluck(:HouseholdID)
+
+    where(HouseholdID: viewable_households)
   end
 
   scope :client_matches_search_term, ->(text_search) do
-    joins(:clients).merge(Hmis::Hud::Client.matching_search_term(text_search.to_s))
+    matching_ids = joins(:clients).
+      merge(Hmis::Hud::Client.matching_search_term(text_search.to_s)).
+      pluck(:id)
+
+    where(id: matching_ids)
   end
 
   scope :open_on_date, ->(date) do

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -28,6 +28,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :units, dependent: :destroy
   has_many :custom_data_elements, as: :owner
 
+  # Households in this Project, NOT including WIP Enrollments
   has_many :households, through: :enrollments
 
   has_and_belongs_to_many :project_groups,
@@ -94,6 +95,12 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     enrollment_ids = enrollments.pluck(:id)
     wip_ids = wip_enrollments.pluck(:id)
     Hmis::Hud::Enrollment.where(id: enrollment_ids + wip_ids)
+  end
+
+  def households_including_wip
+    household_ids = enrollments_including_wip.pluck(:household_id)
+
+    Hmis::Hud::Household.where(HouseholdID: household_ids, data_source_id: data_source_id)
   end
 
   def close_related_funders_and_inventory!


### PR DESCRIPTION
* Fix a bug where households were being resolved repeatedly (once per member) due to joins with enrollments
* Resolve WIP-only households on Project