### PR TITLE
Require name and MCI-fields for ac

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -355,7 +355,7 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   private def client_is_valid
     return unless client.present?
 
-    client.valid?(context: [:form_submission, :new_client_enrollment_form])
+    client.valid?([:form_submission, :new_client_enrollment_form])
     errors.merge!(client.errors)
   end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_payload.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci_payload.rb
@@ -7,9 +7,9 @@
 module HmisExternalApis::AcHmis
   class MciPayload
     def self.from_client(client, mci_id: nil)
-      raise(Error, 'First name is required') unless client.first_name.present?
-      raise(Error, 'Last name is required') unless client.last_name.present?
-      raise(Error, 'DOB is required') unless client.dob.present?
+      raise 'First name is required' unless client.first_name.present?
+      raise 'Last name is required' unless client.last_name.present?
+      raise 'DOB is required' unless client.dob.present?
 
       {
         'userID' => client.user&.user_email&.slice(0, 20),

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -49,23 +49,35 @@ module HmisExternalApis
             where.or(arel_table[:id].in(client_ids))
           end
 
+          private def requires_mci_clearance?
+            # If brand new Client record (NOT in context of an Enrollment), then MCI clearance is required
+            return true if new_record?
+
+            # MCI clearance is required unless this client is ONLY enrolled at SO/NBN program(s)
+            ptypes = HmisExternalApis::AcHmis::Mci::PROJECT_TYPES_NOT_REQUIRING_CLEARANCE
+            so_nbn_enrollment_count = enrollments.with_project_type(ptypes).size
+            only_so_nbn_enrollments = so_nbn_enrollment_count.positive? && so_nbn_enrollment_count == enrollments.size
+
+            !only_so_nbn_enrollments
+          end
+
           private def validate_mci_id_exists
             return unless HmisExternalApis::AcHmis::Mci.enabled?
+
+            # First and Last are required, regardless of context
+            errors.add :first_name, :required unless first_name.present? || names.find(&:primary)&.first.present?
+            errors.add :last_name, :required unless last_name.present? || names.find(&:primary)&.last.present?
+
+            return unless requires_mci_clearance?
+
+            # For contexts where clearance is required, enforce presence of additional fields.
+            # This is needed so that you can't go back and remove DOB for a client that has already cleared, for example.
+            errors.add :dob, :required unless dob.present?
+            errors.add :dob_data_quality, :invalid, message: 'must be Full Name' unless dob_data_quality == 1
+            errors.add :name_data_quality, :invalid, message: 'must be Full DOB' unless name_data_quality == 1
+
             # Valid if client has an MCI ID, or is going to create one
             return if ac_hmis_mci_ids.exists? || send(:create_mci_id)
-
-            # If brand new Client record (NOT in context of an Enrollment), then MCI clearance is required
-            clearance_required = true if new_record?
-
-            if persisted?
-              # MCI clearance is required unless this client is ONLY enrolled at SO/NBN program(s)
-              ptypes = HmisExternalApis::AcHmis::Mci::PROJECT_TYPES_NOT_REQUIRING_CLEARANCE
-              so_nbn_enrollment_count = enrollments.with_project_type(ptypes).size
-              only_so_nbn_enrollments = so_nbn_enrollment_count.positive? && so_nbn_enrollment_count == enrollments.size
-              clearance_required = !only_so_nbn_enrollments
-            end
-
-            return unless clearance_required
 
             # Add in some custom options (handled by HmisErrors::Error) so it shows up on the correct fields
             full_msg = HmisExternalApis::AcHmis::Mci::MCI_REQUIRED_MSG

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -77,7 +77,7 @@ module HmisExternalApis
           private def validate_required_fields_for_clearance
             return unless HmisExternalApis::AcHmis::Mci.enabled?
 
-            errors.add :name_data_quality, :invalid, message: 'must be Full Name' unless name_data_quality == 1 || names.find(&:primary)&.name_data_quality == 1
+            errors.add :name_data_quality, :invalid, message: 'must be Full Name' unless names.find(&:primary)&.name_data_quality == 1
             errors.add :dob, :required unless dob.present?
             errors.add :dob_data_quality, :invalid, message: 'must be Full DOB' unless dob_data_quality == 1
           end
@@ -86,8 +86,8 @@ module HmisExternalApis
             return unless HmisExternalApis::AcHmis::Mci.enabled?
 
             # First and Last are required, regardless of context
-            errors.add :first_name, :required unless first_name.present? || names.find(&:primary)&.first.present?
-            errors.add :last_name, :required unless last_name.present? || names.find(&:primary)&.last.present?
+            errors.add :first_name, :required unless names.find(&:primary)&.first.present?
+            errors.add :last_name, :required unless names.find(&:primary)&.last.present?
           end
 
           private def validate_mci_id_exists

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -50,6 +50,7 @@ module HmisExternalApis
           end
 
           private def requires_mci_clearance?
+            return false unless HmisExternalApis::AcHmis::Mci.enabled?
             # If brand new Client record (NOT in context of an Enrollment), then MCI clearance is required
             return true if new_record?
 

--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -88,17 +88,20 @@ module HmisExternalApis
             # First and Last are required, regardless of context
             errors.add :first_name, :required unless names.find(&:primary)&.first.present?
             errors.add :last_name, :required unless names.find(&:primary)&.last.present?
+
+            # If this client has already cleared MCI, then the DOB/DQ fields must be present, regardless of whether clearance was required in the first place.
+            validate_required_fields_for_clearance if mci_cleared?
           end
 
           private def validate_mci_id_exists
             return unless HmisExternalApis::AcHmis::Mci.enabled?
             return unless requires_mci_clearance?
 
-            # Validate that DOB/DQ fields are there. This is needed so you can't go back and remove fields from a cleared client.
-            validate_required_fields_for_clearance
-
             # Valid if client has an MCI ID, or is going to create one
             return if mci_cleared?
+
+            # Validate that DOB/DQ fields are there. This is needed so you can't go back and remove fields from a cleared client.
+            validate_required_fields_for_clearance
 
             # Add in some custom options (handled by HmisErrors::Error) so it shows up on the correct fields
             full_msg = HmisExternalApis::AcHmis::Mci::MCI_REQUIRED_MSG

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
@@ -55,15 +55,18 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       [:invalid, :dob_data_quality],
     ].freeze
 
