### PR TITLE
Include all clients in omnisearch lookup

### DIFF
--- a/app/models/concerns/client_search.rb
+++ b/app/models/concerns/client_search.rb
@@ -53,8 +53,6 @@ module ClientSearch
         where = metaphone_search(where, :LastName, text)
       end
 
-      where = search_by_external_id(where, text) if alpha_numeric && respond_to?(:search_by_external_id) && RailsDrivers.loaded.include?(:hmis_external_apis)
-
       begin
         # requires a block to calculate which client_ids are acceptable within
         # the search context
@@ -62,6 +60,8 @@ module ClientSearch
       rescue RangeError
         return none
       end
+
+      client_ids += client_ids_with_external_id(text) if alpha_numeric && respond_to?(:client_ids_with_external_id) && RailsDrivers.loaded.include?(:hmis_external_apis)
 
       if numeric
         source_client_ids = GrdaWarehouse::WarehouseClient.where(destination_id: text).pluck(:source_id)

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -42,16 +42,13 @@ module Types
       field.argument :text_search, String, 'Omnisearch string', required: true
     end
 
-    def client_omni_search(text_search:, **args)
-      client_order = Hmis::Hud::Client.searchable_to(current_user).matching_search_term(text_search).
-        joins(:enrollments).
-        merge(Hmis::Hud::Enrollment.open_during_range((Date.current - 1.month)..Date.current)).
-        order(e_t[:date_updated].desc).
-        pluck(:id, e_t[:date_updated]).
-        map(&:first).
-        uniq
-      client_scope = Hmis::Hud::Client.where(id: client_order).order_as_specified(id: client_order)
-      resolve_clients(client_scope, **args)
+    def client_omni_search(text_search:)
+      client_scope = Hmis::Hud::Client.searchable_to(current_user).
+        matching_search_term(text_search).
+        includes(:enrollments).
+        order(qualified_column(e_t[:date_updated]))
+
+      resolve_clients(client_scope, no_sort: true)
     end
 
     field :client, Types::HmisSchema::Client, 'Client lookup', null: true do

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -20,13 +20,11 @@ module HmisExternalApis
                   as: :source
 
           # Used by ClientSearch concern
-          def self.search_by_external_id(where, text)
+          def self.client_ids_with_external_id(value)
             eid_t = HmisExternalApis::ExternalId.arel_table
-            matches_external_value = eid_t[:source_type].eq(sti_name).and(eid_t[:value].eq(text))
-            client_ids = HmisExternalApis::ExternalId.where(matches_external_value).pluck(:source_id)
-            return where unless client_ids.any?
-
-            where.or(c_t[:id].in(client_ids))
+            HmisExternalApis::ExternalId.where(
+              eid_t[:source_type].eq(sti_name).and(eid_t[:value].eq(value)),
+            ).pluck(:source_id)
           end
         end
       end


### PR DESCRIPTION
Continue to sort by recent enrollments updated; but include all clients. If this is going to be used for lookup by ID (which I expect) it should include everyone. 