### PR TITLE
Add form_submission context for assessment validation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/save_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/save_assessment.rb
@@ -31,12 +31,10 @@ module Mutations
       errors.reject!(&:warning?)
       return { errors: errors } if errors.any?
 
-      errors = HmisErrors::Errors.new
-      is_valid = assessment.valid?
-      is_valid = assessment.form_processor.valid? && is_valid
-      if is_valid
+      if assessment.valid?(:form_submission)
         assessment.save_submitted_assessment!(current_user: current_user, as_wip: true)
       else
+        errors = HmisErrors::Errors.new
         errors.add_ar_errors(assessment.errors&.errors)
         errors.add_ar_errors(assessment.form_processor&.errors&.errors)
         errors.deduplicate!

--- a/drivers/hmis/app/graphql/mutations/submit_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_assessment.rb
@@ -63,9 +63,8 @@ module Mutations
       # Run processor to create/update related records
       assessment.form_processor.run!(owner: assessment, user: current_user)
 
-      # Run both validations
-      is_valid = assessment.valid?
-      is_valid = assessment.form_processor.valid? && is_valid
+      # Run validations
+      is_valid = assessment.valid?(:form_submission)
 
       # Collect validations and warnings from AR Validator classes
       record_validations = assessment.form_processor.collect_record_validations(user: current_user)

--- a/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
@@ -87,8 +87,7 @@ module Mutations
       all_valid = true
       household_members = assessments.map(&:enrollment) # Enrollments with unsaved changes to Entry dates
       assessments.each do |assessment|
-        all_valid = false unless assessment.valid?
-        all_valid = false unless assessment.form_processor.valid?
+        all_valid = false unless assessment.valid?(:form_submission)
         record_validations = assessment.form_processor.collect_record_validations(
           user: current_user,
           household_members: household_members,

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -28,7 +28,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   belongs_to :employment_education, class_name: 'Hmis::Hud::EmploymentEducation', optional: true, autosave: true
   belongs_to :current_living_situation, class_name: 'Hmis::Hud::CurrentLivingSituation', optional: true, autosave: true
 
-  validate :hmis_records_are_valid
+  validate :hmis_records_are_valid, on: :form_submission
 
   attr_accessor :owner, :hud_user, :current_user
 

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -53,6 +53,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   attr_accessor :in_progress
 
   validates_with Hmis::Hud::Validators::CustomAssessmentValidator
+  validate :form_processor_is_valid, on: :form_submission
 
   scope :in_progress, -> { where(wip: true) }
   scope :not_in_progress, -> { where(wip: false) }
@@ -112,7 +113,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   def save_submitted_assessment!(current_user:, as_wip: false)
     Hmis::Hud::CustomAssessment.transaction do
       # Save FormProcessor to save wip values and/or related records
-      form_processor.save!
+      form_processor.save!(context: form_submission)
 
       # Save the assessment record
       if as_wip
@@ -181,5 +182,13 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   def self.hud_key
     :CustomAssessmentID
+  end
+
+  # If we are validating a form submission, validate the form processor
+  # which will validate all related records.
+  # Does not merge errors into assessment error object, so caller
+  # must check form_processor.errors for any validation errors.
+  private def form_processor_is_valid
+    form_processor.valid?(:form_submission)
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -113,7 +113,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   def save_submitted_assessment!(current_user:, as_wip: false)
     Hmis::Hud::CustomAssessment.transaction do
       # Save FormProcessor to save wip values and/or related records
-      form_processor.save!(context: form_submission)
+      form_processor.save! # Not passing validation context because records have already been validated
 
       # Save the assessment record
       if as_wip

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       }
 
       assessment.form_processor.run!(owner: assessment, user: hmis_user)
-      expect(assessment.form_processor.valid?).to be false
+      expect(assessment.form_processor.valid?(:form_submission)).to be false
       expect(assessment.form_processor.errors.where(:income_from_any_source).first.options[:full_message]).to eq(Hmis::Hud::Validators::IncomeBenefitValidator::INCOME_SOURCES_UNSPECIFIED)
       expect(assessment.form_processor.errors.where(:benefits_from_any_source).first.options[:full_message]).to eq(Hmis::Hud::Validators::IncomeBenefitValidator::BENEFIT_SOURCES_UNSPECIFIED)
       expect(assessment.form_processor.errors.where(:insurance_from_any_source).first.options[:full_message]).to eq(Hmis::Hud::Validators::IncomeBenefitValidator::INSURANCE_SOURCES_UNSPECIFIED)


### PR DESCRIPTION
This speeds up the `MigrateAssessmentsJob` which was taking a long time due to validating each record when creating the FormProcessor.

It's only necessary to do that validation when we are submitting a form, so I added a validation context.

Some shared code from SaveAssessment/SubmitAssessment/SubmitHouseholdAssessments should prob still be factored out into CustomAssessment, I'm making my way slowly