### PR TITLE
Add bounds to referral request form, pre fill user info

### DIFF
--- a/drivers/hmis/app/controllers/hmis/user_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/user_controller.rb
@@ -24,6 +24,7 @@ class Hmis::UserController < Hmis::BaseController
     render json: {
       name: current_hmis_user.name,
       email: current_hmis_user.email,
+      phone: current_hmis_user.phone,
     }
   end
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -6024,6 +6024,11 @@ type ValueBound {
   id: String
 
   """
+  Value to offset the comparison value. Can be positive or negative. If date, offset is applied as number of days.
+  """
+  offset: Int
+
+  """
   Link ID of dependent question, if this items value should be compared to another items value
   """
   question: String

--- a/drivers/hmis/app/graphql/types/forms/value_bound.rb
+++ b/drivers/hmis/app/graphql/types/forms/value_bound.rb
@@ -13,6 +13,7 @@ module Types
     field :id, String, 'Unique identifier for this bound', null: true
     field :severity, Types::HmisSchema::Enums::ValidationSeverity, 'Severity of bound. If error, user will be unable to submit a value that does not meet this condition.', null: false
     field :type, Forms::Enums::BoundType, null: false
+    field :offset, Integer, 'Value to offset the comparison value. Can be positive or negative. If date, offset is applied as number of days.', null: true
 
     # Note: only one of the below attributes should be specified
     field :value_number, Integer, null: true

--- a/drivers/hmis/lib/form_data/allegheny/records/referral_request.json
+++ b/drivers/hmis/lib/form_data/allegheny/records/referral_request.json
@@ -2,15 +2,33 @@
   "name": "referral-request",
   "item": [
     {
+      "type": "DATE",
+      "link_id": "today",
+      "hidden": true,
+      "initial": [
+        {
+          "initial_behavior": "OVERWRITE",
+          "value_local_constant": "$today"
+        }
+      ]
+    },
+    {
       "type": "GROUP",
       "link_id": "1",
       "item": [
         {
           "type": "DATE",
           "required": true,
-          "link_id": "requestedOn",
+          "link_id": "requested-on",
           "text": "Requested Date",
-          "field_name": "requestedOn"
+          "field_name": "requestedOn",
+          "bounds": [
+            {
+              "id": "min-request-on",
+              "type": "MIN",
+              "question": "today"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -25,28 +43,65 @@
           "required": true,
           "link_id": "neededBy",
           "text": "Estimated Date Needed",
-          "field_name": "neededBy"
+          "field_name": "neededBy",
+          "bounds": [
+            {
+              "id": "min-needed-by-lax",
+              "type": "MIN",
+              "question": "today"
+            },
+            {
+              "id": "min-needed-by",
+              "type": "MIN",
+              "question": "requested-on",
+              "offset": 1
+            },
+            {
+              "id": "max-needed-by",
+              "type": "MAX",
+              "question": "requested-on",
+              "offset": 15
+            }
+          ]
         },
         {
           "type": "STRING",
           "required": true,
           "link_id": "requestorName",
           "text": "Requestor Name",
-          "field_name": "requestorName"
+          "field_name": "requestorName",
+          "initial": [
+            {
+              "initial_behavior": "IF_EMPTY",
+              "value_local_constant": "$userName"
+            }
+          ]
         },
         {
           "type": "STRING",
           "required": true,
           "link_id": "requestorPhone",
           "text": "Requestor Phone",
-          "field_name": "requestorPhone"
+          "field_name": "requestorPhone",
+          "initial": [
+            {
+              "initial_behavior": "IF_EMPTY",
+              "value_local_constant": "$userPhone"
+            }
+          ]
         },
         {
           "type": "STRING",
           "required": true,
           "link_id": "requestorEmail",
           "text": "Requestor Email",
-          "field_name": "requestorEmail"
+          "field_name": "requestorEmail",
+          "initial": [
+            {
+              "initial_behavior": "IF_EMPTY",
+              "value_local_constant": "$userEmail"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This only "validates" dates on the frontend. https://www.pivotaltracker.com/story/show/184404620 is needed to validate on the backend and reject submission if dates fall out of bounds.

Merge with https://github.com/greenriver/hmis-frontend/pull/295

![Screen Shot 2023-06-01 at 11 26 44 AM](https://github.com/greenriver/hmis-warehouse/assets/5333982/7bca17f8-cf39-4980-b61e-3abf688f4082)
