### PR TITLE
AC HMIS job updates, notifier logging

### DIFF
--- a/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
@@ -25,6 +25,11 @@ module Hmis
       Hmis::Hud::Exit,
     ].freeze
 
+    def initialize
+      setup_notifier('Migrate HMIS Assessments')
+      super
+    end
+
     # Construct CustomAssessment and FormProcessor records for Assessment-related records.
     #
     # For Entry/Exit assessments, records are grouped together if they have the same Data Collection Stage.

--- a/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
@@ -25,11 +25,6 @@ module Hmis
       Hmis::Hud::Exit,
     ].freeze
 
-    def initialize
-      setup_notifier('Migrate HMIS Assessments')
-      super
-    end
-
     # Construct CustomAssessment and FormProcessor records for Assessment-related records.
     #
     # For Entry/Exit assessments, records are grouped together if they have the same Data Collection Stage.
@@ -43,6 +38,8 @@ module Hmis
     #  - DateUpdated = latest update date of related records
     #  - UserID = UserID from the related record that was most recently updated
     def perform(data_source_id:, clobber: false)
+      setup_notifier('Migrate HMIS Assessments')
+
       self.data_source_id = data_source_id
       raise 'Not an HMIS Data source' if GrdaWarehouse::DataSource.find(data_source_id).hmis.nil?
 
@@ -147,6 +144,7 @@ module Hmis
       debug_log "Skipped #{skipped_records} records that were already linked to an assessment"
       debug_log "Creating #{assessment_records.keys.size} assessments..."
 
+      skipped_invalid_assessments = 0
       skipped_exit_assessments = 0
       # For each grouping of Enrollment+InformationDate+DataCollectionStage,
       # create a CustomAssessment and a FormProcessor that references the related records
@@ -169,7 +167,11 @@ module Hmis
         # Build FormProcessor with IDs to all related records
         assessment.build_form_processor(**value)
 
-        if assessment.exit? && value[:exit_id].nil?
+        if !assessment.valid?
+          # This check was added because we hit a "Client is invalid", which may have occurred if the client was deleted while the batch was processing?
+          Rails.logger.info "Skipping invalid assessment for EnrollmentID: #{assessment.enrollment_id}"
+          skipped_invalid_assessments += 1
+        elsif assessment.exit? && value[:exit_id].nil?
           # There appear to be lots of "exit" data-collection-stage records for enrollments that don't have an Exit record. Skip those
           Rails.logger.info "Skipping Exit Assessment for open enrollment. EnrollmentID: #{assessment.enrollment_id}"
           skipped_exit_assessments += 1
@@ -178,6 +180,7 @@ module Hmis
         end
       end
 
+      debug_log "Skipped creating #{skipped_invalid_assessments} invalid assessments"
       debug_log "Skipped creating #{skipped_exit_assessments} exit assessments because the enrollment is open"
     end
 

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
@@ -9,13 +9,10 @@ module HmisExternalApis::AcHmis
     include HmisExternalApis::AcHmis::ReferralJobMixin
     include NotifierConfig
 
-    def initialize
-      setup_notifier('Fetch clients with active referrals in LINK')
-      super
-    end
-
     def perform
       return unless HmisExternalApis::AcHmis::LinkApi.enabled?
+
+      setup_notifier('Fetch clients with active referrals in LINK')
 
       # Fetch MCI IDs for clients with active referrals in LINK
       mci_ids = link.active_referral_mci_ids.parsed_body

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
@@ -4,13 +4,26 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# An HMIS User indicates that there is a vacancy in a program.
 module HmisExternalApis::AcHmis
   class FetchClientsWithActiveReferralsJob < BaseJob
     include HmisExternalApis::AcHmis::ReferralJobMixin
+    include NotifierConfig
+
+    def initialize
+      setup_notifier('Fetch clients with active referrals in LINK')
+      super
+    end
 
     def perform
+      unless HmisExternalApis::AcHmis::LinkApi.enabled?
+        Rails.logger.info 'Not running FetchClientsWithActiveReferralsJob due to lack of credentials'
+        return
+      end
+
+      # Fetch MCI IDs for clients with active referrals in LINK
       mci_ids = link.active_referral_mci_ids.parsed_body
