### PR TITLE
Stop MPER importer from importing multiple files

### DIFF
--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -938,6 +938,11 @@ module GrdaWarehouse::Hud
       affiliations.update_all(DateDeleted: deleted_timestamp, source_hash: nil)
       residential_affiliations.update_all(DateDeleted: deleted_timestamp, source_hash: nil)
 
+      # FIXME: this should delete HMIS-related records, too
+      # delete Hmis::Unit
+      # delete Hmis::UnitOccupancyPeriod
+      # delete Hmis::ProjectUnitTypeMapping
+
       # Client enrollment related
       income_benefits.update_all(DateDeleted: deleted_timestamp, source_hash: nil)
       disabilities.update_all(DateDeleted: deleted_timestamp, source_hash: nil)

--- a/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
+++ b/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
@@ -21,6 +21,7 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
     unit_attrs = scope.filter(&:active?).flat_map do |record|
       unit_type = record.unit_type
       project = record.project
+      next if project.nil? # could happen if project was deleted but ProjectUnitTypeMapping wasn't properly cleaned up
 
       # If this ProjectID is already mapped to this UnitTypeID in our system, and it is marked as Active=Y, do nothing.
       key = [project.id, unit_type.id]


### PR DESCRIPTION
## Description

The MPER importer was importing multiple files from s3. we only want to import the most recent one.

Also ignores an issue with dangling records, and a FIXME for it. thats https://green-river.sentry.io/issues/4512666973/?project=4503977346662400

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
