### PR TITLE
Create WIP Enrollments for Assigned referrals in Walk-In programs

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/loaders/referral_postings_loader.rb
@@ -13,10 +13,10 @@ module HmisExternalApis::AcHmis::Importers::Loaders
         # warning- this destroys all referrals regardless of data source
         referral_class.destroy_all
         # is it okay to just destroy all in-progress enrollments?
-        Hmis::Hud::Enrollment
-          .where(data_source: data_source)
-          .in_progress
-          .find_each(&:really_destroy!)
+        Hmis::Hud::Enrollment.
+          where(data_source: data_source).
+          in_progress.
+          find_each(&:really_destroy!)
       end
 
       import_enrollment_records
@@ -100,11 +100,11 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     end
 
     def fixup_hoh_on_referrals
-      hoh_client_pks_by_household_id = Hmis::Hud::Enrollment.order(:id)
-        .hmis.heads_of_households
-        .joins(:client)
-        .pluck(Arel.sql('"Enrollment"."HouseholdID", "Client".id'))
-        .to_h
+      hoh_client_pks_by_household_id = Hmis::Hud::Enrollment.order(:id).
+        hmis.heads_of_households.
+        joins(:client).
+        pluck(Arel.sql('"Enrollment"."HouseholdID", "Client".id')).
+        to_h
 
       HmisExternalApis::AcHmis::Referral.preload(:postings, :household_members).find_each do |referral|
         hoh_members = referral.household_members.filter(&:self_head_of_household?)
@@ -135,10 +135,10 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     # create wip enrollments for accepted pending postings
     def build_enrollment_rows
       accepted_pending_status = HmisExternalApis::AcHmis::ReferralPosting.statuses.fetch('accepted_pending_status')
-      enrollment_coc_by_project_id = Hmis::Hud::ProjectCoc
-        .where(data_source: data_source)
-        .pluck(:project_id, :coc_code)
-        .to_h
+      enrollment_coc_by_project_id = Hmis::Hud::ProjectCoc.
+        where(data_source: data_source).
+        pluck(:project_id, :coc_code).
+        to_h
 
       expected = 0
       seen = Set.new
@@ -224,10 +224,10 @@ module HmisExternalApis::AcHmis::Importers::Loaders
     # assign inferred unit occupancy
     def assign_unit_occupancies
       accepted_status = HmisExternalApis::AcHmis::ReferralPosting.statuses.fetch('accepted_status')
-      enrollment_pk_by_id = Hmis::Hud::Enrollment
-        .where(data_source: data_source)
-        .pluck(:enrollment_id, :id)
-        .to_h
+      enrollment_pk_by_id = Hmis::Hud::Enrollment.
+        where(data_source: data_source).
+        pluck(:enrollment_id, :id).
+        to_h
 
       expected = 0
       actual = 0
@@ -318,18 +318,18 @@ module HmisExternalApis::AcHmis::Importers::Loaders
       accepted_pending_status = HmisExternalApis::AcHmis::ReferralPosting.statuses.fetch('accepted_pending_status')
 
       referral_pks_by_id = referral_class.pluck(:identifier, :id).to_h
-      projects_pks_by_id = Hmis::Hud::Project
-        .where(data_source: data_source)
-        .pluck(:project_id, :id)
-        .to_h
-      household_id_by_enrollment_id = Hmis::Hud::Enrollment
-        .where(data_source: data_source)
-        .pluck(:enrollment_id, :household_id)
-        .to_h
-      unit_types_by_mper = Hmis::UnitType
-        .joins(:mper_id)
-        .pluck('external_ids.value', :id)
-        .to_h
+      projects_pks_by_id = Hmis::Hud::Project.
+        where(data_source: data_source).
+        pluck(:project_id, :id).
+        to_h
+      household_id_by_enrollment_id = Hmis::Hud::Enrollment.
+        where(data_source: data_source).
+        pluck(:enrollment_id, :household_id).
+        to_h
+      unit_types_by_mper = Hmis::UnitType.
+        joins(:mper_id).
+        pluck('external_ids.value', :id).
+        to_h
 
       seen = Set.new
       expected = 0
@@ -406,11 +406,11 @@ module HmisExternalApis::AcHmis::Importers::Loaders
 
     def household_id_by_personal_id_project_id
       # {[personal_id, project_id] => [enrollment_pk, household_id]}
-      @household_id_by_personal_id_project_id ||= Hmis::Hud::Enrollment
-        .where(data_source: data_source)
-        .open_including_wip
-        .preload(wip: :project)
-        .map do |e|
+      @household_id_by_personal_id_project_id ||= Hmis::Hud::Enrollment.
+        where(data_source: data_source).
+        open_including_wip.
+        preload(wip: :project).
+        map do |e|
           # avoid n+1 problems when calling enrollment.project
           project_id = e.project_id || e.wip&.project&.project_id
           next unless project_id
@@ -434,17 +434,17 @@ module HmisExternalApis::AcHmis::Importers::Loaders
 
     def client_ids_by_mci_id
       # {mci_id => [client_pk, personal_id]}
-      @client_ids_by_mci_id ||= Hmis::Hud::Client
-        .joins(:ac_hmis_mci_ids)
-        .where(data_source: data_source)
-        .pluck('external_ids.value', c_t[:id], c_t[:personal_id])
-        .to_h { |mci_id, client_pk, personal_id| [mci_id, [client_pk, personal_id]] }
+      @client_ids_by_mci_id ||= Hmis::Hud::Client.
+        joins(:ac_hmis_mci_ids).
+        where(data_source: data_source).
+        pluck('external_ids.value', c_t[:id], c_t[:personal_id]).
+        to_h { |mci_id, client_pk, personal_id| [mci_id, [client_pk, personal_id]] }
     end
 
     def relationship_to_hoh_string_enum(row)
-      @posting_status_map ||= HmisExternalApis::AcHmis::ReferralHouseholdMember
-        .relationship_to_hohs
-        .invert.stringify_keys
+      @posting_status_map ||= HmisExternalApis::AcHmis::ReferralHouseholdMember.
+        relationship_to_hohs.
+        invert.stringify_keys
       @posting_status_map.fetch(row_value(row, field: 'RELATIONSHIP_TO_HOH_ID'))
     end
 


### PR DESCRIPTION
## Description

When importing referrals that are Assigned to walk-in programs, create WIP Enrollments for them. This is a new addition, so that assigned referrals don't get lost during migration, since these programs do not have referral bulletins in the new hmis.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
