### PR TITLE
Better support for multi-CoC projects

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/enrollment_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/enrollment_processor.rb
@@ -54,8 +54,7 @@ module Hmis::Hud::Processors
       end
 
       # If Project only operates in one CoC, return that CoC
-      project_cocs = enrollment.project&.project_cocs&.pluck(:CoCCode) || []
-      project_cocs = project_cocs.uniq.compact
+      project_cocs = enrollment.project&.project_cocs&.pluck(:CoCCode)&.uniq&.compact || []
       return project_cocs.first if project_cocs.size == 1
 
       nil

--- a/drivers/hmis/app/models/hmis/hud/processors/enrollment_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/enrollment_processor.rb
@@ -36,17 +36,29 @@ module Hmis::Hud::Processors
       # Create Household ID if not present. Should only be the case if this is a new Enrollment creation.
       enrollment.household_id ||= Hmis::Hud::Base.generate_uuid if enrollment.new_record?
 
-      # If there is only 1 possible Enrollment CoC, set it
-      unless enrollment.enrollment_coc.present?
-        coc_codes = enrollment.project&.project_cocs&.pluck(:CoCCode) || []
-        enrollment.enrollment_coc = coc_codes.first if coc_codes.size == 1
-      end
+      # Try to infer EnrollmentCoC
+      enrollment.enrollment_coc ||= determine_enrollment_coc(enrollment)
 
       # Set HUD metadata
       enrollment.assign_attributes(
         user: @processor.hud_user,
         data_source_id: @processor.hud_user.data_source_id,
       )
+    end
+
+    private def determine_enrollment_coc(enrollment)
+      # If non-HoH member, return the HoH's CoC
+      unless enrollment.head_of_household?
+        hoh_coc_code = enrollment.household_members.heads_of_households.first&.enrollment_coc
+        return hoh_coc_code if hoh_coc_code.present?
+      end
+
+      # If Project only operates in one CoC, return that CoC
+      project_cocs = enrollment.project&.project_cocs&.pluck(:CoCCode) || []
+      project_cocs = project_cocs.uniq.compact
+      return project_cocs.first if project_cocs.size == 1
+
+      nil
     end
 
     private def assign_unit(unit_id)

--- a/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
@@ -9,7 +9,7 @@ class Hmis::Hud::Validators::EnrollmentValidator < Hmis::Hud::Validators::BaseVa
     :ExportID,
     :DateCreated,
     :DateUpdated,
-    :EnrollmentCoC, # allowed to be null if wip record is present
+    :EnrollmentCoC,
     :ProjectID, # allowed to be null if wip record is present
     :LastPermanentZIP,
   ].freeze
@@ -111,7 +111,6 @@ class Hmis::Hud::Validators::EnrollmentValidator < Hmis::Hud::Validators::BaseVa
   def validate(record)
     super(record) do
       record.errors.add :project_id, :required if record.project_id.nil? && record.wip.nil?
-      record.errors.add :enrollment_coc, :required if record.enrollment_coc.nil? && record.wip.nil?
     end
   end
 end

--- a/drivers/hmis/lib/form_data/default/fragments/entry.json
+++ b/drivers/hmis/lib/form_data/default/fragments/entry.json
@@ -41,8 +41,7 @@
       "link_id": "3.16",
       "prefix": "3.16",
       "text": "CoC Code for Client Location",
-      "required": false,
-      "warn_if_empty": true,
+      "required": true,
       "mapping": {
         "record_type": "ENROLLMENT",
         "field_name": "enrollmentCoc"

--- a/drivers/hmis/lib/form_data/default/fragments/new_enrollment_details.json
+++ b/drivers/hmis/lib/form_data/default/fragments/new_enrollment_details.json
@@ -65,6 +65,30 @@
           ]
         }
       ]
