### PR TITLE
Task to downgrade situations to 2022 versions

### DIFF
--- a/db/warehouse/migrate/20230926140851_add2022_living_situation_columns.rb
+++ b/db/warehouse/migrate/20230926140851_add2022_living_situation_columns.rb
@@ -1,0 +1,7 @@
+class Add2022LivingSituationColumns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :Exit, :Destination2022, :integer
+    add_column :Enrollment, :LivingSituation2022, :integer
+    add_column :CurrentLivingSituation, :CurrentLivingSituation2022, :integer
+  end
+end

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/aggregated_enrollment/change_living_situation.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/aggregated_enrollment/change_living_situation.rb
@@ -10,6 +10,7 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::AggregatedEnrollment
 
     def process(row)
       situation = row['LivingSituation'].to_i
+      row['LivingSituation2022'] = situation
       new_situation = LIVING_SITUATIONS[situation]
       return row unless new_situation.present?
 

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/aggregated_exit/update_destination.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/aggregated_exit/update_destination.rb
@@ -10,6 +10,7 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::AggregatedExit
 
     def process(row)
       destination = row['Destination'].to_i
+      row['Destination2022'] = destination
       new_destination = LIVING_SITUATIONS[destination]
       return row unless new_destination.present?
 

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/current_living_situation/change_living_situation.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/current_living_situation/change_living_situation.rb
@@ -10,6 +10,7 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::CurrentLivingSituation
 
     def process(row)
       situation = row['CurrentLivingSituation'].to_i
+      row['LivingSituation2022'] = situation
       new_situation = LIVING_SITUATIONS[situation]
       return row unless new_situation.present?
 

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/exit/update_destination.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/exit/update_destination.rb
@@ -10,6 +10,7 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::Exit
 
     def process(row)
       destination = row['Destination'].to_i
+      row['Destination2022'] = destination
       new_destination = LIVING_SITUATIONS[destination]
       return row unless new_destination.present?
 

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/tasks/downgrade.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/tasks/downgrade.rb
@@ -1,0 +1,55 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module HudTwentyTwentyTwoToTwentyTwentyFour::Tasks
+  module Downgrade
+    include HudTwentyTwentyTwoToTwentyTwentyFour::LivingSituationOptions
+
+    def self.downgrade_situations
+      @processed_435 = Set.new
+      {
+        GrdaWarehouse::Hud::Enrollment => {
+          situation: :LivingSituation,
+          subsidy_type: :RentalSubsidyType,
+          situation_2022: :LivingSituation2022,
+        },
+        GrdaWarehouse::Hud::CurrentLivingSituation => {
+          situation: :CurrentLivingSituation,
+          subsidy_type: :CLSSubsidyType,
+          situation_2022: :CurrentLivingSituation2022,
+        },
+        GrdaWarehouse::Hud::Exit => {
+          situation: :Destination,
+          subsidy_type: :DestinationSubsidyType,
+          situation_2022: :Destination2022,
+        },
+      }.each do |situation_class, cols|
+        LIVING_SITUATIONS.each do |situation_2022, situation_2024|
+          if situation_2024 == 435 && ! @processed_435.include?(cols[:situation])
+            SUBSIDY_TYPES.each do |subsidy_type_2022, subsidy_type_2024|
+              puts "Updating #{situation_class.name} #{cols[:situation]} #{situation_2024} and #{cols[:subsidy_type]} #{subsidy_type_2024} to #{cols[:situation]} #{subsidy_type_2022}"
+              situation_class.with_deleted.where(cols[:situation] => situation_2024, cols[:subsidy_type] => subsidy_type_2024).
+                update_all(
+                  cols[:situation] => subsidy_type_2022,
+                  # Make note of this to make the roll-back easier in the future
+                  cols[:situation_2022] => subsidy_type_2022,
+                )
+            end
+            @processed_435 << cols[:situation]
+          else
+            puts "Updating #{situation_class.name} #{cols[:situation]} #{situation_2024} to #{cols[:situation]} #{situation_2022}"
+            situation_class.with_deleted.where(cols[:situation] => situation_2024).
+              update_all(
+                cols[:situation] => situation_2022,
+                # Make note of this to make the roll-back easier in the future
+                cols[:situation_2022] => situation_2022,
+              )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This provides a means of downgrading the 3 situation columns to the 2022 numbers after they have been migrated to the 2024 versions.  It also sets up the migrator to store the 2022 versions so we could potentially update the exporter or HUD reports to use the old data if necessary.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
