### PR TITLE
185510355 update referral posting rollback

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -912,7 +912,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.2.0)
-    uri (0.12.1)
+    uri (0.12.2)
     uri_template (0.7.0)
     validate_url (1.0.13)
       activemodel (>= 3.0.0)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
@@ -140,14 +140,17 @@ module HmisExternalApis
     end
 
     def client
+      connection_build = ->(builder) {
+        # https://gitlab.com/oauth-xx/oauth2/-/blob/main/lib/oauth2/client.rb#L81
+        builder.options.timeout = connection_timeout
+        builder.request :url_encoded
+        builder.adapter Faraday.default_adapter
+      }
       OAuth2::Client.new(
-        client_id, creds.client_secret, token_url: creds.token_url,
-        connection_build: -> (builder) {
-          # https://gitlab.com/oauth-xx/oauth2/-/blob/main/lib/oauth2/client.rb#L81
-          builder.options.timeout = connection_timeout
-          builder.request :url_encoded
-          builder.adapter Faraday.default_adapter
-        }
+        client_id,
+        creds.client_secret,
+        token_url: creds.token_url,
+        connection_build: connection_build,
       )
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185510355

* Move the remote api call into the transaction so it roles back on failure. I'm not a huge fan of this since you could end up with transactions waiting on the remote api if it becomes unresponsive. This is far from bullet proof but it should handle the common case.
* Add a timeout to our oauth connections. This should help reduce impact of unresponsive services (this would apply to all oauth connections, not just link). The default is 5 seconds which is just a guess
* Patch security issue in uri gem so CI will pass