### PR TITLE
CE performance report updates

### DIFF
--- a/drivers/ce_performance/app/models/ce_performance/report.rb
+++ b/drivers/ce_performance/app/models/ce_performance/report.rb
@@ -404,14 +404,14 @@ module CePerformance
         CePerformance::Results::SuccessfulDiversion,
         CePerformance::Results::TimeInProjectAverage,
         CePerformance::Results::TimeInProjectMedian,
+        CePerformance::Results::TimeToAssessmentAverage,
+        CePerformance::Results::TimeToAssessmentMedian,
+        CePerformance::Results::TimeOnListAverage,
+        CePerformance::Results::TimeOnListMedian,
         CePerformance::Results::EntryToReferralAverage,
         CePerformance::Results::EntryToReferralMedian,
         CePerformance::Results::ReferralToHousingAverage,
         CePerformance::Results::ReferralToHousingMedian,
-        CePerformance::Results::TimeOnListAverage,
-        CePerformance::Results::TimeOnListMedian,
-        CePerformance::Results::TimeToAssessmentAverage,
-        CePerformance::Results::TimeToAssessmentMedian,
         CePerformance::Results::EventType,
       ]
       if include_supplemental?

--- a/drivers/ce_performance/app/models/ce_performance/result.rb
+++ b/drivers/ce_performance/app/models/ce_performance/result.rb
@@ -6,6 +6,7 @@
 
 module CePerformance
   class Result < GrdaWarehouseBase
+    include ActionView::Helpers::NumberHelper
     acts_as_paranoid
 
     belongs_to :report

--- a/drivers/ce_performance/app/models/ce_performance/result.rb
+++ b/drivers/ce_performance/app/models/ce_performance/result.rb
@@ -23,6 +23,10 @@ module CePerformance
       []
     end
 
+    def sub_results
+      []
+    end
+
     def self.category
       'Participation'
     end

--- a/drivers/ce_performance/app/models/ce_performance/results/category_one.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_one.rb
@@ -49,7 +49,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "#{value.to_i} #{unit}"
+      "#{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/category_one.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_one.rb
@@ -42,7 +42,7 @@ module CePerformance
       'Count of clients enrolled in CE who entered with a prior living situation of literally homeless, or who\'s length of time was under the threshold and were previously on the street or in shelter, or who had a literally homeless Current Living Situation collected during the report range.'
     end
 
-    def nested_results
+    def sub_results
       [
         CePerformance::Results::CategoryOneHousehold,
       ]

--- a/drivers/ce_performance/app/models/ce_performance/results/category_one_household.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_one_household.rb
@@ -47,7 +47,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "#{value.to_i} #{unit}"
+      "#{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/category_two.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_two.rb
@@ -49,7 +49,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "#{value.to_i} #{unit}"
+      "#{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/category_two.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_two.rb
@@ -42,7 +42,7 @@ module CePerformance
       'Count of clients enrolled in CE who did not enter with a prior living situation of literally homeless, nor who\'s length of time was under the threshold and were previously on the street or in shelter, nor who had a literally homeless Current Living Situation collected during the report range.'
     end
 
-    def nested_results
+    def sub_results
       [
         CePerformance::Results::CategoryTwoHousehold,
       ]

--- a/drivers/ce_performance/app/models/ce_performance/results/category_two_household.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/category_two_household.rb
@@ -47,7 +47,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "#{value.to_i} #{unit}"
+      "#{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/clients_screened.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/clients_screened.rb
@@ -78,7 +78,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "#{value.to_i} clients"
+      "#{number_with_delimiter(value.to_i)} clients"
     end
 
     def indicator(comparison)

