### PR TITLE
Ignore empty strings in referral api, dont validate phone format

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/has_units.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_units.rb
@@ -23,7 +23,7 @@ module Types
       end
 
       def resolve_units(scope = object.units, filters: nil)
-        scope = scope.active
+        # scope = scope.active
         scope = scope.apply_filters(filters) if filters.present?
         scope.order(created_at: :desc)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -113,7 +113,7 @@ module Types
 
     # Build OpenStructs to resolve as UnitTypeCapacity
     def unit_types
-      project_units = object.units.active
+      project_units = object.units
       capacity = project_units.group(:unit_type_id).count
       unoccupied = project_units.unoccupied_on.group(:unit_type_id).count
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
@@ -185,13 +185,19 @@ module HmisExternalApis::AcHmis::Importers
         when 'N'
           false
         else
-          raise "unknown value for IsActive"
+          raise 'unknown value for IsActive'
         end
+        db_project_id = projects_ids_by_hud.fetch(row['ProgramID'], nil)
+        raise "UnitTypeMapping error: ProgramID not found: #{row['ProgramID']}" unless db_project_id.present?
+
+        db_unit_type_id = unit_type_ids_by_mper.fetch(row['UnitTypeID'], nil)
+        raise "UnitTypeMapping error: UnitTypeID not found: #{row['UnitTypeID']}" unless db_unit_type_id.present?
+
         {
-          project_id: projects_ids_by_hud.fetch(row['ProgramID']),
-          unit_type_id: unit_type_ids_by_mper.fetch(row['UnitTypeID']),
+          project_id: db_project_id,
+          unit_type_id: db_unit_type_id,
           unit_capacity: row.fetch('UnitCapacity'),
-          active: active
+          active: active,
         }
       end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
@@ -203,7 +203,7 @@ module HmisExternalApis::AcHmis::Importers
           unit_capacity: row.fetch('UnitCapacity'),
           active: active,
         }
-      end
+      end.compact
 
       Hmis::ProjectUnitTypeMapping.import!(
         records,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
@@ -187,8 +187,12 @@ module HmisExternalApis::AcHmis::Importers
         else
           raise 'unknown value for IsActive'
         end
+
         db_project_id = projects_ids_by_hud.fetch(row['ProgramID'], nil)
-        raise "UnitTypeMapping error: ProgramID not found: #{row['ProgramID']}" unless db_project_id.present?
+        if db_project_id.nil?
+          Rails.logger.info "Skipping unrecognized ProgramID: #{row['ProgramID']}"
+          next
+        end
 
         db_unit_type_id = unit_type_ids_by_mper.fetch(row['UnitTypeID'], nil)
         raise "UnitTypeMapping error: UnitTypeID not found: #{row['UnitTypeID']}" unless db_unit_type_id.present?

--- a/drivers/hmis_external_apis/lib/data/ac_hmis/unit_types.json
+++ b/drivers/hmis_external_apis/lib/data/ac_hmis/unit_types.json
@@ -120,7 +120,7 @@
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": "OtherBedInventory",
+    "external_id": 13,
     "name": "SRO",
     "hud_bed_type": "OtherBedInventory"
   },

