### PR TITLE
Send link errors to sentry correctly

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
@@ -50,7 +50,7 @@ module HmisExternalApis::AcHmis
     protected
 
     def handle_error(result)
-      Sentry.capture_exception(result.error) if result.error
+      Sentry.capture_exception(StandardError.new(result.error)) if result.error
       raise HmisErrors::ApiError, result.error if result.error
 
       result


### PR DESCRIPTION
Fix issue 
> /usr/local/bundle/gems/sentry-ruby-5.7.0/lib/sentry/utils/argument_checking_helper.rb:9:in `check_argument_type!': expect the argument to be a Exception, got Hash ({"message"=>"Posting Status Id is not valid. ", "detail"=>"Invalid Parameters."}) (ArgumentError)