### PR TITLE
Don't recalculate existing HealthFile metadata

### DIFF
--- a/app/models/concerns/notifier_config.rb
+++ b/app/models/concerns/notifier_config.rb
@@ -23,14 +23,18 @@ module NotifierConfig
       end
     end
 
-    def self.send_single_notification(message)
+    def self.send_single_notification(message, username)
       notifier_config = Rails.application.config_for(:exception_notifier)&.fetch(:slack, nil)
       return unless notifier_config.present? && notifier_config[:webhook_url].present? && (Rails.env.development? || Rails.env.production? || ENV['FORCE_EXCEPTION_NOTIFIER'] == 'true')
 
       slack_url = notifier_config[:webhook_url]
       channel   = notifier_config[:channel]
-      notifier = ApplicationNotifier.new(slack_url, channel: channel, username: 'NominatimWarning')
+      notifier = ApplicationNotifier.new(slack_url, channel: channel, username: username)
       notifier.ping(message)
+    end
+
+    def send_single_notification(message, username)
+      self.class.send_single_notification(message, username)
     end
   end
 end

--- a/app/models/grda_warehouse/place.rb
+++ b/app/models/grda_warehouse/place.rb
@@ -34,7 +34,7 @@ module GrdaWarehouse
     rescue NominatimApiPaused
       return nil
     rescue StandardError
-      send_single_notification('Error contacting the OSM Nominatim API.')
+      send_single_notification('Error contacting the OSM Nominatim API.', 'NominatimWarning')
     end
 
     def self.nominatim_lookup(query, city, state, postalcode, country)

--- a/app/models/health/health_file.rb
+++ b/app/models/health/health_file.rb
@@ -9,6 +9,7 @@
 # Control: PHI attributes documented
 module Health
   class HealthFile < HealthBase
+    include NotifierConfig
     acts_as_paranoid
 
     phi_attr :file, Phi::FreeText, 'Name of health file'
@@ -58,10 +59,16 @@ module Health
     def set_calculated!(user_id, client_id)
       self.user_id ||= user_id
       self.client_id ||= client_id
-      self.content ||= file.read
-      self.content_type ||= file.content_type
-      self.size ||= content&.size
-      self.name ||= file.filename
+
+      if File.exist?(file.path)
+        self.content ||= file.read
+        self.content_type ||= file.content_type
+        self.size ||= content&.size
+        self.name ||= file.filename
+      else
+        error_message = "set_calculated! without upload. id: #{id}, user_id: #{user_id}, client_id: #{client_id}"
+        send_single_notification(error_message, 'HealthFile')
+      end
     end
   end
 end

--- a/app/models/health/health_file.rb
+++ b/app/models/health/health_file.rb
@@ -56,12 +56,12 @@ module Health
     end
 
     def set_calculated!(user_id, client_id)
-      self.user_id = user_id
-      self.client_id = client_id
-      self.content = file.read
-      self.content_type = file.content_type
-      self.size = content&.size
-      self.name = file.filename
+      self.user_id ||= user_id
+      self.client_id ||= client_id
+      self.content ||= file.read
+      self.content_type ||= file.content_type
+      self.size ||= content&.size
+      self.name ||= file.filename
     end
   end
 end

--- a/drivers/health_pctp/app/models/health_pctp/careplan.rb
+++ b/drivers/health_pctp/app/models/health_pctp/careplan.rb
@@ -69,7 +69,7 @@ module HealthPctp
     end
 
     def editable?
-      patient_signed_on.nil?
+      sent_to_pcp_on.nil?
     end
 
     def completed?


### PR DESCRIPTION
We expect set_calculated! to only be triggered for new files, but it isn't doing what we expect. This can result in errors if the uploaded file isn't in tmp. For now, just don't update non-nil fields.