### PR TITLE
Numbers should have delimiters

### DIFF
--- a/app/views/warehouse_reports/client_details/actives/_report.haml
+++ b/app/views/warehouse_reports/client_details/actives/_report.haml
@@ -1,6 +1,6 @@
 .d-flex
   %p
-    = "The following #{@report.enrollments.count} clients with #{@report.enrollments.values.flatten(1).count} enrollments, have at least one day of service between #{@filter.start} and #{@filter.end}."
+    = "The following #{number_with_delimiter(@report.enrollments.count)} clients with #{number_with_delimiter(@report.enrollments.values.flatten(1).count)} enrollments, have at least one day of service between #{@filter.start} and #{@filter.end}."
     %br
     This report was built to provide supporting details to the "Active Clients" section of the Population Dashboards.
 

--- a/app/views/warehouse_reports/client_details/entries/_report.haml
+++ b/app/views/warehouse_reports/client_details/entries/_report.haml
@@ -1,6 +1,6 @@
 .d-flex
   %p
-    = pluralize(@report.enrollments.count, 'Client')
+    = pluralize(number_with_delimiter(@report.enrollments.count), 'Client')
     have entries in
     = @filter.selected_project_type_names.join(', ')
     between

--- a/app/views/warehouse_reports/client_details/exits/_report.haml
+++ b/app/views/warehouse_reports/client_details/exits/_report.haml
@@ -8,9 +8,9 @@
 
     %br
     During that time there were
-    = @report.clients.count
+    = number_with_delimiter(@report.clients.count)
     exits consisting of
-    #{pluralize(@report.clients.map{ |row| row[:client_id]}.uniq.count, 'unique client')}.
+    #{pluralize(number_with_delimiter(@report.clients.map{ |row| row[:client_id]}.uniq.count), 'unique client')}.
     %br
     This report was built to provide supporting details to the "Exiters" and Exits to Permanent Housing" sections of the Population Dashboards.
   .ml-auto.mb-2


### PR DESCRIPTION
## Description

Some reports show large numbers with no commas, this should fix 3 of them.

## Type of change
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
