### PR TITLE
Unpluralize all filter names

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -139,7 +139,7 @@ type AssessmentAccess {
 }
 
 input AssessmentFilterOptions {
-  roles: [AssessmentRole!]
+  type: [AssessmentRole!]
 }
 
 input AssessmentInput {
@@ -1960,14 +1960,15 @@ enum EnrollmentStatus {
 
 input EnrollmentsForClientFilterOptions {
   openOnDate: ISO8601Date
-  projectTypes: [ProjectType!]
-  statuses: [EnrollmentFilterOptionStatus!]
+  projectType: [ProjectType!]
+  status: [EnrollmentFilterOptionStatus!]
 }
 
 input EnrollmentsForProjectFilterOptions {
   openOnDate: ISO8601Date
+  projectType: [ProjectType!]
   searchTerm: String
-  statuses: [EnrollmentFilterOptionStatus!]
+  status: [EnrollmentFilterOptionStatus!]
 }
 
 type EnrollmentsPaginated {
@@ -3052,7 +3053,7 @@ input HouseholdFilterOptions {
   hohAgeRange: AgeRange
   openOnDate: ISO8601Date
   searchTerm: String
-  statuses: [EnrollmentFilterOptionStatus!]
+  status: [EnrollmentFilterOptionStatus!]
 }
 
 """
@@ -4312,10 +4313,10 @@ enum ProjectFilterOptionStatus {
 }
 
 input ProjectFilterOptions {
-  funders: [FundingSource!]
-  projectTypes: [ProjectType!]
+  funder: [FundingSource!]
+  projectType: [ProjectType!]
   searchTerm: String
-  statuses: [ProjectFilterOptionStatus!]
+  status: [ProjectFilterOptionStatus!]
 }
 
 """

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1966,7 +1966,6 @@ input EnrollmentsForClientFilterOptions {
 
 input EnrollmentsForProjectFilterOptions {
   openOnDate: ISO8601Date
-  projectType: [ProjectType!]
   searchTerm: String
   status: [EnrollmentFilterOptionStatus!]
 }

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -12,7 +12,7 @@ module Types
     include Types::HmisSchema::HasCustomDataElements
 
     available_filter_options do
-      arg :roles, [Types::Forms::Enums::AssessmentRole]
+      arg :type, [Types::Forms::Enums::AssessmentRole]
     end
 
     description 'Custom Assessment'

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -23,9 +23,9 @@ module Types
     end
 
     available_filter_options do
-      arg :statuses, [HmisSchema::Enums::EnrollmentFilterOptionStatus]
+      arg :status, [HmisSchema::Enums::EnrollmentFilterOptionStatus]
       arg :open_on_date, GraphQL::Types::ISO8601Date
-      arg :project_types, [Types::HmisSchema::Enums::ProjectType]
+      arg :project_type, [Types::HmisSchema::Enums::ProjectType]
       arg :search_term, String
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -17,7 +17,7 @@ module Types
     # object is a Hmis::Hud::Household
 
     available_filter_options do
-      arg :statuses, [HmisSchema::Enums::EnrollmentFilterOptionStatus]
+      arg :status, [HmisSchema::Enums::EnrollmentFilterOptionStatus]
       arg :open_on_date, GraphQL::Types::ISO8601Date
       arg :hoh_age_range, HmisSchema::Enums::AgeRange
       arg :search_term, String

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -60,7 +60,7 @@ module Types
     hud_field :date_deleted
     field :user, HmisSchema::User, null: true
     field :active, Boolean, null: false
-    enrollments_field filter_args: { omit: [:project_types], type_name: 'EnrollmentsForProject' }
+    enrollments_field filter_args: { omit: [:project_type], type_name: 'EnrollmentsForProject' }
     custom_data_elements_field
     referral_requests_field :referral_requests
     referral_postings_field :incoming_referral_postings

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -23,14 +23,14 @@ module Types
     end
 
     available_filter_options do
-      arg :statuses, [
+      arg :status, [
         Types::BaseEnum.generate_enum('ProjectFilterOptionStatus') do
           value 'OPEN', description: 'Open'
           value 'CLOSED', description: 'Closed'
         end,
       ]
-      arg :project_types, [Types::HmisSchema::Enums::ProjectType]
-      arg :funders, [HmisSchema::Enums::Hud::FundingSource]
+      arg :project_type, [Types::HmisSchema::Enums::ProjectType]
+      arg :funder, [HmisSchema::Enums::Hud::FundingSource]
       arg :search_term, String
     end
 

--- a/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
@@ -14,6 +14,6 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_roles(scope)
-    with_filter(scope, :roles) { scope.with_role(input.roles) }
+    with_filter(scope, :type) { scope.with_role(input.type) }
   end
 end

--- a/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
@@ -18,7 +18,7 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
 
   def with_statuses(scope)
     with_filter(scope, :status) do
-      if input.statuses.present?
+      if input.status.present?
         ids = []
 
         ids += scope.active.pluck(:id) if input.status.include?('ACTIVE')

--- a/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
@@ -17,13 +17,13 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_statuses(scope)
-    with_filter(scope, :statuses) do
+    with_filter(scope, :status) do
       if input.statuses.present?
         ids = []
 
-        ids += scope.active.pluck(:id) if input.statuses.include?('ACTIVE')
-        ids += scope.incomplete.pluck(:id) if input.statuses.include?('INCOMPLETE')
-        ids += scope.exited.pluck(:id) if input.statuses.include?('EXITED')
+        ids += scope.active.pluck(:id) if input.status.include?('ACTIVE')
+        ids += scope.incomplete.pluck(:id) if input.status.include?('INCOMPLETE')
+        ids += scope.exited.pluck(:id) if input.status.include?('EXITED')
 
         return scope.where(id: ids)
       end
@@ -37,7 +37,7 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
   end
 
   def with_project_types(scope)
-    with_filter(scope, :project_types) { scope.with_project_type(input.project_types) }
+    with_filter(scope, :project_type) { scope.with_project_type(input.project_type) }
   end
 
   def with_search_term(scope)

--- a/drivers/hmis/app/models/hmis/filter/household_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/household_filter.rb
@@ -18,7 +18,7 @@ class Hmis::Filter::HouseholdFilter < Hmis::Filter::BaseFilter
 
   def with_statuses(scope)
     with_filter(scope, :status) do
-      if input.statuses.present?
+      if input.status.present?
         ids = []
 
         ids += scope.merge(Hmis::Hud::Enrollment.active).pluck(:id) if input.status.include?('ACTIVE')

--- a/drivers/hmis/app/models/hmis/filter/household_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/household_filter.rb
@@ -17,13 +17,13 @@ class Hmis::Filter::HouseholdFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_statuses(scope)
-    with_filter(scope, :statuses) do
+    with_filter(scope, :status) do
       if input.statuses.present?
         ids = []
 
-        ids += scope.merge(Hmis::Hud::Enrollment.active).pluck(:id) if input.statuses.include?('ACTIVE')
-        ids += scope.merge(Hmis::Hud::Enrollment.incomplete).pluck(:id) if input.statuses.include?('INCOMPLETE')
-        ids += scope.merge(Hmis::Hud::Enrollment.exited).pluck(:id) if input.statuses.include?('EXITED')
+        ids += scope.merge(Hmis::Hud::Enrollment.active).pluck(:id) if input.status.include?('ACTIVE')
+        ids += scope.merge(Hmis::Hud::Enrollment.incomplete).pluck(:id) if input.status.include?('INCOMPLETE')
+        ids += scope.merge(Hmis::Hud::Enrollment.exited).pluck(:id) if input.status.include?('EXITED')
 
         return scope.where(id: ids)
       end
@@ -37,7 +37,7 @@ class Hmis::Filter::HouseholdFilter < Hmis::Filter::BaseFilter
   end
 
   def with_project_types(scope)
-    with_filter(scope, :project_types) { scope.merge(Hmis::Hud::Enrollment.with_project_type(input.project_types)) }
+    with_filter(scope, :project_type) { scope.merge(Hmis::Hud::Enrollment.with_project_type(input.project_type)) }
   end
 
   def with_search_term(scope)

--- a/drivers/hmis/app/models/hmis/filter/project_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/project_filter.rb
@@ -17,15 +17,15 @@ class Hmis::Filter::ProjectFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_statuses(scope)
-    with_filter(scope, :statuses) { scope.with_statuses(input.statuses) }
+    with_filter(scope, :status) { scope.with_statuses(input.status) }
   end
 
   def with_funders(scope)
-    with_filter(scope, :funders) { scope.with_funders(input.funders) }
+    with_filter(scope, :funder) { scope.with_funders(input.funder) }
   end
 
   def with_project_types(scope)
-    with_filter(scope, :project_types) { scope.with_project_type(input.project_types) }
+    with_filter(scope, :project_type) { scope.with_project_type(input.project_type) }
   end
 
   def with_search_term(scope)

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         query GetProject($id: ID!) {
           project(id: $id) {
             id
-            enrollments(limit: 10, offset: 0, filters: { statuses: [INCOMPLETE] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: [INCOMPLETE] }) {
               nodesCount
               nodes {
                 id
@@ -66,7 +66,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         query GetProject($id: ID!) {
           project(id: $id) {
             id
-            enrollments(limit: 10, offset: 0, filters: { statuses: [ACTIVE, EXITED] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: [ACTIVE, EXITED] }) {
               nodesCount
               nodes {
                 id

--- a/drivers/hmis/spec/requests/hmis/get_projects_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/get_projects_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let(:query) do
     <<~GRAPHQL
       query GetProject($projectTypes: [ProjectType!], $searchTerm: String, $sortOrder: ProjectSortOption, $offset: Int = 0, $limit: Int = 5) {
-        projects(filters: { projectTypes: $projectTypes, searchTerm: $searchTerm }, sortOrder: $sortOrder, offset: $offset, limit: $limit) {
+        projects(filters: { projectType: $projectTypes, searchTerm: $searchTerm }, sortOrder: $sortOrder, offset: $offset, limit: $limit) {
           nodesCount
           nodes {
             #{scalar_fields(Types::HmisSchema::Project)}

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       query Client($id: ID!) {
         client(id: $id) {
           id
-          enrollments(limit: 10, offset: 0, filters: { statuses: [INCOMPLETE] }) {
+          enrollments(limit: 10, offset: 0, filters: { status: [INCOMPLETE] }) {
             nodesCount
             nodes {
               id
@@ -163,7 +163,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       query Client($id: ID!) {
         client(id: $id) {
           id
-          enrollments(limit: 10, offset: 0, filters: { statuses: [ACTIVE, EXITED] }) {
+          enrollments(limit: 10, offset: 0, filters: { status: [ACTIVE, EXITED] }) {
             nodesCount
             nodes {
               id

--- a/drivers/hmis/spec/requests/hmis/project_enrollments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollments_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         query GetProject($id: ID!) {
           project(id: $id) {
             id
-            enrollments(limit: 10, offset: 0, filters: { statuses: [INCOMPLETE] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: [INCOMPLETE] }) {
               nodesCount
               nodes {
                 id
@@ -66,7 +66,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         query GetProject($id: ID!) {
           project(id: $id) {
             id
-            enrollments(limit: 10, offset: 0, filters: { statuses: [ACTIVE, EXITED] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: [ACTIVE, EXITED] }) {
               nodesCount
               nodes {
                 id


### PR DESCRIPTION
Argument names are used for display values, they shouldn't be plural

<img width="375" alt="Screen Shot 2023-06-07 at 5 41 55 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/302d0a78-5987-4503-93ad-f79d5717d7dc">
