### PR TITLE
Patch to ClientContactsLoader

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_contacts_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/client_contacts_loader.rb
@@ -25,7 +25,13 @@ module HmisExternalApis::AcHmis::Importers::Loaders
       expected = 0
       seen = Set.new
       records = rows.map do |row|
-        value = phone_value(row)
+        phone_or_email = row_value(row, field: 'SYSTM').downcase
+        value = case phone_or_email
+        when 'phone'
+          phone_value(row)
+        when 'email'
+          row_value(row, field: 'VALUE')&.strip
+        end
         next unless value
 
         expected += 1
@@ -40,7 +46,7 @@ module HmisExternalApis::AcHmis::Importers::Loaders
           UserID: user_id_value(row),
           PersonalID: personal_id,
           use: use_value(row),
-          system: row_value(row, field: 'SYSTM').downcase,
+          system: phone_or_email,
           notes: row_value(row, field: 'NOTES', required: false),
           value: value,
           # these fields should be required but are sometimes missing or unparsable

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/client_contacts_loader_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/client_contacts_loader_spec.rb
@@ -17,8 +17,18 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::Loaders::ClientContactsLoade
         'PersonalID' => client.PersonalID,
         'PHONE_TYPE' => 'Home',
         'SYSTM' => 'PHONE',
-        'VALUE' => '8675309',
+        'VALUE' => '(123) 867-5309',
         'NOTES' => 'test notes',
+        'UserID' => '',
+        'DateCreated' => '7/1/2020 16:10',
+        'DateUpdated' => '7/1/2020 16:10',
+      },
+      {
+        'PersonalID' => client.PersonalID,
+        'PHONE_TYPE' => 'EMAIL',
+        'SYSTM' => 'EMAIL',
+        'VALUE' => 'foo123@gmail.com',
+        'NOTES' => '',
         'UserID' => '',
         'DateCreated' => '7/1/2020 16:10',
         'DateUpdated' => '7/1/2020 16:10',
@@ -30,6 +40,11 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::Loaders::ClientContactsLoade
     csv_files = { 'ClientContacts.csv' => rows }
     expect do
       run_cde_import(csv_files: csv_files, clobber: true)
-    end.to change(client.contact_points, :count).by(1)
+    end.to change(client.contact_points, :count).by(2)
+
+    expect(client.contact_points.phones.count).to eq(1)
+    expect(client.contact_points.phones.first.value).to eq('1238675309')
+    expect(client.contact_points.emails.count).to eq(1)
+    expect(client.contact_points.emails.first.value).to eq('foo123@gmail.com')
   end
 end


### PR DESCRIPTION
## Description

Bug: emails were being treated like phone numbers. (Emails like "gig123@gmail.com" were being saved as "123". Emails without numbers were being skipped.)

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
