### PR TITLE
Deployment tweaks

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -167,7 +167,7 @@
       "check_name": "FileAccess",
       "message": "Parameter value used in file name",
       "file": "drivers/client_access_control/app/controllers/client_access_control/history_controller.rb",
-      "line": 104,
+      "line": 119,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(Rails.root.join(\"tmp\", \"service_history_pdf_#{::GrdaWarehouse::Hud::Client.destination.find(params[:client_id].to_i).id}.pdf\"), \"wb\")",
       "render_path": null,
@@ -871,29 +871,6 @@
       "note": "Considering AWS provided URI okay to inject"
     },
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "54f8e790a2519455109daadf5dd74297f7684aa397825fa9c2f1bf9bdef73192",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 150,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`git ls-remote origin | grep refs/heads/#{`git rev-parse --abbrev-ref HEAD`.chomp}$`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Deployer",
-        "method": "_check_that_you_pushed_to_remote!"
-      },
-      "user_input": "`git rev-parse --abbrev-ref HEAD`.chomp",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "560654d4119023b98ace9aa621f8578d4bbf9842e89acc251bda37a3ca2476ab",
@@ -913,6 +890,29 @@
       "confidence": "Weak",
       "cwe_id": [
         89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "5bc404c91fe46e9bbcfd3cd9bdca6c45a1bd7fb89281f8a8fda56fc1da2ff876",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "config/deploy/docker/lib/deployer.rb",
+      "line": 116,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`git rev-parse #{`git rev-parse --abbrev-ref HEAD`.chomp}`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Deployer",
+        "method": "s(:self).check_that_you_pushed_to_remote!"
+      },
+      "user_input": "`git rev-parse --abbrev-ref HEAD`.chomp",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
       ],
       "note": ""
     },
@@ -1084,29 +1084,6 @@
       "confidence": "Medium",
       "cwe_id": [
         89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "6cfd47b3522f879e176ed00c1639c8431e26cf5798564e7ba8e89633bdda9f61",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 151,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`git rev-parse #{`git rev-parse --abbrev-ref HEAD`.chomp}`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Deployer",
-        "method": "_check_that_you_pushed_to_remote!"
-      },
-      "user_input": "`git rev-parse --abbrev-ref HEAD`.chomp",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
       ],
       "note": ""
     },
@@ -1461,7 +1438,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "app/models/dba/database_bloat.rb",
-      "line": 143,
+      "line": 142,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "system(\"pg_repack #{\"--no-superuser-check -U #{ar_base_class.connection_db_config.configuration_hash[:username]} -d #{ar_base_class.connection_db_config.configuration_hash[:database]} -h #{(CGI.escape(ar_base_class.connection_db_config.configuration_hash[:host]) or ar_base_class.connection_db_config.configuration_hash[:host])} -p #{(ar_base_class.connection_db_config.configuration_hash[:port] or \"5432\")} -t #{row[\"schemaname\"]}.#{row[\"tblname\"]}\"}\")",
       "render_path": null,
@@ -1507,7 +1484,7 @@
       "check_name": "FileAccess",
       "message": "Parameter value used in file name",
       "file": "drivers/client_access_control/app/controllers/client_access_control/history_controller.rb",
-      "line": 107,
+      "line": 122,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(Rails.root.join(\"tmp\", \"service_history_pdf_#{::GrdaWarehouse::Hud::Client.destination.find(params[:client_id].to_i).id}.pdf\"))",
       "render_path": null,
@@ -1708,6 +1685,29 @@
       "note": ""
     },
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "85e335c4575b12b61263ca6d933cb810fe5f86ad44c5f53e83e8558af7897a58",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "config/deploy/docker/lib/deployer.rb",
+      "line": 115,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`git ls-remote origin | grep refs/heads/#{`git rev-parse --abbrev-ref HEAD`.chomp}$`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Deployer",
+        "method": "s(:self).check_that_you_pushed_to_remote!"
+      },
+      "user_input": "`git rev-parse --abbrev-ref HEAD`.chomp",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "88ba6947358eb613f838a50fc8a1b137f655dda08126594643d90dca1df7daa9",
@@ -1737,7 +1737,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 329,
+      "line": 337,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`docker image ls -f 'reference=#{repo_name}' | grep \"#{_ruby_version}-#{_pre_cache_version}--pre-cache\"`",
       "render_path": null,
@@ -2116,7 +2116,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "config/deploy/docker/lib/deployer.rb",
-      "line": 145,
+      "line": 157,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`git rev-parse HEAD > #{_assets_path}/REVISION`",
       "render_path": null,
@@ -2514,7 +2514,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/grda_warehouse/data_source.rb",
-      "line": 73,
+      "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"#{has_access_to_data_source_through_viewable_entities(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{has_access_to_data_source_through_organizations(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{has_access_to_data_source_through_projects(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)}\")",
       "render_path": null,
