### PR TITLE
185762378 fix assessment resolver

### DIFF
--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -56,11 +56,13 @@ module Types
       value == ::HudUtility.ignored_enum_value ? nil : value
     end
 
-    # Use data loader to load an ActiveRecored association.
+    # Use data loader to load an ActiveRecord association.
     # Note: 'scope' is intended for ordering or to modify the default
     # association in a way that is constant with respect to the resolver,
     # for example `scope: FooBar.order(:name)`. It is NOT used to filter down results.
     def load_ar_association(object, association, scope: nil)
+      raise "object must be an ApplicationRecord, got #{object.class.name}" unless object.is_a?(ApplicationRecord)
+
       dataloader.with(Sources::ActiveRecordAssociation, association, scope).load(object)
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -65,7 +65,7 @@ module Types
       # TODO: check if form is retired? For non-WIP assessments, we should
       # really be choosing the "latest" form, which may not be the one on the FormProcessor.
       form_processor = load_ar_association(object, :form_processor)
-      definition = load_ar_association(form_processor, :definition)
+      definition = load_ar_association(form_processor, :definition) if form_processor
       definition ||= Hmis::Form::Definition.find_definition_for_role(role, project: project)
       definition.filter_context = { project: project }
       definition


### PR DESCRIPTION
* fix missing nil check on assessment resolver
* add arg type check to Active Record data loader; this will simplify stack traces if we encounter this issue in future

Note, I'm not sure how we get assessments without a processor in practice.
