### PR TITLE
Add can_view_project permission

### DIFF
--- a/db/migrate/20230916124819_add_hmis_view_project_permission.rb
+++ b/db/migrate/20230916124819_add_hmis_view_project_permission.rb
@@ -1,0 +1,10 @@
+class AddHmisViewProjectPermission < ActiveRecord::Migration[6.1]
+  def up
+    Hmis::Role.ensure_permissions_exist
+    Hmis::Role.reset_column_information
+  end
+
+  def down
+    remove_column :hmis_roles, :can_view_project
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -740,7 +740,8 @@ CREATE TABLE public.hmis_roles (
     can_manage_outgoing_referrals boolean DEFAULT false,
     can_manage_denied_referrals boolean DEFAULT false,
     can_enroll_clients boolean DEFAULT false,
-    can_view_open_enrollment_summary boolean DEFAULT false
+    can_view_open_enrollment_summary boolean DEFAULT false,
+    can_view_project boolean DEFAULT false
 );
 
 
@@ -3989,6 +3990,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230807193335'),
 ('20230910175113'),
 ('20230910175333'),
-('20230910180118');
+('20230910180118'),
+('20230916124819');
 
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -7460,7 +7460,6 @@ type QueryAccess {
   canAdministerHmis: Boolean!
   canAuditClients: Boolean!
   canDeleteAssessments: Boolean!
-  canDeleteAssignedProjectData: Boolean!
   canDeleteClients: Boolean!
   canDeleteEnrollments: Boolean!
   canDeleteOrganization: Boolean!
@@ -7484,6 +7483,7 @@ type QueryAccess {
   canViewFullSsn: Boolean!
   canViewOpenEnrollmentSummary: Boolean!
   canViewPartialSsn: Boolean!
+  canViewProject: Boolean!
   id: ID!
 }
 

--- a/drivers/hmis/app/models/hmis/access_group.rb
+++ b/drivers/hmis/app/models/hmis/access_group.rb
@@ -38,8 +38,17 @@ class Hmis::AccessGroup < ApplicationRecord
     joins(:roles).merge(Hmis::Role.with_editable_permissions)
   end
 
-  scope :with_permissions, ->(*perms, mode: 'any') do
-    joins(:roles).merge(mode == 'all' ? Hmis::Role.with_all_permissions(*perms) : Hmis::Role.with_any_permissions(*perms))
+  scope :with_permissions, ->(*perms, mode: :any) do
+    role_scope = case mode.to_sym
+    when :all
+      Hmis::Role.with_all_permissions(*perms)
+    when :any
+      Hmis::Role.with_any_permissions(*perms)
+    else
+      raise "Invalid permission mode: #{mode}"
+    end
+
+    joins(:roles).merge(role_scope)
   end
 
   scope :contains, ->(entity) do

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -96,6 +96,12 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     end
   end
 
+  # Includes clients where..
+  #  1. The Client has enrollment(s) at any Project where the User has this specified Permissions(s)
+  #     OR,
+  #  2. The Client has NO enrollments AND the User has these Permission(s) at _any_ project
+  #
+  # NOTE: This could include clients that are enrolled at projects that the User can't necessarily see (e.g. they lack can_view_projects at that project).
   scope :with_access, ->(user, *permissions, **kwargs) do
     pids = Hmis::Hud::Project.with_access(user, *permissions, **kwargs).pluck(:id)
 

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -89,10 +89,13 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     age_oldest_to_youngest: 'Age: Oldest to Youngest',
   }.freeze
 
-  scope :with_access, ->(user, *permissions) do
+  # Enrollments at Projects where the user has the specified permission(s).
+  # WARNING UNSAFE! This does not check for can_view_project or can_view_enrollment_details.
+  # This scope should almost always be used in conjunction with viewable_by.
+  scope :with_access, ->(user, *permissions, **kwargs) do
     return none unless user.permissions?(*permissions)
 
