### PR TITLE
Support source hash preference for MigrateAssessmentsJob, turn off synthetic YouthEducationStatus 

### DIFF
--- a/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
+++ b/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
@@ -151,6 +151,26 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
           expect(record.date_deleted).to be_present, record.class.name
         end
       end
+
+      it 'prefers specific source hash for duplicate records' do
+        education_status1 = records_by_data_collaction_stage[1].find { |record| record.instance_of?(Hmis::Hud::YouthEducationStatus) }
+        # create a duplicate record that is older, but has the preferred hash
+        education_status2 = create(:hmis_youth_education_status, source_hash: 'PREFERRED_HASH', date_created: education_status1.date_updated - 1.day, **education_status1.slice(:data_source, :enrollment, :client, :data_collection_stage, :information_date, :date_created))
+
+        # without hash preference, it should choose education_status1
+        Hmis::MigrateAssessmentsJob.perform_now(data_source_id: ds1.id)
+        expect(e1.custom_assessments.intakes.first.form_processor.youth_education_status).to eq(education_status1)
+
+        # with hash preference, it should choose education_status2
+        e1.custom_assessments.intakes.first.destroy!
+        Hmis::MigrateAssessmentsJob.perform_now(data_source_id: ds1.id, delete_dangling_records: true, preferred_source_hash: 'PREFERRED_HASH')
+
+        expect(e1.custom_assessments.intakes.count).to eq(1)
+        expect(e1.custom_assessments.intakes.first.form_processor.youth_education_status).to eq(education_status2)
+
+        education_status1.reload
+        expect(education_status1.date_deleted).to be_present
+      end
     end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/sh_hmis/importers/s3_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/sh_hmis/importers/s3_importer.rb
@@ -4,6 +4,9 @@ module HmisExternalApis::ShHmis::Importers
   # importer.select_latest_file
   # importer.fetch_and_unzip_latest_file
   # importer.run_migration!(clobber: true)
+  #
+  # To run assessment migration (WARNING! DELETES RECORDS!)
+  # Hmis::MigrateAssessmentsJob.perform_later(data_source_id: data_source_id, clobber: true, delete_dangling_records: true, preferred_source_hash: 'OP-HMIS-MIGRATION-2023')
   class S3Importer
     attr_accessor :creds
     attr_accessor :s3

--- a/drivers/ma_yya_report/config/initializers/ma_yya_report_feature.rb
+++ b/drivers/ma_yya_report/config/initializers/ma_yya_report_feature.rb
@@ -12,4 +12,4 @@
 # use with caution!
 RailsDrivers.loaded << :ma_yya_report
 
-Rails.application.config.synthetic_youth_education_status_types << 'MaYyaReport::Synthetic::YouthEducationStatus'
+# Rails.application.config.synthetic_youth_education_status_types << 'MaYyaReport::Synthetic::YouthEducationStatus'


### PR DESCRIPTION
## Description

* Support specifying which Source Hash is preferred for duplicate records when generating assessments. NOTE: it just chooses the first one that matches the hash (if any). If multiple have the preferred hash, it doesn't do a secondary sort on date. 
* Turn off synthetic YouthEducationStatus

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
