### PR TITLE
Try sending error directly to sentry

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
@@ -50,6 +50,7 @@ module HmisExternalApis::AcHmis
     protected
 
     def handle_error(result)
+      Sentry.capture_exception(result.error) if result.error
       raise HmisErrors::ApiError, result.error if result.error
 
       result


### PR DESCRIPTION
Errors from this job arent showing up in sentry for some reason.