### PR TITLE
186135249 fix stale object errror in create referral job

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/base.rb
@@ -14,6 +14,16 @@ class Hmis::Hud::Base < ::GrdaWarehouseBase
   attr_writer :skip_validations
   attr_writer :required_fields
 
+  def self.without_optimistic_locking
+    prev = self.lock_optimistically
+    self.lock_optimistically = false
+    begin
+      yield
+    ensure
+      self.lock_optimistically = prev
+    end
+  end
+
   before_validation :ensure_id
 
   scope :viewable_by, ->(_) do

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
@@ -23,7 +23,9 @@ module HmisExternalApis::AcHmis
 
         raise ActiveRecord::Rollback unless create_referral_posting(referral)
 
-        raise ActiveRecord::Rollback unless create_or_update_referral_household_members(referral)
+        Hmis::Hud::Client.without_optimistic_locking do
+          raise ActiveRecord::Rollback unless create_or_update_referral_household_members(referral)
+        end
 
         record = referral
       end


### PR DESCRIPTION
## Description
https://www.pivotaltracker.com/n/projects/2591838

Disables optimistic locking within the job. Also adds generic method to disable optimistic locking on hud AR objects.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
