### PR TITLE
Add route configs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,4 +97,8 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, redis_config
 
   config.action_controller.perform_caching = true
+
+  routes.default_url_options ||= {}
+  routes.default_url_options[:script_name] = ''
+  routes.default_url_options[:host] = ENV['FQDN']
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -97,4 +97,8 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, redis_config
 
   config.action_controller.perform_caching = true
+
+  routes.default_url_options ||= {}
+  routes.default_url_options[:script_name] = ''
+  routes.default_url_options[:host] = ENV['FQDN']
 end


### PR DESCRIPTION
I don't know what this does, but the `HmisExternalApis::AcHmis::Exporters::HmisExportFetcher` can't run without it in prod.

https://green-river.sentry.io/issues/4285558665/?referrer=slack&notification_uuid=eba8d40f-52a1-4082-8198-14f86eaf35cb&alert_rule_id=12523843&alert_type=issue