### PR TITLE
Update MCI mapping

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_mapping.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_mapping.rb
@@ -68,8 +68,8 @@ module HmisExternalApis::AcHmis
       # Female only
       elsif client.gender_multi == [0]
         2
-      # Any other gender(s)
-      elsif client.gender_multi.excluding(8, 9, 99).any?
+      # Missing or any other gender(s)
+      else
         4
       end
     end


### PR DESCRIPTION
`genderCode` is now a required field, so we need to send 4 when it's not present.