### PR TITLE
Add fallback route for /hmis

### DIFF
--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -34,7 +34,7 @@ BostonHmis::Application.routes.draw do
       # Fall back to HMIS origin for any other `hmis/*` route.
       # We need this because the frontend proxies ALL requests to hmis/* to the backend.
       # Note: in a development environment, this ends up redirecting to the warehouse.
-      get '*other', to: redirect { |_, req| req.origin || '' }
+      get '*other', to: redirect { |_, req| req.origin || '404' }
     end
     namespace :hmis_admin do
       resources :roles

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -34,7 +34,7 @@ BostonHmis::Application.routes.draw do
       # Fall back to HMIS origin for any other `hmis/*` route.
       # We need this because the frontend proxies ALL requests to hmis/* to the backend.
       # Note: in a development environment, this ends up redirecting to the warehouse.
-      get '*other', to: redirect { |_, req| req.origin }
+      get '*other', to: redirect { |_, req| req.origin || '' }
     end
     namespace :hmis_admin do
       resources :roles

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -30,6 +30,11 @@ BostonHmis::Application.routes.draw do
 
       post 'hmis-gql', to: 'graphql#execute', defaults: { schema: :hmis }
       mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/hmis/hmis-gql', defaults: { format: :html } if Rails.env.development?
+
+      # Fall back to HMIS origin for any other `hmis/*` route.
+      # We need this because the frontend proxies ALL requests to hmis/* to the backend.
+      # Note: in a development environment, this ends up redirecting to the warehouse.
+      get '*other', to: redirect { |_, req| req.origin }
     end
     namespace :hmis_admin do
       resources :roles


### PR DESCRIPTION
Prevent this from happening: https://qa-hmis.openpath.host/hmis/not/a/path


https://qa-hmis-warehouse.openpath.host/hmis/not/a/path will redirect to `/404` (not a real route) to show a 404 error.