### PR TITLE
Remove separate participation date in UI.

### DIFF
--- a/app/controllers/health/release_forms_controller.rb
+++ b/app/controllers/health/release_forms_controller.rb
@@ -30,6 +30,7 @@ module Health
 
     def create
       @release_form = @patient.release_forms.build(form_params)
+      @release_form.participation_signature_on = @release_form.signature_on
       set_upload_object
       @release_form.health_file.set_calculated!(current_user.id, @client.id) if @release_form.health_file.present?
       @release_form.reviewed_by = current_user if reviewed?
@@ -51,6 +52,7 @@ module Health
     def update
       @release_form.reviewed_by = current_user if reviewed?
       @release_form.assign_attributes(form_params)
+      @release_form.participation_signature_on = @release_form.signature_on
       # NOTE: for future people troubleshooting why the submission isn't "remote" when a file is attached
       # https://stackoverflow.com/questions/65135135/rails-6-remote-true-and-multipart-true-file-uploads-not-working
       @release_form.health_file.set_calculated!(current_user.id, @client.id) if @release_form.health_file&.new_record?
@@ -73,7 +75,6 @@ module Health
 
     private def form_params
       local_params = params.require(:form).permit(
-        :participation_signature_on,
         :signature_on,
         :reviewed_by_supervisor,
         health_file_attributes: [

--- a/app/views/health/release_forms/_blank_form_button.haml
+++ b/app/views/health/release_forms/_blank_form_button.haml
@@ -2,7 +2,7 @@
   .dropdown
     %button#dropdownButton.btn.btn-secondary.dropdown-toggle{aria: {expanded: "false", haspopup: "true"}, data:{toggle: "dropdown"}, type: "button"}
       %i.icon-download2
-      Blank Participation and Release Forms
+      Consent and Participation Agreement Forms
     .dropdown-menu.dropdown-menu-right.px-0.py-2{style: 'min-width: 200px', aria: {labelledby:"downloadButton"}}
       - if @blank_release_form_url.present?
         %a.dropdown-item.d-flex.align-items-center.mb-1.py-2{href: @blank_release_form_url}

--- a/app/views/health/release_forms/_form.haml
+++ b/app/views/health/release_forms/_form.haml
@@ -6,10 +6,8 @@
         - @release_form.errors.messages.values.first.each do |msg|
           %li= msg
   .row
-    .col-sm-6
-      = f.input :participation_signature_on, as: :date_picker
-    .col-sm-6
-      = f.input :signature_on, as: :date_picker, label: 'Release Signature On'
+    .col
+      = f.input :signature_on, as: :date_picker
 
   .row
     .col-sm-6

--- a/app/views/health/release_forms/edit.haml
+++ b/app/views/health/release_forms/edit.haml
@@ -1,4 +1,4 @@
-- content_for :modal_title, 'Participation and Release of Information'
+- content_for :modal_title, 'Consent and Participation Agreement'
 
 .release-form
   = render 'form', form_url: client_health_release_form_path(client_id: @client.id, id: @release_form.id)

--- a/app/views/health/release_forms/new.haml
+++ b/app/views/health/release_forms/new.haml
@@ -1,4 +1,4 @@
-- content_for :modal_title, 'Participation and Release of Information'
+- content_for :modal_title, 'Consent and Participation Agreement'
 
 .release-form
   = render 'form', form_url: client_health_release_forms_path(@client.id)

--- a/app/views/health/release_forms/show.haml
+++ b/app/views/health/release_forms/show.haml
@@ -1,4 +1,4 @@
-- content_for :modal_title, 'Participation and Release of Information'
+- content_for :modal_title, 'Consent and Participation Agreement'
 
 %dl.release-form
   %dt Date of Signature


### PR DESCRIPTION
Depending on the readiness of the forms, this may or may not launch with the other form updates.