### PR TITLE
Set git revision header, allow HMIS to fetch system status

### DIFF
--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -31,6 +31,8 @@ class Hmis::AppSettingsController < Hmis::BaseController
       unlockAccountUrl: "https://#{hostname}/users/unlock/new",
       manageAccountUrl: "https://#{hostname}/account/edit",
       casUrl: GrdaWarehouse::Config.get(:cas_url),
+      revision: Git.revision,
+      branch: Git.branch,
       theme: themes.first&.hmis_value,
       globalFeatureFlags: {
         # Whether to show MCI ID in client search results

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -8,6 +8,8 @@ class Hmis::BaseController < ApplicationController
   include Hmis::Concerns::JsonErrors
   respond_to :json
   before_action :set_csrf_cookie
+  before_action :set_app_user_header
+  before_action :set_git_revision_header
 
   private def set_csrf_cookie
     cookies['CSRF-Token'] = form_authenticity_token
@@ -45,8 +47,11 @@ class Hmis::BaseController < ApplicationController
     current_hmis_user&.id
   end
 
-  before_action :set_app_user_header
   def set_app_user_header
     response.headers['X-app-user-id'] = current_hmis_user&.id
+  end
+
+  def set_git_revision_header
+    response.headers['X-git-revision'] = Git.revision
   end
 end

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -5,6 +5,12 @@
 ###
 
 BostonHmis::Application.routes.draw do
+  get 'hmis/system_status/operational', to: 'system_status#operational'
+  get 'hmis/system_status/cache_status', to: 'system_status#cache_status'
+  get 'hmis/system_status/details', to: 'system_status#details'
+  get 'hmis/system_status/ping', to: 'system_status#ping'
+  get 'hmis/system_status/exception', to: 'system_status#exception'
+
   # Routes for the HMIS API
   if ENV['ENABLE_HMIS_API'] == 'true'
     namespace :hmis, defaults: { format: :json } do


### PR DESCRIPTION
System status will be accessible in HMIS in two ways:
1. Navigate to `/hmis/system_status/details` --  nginx will send that request straight to the warehouse, bypassing the hmis javascript entirely
2. Navigate to `/system_status/details` -- HMIS js will make a Fetch request to get the data from the warehouse, and display it. (once https://github.com/greenriver/hmis-frontend/pull/451 is up)



Also adds git revision header for https://www.pivotaltracker.com/n/projects/2591838/stories/184908546