### PR TITLE
Join HMIS Enrollment-related models on PersonalID+EnrollmentID

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -19,7 +19,7 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
     date_updated: 'Last Updated: Most Recent First',
   }.freeze
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -19,7 +19,7 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
     date_updated: 'Last Updated: Most Recent First',
   }.freeze
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/assessment_question.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_question.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::AssessmentQuestion < Hmis::Hud::Base
 
   belongs_to :assessment, **hmis_relation(:AssessmentID, 'Assessment')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
 end

--- a/drivers/hmis/app/models/hmis/hud/assessment_question.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_question.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::AssessmentQuestion < Hmis::Hud::Base
 
   belongs_to :assessment, **hmis_relation(:AssessmentID, 'Assessment')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
 end

--- a/drivers/hmis/app/models/hmis/hud/assessment_result.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_result.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::AssessmentResult < Hmis::Hud::Base
 
   belongs_to :assessment, **hmis_relation(:AssessmentID, 'Assessment')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
 end

--- a/drivers/hmis/app/models/hmis/hud/assessment_result.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_result.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::AssessmentResult < Hmis::Hud::Base
 
   belongs_to :assessment, **hmis_relation(:AssessmentID, 'Assessment')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
 end

--- a/drivers/hmis/app/models/hmis/hud/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/base.rb
@@ -36,6 +36,29 @@ class Hmis::Hud::Base < ::GrdaWarehouseBase
     h
   end
 
+  def self.hmis_enrollment_relation(model_name = nil)
+    model_name = if model_name.present?
+      "Hmis::Hud::#{model_name}"
+    else
+      'Hmis::Hud::Enrollment'
+    end
+    h = {
+      primary_key: [
+        :EnrollmentID,
+        :PersonalID,
+        :data_source_id,
+      ],
+      foreign_key: [
+        :EnrollmentID,
+        :PersonalID,
+        :data_source_id,
+      ],
+      class_name: model_name,
+      autosave: false,
+    }
+    h
+  end
+
   def self.alias_to_underscore(cols)
     Array.wrap(cols).each do |col|
       alias_attribute col.to_s.underscore.to_sym, col

--- a/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
+++ b/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::CurrentLivingSituation < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
+++ b/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::CurrentLivingSituation < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -22,7 +22,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   SORT_OPTIONS = [:assessment_date, :date_updated].freeze
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
@@ -200,10 +200,10 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   def deletion_would_cause_conflicting_enrollments?
     return false if in_progress?
 
-    exit? && enrollment.client.enrollments
-      .where(data_source: enrollment.data_source, project_id: enrollment.project_id)
-      .where.not(id: enrollment.id)
-      .where(e_t[:entry_date].gteq(enrollment.entry_date))
-      .any?
+    exit? && enrollment.client.enrollments.
+      where(data_source: enrollment.data_source, project_id: enrollment.project_id).
+      where.not(id: enrollment.id).
+      where(e_t[:entry_date].gteq(enrollment.entry_date)).
+      any?
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -22,7 +22,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   SORT_OPTIONS = [:assessment_date, :date_updated].freeze
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
@@ -9,7 +9,7 @@ class Hmis::Hud::CustomCaseNote < Hmis::Hud::Base
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   alias_to_underscore [:CustomCaseNoteID, :PersonalID, :EnrollmentID]

--- a/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
@@ -9,7 +9,7 @@ class Hmis::Hud::CustomCaseNote < Hmis::Hud::Base
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   alias_to_underscore [:CustomCaseNoteID, :PersonalID, :EnrollmentID]
@@ -18,15 +18,15 @@ class Hmis::Hud::CustomCaseNote < Hmis::Hud::Base
     client_scope = Hmis::Hud::Client.viewable_by(user)
     enrollment_scope = Hmis::Hud::Enrollment.viewable_by(user)
 
