### PR TITLE
Patch CustomDataElement resolver bug

### DIFF
--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -56,6 +56,10 @@ module Types
       value == ::HudUtility.ignored_enum_value ? nil : value
     end
 
+    # Use data loader to load an ActiveRecored association.
+    # Note: 'scope' is intended for ordering or to modify the default
+    # association in a way that is constant with respect to the resolver,
+    # for example `scope: FooBar.order(:name)`. It is NOT used to filter down results.
     def load_ar_association(object, association, scope: nil)
       dataloader.with(Sources::ActiveRecordAssociation, association, scope).load(object)
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/custom_data_element.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/custom_data_element.rb
@@ -22,7 +22,7 @@ module Types
 
     def all_values(parent:)
       parent = load_ar_association(parent, :owner) if parent.is_a? Hmis::Hud::HmisService # special case for view
-      ids = parent.custom_data_elements.pluck(:id)
+      ids = load_ar_association(parent, :custom_data_elements).pluck(:id)
       # get all values existing for this CustomDataElementDefinition, and filter
       # it down to only elemnts that are relevant to this parent
       load_ar_association(object, :values).where(id: ids)

--- a/drivers/hmis/app/graphql/types/hmis_schema/custom_data_element.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/custom_data_element.rb
@@ -22,10 +22,10 @@ module Types
 
     def all_values(parent:)
       parent = load_ar_association(parent, :owner) if parent.is_a? Hmis::Hud::HmisService # special case for view
-      ids = load_ar_association(parent, :custom_data_elements).pluck(:id)
+      ids = load_ar_association(parent, :custom_data_elements).map(&:id).to_set
       # get all values existing for this CustomDataElementDefinition, and filter
       # it down to only elemnts that are relevant to this parent
-      load_ar_association(object, :values).where(id: ids)
+      load_ar_association(object, :values).filter { |v| v.id.in?(ids) }
     end
 
     # Unique ID based on values


### PR DESCRIPTION
I misunderstood how the `scope` param works, and I still don't really get what it's supposed to do https://www.rubydoc.info/docs/rails/ActiveRecord/Associations/Preloader#initialize-instance_method. But it doesn't filter down the results, which is what we need.