### PR TITLE
Raise exceptions in GQL Mutations, resolve null permissions as false, fix some permission checks

### DIFF
--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -86,8 +86,8 @@ module Mutations
 
     # Default CRUD Delete functionality
     def default_delete_record(record:, field_name:, after_delete: nil, **auth_args)
-      return { errors: [HmisErrors::Error.new(field_name, :not_found)] } unless record.present?
-      return { errors: [HmisErrors::Error.new(field_name, :not_allowed)] } unless allowed?(record: record, **auth_args)
+      raise HmisErrors::ApiError, 'Record not found' unless record.present?
+      raise HmisErrors::ApiError, 'Access denied' unless allowed?(record: record, **auth_args)
 
       record.destroy
       after_delete&.call

--- a/drivers/hmis/app/graphql/mutations/delete_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_assessment.rb
@@ -12,7 +12,7 @@ module Mutations
 
     def resolve(id:)
       record = Hmis::Hud::CustomAssessment.viewable_by(current_user).find_by(id: id)
-      return { errors: [HmisErrors::Error.new(:assessment, :not_found)] } unless record.present?
+      raise HmisErrors::ApiError, 'Record not found' unless record.present?
 
       record.transaction do
         role = record.custom_form.definition.role

--- a/drivers/hmis/app/graphql/mutations/delete_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client_image.rb
@@ -12,11 +12,8 @@ module Mutations
 
     def resolve(client_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
-
-      errors = HmisErrors::Errors.new
-      errors.add :client_id, :not_found unless client.present?
-      errors.add :client_id, :not_allowed if client.present? && !current_user.permission?(:can_edit_clients)
-      return { errors: errors } if errors.any?
+      raise HmisErrors::ApiError, 'Record not found' unless client.present?
+      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
 
       client.delete_image
       client = client.reload

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -12,9 +12,8 @@ module Mutations
 
     def resolve(id:)
       enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
-
-      return { errors: [HmisErrors::Error.new(:enrollment, :not_found)] } unless enrollment.present?
-      return { errors: [HmisErrors::Error.new(:enrollment, :not_allowed)] } unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
+      raise HmisErrors::ApiError, 'Record not found' unless enrollment.present?
+      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
 
       errors = []
       if enrollment.in_progress?
@@ -22,8 +21,6 @@ module Mutations
       else
         errors << HmisErrors::Error.new(:base, full_message: 'Completed enrollments can not be deleted. Please exit the client instead.')
       end
-
-      errors << enrollment.errors.errors unless enrollment.valid?
 
       {
         enrollment: enrollment,

--- a/drivers/hmis/app/graphql/mutations/delete_service.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_service.rb
@@ -11,7 +11,7 @@ module Mutations
     field :service, Types::HmisSchema::Service, null: true
 
     def resolve(id:)
-      return { errors: [HmisErrors::Error.new(:service, :not_found)] } unless Hmis::Hud::HmisService.valid_id?(id)
+      raise HmisErrors::ApiError, 'Invalid service ID' unless Hmis::Hud::HmisService.valid_id?(id)
 
       hmis_service = Hmis::Hud::HmisService.viewable_by(current_user).find_by(id: id)
       result = default_delete_record(

--- a/drivers/hmis/app/graphql/mutations/update_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client_image.rb
@@ -14,10 +14,8 @@ module Mutations
     def resolve(client_id:, image_blob_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
 
-      errors = HmisErrors::Errors.new
-      errors.add :client_id, :not_found unless client.present?
-      errors.add :client_id, :not_allowed if client.present? && !current_user.permission?(:can_edit_clients)
-      return { errors: errors } if errors.any?
+      raise HmisErrors::ApiError, 'Record not found' unless client.present?
+      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
 
       client.image_blob_id = image_blob_id
       client.save!

--- a/drivers/hmis/app/graphql/types/base_access.rb
+++ b/drivers/hmis/app/graphql/types/base_access.rb
@@ -29,9 +29,12 @@ module Types
 
         method_name ||= root ? "can_#{permission}?" : "can_#{permission}_for?"
         return false unless current_user.respond_to?(method_name)
-        return current_user.send(method_name) if root
 
-        current_user.send(method_name, object)
+        if root
+          current_user.send(method_name) || false
+        else
+          current_user.send(method_name, object) || false
+        end
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
@@ -77,11 +77,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       remove_permissions(hmis_user, permission)
       action.call(a1)
 
-      mutate(input: { id: a1.id }) do |assessment_id, errors|
-        expect(assessment_id).to be_nil
-        expect(errors).to contain_exactly(include('type' => 'not_allowed'))
-      end
-
+      expect { mutate(input: { id: a1.id }) }.to raise_error(HmisErrors::ApiError)
       expect(Hmis::Hud::CustomAssessment.all).to include(have_attributes(id: a1.id))
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
@@ -89,19 +89,16 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       action.call(a1)
       fd1.update(role: 'INTAKE')
 
-      mutate(input: { id: a1.id }) do |assessment_id, errors|
-        a1.reload
-        e1.reload
-        if key == :wip
+      if key == :submitted
+        expect { mutate(input: { id: a1.id }) }.to raise_error(HmisErrors::ApiError)
+      else
+        mutate(input: { id: a1.id }) do |assessment_id, errors|
+          a1.reload
+          e1.reload
           expect(assessment_id).to be_present
           expect(errors).to be_empty
           expect(a1.date_deleted).to be_present
           expect(e1.date_deleted).to be_present
-        elsif key == :submitted
-          expect(assessment_id).to be_nil
-          expect(errors).to contain_exactly(include('type' => 'not_allowed'))
-          expect(a1.date_deleted).to be_nil
-          expect(e1.date_deleted).to be_nil
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/delete_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_client_spec.rb
@@ -106,13 +106,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     e2 = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, relationship_to_ho_h: 2, household_id: '1', user: u1
     prev_hoh_value = e2.relationship_to_ho_h
 
-    mutate(input: { id: c1.id }) do |client, errors|
-      expect(client).to be_nil
-      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
-      expect(Hmis::Hud::Client.all).to include(have_attributes(id: c1.id))
-      # Should NOT modify HoH of other enrollments if client is not deleted
-      expect(e2.reload.relationship_to_ho_h).to eq(prev_hoh_value)
-    end
+    expect { mutate(input: { id: c1.id }) }.to raise_error(HmisErrors::ApiError)
+    expect(Hmis::Hud::Client.all).to include(have_attributes(id: c1.id))
+    # Should NOT modify HoH of other enrollments if client is not deleted
+    expect(e2.reload.relationship_to_ho_h).to eq(prev_hoh_value)
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -76,19 +76,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'should throw error if unauthorized' do
     remove_permissions(hmis_user, :can_delete_enrollments)
-    response, result = post_graphql(input: { id: e2.id }) { mutation }
-
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
-      errors = result.dig('data', 'deleteEnrollment', 'errors')
-      expect(enrollment).to be_nil
-      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
-      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
-        have_attributes(id: e1.id),
-        have_attributes(id: e2.id),
-      )
-    end
+    expect { post_graphql(input: { id: e2.id }) { mutation } }.to raise_error(HmisErrors::ApiError)
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
@@ -61,9 +61,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'should throw error if not allowed to manage files' do
       remove_permissions(hmis_user, :can_manage_any_client_files, :can_manage_own_client_files)
       file_id = f1.id
-      file, errors = call_mutation(file_id)
-      expect(file).to be_nil
-      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
+      expect { call_mutation(file_id) }.to raise_error(HmisErrors::ApiError)
       expect(Hmis::File.all).to include(have_attributes(id: file_id))
     end
 
@@ -71,9 +69,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       remove_permissions(hmis_user, :can_manage_any_client_files)
       file_id = f1.id
       f1.update!(user_id: u2.id)
-      file, errors = call_mutation(file_id)
-      expect(file).to be_nil
-      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
+      expect { call_mutation(file_id) }.to raise_error(HmisErrors::ApiError)
       expect(Hmis::File.all).to include(have_attributes(id: file_id))
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
@@ -70,29 +70,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   it 'should error if a service does not exist' do
-    response, result = post_graphql(id: '123') { mutation }
-
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      service = result.dig('data', 'deleteService', 'service')
-      errors = result.dig('data', 'deleteService', 'errors')
-      expect(service).to be_nil
-      expect(errors).to contain_exactly(include('fullMessage' => 'Service not found'))
-    end
+    expect { post_graphql(id: '123') { mutation } }.to raise_error(HmisErrors::ApiError)
   end
 
   it 'should error if not allowed to delete a service' do
     remove_permissions(hmis_user, :can_edit_enrollments)
-    response, result = post_graphql(id: s1.id) { mutation }
-
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      service = result.dig('data', 'deleteService', 'service')
-      errors = result.dig('data', 'deleteService', 'errors')
-      expect(service).to be_nil
-      expect(errors).to contain_exactly(include('type' => 'not_allowed'))
-      expect(Hmis::Hud::Service.count).to eq(1)
-    end
+    expect { post_graphql(id: s1.id) { mutation } }.to raise_error(HmisErrors::ApiError)
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/save_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/save_assessment_spec.rb
@@ -157,42 +157,25 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     [
       [
-        'should emit error if enrollment doesn\'t exist',
+        'should error if enrollment doesn\'t exist',
         ->(input) { input.merge(enrollment_id: '999') },
-        {
-          'fullMessage' => 'Enrollment must exist',
-        },
       ],
       [
-        'should emit error if cannot find form definition',
+        'should error if cannot find form definition',
         ->(input) { input.merge(form_definition_id: '999') },
-        {
-          'fullMessage' => 'Form definition must exist',
-        },
       ],
       [
-        'should emit error if cannot find assessment',
+        'should error if cannot find assessment',
         ->(input) { input.merge(assessment_id: '999') },
-        {
-          'fullMessage' => 'Assessment must exist',
-        },
       ],
       [
-        'should emit error if neithor enrollment nor assessment are provided',
+        'should error if neithor enrollment nor assessment are provided',
         ->(input) { input.except(:enrollment_id, :assessment_id) },
-        {
-          'fullMessage' => 'Enrollment must exist',
-        },
       ],
-    ].each do |test_name, input_proc, *expected_errors|
+    ].each do |test_name, input_proc|
       it test_name do
         input = input_proc.call(test_input)
-        response, result = post_graphql(input: { input: input }) { mutation }
-        errors = result.dig('data', 'saveAssessment', 'errors')
-        aggregate_failures 'checking response' do
-          expect(response.status).to eq 200
-          expect(errors).to match(expected_errors.map { |h| a_hash_including(**h) })
-        end
+        expect { post_graphql(input: { input: input }) { mutation } }.to raise_error(HmisErrors::ApiError)
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     before(:each) { e1_exit.update(exit_date: 3.days.ago) }
 
     it 'should error if assessment doesn\'t exist' do
-      expect { post_graphql(input: { input: input.merge(assessment_id: '999') }) { mutation } }.to raise_error(HmisErrors::ApiError)
+      expect { post_graphql(input: { input: test_input.merge(assessment_id: '999') }) { mutation } }.to raise_error(HmisErrors::ApiError)
     end
 
     [

--- a/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
@@ -207,10 +207,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     [
       [
-        'should return an error if assessment doesn\'t exist',
-        ->(input) { input.merge(assessment_id: '999') },
-      ],
-      [
         'should return an error if a required field is missing',
         ->(input) {
           input.merge(

--- a/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
@@ -201,14 +201,17 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:e1_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: e1, client: e1.client }
     before(:each) { e1_exit.update(exit_date: 3.days.ago) }
 
+    it 'should error if assessment doesn\'t exist' do
+      expect { post_graphql(input: { input: input.merge(assessment_id: '999') }) { mutation } }.to raise_error(HmisErrors::ApiError)
+    end
+
     [
       [
-        'should emit error if assessment doesn\'t exist',
+        'should return an error if assessment doesn\'t exist',
         ->(input) { input.merge(assessment_id: '999') },
-        { 'fullMessage' => 'Assessment must exist' },
       ],
       [
-        'should return error if a required field is missing',
+        'should return an error if a required field is missing',
         ->(input) {
           input.merge(
             hud_values: { **input[:hud_values], 'linkid-required' => nil },


### PR DESCRIPTION
* resolve all permissions as non null to fix https://green-river.sentry.io/issues/4202813448/?referrer=slack
* raise exceptions instead of returning validation errors for errors that should not be interpreted by the user (Except in development). this was discussed in another PR. one big reason is track them in Sentry because these are actual exceptions. 
* fix some places where we didn't use a scoped call to check can_edit_clients