-    project_ids = Hmis::Hud::Project.with_access(user, *permissions).pluck(:id, :ProjectID)
+    project_ids = Hmis::Hud::Project.with_access(user, *permissions, **kwargs).pluck(:id, :ProjectID)
     viewable_wip = wip_t[:project_id].in(project_ids.map(&:first))
     viewable_enrollment = e_t[:ProjectID].in(project_ids.map(&:second))
 
@@ -100,8 +103,10 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   end
 
   # hide previous declaration of :viewable_by, we'll use this one
-  # A user can see any enrollment associated with a project they can access
-  replace_scope :viewable_by, ->(user) { with_access(user, :can_view_enrollment_details) }
+  # A user can see any enrollment associated with a project they can view
+  replace_scope :viewable_by, ->(user) do
+    with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all')
+  end
 
   # Free-text search for Enrollment
   scope :matching_search_term, ->(search_term) do

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -93,10 +93,19 @@ class Hmis::Role < ::ApplicationRecord
           'Administration',
         ],
       },
-      can_delete_assigned_project_data: {
-        description: 'Grants access to delete project related data for projects the user can see',
+      # remove...
+      # can_delete_assigned_project_data: {
+      #   description: 'Grants access to delete project related data for projects the user can see',
+      #   administrative: false,
+      #   access: [:editable],
+      #   categories: [
+      #     'Projects',
+      #   ],
+      # },
+      can_view_project: {
+        description: 'Grants access to view the project page',
         administrative: false,
-        access: [:editable],
+        access: [:viewable],
         categories: [
           'Projects',
         ],

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -94,7 +94,7 @@ class Hmis::Role < ::ApplicationRecord
         ],
       },
       can_view_project: {
-        description: 'Grants access to view the project page',
+        description: 'Grants access to view the project page. This permission also limits enrollment access. For example, a user with "can view enrollment details" can only view enrollment details at projects that they can view.',
         administrative: false,
         access: [:viewable],
         categories: [

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -93,15 +93,6 @@ class Hmis::Role < ::ApplicationRecord
           'Administration',
         ],
       },
