### PR TITLE
Upload Warehouse ID instead of source PersonalID

### DIFF
--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -45,4 +45,10 @@ FactoryBot.define do
       HudUtility2024.gender_fields.excluding(:GenderNone).each { |f| client.send("#{f}=", 0) }
     end
   end
+
+  factory :hmis_hud_client_with_warehouse_client, parent: :hmis_hud_base_client do
+    after(:create) do |client|
+      create(:warehouse_client, data_source: client.data_source, source: client.as_warehouse)
+    end
+  end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
@@ -31,6 +31,7 @@ module HmisExternalApis::AcHmis::Exporters
 
         seen << warehouse_id
 
+        # Upload the Warehouse ID as the PersonalID, since that's what it is in the HMIS Export
         client_values = [warehouse_id]
 
         # If the client has multiple MCI IDs, it doesn't matter which one we send

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
@@ -21,12 +21,17 @@ module HmisExternalApis::AcHmis::Exporters
 
       Rails.logger.error "There are #{total} clients to export. That doesn't look right" if total < 10
 
+      seen = Set.new
       clients.find_each.with_index do |client, i|
         Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?
 
-        client_values = client_columns.map do |col|
-          client.send(col)
-        end
+        warehouse_id = client.warehouse_id
+        next unless warehouse_id.present?
+        next if seen.include?(warehouse_id)
+
+        seen << warehouse_id
+
+        client_values = [warehouse_id]
 
         # If the client has multiple MCI IDs, it doesn't matter which one we send
         external_id_values = [client.ac_hmis_mci_ids&.first&.value]
@@ -78,10 +83,12 @@ module HmisExternalApis::AcHmis::Exporters
     end
 
     def clients
-      Hmis::Hud::Client
-        .where(data_source: data_source)
-        .preload(:addresses)
-        .preload(:ac_hmis_mci_ids)
+      Hmis::Hud::Client.
+        where(data_source: data_source).
+        joins(:warehouse_client_source).
+        preload(:warehouse_client_source).
+        preload(:addresses).
+        preload(:ac_hmis_mci_ids)
     end
 
     def data_source

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
@@ -9,7 +9,7 @@ require 'rails_helper'
 RSpec.describe HmisExternalApis::AcHmis::Exporters::ClientExport, type: :model do
   let(:today) { Date.today }
   let!(:ds) { create(:hmis_data_source) }
-  let!(:client) { create(:hmis_hud_client, data_source: ds, DateCreated: today) }
+  let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: ds, DateCreated: today) }
   let(:subject) { HmisExternalApis::AcHmis::Exporters::ClientExport.new }
   let(:output) do
     subject.output.rewind
@@ -25,7 +25,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::ClientExport, type: :model d
     subject.run!
     result = CSV.parse(output, headers: true)
     expect(result.length).to eq(1)
-    expect(result.first['PersonalID']).to eq(client.personal_id)
+    expect(result.first['PersonalID']).to eq(client.warehouse_id.to_s)
   end
 
   it 'includes most recently updated address' do


### PR DESCRIPTION
## Description

Send the Warehouse ID in stead of the source personal id, since that's what the HMIS HUD export has. Has been tested in prod.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
