### PR TITLE
Update form override

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/records/client.json
+++ b/drivers/hmis/lib/form_data/allegheny/records/client.json
@@ -7,6 +7,18 @@
       "field_name": "id"
     },
     {
+      "type": "OBJECT",
+      "link_id": "current-mci-id",
+      "repeats": false,
+      "hidden": true,
+      "initial": [
+        {
+          "initial_behavior": "OVERWRITE",
+          "value_local_constant": "$mciId"
+        }
+      ]
+    },
+    {
       "fragment": "#client_names"
     },
     {


### PR DESCRIPTION
Hack-ish way to include current value in the form state, so we don't need to depend on the "dashboard context" to know the current client's information.  Not strictly necessary now, but future-proofs in case we need to show client editing forms in other contexts outside the client dash.