### PR TITLE
Fix ApiError class

### DIFF
--- a/drivers/hmis/lib/hmis_errors/api_error.rb
+++ b/drivers/hmis/lib/hmis_errors/api_error.rb
@@ -9,7 +9,8 @@ module HmisErrors
     attr_reader :display_message
     INTERNAL_ERROR_DISPLAY_MESSAGE = 'An error occurred'.freeze
 
-    def initialize(display_message: INTERNAL_ERROR_DISPLAY_MESSAGE)
+    def initialize(msg = nil, display_message: INTERNAL_ERROR_DISPLAY_MESSAGE)
+      super(msg)
       @display_message = display_message
     end
   end


### PR DESCRIPTION
Fixes [this sentry error](https://green-river.sentry.io/issues/4359599704/?alert_rule_id=12523843&alert_type=issue&project=4503977346662400&referrer=slack) 🤦  and improves error displays in dev.