### PR TITLE
185495405 import fixes and additional logging

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/custom_data_elements_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/custom_data_elements_importer.rb
@@ -34,21 +34,21 @@ module HmisExternalApis::AcHmis::Importers
         Loaders::ReferralRequestsLoader,
       ]
 
-      Hmis::Hud::Base.transaction do
-        loaders.each do |loader_class|
-          loader = loader_class.new(
-            clobber: clobber,
-            reader: Loaders::CsvReader.new(dir),
-            tracker: tracker,
-          )
-          run_loader(loader)
-        end
-
-        # process collected unit occupancy assignments
-        run_loader(
-          Loaders::DeferredProjectUnitOccupancyLoader.new(clobber: clobber, tracker: tracker),
+      # disable paper trail to improve importer performance
+      PaperTrail.enabled = false
+      loaders.each do |loader_class|
+        loader = loader_class.new(
+          clobber: clobber,
+          reader: Loaders::CsvReader.new(dir),
+          tracker: tracker,
         )
+        run_loader(loader)
       end
+
+      # process collected unit occupancy assignments
+      run_loader(
+        Loaders::DeferredProjectUnitOccupancyLoader.new(clobber: clobber, tracker: tracker),
+      )
 
       analyze_tables
     rescue StandardError => e

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/base_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/base_loader.rb
@@ -165,5 +165,11 @@ module HmisExternalApis::AcHmis::Importers::Loaders
       value = row_value(row, field: field)
       log_info "#{row.context} could not resolve \"#{field}\":\"#{value}\""
     end
+
+    def log_processed_result(name: nil, expected:, actual:)
+      name ||= model_class.name
+      rate = expected.zero? ? 0 : (actual.to_f / expected).round(3)
+      log_info("processed #{name}: #{actual} of #{expected} records (#{(1.0 - rate) * 100}% skipped)")
+    end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_address_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_address_loader.rb
@@ -21,15 +21,21 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     protected
 
     def build_records
-      rows.map do |row|
+      valid_personal_ids = Hmis::Hud::Client.hmis.pluck(:personal_id).to_set
+      expected = 0
+      records = rows.map do |row|
+        expected += 1
         use_value = row_value(row, field: 'use')
         use_mapped = USE_MAP[use_value.downcase]
+
+        personal_id = row_value(row, field: 'PersonalID')
+        next nil unless personal_id.in?(valid_personal_ids)
 
         default_attrs.merge(
           {
             AddressID: Hmis::Hud::Base.generate_uuid,
             UserID: row_value(row, field: 'UserID', required: false) || system_user_id,
-            PersonalID: row_value(row, field: 'PersonalID'),
+            PersonalID: personal_id,
             use: use_mapped,
             notes: use_value && use_mapped.nil? ? use_value : nil, # save use as a note if we can't map it
             line1: row_value(row, field: 'line1', required: false),
@@ -43,7 +49,9 @@ module HmisExternalApis::AcHmis::Importers::Loaders
             DateUpdated: parse_date(row_value(row, field: 'DateUpdated')),
           },
         )
-      end
+      end.compact
+      log_processed_result(expected: expected, actual: records.size)
+      records
     end
 
     def date_created(row)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_contacts_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_contacts_loader.rb
@@ -15,20 +15,26 @@ module HmisExternalApis::AcHmis::Importers::Loaders
       records = build_records
       # destroy existing records and re-import
       model_class.where(data_source: data_source).each(&:really_destroy!) if clobber
-      ar_import(model_class, records.compact)
+      ar_import(model_class, records)
     end
 
     protected
 
     def build_records
-      rows.map do |row|
+      valid_personal_ids = Hmis::Hud::Client.hmis.pluck(:personal_id).to_set
+      expected = 0
+      records = rows.map do |row|
         value = phone_value(row)
         next unless value
+
+        expected += 1
+        personal_id = row_value(row, field: 'PersonalID')
+        next nil unless personal_id.in?(valid_personal_ids)
 
         attrs = {
           ContactPointID: Hmis::Hud::Base.generate_uuid,
           UserID: user_id_value(row),
-          PersonalID: row_value(row, field: 'PersonalID'),
+          PersonalID: personal_id,
           use: use_value(row),
           system: row_value(row, field: 'SYSTM').downcase,
           notes: row_value(row, field: 'NOTES', required: false),
@@ -38,7 +44,9 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           DateUpdated: parse_date(row_value(row, field: 'DateUpdated', required: false)),
         }
         default_attrs.merge(attrs)
-      end
+      end.compact
+      log_processed_result(expected: expected, actual: records.size)
+      records
     end
 
     PHONE_TYPE_MAP = {

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/esg_funding_assistance_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/esg_funding_assistance_loader.rb
@@ -33,9 +33,11 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .pluck(:enrollment_id, :personal_id)
         .to_h
 
-      rows.map do |row|
+      expected = 0
+      records = rows.map do |row|
         enrollment_id = row_value(row, field: 'ENROLLMENTID')
         personal_id = personal_id_by_enrollment_id[enrollment_id]
+        expected += 1
         unless personal_id
           log_skipped_row(row, field: 'ENROLLMENTID')
           next # early return
@@ -61,6 +63,8 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         end
         record
       end.compact
+      log_processed_result(expected: expected, actual: records.size)
+      records
     end
 
     def cde_attrs(row)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -22,6 +22,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
       import_enrollment_records
       import_referral_records
       import_referral_posting_records
+      delete_orphan_referral_posting_records
       import_referral_household_members_records
       assign_unit_occupancies
     end
@@ -88,6 +89,13 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         build_posting_records,
         on_duplicate_key_update: { conflict_target: :identifier, columns: :all },
       )
+    end
+
+    def delete_orphan_referral_posting_records
+      orphans = HmisExternalApis::AcHmis::Referral.where.not(id: HmisExternalApis::AcHmis::ReferralPosting.select(:referral_id))
+      total = orphans.count
+      log_info "Deleting #{total} referrals with no postings"
+      orphans.find_each(&:destroy!)
     end
 
     def import_referral_household_members_records

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_requests_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_requests_loader.rb
@@ -50,7 +50,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .pluck('external_ids.value', :id)
         .to_h
 
-      rows.map do |row|
+      records = rows.map do |row|
         {
           identifier: row_value(row, field: 'REFERRAL_REQUEST_ID'),
           project_id: projects_by_id.fetch(row_value(row, field: 'PROGRAM_ID')),
@@ -63,6 +63,9 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           requestor_email: row_value(row, field: 'REQUESTOR_EMAIL', required: false) || '',
         }
       end
+      # this crashes on missed rows so report 100%
+      log_processed_result(expected: records.size, actual: records.size)
+      records
     end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
@@ -36,7 +36,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           value: parse_date(row_value(row, field: 'RENTALASSISTANCEENDDATE')),
           definition_key: :rental_assistance_end_date,
         ).merge(owner_id: owner_id)
