### PR TITLE
Don't remove unused clients from HMIS

### DIFF
--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -100,6 +100,8 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     scope
   end
 
+  scope :not_hmis, -> { where(hmis: nil) }
+
   scope :scannable, -> do
     where(service_scannable: true)
   end

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -208,7 +208,7 @@ module GrdaWarehouse::Tasks
     # where the client has no enrollments.  These generally arise from
     # clients being merged or deleted in the sending system.
     def remove_unused_source_clients
-      ds_ids = GrdaWarehouse::DataSource.importable.source.pluck(:id)
+      ds_ids = GrdaWarehouse::DataSource.importable.source.not_hmis.pluck(:id)
       with_enrollments = GrdaWarehouse::Hud::Client.source.
         where(data_source_id: ds_ids).
         joins(:enrollments).


### PR DESCRIPTION
We still will want to run this manually, once, to remove CE clients after import. But we shouldn't run it regularly

I still need to figure out if this action is also somehow triggered by an import occurring, which would be a problem.