### PR TITLE
Add job to create MCI Uniques from Personal IDs

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/migration/initial_mci_unique_id_creation_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/migration/initial_mci_unique_id_creation_job.rb
@@ -24,7 +24,7 @@ module HmisExternalApis::AcHmis::Migration
       raise 'No remote credential for MCI Unique ID' unless ac_warehouse_cred.present?
 
       # { Client ID => Personal ID }
-      hmis_client_lookup = GrdaWarehouse::Hud::Client.where(data_source_id: data_source_id).
+      hmis_client_lookup = Hmis::Hud::Client.where(data_source_id: data_source_id).
         pluck(:id, :personal_id).to_h
 
       mci_unique_ids = hmis_client_lookup.map do |client_id, personal_id|

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/migration/initial_mci_unique_id_creation_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/migration/initial_mci_unique_id_creation_job.rb
@@ -1,0 +1,49 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module HmisExternalApis::AcHmis::Migration
+  class InitialMciUniqueIdCreationJob < ApplicationJob
+    def perform
+      create_mci_unique_ids_from_personal_ids
+    end
+
+    private
+
+    # Create initial set of MCI Unique IDs based on the Personal IDs.
+    # This works because the HUD CSV export we get from the AC Warehouse
+    # contains MCI Unique IDs in the Personal ID column.
+    def create_mci_unique_ids_from_personal_ids
+      data_source_id = GrdaWarehouse::DataSource.hmis.first&.id
+      raise 'No HMIS Data Source' unless data_source_id.present?
+
+      ac_warehouse_cred = ::GrdaWarehouse::RemoteCredential.active.
+        find_by(slug: HmisExternalApis::AcHmis::DataWarehouseApi::SYSTEM_ID)
+      raise 'No remote credential for MCI Unique ID' unless ac_warehouse_cred.present?
+
+      # { Client ID => Personal ID }
+      hmis_client_lookup = GrdaWarehouse::Hud::Client.where(data_source_id: data_source_id).
+        pluck(:id, :personal_id).to_h
+
+      mci_unique_ids = hmis_client_lookup.map do |client_id, personal_id|
+        next unless personal_id.scan(/\D/).empty? # ignore non-numeric values
+
+        {
+          value: personal_id,
+          source_type: 'Hmis::Hud::Client',
+          source_id: client_id,
+          namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE,
+          # Use the AC Data Warehouse credential as the remote credentials,
+          # since that's where it originally came from. In the future when we
+          # are getting MCI Unique Ids using the WarehouseChangesJob, it will
+          # be using this credential.
+          remote_credential_id: ac_warehouse_cred.id,
+        }
+      end.compact
+
+      HmisExternalApis::ExternalId.import!(mci_unique_ids, on_duplicate_key_ignore: true)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/migration/mci_mapping_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/migration/mci_mapping_importer.rb
@@ -43,7 +43,7 @@ module HmisExternalApis::AcHmis::Importers::Migration
         .where(namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE)
         .where(value: lookup.keys)
 
-      Rails.logger.warn("We could not find any matching MCI unique IDs. That doesn't seem right") if result.none?
+      Rails.logger.warn("We could not find any matching MCI unique IDs. That doesn't seem right. You may need to run InitialMciUniqueIdCreationJob.") if result.none?
 
       result
     end

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -18,6 +18,10 @@ module HmisExternalApis
                    -> { where(namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID) },
                    class_name: 'HmisExternalApis::ExternalId',
                    as: :source
+          has_one :ac_hmis_mci_unique_id,
+                  -> { where(namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE) },
+                  class_name: 'HmisExternalApis::ExternalId',
+                  as: :source
 
           # prepend is needed to destroy referrals before household_members are destroyed
           before_destroy :destroy_hoh_external_referrals, prepend: true

--- a/drivers/hmis_external_apis/spec/factories/ac_hmis/credentials.rb
+++ b/drivers/hmis_external_apis/spec/factories/ac_hmis/credentials.rb
@@ -12,9 +12,6 @@ FactoryBot.define do
     factory :ac_hmis_mci_credential, parent: :grda_remote_oauth_credential do
       slug { 'ac_hmis_mci' }
     end
-    factory :ac_hmis_mci_unique_id_credential, parent: :grda_remote_oauth_credential do
-      slug { 'ac_hmis_mci_unique_id' }
-    end
     factory :ac_hmis_warehouse_credential, parent: :grda_remote_oauth_credential do
       slug { HmisExternalApis::AcHmis::DataWarehouseApi::SYSTEM_ID }
     end

--- a/drivers/hmis_external_apis/spec/factories/external_ids.rb
+++ b/drivers/hmis_external_apis/spec/factories/external_ids.rb
@@ -9,18 +9,13 @@ FactoryBot.define do
     end
 
     trait :mci_unique do
