### PR TITLE
Process client names from custom Name input component

### DIFF
--- a/db/warehouse/migrate/20230525202043_remove_name_uniqueness_index.rb
+++ b/db/warehouse/migrate/20230525202043_remove_name_uniqueness_index.rb
@@ -1,0 +1,9 @@
+class RemoveNameUniquenessIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :CustomClientName, name: "unique_index_ensuring_one_primary_per_client"
+  end
+
+  def down
+    execute('CREATE UNIQUE INDEX unique_index_ensuring_one_primary_per_client ON "CustomClientName" ("PersonalID", data_source_id) WHERE "primary" = true')
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -123,225 +123,115 @@ CREATE TYPE public.record_type AS ENUM (
 CREATE FUNCTION public.service_history_service_insert_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-
       BEGIN
-
       IF  ( NEW.date BETWEEN DATE '2050-01-01' AND DATE '2050-12-31' ) THEN
-
             INSERT INTO service_history_services_2050 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2049-01-01' AND DATE '2049-12-31' ) THEN
-
             INSERT INTO service_history_services_2049 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2048-01-01' AND DATE '2048-12-31' ) THEN
-
             INSERT INTO service_history_services_2048 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2047-01-01' AND DATE '2047-12-31' ) THEN
-
             INSERT INTO service_history_services_2047 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2046-01-01' AND DATE '2046-12-31' ) THEN
-
             INSERT INTO service_history_services_2046 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2045-01-01' AND DATE '2045-12-31' ) THEN
-
             INSERT INTO service_history_services_2045 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2044-01-01' AND DATE '2044-12-31' ) THEN
-
             INSERT INTO service_history_services_2044 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2043-01-01' AND DATE '2043-12-31' ) THEN
-
             INSERT INTO service_history_services_2043 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2042-01-01' AND DATE '2042-12-31' ) THEN
-
             INSERT INTO service_history_services_2042 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2041-01-01' AND DATE '2041-12-31' ) THEN
-
             INSERT INTO service_history_services_2041 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2040-01-01' AND DATE '2040-12-31' ) THEN
-
             INSERT INTO service_history_services_2040 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2039-01-01' AND DATE '2039-12-31' ) THEN
-
             INSERT INTO service_history_services_2039 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2038-01-01' AND DATE '2038-12-31' ) THEN
-
             INSERT INTO service_history_services_2038 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2037-01-01' AND DATE '2037-12-31' ) THEN
-
             INSERT INTO service_history_services_2037 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2036-01-01' AND DATE '2036-12-31' ) THEN
-
             INSERT INTO service_history_services_2036 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2035-01-01' AND DATE '2035-12-31' ) THEN
-
             INSERT INTO service_history_services_2035 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2034-01-01' AND DATE '2034-12-31' ) THEN
-
             INSERT INTO service_history_services_2034 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2033-01-01' AND DATE '2033-12-31' ) THEN
-
             INSERT INTO service_history_services_2033 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2032-01-01' AND DATE '2032-12-31' ) THEN
-
             INSERT INTO service_history_services_2032 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2031-01-01' AND DATE '2031-12-31' ) THEN
-
             INSERT INTO service_history_services_2031 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2030-01-01' AND DATE '2030-12-31' ) THEN
-
             INSERT INTO service_history_services_2030 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2029-01-01' AND DATE '2029-12-31' ) THEN
-
             INSERT INTO service_history_services_2029 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2028-01-01' AND DATE '2028-12-31' ) THEN
-
             INSERT INTO service_history_services_2028 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2027-01-01' AND DATE '2027-12-31' ) THEN
-
             INSERT INTO service_history_services_2027 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2026-01-01' AND DATE '2026-12-31' ) THEN
-
             INSERT INTO service_history_services_2026 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2025-01-01' AND DATE '2025-12-31' ) THEN
-
             INSERT INTO service_history_services_2025 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2024-01-01' AND DATE '2024-12-31' ) THEN
-
             INSERT INTO service_history_services_2024 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2023-01-01' AND DATE '2023-12-31' ) THEN
-
             INSERT INTO service_history_services_2023 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2022-01-01' AND DATE '2022-12-31' ) THEN
-
             INSERT INTO service_history_services_2022 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2021-01-01' AND DATE '2021-12-31' ) THEN
-
             INSERT INTO service_history_services_2021 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2020-01-01' AND DATE '2020-12-31' ) THEN
-
             INSERT INTO service_history_services_2020 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2019-01-01' AND DATE '2019-12-31' ) THEN
-
             INSERT INTO service_history_services_2019 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2018-01-01' AND DATE '2018-12-31' ) THEN
-
             INSERT INTO service_history_services_2018 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2017-01-01' AND DATE '2017-12-31' ) THEN
-
             INSERT INTO service_history_services_2017 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2016-01-01' AND DATE '2016-12-31' ) THEN
-
             INSERT INTO service_history_services_2016 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2015-01-01' AND DATE '2015-12-31' ) THEN
-
             INSERT INTO service_history_services_2015 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2014-01-01' AND DATE '2014-12-31' ) THEN
-
             INSERT INTO service_history_services_2014 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2013-01-01' AND DATE '2013-12-31' ) THEN
-
             INSERT INTO service_history_services_2013 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2012-01-01' AND DATE '2012-12-31' ) THEN
-
             INSERT INTO service_history_services_2012 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2011-01-01' AND DATE '2011-12-31' ) THEN
-
             INSERT INTO service_history_services_2011 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2010-01-01' AND DATE '2010-12-31' ) THEN
-
             INSERT INTO service_history_services_2010 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2009-01-01' AND DATE '2009-12-31' ) THEN
-
             INSERT INTO service_history_services_2009 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2008-01-01' AND DATE '2008-12-31' ) THEN
-
             INSERT INTO service_history_services_2008 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2007-01-01' AND DATE '2007-12-31' ) THEN
-
             INSERT INTO service_history_services_2007 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2006-01-01' AND DATE '2006-12-31' ) THEN
-
             INSERT INTO service_history_services_2006 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2005-01-01' AND DATE '2005-12-31' ) THEN
-
             INSERT INTO service_history_services_2005 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2004-01-01' AND DATE '2004-12-31' ) THEN
-
             INSERT INTO service_history_services_2004 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2003-01-01' AND DATE '2003-12-31' ) THEN
-
             INSERT INTO service_history_services_2003 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2002-01-01' AND DATE '2002-12-31' ) THEN
-
             INSERT INTO service_history_services_2002 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2001-01-01' AND DATE '2001-12-31' ) THEN
-
             INSERT INTO service_history_services_2001 VALUES (NEW.*);
-
          ELSIF  ( NEW.date BETWEEN DATE '2000-01-01' AND DATE '2000-12-31' ) THEN
-
             INSERT INTO service_history_services_2000 VALUES (NEW.*);
-
-
-
+        
       ELSE
-
         INSERT INTO service_history_services_remainder VALUES (NEW.*);
-
         END IF;
-
         RETURN NULL;
-
     END;
-
     $$;
 
 
@@ -6192,8 +6082,8 @@ CREATE TABLE public.configs (
     roi_model character varying DEFAULT 'explicit'::character varying,
     client_dashboard character varying DEFAULT 'default'::character varying NOT NULL,
     require_service_for_reporting_default boolean DEFAULT true NOT NULL,
-    supplemental_enrollment_importer character varying DEFAULT 'GrdaWarehouse::Tasks::EnrollmentExtrasImport'::character varying,
     verified_homeless_history_method character varying DEFAULT 'visible_in_window'::character varying,
+    supplemental_enrollment_importer character varying DEFAULT 'GrdaWarehouse::Tasks::EnrollmentExtrasImport'::character varying,
     youth_hoh_cohort boolean DEFAULT false NOT NULL,
     youth_hoh_cohort_project_group_id integer,
     chronic_tab_justifications boolean DEFAULT true,
@@ -7241,7 +7131,6 @@ CREATE TABLE public.external_request_logs (
     request_headers jsonb DEFAULT '{}'::jsonb NOT NULL,
     request text NOT NULL,
     response text NOT NULL,
-    http_status integer,
     requested_at timestamp without time zone NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -7453,7 +7342,7 @@ CREATE TABLE public.files (
     consent_revoked_at timestamp without time zone,
     coc_codes jsonb DEFAULT '[]'::jsonb,
     enrollment_id bigint,
-    confidential boolean DEFAULT false NOT NULL,
+    confidential boolean,
     updated_by_id bigint
 );
 
@@ -15774,8 +15663,8 @@ CREATE TABLE public.hud_report_apr_clients (
     source_enrollment_id integer,
     los_under_threshold integer,
     project_id integer,
-    client_created_at timestamp without time zone,
-    personal_id character varying
+    personal_id character varying,
+    client_created_at timestamp without time zone
 );
 
 
@@ -18861,34 +18750,6 @@ CREATE TABLE public.recent_report_enrollments (
     "HOHLeaseholder" integer,
     demographic_id integer,
     client_id integer
-);
-
-
---
--- Name: recent_service_history; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.recent_service_history (
-    id bigint,
-    client_id integer,
-    data_source_id integer,
-    date date,
-    first_date_in_program date,
-    last_date_in_program date,
-    enrollment_group_id character varying(50),
-    age smallint,
-    destination integer,
-    head_of_household_id character varying(50),
-    household_id character varying(50),
-    project_id integer,
-    project_type smallint,
-    project_tracking_method integer,
-    organization_id integer,
-    housing_status_at_entry integer,
-    housing_status_at_exit integer,
-    service_type smallint,
-    computed_project_type smallint,
-    presented_as_individual boolean
 );
 
 
@@ -28309,20 +28170,6 @@ CREATE INDEX assessment_r_a_id_ds_id_p_id_en_id_ar_id ON public."AssessmentResul
 
 
 --
--- Name: c_r_system_pathways_clients_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX c_r_system_pathways_clients_idx ON public.system_pathways_clients USING btree (client_id, report_id);
-
-
---
--- Name: c_r_system_pathways_enrollments_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX c_r_system_pathways_enrollments_idx ON public.system_pathways_enrollments USING btree (client_id, report_id);
-
-
---
 -- Name: ch_enrollments_e_id_ch; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -28372,13 +28219,6 @@ CREATE INDEX client_id_ret_index ON public.recent_report_enrollments USING btree
 
 
 --
--- Name: client_id_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX client_id_rsh_index ON public.recent_service_history USING btree (client_id);
-
-
---
 -- Name: client_last_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -28390,13 +28230,6 @@ CREATE INDEX client_last_name ON public."Client" USING btree ("LastName");
 --
 
 CREATE INDEX client_personal_id ON public."Client" USING btree ("PersonalID");
-
-
---
--- Name: computed_project_type_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX computed_project_type_rsh_index ON public.recent_service_history USING btree (computed_project_type);
 
 
 --
@@ -28418,13 +28251,6 @@ CREATE INDEX cur_liv_sit_p_id_en_id_ds_id_cur_id ON public."CurrentLivingSituati
 --
 
 CREATE UNIQUE INDEX cur_liv_sit_sit_id_ds_id ON public."CurrentLivingSituation" USING btree ("CurrentLivingSitID", data_source_id);
-
-
---
--- Name: date_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX date_rsh_index ON public.recent_service_history USING btree (date);
 
 
 --
@@ -41091,13 +40917,6 @@ CREATE INDEX "hmiscsv2022youtheducationstatuses_xGU1" ON public.hmis_csv_2022_yo
 
 
 --
--- Name: household_id_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX household_id_rsh_index ON public.recent_service_history USING btree (household_id);
-
-
---
 -- Name: hud_path_client_conflict_columns; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -41151,13 +40970,6 @@ CREATE UNIQUE INDEX hud_report_hic_projects_uniqueness_constraint ON public.hud_
 --
 
 CREATE UNIQUE INDEX id_ret_index ON public.recent_report_enrollments USING btree (id);
-
-
---
--- Name: id_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX id_rsh_index ON public.recent_service_history USING btree (id);
 
 
 --
@@ -43335,6 +43147,13 @@ CREATE INDEX index_external_ids_on_external_request_log_id ON public.external_id
 --
 
 CREATE INDEX index_external_ids_on_remote_credential_id ON public.external_ids USING btree (remote_credential_id);
+
+
+--
+-- Name: index_external_ids_on_source_id_and_source_type_and_value; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_external_ids_on_source_id_and_source_type_and_value ON public.external_ids USING btree (source_id, source_type, value);
 
 
 --
@@ -49407,6 +49226,27 @@ CREATE INDEX index_synthetic_youth_education_statuses_on_source ON public.synthe
 
 
 --
+-- Name: index_system_pathways_clients_on_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_system_pathways_clients_on_client_id ON public.system_pathways_clients USING btree (client_id);
+
+
+--
+-- Name: index_system_pathways_clients_on_report_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_system_pathways_clients_on_report_id ON public.system_pathways_clients USING btree (report_id);
+
+
+--
+-- Name: index_system_pathways_enrollments_on_client_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_system_pathways_enrollments_on_client_id ON public.system_pathways_enrollments USING btree (client_id);
+
+
+--
 -- Name: index_system_pathways_enrollments_on_enrollment_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -49418,6 +49258,13 @@ CREATE INDEX index_system_pathways_enrollments_on_enrollment_id ON public.system
 --
 
 CREATE INDEX index_system_pathways_enrollments_on_project_id ON public.system_pathways_enrollments USING btree (project_id);
+
+
+--
+-- Name: index_system_pathways_enrollments_on_report_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_system_pathways_enrollments_on_report_id ON public.system_pathways_enrollments USING btree (report_id);
 
 
 --
@@ -49988,20 +49835,6 @@ CREATE INDEX project_project_override_index ON public."Project" USING btree (COA
 
 
 --
--- Name: project_tracking_method_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX project_tracking_method_rsh_index ON public.recent_service_history USING btree (project_tracking_method);
-
-
---
--- Name: project_type_rsh_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX project_type_rsh_index ON public.recent_service_history USING btree (project_type);
-
-
---
 -- Name: services_date_created; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -50160,13 +49993,6 @@ CREATE UNIQUE INDEX uniq_simple_report_universe_members ON public.simple_report_
 --
 
 CREATE UNIQUE INDEX unique_index_ensuring_one_key_per_record_type ON public."CustomDataElementDefinitions" USING btree (owner_type, key);
-
-
---
--- Name: unique_index_ensuring_one_primary_per_client; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX unique_index_ensuring_one_primary_per_client ON public."CustomClientName" USING btree ("PersonalID", data_source_id) WHERE ("primary" = true);
 
 
 --
@@ -53033,10 +52859,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230518172244'),
 ('20230519175812'),
 ('20230519185108'),
-('20230522112541'),
-('20230522112645'),
-('20230522112916'),
-('20230522183433'),
-('20230523142004');
+('20230523142004'),
+('20230525202043');
 
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -465,8 +465,19 @@ type ClientAddress {
 Allowed values for ClientAddress.type
 """
 enum ClientAddressType {
+  """
+  Both
+  """
   both
+
+  """
+  Physical
+  """
   physical
+
+  """
+  Postal
+  """
   postal
 }
 
@@ -474,10 +485,29 @@ enum ClientAddressType {
 Allowed values for ClientAddress.use
 """
 enum ClientAddressUse {
+  """
+  Home
+  """
   home
+
+  """
+  Mail
+  """
   mail
+
+  """
+  Old
+  """
   old
+
+  """
+  Temp
+  """
   temp
+
+  """
+  Work
+  """
   work
 }
 
@@ -521,12 +551,39 @@ type ClientContactPoint {
 Allowed values for ClientContactPoint.system
 """
 enum ClientContactPointSystem {
+  """
+  Email
+  """
   email
+
+  """
+  Fax
+  """
   fax
+
+  """
+  Other
+  """
   other
+
+  """
+  Pager
+  """
   pager
+
+  """
+  Phone
+  """
   phone
+
+  """
+  Sms
+  """
   sms
+
+  """
+  Url
+  """
   url
 }
 
@@ -534,10 +591,29 @@ enum ClientContactPointSystem {
 Allowed values for ClientContactPoint.use
 """
 enum ClientContactPointUse {
+  """
+  Home
+  """
   home
+
+  """
+  Mobile
+  """
   mobile
+
+  """
+  Old
+  """
   old
+
+  """
+  Temp
+  """
   temp
+
+  """
+  Work
+  """
   work
 }
 
@@ -571,12 +647,39 @@ type ClientName {
 Allowed values for ClientName.use
 """
 enum ClientNameUse {
+  """
+  Anonymous
+  """
   anonymous
+
+  """
+  Maiden
+  """
   maiden
+
+  """
+  Nickname
+  """
   nickname
+
+  """
+  Official
+  """
   official
+
+  """
+  Old
+  """
   old
+
+  """
+  Temp
+  """
   temp
+
+  """
+  Usual
+  """
   usual
 }
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -659,6 +659,11 @@ type ClientsPaginated {
 
 enum Component {
   """
+  Client Address input
+  """
+  ADDRESS
+
+  """
   Display text as an error alert
   """
   ALERT_ERROR
@@ -689,6 +694,11 @@ enum Component {
   DISABILITY_TABLE
 
   """
+  Email address input for ContactPoint
+  """
+  EMAIL
+
+  """
   Render a group of inputs horizontally
   """
   HORIZONTAL_GROUP
@@ -707,6 +717,16 @@ enum Component {
   MCI linking component
   """
   MCI
+
+  """
+  Client Name input
+  """
+  NAME
+
+  """
+  Phone number input for ContactPoint
+  """
+  PHONE
 
   """
   Render a choice input item as radio buttons
@@ -3150,6 +3170,7 @@ enum ItemType {
   GROUP
   IMAGE
   INTEGER
+  OBJECT
   OPEN_CHOICE
   STRING
   TEXT

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -46,14 +46,14 @@ module Types
 
       result = transform_changes(object, result).map do |key, value|
         name = key.camelize(:lower)
-        field = Hmis::Hud::Processors::Base.hud_type(name, schema_type)
+        gql_enum = Hmis::Hud::Processors::Base.graphql_enum(name, schema_type)
 
         values = value.map do |val|
           next unless val.present?
-          next val unless field.present?
-          next val.map { |v| v.present? ? field.key_for(v) : nil } if val.is_a? Array
+          next val unless gql_enum.present?
+          next val.map { |v| v.present? ? gql_enum.key_for(v) : nil } if val.is_a? Array
 
-          field.key_for(val)
+          gql_enum.key_for(val)
         end
 
         values = 'changed' unless authorize_field(object, key)

--- a/drivers/hmis/app/graphql/types/forms/enums/component.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/component.rb
@@ -11,6 +11,7 @@ module Types
     graphql_name 'Component'
 
     value 'INPUT_GROUP', 'Render a group that contains children of the same type (e.g. all booleans)'
+    # value 'REPEATED_INPUT_GROUP', 'Group that contains children of the same field type (e.g. all names) that should be revealed 1-at-a-time'
     value 'DISABILITY_TABLE', 'Specialized component for rendering disabilities in a table'
     value 'HORIZONTAL_GROUP', 'Render a group of inputs horizontally'
     value 'INFO_GROUP', 'Render contents in an info box'
@@ -24,5 +25,9 @@ module Types
     value 'ALERT_SUCCESS', 'Display text as a success alert'
     value 'SSN', 'SSN input component'
     value 'MCI', 'MCI linking component'
+    value 'NAME', 'Client Name input'
+    value 'ADDRESS', 'Client Address input'
+    value 'PHONE', 'Phone number input for ContactPoint'
+    value 'EMAIL', 'Email address input for ContactPoint'
   end
 end

--- a/drivers/hmis/app/graphql/types/forms/enums/component.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/component.rb
@@ -10,20 +10,25 @@ module Types
   class Forms::Enums::Component < Types::BaseEnum
     graphql_name 'Component'
 
+    # Grouping components
     value 'INPUT_GROUP', 'Render a group that contains children of the same type (e.g. all booleans)'
-    # value 'REPEATED_INPUT_GROUP', 'Group that contains children of the same field type (e.g. all names) that should be revealed 1-at-a-time'
     value 'DISABILITY_TABLE', 'Specialized component for rendering disabilities in a table'
     value 'HORIZONTAL_GROUP', 'Render a group of inputs horizontally'
     value 'INFO_GROUP', 'Render contents in an info box'
 
+    # Input components
     value 'CHECKBOX', 'Render a boolean input item as a checkbox'
     value 'RADIO_BUTTONS', 'Render a choice input item as radio buttons'
     value 'RADIO_BUTTONS_VERTICAL', 'Render a choice input item as vertical radio buttons'
+    value 'SSN', 'SSN input component'
+
+    # Display components
     value 'ALERT_INFO', 'Display text as an info alert'
     value 'ALERT_WARNING', 'Display text as a warning alert'
     value 'ALERT_ERROR', 'Display text as an error alert'
     value 'ALERT_SUCCESS', 'Display text as a success alert'
-    value 'SSN', 'SSN input component'
+
+    # Specialized input components
     value 'MCI', 'MCI linking component'
     value 'NAME', 'Client Name input'
     value 'ADDRESS', 'Client Address input'

--- a/drivers/hmis/app/graphql/types/forms/enums/item_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/item_type.rb
@@ -26,5 +26,6 @@ module Types
     value 'OPEN_CHOICE'
     value 'IMAGE'
     value 'FILE'
+    value 'OBJECT'
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -187,6 +187,7 @@ module Types
 
     def names
       if object.names.empty?
+        # If client has no CustomClientNames, construct one based on the HUD Client name fields
         return [
           object.names.new(
             id: '0',
@@ -194,10 +195,8 @@ module Types
             last: object.last_name,
             middle: object.middle_name,
             suffix: object.name_suffix,
-            name_data_quality: object.name_data_quality,
             primary: true,
-            user: object.user,
-            data_source: object.data_source,
+            **object.slice(:name_data_quality, :user_id, :data_source_id, :date_created, :date_updated),
           ),
         ]
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/client_address_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/client_address_type.rb
@@ -12,7 +12,7 @@ module Types
     graphql_name 'ClientAddressType'
 
     Hmis::Hud::CustomClientAddress.type_values.each do |val|
-      value val
+      value val, val.to_s.humanize
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/client_address_use.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/client_address_use.rb
@@ -12,7 +12,7 @@ module Types
     graphql_name 'ClientAddressUse'
 
     Hmis::Hud::CustomClientAddress.use_values.each do |val|
-      value val
+      value val, val.to_s.humanize
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/client_contact_point_system.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/client_contact_point_system.rb
@@ -12,7 +12,7 @@ module Types
     graphql_name 'ClientContactPointSystem'
 
     Hmis::Hud::CustomClientContactPoint.system_values.each do |val|
-      value val
+      value val, val.to_s.humanize
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/client_contact_point_use.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/client_contact_point_use.rb
@@ -12,7 +12,7 @@ module Types
     graphql_name 'ClientContactPointUse'
 
     Hmis::Hud::CustomClientContactPoint.use_values.each do |val|
-      value val
+      value val, val.to_s.humanize
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/client_name_use.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/client_name_use.rb
@@ -12,7 +12,7 @@ module Types
     graphql_name 'ClientNameUse'
 
     Hmis::Hud::CustomClientName.use_values.each do |val|
-      value val
+      value val, val.to_s.humanize
     end
   end
 end

--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -116,7 +116,13 @@ module Hmis
       pairs = client_to_retain.send(relation).to_a.combination(2)
 
       pairs.each do |pair|
-        next unless pair[0] == pair[1]
+        equivalent = if pair[0].respond_to?(:equal_for_merge?)
+          pair[0].equal_for_merge?(pair[1])
+        else
+          pair[0] == pair[1]
+        end
+
+        next unless equivalent
         next if pair[1].in?(keepers)
 
         Rails.logger.info "Removing #{pair[1]} which is a duplicate"

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -271,7 +271,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
 
       # Skip relation fields, to avoid errors like "Income Benefit is invalid" on the Enrollment
       ar_errors = record.errors.errors.reject do |e|
-        e.attribute.to_s.underscore.ends_with?('_id') || record.send(e.attribute).is_a?(ActiveRecord::Relation)
+        e.attribute.to_s.underscore.ends_with?('_id') || (record.respond_to?(e.attribute) && record.send(e.attribute).is_a?(ActiveRecord::Relation))
       end
       errors.add_ar_errors(ar_errors)
     end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -18,10 +18,10 @@ class Hmis::Hud::Client < Hmis::Hud::Base
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
-  has_many :names, **hmis_relation(:PersonalID, 'CustomClientName')
-  has_many :addresses, **hmis_relation(:PersonalID, 'CustomClientAddress')
-  has_many :contact_points, **hmis_relation(:PersonalID, 'CustomClientContactPoint')
-  has_one :primary_name, -> { where(primary: true) }, **hmis_relation(:PersonalID, 'CustomClientName')
+  has_many :names, **hmis_relation(:PersonalID, 'CustomClientName'), inverse_of: :client
+  has_many :addresses, **hmis_relation(:PersonalID, 'CustomClientAddress'), inverse_of: :client
+  has_many :contact_points, **hmis_relation(:PersonalID, 'CustomClientContactPoint'), inverse_of: :client
+  has_one :primary_name, -> { where(primary: true) }, **hmis_relation(:PersonalID, 'CustomClientName'), inverse_of: :client
 
   # Enrollments for this Client, including WIP Enrollments
   has_many :enrollments, **hmis_relation(:PersonalID, 'Enrollment'), dependent: :destroy

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -42,6 +42,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   has_many :custom_data_elements, as: :owner
 
   accepts_nested_attributes_for :custom_data_elements, allow_destroy: true
+  accepts_nested_attributes_for :names, allow_destroy: true
 
   # NOTE: only used for getting the client's Warehouse ID. Should not be used for anything else. See #184132767
   has_one :warehouse_client_source, class_name: 'GrdaWarehouse::WarehouseClient', foreign_key: :source_id, inverse_of: :source

--- a/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
@@ -36,7 +36,7 @@ class Hmis::Hud::CustomClientAddress < Hmis::Hud::Base
     joins(:client).merge(Hmis::Hud::Client.viewable_by(user))
   end
 
-  def ==(other)
+  def equal_for_merge?(other)
     columns = [
       :address_type,
       :city,

--- a/drivers/hmis/app/models/hmis/hud/custom_client_contact_point.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_contact_point.rb
@@ -52,7 +52,7 @@ class Hmis::Hud::CustomClientContactPoint < Hmis::Hud::Base
     SYSTEM_VALUES
   end
 
-  def ==(other)
+  def equal_for_merge?(other)
     columns = [:system, :use, :value]
 
     columns.all? do |col|

--- a/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
@@ -25,15 +25,19 @@ class Hmis::Hud::CustomClientName < Hmis::Hud::Base
   class CannotDestroyPrimaryNameException < StandardError
   end
 
-  before_destroy do
-    raise(CannotDestroyPrimaryNameException) if primary
-  end
+  # before_destroy do
+  #   # binding.pry
+  #   raise(CannotDestroyPrimaryNameException) if primary
+  # end
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :CustomClientNameID]
+
+  # Validate 1 primary name per client
+  # validates_uniqueness_of :PersonalID, scope: [:data_source_id], conditions: -> { where(primary: true) }
 
   scope :primary_names, -> { where(primary: true) }
 

--- a/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
@@ -25,19 +25,15 @@ class Hmis::Hud::CustomClientName < Hmis::Hud::Base
   class CannotDestroyPrimaryNameException < StandardError
   end
 
-  # before_destroy do
-  #   # binding.pry
-  #   raise(CannotDestroyPrimaryNameException) if primary
-  # end
+  before_destroy do
+    raise(CannotDestroyPrimaryNameException) if primary
+  end
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :CustomClientNameID]
-
-  # Validate 1 primary name per client
-  # validates_uniqueness_of :PersonalID, scope: [:data_source_id], conditions: -> { where(primary: true) }
 
   scope :primary_names, -> { where(primary: true) }
 

--- a/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
@@ -51,14 +51,6 @@ class Hmis::Hud::CustomClientName < Hmis::Hud::Base
     errors.add(:first, :invalid, full_message: self.class.first_or_last_required_message) unless first.present? || last.present?
   end
 
-  def ==(other)
-    columns = [:first, :last, :middle, :suffix, :use]
-
-    columns.all? do |col|
-      send(col)&.strip&.downcase == other.send(col)&.strip&.downcase
-    end
-  end
-
   def primary?
     !!primary
   end

--- a/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
@@ -72,4 +72,11 @@ class Hmis::Hud::CustomClientName < Hmis::Hud::Base
   def self.use_values
     USE_VALUES
   end
+
+  def equal_for_merge?(other)
+    columns = [:first, :last, :middle, :suffix, :use]
+    columns.all? do |col|
+      send(col)&.strip&.downcase == other.send(col)&.strip&.downcase
+    end
+  end
 end

--- a/drivers/hmis/app/models/hmis/hud/custom_data_element.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_data_element.rb
@@ -52,7 +52,7 @@ class Hmis::Hud::CustomDataElement < Hmis::Hud::Base
     errors.add(:base, :invalid, full_message: "Found value for '#{values.keys.first}' but definition is for type '#{data_element_definition.field_type}") unless data_element_definition.field_type.to_s == field_type.to_s
   end
 
-  def ==(other)
+  def equal_for_merge?(other)
     columns = [:data_element_definition_id, *VALUE_COLUMNS]
 
     columns.all? do |col|

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -150,9 +150,12 @@ class Hmis::Hud::Processors::Base
     values = Array.wrap(value)
 
     object_type = graphql_type(attribute_name) # eg the ClientName type
+    raise "'#{attribute_name}' not found in gql schema" unless object_type.present?
 
     # Construct attribute objects for creating/updating records
     attributes = values.map do |attribute_hash|
+      raise "Error constructing nested attributes: expected Hash, found #{attribute_hash.class.name}" unless attribute_hash.is_a?(Hash)
+
       transformed = attribute_hash.map do |field_name, field_value|
         # transform "nameDataQuality"=>"FULL_NAME_REPORTED" to "name_data_quality"=>1
         transformed_value = attribute_value_for_enum(self.class.graphql_enum(field_name, object_type), field_value)

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -137,8 +137,8 @@ class Hmis::Hud::Processors::Base
   end
 
   # Get attributes for nested record(s)
-  def construct_nested_attributes(attribute_name, values, additional_attributes = {})
-    values ||= []
+  def construct_nested_attributes(attribute_name, value, additional_attributes = {})
+    values = Array.wrap(value)
 
     object_type = graphql_type(attribute_name) # eg the ClientName type
 

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -13,8 +13,8 @@ module Hmis::Hud::Processors
     MCI_CREATE_UNCLEARED_CLIENT_VALUE = '_CREATE_UNCLEARED_CLIENT'.freeze
 
     def process(field, value)
-      attribute_name = hud_name(field)
-      attribute_value = attribute_value_for_enum(hud_type(field), value)
+      attribute_name = ar_attribute_name(field)
+      attribute_value = attribute_value_for_enum(graphql_enum(field), value)
 
       # Skip SSN/DOB fields if hidden, because they are always hidden due to lack of permissions (see client.json form definition)
       return if value == Base::HIDDEN_FIELD_VALUE && ['ssn', 'dob'].include?(attribute_name)

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -20,7 +20,6 @@ module Hmis::Hud::Processors
       return if value == Base::HIDDEN_FIELD_VALUE && ['ssn', 'dob'].include?(attribute_name)
 
       client = @processor.send(factory_name)
-      hud_metadata_attributes = { user: @processor.hud_user, data_source_id: @processor.hud_user.data_source_id, client: client }
 
       attributes = case attribute_name
       when 'race'
@@ -41,10 +40,11 @@ module Hmis::Hud::Processors
         { attribute_name => attribute_value }
       when 'names'
         process_names(attribute_name, value)
-      when 'addresses'
-        construct_nested_attributes(attribute_name, value, hud_metadata_attributes)
-      when 'contact_points'
-        construct_nested_attributes(attribute_name, value, hud_metadata_attributes)
+      # TODO: implement, add tests. They _should_ be able to use the generic attribute generator..
+      # when 'addresses'
+      #   construct_nested_attributes(attribute_name, value, hud_metadata_attributes)
+      # when 'contact_points'
+      #   construct_nested_attributes(attribute_name, value, hud_metadata_attributes)
       when 'mci_id'
         process_mci(value)
         {}

--- a/drivers/hmis/app/models/hmis/hud/processors/enrollment_coc_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/enrollment_coc_processor.rb
@@ -10,8 +10,8 @@ module Hmis::Hud::Processors
       :enrollment_coc_factory
     end
 
-    def hud_type(_)
-      nil # No schema, so hud_type is always nil
+    def graphql_enum(_)
+      nil # No schema, so graphql_enum is always nil
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/processors/file_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/file_processor.rb
@@ -15,8 +15,8 @@ module Hmis::Hud::Processors
     end
 
     def process(field, value)
-      attribute_name = hud_name(field)
-      attribute_value = attribute_value_for_enum(hud_type(field), value)
+      attribute_name = ar_attribute_name(field)
+      attribute_value = attribute_value_for_enum(graphql_enum(field), value)
 
       if attribute_name == 'tags'
         @processor.send(factory_name).tag_list = Array(attribute_value)

--- a/drivers/hmis/app/models/hmis/hud/processors/income_benefit_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/income_benefit_processor.rb
@@ -7,8 +7,8 @@
 module Hmis::Hud::Processors
   class IncomeBenefitProcessor < Base
     def process(field, value)
-      attribute_name = hud_name(field)
-      attribute_value = attribute_value_for_enum(hud_type(field), value)
+      attribute_name = ar_attribute_name(field)
+      attribute_value = attribute_value_for_enum(graphql_enum(field), value)
       attribute_value = 0 if override_to_no?(attribute_name, attribute_value)
 
       @processor.send(factory_name).assign_attributes(attribute_name => attribute_value)

--- a/drivers/hmis/app/models/hmis/hud/processors/service_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/service_processor.rb
@@ -8,8 +8,8 @@ module Hmis::Hud::Processors
   class ServiceProcessor < Base
     # Process as HUD Service. This needs to be updated to support Custom Services.
     def process(field, value)
-      attribute_name = hud_name(field)
-      attribute_value = attribute_value_for_enum(hud_type(field), value)
+      attribute_name = ar_attribute_name(field)
+      attribute_value = attribute_value_for_enum(graphql_enum(field), value)
 
       return if attribute_name == 'custom_service_type'
 

--- a/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
@@ -24,7 +24,7 @@ class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValida
 
       # Validate exactly 1 primary name
       if record.names.any?
-        num_primary_names = record.names.map(&:primary).count(true)
+        num_primary_names = record.names.reject(&:marked_for_destruction?).map(&:primary).count(true)
         record.errors.add :names, :invalid, full_message: 'One primary name is required' if num_primary_names != 1
       end
     end

--- a/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
@@ -19,10 +19,14 @@ class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValida
 
   def validate(record)
     super(record) do
-      record.errors.add :first_name, :required if record.first_name.blank? && record.last_name.blank?
-      record.errors.add :last_name, :required if record.first_name.blank? && record.last_name.blank?
       record.errors.add :gender, :required if !skipped_attributes(record).include?(:gender) && ::HudUtility.gender_id_to_field_name.except(8, 9, 99).values.any? { |field| record.send(field).nil? }
       record.errors.add :race, :required if !skipped_attributes(record).include?(:race) && ::HudUtility.races.except('RaceNone').keys.any? { |field| record.send(field).nil? }
+
+      # Validate exactly 1 primary name
+      if record.names.any?
+        num_primary_names = record.names.map(&:primary).count(true)
+        record.errors.add :names, :invalid, full_message: 'One primary name is required' if num_primary_names != 1
+      end
     end
   end
 end

--- a/drivers/hmis/lib/form_data/allegheny/fragments/client_mci.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/client_mci.json
@@ -16,12 +16,8 @@
       "enable_behavior": "ALL",
       "enable_when": [
         {
-          "question": "first-name",
-          "operator": "EXISTS",
-          "answer_boolean": true
-        },
-        {
-          "question": "last-name",
+          "question": "names",
+          "_comment": "further check for First/Last and DQ happens in the MCI component",
           "operator": "EXISTS",
           "answer_boolean": true
         },
@@ -31,20 +27,9 @@
           "answer_boolean": true
         },
         {
-          "question": "name-dq",
-          "operator": "EQUAL",
-          "answer_code": "FULL_NAME_REPORTED"
-        },
-        {
           "question": "dob-dq",
           "operator": "EQUAL",
           "answer_code": "FULL_DOB_REPORTED"
-        },
-        {
-          "_comment": "dummy dependency to enable reset when field changes",
-          "question": "middle-name",
-          "operator": "ENABLED",
-          "answer_boolean": true
         },
         {
           "_comment": "dummy dependency to enable reset when field changes",

--- a/drivers/hmis/lib/form_data/allegheny/records/client.json
+++ b/drivers/hmis/lib/form_data/allegheny/records/client.json
@@ -7,7 +7,7 @@
       "field_name": "id"
     },
     {
-      "fragment": "#client_name"
+      "fragment": "#client_names"
     },
     {
       "fragment": "#client_identification"

--- a/drivers/hmis/lib/form_data/default/fragments/client_addresses.json
+++ b/drivers/hmis/lib/form_data/default/fragments/client_addresses.json
@@ -1,0 +1,15 @@
+{
+  "type": "GROUP",
+  "link_id": "address-group",
+  "text": "Address",
+  "required": false,
+  "item": [
+    {
+      "type": "OBJECT",
+      "component": "ADDRESS",
+      "repeats": true,
+      "link_id": "addresses",
+      "field_name": "addresses"
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/default/fragments/client_names.json
+++ b/drivers/hmis/lib/form_data/default/fragments/client_names.json
@@ -1,0 +1,15 @@
+{
+  "type": "GROUP",
+  "link_id": "name",
+  "text": "Name",
+  "required": false,
+  "item": [
+    {
+      "type": "OBJECT",
+      "component": "NAMES",
+      "repeats": true,
+      "link_id": "names",
+      "field_name": "names"
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/default/fragments/client_names.json
+++ b/drivers/hmis/lib/form_data/default/fragments/client_names.json
@@ -6,7 +6,7 @@
   "item": [
     {
       "type": "OBJECT",
-      "component": "NAMES",
+      "component": "NAME",
       "repeats": true,
       "link_id": "names",
       "field_name": "names"

--- a/drivers/hmis/lib/form_data/default/records/client.json
+++ b/drivers/hmis/lib/form_data/default/records/client.json
@@ -7,7 +7,7 @@
       "field_name": "id"
     },
     {
-      "fragment": "#client_name"
+      "fragment": "#client_names"
     },
     {
       "fragment": "#client_identification"

--- a/drivers/hmis/spec/factories/hmis/hud/custom_client_names.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_client_names.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     sequence(:CustomClientNameID) { |n| n + 100 }
     sequence(:first) { |n| ['Jim', 'Sue', 'Bob'][n % 3] }
     sequence(:last) { |n| ['Smith', 'Brown', 'Portman', 'Underwood', 'Jordan', 'White', 'Black'][n % 7] }
-
+    NameDataQuality { 1 }
     after(:build) do |client_name|
       client_name.user ||= create(:hmis_hud_user, data_source: client_name.data_source)
     end

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -516,14 +516,26 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
 
   describe 'Form processing for Clients' do
     let(:definition) { Hmis::Form::Definition.find_by(role: :CLIENT) }
+    let(:primary_name) do
+      {
+        primary: true,
+        first: 'Terry',
+        middle: 'Mid',
+        last: 'Breeze',
+        suffix: 'Jr',
+        nameDataQuality: 'FULL_NAME_REPORTED',
+      }
+    end
+    let(:secondary_name) do
+      {
+        primary: false,
+        first: 'Gerome',
+        nameDataQuality: 'PARTIAL_STREET_NAME_OR_CODE_NAME_REPORTED',
+      }
+    end
     let(:complete_hud_values) do
       {
-        'firstName' => 'First',
-        'middleName' => 'Middle',
-        'lastName' => 'Last',
-        'nameSuffix' => 'Sf',
-        'preferredName' => 'Pref',
-        'nameDataQuality' => 'FULL_NAME_REPORTED',
+        "names": [primary_name.stringify_keys, secondary_name.stringify_keys],
         'dob' => '2000-03-29',
         'dobDataQuality' => 'FULL_DOB_REPORTED',
         'ssn' => 'XXXXX1234',
@@ -547,7 +559,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     end
     let(:empty_hud_values) do
       empty = complete_hud_values.map { |k, _| [k, nil] }.to_h
-      empty['firstName'] = 'First' # First or last is required
+      empty['names'] = { **primary_name.map { |k, _| [k, nil] }.to_h, primary: true }.stringify_keys
       empty
     end
 
@@ -559,15 +571,22 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         custom_form = Hmis::Form::CustomForm.new(owner: client, definition: definition)
         custom_form.hud_values = complete_hud_values
         custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
+        # binding.pry unless client.persisted?
         custom_form.owner.save!
         client.reload
 
-        expect(client.first_name).to eq('First')
-        expect(client.middle_name).to eq('Middle')
-        expect(client.last_name).to eq('Last')
-        expect(client.name_suffix).to eq('Sf')
-        expect(client.preferred_name).to eq('Pref')
+        # Ensure primary name is stored on Client
+        expect(client.first_name).to eq(primary_name[:first])
+        expect(client.middle_name).to eq(primary_name[:middle])
+        expect(client.last_name).to eq(primary_name[:last])
+        expect(client.name_suffix).to eq(primary_name[:suffix])
         expect(client.name_data_quality).to eq(1)
+        # Ensure all names persisted
+        expect(client.names.count).to eq(2)
+        expect(client.names.map(&:attributes)).to match([
+                                                          a_hash_including(primary_name.excluding(:nameDataQuality).stringify_keys),
+                                                          a_hash_including(secondary_name.excluding(:nameDataQuality).stringify_keys),
+                                                        ])
         expect(client.dob.strftime('%Y-%m-%d')).to eq('2000-03-29')
         expect(client.dob_data_quality).to eq(1)
         expect(client.ssn).to eq('XXXXX1234')
@@ -599,12 +618,13 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         custom_form.owner.save!
         client.reload
 
-        expect(client.first_name).to eq('First')
+        expect(client.first_name).to be nil
         expect(client.middle_name).to be nil
         expect(client.last_name).to be nil
         expect(client.name_suffix).to be nil
         expect(client.preferred_name).to be nil
         expect(client.name_data_quality).to eq(99)
+        expect(client.names.size).to eq(1)
         expect(client.dob).to be nil
         expect(client.dob_data_quality).to eq(99)
         expect(client.ssn).to be nil
@@ -705,21 +725,97 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       end
     end
 
-    [
-      [
-        'fails if first and last are both nil',
-        ->(input) { input.merge('firstName' => nil, 'lastName' => nil) },
-      ],
-    ].each do |test_name, input_proc|
-      it test_name do
-        existing_record = c1
-        new_record = Hmis::Hud::Client.new(data_source: ds, user: hmis_hud_user)
-        [existing_record, new_record].each do |record|
-          custom_form = Hmis::Form::CustomForm.new(owner: record, definition: definition)
-          custom_form.hud_values = input_proc.call(complete_hud_values)
-          custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
-          expect(custom_form.owner.valid?).to eq(false)
-        end
+    it 'updates, adds, and deletes CustomClientNames' do
+      # Give client some names
+      client = c1
+      old_primary_name = create(:hmis_hud_custom_client_name, client: client, first: 'Atticus', primary: true)
+      old_secondary_name = create(:hmis_hud_custom_client_name, client: client, first: 'Benjamin', primary: false)
+      client.update(names: [old_primary_name, old_secondary_name])
+      expect(client.names.size).to eq(2)
+
+      # Submit a form that changes the names
+      custom_form = Hmis::Form::CustomForm.new(owner: client, definition: definition)
+      custom_form.hud_values = complete_hud_values.merge(
+        'names' => [
+          # 1) Make the old primary name non-primary, _and_ update the name
+          {
+            id: old_primary_name.id,
+            primary: false,
+            first: 'Atticus Changed',
+            nameDataQuality: 'CLIENT_REFUSED',
+          }.stringify_keys,
+          # 2) Add a NEW primary name
+          {
+            primary: true,
+            first: 'Charlotte',
+            nameDataQuality: 'CLIENT_REFUSED',
+          }.stringify_keys,
+          # 3) Delete the old secondary name (by not including it)
+        ],
+      )
+      custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
+      # binding.pry
+      custom_form.owner.save!
+      client.reload
+
+      # Ensure primary name is stored on Client
+      expect(client.first_name).to eq('Charlotte')
+      # Ensure all names persisted
+      expect(client.names.size).to eq(2)
+      expect(client.names.pluck(:id)).not_to include(old_secondary_name.id)
+      expect(client.names.map(&:attributes)).to match([
+                                                        a_hash_including({ first: 'Atticus Changed', primary: false, id: old_primary_name.id }.stringify_keys),
+                                                        a_hash_including({ first: 'Charlotte', primary: true }.stringify_keys),
+                                                      ])
+    end
+
+    it 'handles "deleting" primary name' do
+      client = c1
+      # Give client a primary names
+      old_primary_name = create(:hmis_hud_custom_client_name, client: c1, first: 'Atticus', primary: true)
+      expect(client.names.size).to eq(1)
+
+      # Submit a form that changes the primary  name but doesn't include the old ID
+      custom_form = Hmis::Form::CustomForm.new(owner: client, definition: definition)
+      custom_form.hud_values = complete_hud_values.merge(
+        'names' => [
+          {
+            primary: true,
+            first: 'Charlotte',
+            nameDataQuality: 'CLIENT_REFUSED',
+          }.stringify_keys,
+        ],
+      )
+      custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
+      custom_form.owner.save!
+      client.reload
+
+      expect(client.names.primary_names.first.first).to eq('Charlotte')
+      expect(client.names.size).to eq(1)
+      # Even though ID was not specified, it is updated because client already had a primary
+      expect(client.names.first.id).to eq(old_primary_name.id)
+      expect(client.first_name).to eq('Charlotte')
+    end
+
+    it 'fails if no names are primary' do
+      existing_record = c1
+      new_record = Hmis::Hud::Client.new(data_source: ds, user: hmis_hud_user)
+      [existing_record, new_record].each do |record|
+        custom_form = Hmis::Form::CustomForm.new(owner: record, definition: definition)
+        custom_form.hud_values = complete_hud_values.merge('names' => [secondary_name.stringify_keys])
+        custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
+        expect(custom_form.owner.valid?).to eq(false)
+      end
+    end
+
+    it 'fails if two names are primary' do
+      existing_record = c1
+      new_record = Hmis::Hud::Client.new(data_source: ds, user: hmis_hud_user)
+      [existing_record, new_record].each do |record|
+        custom_form = Hmis::Form::CustomForm.new(owner: record, definition: definition)
+        custom_form.hud_values = complete_hud_values.merge('names' => [primary_name.stringify_keys, primary_name.stringify_keys])
+        custom_form.form_processor.run!(owner: custom_form.owner, user: hmis_user)
+        expect(custom_form.owner.valid?).to eq(false)
       end
     end
   end

--- a/drivers/hmis/spec/models/hmis/hud/client_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/client_spec.rb
@@ -39,18 +39,21 @@ RSpec.describe Hmis::Hud::Client, type: :model do
   end
 
   describe 'with multiple names' do
+    let!(:c1) { create :hmis_hud_client_complete, data_source: ds1, user: u1, FirstName: 'Jelly', LastName: 'Bean' }
+
     it 'should handle names correctly' do
       n1 = create(:hmis_hud_custom_client_name, user: u1, data_source: ds1, client: c1, first: 'First', primary: true)
       n2 = create(:hmis_hud_custom_client_name, user: u1, data_source: ds1, client: c1, first: 'Second')
       n3 = create(:hmis_hud_custom_client_name, user: u1, data_source: ds1, client: c1, first: 'Third')
-
+      c1.update(names: [n1, n2, n3])
       expect(c1.names).to contain_exactly(*[n1, n2, n3].map { |n| have_attributes(id: n.id) })
       expect(c1.names.primary_names).to contain_exactly(have_attributes(id: n1.id))
       expect(c1.primary_name).to have_attributes(id: n1.id)
+      expect(c1.valid?).to be true
 
-      expect do
-        create(:hmis_hud_custom_client_name, user: u1, data_source: ds1, client: c1, first: 'Fourth', primary: true)
-      end.to raise_error(ActiveRecord::RecordNotUnique)
+      n4 = create(:hmis_hud_custom_client_name, user: u1, data_source: ds1, client: c1, first: 'Fourth', primary: true)
+      c1.update(names: [n1, n2, n3, n4])
+      expect(c1.valid?).to be false
     end
 
     it 'should update name when primary name is updated' do

--- a/drivers/hmis/spec/models/hmis/hud/custom_client_name_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_client_name_spec.rb
@@ -7,11 +7,7 @@
 require 'rails_helper'
 
 RSpec.describe Hmis::Hud::CustomClientName, type: :model do
-  it "doesn't allow deletion of primary name" do
-    name = create(:hmis_hud_custom_client_name, primary: true)
-    name.destroy
-    expect(name).to_not be_destroyed
-  rescue Hmis::Hud::CustomClientName::CannotDestroyPrimaryNameException
-    expect(name.reload).to_not be_destroyed
+  it "doesn't allow primary name with empty first and last" do
+    expect { create(:hmis_hud_custom_client_name, primary: true, first: nil, last: nil) }.to raise_error(ActiveRecord::RecordInvalid)
   end
 end

--- a/drivers/hmis/spec/support/form_helpers.rb
+++ b/drivers/hmis/spec/support/form_helpers.rb
@@ -79,12 +79,6 @@ module FormHelpers
     },
     CLIENT: {
       values: {
-        'first-name' => 'First',
-        'middle-name' => 'Middle',
-        'last-name' => 'Last',
-        'name-suffix' => 'Sf',
-        'preferred-name' => 'Pref',
-        'name-dq' => 'FULL_NAME_REPORTED',
         'dob' => '2000-03-29T05:00:00.000Z',
         'dob-dq' => 'FULL_DOB_REPORTED',
         'ssn' => 'XXXXX1234',
@@ -97,12 +91,18 @@ module FormHelpers
         'image_blob_id' => nil,
       },
       hud_values: {
-        'firstName' => 'First',
-        'middleName' => 'Middle',
-        'lastName' => 'Last',
-        'nameSuffix' => 'Sf',
-        'preferredName' => 'Pref',
-        'nameDataQuality' => 'FULL_NAME_REPORTED',
+        "names": [
+          {
+            "first": 'First',
+            "middle": 'Middle',
+            "last": 'Last',
+            "suffix": 'Sf',
+            "nameDataQuality": 'FULL_NAME_REPORTED',
+            "use": nil,
+            "notes": nil,
+            "primary": true,
+          },
+        ],
         'dob' => '2000-03-29',
         'dobDataQuality' => 'FULL_DOB_REPORTED',
         'ssn' => 'XXXXX1234',


### PR DESCRIPTION
1. Add custom component types for collecting client Names (and Addresses, Phones, and Emails). Name is complicated enough to warrant a custom component (since it requires a special layout). And, maybe more importantly, it is quicker to build that way. In the future if we need to be able to customize the name form element, we would need to build a new component or perhaps split it out so that the Form Definition specifies the individual fields. I kept the old `client_name` fragment, though it is not used.
2. Add a function `construct_nested_attributes` to the base processor that can be used to construct the attributes for a related record (via the `accepts_nested_attributes_for` approach ) based on the form values.
3. Add special logic to the Client Processor that does some (kind of wonky) special things for the name attributes.
4. Tests 🧪 
5. Rename some functions in the processor to be (hopefully) clearer, like `hud_type`=>`graphql_enum` since we're not strictly dealing in HUD here.
