### PR TITLE
Add extra ID to form definition

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3160,7 +3160,7 @@ type FilesPaginated {
 FormDefinition
 """
 type FormDefinition {
-  cacheKey: ID
+  cacheKey: ID!
   definition: FormDefinitionJson!
   id: ID!
   role: FormRole!

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3160,8 +3160,8 @@ type FilesPaginated {
 FormDefinition
 """
 type FormDefinition {
+  cacheKey: ID
   definition: FormDefinitionJson!
-  forProjectId: ID
   id: ID!
   role: FormRole!
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3161,6 +3161,7 @@ FormDefinition
 """
 type FormDefinition {
   definition: FormDefinitionJson!
+  forProjectId: ID
   id: ID!
   role: FormRole!
 }

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -23,7 +23,7 @@ module Types
     end
 
     def cache_key
-      [id, project&.id, active_date].join('|')
+      [object.id, project&.id, active_date].join('|')
     end
 
     protected

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -10,6 +10,7 @@ module Types
   class Forms::FormDefinition < Types::BaseObject
     description 'FormDefinition'
     field :id, ID, null: false
+    field :for_project_id, ID, null: true
     field :role, Types::Forms::Enums::FormRole, null: false
     field :definition, Forms::FormDefinitionJson, null: false
 
@@ -19,6 +20,10 @@ module Types
     # class down the road
     def definition
       eval_items([object.definition])[0]
+    end
+
+    def for_project_id
+      project&.id
     end
 
     protected

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -10,7 +10,7 @@ module Types
   class Forms::FormDefinition < Types::BaseObject
     description 'FormDefinition'
     field :id, ID, null: false
-    field :cache_key, ID, null: true
+    field :cache_key, ID, null: false
     field :role, Types::Forms::Enums::FormRole, null: false
     field :definition, Forms::FormDefinitionJson, null: false
 

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -10,7 +10,7 @@ module Types
   class Forms::FormDefinition < Types::BaseObject
     description 'FormDefinition'
     field :id, ID, null: false
-    field :for_project_id, ID, null: true
+    field :cache_key, ID, null: true
     field :role, Types::Forms::Enums::FormRole, null: false
     field :definition, Forms::FormDefinitionJson, null: false
 
@@ -22,8 +22,8 @@ module Types
       eval_items([object.definition])[0]
     end
 
-    def for_project_id
-      project&.id
+    def cache_key
+      [id, project&.id, active_date].join('|')
     end
 
     protected


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185940925

Relies on frontend PR: https://github.com/greenriver/hmis-frontend/pull/439

@gigxz To solve this I decided to add an additional ID to the FormDefinition to indicate what project that definition was fetched for. I think this is okay, but it could probably be argued that the FormDefinition isn't the right place to include that info. A logically cleaner alternative would probably be to have `getFormDefinition` return a `FormDefinitionResult` that has both the project ID and the form definition info, but that would require a lot more adjustments to make work. Let me know if this solution is fine with you or if you'd like me to do it another way.