-      end
+      end.compact
       log_processed_result(expected: expected, actual: records.size)
       records
     end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
@@ -23,7 +23,9 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .where(data_source: data_source)
         .pluck(:enrollment_id, :id)
         .to_h
-      rows.map do |row|
+      expected = 0
+      records = rows.map do |row|
+        expected += 1
         enrollment_id = row_value(row, field: 'ENROLLMENTID')
         owner_id = owner_id_by_enrollment_id[enrollment_id]
         unless owner_id
@@ -35,6 +37,8 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           definition_key: :rental_assistance_end_date,
         ).merge(owner_id: owner_id)
       end
+      log_processed_result(expected: expected, actual: records.size)
+      records
     end
 
     def owner_class

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/rental_assistance_end_date_loader.rb
@@ -19,7 +19,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
 
     def build_records
       owner_id_by_enrollment_id = Hmis::Hud::Enrollment
-        .heads_of_households # enrollments should HOH
+        # .heads_of_households # enrollments should HOH but many are not
         .where(data_source: data_source)
         .pluck(:enrollment_id, :id)
         .to_h

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/walk_in_enrollment_unit_types_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/walk_in_enrollment_unit_types_loader.rb
@@ -18,8 +18,10 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .where(data_source: data_source)
         .pluck(:enrollment_id, :id, :project_id)
         .to_h { |enrollment_id, pk, project_id| [enrollment_id, [pk, project_id]] }
-
+      expected = 0
+      actual = 0
       rows.each do |row|
+        expected += 1
         enrollment_id = row_value(row, field: 'ENROLLMENTID')
         enrollment_pk, project_id = pks_by_enrollment_id[enrollment_id]
         unless enrollment_pk
@@ -30,16 +32,19 @@ module HmisExternalApis::AcHmis::Importers::Loaders
 
         unit_type_mper_id = row_value(row, field: 'UNITTYPEID')
         # Some enrollments provided in this file appear to be exited. If they are exited,
-        # unit assignment will receve and end date equal to the exit date.
+        # unit assignment will receive an end date equal to the exit date.
         unit_id = tracker.assign_next_unit(
           enrollment_pk: enrollment_pk,
           unit_type_mper_id: unit_type_mper_id,
         )
-        unless unit_id
+        if unit_id
+          actual += 1
+        else
           msg = "could not assign a unit for project_id: #{project_id}, enrollment_id: #{enrollment_id}, mper_unit_type_id: #{unit_type_mper_id}"
           log_info("[#{row.context}] #{msg}")
         end
       end
+      log_processed_result(expected: expected, actual: actual)
     end
 
     protected


### PR DESCRIPTION
* Check for validity of Personal ID before importing client address/contact points
* Remove encapsulating transaction from loader and disable papertrail (perf/stability)
* Log expected/actual processed rows and percents
* Allow RentalAssistanceEndDateLoader enrollments to be non-HOH