-      # remove...
-      # can_delete_assigned_project_data: {
-      #   description: 'Grants access to delete project related data for projects the user can see',
-      #   administrative: false,
-      #   access: [:editable],
-      #   categories: [
-      #     'Projects',
-      #   ],
-      # },
       can_view_project: {
         description: 'Grants access to view the project page',
         administrative: false,

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -125,7 +125,8 @@ class Hmis::User < ApplicationRecord
   end
 
   private def viewable(model)
-    entities_with_permissions(model, *Hmis::Role.permissions_for_access(:viewable), mode: 'any')
+    # An entity is only considered "viewable" if the user has can_view_project permission for it.
+    entities_with_permissions(model, :can_view_project)
   end
 
   def viewable_data_sources

--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -19,6 +19,13 @@ FactoryBot.define do
     FirstName { 'Bob' }
     LastName { 'Ross' }
     DOB { '1999-12-01' }
+    transient do
+      with_enrollment_at { nil }
+    end
+    after(:create) do |client, evaluator|
+      create(:hmis_hud_enrollment, client: client, data_source: client.data_source, project: evaluator.with_enrollment_at) if evaluator.with_enrollment_at.present?
+      client.reload
+    end
   end
 
   factory :hmis_hud_client_complete, parent: :hmis_hud_base_client do

--- a/drivers/hmis/spec/factories/hmis/users.rb
+++ b/drivers/hmis/spec/factories/hmis/users.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :hmis_user, class: 'Hmis::User', parent: :user do
     first_name { 'Test' }
     last_name { 'User' }
+    transient do
+      data_source { nil }
+    end
+    after(:create) do |hmis_user, evaluator|
+      hmis_user.hmis_data_source_id = evaluator.data_source.id if evaluator.data_source.present?
+    end
   end
 end

--- a/drivers/hmis/spec/models/hmis/hud/client_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/client_access_spec.rb
@@ -1,0 +1,94 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../requests/hmis/login_and_permissions'
+
+RSpec.describe Hmis::Hud::Client, type: :model do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  let!(:ds1) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+
+  let!(:unenrolled_client) { create(:hmis_hud_client, data_source: ds1) }
+
+  let!(:client_at_p1) do
+    # Client with non-WIP enrollment at p1
+    create(:hmis_hud_client, data_source: ds1, with_enrollment_at: p1)
+  end
+
+  let!(:client_at_p2) do
+    # Client with WIP enrollment at p2
+    client = create(:hmis_hud_client, data_source: ds1, with_enrollment_at: p2)
+    client.enrollments.first.save_in_progress
+    client
+  end
+
+  let!(:user_with_no_access) { create(:hmis_user, data_source: ds1) }
+
+  let!(:user_with_access_to_p1_clients) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p1, with_permission: [:can_view_clients, :can_view_project])
+    hmis_user
+  end
+
+  let!(:user_with_access_to_p2_clients) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p2, with_permission: [:can_view_clients, :can_view_project])
+    hmis_user
+  end
+
+  let!(:user_with_perms_but_no_project_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p1, with_permission: [:can_manage_incoming_referrals])
+    create_access_control(hmis_user, p2, with_permission: [:can_enroll_clients])
+    hmis_user
+  end
+
+  let!(:user_with_can_view_clients_but_no_project_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p1, with_permission: [:can_view_clients])
+    create_access_control(hmis_user, p2, with_permission: [:can_view_clients])
+    hmis_user
+  end
+
+  describe 'viewable_by scope' do
+    it 'is empty if I have no access' do
+      viewable_clients = Hmis::Hud::Client.viewable_by(user_with_no_access)
+      expect(viewable_clients).to be_empty
+    end
+
+    it 'includes clients with enrollments at projects I can see, plus unenrolled clients' do
+      # Client with enrollment at p1 + unenrolled
+      viewable_clients = Hmis::Hud::Client.viewable_by(user_with_access_to_p1_clients)
+      expect(viewable_clients).to contain_exactly(client_at_p1, unenrolled_client)
+    end
+
+    it 'includes clients with WIP enrollments at projects I can see, plus unenrolled clients' do
+      # Client with enrollment at p2 (WIP) + unenrolled
+      viewable_clients = Hmis::Hud::Client.viewable_by(user_with_access_to_p2_clients)
+      expect(viewable_clients).to contain_exactly(client_at_p2, unenrolled_client)
+    end
+
+    it 'is empty if I dont have can_view_clients, even if I have other perms at projects' do
+      # Can't see unenrolled client because doesn't have can_view_clients anywhere
+      viewable_clients = Hmis::Hud::Client.viewable_by(user_with_perms_but_no_project_access)
+      expect(viewable_clients).to be_empty
+    end
+
+    it 'includes clients at projects where I have can_view_clients, even if I cant see those projects' do
+      viewable_clients = Hmis::Hud::Client.viewable_by(user_with_can_view_clients_but_no_project_access)
+      expect(viewable_clients).to contain_exactly(client_at_p1, client_at_p2, unenrolled_client)
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/enrollment_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/enrollment_access_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe Hmis::Hud::Enrollment, type: :model do
     end
 
     it 'includes enrollments that I can see (WIP and non-WIP), and excludes ones I cant see' do
-      # Client with enrollment at p1 + unenrolled
       viewable_enrollments = Hmis::Hud::Enrollment.viewable_by(user_with_p1_p2_access)
       expect(viewable_enrollments).to contain_exactly(e1, e2)
       # e3 not visible because user lacks :can_view_enrollment_details

