### PR TITLE
PCTP signature uploads should be possible when missing

### DIFF
--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -204,6 +204,10 @@ module Health
       edit_path(anchor: 'complete')
     end
 
+    def signature_complete?
+      patient_signed_on.present?
+    end
+
     def download_partial
       'signable_document'
     end

--- a/app/views/health/careplans/_signatures.haml
+++ b/app/views/health/careplans/_signatures.haml
@@ -1,12 +1,17 @@
 .pctp__signature.mb-4
-  - if careplan.patient_signed_on
+  - if careplan.signature_complete?
     .signature-words
       = checkmark(true)
       Patient Signature
     .signature-date
       (#{careplan.patient_signed_on&.to_date})
   - elsif careplan.id == @careplan.id
-    = link_to careplan.edit_path(anchor: 'complete'), class: 'btn btn-sm btn-secondary' do
+    - link_params = Array.wrap(careplan.signature_path)
+    - if link_params.length > 1 # If there are more than one param, there is a hash of additional link params
+      - link_params.last.merge!(class: 'btn btn-sm btn-secondary')
+    - else
+      - link_params << {class: 'btn btn-sm btn-secondary'}
+    = link_to *link_params do
       Enter Patient Signature
 .pctp__signature
   - if careplan.careplan_sent_on.present?

--- a/drivers/health_pctp/app/models/health_pctp/careplan.rb
+++ b/drivers/health_pctp/app/models/health_pctp/careplan.rb
@@ -100,6 +100,10 @@ module HealthPctp
       [edit_client_health_pctp_careplan_update_signature_path(patient.client, id), data: { loads_in_ajax_modal: true }]
     end
 
+    def signature_complete?
+      patient_signed_on.present? && health_file.present?
+    end
+
     def download_partial
       'health_pctp/careplans/downloads'
     end


### PR DESCRIPTION
It is possible for a CC to indicate a patient signature date but not have the form to upload, enable to upload pop-up in this case.