+    ALL_MCI_FIELDS_AND_MCI = [
+      *ALL_MCI_FIELDS,
+      [:required, :mci_id],
+    ].freeze
+
     describe 'when submitting Client Form' do
       it 'should require all MCI fields (new client)' do
-        expected = [*ALL_MCI_FIELDS, [:required, :mci_id]]
-        expect_validations(c2, expected_errors: expected, context: :client_form)
+        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
       end
 
       it 'should require all MCI fields (persisted client with no enrollments)' do
-        expected = [*ALL_MCI_FIELDS, [:required, :mci_id]]
-        expect_validations(c1, expected_errors: expected, context: :client_form)
+        expect_validations(c1, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
       end
 
       it 'should not require MCI fields (persisted client with only NBN enrollments)' do
@@ -72,17 +75,15 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       end
 
       it 'should require MCI fields (persisted client with only NBN enrollments that has already been cleared)' do
-        expected = [*ALL_MCI_FIELDS, [:required, :mci_id]]
         c1.create_mci_id = true
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
-        expect_validations(c2, expected_errors: expected, context: :client_form)
+        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
       end
 
       it 'should require MCI fields (persisted client with NBN & RRH enrollments)' do
-        expected = [*ALL_MCI_FIELDS, [:required, :mci_id]]
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
         create(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: c1)
-        expect_validations(c2, expected_errors: expected, context: :client_form)
+        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
       end
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
@@ -23,11 +23,25 @@ RSpec.describe Hmis::Hud::Client, type: :model do
 
   describe 'AC client validation' do
     let!(:mci_cred) { create(:ac_hmis_mci_credential) }
-    let(:c1) {  create(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
-    let(:c2) {  build(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
+    # persisted
+    let(:c1) do
+      client = create(:hmis_hud_client, data_source: ds1, dob: nil, dob_data_quality: 8)
+      name = create(:hmis_hud_custom_client_name, client: client, data_source: ds1, last: nil, name_data_quality: 8, primary: true)
+      client.names = [name]
+      client.save!
+      client
+    end
+    # unpersisted
+    let(:c2) do
+      client = build(:hmis_hud_client, data_source: ds1, dob: nil, dob_data_quality: 8)
+      name = build(:hmis_hud_custom_client_name, client: client, data_source: ds1, last: nil, name_data_quality: 8, primary: true)
+      client.names = [name]
+      client
+    end
 
     FIRST_LAST = [
-      [:required, :first_name],
+      # Examples all have a first name, so that we don't hit the "first or last required" err
+      # [:required, :first_name],
       [:required, :last_name],
     ].freeze
 
@@ -51,12 +65,6 @@ RSpec.describe Hmis::Hud::Client, type: :model do
 
     it 'should accept primary name in names array as valid first/last' do
       c2.names = [build(:hmis_hud_custom_client_name, data_source: ds1, client: c2, primary: true)]
-      expect_validations(c2, expected_errors: [], context: :new_client_enrollment_form)
-    end
-
-    it 'should accept name fields as valid first/last' do
-      c2.first_name = 'first'
-      c2.last_name = 'last'
       expect_validations(c2, expected_errors: [], context: :new_client_enrollment_form)
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
@@ -42,53 +42,56 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       client
     end
 
-    # Examples all have a first name, so that we don't hit the "first or last required" err
-    LAST_REQUIRED = [
-      [:required, :last_name],
-    ].freeze
+    let(:last_required) do
+      [[:required, :last_name]]
+    end
 
-    ALL_MCI_FIELDS = [
-      *LAST_REQUIRED,
-      [:invalid, :name_data_quality],
-      [:required, :dob],
-      [:invalid, :dob_data_quality],
-    ].freeze
+    let(:all_fields_required) do
+      [
+        *last_required,
+        [:invalid, :name_data_quality],
+        [:required, :dob],
+        [:invalid, :dob_data_quality],
+      ]
+    end
 
-    ALL_MCI_FIELDS_AND_MCI = [
-      *ALL_MCI_FIELDS,
-      [:required, :mci_id],
-    ].freeze
+    let(:all_fields_and_mci_required) do
+      [
+        *all_fields_required,
+        [:required, :mci_id],
+      ]
+    end
 
     describe 'when submitting Client Form' do
       it 'should require all MCI fields (new client)' do
-        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
+        expect_validations(c2, expected_errors: all_fields_and_mci_required, context: :client_form)
       end
 
       it 'should require all MCI fields (persisted client with no enrollments)' do
-        expect_validations(c1, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
+        expect_validations(c1, expected_errors: all_fields_and_mci_required, context: :client_form)
       end
 
       it 'should not require MCI fields (persisted client with only NBN enrollments)' do
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
-        expect_validations(c1, expected_errors: LAST_REQUIRED, context: :client_form)
+        expect_validations(c1, expected_errors: last_required, context: :client_form)
       end
 
       it 'should require MCI fields (persisted client with only NBN enrollments that has already been cleared)' do
         c1.create_mci_id = true
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
-        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
+        expect_validations(c2, expected_errors: all_fields_and_mci_required, context: :client_form)
       end
 
       it 'should require MCI fields (persisted client with NBN & RRH enrollments)' do
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
         create(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: c1)
-        expect_validations(c2, expected_errors: ALL_MCI_FIELDS_AND_MCI, context: :client_form)
+        expect_validations(c2, expected_errors: all_fields_and_mci_required, context: :client_form)
       end
     end
 
     it 'should require first/last on new client enrollment form' do
-      expect_validations(c1, expected_errors: LAST_REQUIRED, context: :new_client_enrollment_form)
-      expect_validations(c2, expected_errors: LAST_REQUIRED, context: :new_client_enrollment_form)
+      expect_validations(c1, expected_errors: last_required, context: :new_client_enrollment_form)
+      expect_validations(c2, expected_errors: last_required, context: :new_client_enrollment_form)
     end
 
     it 'should accept primary name in names array as valid first/last' do
@@ -99,8 +102,8 @@ RSpec.describe Hmis::Hud::Client, type: :model do
     it 'should require MCI fields on new client enrollment form if extra context is included' do
       # Note: doesn't validate MCI ID field. That happens on Enrollment because the client doesn't know which project
       # that it's being created in.
-      expect_validations(c1, expected_errors: ALL_MCI_FIELDS, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
-      expect_validations(c2, expected_errors: ALL_MCI_FIELDS, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
+      expect_validations(c1, expected_errors: all_fields_required, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
+      expect_validations(c2, expected_errors: all_fields_required, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
     end
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
@@ -1,0 +1,70 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe Hmis::Hud::Client, type: :model do
+  let!(:ds1) { create :hmis_data_source }
+
+  def expect_validations(client, expected_errors:, context:)
+    client.valid?(context)
+    errors = client.errors.map { |e| [e.type, e.options[:attribute_override] || e.attribute] }
+    expect(errors).to contain_exactly(*expected_errors)
+  end
+
+  it 'shouldn\'t validate MCI fields if MCI credential is not present' do
+    client = build(:hmis_hud_client, data_source: ds1, first_name: nil, dob: nil)
+    expect_validations(client, expected_errors: [], context: :client_form)
+    expect_validations(client, expected_errors: [], context: :new_client_enrollment_form)
+  end
+
+  describe 'AC client validation' do
+    let!(:mci_cred) { create(:ac_hmis_mci_credential) }
+    let(:c1) {  create(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
+    let(:c2) {  build(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
+
+    FIRST_LAST = [
+      [:required, :first_name],
+      [:required, :last_name],
+    ].freeze
+
+    ALL_MCI_FIELDS = [
+      *FIRST_LAST,
+      [:invalid, :name_data_quality],
+      [:required, :dob],
+      [:invalid, :dob_data_quality],
+    ].freeze
+
+    it 'should require all MCI fields on client form' do
+      expected = [*ALL_MCI_FIELDS, [:required, :mci_id]]
+      expect_validations(c1, expected_errors: expected, context: :client_form)
+      expect_validations(c2, expected_errors: expected, context: :client_form)
+    end
+
+    it 'should require first/last on new client enrollment form' do
+      expect_validations(c1, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
+      expect_validations(c2, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
+    end
+
+    it 'should accept primary name in names array as valid first/last' do
+      c2.names = [build(:hmis_hud_custom_client_name, data_source: ds1, client: c2, primary: true)]
+      expect_validations(c2, expected_errors: [], context: :new_client_enrollment_form)
+    end
+
+    it 'should accept name fields as valid first/last' do
+      c2.first_name = 'first'
+      c2.last_name = 'last'
+      expect_validations(c2, expected_errors: [], context: :new_client_enrollment_form)
+    end
+
+    it 'should require MCI fields on new client enrollment form if extra context is included' do
+      # Note: doesn't validate MCI ID field. That happens on Enrollment because the client doesn't know which project
+      # that it's being created in.
+      expect_validations(c1, expected_errors: ALL_MCI_FIELDS, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
+      expect_validations(c2, expected_errors: ALL_MCI_FIELDS, context: [:new_client_enrollment_form, :enrollment_requiring_mci])
+    end
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/client_spec.rb
@@ -42,14 +42,13 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       client
     end
 
-    FIRST_LAST = [
-      # Examples all have a first name, so that we don't hit the "first or last required" err
-      # [:required, :first_name],
+    # Examples all have a first name, so that we don't hit the "first or last required" err
+    LAST_REQUIRED = [
       [:required, :last_name],
     ].freeze
 
     ALL_MCI_FIELDS = [
-      *FIRST_LAST,
+      *LAST_REQUIRED,
       [:invalid, :name_data_quality],
       [:required, :dob],
       [:invalid, :dob_data_quality],
@@ -71,7 +70,7 @@ RSpec.describe Hmis::Hud::Client, type: :model do
 
       it 'should not require MCI fields (persisted client with only NBN enrollments)' do
         create(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: c1)
-        expect_validations(c1, expected_errors: FIRST_LAST, context: :client_form)
+        expect_validations(c1, expected_errors: LAST_REQUIRED, context: :client_form)
       end
 
       it 'should require MCI fields (persisted client with only NBN enrollments that has already been cleared)' do
@@ -88,8 +87,8 @@ RSpec.describe Hmis::Hud::Client, type: :model do
     end
 
     it 'should require first/last on new client enrollment form' do
-      expect_validations(c1, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
-      expect_validations(c2, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
+      expect_validations(c1, expected_errors: LAST_REQUIRED, context: :new_client_enrollment_form)
+      expect_validations(c2, expected_errors: LAST_REQUIRED, context: :new_client_enrollment_form)
     end
 
     it 'should accept primary name in names array as valid first/last' do

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/enrollment_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/enrollment_spec.rb
@@ -26,30 +26,29 @@ RSpec.describe Hmis::Hud::Enrollment, type: :model do
 
   describe 'AC Enrollment validation' do
     let!(:mci_cred) { create(:ac_hmis_mci_credential) }
+    let(:first_last_required) do
+      [
+        [:required, :first_name],
+        [:required, :last_name],
+      ]
+    end
 
-    FIRST_LAST = [
-      [:required, :first_name],
-      [:required, :last_name],
-    ].freeze
-
-    MCI_FIELD = [
-      [:required, :mci_id],
-    ].freeze
-
-    ALL_MCI_FIELDS = [
-      *FIRST_LAST,
-      [:invalid, :name_data_quality],
-      [:required, :dob],
-      [:invalid, :dob_data_quality],
-      *MCI_FIELD,
-    ].freeze
+    let(:all_fields_and_mci_required) do
+      [
+        *first_last_required,
+        [:invalid, :name_data_quality],
+        [:required, :dob],
+        [:invalid, :dob_data_quality],
+        [:required, :mci_id],
+      ]
+    end
 
     describe 'should validate when enrolling an EXISTING client' do
       let(:client) { create(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
 
       it 'in RRH project (only validate presence of MCI, not individual name fields)' do
         en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
-        expect_validations(en, expected_errors: MCI_FIELD, context: :enrollment_form)
+        expect_validations(en, expected_errors: [[:required, :mci_id]], context: :enrollment_form)
       end
 
       it 'in ES NBN project (no validations, MCI not required)' do
@@ -63,12 +62,12 @@ RSpec.describe Hmis::Hud::Enrollment, type: :model do
 
       it 'in RRH project (all fields required, and clearance)' do
         en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
-        expect_validations(en, expected_errors: ALL_MCI_FIELDS, context: :new_client_enrollment_form)
+        expect_validations(en, expected_errors: all_fields_and_mci_required, context: :new_client_enrollment_form)
       end
 
       it 'in ES NBN project (first/last required)' do
         en = build(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: client)
-        expect_validations(en, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
+        expect_validations(en, expected_errors: first_last_required, context: :new_client_enrollment_form)
       end
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/enrollment_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/enrollment_spec.rb
@@ -1,0 +1,92 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe Hmis::Hud::Enrollment, type: :model do
+  let!(:ds1) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:rrh) { create :hmis_hud_project, data_source: ds1, organization: o1, project_type: 13 }
+  let!(:nbn) { create :hmis_hud_project, data_source: ds1, organization: o1, project_type: 1  }
+
+  def expect_validations(enrollment, expected_errors:, context:)
+    enrollment.valid?([:form_submission, context])
+    errors = enrollment.errors.map { |e| [e.type, e.options[:attribute_override] || e.attribute] }
+    expect(errors).to contain_exactly(*expected_errors)
+  end
+
+  it 'shouldn\'t validate MCI fields if MCI credential is not present' do
+    client = build(:hmis_hud_client, data_source: ds1, first_name: nil, dob: nil)
+    en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+    expect_validations(en, expected_errors: [], context: :new_client_enrollment_form)
+  end
+
+  describe 'AC Enrollment validation' do
+    let!(:mci_cred) { create(:ac_hmis_mci_credential) }
+
+    FIRST_LAST = [
+      [:required, :first_name],
+      [:required, :last_name],
+    ].freeze
+
+    MCI_FIELD = [
+      [:required, :mci_id],
+    ].freeze
+
+    ALL_MCI_FIELDS = [
+      *FIRST_LAST,
+      [:invalid, :name_data_quality],
+      [:required, :dob],
+      [:invalid, :dob_data_quality],
+      *MCI_FIELD,
+    ].freeze
+
+    describe 'should validate when enrolling an EXISTING client' do
+      let(:client) { create(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
+
+      it 'in RRH project (only validate presence of MCI, not individual name fields)' do
+        en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+        expect_validations(en, expected_errors: MCI_FIELD, context: :enrollment_form)
+      end
+
+      it 'in ES NBN project (no validations, MCI not required)' do
+        en = build(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: client)
+        expect_validations(en, expected_errors: [], context: :enrollment_form)
+      end
+    end
+
+    describe 'should validate when enrolling a NEW client' do
+      let(:client) { build(:hmis_hud_client, data_source: ds1, first_name: nil, last_name: nil, dob: nil, name_data_quality: 8, dob_data_quality: 9) }
+
+      it 'in RRH project (all fields required, and clearance)' do
+        en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+        expect_validations(en, expected_errors: ALL_MCI_FIELDS, context: :new_client_enrollment_form)
+      end
+
+      it 'in ES NBN project (first/last required)' do
+        en = build(:hmis_hud_enrollment, data_source: ds1, project: nbn, client: client)
+        expect_validations(en, expected_errors: FIRST_LAST, context: :new_client_enrollment_form)
+      end
+    end
+
+    # When submitting any old enrollment form - like updating move in date - we should not validate MCI
+    it 'should not perform any MCI validation outside of new_client_enrollment_form/enrollment_form contexts' do
+      client = create(:hmis_hud_client, data_source: ds1, first_name: nil, dob: nil)
+      en = create(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+      expect(en.valid?(:form_submission)).to eq(true)
+
+      en = build(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+      expect(en.valid?(:form_submission)).to eq(true)
+    end
+
+    # MCI validation should only happen when enrolling a client, not updating an existing enrollment
+    it 'should not perform any MCI validation on persisted Enrollment record' do
+      client = create(:hmis_hud_client, data_source: ds1, first_name: nil, dob: nil)
+      en = create(:hmis_hud_enrollment, data_source: ds1, project: rrh, client: client)
+      expect_validations(en, expected_errors: [], context: :enrollment_form)
+    end
+  end
+end


### PR DESCRIPTION
Address [qa](https://www.pivotaltracker.com/story/show/185863108/comments/238386659) and [sentry](https://green-river.sentry.io/issues/4473350436/?alert_rule_id=12523843&alert_type=issue&notification_uuid=3da953eb-ae7b-4d3b-ac78-513ae6fb582b&project=4503977346662400&referrer=slack).

It would be more ideal if we could use the FormDefinition to specify the required-ness of these fields, but its complicated because (1) the logic for whether clearance is required or not is not readily available to the form, and (2) the name input component is grouped into 1 so you can't specify which name fields are required using the form. We really should address (2), but, this is a quick fix.