### PR TITLE
186114711 duplicate search results

### DIFF
--- a/app/models/client_search_util/name_search.rb
+++ b/app/models/client_search_util/name_search.rb
@@ -58,9 +58,9 @@ module ClientSearchUtil
         term_weight = variant == original_term ? 1.0 : 0.75
         score_sql = term_score_sql(variant, term_weight: term_weight)
 
-        search_term_scope(variant)
-          .group(:client_id)
-          .select(:client_id, Arel.sql("MAX(#{score_sql}) AS search_score"))
+        search_term_scope(variant).
+          group(:client_id).
+          select(:client_id, Arel.sql("MAX(#{score_sql}) AS search_score"))
       end
 
       # include first/last prefix match
@@ -116,8 +116,8 @@ module ClientSearchUtil
       # q_ln_pfx = '"Smith%"'
       return unless q_fn_pfx && q_ln_pfx
 
-      ClientSearchUtil::ClientSearchableName
-        .where("#{csn_fn(:last_name)} ILIKE #{q_ln_pfx} AND #{csn_fn(:full_name)} ILIKE #{q_fn_pfx}")
+      ClientSearchUtil::ClientSearchableName.
+        where("#{csn_fn(:last_name)} ILIKE #{q_ln_pfx} AND #{csn_fn(:full_name)} ILIKE #{q_fn_pfx}")
     end
 
     def search_term_scope(term)
@@ -132,9 +132,9 @@ module ClientSearchUtil
       term = term.downcase
       parts = term.split(' ').map(&:downcase).filter { |str| str.length > 1 }
       # [name, nickname]
-      nickname_map = Nickname.joins(:nicknames)
-        .where(name: parts)
-        .pluck(:name, Arel.sql('nicknames_nicknames.name'))
+      nickname_map = Nickname.joins(:nicknames).
+        where(name: parts).
+        pluck(:name, Arel.sql('nicknames_nicknames.name'))
 
       nickname_map.map do |name, nickname|
         parts.map { |part| part == name ? nickname : part }.join(' ')

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -121,7 +121,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/grda_warehouse/hud/project.rb",
-      "line": 383,
+      "line": 307,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"#{access_to_project_through_viewable_entities(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_organization(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_data_source(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_coc_codes(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_project_access_groups(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)}\")",
       "render_path": null,
@@ -236,7 +236,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/bi/view_maintainer.rb",
-      "line": 398,
+      "line": 396,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "GrdaWarehouseBase.connection.execute(\"DROP VIEW IF EXISTS #{name}\")",
       "render_path": null,
@@ -351,7 +351,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/bi/view_maintainer.rb",
-      "line": 418,
+      "line": 416,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "GrdaWarehouseBase.connection.execute(\"CREATE OR REPLACE VIEW #{name} AS #{sql_definition}\")",
       "render_path": null,