+      debug_msg "Fetched #{mci_ids.uniq} MCI IDs with active referrals from LINK"
+
       client_ids = HmisExternalApis::ExternalId.where(
         namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID,
         value: mci_ids.map(&:to_s),
@@ -22,14 +35,17 @@ module HmisExternalApis::AcHmis
         field_type: :boolean,
         key: :has_active_referrals_in_link,
         label: 'Has Active Referrals in LINK',
-        repeats: false,   # client can only have 1 value
+        repeats: false, # client can only have 1 value
         data_source: data_source,
         user: system_user,
       )
 
+      # Update clients who already had a CDE value (and are present in this batch)
       cdes_to_update = Hmis::Hud::CustomDataElement.where(owner_type: 'Hmis::Hud::Client', owner_id: client_ids, data_element_definition: cded)
       cdes_to_update.update_all(value_boolean: true, user_id: system_user.user_id)
+      debug_msg "Updated #{cdes_to_update.uniq} existing records for clients with active referrals"
 
+      # Create new records for clients that didn't have a CDE value
       cde_attributes_to_create = (client_ids - cdes_to_update.pluck(:owner_id)).map do |client_id|
         {
           owner_type: 'Hmis::Hud::Client',
@@ -41,11 +57,18 @@ module HmisExternalApis::AcHmis
         }
       end
       Hmis::Hud::CustomDataElement.import(cde_attributes_to_create)
+      debug_msg "Created #{cde_attributes_to_create.count} new records"
 
-      Hmis::Hud::CustomDataElement.
+      # Update clients who already had a CDE value (and are NOT present in this batch)
+      num_updated = Hmis::Hud::CustomDataElement.
         where(owner_type: 'Hmis::Hud::Client', data_element_definition: cded).
         where.not(owner_id: client_ids).
         update_all(value_boolean: false)
+      debug_msg "Updated #{num_updated} existing records for clients without active referrals"
+    end
+
+    def debug_msg(str)
+      @notifier.ping(str)
     end
   end
 end

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/fetch_clients_with_active_referrals_job.rb
@@ -15,10 +15,7 @@ module HmisExternalApis::AcHmis
     end
 
     def perform
-      unless HmisExternalApis::AcHmis::LinkApi.enabled?
-        Rails.logger.info 'Not running FetchClientsWithActiveReferralsJob due to lack of credentials'
-        return
-      end
+      return unless HmisExternalApis::AcHmis::LinkApi.enabled?
 
       # Fetch MCI IDs for clients with active referrals in LINK
       mci_ids = link.active_referral_mci_ids.parsed_body

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -13,17 +13,14 @@ module HmisExternalApis::AcHmis
 
     NAMESPACE = 'ac_hmis_mci_unique_id'.freeze
 
-    def initialize
-      setup_notifier('Fetch changes from AC Data Warehouse')
-      super
-    end
-
     def perform(since: Time.now - 3.days, actor_id:)
       return unless HmisExternalApis::AcHmis::DataWarehouseApi.enabled?
 
       self.since = since
       self.records_needing_processing = []
       self.actor_id = actor_id
+
+      setup_notifier('Fetch changes from AC Data Warehouse')
 
       collect_records_to_inspect
       fetch_clients

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -19,6 +19,8 @@ module HmisExternalApis::AcHmis
     end
 
     def perform(since: Time.now - 3.days, actor_id:)
+      return unless HmisExternalApis::AcHmis::DataWarehouseApi.enabled?
+
       self.since = since
       self.records_needing_processing = []
       self.actor_id = actor_id

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -6,11 +6,17 @@
 
 module HmisExternalApis::AcHmis
   class WarehouseChangesJob < BaseJob
+    include NotifierConfig
     include ArelHelper
 
     attr_accessor :since, :records_needing_processing, :clients, :external_ids, :merge_sets, :actor_id
 
     NAMESPACE = 'ac_hmis_mci_unique_id'.freeze
+
+    def initialize
+      setup_notifier('Fetch changes from AC Data Warehouse')
+      super
+    end
 
     def perform(since: Time.now - 3.days, actor_id:)
       self.since = since
@@ -29,7 +35,7 @@ module HmisExternalApis::AcHmis
     # It's more efficent to get all the records we're interested in before
     # hitting the database to avoid excessive queries.
     def collect_records_to_inspect
-      Rails.logger.info 'Collection records to inspect'
+      Rails.logger.info 'Collecting records to inspect'
 
       count = 0
       each_record_we_are_interested_in do |record|
@@ -96,9 +102,9 @@ module HmisExternalApis::AcHmis
         end
       end
 