-    case_statement = Arel::Nodes::Case.new
-      .when(arel_table[:EnrollmentID].not_eq(nil))
-      .then(arel_table[:EnrollmentID].in(enrollment_scope.select(:enrollment_id).arel))
-      .else(arel_table[:PersonalID].in(client_scope.select(:personal_id).arel))
+    case_statement = Arel::Nodes::Case.new.
+      when(arel_table[:EnrollmentID].not_eq(nil)).
+      then(arel_table[:EnrollmentID].in(enrollment_scope.select(:enrollment_id).arel)).
+      else(arel_table[:PersonalID].in(client_scope.select(:personal_id).arel))
 
-    viewable_scope = Hmis::Hud::CustomCaseNote
-      .left_outer_joins(:client)
-      .left_outer_joins(:enrollment)
-      .where(case_statement)
+    viewable_scope = Hmis::Hud::CustomCaseNote.
+      left_outer_joins(:client).
+      left_outer_joins(:enrollment).
+      where(case_statement)
     where(id: viewable_scope.select(:id))
   end
 

--- a/drivers/hmis/app/models/hmis/hud/custom_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::CustomService < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/custom_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::CustomService < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/disability.rb
+++ b/drivers/hmis/app/models/hmis/hud/disability.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Disability < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/disability.rb
+++ b/drivers/hmis/app/models/hmis/hud/disability.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Disability < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/employment_education.rb
+++ b/drivers/hmis/app/models/hmis/hud/employment_education.rb
@@ -13,7 +13,7 @@ class Hmis::Hud::EmploymentEducation < Hmis::Hud::Base
   self.table_name = 'EmploymentEducation'
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/employment_education.rb
+++ b/drivers/hmis/app/models/hmis/hud/employment_education.rb
@@ -13,7 +13,7 @@ class Hmis::Hud::EmploymentEducation < Hmis::Hud::Base
   self.table_name = 'EmploymentEducation'
   self.sequence_name = "public.\"#{table_name}_id_seq\""
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -20,31 +20,29 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
 
   # CAUTION: enrollment.project accessor is overridden below
   belongs_to :project, **hmis_relation(:ProjectID, 'Project'), optional: true
-  has_one :exit, **hmis_relation(:EnrollmentID, 'Exit'), dependent: :destroy
+  has_one :exit, **hmis_enrollment_relation('Exit'), inverse_of: :enrollment, dependent: :destroy
 
   # HUD services
-  has_many :services, **hmis_relation(:EnrollmentID, 'Service'), dependent: :destroy
-  has_many :bed_nights, -> { bed_nights }, **hmis_relation(:EnrollmentID, 'Service')
+  has_many :services, **hmis_enrollment_relation('Service'), inverse_of: :enrollment, dependent: :destroy
+  has_many :bed_nights, -> { bed_nights }, **hmis_enrollment_relation('Service')
   # Custom services
-  has_many :custom_services, **hmis_relation(:EnrollmentID, 'CustomService'), dependent: :destroy
-  has_many :custom_case_notes, **hmis_relation(:EnrollmentID, 'CustomCaseNote'), inverse_of: :enrollment, dependent: :destroy
+  has_many :custom_services, **hmis_enrollment_relation('CustomService'), inverse_of: :enrollment, dependent: :destroy
+  has_many :custom_case_notes, **hmis_enrollment_relation('CustomCaseNote'), inverse_of: :enrollment, dependent: :destroy
   # All services (combined view of HUD and Custom services)
-  has_many :hmis_services, **hmis_relation(:EnrollmentID, 'HmisService')
+  has_many :hmis_services, **hmis_enrollment_relation('HmisService'), inverse_of: :enrollment
 
