### PR TITLE
Notify on failed MCI update

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_mci_client_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_mci_client_job.rb
@@ -25,6 +25,8 @@ module HmisExternalApis::AcHmis
     def perform(client_id:)
       return unless HmisExternalApis::AcHmis::Mci.enabled?
 
+      setup_notifier('UpdateMciClientJob')
+
       client = Hmis::Hud::Client.find(client_id)
 
       mci = HmisExternalApis::AcHmis::Mci.new


### PR DESCRIPTION
I haven't seen any of the notifier messages for this one getting to slack, even though I know it has errored because I see it in the delayed job queue. Hopefully this is why.