### PR TITLE
Make confidential required for files

### DIFF
--- a/drivers/hmis/lib/form_data/default/records/file.json
+++ b/drivers/hmis/lib/form_data/default/records/file.json
@@ -53,7 +53,7 @@
         },
         {
           "type": "BOOLEAN",
-          "required": false,
+          "required": true,
           "link_id": "file-confidential",
           "text": "Confidential File?",
           "readonly_text": "Confidential File",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185906093

The quickest solution here would be to just make the field required so the error message is useful, which is what I've done here