### PR TITLE
Expose chronic at entry when you age in

### DIFF
--- a/app/models/grda_warehouse/hud/enrollment.rb
+++ b/app/models/grda_warehouse/hud/enrollment.rb
@@ -370,6 +370,18 @@ module GrdaWarehouse::Hud
       GrdaWarehouse::ChEnrollment.chronically_homeless_at_start(self, date: date)
     end
 
+    # Taken from Client.enrollments_for to be able to use it on the chronic page more easily
+    def max_date_served
+      @max_date_served ||= begin
+        services = service_history_enrollment.service_history_services
+        if GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
+          services.where(record_type: GrdaWarehouse::Hud::Client.service_types).maximum(:date)
+        else
+          services.service_excluding_extrapolated.maximum(:date)
+        end
+      end
+    end
+
     # NOTE: this must be included at the end of the class so that scopes can override correctly
     include RailsDrivers::Extensions
   end # End Enrollment

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -92,7 +92,10 @@
             - destination = 'Unknown'
           %span{data: {toggle: :tooltip, title: "Destination: #{destination}"}}
             = e[:exit_date]
-        %td= e[:most_recent_service]
+        %td
+          = e[:most_recent_service]
+          - if e[:chronically_homeless_at_most_recent]
+            %i.icon-passport{data: {toggle: :tooltip, title: 'Chronic at most recent day served'}}
         %td.num-cell= e[:days]
         %td.num-cell
           - if e[:homeless]

--- a/app/views/clients/enrollments/show.haml
+++ b/app/views/clients/enrollments/show.haml
@@ -22,6 +22,12 @@
             %td Chronic at Entry
             %td= yes_no(@enrollment.chronically_homeless_at_start?)
           %tr
+            %td Most Recent Date Served
+            %td= @enrollment.max_date_served
+          %tr
+            %td Chronic at Most Recent Date Served
+            %td= yes_no(@enrollment.chronically_homeless_at_start?(date: @enrollment.max_date_served))
+          %tr
             %td Prior Living Situation
             %td= ::HudUtility.living_situation(@enrollment.LivingSituation) || '-'
           %tr

--- a/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
@@ -174,6 +174,7 @@ module ClientAccessControl::GrdaWarehouse::Hud
               entry_date: entry.first_date_in_program,
               living_situation: entry.enrollment.LivingSituation,
               chronically_homeless_at_start: entry.enrollment.chronically_homeless_at_start?,
+              chronically_homeless_at_most_recent: entry.enrollment.chronically_homeless_at_start?(date: most_recent_service),
               exit_date: entry.last_date_in_program,
               destination: entry.destination,
               move_in_date_inherited: entry.enrollment.MoveInDate.blank? && entry.move_in_date.present?,


### PR DESCRIPTION
Adds chronic at most-recent date served rows to the chronic at entry page:
<img width="1144" alt="Screenshot 2023-09-11 at 3 11 44 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/1be455b0-3e04-4e45-95da-2cd503e06ed6">

Exposes chronic at entry at most-recent day served on the client enrollment table
<img width="1158" alt="Screenshot 2023-09-11 at 3 11 50 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/d50d816d-ad00-40db-a30f-1d9c4614d626">
<img width="885" alt="Screenshot 2023-09-11 at 3 12 01 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/34ee0690-6664-468f-80f9-2f53a4d940f1">
