### PR TITLE
Validate DOB is not in the future; only send full SSN to MCI

### DIFF
--- a/drivers/hmis/app/graphql/mutations/submit_form.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_form.rb
@@ -95,6 +95,9 @@ module Mutations
         record = nil
       end
 
+      # Reload to get changes from post_save actions, such as newly created MCI ID.
+      record&.reload
+
       {
         record: record,
         errors: errors,

--- a/drivers/hmis/app/graphql/types/ac_hmis/mci_clearance_input.rb
+++ b/drivers/hmis/app/graphql/types/ac_hmis/mci_clearance_input.rb
@@ -17,7 +17,7 @@ module Types
 
     def to_client
       attributes = to_h.except(:gender)
-      hud_user = Hmis::Hud::User.system_user(data_source_id: GrdaWarehouse::DataSource.hmis.pluck(:id).first)
+      hud_user = Hmis::Hud::User.system_user(data_source_id: current_user.hmis_data_source_id)
       Hmis::Hud::Client.new(
         **attributes,
         **Hmis::Hud::Processors::ClientProcessor.gender_attributes(gender || []),

--- a/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
@@ -20,6 +20,7 @@ class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValida
   def self.hmis_validate(record, options: {}, **_)
     errors = HmisErrors::Errors.new
     errors.add :dob, :out_of_range, severity: :error, message: future_message, **options if record.dob&.future?
+    errors.add :dob, :invalid, severity: :error, **options if record.dob && record.dob < (Date.current - 120.years)
     errors.errors
   end
 

--- a/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
@@ -17,6 +17,12 @@ class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValida
     Hmis::Hud::Client.hmis_configuration(version: '2022').except(*IGNORED)
   end
 
+  def self.hmis_validate(record, options: {}, **_)
+    errors = HmisErrors::Errors.new
+    errors.add :dob, :out_of_range, severity: :error, message: future_message, **options if record.dob&.future?
+    errors.errors
+  end
+
   def validate(record)
     super(record) do
       record.errors.add :gender, :required if !skipped_attributes(record).include?(:gender) && ::HudUtility.gender_id_to_field_name.except(8, 9, 99).values.any? { |field| record.send(field).nil? }

--- a/drivers/hmis/lib/form_data/allegheny/records/client.json
+++ b/drivers/hmis/lib/form_data/allegheny/records/client.json
@@ -19,6 +19,17 @@
       ]
     },
     {
+      "type": "DATE",
+      "link_id": "today",
+      "hidden": true,
+      "initial": [
+        {
+          "initial_behavior": "OVERWRITE",
+          "value_local_constant": "$today"
+        }
+      ]
+    },
+    {
       "fragment": "#client_names"
     },
     {

--- a/drivers/hmis/lib/form_data/default/fragments/client_identification.json
+++ b/drivers/hmis/lib/form_data/default/fragments/client_identification.json
@@ -27,6 +27,13 @@
           "operator": "EQUAL",
           "answer_boolean": true
         }
+      ],
+      "bounds": [
+        {
+          "id": "max-dob",
+          "type": "MAX",
+          "question": "today"
+        }
       ]
     },
     {

--- a/drivers/hmis/lib/form_data/default/records/client.json
+++ b/drivers/hmis/lib/form_data/default/records/client.json
@@ -7,6 +7,17 @@
       "field_name": "id"
     },
     {
+      "type": "DATE",
+      "link_id": "today",
+      "hidden": true,
+      "initial": [
+        {
+          "initial_behavior": "OVERWRITE",
+          "value_local_constant": "$today"
+        }
+      ]
+    },
+    {
       "fragment": "#client_names"
     },
     {

--- a/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   it 'should transform MciClearanceInput into Client with correct values' do
-    client = to_gql_input_object({ **input, gender: [0, 1] }, Types::AcHmis::MciClearanceInput).to_client
+    client = to_gql_input_object({ **input, gender: [0, 1] }, Types::AcHmis::MciClearanceInput, current_user: hmis_user).to_client
 
     expect(client.persisted?).to eq(false)
     expect(client.first_name).to eq(input[:first_name])
@@ -99,7 +99,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   it 'should transform MciClearanceInput into Client with minimal values' do
-    client = to_gql_input_object({ **input.except(:middle_name, :ssn, :gender) }, Types::AcHmis::MciClearanceInput).to_client
+    client = to_gql_input_object({ **input.except(:middle_name, :ssn, :gender) }, Types::AcHmis::MciClearanceInput, current_user: hmis_user).to_client
 
     expect(client.persisted?).to eq(false)
     expect(client.first_name).to eq(input[:first_name])

--- a/drivers/hmis/spec/support/graphql_helpers.rb
+++ b/drivers/hmis/spec/support/graphql_helpers.rb
@@ -61,7 +61,7 @@ module GraphqlHelpers
     ERRORS
   end
 
-  def to_gql_input_object(values, klass)
-    klass.new(nil, context: nil, defaults_used: Set.new, ruby_kwargs: values)
+  def to_gql_input_object(values, klass, current_user: nil)
+    klass.new(nil, context: { current_user: current_user }, defaults_used: Set.new, ruby_kwargs: values)
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_payload.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_payload.rb
@@ -18,8 +18,8 @@ module HmisExternalApis::AcHmis
         'middleName' => client.middle_name,
         'lastName' => client.last_name,
         'suffix' => client.name_suffix,
-        'ssn' => client.ssn,
-        # 'ssnAlias' => client.ssn,
+        # API only accepts full SSNs
+        'ssn' => client.ssn&.match?(/^\d{9}$/) ? client.ssn : nil,
         'birthDate' => client.dob.to_s(:db) + 'T00:00:00',
         'raceCodes' => MciMapping.mci_races(client),
         'ethnicityCode' => MciMapping.mci_ethnicity(client),


### PR DESCRIPTION
Some fixes from more thorough MCI clearance QA.
* MCI api rejects incomplete SSNs, so don't send them
* MCI also rejects future DOBs, so dont send that, and dont allow it as input
* Reload record before returning from SubmitForm so that newly created MCI ID is immediately available