### PR TITLE
Fix broken assessment project type and project filters

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
@@ -20,10 +20,10 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
   end
 
   def with_project_type(scope)
-    with_filter(scope, :project_types) { scope.with_project_type(input.project_types) }
+    with_filter(scope, :project_type) { scope.with_project_type(input.project_type) }
   end
 
   def with_project(scope)
-    with_filter(scope, :projects) { scope.with_project(input.projects) }
+    with_filter(scope, :project) { scope.with_project(input.project) }
   end
 end


### PR DESCRIPTION
These were missed with https://github.com/greenriver/hmis-warehouse/pull/3129/commits/3e9ee358b06b112900b966afb73d6b676d0bbcc7, I only noticed because the filters weren't working. I can see this causing bugs in the future, because the variable names need to match exactly in 3 places, or else it just fails silently. Do you think there's a way we could DRY that up @ZachCMP ?