### PR TITLE
185334192 admin dashboard and referral denial

### DIFF
--- a/db/warehouse/migrate/20230611160741_add_mci_id_to_referral_household_members.rb
+++ b/db/warehouse/migrate/20230611160741_add_mci_id_to_referral_household_members.rb
@@ -1,0 +1,5 @@
+class AddMciIdToReferralHouseholdMembers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :hmis_external_referral_household_members, :mci_id, :string
+  end
+end

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4730,11 +4730,13 @@ type ReferralPosting {
   denialNote: String
   denialReason: String
   hohEnrollment: Enrollment
+  hohMciId: ID
   hohName: String!
   householdMembers: [ReferralHouseholdMember!]!
   householdSize: Int!
   id: ID!
   needsWheelchairAccessibleUnit: Boolean
+  organizationName: String
   postingIdentifier: ID
   referralDate: ISO8601Date!
   referralIdentifier: ID

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4447,6 +4447,7 @@ type Query {
   """
   clientSearch(input: ClientSearchInput!, limit: Int, offset: Int, sortOrder: ClientSortOption): ClientsPaginated!
   currentUser: ApplicationUser
+  deniedPendingReferralPostings(limit: Int, offset: Int): ReferralPostingsPaginated!
 
   """
   Enrollment lookup

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -15,6 +15,7 @@ module Types
     include Types::HmisSchema::HasProjects
     include Types::HmisSchema::HasOrganizations
     include Types::HmisSchema::HasClients
+    include Types::HmisSchema::HasReferralPostings
     include ::Hmis::Concerns::HmisArelHelper
 
     projects_field :projects
@@ -190,6 +191,15 @@ module Types
 
     def referral_posting(id:)
       HmisExternalApis::AcHmis::ReferralPosting.viewable_by(current_user).find_by(id: id)
+    end
+
+    referral_postings_field :denied_pending_referral_postings
+    def denied_pending_referral_postings(**args)
+      return [] unless current_user.can_manage_denied_referrals?
+
+      postings = HmisExternalApis::AcHmis::ReferralPosting.denied_pending_status
+
+      scoped_referral_postings(postings, **args)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -21,6 +21,7 @@ module Types
 
     # Fields that come from ReferralHouseholdMembers
     field :hoh_name, String, null: false
+    field :hoh_mci_id, ID, null: true
     field :household_size, Integer, null: false
     field :household_members, [HmisSchema::ReferralHouseholdMember], null: false
 
@@ -40,16 +41,23 @@ module Types
     field :denial_note, String
     field :referred_from, String, null: false
     field :unit_type, HmisSchema::UnitTypeObject, null: false
+    field :organization_name, String, null: true
 
     # If this posting has been accepted, this is the enrollment for the HoH at the enrolled household.
     # This enrollment is NOT necessarily the same as the `hoh_name`, because the HoH may have changed after
     # posting was accepted.
     field :hoh_enrollment, HmisSchema::Enrollment, null: true
 
+    def hoh_member
+      object.referral.household_members.detect(&:self_head_of_household?)
+    end
+
     def hoh_name
-      object.referral.household_members
-        .detect(&:self_head_of_household?)
-        &.client&.brief_name
+      hoh_member&.client&.brief_name
+    end
+
+    def hoh_mci_id
+      hoh_member&.mci_id
     end
 
     def hoh_enrollment
@@ -68,6 +76,10 @@ module Types
 
     def referred_from
       object.project&.project_name || 'Coordinated Entry'
+    end
+
+    def organization_name
+      object.project&.organization&.organization_name
     end
 
     def status

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
@@ -227,6 +227,7 @@ module HmisExternalApis::AcHmis
 
         member = referral.household_members.where(client: client).first_or_initialize
         member.relationship_to_hoh = relationship_to_hoh
+        member.mci_id = mci_id
         member.save!
       end
     end


### PR DESCRIPTION
reference
https://www.pivotaltracker.com/story/show/185334192
https://github.com/greenriver/hmis-frontend/pull/317

* Endpoint for denied pending referral postings
* Capture MCI ID on referral household members, add to HOH MCI ID to graphql type (per mock). We could also pull this from the client external_ids but I think using the original value on household member has value (in case there are duplicate MCI ids on the client, or the ID changes somehow)
* Add organization name to referral posting  graphql type(per mock)