-  has_many :events, **hmis_relation(:EnrollmentID, 'Event'), dependent: :destroy
-  has_many :income_benefits, **hmis_relation(:EnrollmentID, 'IncomeBenefit'), dependent: :destroy
-  has_many :disabilities, **hmis_relation(:EnrollmentID, 'Disability'), dependent: :destroy
-  has_many :health_and_dvs, **hmis_relation(:EnrollmentID, 'HealthAndDv'), dependent: :destroy
-  has_many :current_living_situations, **hmis_relation(:EnrollmentID, 'CurrentLivingSituation'), inverse_of: :enrollment, dependent: :destroy
-  # TODO: remove
-  has_many :enrollment_cocs, **hmis_relation(:EnrollmentID, 'EnrollmentCoc'), dependent: :destroy
-  has_many :employment_educations, **hmis_relation(:EnrollmentID, 'EmploymentEducation'), dependent: :destroy
-  has_many :youth_education_statuses, **hmis_relation(:EnrollmentID, 'YouthEducationStatus'), dependent: :destroy
+  has_many :events, **hmis_enrollment_relation('Event'), inverse_of: :enrollment, dependent: :destroy
+  has_many :income_benefits, **hmis_enrollment_relation('IncomeBenefit'), inverse_of: :enrollment, dependent: :destroy
+  has_many :disabilities, **hmis_enrollment_relation('Disability'), inverse_of: :enrollment, dependent: :destroy
+  has_many :health_and_dvs, **hmis_enrollment_relation('HealthAndDv'), inverse_of: :enrollment, dependent: :destroy
+  has_many :current_living_situations, **hmis_enrollment_relation('CurrentLivingSituation'), inverse_of: :enrollment, dependent: :destroy
+  has_many :employment_educations, **hmis_enrollment_relation('EmploymentEducation'), inverse_of: :enrollment, dependent: :destroy
+  has_many :youth_education_statuses, **hmis_enrollment_relation('YouthEducationStatus'), inverse_of: :enrollment, dependent: :destroy
 
   # CE Assessments
-  has_many :assessments, **hmis_relation(:EnrollmentID, 'Assessment'), dependent: :destroy
+  has_many :assessments, **hmis_enrollment_relation('Assessment'), inverse_of: :enrollment, dependent: :destroy
   # Custom Assessments
-  has_many :custom_assessments, **hmis_relation(:EnrollmentID, 'CustomAssessment'), dependent: :destroy
+  has_many :custom_assessments, **hmis_enrollment_relation('CustomAssessment'), inverse_of: :enrollment, dependent: :destroy
 
   # Files
   has_many :files, class_name: '::Hmis::File', dependent: :destroy, inverse_of: :enrollment
@@ -187,22 +185,22 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     scope = with_project([project.id])
     exit_date = range.end # maybe nil if endless range
     if exit_date
