### PR TITLE
Always save missing vet status as 99

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -49,6 +49,9 @@ module Hmis::Hud::Processors
       when 'mci_id'
         process_mci(value)
         {}
+      when 'veteran_status'
+        # Veteran status is non-nullable. It should be saved as 99 even if hidden. (It's hidden for minors)
+        { attribute_name => attribute_value || 99 }
       else
         { attribute_name => attribute_value }
       end

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -909,6 +909,16 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       end
     end
 
+    it 'stores hidden fields correctly' do
+      existing_client = c1
+      new_client = Hmis::Hud::Client.new(data_source: ds1, user: u1)
+      [existing_client, new_client].each do |client|
+        hud_values = empty_hud_values.merge({ 'veteranStatus': HIDDEN_FIELD_VALUE })
+        process_record(record: client, hud_values: hud_values, user: hmis_user)
+        expect(client.veteran_status).to eq(99)
+      end
+    end
+
     it 'handles empty arrays' do
       existing_client = c1
       existing_client.update(NonBinary: 1, BlackAfAmerican: 1)

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -913,7 +913,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       existing_client = c1
       new_client = Hmis::Hud::Client.new(data_source: ds1, user: u1)
       [existing_client, new_client].each do |client|
-        hud_values = empty_hud_values.merge({ 'veteranStatus': HIDDEN_FIELD_VALUE })
+        hud_values = empty_hud_values.merge({ 'veteranStatus': HIDDEN })
         process_record(record: client, hud_values: hud_values, user: hmis_user)
         expect(client.veteran_status).to eq(99)
       end


### PR DESCRIPTION
This doesn't feel ideal, but any alternative I can think of is complicated.

Basically the existing logic is "save 99 if its present but unanswered, and save nil if the field is disabled".

That works for most things. Not for vet status, though, because it's not allowed to be null (yet it can and should be hidden for minors).