+    },
+    {
+      "type": "CHOICE",
+      "link_id": "enrollment-coc",
+      "required": true,
+      "text": "Enrollment CoC",
+      "mapping": {
+        "record_type": "ENROLLMENT",
+        "field_name": "enrollmentCoc"
+      },
+      "pick_list_reference": "COC",
+      "enable_behavior": "ALL",
+      "enable_when": [
+        {
+          "local_constant": "$projectHasExactlyOneCoc",
+          "operator": "EQUAL",
+          "answer_boolean": false
+        },
+        {
+          "question": "household-id",
+          "operator": "EXISTS",
+          "answer_boolean": false
+        }
+      ]
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/default/fragments/new_enrollment_details.json
+++ b/drivers/hmis/lib/form_data/default/fragments/new_enrollment_details.json
@@ -79,9 +79,9 @@
       "enable_behavior": "ALL",
       "enable_when": [
         {
-          "local_constant": "$projectHasExactlyOneCoc",
-          "operator": "EQUAL",
-          "answer_boolean": false
+          "local_constant": "$projectCocCount",
+          "operator": "NOT_EQUAL",
+          "answer_number": 1
         },
         {
           "question": "household-id",

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -516,7 +516,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     it 'adds an exit record when appropriate' do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
       assessment.form_processor.hud_values = {
-        'EnrollmentCoc.cocCode' => 'MA-507',
+        'Enrollment.enrollmentCoc' => 'MA-507',
       }
 
       assessment.form_processor.run!(owner: assessment, user: hmis_user)
@@ -608,7 +608,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     it 'updates enrollment entry date when appropriate' do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
       assessment.form_processor.hud_values = {
-        'EnrollmentCoc.cocCode' => 'MA-507',
+        'Enrollment.enrollmentCoc' => 'MA-507',
       }
 
       assessment.form_processor.run!(owner: assessment, user: hmis_user)
@@ -640,7 +640,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     it 'correctly sets all fields' do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
       assessment.form_processor.hud_values = {
-        "EnrollmentCoc.cocCode": 'SC-501',
+        "Enrollment.enrollmentCoc": 'SC-501',
         "Enrollment.livingSituation": 'HOSPITAL_OR_OTHER_RESIDENTIAL_NON_PSYCHIATRIC_MEDICAL_FACILITY',
         "Enrollment.lengthOfStay": 'ONE_MONTH_OR_MORE_BUT_LESS_THAN_90_DAYS',
         "Enrollment.losUnderThreshold": 'YES',
@@ -670,7 +670,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
 
       assessment.form_processor.hud_values = {
-        'EnrollmentCoc.cocCode' => 'MA-507',
+        'Enrollment.enrollmentCoc' => 'MA-507',
         'Enrollment.livingSituation' => nil,
         'Enrollment.lengthOfStay' => nil,
         'Enrollment.losUnderThreshold' => nil,
@@ -1240,6 +1240,14 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       expect(enrollment.client.persisted?).to eq(true)
       expect(enrollment.client.first_name).to eq('First')
       expect(enrollment.client.last_name).to eq('Last')
+    end
+
+    it 'adds new enrollment to existing household, and takes HoH\'s coc code' do
+      hoh_enrollment = create(:hmis_hud_enrollment, data_source: ds1, project: p1, enrollment_coc: 'XX-500')
+      new_enrollment = Hmis::Hud::Enrollment.new(data_source: ds1, user: u1, project: p1, household_id: hoh_enrollment.household_id)
+      hud_values = complete_hud_values.merge('Enrollment.enrollmentCoc' => nil, 'Enrollment.relationshipToHoH' => 'CHILD')
+      process_record(record: new_enrollment, hud_values: hud_values, user: hmis_user)
+      expect(new_enrollment.enrollment_coc).to eq(hoh_enrollment.enrollment_coc)
     end
 
     it 'validates Client record' do


### PR DESCRIPTION
1. If project operates in 0 or >1 CoCs, ask about Enrollment CoC at time of enrollment for HoH. (If there are no CoCs set up, the user will get an error saying CoC is needed, but at least it will kind of make sense since the field is visible).
2. Support setting COC for non-HOH members
3. Remove error from validator
4. Make CoC required (for HoH) on the intake form as well. It should always be auto-populated if enrollment was specified at enrollment (or if there is only 1)