--- a/drivers/ce_performance/app/models/ce_performance/results/entry_to_referral_average.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/entry_to_referral_average.rb
@@ -82,7 +82,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Average: #{value.to_i} #{unit}"
+      "Average: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/entry_to_referral_median.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/entry_to_referral_median.rb
@@ -72,7 +72,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Median: #{value.to_i} #{unit}"
+      "Median: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/referral_to_housing_average.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/referral_to_housing_average.rb
@@ -82,7 +82,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Average: #{value.to_i} #{unit}"
+      "Average: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/referral_to_housing_median.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/referral_to_housing_median.rb
@@ -72,7 +72,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Median: #{value.to_i} #{unit}"
+      "Median: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/models/ce_performance/results/time_in_project_average.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_in_project_average.rb
@@ -66,7 +66,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Average: #{value.to_i} days"
+      "Average: #{number_with_delimiter(value.to_i)} days"
     end
 
     def indicator(comparison)

--- a/drivers/ce_performance/app/models/ce_performance/results/time_in_project_median.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_in_project_median.rb
@@ -60,7 +60,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Median: #{value.to_i} days"
+      "Median: #{number_with_delimiter(value.to_i)} days"
     end
 
     def indicator(comparison)

--- a/drivers/ce_performance/app/models/ce_performance/results/time_on_list_average.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_on_list_average.rb
@@ -54,7 +54,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Average: #{value.to_i} #{unit}"
+      "Average: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def goal_direction

--- a/drivers/ce_performance/app/models/ce_performance/results/time_on_list_median.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_on_list_median.rb
@@ -60,7 +60,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Median: #{value.to_i} days"
+      "Median: #{number_with_delimiter(value.to_i)} days"
     end
 
     def indicator(comparison)

--- a/drivers/ce_performance/app/models/ce_performance/results/time_to_assessment_average.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_to_assessment_average.rb
@@ -53,7 +53,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Average: #{value.to_i} days"
+      "Average: #{number_with_delimiter(value.to_i)} days"
     end
 
     def indicator(comparison)

--- a/drivers/ce_performance/app/models/ce_performance/results/time_to_assessment_median.rb
+++ b/drivers/ce_performance/app/models/ce_performance/results/time_to_assessment_median.rb
@@ -43,7 +43,7 @@ module CePerformance
     end
 
     def detail_link_text
-      "Median: #{value.to_i} #{unit}"
+      "Median: #{number_with_delimiter(value.to_i)} #{unit}"
     end
 
     def unit

--- a/drivers/ce_performance/app/views/ce_performance/results/category_ones/_category_one.haml
+++ b/drivers/ce_performance/app/views/ce_performance/results/category_ones/_category_one.haml
@@ -1,1 +1,2 @@
-= render 'ce_performance/warehouse_reports/reports/row_with_nested_rows', category_name: category_name, result_class: result_class, result: result, pdf: pdf
+.card.mb-0.pb-0.page-break-avoid
+  = render 'ce_performance/warehouse_reports/reports/row_without_nested_rows', category_name: category_name, result_class: result_class, result: result, pdf: pdf

--- a/drivers/ce_performance/app/views/ce_performance/results/category_twos/_category_two.haml
+++ b/drivers/ce_performance/app/views/ce_performance/results/category_twos/_category_two.haml
@@ -1,1 +1,2 @@
-= render 'ce_performance/warehouse_reports/reports/row_with_nested_rows', category_name: category_name, result_class: result_class, result: result, pdf: pdf
+.card.mb-0.pb-0.page-break-avoid
+  = render 'ce_performance/warehouse_reports/reports/row_without_nested_rows', category_name: category_name, result_class: result_class, result: result, pdf: pdf

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
@@ -18,4 +18,4 @@
           %tr
             %th= k
             - [[:comparison, comparison[k]], [:reporting, v]].each do |period, value|
-              %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, value.round, clients_ce_performance_warehouse_reports_report_path(@report, period: period, event_type: ::HudUtility.event(k, true), key: @key, category_name: @category_name)
+              %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, number_with_delimiter(value.round), clients_ce_performance_warehouse_reports_report_path(@report, period: period, event_type: ::HudUtility.event(k, true), key: @key, category_name: @category_name)

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents.haml
@@ -7,10 +7,10 @@
   %p= raw markdown.render(result.description)
 .col-sm-2
   .text-uppercase This Year
