### PR TITLE
Fix RelationshipToHoh in migration enrollment creation; skip duplicate Address/Contacts

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/deferred_project_unit_occupancy_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/deferred_project_unit_occupancy_loader.rb
@@ -32,12 +32,19 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .where(data_source: data_source)
         .joins(:enrollment)
         .pluck(e_t[:id], :exit_date)
+        .to_h
+
       rows.map do |row|
         unit_id, enrollment_id, start_date = row.fetch_values(:unit_id, :enrollment_id, :start_date)
         record = model_class.new(unit_id: unit_id, enrollment_id: enrollment_id)
+
+        occupancy_start_date = start_date || today
+        occupancy_end_date = exit_dates_by_pk[enrollment_id]
+        raise 'Invalid occupancy period' if occupancy_end_date.present? && occupancy_start_date > occupancy_end_date
+
         record.build_occupancy_period(
-          start_date: start_date || today,
-          end_date: exit_dates_by_pk[enrollment_id],
+          start_date: occupancy_start_date,
+          end_date: occupancy_end_date,
           user_id: system_user_pk,
         )
         record

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/project_unit_tracker.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/project_unit_tracker.rb
@@ -15,7 +15,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
 
       # {enrollment_pk => [project_pk, household_id]}
       @enrollment_lookup = {}
-      # {enrollment_pk => hoh_entry_date}
+      # {enrollment_pk => entry_date}
       @enrollment_entry_dates = {}
       enrollment_scope.preload(:project).preload(wip: :project).find_each do |enrollment|
         add_enrollment(enrollment)
@@ -40,7 +40,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     def add_enrollment(enrollment)
       project_pk = enrollment.project_id ? enrollment.project.id : enrollment.wip&.project&.id
       @enrollment_lookup[enrollment.id] = [project_pk, enrollment.household_id] if project_pk
-      @enrollment_entry_dates[enrollment.id] ||= enrollment.entry_date if enrollment.head_of_household?
+      @enrollment_entry_dates[enrollment.id] ||= enrollment.entry_date
     end
 
     def assign_next_unit(enrollment_pk:, unit_type_mper_id:, fallback_start_date: nil)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -146,7 +146,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
             personal_id: personal_id,
             entry_date: entry_date,
             household_id: household_id,
-            relationship_to_hoh: relationship_to_hoh(member_row),
+            relationship_to_hoh: row_value(member_row, field: 'RELATIONSHIP_TO_HOH_ID'),
             enrollment_coc: enrollment_coc_by_project_id[project_id],
           }
           enrollment.build_wip(
@@ -264,7 +264,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         end
         HmisExternalApis::AcHmis::ReferralHouseholdMember.new(
           referral_id: referral_id,
-          relationship_to_hoh: relationship_to_hoh(row),
+          relationship_to_hoh: relationship_to_hoh_string_enum(row),
           mci_id: mci_id,
           client_id: client_pk,
         )
@@ -392,8 +392,11 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .to_h { |mci_id, client_pk, personal_id| [mci_id, [client_pk, personal_id]] }
     end
 
-    def relationship_to_hoh(row)
-      row_value(row, field: 'RELATIONSHIP_TO_HOH_ID') || 99
+    def relationship_to_hoh_string_enum(row)
+      @posting_status_map ||= HmisExternalApis::AcHmis::ReferralHouseholdMember
+        .relationship_to_hohs
+        .invert.stringify_keys
+      @posting_status_map.fetch(row_value(row, field: 'RELATIONSHIP_TO_HOH_ID'))
     end
 
     def posting_status(row)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -393,10 +393,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     end
 
     def relationship_to_hoh(row)
-      @posting_status_map ||= HmisExternalApis::AcHmis::ReferralHouseholdMember
-        .relationship_to_hohs
-        .invert.stringify_keys
-      @posting_status_map.fetch(row_value(row, field: 'RELATIONSHIP_TO_HOH_ID'))
+      row_value(row, field: 'RELATIONSHIP_TO_HOH_ID') || 99
     end
 
     def posting_status(row)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -317,7 +317,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           # For Accepted referrals, the Enrollment ID should be present on the row.
           enrollment_id = row_value(row, field: 'ENROLLMENTID', required: false)
           unless enrollment_id.present?
-            log_info("#{posting_row.context} ENROLLMENTID missing from Accepted referral")
+            log_info("#{row.context} ENROLLMENTID missing from Accepted referral")
             next
           end
           household_id = household_id_by_enrollment_id[enrollment_id]

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -282,7 +282,10 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         .where(data_source: data_source)
         .pluck(:project_id, :id)
         .to_h
-
+      household_id_by_enrollment_id = Hmis::Hud::Enrollment
+        .where(data_source: data_source)
+        .pluck(:enrollment_id, :household_id)
+        .to_h
       unit_types_by_mper = Hmis::UnitType
         .joins(:mper_id)
         .pluck('external_ids.value', :id)
@@ -294,6 +297,9 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         project_id = row_value(row, field: 'PROGRAM_ID')
         referral_id = row_value(row, field: 'REFERRAL_ID')
 
+        # There is one row per household member in the referral, but we only need to process one of them.
+        next if seen.include?(referral_id)
+
         # find household id for this posting:
         # 1) find the head-of-household's MCI for this referral
         hoh_member_row = household_member_rows_by_referral(referral_id).detect do |mr|
@@ -303,17 +309,31 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           log_info "#{row.context} Skipping Referral #{referral_id} - no HoH"
           next
         end
-        hoh_mci_id = row_value(hoh_member_row, field: 'MCI_ID')
-        # 2) find the household_id for the project enrollment with that MCI
-        household_id = referral_household_id(hoh_mci_id, project_id)
-        # Household must be present for Accepted and Accepted Pending postings
+
         status = posting_status(row)
+        # 2) Find the household_id for the enrollment linked to this ReferralPosting row, if any.
+        household_id = nil
+        if status == accepted_status
+          # For Accepted referrals, the Enrollment ID should be present on the row.
+          enrollment_id = row_value(row, field: 'ENROLLMENTID', required: false)
+          unless enrollment_id.present?
+            log_info("#{posting_row.context} ENROLLMENTID missing from Accepted referral")
+            next
+          end
+          household_id = household_id_by_enrollment_id[enrollment_id]
+        elsif status == accepted_pending_status
+          # For Accepted Pending referrals, we should have created the WIP Enrollment(s) in an earlier step.
+          # find the HoH's MCI ID
+          hoh_mci_id = row_value(hoh_member_row, field: 'MCI_ID')
+          # find the household_id for the project enrollment with that MCI
+          household_id = referral_household_id(hoh_mci_id, project_id)
+        end
+
+        # Household MUST be present on Accepted and Accepted Pending postings
         if household_id.nil? && [accepted_status, accepted_pending_status].include?(status)
           log_info "#{row.context} No enrollments match Referral #{referral_id} with status #{status}. Skipping"
           next
         end
-
-        next if seen.include?(referral_id)
 
         expected += 1
 
@@ -321,6 +341,8 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           log_info "#{row.context} Skipping posting for referral #{referral_id} because the referral didn't get created."
           next
         end
+
+        # Only add to "seen" once we successfully processed the row
         seen.add(referral_id)
 
         HmisExternalApis::AcHmis::ReferralPosting.new(


### PR DESCRIPTION
* Fix bug where all Relationship To Hoh was set to 0 (invalid) on created Enrollments
* Log when we skip an Address/Contact
* Don't add duplicated addresses/contacts
