### PR TITLE
Patch household id bug

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -9,7 +9,7 @@
 module Types
   class HmisSchema::Household < Types::BaseObject
     description 'HUD Household'
-    field :id, ID, null: false
+    field :id, ID, null: false, method: :household_id
     field :short_id, ID, null: false
     field :household_clients, [HmisSchema::HouseholdClient], null: false
     field :household_size, Int, null: false

--- a/drivers/hmis/app/models/hmis/hud/household.rb
+++ b/drivers/hmis/app/models/hmis/hud/household.rb
@@ -13,6 +13,7 @@ class Hmis::Hud::Household < Hmis::Hud::Base
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
   has_many :enrollments, **hmis_relation(:HouseholdID, 'Enrollment')
   has_many :clients, through: :enrollments
+  alias_attribute :household_id, :HouseholdID
 
   replace_scope :viewable_by, ->(user) do
     viewable_households = joins(:enrollments).
@@ -53,7 +54,9 @@ class Hmis::Hud::Household < Hmis::Hud::Base
 
   TRIMMED_HOUSEHOLD_ID_LENGTH = 6
   def short_id
-    id.first(TRIMMED_HOUSEHOLD_ID_LENGTH)
+    return household_id unless household_id.length == 32
+
+    household_id.first(TRIMMED_HOUSEHOLD_ID_LENGTH)
   end
 
   SORT_OPTIONS = [


### PR DESCRIPTION
GQL was incorrectly resolving the database ID in from the Household View, which has the datasource id concatenated.