### PR TITLE
Reduce complexity of income fragment

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/income_benefit_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/income_benefit_processor.rb
@@ -9,9 +9,15 @@ module Hmis::Hud::Processors
     def process(field, value)
       attribute_name = ar_attribute_name(field)
       attribute_value = attribute_value_for_enum(graphql_enum(field), value)
-      attribute_value = 0 if override_to_no?(attribute_name, attribute_value)
 
-      @processor.send(factory_name).assign_attributes(attribute_name => attribute_value)
+      attributes = if field.end_with?('Amount')
+        income_source_attributes(field, attribute_value)
+      else
+        attribute_value = 0 if override_to_no?(attribute_name, attribute_value)
+        { attribute_name => attribute_value }
+      end
+
+      @processor.send(factory_name).assign_attributes(attributes)
     end
 
     def factory_name
@@ -22,6 +28,7 @@ module Hmis::Hud::Processors
       Types::HmisSchema::IncomeBenefit
     end
 
+    # For specific benefit/insurance fields, override Yes/No value based on "from any source" field
     def override_to_no?(attribute_name, attribute_value)
       summary_item_dependents.each do |field_key, dependents|
         next unless dependents.include?(attribute_name.to_sym)
@@ -36,12 +43,48 @@ module Hmis::Hud::Processors
       false
     end
 
+    # For specific income fields, set Yes/No value base on income amount.
+    def income_source_attributes(amount_field, value)
+      # Attribute for dollar amount (eg "unemployment_amount")
+      amount_attribute_name = ar_attribute_name(amount_field)
+      amount_attribute_value = value
+
+      # Attribute for 0/1/99 status (eg "unemployment")
+      bool_attribute_name = income_bool_field_name(amount_attribute_name)
+      bool_attribute_value = nil
+
+      case @hud_values['IncomeBenefit.incomeFromAnySource']
+      when 'YES'
+        # If overall income was 1 (yes), then this specific income field must be 1 or 0 (yes or no)
+        bool_attribute_value = amount_attribute_value&.positive? ? 1 : 0
+      when 'NO'
+        # If overall income was 0 (no), then this specific income field is 0 (no)
+        amount_attribute_value = nil
+        bool_attribute_value = 0
+      else
+        # If overall income was 8/9/99, then this specific income field is 99 (not collected)
+        amount_attribute_value = nil
+        bool_attribute_value = 99
+      end
+
+      {
+        amount_attribute_name => amount_attribute_value,
+        bool_attribute_name => bool_attribute_value,
+      }
+    end
+
     def summary_item_dependents
       {
         'IncomeBenefit.incomeFromAnySource' => Hmis::Hud::Validators::IncomeBenefitValidator.dependent_items[:income_from_any_source],
         'IncomeBenefit.benefitsFromAnySource' => Hmis::Hud::Validators::IncomeBenefitValidator.dependent_items[:benefits_from_any_source],
         'IncomeBenefit.insuranceFromAnySource' => Hmis::Hud::Validators::IncomeBenefitValidator.dependent_items[:insurance_from_any_source],
       }
+    end
+
+    private def income_bool_field_name(field)
+      return 'other_income_source' if field == 'other_income_amount'
+
+      ar_attribute_name(field.sub(/_amount$/, ''))
     end
   end
 end

