### PR TITLE
Add support for filtering HMIS ACLs, allow linking to uploads for HMIS

### DIFF
--- a/app/views/data_sources/_source_details.haml
+++ b/app/views/data_sources/_source_details.haml
@@ -8,7 +8,7 @@
       %td
         - if data_span = @data_source.data_span
           = "#{data_span[:start_date]} - #{data_span[:end_date]}"
-    - if ! @data_source.authoritative? && can_view_imports? && @data_source.uploads.any? && @data_source.directly_viewable_by?(current_user, permission: :can_view_imports)
+    - if (!@data_source.authoritative? || @data_source.hmis?) && can_view_imports? && @data_source.uploads.any? && @data_source.directly_viewable_by?(current_user, permission: :can_view_imports)
       %tr
         %th.pl-2 Uploads
         %td

--- a/drivers/hmis/app/controllers/hmis_admin/access_controls_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/access_controls_controller.rb
@@ -12,7 +12,10 @@ class HmisAdmin::AccessControlsController < ApplicationController
   before_action :set_access_control, only: [:edit, :update, :destroy]
 
   def index
-    @access_controls = access_control_scope.order(:role_id)
+    @access_controls = access_control_scope.
+      ordered.
+      filtered(params[:filter])
+
     @pagy, @access_controls = pagy(@access_controls)
   end
 

--- a/drivers/hmis/app/models/hmis/access_control.rb
+++ b/drivers/hmis/app/models/hmis/access_control.rb
@@ -12,4 +12,37 @@ class Hmis::AccessControl < ApplicationRecord
   belongs_to :role, class_name: 'Hmis::Role'
   belongs_to :user_group, class_name: '::Hmis::UserGroup', required: false, inverse_of: :access_controls
   has_many :users, through: :user_group
+
+  scope :ordered, -> do
+    joins(:user_group, :role, :access_group).
+      order(
+        Hmis::UserGroup.arel_table[:name].lower.asc,
+        Hmis::Role.arel_table[:name].lower.asc,
+        Hmis::AccessGroup.arel_table[:name].lower.asc,
+      )
+  end
+
+  # filter for access controls that somehow interact with the following
+  # User, UserGroup, Role, AccessGroup
+  scope :filtered, ->(filter_params) do
+    return current_scope unless filter_params
+
+    user_scope = current_scope
+    user_group_scope = current_scope
+    role_scope = current_scope
+    entity_group_scope = current_scope
+
+    user_scope = Hmis::UserGroup.with_user_id(filter_params[:user_id].to_i) if filter_params[:user_id].present?
+    user_group_scope = where(user_group_id: filter_params[:user_group_id].to_i) if filter_params[:user_group_id].present?
+    role_scope = where(role_id: filter_params[:role_id].to_i) if filter_params[:role_id].present?
+    entity_group_scope = where(access_group_id: filter_params[:access_group_id].to_i) if filter_params[:access_group_id].present?
+
+    ids = joins(:user_group, :role, :access_group).
+      merge(user_scope).
+      merge(user_group_scope).
+      merge(role_scope).
+      merge(entity_group_scope).
+      pluck(:id)
+    where(id: ids)
+  end
 end

--- a/drivers/hmis/app/views/hmis_admin/_tabs.haml
+++ b/drivers/hmis/app/views/hmis_admin/_tabs.haml
@@ -2,15 +2,15 @@
   - nav_class = if active_tab == :users then 'active' else '' end
   %li.nav-item{class: nav_class}
     = link_to 'Users', hmis_admin_users_path, class: 'nav-link'
+  - nav_class = if active_tab.to_sym == :user_groups then 'active' else '' end
+  %li.nav-item{class: nav_class}
+    = link_to 'User Groups', hmis_admin_user_groups_path, class: 'nav-link'
   - nav_class = if active_tab == :roles then 'active' else '' end
   %li.nav-item{class: nav_class}
     = link_to 'Roles', hmis_admin_roles_path, class: 'nav-link'
   - nav_class = if active_tab == :groups then 'active' else '' end
   %li.nav-item{class: nav_class}
     = link_to 'Collections', hmis_admin_groups_path, class: 'nav-link'
-  - nav_class = if active_tab.to_sym == :user_groups then 'active' else '' end
-  %li.nav-item{class: nav_class}
-    = link_to 'User Groups', hmis_admin_user_groups_path, class: 'nav-link'
   - nav_class = if active_tab.to_sym == :access_controls then 'active' else '' end
   %li.nav-item{class: nav_class}
     = link_to 'Access Controls', hmis_admin_access_controls_path, class: 'nav-link'

--- a/drivers/hmis/app/views/hmis_admin/access_controls/_filter.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/_filter.haml
@@ -1,0 +1,18 @@
+.well
+  = simple_form_for :filter, method: :get do |f|
+    .row
+      .col-3
+        = f.input :user_id, as: :select_two, collection: User.active.not_system.order(:first_name, :last_name), selected: params.dig(:filter, :user_id).to_i, required: false, include_blank: 'Any user'
+    .row
+      .col
+        = f.input :user_group_id, as: :select_two, collection: Hmis::UserGroup.all.order(:name), selected: params.dig(:filter, :user_group_id).to_i, required: false, include_blank: 'Any user group'
+      .col
+        = f.input :role_id, as: :select_two, collection: Hmis::Role.order(:name), selected: params.dig(:filter, :role_id).to_i, required: false, include_blank: 'Any role'
+      .col
+        = f.input :access_group_id, as: :select_two, label: 'Collection', collection: Hmis::AccessGroup.all.order(:name), selected: params.dig(:filter, :access_group_id).to_i, required: false, include_blank: 'Any collection'
+      .col-3.d-flex.align-items-center
+        .ml-4.d-flex
+          = f.button :submit, value: 'Apply Filter'
+          .ml-6.align-self-center
+            = link_to 'Reset', hmis_admin_access_controls_path
+    

--- a/drivers/hmis/app/views/hmis_admin/access_controls/index.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/index.haml
@@ -10,6 +10,7 @@
     %span.icon-plus
     Create a new Access Control
 - if @pagy.count.positive?
+  = render 'filter'
   = render 'common/pagination_top', item_name: 'access control list'
   .table-responsive
     %table.table.table-striped
@@ -23,7 +24,7 @@
             %i.font-weight-light Which permissions are they receiving?
           %th
             .div.mb-1 Collection
-            %i.font-weight-light Which projects are the permissions are applied to?
+            %i.font-weight-light Which projects are the permissions being applied to?
           %th
       %tbody
         - @access_controls.each do |acl|
@@ -34,7 +35,7 @@
             %td= link_to acl.role.name, hmis_admin_roles_path
             %td= link_to acl.access_group.name, edit_hmis_admin_group_path(acl.access_group)
             %td
-              .float-right
+              .d-flex.justify-content-end
                 = link_to edit_hmis_admin_access_control_path(acl), class: ['btn', 'btn-sm', 'btn-secondary'] do
                   %span.icon-pencil
                   Edit


### PR DESCRIPTION
## Description

* add support for filtering HMIS access controls
* sort access controls
* consistent ordering of `user group > role > collection`
* show link to "uploads" for HMIS data source (sorry it took me forever to fix this)

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