-  .performance-measurement__result-number.font-weight-bold= result.value.round
+  .performance-measurement__result-number.font-weight-bold= number_with_delimiter(result.value.round)
   .text-capitalize= result.unit
 .col-sm-2
   - if comparison.present?
     .text-uppercase Last Year
-    .performance-measurement__result-number.font-weight-bold= comparison.value.round
+    .performance-measurement__result-number.font-weight-bold= number_with_delimiter(comparison.value.round)
     .text-capitalize= comparison.unit

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents.haml
@@ -5,12 +5,5 @@
   - if result_class.ce_apr_question.present?
     .spm-measure.font-weight-bold= "CE APR #{result_class.ce_apr_question}"
   %p= raw markdown.render(result.description)
-.col-sm-2
-  .text-uppercase This Year
-  .performance-measurement__result-number.font-weight-bold= number_with_delimiter(result.value.round)
-  .text-capitalize= result.unit
-.col-sm-2
-  - if comparison.present?
-    .text-uppercase Last Year
-    .performance-measurement__result-number.font-weight-bold= number_with_delimiter(comparison.value.round)
-    .text-capitalize= comparison.unit
+.col-sm-4
+  = render 'row_contents_comparisons', result: result, comparison: comparison, category_name: category_name

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents_comparisons.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_contents_comparisons.haml
@@ -1,0 +1,24 @@
+.row
+  .col-sm-6
+    .text-uppercase This Year
+    .performance-measurement__result-number.font-weight-bold= result.value.round
+    .text-capitalize= result.unit
+  .col-sm-6
+    - if comparison.present?
+      .text-uppercase Last Year
+      .performance-measurement__result-number.font-weight-bold= comparison.value.round
+      .text-capitalize= comparison.unit
+
+- result.sub_results.each do |sub_result_class|
+  - sub_result = @report.results_for_display[category_name][:reporting][sub_result_class]
+  - sub_comparison = @report.results_for_display[category_name][:comparison][sub_result_class]
+  .row.mt-4
+    .col-sm-6
+      .text-uppercase This Year
+      .performance-measurement__result-number.font-weight-bold= sub_result.value.round
+      .text-capitalize= sub_result.unit
+    .col-sm-6
+      - if sub_comparison.present?
+        .text-uppercase Last Year
+        .performance-measurement__result-number.font-weight-bold= sub_comparison.value.round
+        .text-capitalize= sub_comparison.unit

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_without_nested_rows.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_row_without_nested_rows.haml
@@ -19,4 +19,9 @@
   - else
     .col-sm-2.ml-auto.d-flex
       .text-small.ml-auto
-        = link_to result.detail_link_text, details_ce_performance_warehouse_reports_report_path(@report, key: result_class, category_name: category_name, target: :_blank), class: 'j-click-row-source'
+        .w-100.mb-8
+          = link_to result.detail_link_text, details_ce_performance_warehouse_reports_report_path(@report, key: result_class, category_name: category_name, target: :_blank), class: 'j-click-row-source'
+        - result.sub_results.each do |sub_result_class|
+          - sub_result = @report.results_for_display[category_name][:reporting][sub_result_class]
+          .w-100.mb-12
+            = link_to sub_result.detail_link_text, details_ce_performance_warehouse_reports_report_path(@report, key: sub_result_class, category_name: category_name, target: :_blank), class: 'j-click-row-source'

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
@@ -21,4 +21,4 @@
         %tr
           %th= k
           - [[:comparison, comparison[k]], [:reporting, v]].each do |period, value|