--- a/drivers/hmis/spec/models/hmis/hud/enrollment_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/enrollment_access_spec.rb
@@ -1,0 +1,69 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../requests/hmis/login_and_permissions'
+
+RSpec.describe Hmis::Hud::Enrollment, type: :model do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  let!(:ds1) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p3) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p4) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p5) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p6) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+
+  let!(:c1) { create(:hmis_hud_client, data_source: ds1) }
+
+  let!(:e1) { create(:hmis_hud_enrollment, client: c1, project: p1, data_source: ds1) }
+  let!(:e2) { create(:hmis_hud_wip_enrollment, client: c1, project: p2, data_source: ds1) }
+  let!(:e3) { create(:hmis_hud_enrollment, client: c1, project: p3, data_source: ds1) }
+  let!(:e4) { create(:hmis_hud_enrollment, client: c1, project: p4, data_source: ds1) }
+  let!(:e5) { create(:hmis_hud_enrollment, client: c1, project: p5, data_source: ds1) }
+  let!(:e6) { create(:hmis_hud_enrollment, client: c1, project: p6, data_source: ds1) }
+
+  let!(:user_with_no_access) { create(:hmis_user, data_source: ds1) }
+
+  let!(:user_with_p1_p2_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    # p1: can see enrollments
+    create_access_control(hmis_user, p1, with_permission: [:can_view_clients, :can_view_project, :can_view_enrollment_details])
+    # p2: can see enrollments
+    create_access_control(hmis_user, p2, with_permission: [:can_view_clients, :can_view_project, :can_view_enrollment_details])
+    # p3: can see project, but not enrollments
+    create_access_control(hmis_user, p3, with_permission: [:can_view_clients, :can_view_project])
+    # p4: no project access
+    create_access_control(hmis_user, p4, with_permission: [:can_view_enrollment_details])
+    # p5: no project access, no enrollment access
+    create_access_control(hmis_user, p4, with_permission: [:can_view_clients])
+    hmis_user
+  end
+
+  describe 'viewable_by scope' do
+    it 'is empty if I have no access' do
+      viewable_enrollments = Hmis::Hud::Enrollment.viewable_by(user_with_no_access)
+      expect(viewable_enrollments).to be_empty
+    end
+
+    it 'includes enrollments that I can see (WIP and non-WIP), and excludes ones I cant see' do
+      # Client with enrollment at p1 + unenrolled
+      viewable_enrollments = Hmis::Hud::Enrollment.viewable_by(user_with_p1_p2_access)
+      expect(viewable_enrollments).to contain_exactly(e1, e2)
+      # e3 not visible because user lacks :can_view_enrollment_details
+      # e4 not visible because user lacks :can_view_project
+      # e5 not visible because user lacks both :can_view_enrollment_details and :can_view_project
+      # e6 not visible because user lacks any assignment
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb
@@ -1,0 +1,65 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../requests/hmis/login_and_permissions'
+
+RSpec.describe Hmis::Hud::Project, type: :model do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  let!(:ds1) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+
+  let!(:o2) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o2 }
+
+  let!(:o3) { create :hmis_hud_organization, data_source: ds1 }
+
+  let!(:user_with_no_access) { create(:hmis_user, data_source: ds1) }
+
+  let!(:user_with_ds1_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, ds1, with_permission: :can_view_project)
+    hmis_user
+  end
+
+  let!(:user_with_o1_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, o1, with_permission: :can_view_project) # access to view o1
+    create_access_control(hmis_user, o2, with_permission: :can_view_enrollment_details) # should not grant any access
+    hmis_user
+  end
+
+  let!(:user_with_p2_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p2, with_permission: :can_view_project) # access to view p2
+    create_access_control(hmis_user, o3, with_permission: :can_view_enrollment_details) # should not grant any access
+    hmis_user
+  end
+
+  describe 'viewable_by scope' do
+    it 'includes organizations where use has can_view_project (data source)' do
+      viewable_orgs = Hmis::Hud::Organization.viewable_by(user_with_ds1_access)
+      expect(viewable_orgs).to contain_exactly(o1, o2, o3)
+    end
+
+    it 'includes organizations where use has can_view_project (organization-level)' do
+      viewable_orgs = Hmis::Hud::Organization.viewable_by(user_with_o1_access)
+      expect(viewable_orgs).to contain_exactly(o1)
+    end
+
+    it 'includes organizations where use has can_view_project (project-level)' do
+      viewable_orgs = Hmis::Hud::Organization.viewable_by(user_with_p2_access)
+      expect(viewable_orgs).to contain_exactly(o2)
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
@@ -24,13 +24,22 @@ RSpec.describe Hmis::Hud::Project, type: :model do
 
   let!(:user_with_p1_access) do
     hmis_user = create(:hmis_user, data_source: ds1)