@@ -569,7 +569,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/client_search_util/name_search.rb",
-      "line": 120,
+      "line": 125,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ClientSearchUtil::ClientSearchableName.where(\"#{csn_fn(:last_name)} ILIKE #{q_ln_pfx} AND #{csn_fn(:full_name)} ILIKE #{q_fn_pfx}\")",
       "render_path": null,
@@ -763,7 +763,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/client_search_util/name_search.rb",
-      "line": 127,
+      "line": 132,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "ClientSearchUtil::ClientSearchableName.where(\"#{search_class.connection.quote(term)} <% #{csn_fn(:full_name)}\")",
       "render_path": null,
@@ -1046,7 +1046,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/concerns/reporting/project_data_quality_reports/version_four/display.rb",
-      "line": 1193,
+      "line": 1184,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "send(options[:denominator]).where(\"#{key}_#{measure}\" => true)",
       "render_path": null,
@@ -1348,6 +1348,29 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "767755b5093a0a0e3dfa4a274187a35692b8b193ddc82131ffa7696be25fafef",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/client_search_util/name_search.rb",
+      "line": 82,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "scope.joins(\"JOIN (\\n  SELECT client_id, MAX(search_score) as search_score FROM (#{([ActiveSupport::Inflector.transliterate(original_term)] + expand_nicknames(original_term).map do\n ActiveSupport::Inflector.transliterate(variant)\n end).map do\n term_weight = if (variant == ActiveSupport::Inflector.transliterate(original_term)) then\n  1.0\nelse\n  0.75\nend\nscore_sql = term_score_sql(variant, :term_weight => ((1.0 or 0.75)))\nsearch_term_scope(variant).group(:client_id).select(:client_id, Arel.sql(\"MAX(#{term_score_sql(variant, :term_weight => ((1.0 or 0.75)))}) AS search_score\"))\n end.compact.map do\n \"(#{query.to_sql})\"\n end.join(\" UNION ALL \")}) names GROUP BY 1\\n) names ON \\\"Client\\\".id = names.client_id\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ClientSearchUtil::NameSearch",
+        "method": "filter_clients"
+      },
+      "user_input": "([ActiveSupport::Inflector.transliterate(original_term)] + expand_nicknames(original_term).map do\n ActiveSupport::Inflector.transliterate(variant)\n end).map do\n term_weight = if (variant == ActiveSupport::Inflector.transliterate(original_term)) then\n  1.0\nelse\n  0.75\nend\nscore_sql = term_score_sql(variant, :term_weight => ((1.0 or 0.75)))\nsearch_term_scope(variant).group(:client_id).select(:client_id, Arel.sql(\"MAX(#{term_score_sql(variant, :term_weight => ((1.0 or 0.75)))}) AS search_score\"))\n end.compact.map do\n \"(#{query.to_sql})\"\n end.join(\" UNION ALL \")",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "781aac46e7b1378f886f2b9f429b4b36766b82a3ce2c8453f8be825781ea49b5",
@@ -1456,7 +1479,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/concerns/reporting/project_data_quality_reports/version_four/display.rb",
-      "line": 1225,
+      "line": 1216,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "send(options[:denominator]).where(:project_id => hud_project.id, \"#{key}_#{measure}\" => true)",
       "render_path": null,
@@ -1753,29 +1776,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "82e659e3c26b016652cb4f7b2ff4b27a0ecc1e24e74af02de95ac355d080738e",
-      "check_name": "UnsafeReflection",
-      "message": "Unsafe reflection method `constantize` called on model attribute",
-      "file": "drivers/hmis/app/graphql/mutations/submit_form.rb",
-      "line": 21,
-      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "Hmis::Form::Definition.find_by(:id => input.form_definition_id).record_class_name.constantize",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Mutations::SubmitForm",
-        "method": "resolve"
-      },
-      "user_input": "Hmis::Form::Definition.find_by(:id => input.form_definition_id).record_class_name",
-      "confidence": "Medium",
-      "cwe_id": [
-        470
       ],
       "note": ""
     },
@@ -2269,7 +2269,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/bi/view_maintainer.rb",
-      "line": 412,
+      "line": 410,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "GrdaWarehouseBase.connection.execute(\"DO $$\\nBEGIN\\n  CREATE ROLE #{role} WITH NOLOGIN;\\n  EXCEPTION WHEN DUPLICATE_OBJECT THEN\\n  RAISE NOTICE 'not creating role #{role} -- it already exists';\\nEND\\n$$;\\n\")",
       "render_path": null,
@@ -2372,7 +2372,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb",
-      "line": 990,
+      "line": 949,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "clients.send(variant).send(\"spm_#{field}\").average(\"spm_#{field}\")",
       "render_path": null,
