### PR TITLE
Check HUD Key constraints

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -20,5 +20,40 @@ module Hmis::Hud::Concerns::Shared
     def as_warehouse
       "GrdaWarehouse::Hud::#{self.class.name.demodulize}".constantize.find(id)
     end
+
+    def self.hud_class_names
+      [
+        'Export',
+        'Organization',
+        'Project',
+        'Client',
+        'Disability',
+        'EmploymentEducation',
+        'Enrollment',
+        'HmisParticipation',
+        'CeParticipation',
+        'Exit',
+        'Funder',
+        'HealthAndDv',
+        'IncomeBenefit',
+        'Inventory',
+        'ProjectCoc',
+        'Affiliation',
+        'Service',
+        'CurrentLivingSituation',
+        'Assessment',
+        'AssessmentQuestion',
+        'AssessmentResult',
+        'Event',
+        'User',
+        'YouthEducationStatus',
+      ].freeze
+    end
+
+    def self.hmis_classes
+      hud_class_names.map do |name|
+        "Hmis::Hud::#{name}".constantize
+      end
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/tasks/check_constraints.rb
+++ b/drivers/hmis/app/models/hmis/tasks/check_constraints.rb
@@ -1,0 +1,34 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Hmis
+  module Tasks
+    class CheckConstraints
+      include NotifierConfig
+
+      def self.check_hud_constraints
+        results = {}
+        # test_results = {}
+        Hmis::Hud::Enrollment.hmis_classes.each do |klass|
+          # Client will always fail because of source/destination setup
+          next if klass.name == 'Hmis::Hud::Client'
+
+          dupes = klass.group(klass.hud_key, :data_source_id).having("count(\"#{klass.hud_key}\") > 1").count
+          # test_results[klass.name] = dupes.count
+          next unless dupes.present?
+
+          results[klass.name] = dupes.count
+        end
+        if results.present?
+          send_single_notification("Found the following duplicate HUD keys, this will prevent adding a DB constraint: #{results}", 'CheckConstraintTask')
+        else
+          send_single_notification('No duplicate HUD keys found', 'CheckConstraintTask')
+        end
+        # send_single_notification("Found the following duplicate HUD keys, this will prevent adding a DB constraint: #{test_results}", 'CheckConstraintTask')
+      end
+    end
+  end
+end

--- a/drivers/hmis/config/initializers/hmis_feature.rb
+++ b/drivers/hmis/config/initializers/hmis_feature.rb
@@ -11,3 +11,7 @@
 #
 # use with caution!
 RailsDrivers.loaded << :hmis
+
+Rails.application.config.queued_tasks[:hmis_check_constraints] = -> do
+  Hmis::Tasks::CheckConstraints.check_hud_constraints
+end


### PR DESCRIPTION
## Description

This provides a task that will run after deployment (once) to check all HUD tables for duplicate HUD Keys.  If any are found it sends a notification listing the count and table.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
