### PR TITLE
Change active referral definition

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -151,7 +151,7 @@ module Types
     def outgoing_referral_postings(**args)
       raise HmisErrors::ApiError, 'Access denied' unless current_permission?(entity: object, permission: :can_manage_outgoing_referrals)
 
-      scope = HmisExternalApis::AcHmis::ReferralPosting.outgoing
+      scope = HmisExternalApis::AcHmis::ReferralPosting.active
         .joins(referral: :enrollment)
         .where(arel.e_t[:ProjectID].eq(object.ProjectID))
       scoped_referral_postings(scope, **args)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
@@ -89,11 +89,8 @@ module HmisExternalApis::AcHmis
       self.status_updated_at ||= created_at
     end
 
-    INACTIVE_STATUSES = [:closed_status, :accepted_by_other_program_status, :denied_status].freeze
-    scope :active, -> { where.not(status: INACTIVE_STATUSES) }
-
-    OUTGOING_STATUSES = [:assigned_status, :accepted_pending_status, :denied_pending_status].freeze
-    scope :outgoing, -> { where(status: OUTGOING_STATUSES) }
+    ACTIVE_STATUSES = [:assigned_status, :accepted_pending_status, :denied_pending_status].freeze
+    scope :active, -> { where(status: ACTIVE_STATUSES) }
 
     private def validate_status_change
       return unless status_changed? && status.present? && status_was.present?


### PR DESCRIPTION
I missed this earlier. Only Assigned/AcceptedPending/DeniedPending should show up on the project referral page. 