--- a/drivers/hmis_external_apis/lib/data/ac_hmis/unit_types.json
+++ b/drivers/hmis_external_apis/lib/data/ac_hmis/unit_types.json
@@ -1,18 +1,38 @@
 [
   {
-    "external_id": 22,
-    "name": "0 Bed Room",
+    "external_id": 1,
+    "name": "5+ Bed Room Accessible",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 24,
-    "name": "0 Bed Room Accessible",
+    "external_id": 2,
+    "name": "5+ Bed Room",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 23,
-    "name": "0 Bed Room Chronic Homeless",
+    "external_id": 3,
+    "name": "5+ Bed Room Chronic Homeless",
     "hud_bed_type": "CHBedInventory"
+  },
+  {
+    "external_id": 4,
+    "name": "4 Bed Room",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 5,
+    "name": "4 Bed Room Chronic Homeless",
+    "hud_bed_type": "CHBedInventory"
+  },
+  {
+    "external_id": 6,
+    "name": "4 Bed Room Accessible",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 7,
+    "name": "Mass Shelter Single",
+    "hud_bed_type": "OtherBedInventory"
   },
   {
     "external_id": 8,
@@ -20,13 +40,58 @@
     "hud_bed_type": "OtherBedInventory"
   },
   {
+    "external_id": 9,
+    "name": "1 Bed Room Chronic Homeless",
+    "hud_bed_type": "CHBedInventory"
+  },
+  {
     "external_id": 10,
     "name": "1 Bed Room Accessible",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 9,
-    "name": "1 Bed Room Chronic Homeless",
+    "external_id": 11,
+    "name": "Rapid Re-Housing",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 12,
+    "name": "Rental Assistance",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 13,
+    "name": "SRO",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 14,
+    "name": "SRO Chronic Homeless",
+    "hud_bed_type": "CHBedInventory"
+  },
+  {
+    "external_id": 15,
+    "name": "SRO Accessible",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 16,
+    "name": "3 Bed Room",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 17,
+    "name": "3 Bed Room Chronic Homeless",
+    "hud_bed_type": "CHBedInventory"
+  },
+  {
+    "external_id": 18,
+    "name": "3 Bed Room Accessible",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 19,
+    "name": "2 Bed Room Chronic Homeless",
     "hud_bed_type": "CHBedInventory"
   },
   {
@@ -40,54 +105,49 @@
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 19,
-    "name": "2 Bed Room Chronic Homeless",
+    "external_id": 22,
+    "name": "0 Bed Room",
+    "hud_bed_type": "OtherBedInventory"
+  },
+  {
+    "external_id": 23,
+    "name": "0 Bed Room Chronic Homeless",
     "hud_bed_type": "CHBedInventory"
   },
   {
-    "external_id": 16,
-    "name": "3 Bed Room",
+    "external_id": 24,
+    "name": "0 Bed Room Accessible",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 18,
-    "name": "3 Bed Room Accessible",
+    "external_id": 25,
+    "name": "Mass Shelter Family",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 17,
-    "name": "3 Bed Room Chronic Homeless",
-    "hud_bed_type": "CHBedInventory"
-  },
-  {
-    "external_id": 4,
-    "name": "4 Bed Room",
+    "external_id": 26,
+    "name": "Mass Shelter Accessible",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 6,
-    "name": "4 Bed Room Accessible",
+    "external_id": 27,
+    "name": "Prevention",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 5,
-    "name": "4 Bed Room Chronic Homeless",
-    "hud_bed_type": "CHBedInventory"
-  },
-  {
-    "external_id": 2,
-    "name": "5+ Bed Room",
+    "external_id": 28,
+    "name": "Supportive Service Only Capacity",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 1,
-    "name": "5+ Bed Room Accessible",
+    "external_id": 29,
+    "name": "Street Outreach Capacity",
     "hud_bed_type": "OtherBedInventory"
   },
   {
-    "external_id": 3,
-    "name": "5+ Bed Room Chronic Homeless",
-    "hud_bed_type": "CHBedInventory"
+    "external_id": 30,
+    "name": "Case Management",
+    "hud_bed_type": "OtherBedInventory"
   },
   {
     "external_id": 31,
@@ -97,66 +157,6 @@
   {
     "external_id": 32,
     "name": "Households without Children",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 26,
-    "name": "Mass Shelter Accessible",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 25,
-    "name": "Mass Shelter Family",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 7,
-    "name": "Mass Shelter Single",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 11,
-    "name": "Rapid Re-Housing",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 13,
-    "name": "SRO",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 15,
-    "name": "SRO Accessible",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 14,
-    "name": "SRO Chronic Homeless",
-    "hud_bed_type": "CHBedInventory"
-  },
-  {
-    "external_id": 30,
-    "name": "Case Management",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 27,
-    "name": "Prevention",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 12,
-    "name": "Rental Assistance",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 29,
-    "name": "Street Outreach Capacity",
-    "hud_bed_type": "OtherBedInventory"
-  },
-  {
-    "external_id": 28,
-    "name": "Supportive Service Only Capacity",
     "hud_bed_type": "OtherBedInventory"
   }
 ]

--- a/drivers/hmis_external_apis/public/schemas/referral.json
+++ b/drivers/hmis_external_apis/public/schemas/referral.json
@@ -11,7 +11,8 @@
     "service_coordinator",
     "posting_id",
     "program_id",
-    "unit_type_id"
+    "unit_type_id",
+    "household_members"
   ],
   "properties": {
     "referral_id": { "type": ["integer", "string"] },
@@ -22,7 +23,7 @@
     "chronic": { "type": ["boolean", "null"] },
     "addresses": {
       "type": "array",
-      "maxItems": 3,
+      "maxItems": 6,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -39,7 +40,7 @@
     },
     "phone_numbers": {
       "type": "array",
-      "maxItems": 3,
+      "maxItems": 6,
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/drivers/hmis_external_apis/public/schemas/referral.json
+++ b/drivers/hmis_external_apis/public/schemas/referral.json
@@ -45,7 +45,7 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "number": { "type": "string", "pattern": "^[0-9]{10}$" },
+          "number": { "type": "string" },
           "notes": { "type": ["string", "null"] },
           "type": { "enum": ["home", "mobile", "work", null] }
         }


### PR DESCRIPTION
Ignore `"ssn": ""` which was previously erroring due to mismatched pattern expectation.