### PR TITLE
Fix track_availability check; don't error if client is not in unit when exiting

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -317,11 +317,8 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
 
   def release_unit!(occupancy_end_date = Date.current, user:)
     occupancy = active_unit_occupancy
-    if occupancy.nil? || occupancy.occupancy_period.nil?
-      msg = "Attempted to release nonexistent unit occupancy for Enrollment##{id}"
-      Sentry.capture_message(msg)
-      return
-    end
+    # If enrollment isn't assigned to any unit, do nothing
+    return if occupancy.nil? || occupancy.occupancy_period.nil?
 
     transaction do
       occupancy.occupancy_period.update!(end_date: occupancy_end_date, user: user)

--- a/drivers/hmis_external_apis/extensions/hmis/unit_type_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/unit_type_extension.rb
@@ -25,7 +25,7 @@ module HmisExternalApis
         return unless HmisEnforcement.hmis_enabled? && HmisExternalApis::AcHmis::Mper.enabled? && mper_id
 
         # Skip if ProjectID is UUID, which means that this was a project created within the HMIS.
-        return if Hmis::Hud::Project.find(project_id).project_id.size == 32
+        return if ::Hmis::Hud::Project.find(project_id).project_id.size == 32
 
         HmisExternalApis::AcHmis::UnitAvailabilitySync.upsert_or_bump_version(
           project_id: project_id,

--- a/drivers/hmis_external_apis/extensions/hmis/unit_type_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/unit_type_extension.rb
@@ -24,8 +24,8 @@ module HmisExternalApis
       def track_availability(project_id:, user_id:)
         return unless HmisEnforcement.hmis_enabled? && HmisExternalApis::AcHmis::Mper.enabled? && mper_id
 
-        # Skip if UUID, which means that this was a project created within the HMIS.
-        return if project_id.size == 32
+        # Skip if ProjectID is UUID, which means that this was a project created within the HMIS.
+        return if Hmis::Hud::Project.find(project_id).project_id.size == 32
 
         HmisExternalApis::AcHmis::UnitAvailabilitySync.upsert_or_bump_version(
           project_id: project_id,


### PR DESCRIPTION
https://green-river.sentry.io/issues/4436097443/?alert_rule_id=12523843&alert_type=issue&project=4503977346662400&referrer=slack