-    create_access_control(hmis_user, p1, with_permission: [:can_view_clients, :can_view_project])
+    create_access_control(hmis_user, p1, with_permission: :can_view_project)
+    hmis_user
+  end
+
+  let!(:user_with_p2_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    # p2 view access
+    create_access_control(hmis_user, p2, with_permission: :can_view_project)
+    # some other broad org access should still not let you see p1
+    create_access_control(hmis_user, o1, with_permission: :can_manage_incoming_referrals)
     hmis_user
   end
 
   let!(:user_with_limited_access) do
     hmis_user = create(:hmis_user, data_source: ds1)
-    create_access_control(hmis_user, p1, with_permission: [:can_manage_incoming_referrals])
+    create_access_control(hmis_user, o1, with_permission: :can_manage_incoming_referrals)
     hmis_user
   end
 
@@ -38,6 +47,9 @@ RSpec.describe Hmis::Hud::Project, type: :model do
     it 'includes projects where I have can_view_project' do
       viewable_projects = Hmis::Hud::Project.viewable_by(user_with_p1_access)
       expect(viewable_projects).to contain_exactly(p1)
+
+      viewable_projects = Hmis::Hud::Project.viewable_by(user_with_p2_access)
+      expect(viewable_projects).to contain_exactly(p2)
     end
 
     it 'excludes projects where I dont have can_view_project, even if I have other permissions there' do

--- a/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
@@ -1,0 +1,48 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../requests/hmis/login_and_permissions'
+
+RSpec.describe Hmis::Hud::Project, type: :model do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  let!(:ds1) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+  let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+  let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+
+  let!(:user_with_no_access) { create(:hmis_user, data_source: ds1) }
+
+  let!(:user_with_p1_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p1, with_permission: [:can_view_clients, :can_view_project])
+    hmis_user
+  end
+
+  let!(:user_with_limited_access) do
+    hmis_user = create(:hmis_user, data_source: ds1)
+    create_access_control(hmis_user, p1, with_permission: [:can_manage_incoming_referrals])
+    hmis_user
+  end
+
+  describe 'viewable_by scope' do
+    it 'includes projects where I have can_view_project' do
+      viewable_projects = Hmis::Hud::Project.viewable_by(user_with_p1_access)
+      expect(viewable_projects).to contain_exactly(p1)
+    end
+
+    it 'excludes projects where I dont have can_view_project, even if I have other permissions there' do
+      viewable_projects = Hmis::Hud::Project.viewable_by(user_with_limited_access)
+      expect(viewable_projects).to be_empty
+    end
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
   let!(:ds_access_control) do
-    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details])
+    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details, :can_view_project])
   end
 
   before(:each) do

--- a/drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   let!(:ds_access_control) do
-    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details])
+    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details, :can_view_project])
   end
 
   before(:each) do

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   describe 'permissions base tests' do
     # Grant a few viewing permission to the whole data source
     let!(:ds_access_control) do
-      create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details])
+      create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
     end
 
     def expected_hash_from_role(role)

--- a/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   let!(:ds_access_control) do
-    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details])
+    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
   end
 
   before(:each) do

--- a/drivers/hmis/spec/requests/hmis/reminder_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/reminder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   include_context 'hmis base setup'
 
   let!(:ds_access_control) do
-    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_enrollment_details])
+    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
   end
 
   before(:each) do


### PR DESCRIPTION
* Add a permission "can view project". ONLY projects with this permission should be included in Project.viewable_by scope.
* This is necessary to support scenario where a provider can see all clients, but not all projects.
* Tests

https://www.pivotaltracker.com/n/projects/2591838/stories/186053202