--- a/drivers/hmis/lib/form_data/default/fragments/income_and_sources.json
+++ b/drivers/hmis/lib/form_data/default/fragments/income_and_sources.json
@@ -122,45 +122,6 @@
       ],
       "item": [
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.3",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "earned"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.A",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.A",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.A",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.A",
           "text": "Earned Income (i.e., employment income)",
@@ -168,45 +129,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "earnedAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.4",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "unemployment"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.B",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.B",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.B",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -218,45 +140,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.5",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "ssi"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.C",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.C",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.C",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.C",
           "text": "Supplemental Security Income (SSI)",
@@ -264,45 +147,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "ssiAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.6",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "ssdi"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.D",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.D",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.D",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -314,45 +158,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.7",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "vaDisabilityService"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.E",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.E",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.E",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.E",
           "text": "VA Service-Connected Disability Compensation",
@@ -360,45 +165,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "vaDisabilityServiceAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.8",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "vaDisabilityNonService"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.F",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.F",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.F",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -410,45 +176,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.9",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "privateDisability"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.G",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.G",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.G",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.G",
           "text": "Private disability insurance",
@@ -456,45 +183,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "privateDisabilityAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.10",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "workersComp"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.H",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.H",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.H",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -506,45 +194,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.11",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "tanf"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.I",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.I",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.I",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.I",
           "text": "Temporary Assistance for Needy Families (TANF)",
@@ -552,45 +201,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "tanfAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.12",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "ga"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.J",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.J",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.J",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -602,45 +212,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.13",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "socSecRetirement"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.K",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.K",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.K",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.K",
           "text": "Retirement Income from Social Security",
@@ -648,45 +219,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "socSecRetirementAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.14",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "pension"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.L",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.L",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.L",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",
@@ -698,45 +230,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.15",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "childSupport"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.M",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.M",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.M",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.M",
           "text": "Child support",
@@ -746,45 +239,6 @@
           }
         },
         {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.16",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "alimony"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.N",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.N",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.N",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "CURRENCY",
           "link_id": "4.02.N",
           "text": "Alimony and other spousal support",
@@ -792,45 +246,6 @@
             "record_type": "INCOME_BENEFIT",
             "field_name": "alimonyAmount"
           }
-        },
-        {
-          "type": "CHOICE",
-          "pick_list_reference": "NoYesMissing",
-          "link_id": "4.02.17",
-          "hidden": true,
-          "mapping": {
-            "record_type": "INCOME_BENEFIT",
-            "field_name": "otherIncomeSource"
-          },
-          "autofill_values": [
-            {
-              "value_code": "YES",
-              "autofill_behavior": "ALL",
-              "autofill_when": [
-                {
-                  "question": "4.02.O",
-                  "operator": "GREATER_THAN",
-                  "answer_number": 0
-                }
-              ]
-            },
-            {
-              "value_code": "NO",
-              "autofill_behavior": "ANY",
-              "autofill_when": [
-                {
-                  "question": "4.02.O",
-                  "operator": "LESS_THAN_EQUAL",
-                  "answer_number": 0
-                },
-                {
-                  "question": "4.02.O",
-                  "operator": "EXISTS",
-                  "answer_boolean": false
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "CURRENCY",

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -29,11 +29,8 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
       assessment.form_processor.hud_values = {
         'IncomeBenefit.incomeFromAnySource' => 'YES',
-        'IncomeBenefit.earned' => nil,
         'IncomeBenefit.earnedAmount' => nil,
-        'IncomeBenefit.unemployment' => 'YES',
         'IncomeBenefit.unemploymentAmount' => 100,
-        'IncomeBenefit.otherIncomeSource' => 'NO',
         'IncomeBenefit.otherIncomeAmount' => 0,
         'IncomeBenefit.otherIncomeSourceIdentify' => HIDDEN,
       }
@@ -58,11 +55,8 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       assessment = Hmis::Hud::CustomAssessment.new_with_defaults(enrollment: e1, user: u1, form_definition: fd, assessment_date: Date.yesterday)
       assessment.form_processor.hud_values = {
         'IncomeBenefit.incomeFromAnySource' => nil,
-        'IncomeBenefit.earned' => nil,
         'IncomeBenefit.earnedAmount' => nil,
-        'IncomeBenefit.unemployment' => nil,
         'IncomeBenefit.unemploymentAmount' => nil,
-        'IncomeBenefit.otherIncomeSource' => nil,
         'IncomeBenefit.otherIncomeAmount' => nil,
         'IncomeBenefit.otherIncomeSourceIdentify' => HIDDEN,
       }


### PR DESCRIPTION
There was a LOT of complexity in the Income Sources fragment, which is making it hard to track down bugs. We were relying on the frontend hide/show logic to make sure that "earned" is correctly set to 0/1/99 based on "earnedAmount". This logic is pure HUD, there is really no reason for it to live in the Form Definition imo. It should not be configurable. I moved it to the processor.