### PR TITLE
Return Apollo errors in non-dev environments too

### DIFF
--- a/drivers/hmis/app/controllers/hmis/graphql_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/graphql_controller.rb
@@ -70,11 +70,17 @@ module Hmis
       Rails.logger.error err.message
       Rails.logger.error err.backtrace.join("\n")
 
+      Sentry.capture_exception_with_info(
+        err,
+        err.message,
+        { backtrace: err.backtrace.to_s },
+      )
+
       render status: 500, json: {
         errors: [
           {
-            message: err.message,
-            backtrace: err.backtrace,
+            message: Rails.env.development? ? err.message : 'An internal server error occurred.',
+            backtrace: Rails.env.development? ? err.backtrace : nil,
           },
         ],
         data: {},

--- a/drivers/hmis/app/controllers/hmis/graphql_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/graphql_controller.rb
@@ -40,9 +40,7 @@ module Hmis
       end
       render json: result
     rescue StandardError => e
-      raise e unless Rails.env.development?
-
-      handle_error_in_development(e)
+      handle_graphql_exception(e)
     end
 
     private
@@ -67,11 +65,20 @@ module Hmis
       end
     end
 
-    def handle_error_in_development(err)
+    # Return exception as an Apollo-formatted error response
+    def handle_graphql_exception(err)
       Rails.logger.error err.message
       Rails.logger.error err.backtrace.join("\n")
 
-      render json: { errors: [{ message: err.message, backtrace: err.backtrace }], data: {} }, status: 500
+      render status: 500, json: {
+        errors: [
+          {
+            message: err.message,
+            backtrace: err.backtrace,
+          },
+        ],
+        data: {},
+      }
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/add_to_household_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/add_to_household_spec.rb
@@ -127,17 +127,17 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     it 'should throw error if unauthorized' do
       remove_permissions(access_control, :can_edit_enrollments)
-      expect { post_graphql(input: test_input) { mutation } }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(input: test_input) { mutation }
     end
 
     it 'should error if client is already in the household' do
       input = test_input.merge(client_id: c1.id)
-      expect { post_graphql(input: input) { mutation } }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(input: input) { mutation }
     end
 
     it 'should error if household doesnt exist' do
       input = test_input.merge(household_id: 'notreal')
-      expect { post_graphql(input: input) { mutation } }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(input: input) { mutation }
     end
 
     describe 'Validity tests' do

--- a/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
@@ -164,9 +164,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'should catch and resolve errors' do
     allow(stub_mci).to receive(:clearance).and_raise(StandardError, 'Test error')
-    expect do
-      post_graphql(input: { input: input }) { mutation }
-    end.to raise_error(StandardError)
+    expect_gql_error(post_graphql(input: { input: input }) { mutation })
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_assessment_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       remove_permissions(access_control, permission)
       action.call(a1)
 
-      expect { mutate(input: { id: a1.id }) }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(input: { id: a1.id }) { mutation }
       expect(Hmis::Hud::CustomAssessment.all).to include(have_attributes(id: a1.id))
     end
   end
@@ -90,7 +90,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       fd1.update(role: 'INTAKE')
 
       if key == :submitted
-        expect { mutate(input: { id: a1.id }) }.to raise_error(HmisErrors::ApiError)
+        expect_gql_error post_graphql(input: { id: a1.id }) { mutation }
       else
         mutate(input: { id: a1.id }) do |assessment_id, errors|
           a1.reload

--- a/drivers/hmis/spec/requests/hmis/delete_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_client_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     e2 = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, relationship_to_ho_h: 2, household_id: '1', user: u1
     prev_hoh_value = e2.relationship_to_ho_h
 
-    expect { mutate(input: { id: c1.id }) }.to raise_error(HmisErrors::ApiError)
+    expect_gql_error post_graphql(input: { id: c1.id }) { mutation }
     expect(Hmis::Hud::Client.all).to include(have_attributes(id: c1.id))
     # Should NOT modify HoH of other enrollments if client is not deleted
     expect(e2.reload.relationship_to_ho_h).to eq(prev_hoh_value)

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'should throw error if unauthorized' do
     remove_permissions(access_control, :can_delete_enrollments)
-    expect { post_graphql(input: { id: e2.id }) { mutation } }.to raise_error(HmisErrors::ApiError)
+    expect_gql_error post_graphql(input: { id: e2.id }) { mutation }
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'should throw error if not allowed to manage files' do
       remove_permissions(access_control, :can_manage_any_client_files, :can_manage_own_client_files)
       file_id = f1.id
-      expect { call_mutation(file_id) }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(file_id: file_id) { mutation }
       expect(Hmis::File.all).to include(have_attributes(id: file_id))
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       remove_permissions(access_control, :can_manage_any_client_files)
       file_id = f1.id
       f1.update!(user_id: u2.id)
-      expect { call_mutation(file_id) }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(file_id: file_id) { mutation }
       expect(Hmis::File.all).to include(have_attributes(id: file_id))
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_service_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   it 'should error if a service does not exist' do
-    expect { post_graphql(id: '123') { mutation } }.to raise_error(HmisErrors::ApiError)
+    expect_gql_error post_graphql(id: '123') { mutation }
   end
 
   it 'should error if not allowed to delete a service' do
     remove_permissions(access_control, :can_edit_enrollments)
-    expect { post_graphql(id: s1.id) { mutation } }.to raise_error(HmisErrors::ApiError)
+    expect_gql_error post_graphql(id: s1.id) { mutation }
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/save_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/save_assessment_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     ].each do |test_name, input_proc|
       it test_name do
         input = input_proc.call(test_input)
-        expect { post_graphql(input: { input: input }) { mutation } }.to raise_error(HmisErrors::ApiError)
+        expect_gql_error post_graphql(input: { input: input }) { mutation }
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_assessment_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     before(:each) { e1_exit.update(exit_date: 3.days.ago) }
 
     it 'should error if assessment doesn\'t exist' do
-      expect { post_graphql(input: { input: test_input.merge(assessment_id: '999') }) { mutation } }.to raise_error(HmisErrors::ApiError)
+      expect_gql_error post_graphql(input: { input: test_input.merge(assessment_id: '999') }) { mutation }
     end
 
     [

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
         it 'should fail if user lacks permission' do
           remove_permissions(access_control, *Array(definition.record_editing_permission))
-          expect { post_graphql(input: { input: test_input }) { mutation } }.to raise_error(HmisErrors::ApiError)
+          expect_gql_error post_graphql(input: { input: test_input }) { mutation }
         end
 
         it 'should update user correctly' do

--- a/drivers/hmis/spec/support/graphql_helpers.rb
+++ b/drivers/hmis/spec/support/graphql_helpers.rb
@@ -64,4 +64,12 @@ module GraphqlHelpers
   def to_gql_input_object(values, klass, current_user: nil)
     klass.new(nil, context: { current_user: current_user }, defaults_used: Set.new, ruby_kwargs: values)
   end
+
+  def expect_gql_error(arr, message: nil)
+    response, result = arr
+    error_message = result.dig('errors', 0, 'message')
+    expect(response.status).to eq 500
+    expect(error_message).to be_present
+    expect(error_message).to eq(message) if message.present?
+  end
 end


### PR DESCRIPTION
The message and backtrace will only be shown to the user in Dev, but I think we should always send them so they get to Sentry.