@@ -3111,7 +3111,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on model attribute",
       "file": "drivers/hmis/app/graphql/types/hmis_schema/submit_form_result.rb",
-      "line": 30,
+      "line": 34,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Hmis::Form::Definition::FORM_ROLE_CONFIG.find do\n (value[:class_name] == object.class.name)\n end.last[:resolve_as].constantize",
       "render_path": null,
@@ -3128,6 +3128,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-06-28 23:15:05 +0000",
+  "updated": "2023-08-28 19:11:14 +0000",
   "brakeman_version": "5.4.1"
 }

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -52,7 +52,7 @@ class Deployer
 
   attr_accessor :service_registry_arns
 
-  def initialize(target_group_name:, assume_ci_build: true, secrets_arn:, execution_role:, task_role:, dj_options: nil, web_options:, registry_id:, repo_name:, fqdn:, service_registry_arns:)
+  def initialize(target_group_name:, assume_ci_build: true, secrets_arn:, execution_role:, task_role:, dj_options: nil, web_options:, registry_id:, repo_name:, fqdn:, service_registry_arns:) # rubocop:disable Metrics/ParameterLists
     self.service_registry_arns    = service_registry_arns
     self.cluster                  = _cluster_name
     self.target_group_name        = target_group_name
@@ -110,6 +110,14 @@ class Deployer
     roll_out.bootstrap_databases!
   end
 
+  def self.check_that_you_pushed_to_remote!
+    branch = `git rev-parse --abbrev-ref HEAD`.chomp
+    remote = `git ls-remote origin | grep refs/heads/#{branch}$`.chomp
+    our_commit = `git rev-parse #{branch}`.chomp
+
+    raise '[FATAL] Push or pull your branch first!' unless remote.start_with?(our_commit)
+  end
+
   private
 
   def _initial_steps
@@ -150,11 +158,7 @@ class Deployer
   end
 
   def _check_that_you_pushed_to_remote!
-    branch = `git rev-parse --abbrev-ref HEAD`.chomp
-    remote = `git ls-remote origin | grep refs/heads/#{branch}$`.chomp
-    our_commit = `git rev-parse #{branch}`.chomp
-
-    raise '[FATAL] Push or pull your branch first!' unless remote.start_with?(our_commit)
+    self.class.check_that_you_pushed_to_remote!
   end
 
   def _check_compiled_assets!

--- a/config/deploy/docker/vault_deploy
+++ b/config/deploy/docker/vault_deploy
@@ -1,16 +1,8 @@
 #!/usr/bin/env ruby
 
-require_relative 'lib/command_args'
-require_relative 'lib/deployer'
-
 # Confirm we've pushed/pulled before we ask for a password
-args = CommandArgs.new
-
-args.deployments.each do |deployment|
-  deployer = Deployer.new(**deployment)
-  deployer._set_revision!
-  deployer._check_that_you_pushed_to_remote!
-end
+require_relative 'lib/deployer'
+Deployer.check_that_you_pushed_to_remote!
 
 cmd = "aws-vault exec openpath -- bin/deploy #{ARGV.join(' ')}"
 system(cmd)

--- a/config/deploy/docker/vault_deploy
+++ b/config/deploy/docker/vault_deploy
@@ -1,4 +1,16 @@
 #!/usr/bin/env ruby
 
+require_relative 'lib/command_args'
+require_relative 'lib/deployer'
+
+# Confirm we've pushed/pulled before we ask for a password
+args = CommandArgs.new
+
+args.deployments.each do |deployment|
+  deployer = Deployer.new(**deployment)
+  deployer._set_revision!
+  deployer._check_that_you_pushed_to_remote!
+end
+
 cmd = "aws-vault exec openpath -- bin/deploy #{ARGV.join(' ')}"
 system(cmd)


### PR DESCRIPTION
- [x] Check local git status before asking for vault password
- [x] Confirm tags are added to ECR image before we begin polling for state so it's safe to kill the deployment at that point and we won't end up with an incorrectly tagged image in ECR that ends up being removed/cleaned while still deployed.

@yakloinsteak can you confirm number 2?

My understanding is that `bin/deploy` calls `Deployer.new(**deployment).run!` which eventually calls `_add_latest_tags!`.

After that is successful it calls `EcsTools.new.poll_state_until_stable!(CommandArgs.cluster)` which is the polling tool.  At that point `run!` and `_add_latest_tags!` should have completed, so it should be safe to kill the deployment.  The only remaining step is to flag ECS agents for update with `EcsTools.new.update_ecs_agents!(CommandArgs.cluster)`.  As long as that runs sometimes, it should be all set right?

