### PR TITLE
Use reprojected zip codes

### DIFF
--- a/app/models/grda_warehouse/shape/zip_code.rb
+++ b/app/models/grda_warehouse/shape/zip_code.rb
@@ -47,10 +47,7 @@ module GrdaWarehouse
       end
 
       def self.all_we_need?
-        # count >= 30_000
-        # There is a postgis error: (transform: point not within available datum shift grids (-48)) that is preventing many inserts
-        # We need to upgrade postgis to 3.3 or fix the shape file and then change the count here to the real number
-        count >= 26_000
+        count >= 33_000
       end
 
       def self.calculate_states

--- a/shape_files/zip_codes.census.2018/README.md
+++ b/shape_files/zip_codes.census.2018/README.md
@@ -1,1 +1,18 @@
 https://www.census.gov/geo/maps-data/data/tiger-line.html
+
+Due to bugs in postgis 3.1, we had to reproject the shape file from that source.
+
+It's roughly this. As root in a container:
+```
+apk update
+apk add gdal-tools
+su - app
+cd /app/shape_files/...
+ogr2ogr -t_srs EPSG:4326 tl_2018_us_zcta510.reprojected.4326.shp tl_2018_us_zcta510.shp
+```
+
+and zip the resulting files into `tl_2018_us_zcta510.reprojected.4326.zip`. When
+we eventually get updated zip code shapes, just pay attention to the projection
+and don't blindly drop it in here. shp2pgsql can add transforms to the insert
+statements, but that's what was breaking for many 1000s of zip codes on
+postgres 12 with postgis 3.1.

--- a/shape_files/zip_codes.census.2018/make.inserts
+++ b/shape_files/zip_codes.census.2018/make.inserts
@@ -6,19 +6,26 @@ require 'zip'
 
 FileUtils.chdir(Pathname.new(__FILE__).dirname)
 
-Dir.glob("*.zip").each do |zipfile_path|
+Dir.glob('*.zip').each do |zipfile_path|
   Zip::File.open(zipfile_path) do |zipfile|
     zipfile.each do |file|
-      zipfile.extract(file, "#{file.name}") unless File.exist?(file.name)
+      zipfile.extract(file, file.name.to_s) unless File.exist?(file.name)
     end
   end
 end
 
-system('shp2pgsql -s 4269:4326 -p -I tl_2018_us_zcta510.shp shape_zip_codes > zip.codes.structure.sql')
+# Reproject with another tool so that the inserts to postres don't involve a
+# transform
+# apk add gdal-tools
+# https://gdal.org/programs/ogr2ogr.html
+# system('ogr2ogr -t_srs EPSG:4326 tl_2018_us_zcta510.reprojected.4326.shp tl_2018_us_zcta510.shp")
 
-system(<<~EOS)
-  shp2pgsql -s 4269:4326 -c -I tl_2018_us_zcta510.shp shape_zip_codes \
+system('shp2pgsql -p -I tl_2018_us_zcta510.reprojected.4326.shp shape_zip_codes > zip.codes.structure.sql')
+# system('shp2pgsql -s 4269:4326 -p -I tl_2018_us_zcta510.shp shape_zip_codes > zip.codes.structure.sql')
+
+system(<<~HEREDOC)
+  shp2pgsql -s 4326 -c -I tl_2018_us_zcta510.reprojected.4326.shp shape_zip_codes \
     | sed -e 's/gid/id/' \
     | grep INSERT \
     > inserts.sql
-EOS
+HEREDOC


### PR DESCRIPTION
The problem was transformations as part of the generated insert statements into postgres/postgis, so I reprojected the shape file into 4326, uploaded that to s3, and made the code no longer transform the insert statements. 