### PR TITLE
Fix referral unit assignment

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
@@ -43,7 +43,7 @@ module Mutations
         # if moving from assigned to accepted_pending, enroll household and assign to unit
         if errors.empty? && posting_status_change == ['assigned_status', 'accepted_pending_status']
           # choose any available unit of type, error if none available
-          unit_to_assign = Hmis::Unit.active.find_by(unit_type_id: posting.unit_type_id)
+          unit_to_assign = posting.project&.units&.unoccupied_on&.find_by(unit_type_id: posting.unit_type_id)
           errors.add :base, :invalid, full_message: "Unable to accept this referral because there are no #{posting.unit_type.description} units available." unless unit_to_assign.present?
           raise ActiveRecord::Rollback if errors.any?
 


### PR DESCRIPTION
patch mistake in unit assignment. needs to be assigned to an unoccupied unit in the project.
https://green-river.sentry.io/issues/4321736292/?referrer=slack&alert_rule_id=12523843&alert_type=issue