### PR TITLE
Move MCI clearance to bottom, add deps

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/fragments/client_mci.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/client_mci.json
@@ -39,6 +39,24 @@
           "question": "dob-dq",
           "operator": "EQUAL",
           "answer_code": "FULL_DOB_REPORTED"
+        },
+        {
+          "_comment": "dummy dependency to enable reset when field changes",
+          "question": "middle-name",
+          "operator": "ENABLED",
+          "answer_boolean": true
+        },
+        {
+          "_comment": "dummy dependency to enable reset when field changes",
+          "question": "ssn",
+          "operator": "ENABLED",
+          "answer_boolean": true
+        },
+        {
+          "_comment": "dummy dependency to enable reset when field changes",
+          "question": "gender",
+          "operator": "ENABLED",
+          "answer_boolean": true
         }
       ]
     }

--- a/drivers/hmis/lib/form_data/allegheny/records/client.json
+++ b/drivers/hmis/lib/form_data/allegheny/records/client.json
@@ -16,9 +16,6 @@
       "fragment": "#client_demographics"
     },
     {
-      "fragment": "#client_mci"
-    },
-    {
       "fragment": "#client_photo",
       "enable_when": [
         {
@@ -27,6 +24,9 @@
           "answer_boolean": false
         }
       ]
+    },
+    {
+      "fragment": "#client_mci"
     }
   ]
 }


### PR DESCRIPTION
Not my favorite to add the dummy dependencies in EnableWhen, but I need the super-special MCI Clearance component to have a dependency on all the related fields, so that it can re-render when they change.