### PR TITLE
Use Enrollment.DisablingCondition to populate/persist value, add bounds to info data on Update/Annual

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/disability.json
@@ -12,7 +12,7 @@
       "required": false,
       "warn_if_empty": true,
       "mapping": {
-        "record_type": "DISABILITY_GROUP",
+        "record_type": "ENROLLMENT",
         "field_name": "disablingCondition"
       },
       "pick_list_reference": "NoYesReasonsForMissingData",
@@ -655,7 +655,7 @@
               "text": "Disabling Condition",
               "disabled_display": "PROTECTED_WITH_VALUE",
               "mapping": {
-                "record_type": "DISABILITY_GROUP",
+                "record_type": "ENROLLMENT",
                 "field_name": "disablingCondition"
               },
               "pick_list_reference": "NoYesReasonsForMissingData"

--- a/drivers/hmis/lib/form_data/default/fragments/information_date.json
+++ b/drivers/hmis/lib/form_data/default/fragments/information_date.json
@@ -11,7 +11,30 @@
       "mapping": { "field_name": "assessmentDate" },
       "required": true,
       "warn_if_empty": false,
-      "assessment_date": true
+      "assessment_date": true,
+      "initial": [
+        {
+          "initial_behavior": "IF_EMPTY",
+          "value_local_constant": "$today"
+        }
+      ],
+      "bounds": [
+        {
+          "id": "min-date",
+          "type": "MIN",
+          "value_local_constant": "$entryDate"
+        },
+        {
+          "id": "max-date",
+          "type": "MAX",
+          "value_local_constant": "$exitDate"
+        },
+        {
+          "id": "max-today",
+          "type": "MAX",
+          "value_local_constant": "$today"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

* Use Enrollment.DisablingCondition to populate/persist value. This fixes a bug where the DisablingCondition doesn't properly autofill when starting a new assessment. With this change, each time you create a new assessment, the value will always be filled with the current value.
* Set bounds around information date for Update and Annual

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
