### PR TITLE
Use node_modules as a docker volume instead of bind-mounted

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG RUBY_VERSION
 FROM ruby:$RUBY_VERSION-alpine3.17
 
 ARG BUNDLER_VERSION
+ARG USER_ID=1001
+ARG GROUP_ID=1001
 
 ENV RAILS_ENV ${RAILS_ENV}
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
@@ -50,14 +52,25 @@ WORKDIR /app
 RUN gem update --system \
     && gem install bundler:$BUNDLER_VERSION
 
+RUN addgroup -g ${GROUP_ID} app \
+  && adduser -u ${USER_ID} -G app -h /home/app -D app
+
 # Install gems
-COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock
+COPY --chown=app:app Gemfile /app/Gemfile
+COPY --chown=app:app Gemfile.lock /app/Gemfile.lock
 
 ENV BUNDLE_PATH=/bundle
-ENV PATH=$PATH:/app/bin
+ENV GEM_HOME=/bundle
+ENV BUNDLE_JOBS=4
+ENV BUNDLE_RETRY=3
+ENV BUNDLE_APP_CONFIG=$BUNDLE_PATH
+ENV BUNDLE_BIN=$BUNDLE_PATH/bin
+ENV PATH=$BUNDLE_BIN:$PATH:/app/bin
 COPY docker/entrypoint.sh /usr/bin/
 COPY docker/spec.entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/spec.entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
+
+# We should do this, but I don't want to break anything for anybody
+# USER app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,14 @@
 version: '3.8'
 
 x-app: &app
-  image: hmis-warehouse:3.5
+  image: hmis-warehouse:3.6
   build:
     context: .
     args:
       RUBY_VERSION: 3.1.3
       BUNDLER_VERSION: '2.4.10'
+      USER_ID: ${USER_ID:-1001}
+      GROUP_ID: ${GROUP_ID:-1001}
   environment: &env
     AWS_REGION: ${AWS_REGION:-us-east-1}
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
@@ -38,6 +40,7 @@ x-backend: &backend
     - bundle_alpine:/bundle
     - /usr/local/share/ca-certificates:/usr/local/share/ca-certificates
     - /etc/ssl/certs:/etc/ssl/certs
+    - node_modules_alpine:/node_modules
 
 services:
   shell:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -e
 
+if [[ -d /node_modules ]]
+then
+  if [[ -L /app/node_modules ]]
+  then
+    echo /app/node_modules is a symlink as desired
+  else
+    echo Saving /app/node_modules with alternate name
+    mv /app/node_modules "/app/node_modules.`date +'%s'`"
+
+    echo Symlinking /app/node_modules to /node_modules
+    ln -s /node_modules /app/node_modules
+  fi
+fi
+
+
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /app/tmp/pids/server.pid
 


### PR DESCRIPTION
* also allow users to run containers as the same user ID and group ID  as on their host.