-      Rails.logger.info "Inserted #{insert_count} MCI unique IDs"
-      Rails.logger.info "Updated #{update_count} MCI unique IDs"
-      Rails.logger.info "Ignored #{no_change_count} MCI unique IDs"
+      debug_msg "Inserted #{insert_count} MCI unique IDs"
+      debug_msg "Updated #{update_count} MCI unique IDs"
+      debug_msg "Ignored #{no_change_count} MCI unique IDs"
     end
 
     def merge_clients_by_mci_unique_id
@@ -111,9 +117,9 @@ module HmisExternalApis::AcHmis
         .having('count(*) > 1')
         .select('value, array_agg(source_id ORDER BY source_id) AS client_ids')
 
-      Rails.logger.info "Found #{merge_sets.length} duplicate MCI unique IDs"
+      debug_msg "Found #{merge_sets.length} duplicate MCI unique IDs"
 
-      Rails.logger.info 'Enqueuing dedup jobs for each one'
+      debug_msg 'Enqueuing dedup jobs for each one'
 
       merge_sets.each do |set|
         Hmis::MergeClientsJob.perform_later(client_ids: set.client_ids, actor_id: actor_id)
@@ -130,21 +136,20 @@ module HmisExternalApis::AcHmis
         record['mci_unique_id_date_time'] = Time.zone.parse(record['mciUniqIdDate'])
 
         if record['last_modified_date_time'] < since
-          Rails.logger.info "Got to the end of the changes we're interested in. Finishing up"
+          debug_msg "Got to the end of the changes we're interested in. Finishing up"
           break
         end
 
-        # From Gig: I think we can just filter out any records where
-        # mciUniqIdDate is not within our requested 3-day period. Aka if it's
-        # only included in the response because of demographic changes, throw
-        # it out.
-        if record['mci_unique_id_date_time'] < since
-          Rails.logger.info "Skipping a record that changed for a reason we don't care about"
-          next
-        end
+        # We can filter out any records where mciUniqIdDate is not within our requested 3-day period.
+        # Aka if it's only included in the response because of demographic changes, throw it out.
+        next if record['mci_unique_id_date_time'] < since
 
         yield record
       end
+    end
+
+    def debug_msg(str)
+      @notifier.ping(str)
     end
 
     def data_warehouse_api

--- a/drivers/hmis_external_apis/lib/tasks/import.rake
+++ b/drivers/hmis_external_apis/lib/tasks/import.rake
@@ -5,6 +5,12 @@ namespace :import do
     HmisExternalApis::AcHmis::ImportProjectsJob.perform_now
   end
 
+  # ./bin/rake driver:hmis_external_apis:import:ac_clients_with_active_referrals
+  desc 'Fetch MCI IDs of Clients with active referrals in LINK'
+  task :ac_clients_with_active_referrals, [] => [:environment] do
+    HmisExternalApis::AcHmis::FetchClientsWithActiveReferralsJob.perform_now
+  end
+
   # Usage: rails driver:hmis_external_apis:import:ac_custom_data_elements[/tmp/dir,true]
   #   * dir: directory containing CSV files to import. Consult the loader classes for expected
   #     CSV filenames

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,8 +2,12 @@ namespace :import do
   task :remote_data, [] => [:environment] do
     tasks = []
 
-    tasks << 'driver:hmis_external_apis:import:ac_projects' if RailsDrivers.loaded.include?(:hmis_external_apis)
-    tasks << 'driver:hmis_external_apis:export:ac_clients' if RailsDrivers.loaded.include?(:hmis_external_apis)
+    if ENV['ENABLE_HMIS_API'] == 'true'
+      tasks << 'driver:hmis_external_apis:import:ac_projects' if RailsDrivers.loaded.include?(:hmis_external_apis)
+      tasks << 'driver:hmis_external_apis:import:ac_clients_with_active_referrals' if RailsDrivers.loaded.include?(:hmis_external_apis)
+      tasks << 'driver:hmis_external_apis:export:ac_clients' if RailsDrivers.loaded.include?(:hmis_external_apis)
+    end
+
     tasks << 'eto:import:demographics_and_touch_points'
 
     tasks.each do |task|


### PR DESCRIPTION
- Fix usage of Notifier in migrate assessments job (was missing init step https://github.com/greenriver/hmis-warehouse/pull/3466)
- Add notifier logging to FetchClientsWithActiveReferralsJob
- Schedule FetchClientsWithActiveReferralsJob nightly
- Add notifier logging to WarehouseChangesJob