@@ -2431,29 +2431,6 @@
       "confidence": "Medium",
       "cwe_id": [
         77
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "b606981f484b210f6c91b917e6c6646588bbc30b29ada9e65ce6f7cd8e6967f1",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/client_search_util/name_search.rb",
-      "line": 80,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "scope.joins(\"JOIN (#{([ActiveSupport::Inflector.transliterate(original_term)] + expand_nicknames(original_term).map do\n ActiveSupport::Inflector.transliterate(variant)\n end).map do\n term_weight = if (variant == ActiveSupport::Inflector.transliterate(original_term)) then\n  1.0\nelse\n  0.75\nend\nscore_sql = term_score_sql(variant, :term_weight => ((1.0 or 0.75)))\nsearch_term_scope(variant).group(:client_id).select(:client_id, Arel.sql(\"MAX(#{term_score_sql(variant, :term_weight => ((1.0 or 0.75)))}) AS search_score\"))\n end.compact.map do\n \"(#{query.to_sql})\"\n end.join(\" UNION \")}) names ON \\\"Client\\\".id = names.client_id\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ClientSearchUtil::NameSearch",
-        "method": "filter_clients"
-      },
-      "user_input": "([ActiveSupport::Inflector.transliterate(original_term)] + expand_nicknames(original_term).map do\n ActiveSupport::Inflector.transliterate(variant)\n end).map do\n term_weight = if (variant == ActiveSupport::Inflector.transliterate(original_term)) then\n  1.0\nelse\n  0.75\nend\nscore_sql = term_score_sql(variant, :term_weight => ((1.0 or 0.75)))\nsearch_term_scope(variant).group(:client_id).select(:client_id, Arel.sql(\"MAX(#{term_score_sql(variant, :term_weight => ((1.0 or 0.75)))}) AS search_score\"))\n end.compact.map do\n \"(#{query.to_sql})\"\n end.join(\" UNION \")",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
       ],
       "note": ""
     },
@@ -2689,6 +2666,29 @@
       },
       "user_input": "Reporting::MonthlyReports::Base.remainder_table",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "c683005ae13eea318d5339eba368410cae8af18ef3b3174d0e93e4ed6ec90c29",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "drivers/hmis/app/models/hmis/tasks/check_constraints.rb",
+      "line": 19,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "klass.group(klass.hud_key, :data_source_id).having(\"count(\\\"#{klass.hud_key}\\\") > 1\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Hmis::Tasks::CheckConstraints",
+        "method": "Hmis::Tasks::CheckConstraints.check_hud_constraints"
+      },
+      "user_input": "klass.hud_key",
+      "confidence": "Weak",
       "cwe_id": [
         89
       ],
@@ -3009,7 +3009,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/concerns/hmis_structure/base.rb",
-      "line": 153,
+      "line": 154,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "connection.execute(\"CREATE INDEX #{((table_name.gsub(/[^0-9a-z ]/i, \"\") + \"_\") + Digest::MD5.hexdigest(columns.join(\"_\"))[0, 4])} ON #{connection.quote_table_name(table_name)} (#{columns.map do\n connection.quote_column_name(c)\n end.join(\", \")}) INCLUDE (#{details[:include].map do\n connection.quote_column_name(c)\n end.join(\", \")})\")",
       "render_path": null,
@@ -3055,7 +3055,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/bi/view_maintainer.rb",
-      "line": 421,
+      "line": 419,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "GrdaWarehouseBase.connection.execute(\"GRANT SELECT ON #{name} TO #{\"bi\"}\")",
       "render_path": null,
@@ -3415,31 +3415,8 @@
         89
       ],
       "note": ""
-    },
-    {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "ff4e9944330ec5bf9f13b025d9b4151a4abc8f503b0191e7e6367e206a360fdf",
-      "check_name": "UnsafeReflection",
-      "message": "Unsafe reflection method `constantize` called on model attribute",
-      "file": "drivers/hmis/app/graphql/types/hmis_schema/submit_form_result.rb",
-      "line": 34,
-      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "Hmis::Form::Definition::FORM_ROLE_CONFIG.find do\n (value[:class_name] == object.class.name)\n end.last[:resolve_as].constantize",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Types::HmisSchema::SubmitFormResult",
-        "method": "s(:self).resolve_type"
-      },
-      "user_input": "Hmis::Form::Definition::FORM_ROLE_CONFIG.find",
-      "confidence": "Medium",
-      "cwe_id": [
-        470
-      ],
-      "note": ""
     }
   ],
-  "updated": "2023-09-12 23:20:51 +0000",
+  "updated": "2023-09-26 01:10:32 +0000",
   "brakeman_version": "5.4.1"
 }


### PR DESCRIPTION
## Description
https://www.pivotaltracker.com/story/show/186114711

Fix client name search bug that returns duplicate results if the search query was a name that had nicknames that were very similar to the original name. The bug manifested if the names matched but the match score was different, due to deduplication in the SQL union.

Note, I don't think this bug would have manifested on the warehouse side since it's doing a higher level deduplication due to client source mapping.

To test: search for any user with the first name Linda, including the last name (e.g. Linda Lettuce).

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
