### PR TITLE
Deterministic name sort for merging clients

### DIFF
--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -76,7 +76,7 @@ module Hmis
       Hmis::Hud::CustomClientName.where(id: name_ids).update_all(primary: false)
 
       primary_found = false
-      clients.flat_map(&:names).each do |name|
+      clients.flat_map(&:names).sort_by(&:id).each do |name|
         client_val = [client_to_retain.first_name, client_to_retain.middle_name, client_to_retain.last_name, client_to_retain.name_suffix]
         custom_client_name_val = [name.first, name.middle, name.last, name.suffix]
         primary = (client_val == custom_client_name_val) && !primary_found

--- a/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
+++ b/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
@@ -150,6 +150,11 @@ RSpec.describe Hmis::MergeClientsJob, type: :model do
       d
     end
 
+    # Give client a different primary name
+    let!(:client2_primary_name) do
+      create(:hmis_hud_custom_client_name, client: client2, data_source: data_source)
+    end
+
     let!(:client2_contact_point_dup) do
       d = client1_contact_point.dup
       d.save!
@@ -171,11 +176,10 @@ RSpec.describe Hmis::MergeClientsJob, type: :model do
 
     before { Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id) }
 
-    it 'dedups names' do
-      # Dedup deletes record based on sort by ID.
-      # Don't assume that IDs are in a particular order from tests, because this is flaking.
+    it 'dedups non-primary names' do
       dup = [client1_name, client2_name_dup].max_by(&:id)
       expect(dup.reload).to be_deleted
+      expect(client2_primary_name.reload).to be_present
     end
 
     it 'dedups addresses' do


### PR DESCRIPTION
If, when merging, a client has no primary names, it marks the last name as primary. Make it deterministic by sorting by id first.