### PR TITLE
Add back bounds for services

### DIFF
--- a/drivers/hmis/lib/form_data/default/records/service.json
+++ b/drivers/hmis/lib/form_data/default/records/service.json
@@ -101,7 +101,23 @@
       "mapping": {
         "field_name": "dateProvided"
       },
-      "_comment": "bounds: [ { id: 'min-start-date', type: 'MIN', value_local_constant: '$entryDate'}]"
+      "bounds": [
+        {
+          "id": "min-service-date",
+          "type": "MIN",
+          "value_local_constant": "$entryDate"
+        },
+        {
+          "id": "max-service-date",
+          "type": "MAX",
+          "value_local_constant": "$today"
+        },
+        {
+          "id": "max-service-date-exit-date",
+          "type": "MAX",
+          "value_local_constant": "$exitDate"
+        }
+      ]
     },
     {
       "type": "CURRENCY",


### PR DESCRIPTION
This was requested, and is the spec for Bed Nights. Other service types don't have explicit guidance. Can be overridden by a service-specific form if something different is needed.