### PR TITLE
Stop re creating service instances on deploy

### DIFF
--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -366,18 +366,6 @@ class SeedMaker
       builder.seed_record_form_definitions
       builder.seed_assessment_form_definitions
     end
-
-    datasources = GrdaWarehouse::DataSource.hmis
-    return unless datasources.present?
-
-    # Create 1 CustomServiceCategory per HUD RecordType, and
-    # 1 CustomServiceType per HUD TypeProvided
-    datasources.each do |hmis_ds|
-      HmisUtil::ServiceTypes.seed_hud_service_types(hmis_ds.id)
-    end
-
-    # Create FormInstances specifying which Services are available per Project Type / Funder
-    HmisUtil::ServiceTypes.seed_hud_service_form_instances
   end
 
   def populate_internal_system_choices

--- a/drivers/hmis/lib/tasks/setup.rake
+++ b/drivers/hmis/lib/tasks/setup.rake
@@ -11,7 +11,12 @@ task seed_service_types: [:environment, 'log:info_to_stdout'] do
   data_source_id = GrdaWarehouse::DataSource.hmis.first&.id
   next unless data_source_id.present?
 
+  # Create 1 CustomServiceCategory per HUD RecordType, and
+  # 1 CustomServiceType per HUD TypeProvided
   ::HmisUtil::ServiceTypes.seed_hud_service_types(data_source_id)
+  # Create FormInstances specifying which Services are available per Project Type / Funder
+  # NOTE: This should be run once on setup, but we don't want to re-run on each deploy
+  # because each installation may need a different setup.
   ::HmisUtil::ServiceTypes.seed_hud_service_form_instances
 end
 


### PR DESCRIPTION
This shouldn't be happening on deploy, because some installations may not want the "default" HUD services available in the same way.