-      scope.left_outer_joins(:exit)
-        .where(
-          e_t[:entry_date].eq(entry_date)
-          .or(
-            e_t[:entry_date].lt(exit_date) # enrollments started before exit date
-            .and(
+      scope.left_outer_joins(:exit).
+        where(
+          e_t[:entry_date].eq(entry_date).
+          or(
+            e_t[:entry_date].lt(exit_date). # enrollments started before exit date
+            and(
               ex_t[:exit_date].gt(entry_date).or(ex_t[:exit_date].eq(nil)),
             ), # enrollments with an exit date after the entry date
           ),
         )
     else
-      scope.left_outer_joins(:exit)
-        .where(
-          ex_t[:exit_date].eq(nil) # we already have an open enrollment
-          .or(ex_t[:exit_date].gt(entry_date))
-          .or(e_t[:entry_date].gteq(entry_date)),
+      scope.left_outer_joins(:exit).
+        where(
+          ex_t[:exit_date].eq(nil). # we already have an open enrollment
+          or(ex_t[:exit_date].gt(entry_date)).
+          or(e_t[:entry_date].gteq(entry_date)),
         )
     end
   end

--- a/drivers/hmis/app/models/hmis/hud/enrollment_coc.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment_coc.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::EnrollmentCoc < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::Shared
   include ::Hmis::Hud::Concerns::EnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/enrollment_coc.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment_coc.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::EnrollmentCoc < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::Shared
   include ::Hmis::Hud::Concerns::EnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/event.rb
+++ b/drivers/hmis/app/models/hmis/hud/event.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Event < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :events
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/event.rb
+++ b/drivers/hmis/app/models/hmis/hud/event.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Event < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :events
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
+++ b/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::HealthAndDv < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
+++ b/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::HealthAndDv < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/hmis_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/hmis_service.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::HmisService < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/hmis_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/hmis_service.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::HmisService < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/income_benefit.rb
+++ b/drivers/hmis/app/models/hmis/hud/income_benefit.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::IncomeBenefit < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/income_benefit.rb
+++ b/drivers/hmis/app/models/hmis/hud/income_benefit.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::IncomeBenefit < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
+++ b/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::YouthEducationStatus < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_enrollment_relation
+  belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
+++ b/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
@@ -12,7 +12,7 @@ class Hmis::Hud::YouthEducationStatus < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
 
-  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment')
+  belongs_to :enrollment, **hmis_enrollment_relation
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'

--- a/drivers/hmis/spec/factories/hmis/hud/assessment_questions.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessment_questions.rb
@@ -9,9 +9,9 @@ FactoryBot.define do
     sequence(:AssessmentQuestionID, 500)
     data_source { association :hmis_data_source }
     assessment { association :hmis_hud_assessment, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     assessment_question { 'Question?' }
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }

--- a/drivers/hmis/spec/factories/hmis/hud/assessment_results.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessment_results.rb
@@ -9,9 +9,9 @@ FactoryBot.define do
     sequence(:AssessmentResultID, 500)
     data_source { association :hmis_data_source }
     assessment { association :hmis_hud_assessment, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     assessment_result_type { 'Result Type' }
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }

--- a/drivers/hmis/spec/factories/hmis/hud/assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessments.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_hud_assessment, class: 'Hmis::Hud::Assessment' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:AssessmentID, 500)
     AssessmentDate { Date.parse('2019-01-01') }
     AssessmentLocation { 'Test Location' }

--- a/drivers/hmis/spec/factories/hmis/hud/current_living_situations.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/current_living_situations.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_current_living_situation, class: 'Hmis::Hud::CurrentLivingSituation' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:CurrentLivingSitID, 500)
     information_date { Date.yesterday }
     current_living_situation { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
@@ -13,8 +13,8 @@ FactoryBot.define do
   factory :hmis_custom_assessment, class: 'Hmis::Hud::CustomAssessment' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     wip { false }
     AssessmentDate { Date.yesterday }
     DataCollectionStage { 1 }
@@ -28,8 +28,8 @@ FactoryBot.define do
   factory :hmis_wip_custom_assessment, class: 'Hmis::Hud::CustomAssessment' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     wip { true }
     AssessmentDate { Date.yesterday }
     DataCollectionStage { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_hud_custom_case_note, class: 'Hmis::Hud::CustomCaseNote' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }
     content { 'test note' }

--- a/drivers/hmis/spec/factories/hmis/hud/custom_services.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_services.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_custom_service, class: 'Hmis::Hud::CustomService' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     custom_service_type { association :hmis_custom_service_type, data_source: data_source }
     sequence(:CustomServiceID, 500)
     DateCreated { Date.parse('2019-01-01') }

--- a/drivers/hmis/spec/factories/hmis/hud/disabilities.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/disabilities.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_disability, class: 'Hmis::Hud::Disability' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:DisabilitiesID, 500)
     disability_type { 7 }
     disability_response { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/employment_educations.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/employment_educations.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_employment_education, class: 'Hmis::Hud::EmploymentEducation' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:EmploymentEducationID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/enrollment_cocs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/enrollment_cocs.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_enrollment_coc, class: 'Hmis::Hud::EnrollmentCoc' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:EnrollmentCoCID, 500)
     information_date { Date.yesterday }
     coc_code { 'XX-500' }

--- a/drivers/hmis/spec/factories/hmis/hud/events.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/events.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_hud_event, class: 'Hmis::Hud::Event' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:EventID, 500)
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }

--- a/drivers/hmis/spec/factories/hmis/hud/health_and_dvs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/health_and_dvs.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_health_and_dv, class: 'Hmis::Hud::HealthAndDv' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:HealthAndDVID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/income_benefits.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/income_benefits.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_income_benefit, class: 'Hmis::Hud::IncomeBenefit' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:IncomeBenefitsID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }

--- a/drivers/hmis/spec/factories/hmis/hud/services.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/services.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_hud_service, class: 'Hmis::Hud::Service' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:ServicesID, 500)
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }

--- a/drivers/hmis/spec/factories/hmis/hud/youth_education_statuses.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/youth_education_statuses.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
   factory :hmis_youth_education_status, class: 'Hmis::Hud::YouthEducationStatus' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
-    enrollment { association :hmis_hud_enrollment, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:YouthEducationStatusID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -152,9 +152,13 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
 
   describe 'grouping related assessments' do
     include_context 'hmis base setup'
-    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, relationship_to_ho_h: 1 }
-    let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id, relationship_to_ho_h: 8 }
-    let!(:e3) { create :hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id, relationship_to_ho_h: 8 }
+    let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+    let!(:c2) { create :hmis_hud_client, data_source: ds1 }
+    let!(:c3) { create :hmis_hud_client, data_source: ds1 }
+
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, relationship_to_ho_h: 1 }
+    let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: e1.household_id, relationship_to_ho_h: 8 }
+    let!(:e3) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c3, household_id: e1.household_id, relationship_to_ho_h: 8 }
 
     it 'groups intake assessments, including WIP assessments' do
       a1 = create(:hmis_custom_assessment, data_collection_stage: 1, data_source: ds1, enrollment: e1)

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -176,8 +176,8 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
 
     it 'groups intake assessments on WIP enrollments' do
       e1.save_in_progress
-      a1 = create(:hmis_wip_custom_assessment, data_collection_stage: 1, data_source: ds1, enrollment: e1)
-      a2 = create(:hmis_custom_assessment, data_collection_stage: 1, data_source: ds1, enrollment: e2)
+      a1 = create(:hmis_wip_custom_assessment, data_collection_stage: 1, data_source: ds1, enrollment: e1, client: e1.client)
+      a2 = create(:hmis_custom_assessment, data_collection_stage: 1, data_source: ds1, enrollment: e2, client: e2.client)
 
       grouped = Hmis::Hud::CustomAssessment.group_household_assessments(
         household_enrollments: [e1, e2, e3],
@@ -185,18 +185,18 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         threshold: 1.day,
         assessment_id: nil,
       )
-      expect(grouped).to include(a1, a2)
+      expect(grouped).to contain_exactly(a1, a2)
     end
 
     it 'groups annual assessments by date' do
       e1.save_in_progress
-      e1_a1 = create(:hmis_custom_assessment, assessment_date: 2.years.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1)
+      e1_a1 = create(:hmis_custom_assessment, assessment_date: 2.years.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1, client: e1.client)
 
-      _e2_a1 = create(:hmis_wip_custom_assessment, assessment_date: 6.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1)
-      e2_a2 = create(:hmis_wip_custom_assessment, assessment_date: 3.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1)
+      _e2_a1 = create(:hmis_wip_custom_assessment, assessment_date: 6.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e2, client: e2.client)
+      e2_a2 = create(:hmis_wip_custom_assessment, assessment_date: 2.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e2, client: e2.client)
 
-      e3_a1 = create(:hmis_custom_assessment, assessment_date: 1.month.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1)
-      e3_a2 = create(:hmis_custom_assessment, assessment_date: 3.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e1)
+      e3_a1 = create(:hmis_custom_assessment, assessment_date: 1.month.ago, data_collection_stage: 5, data_source: ds1, enrollment: e3, client: e3.client)
+      e3_a2 = create(:hmis_custom_assessment, assessment_date: 2.months.ago, data_collection_stage: 5, data_source: ds1, enrollment: e3, client: e3.client)
 
       # no source assessments, include past 3 months
       grouped = Hmis::Hud::CustomAssessment.group_household_assessments(
@@ -205,7 +205,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         threshold: 3.months,
         assessment_id: nil,
       )