-            %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, value, clients_ce_performance_warehouse_reports_report_path(@report, period: period, sub_population: sub_pop, key: @key, category_name: @category_name)
+            %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, number_with_delimiter(value), clients_ce_performance_warehouse_reports_report_path(@report, period: period, sub_population: sub_pop, key: @key, category_name: @category_name)

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_summary.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_summary.haml
@@ -40,5 +40,5 @@
                     .ml-auto.mr-4= tagged(passed, status, icon: icon, label: label)
                 - else
                   .col-md-3
-                    .performance-measurement__result-number.font-weight-bold.mt-4= result.value.round
+                    .performance-measurement__result-number.font-weight-bold.mt-4= number_with_delimiter(result.value.round)
                     .text-capitalize= result.unit

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
@@ -19,7 +19,7 @@
             %tr
               %th= vispdat_range
               - [[:comparison, comparison[vispdat_range]], [:reporting, v]].each do |period, value|
-                %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, value, clients_ce_performance_warehouse_reports_report_path(@report, period: period, vispdat_range: vispdat_range, key: @key, category_name: @category_name)
+                %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, number_with_delimiter(value), clients_ce_performance_warehouse_reports_report_path(@report, period: period, vispdat_range: vispdat_range, key: @key, category_name: @category_name)
     - data = @result.data_for_vispdat_types(@report)
     - reporting = data[:reporting]
     - comparison = data[:comparison]
@@ -38,4 +38,4 @@
             %tr
               %th= vispdat_type
               - [[:comparison, comparison[vispdat_type]], [:reporting, v]].each do |period, value|
-                %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, value, clients_ce_performance_warehouse_reports_report_path(@report, period: period, vispdat_type: vispdat_type, key: @key, category_name: @category_name)
+                %td= link_to_if can_view_all_hud_reports? || can_view_own_hud_reports?, number_with_delimiter(value), clients_ce_performance_warehouse_reports_report_path(@report, period: period, vispdat_type: vispdat_type, key: @key, category_name: @category_name)

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/details.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/details.haml
@@ -37,10 +37,10 @@
       - else
         .col-sm-2
       .col-sm-4
-        .performance-measurement__result-number.font-weight-bold=indicator.secondary_value
+        .performance-measurement__result-number.font-weight-bold=number_with_delimiter(indicator.secondary_value)
         .text-capitalize="#{indicator.secondary_unit} #{sanitize(indicator.value_label)}"
       .col-sm-4
-        .performance-measurement__result-number.font-weight-bold=indicator.primary_value
+        .performance-measurement__result-number.font-weight-bold=number_with_delimiter(indicator.primary_value)
         .text-capitalize=indicator.primary_unit
   .col-6.ce-performance
     .c-chart--vertical-bar{ class: chart_class_name, data: { chart: @result.data_for_chart(@report, @comparison).to_json }}

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/show.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/show.haml
@@ -36,7 +36,7 @@
     - periods[:reporting].each do |result_class, result|
       - next unless result_class.display_result?
       %div{id: result_class.title.parameterize}
-      = render result, category_name: category_name, result_class: result_class, result: result, pdf: false
+        = render result, category_name: category_name, result_class: result_class, result: result, pdf: false
 
 
 = content_for :page_js do
@@ -51,7 +51,12 @@
       $('.j-click-row').addClass('cursor-pointer');
       $('.j-click-row').on('click', function(e) {
         e.preventDefault();
-        var link = $(this).find('.j-click-row-source');
+        var link;
+        if($(e.target).is('a')) {
+          link = $(e.target);
+        } else {
+          link = $(this).find('.j-click-row-source');
+        }
         window.open(link.attr('href'), '_blank');
       });
     });


### PR DESCRIPTION
Homeless Client metrics now show clients and households on the same card:
<img width="1199" alt="Screenshot 2023-09-15 at 11 24 21 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/ab06825f-766a-4706-b79e-c1a8c84e646a">
Other items continue to have nested results:
<img width="1224" alt="Screenshot 2023-09-15 at 11 24 26 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/62ef9a54-fa48-4947-8e6e-ab257281f962">
