### PR TITLE
Schedule WarehouseChangesJob, only run HMIS jobs if data source exists

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_unit_availability_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/update_unit_availability_job.rb
@@ -14,6 +14,8 @@ module HmisExternalApis::AcHmis
 
     # @param force [Boolean]
     def perform(force: false)
+      return unless HmisExternalApis::AcHmis::LinkApi.enabled?
+
       setup_notifier(self.class.name)
 
       data_source = HmisExternalApis::AcHmis.data_source

--- a/drivers/hmis_external_apis/lib/tasks/import.rake
+++ b/drivers/hmis_external_apis/lib/tasks/import.rake
@@ -11,6 +11,12 @@ namespace :import do
     HmisExternalApis::AcHmis::FetchClientsWithActiveReferralsJob.perform_now
   end
 
+  # ./bin/rake driver:hmis_external_apis:import:ac_warehouse_changes
+  desc 'Fetch changes to MCI Unique IDs from AC Data Warehouse'
+  task :ac_warehouse_changes, [] => [:environment] do
+    HmisExternalApis::AcHmis::WarehouseChangesJob.perform_now
+  end
+
   # Usage: rails driver:hmis_external_apis:import:ac_custom_data_elements[/tmp/dir,true]
   #   * dir: directory containing CSV files to import. Consult the loader classes for expected
   #     CSV filenames

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -2,9 +2,14 @@ namespace :import do
   task :remote_data, [] => [:environment] do
     tasks = []
 
-    if ENV['ENABLE_HMIS_API'] == 'true'
+    if HmisEnforcement.hmis_enabled? && GrdaWarehouse::DataSource.hmis.exists?
+      # Load MPER projects
       tasks << 'driver:hmis_external_apis:import:ac_projects' if RailsDrivers.loaded.include?(:hmis_external_apis)
+      # Fetch clients with active referrals in LINK
       tasks << 'driver:hmis_external_apis:import:ac_clients_with_active_referrals' if RailsDrivers.loaded.include?(:hmis_external_apis)
+      # Fetch recent client changes from AC Data Warehouse to get MCI Unique IDs
+      tasks << 'driver:hmis_external_apis:import:ac_warehouse_changes' if RailsDrivers.loaded.include?(:hmis_external_apis)
+      # Upload Client and HMIS data to AC Data Warehouse
       tasks << 'driver:hmis_external_apis:export:ac_clients' if RailsDrivers.loaded.include?(:hmis_external_apis)
     end
 


### PR DESCRIPTION
https://docs.google.com/document/d/1TgQ-Y6-49UwQRnpH_7Pz5gnAYDBuzP5ldeS1YL_3z2I/edit#heading=h.pe49dpmv3j4q

This will let us have more control over when these jobs start. We can set up the credentials ahead of time and test them, but the jobs wont actually start until we enable the HMIS Data Source. Each of these is fine to start on 9.22.