### PR TITLE
185336568-log-link-requests

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,5 +14,5 @@
     "typescriptreact",
     "yaml"
   ],
-  "words": ["datetime", "funder", "coc", "hmis", "grda", "mper"]
+  "words": ["datetime", "funder", "coc", "hmis", "grda", "mper", "creds"]
 }

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
@@ -61,14 +61,7 @@ module HmisExternalApis::AcHmis
     end
 
     def conn
-      @conn ||= HmisExternalApis::OauthClientConnection.new(
-        client_id: creds.client_id,
-        client_secret: creds.client_secret,
-        token_url: creds.token_url,
-        base_url: creds.base_url,
-        headers: creds.additional_headers,
-        scope: creds.oauth_scope,
-      )
+      @conn ||= HmisExternalApis::OauthClientConnection.new(creds)
     end
 
     # @param payload [Hash]

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
@@ -6,7 +6,19 @@
 
 module HmisExternalApis
   # https://gitlab.com/oauth-xx/oauth2/
-  OauthClientConnection = Struct.new(:client_id, :client_secret, :token_url, :headers, :scope, :base_url, keyword_init: true) do
+  class OauthClientConnection
+    attr_accessor :creds, :client_id, :scope, :headers, :base_url
+
+    # @param creds [::GrdaWarehouse::RemoteCredential]
+    def initialize(creds)
+      self.creds = creds
+      self.client_id = creds.client_id
+      self.scope = creds.oauth_scope
+      # normalized base_url
+      self.base_url = creds.base_url.strip.gsub(%r{/*\z}, '')
+      self.headers = creds.additional_headers
+    end
+
     def get(path)
       request(:get, url_for(path))
     end
@@ -31,22 +43,31 @@ module HmisExternalApis
 
     private
 
-    # normalize leading/trailing slashes
-    def url_for(path)
-      return normalized_base_url if path.blank?
-
-      normalized_base_url + '/' + path.strip.gsub(%r{\A/*}, '')
+    def log_request(url:, method:, payload:, headers:)
+      HmisExternalApis::ExternalRequestLog.create!(
+        initiator: creds,
+        url: url,
+        http_method: method,
+        request: payload || {},
+        request_headers: headers,
+        requested_at: Time.current,
+        response: 'pending', # can't be null
+      )
     end
 
-    def normalized_base_url
-      base_url.strip.gsub(%r{/*\z}, '')
+    # normalize leading/trailing slashes
+    def url_for(path)
+      return base_url if path.blank?
+
+      base_url + '/' + path.strip.gsub(%r{\A/*}, '')
     end
 
     def request(verb, url, payload = nil)
+      request_log = log_request(url: url, method: verb, payload: payload, headers: merged_headers)
       result =
         case verb
         when :get
-          access.get(url, headers: headers)
+          access.get(url, headers: merged_headers)
         when :post
           access.post(url, headers: merged_headers, body: payload.to_json)
         when :patch
@@ -54,6 +75,14 @@ module HmisExternalApis
         else
           raise "invalid verb #{verb}"
         end
+
+      if result
+        request_log.update!(
+          content_type: result.content_type,
+          response: result.body,
+          http_status: result.status,
+        )
+      end
 
       OauthClientResult.new(
         body: result.body,
@@ -66,6 +95,7 @@ module HmisExternalApis
         parsed_body: try_parse_json(result.body),
         request_headers: merged_headers,
         url: url,
+        request_log: request_log,
       )
     rescue OAuth2::Error => e
       OauthClientResult.new(
@@ -80,6 +110,7 @@ module HmisExternalApis
         request_headers: e.response.response.env.request_headers,
         request_body: e.response.response.env.request_body,
         url: e.response.response.env.url.to_s,
+        request_log: request_log,
       )
     end
 
@@ -108,7 +139,7 @@ module HmisExternalApis
     end
 
     def client
-      OAuth2::Client.new(client_id, client_secret, token_url: token_url)
+      OAuth2::Client.new(client_id, creds.client_secret, token_url: creds.token_url)
     end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_result.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_result.rb
@@ -17,6 +17,7 @@ module HmisExternalApis
     :http_status,
     :url,
     :request_body,
+    :request_log,
     keyword_init: true,
   ) do
   end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/link_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/link_spec.rb
@@ -12,12 +12,17 @@ require 'rails_helper'
 # our own implementation
 RSpec.describe 'LINK API', type: :model do
   if ENV['OAUTH_CREDENTIAL_TEST'] == 'true'
-    let(:base_url) { ENV.fetch('LINK_BASE_URL') + '/' }
-    let(:client_id) { ENV.fetch('LINK_CLIENT_ID') }
-    let(:client_secret) { ENV.fetch('LINK_CLIENT_SECRET') }
-    let(:token_url) { ENV.fetch('LINK_TOKEN_URL') }
-    let(:oauth_scope) { 'GREEN_RIVER' }
-    let(:ocp_apim_subscription_key) { ENV.fetch('LINK_OCP_APIM_SUBSCRIPTION_KEY') }
+    let(:creds) do
+      create(
+        :grda_remote_oauth_credential,
+        client_id: ENV.fetch('LINK_CLIENT_ID'),
+        client_secret: ENV.fetch('LINK_CLIENT_SECRET'),
+        token_url: ENV.fetch('LINK_TOKEN_URL'),
+        additional_headers: { 'Ocp-Apim-Subscription-Key' => ENV.fetch('LINK_OCP_APIM_SUBSCRIPTION_KEY') },
+        base_url: ENV.fetch('LINK_BASE_URL') + '/',
+        oauth_scope: 'GREEN_RIVER',
+      )
+    end
 
     let(:requested_by) { 'test@greenriver.com' }
     let(:now) { Time.now }
@@ -29,14 +34,7 @@ RSpec.describe 'LINK API', type: :model do
     end
 
     let(:subject) do
-      HmisExternalApis::OauthClientConnection.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        token_url: token_url,
-        headers: { 'Ocp-Apim-Subscription-Key' => ocp_apim_subscription_key },
-        base_url: base_url,
-        scope: oauth_scope,
-      )
+      HmisExternalApis::OauthClientConnection.new(creds)
     end
 
     it 'creates referral request' do

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/mci_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/mci_spec.rb
@@ -10,21 +10,20 @@ require 'rails_helper'
 # We need many secrets to test this. Essentially, this runs locally or on staging
 RSpec.describe 'MCI API', type: :model do
   if ENV['OAUTH_CREDENTIAL_TEST'] == 'true'
-    let(:host) { ENV.fetch('MCI_HOST') }
-    let(:client_id) { ENV.fetch('MCI_CLIENT_ID') }
-    let(:client_secret) { ENV.fetch('MCI_CLIENT_SECRET') }
-    let(:token_url) { ENV.fetch('MCI_TOKEN_URL') }
-    let(:ocp_apim_subscription_key) { ENV.fetch('MCI_OCP_APIM_SUBSCRIPTION_KEY') }
+    let(:creds) do
+      create(
+        :grda_remote_oauth_credential,
+        client_id: ENV.fetch('MCI_CLIENT_ID'),
+        client_secret: ENV.fetch('MCI_CLIENT_SECRET'),
+        token_url: ENV.fetch('MCI_TOKEN_URL'),
+        additional_headers: { 'Ocp-Apim-Subscription-Key' => ENV.fetch('MCI_OCP_APIM_SUBSCRIPTION_KEY') },
+        base_url: "https://#{ENV.fetch('MCI_HOST')}/",
+        oauth_scope: 'API_TEST',
+      )
+    end
 
     let(:subject) do
-      HmisExternalApis::OauthClientConnection.new(
-        client_id: client_id,
-        client_secret: client_secret,
-        token_url: token_url,
-        headers: { 'Ocp-Apim-Subscription-Key' => ocp_apim_subscription_key },
-        base_url: "https://#{host}/",
-        scope: 'API_TEST',
-      )
+      HmisExternalApis::OauthClientConnection.new(creds)
     end
 
     it 'supports a get' do

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/oauth_credential_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/oauth_credential_spec.rb
@@ -9,19 +9,10 @@ require 'webmock/rspec'
 
 RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
   let(:fake_token) { 'deadbeefdeadbeefdeadbeefdeadbeef' }
-  let(:host) { 'example.com' }
-  let(:client_id) { '1234567890' }
-  let(:client_secret) { 'secretsecretsecret' }
-  let(:token_url) { 'https://example.com/oauth2/v1/token' }
+  let(:creds) { create(:ac_hmis_link_credential) }
 
   let(:subject) do
-    HmisExternalApis::OauthClientConnection.new(
-      client_id: client_id,
-      client_secret: client_secret,
-      token_url: token_url,
-      base_url: "https://#{host}/",
-      scope: 'API_TEST',
-    )
+    HmisExternalApis::OauthClientConnection.new(creds)
   end
 
   before(:each) do
@@ -33,13 +24,13 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
       "refresh_token": fake_token,
       "scope": subject.scope,
     }.to_json
-    stub_request(:post, 'https://example.com/oauth2/v1/token')
+    stub_request(:post, creds.token_url)
       .to_return(status: 200, body: body,
                  headers: { 'Content-Type' => 'application/json' })
   end
 
   it 'supports a get' do
-    path = 'test/resources/1'
+    path = '/test/resources/1'
     stub_request(:get, "#{subject.base_url}#{path}")
       .to_return(status: 200, body: { helloWorld: 1 }.to_json,
                  headers: { 'Content-Type' => 'application/json' })
@@ -47,10 +38,11 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
     result = subject.get(path)
     expect(result.http_status).to eq(200)
     expect(result.parsed_body).to include('helloWorld')
+    expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
   end
 
   it 'handles errors' do
-    path = 'test/resources/2'
+    path = '/test/resources/2'
     stub_request(:get, "#{subject.base_url}#{path}")
       .to_return(status: 404, body: nil, headers: {})
 
@@ -59,23 +51,26 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
     expect(result.body).to be_blank
     expect(result.parsed_body).to be_blank
     expect(result.error_type).to eq('OAuth2::Error')
+    expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
   end
 
   it 'supports a post' do
-    path = 'test/resources'
+    path = '/test/resources'
     expected_status = 200
     stub_request(:post, "#{subject.base_url}#{path}")
       .to_return(status: expected_status, body: nil, headers: {})
     result = subject.post(path, { 'hello' => 'world' })
+    expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
     expect(result.http_status).to eq(expected_status)
   end
 
   it 'supports a patch' do
-    path = 'test/resources/1'
+    path = '/test/resources/1'
     expected_status = 200
     stub_request(:patch, "#{subject.base_url}#{path}")
       .to_return(status: expected_status, body: nil, headers: {})
     result = subject.patch(path, { 'hello' => 'world' })
+    expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
     expect(result.http_status).to eq(expected_status)
   end
 end


### PR DESCRIPTION
This makes logging the responsibility of OauthClientConnection. Logging will happen by default going forward without needing to reimplement it for every API. The log record is returned as part of the result from the client so that it can be associated with our db records.

Additionally, the request is logged before the external API is invoked. That way we will retain a record of the attempted request if something goes wrong.

To associate the log records with the correct initiator, we pass the credentials into the OauthClientConnection. This presented the opportunity to  simplify the configuration interface for OauthClientConnection. It now takes a credential object and gets it's configuration from that.

Functional changes:
* logs all LINK requests
* replaces previous logging implementation for MCI requests
* side-effect, HmisExternalApis::AcHmis::DataWarehouseApi will now also log requests