-      association :remote_credential, factory: :ac_hmis_mci_unique_id_credential
-    end
-
-    trait :ac_warehouse do
       association :remote_credential, factory: :ac_hmis_warehouse_credential
+      namespace { HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE }
     end
 
     factory :mci_external_id, traits: [:mci]
 
     factory :mci_unique_id_external_id, traits: [:mci_unique]
-
-    factory :ac_warehouse_external_id, traits: [:ac_warehouse]
 
     after(:build) do |external_id|
       external_id.namespace ||= external_id.remote_credential.slug

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/initial_mci_unique_id_creation_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/initial_mci_unique_id_creation_job_spec.rb
@@ -1,0 +1,44 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe HmisExternalApis::AcHmis::Migration::InitialMciUniqueIdCreationJob, type: :job do
+  let(:job) { HmisExternalApis::AcHmis::Migration::InitialMciUniqueIdCreationJob.new }
+  let!(:remote_credential) { create(:ac_hmis_warehouse_credential) }
+
+  let!(:ds1) { create :hmis_data_source }
+  let!(:c1) { create :hmis_hud_client, data_source: ds1, personal_id: Hmis::Hud::Base.generate_uuid }
+  let!(:umci1) { create(:mci_unique_id_external_id, source: c1, value: '100', remote_credential: remote_credential) }
+  let!(:c2) { create :hmis_hud_client, data_source: ds1, personal_id: '123abc' }
+  let!(:c3) { create :hmis_hud_client, data_source: ds1, personal_id: '200' }
+  let!(:c4) { create :hmis_hud_client, data_source: ds1, personal_id: '300' }
+  let!(:umci4) { create(:mci_unique_id_external_id, source: c4, value: '300', remote_credential: remote_credential) }
+  let!(:c5) { create :hmis_hud_client, data_source: ds1, personal_id: '400' }
+  let!(:umci5) { create(:mci_unique_id_external_id, source: c5, value: '500', remote_credential: remote_credential) }
+  let!(:c6) { create :hmis_hud_client, data_source: ds1, personal_id: '600' }
+
+  it 'creates MCI unique IDs' do
+    expect(c1.ac_hmis_mci_unique_id&.value).to eq('100')
+    expect(c2.ac_hmis_mci_unique_id&.value).to be_nil
+    expect(c3.ac_hmis_mci_unique_id&.value).to be_nil
+    expect(c4.ac_hmis_mci_unique_id&.value).to eq('300')
+    expect(c5.ac_hmis_mci_unique_id&.value).to eq('500')
+    expect(c6.ac_hmis_mci_unique_id&.value).to be_nil
+
+    job.perform
+    [c1, c2, c3, c4, c5, c6].each(&:reload)
+
+    expect(c1.ac_hmis_mci_unique_id&.value).to eq('100') # unchanged
+    expect(c2.ac_hmis_mci_unique_id&.value).to be_nil # ignored because non-numeric
+    expect(c3.ac_hmis_mci_unique_id&.value).to eq('200') # new
+    expect(c4.ac_hmis_mci_unique_id&.value).to eq('300') # unchanged
+    expect(c5.ac_hmis_mci_unique_id&.value).to eq('500') # unchanged
+    expect(c6.ac_hmis_mci_unique_id&.value).to eq('600') # new
+    expect(c6.ac_hmis_mci_unique_id.created_at).to be_present
+    expect(c6.ac_hmis_mci_unique_id.updated_at).to be_present
+  end
+end

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     stub_api
 
     other_client = create(:hmis_hud_client, data_source: data_source)
-    create(:ac_warehouse_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client, namespace: 'ac_hmis_mci_unique_id')
+    create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
 
     allow(Hmis::MergeClientsJob).to receive(:perform_later).with(client_ids: [client.id, other_client.id].sort, actor_id: user.id)
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::ClientExport, type: :model d
 
   it 'includes MCIID' do
     mci = create(:mci_external_id, source: client)
-    irrelevant = create(:ac_warehouse_external_id, source: client)
+    irrelevant = create(:mci_unique_id_external_id, source: client)
     subject.run!
     expect(output).to include(mci.value)
     expect(output).to_not include(irrelevant.value)


### PR DESCRIPTION
This needs to be run once (or repeatedly) as part of migration. 
This takes numeric values from PersonalID and stores them as MCI Unique IDs, which they are.
This job needs to run before https://github.com/greenriver/hmis-warehouse/pull/3281, which finds the corresponding MCI IDs for each MCI Unique IDs.
Subsequent new MCI Unique IDs will be received through the data warehouse changes api job.



(Ran this on AC staging already)


Also cleaned up the factories a bit, since there were some non-sensical (I think) credential/external id factories.