### PR TITLE
185552893-delete-assessment-related-records

### DIFF
--- a/drivers/hmis/app/graphql/mutations/base_mutation.rb
+++ b/drivers/hmis/app/graphql/mutations/base_mutation.rb
@@ -89,7 +89,7 @@ module Mutations
       raise HmisErrors::ApiError, 'Record not found' unless record.present?
       raise HmisErrors::ApiError, 'Access denied' unless allowed?(record: record, **auth_args)
 
-      record.destroy
+      record.destroy!
       after_delete&.call
 
       {

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -17,6 +17,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   belongs_to :definition, class_name: 'Hmis::Form::Definition', optional: true
 
   # Related records that were created/updated from this assessment
+  #  * NOTE: add association names to related_records below
   belongs_to :health_and_dv, class_name: 'Hmis::Hud::HealthAndDv', optional: true, autosave: true
   belongs_to :income_benefit, class_name: 'Hmis::Hud::IncomeBenefit', optional: true, autosave: true
   belongs_to :enrollment_coc, class_name: 'Hmis::Hud::EnrollmentCoc', optional: true, autosave: true
@@ -66,6 +67,24 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
     end
 
     owner.enrollment = enrollment_factory if owner.is_a?(Hmis::Hud::CustomAssessment)
+  end
+
+  def related_records
+    [
+      :health_and_dv,
+      :income_benefit,
+      :enrollment_coc,
+      :physical_disability,
+      :developmental_disability,
+      :chronic_health_condition,
+      :hiv_aids,
+      :mental_health_disorder,
+      :substance_use_disorder,
+      :exit,
+      :youth_education_status,
+      :employment_education,
+      :current_living_situation,
+    ].map { |field| send(field) }.compact
   end
 
   def parse_key(key)

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -69,24 +69,6 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
     owner.enrollment = enrollment_factory if owner.is_a?(Hmis::Hud::CustomAssessment)
   end
 
-  def related_records
-    [
-      :health_and_dv,
-      :income_benefit,
-      :enrollment_coc,
-      :physical_disability,
-      :developmental_disability,
-      :chronic_health_condition,
-      :hiv_aids,
-      :mental_health_disorder,
-      :substance_use_disorder,
-      :exit,
-      :youth_education_status,
-      :employment_education,
-      :current_living_situation,
-    ].map { |field| send(field) }.compact
-  end
-
   def parse_key(key)
     # Key format is "Enrollment.entryDate", or simply "projectType" (in which case the container is the owner type ("Project") )
     if key.include?('.')

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -17,7 +17,6 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   belongs_to :definition, class_name: 'Hmis::Form::Definition', optional: true
 
   # Related records that were created/updated from this assessment
-  #  * NOTE: add association names to related_records below
   belongs_to :health_and_dv, class_name: 'Hmis::Hud::HealthAndDv', optional: true, autosave: true
   belongs_to :income_benefit, class_name: 'Hmis::Hud::IncomeBenefit', optional: true, autosave: true
   belongs_to :enrollment_coc, class_name: 'Hmis::Hud::EnrollmentCoc', optional: true, autosave: true

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -193,4 +193,14 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   private def form_processor_is_valid
     form_processor.valid?(:form_submission)
   end
+
+  def deletion_would_cause_conflicting_enrollments?
+    return false if in_progress?
+
+    exit? && enrollment.client.enrollments
+      .where(data_source: enrollment.data_source, project_id: enrollment.project_id)
+      .where.not(id: enrollment.id)
+      .where(e_t[:entry_date].gteq(enrollment.entry_date))
+      .any?
+  end
 end

--- a/drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb
@@ -128,8 +128,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'should un-exit when deleting a submitted exit assessment' do
     a1.save_not_in_progress
-    a1.update(data_collection_stage: 3) # exit
-    create(:hmis_hud_exit, enrollment: e1, client: c1, user: u1, data_source: ds1)
+    a1.update!(data_collection_stage: 3) # exit
+    a1.form_processor.update!(
+      exit: create(:hmis_hud_exit, enrollment: e1, client: c1, user: u1, data_source: ds1),
+    )
 
     mutate(input: { id: a1.id }) do |assessment_id, errors|
       expect(assessment_id).to be_present


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185552893

* destroy form processor related records when assessment is destroyed
* also check that reopening an enrollment by deleting an exit assessment won't cause a conflict.