### PR TITLE
Patch bug in client names submission and MCI linking

### DIFF
--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -44,6 +44,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
       begin
         container_processor(container)&.process(field, value)
       rescue StandardError => e
+        Sentry.capture_exception(e)
         raise $ERROR_INFO, "Error processing field '#{field}': #{e.message}", $ERROR_INFO.backtrace
       end
     end

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -170,7 +170,17 @@ class Hmis::Hud::Processors::Base
     existing_values = @processor.send(factory_name).send(attribute_name)
     existing_values = existing_values.send(scope_name) if scope_name.present?
     existing_values_ids = existing_values.pluck(:id)
-    seen_ids = attributes.map { |obj| obj[:id]&.to_i }.compact
+    seen_ids = []
+    attributes.each do |attrs|
+      id = attrs[:id]&.to_i
+      next unless id.present?
+
+      if existing_values_ids.include?(id)
+        seen_ids << id
+      else
+        attrs.delete(:id) # ID doesn't exist. Remove it so a new record is created.
+      end
+    end
     (existing_values_ids - seen_ids).each do |id_to_delete|
       attributes.unshift({ id: id_to_delete, _destroy: '1' })
     end

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -180,6 +180,7 @@ module Hmis::Hud::Processors
       client.external_ids << HmisExternalApis::ExternalId.new(
         value: value,
         remote_credential: HmisExternalApis::AcHmis::Mci.new.creds,
+        namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID,
       )
     end
   end


### PR DESCRIPTION
This was mysteriously not being sent to sentry, like https://github.com/greenriver/hmis-warehouse/pull/3107. In both those cases we are rescuing and re raising, so maybe that messes with the sentry capture?

The issue was that the "constructed" ClientNames get a fake Id of '0'. When that gets submitted, the processor errors because the ID is not found.

