### PR TITLE
Adds a Content security policy in reporting-only mode

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.font_src    :self, :data, 'https://fonts.gstatic.com'
+  policy.img_src     :self, :data
+  policy.object_src  :none
+  policy.script_src  :self, 'https://cdnjs.cloudflare.com/ajax/libs/chance/1.0.4/chance.min.js', :unsafe_inline, :unsafe_eval
+  policy.style_src   :self, 'https://fonts.googleapis.com', :unsafe_inline
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  #policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
@@ -27,4 +27,7 @@
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+# Initially run in report-only mode to be safe.
+if true #Rails.env.development? || Rails.env.test?
+Rails.application.config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
I found this was a good way to make sure I was drafting what I'll need to manually add to nginx for the hmis frontend, and figured I'd open a PR. It's in reporting-only mode, so I feel like this will be pretty safe.