-      expect(grouped).to include(e2_a2, e3_a1)
+      expect(grouped).to contain_exactly(e2_a2, e3_a1)
 
       # within 3 months of 2 years ago
       grouped = Hmis::Hud::CustomAssessment.group_household_assessments(
@@ -214,7 +214,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         threshold: 3.months,
         assessment_id: e1_a1.id,
       )
-      expect(grouped).to include(e1_a1)
+      expect(grouped).to contain_exactly(e1_a1)
 
       # within 3 months of 3 months ago (ensure closer assmt is chosen)
       grouped = Hmis::Hud::CustomAssessment.group_household_assessments(
@@ -223,7 +223,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         threshold: 3.months,
         assessment_id: e2_a2.id,
       )
-      expect(grouped).to include(e2_a2, e3_a2)
+      expect(grouped).to contain_exactly(e2_a2, e3_a2)
 
       # within 6 months of 1 month ago (ensure closer assmt is chosen)
       grouped = Hmis::Hud::CustomAssessment.group_household_assessments(
@@ -232,7 +232,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         threshold: 6.months,
         assessment_id: e3_a1.id,
       )
-      expect(grouped).to include(e3_a1, e2_a2)
+      expect(grouped).to contain_exactly(e3_a1, e2_a2)
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/hud/household_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/household_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Hmis::Hud::Household, type: :model do
     end
 
     it 'should handle open on correctly' do
-      e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: Date.today - 1.week)
+      e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: Date.today - 1.week, client: c2)
       create(:hmis_hud_exit, data_source: ds1, enrollment: e3, client: c2, exit_date: Date.yesterday)
 
       expect(Hmis::Hud::Household.open_on_date(Date.today)).to contain_exactly(e1.household, e2.household)

--- a/drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb
+++ b/drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     e.save_in_progress
     e
   end
-  let(:c2) { create :hmis_hud_client, dob: Date.today - 1.year, data_source: ds1, user: u1 }
+  let!(:c2) { create :hmis_hud_client, dob: Date.today - 1.year, data_source: ds1, user: u1 }
+  let!(:c2_e1) { create :hmis_hud_enrollment, data_source: ds1, project: p2, client: c2, relationship_to_ho_h: 2, household_id: e1.household_id }
 
   let!(:csc) { create(:hmis_custom_service_category, name: 'ESG Funding Assistance', data_source: ds1, user: u1) }
   let!(:cst) { create(:hmis_custom_service_type, name: 'ESG Funding Assistance', custom_service_category: csc, data_source: ds1, user: u1) }
@@ -35,7 +36,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:cs1) { create(:hmis_custom_service, client: c1, enrollment: e1, custom_service_type: cst, data_source: ds1, user: u1) }
   let!(:cs2) { create(:hmis_custom_service, client: c1, enrollment: e2, custom_service_type: cst, data_source: ds1, user: u1) }
   let!(:cs3) { create(:hmis_custom_service, client: c1, enrollment: e1, custom_service_type: cst2, data_source: ds1, user: u1) }
-  let!(:cs4) { create(:hmis_custom_service, client: c2, enrollment: e1, custom_service_type: cst, data_source: ds1, user: u1) }
+  let!(:cs4) { create(:hmis_custom_service, client: c2, enrollment: c2_e1, custom_service_type: cst, data_source: ds1, user: u1) }
   let!(:cs5) { create(:hmis_custom_service, client: c1, enrollment: e3, custom_service_type: cst, data_source: ds1, user: u1) }
 
   let!(:access_control) { create_access_control(hmis_user, p1) }


### PR DESCRIPTION
## Description

* Update Enrollment-related records to only join with Enrollments where the PersonalID matches, to match warehouse behavior.
* Unrelated bug fix to how household assessments are grouped

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
