### PR TITLE
Adjust form missing value logic

### DIFF
--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -236,7 +236,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
         section: link_id_section_hash[item.link_id],
       }
 
-      is_missing = value.blank? || value == 'DATA_NOT_COLLECTED'
+      is_missing = value.nil? || (value.respond_to?(:empty?) && value.empty?) || value == 'DATA_NOT_COLLECTED'
       field_name = item.mapping&.field_name
       # Validate required status
       if item.required && is_missing


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185906093

@gigxz The error was caused by the form thinking that a `false` value for `confidential` counted as a blank value for a required field. Turns out that `false.blank? == true`, which seems wrong to me, but nothing I can do about that. I adjusted it to use `nil?` and then use `empty?` if the value responds to it, as `empty?` for sets, arrays, hashes and strings is equivalent to `blank?`. Let me know if you have any concerns about that