### PR TITLE
Resolve numUnitsAssignedToHousehold on enrollment

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2653,6 +2653,7 @@ type Enrollment {
   mentalHealthDisorderFam: NoYesMissing
   monthsHomelessPastThreeYears: MonthsHomelessPastThreeYears
   moveInDate: ISO8601Date
+  numUnitsAssignedToHousehold: Int!
   openEnrollmentSummary: [EnrollmentSummary!]!
   percentAmi: PercentAMI
   physicalDisabilityFam: NoYesMissing

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -149,6 +149,7 @@ module Types
     custom_data_elements_field
 
     field :current_unit, HmisSchema::Unit, null: true
+    field :num_units_assigned_to_household, Integer, null: false
     field :reminders, [HmisSchema::Reminder], null: false
     field :open_enrollment_summary, [HmisSchema::EnrollmentSummary], null: false
     field :last_bed_night_date, GraphQL::Types::ISO8601Date, null: true
@@ -260,6 +261,14 @@ module Types
 
     def current_unit
       load_ar_association(object, :current_unit)
+    end
+
+    # ALERT: n+1, dont use when resolving multiple enrollments
+    def num_units_assigned_to_household
+      object.household_members.
+        joins(:current_unit).
+        pluck(Hmis::Unit.arel_table[:id]).
+        uniq.size
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(response.status).to eq 200
       enrollment = result.dig('data', 'enrollment')
       expect(enrollment['id']).to eq(e1.id.to_s)
-      expect(enrollment['currentUnit']['id']).to eq(unit1.id)
+      expect(enrollment['currentUnit']['id']).to eq(unit1.id.to_s)
       expect(enrollment['numUnitsAssignedToHousehold']).to eq(2)
     end
   end

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:access_control) { create_access_control(hmis_user, ds1) }
   let!(:c1) { create :hmis_hud_client_complete, data_source: ds1, user: u1 }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1 }
-  let!(:e2_wip) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+  let!(:e2_wip) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c1 }
   let!(:income_benefit) { create :hmis_income_benefit, data_source: ds1, client: c1, user: u1, enrollment: e1 }
   let!(:health) { create :hmis_health_and_dv, data_source: ds1, client: c1, user: u1, enrollment: e1 }
   let!(:yes) { create :hmis_youth_education_status, data_source: ds1, client: c1, user: u1, enrollment: e1 }
@@ -38,7 +38,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   before(:each) do
     hmis_login(user)
-    e2_wip.save_in_progress
   end
 
   let(:client_query) do
@@ -170,6 +169,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               #{scalar_fields(Types::HmisSchema::Disability)}
             }
           }
+          currentUnit {
+            #{scalar_fields(Types::HmisSchema::Unit)}
+          }
         }
       }
     GRAPHQL
@@ -285,6 +287,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(enrollment['youthEducationStatuses']['nodesCount']).to eq(1)
       expect(enrollment['employmentEducations']['nodesCount']).to eq(1)
       expect(enrollment['currentLivingSituations']['nodesCount']).to eq(1)
+      expect(enrollment['currentUnit']).to be_nil
+      expect(enrollment['numUnitsAssignedToHousehold']).to eq(0)
+    end
+
+    it 'should resolve the current unit and number of units assigned to household' do
+      # Put e1 in unit1
+      unit1 = create(:hmis_unit, project: p1)
+      create(:hmis_unit_occupancy, unit: unit1, enrollment: e1, start_date: e1.entry_date)
+      # Put e3 and e4 in unit2
+      unit2 = create(:hmis_unit, project: p1)
+      e3 = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id)
+      create(:hmis_unit_occupancy, unit: unit2, enrollment: e3, start_date: e3.entry_date)
+      e4 = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id)
+      create(:hmis_unit_occupancy, unit: unit2, enrollment: e4, start_date: e4.entry_date)
+
+      response, result = post_graphql(id: e1.id) { enrollment_query }
+      expect(response.status).to eq 200
+      enrollment = result.dig('data', 'enrollment')
+      expect(enrollment['id']).to eq(e1.id.to_s)
+      expect(enrollment['currentUnit']['id']).to eq(unit1.id)
+      expect(enrollment['numUnitsAssignedToHousehold']).to eq(2)
     end
   end
 end


### PR DESCRIPTION
## Description

feature request to show # units assigned to household on the enrollment dash. will add a separate form for it so it only shows up for the specific installation.

https://www.pivotaltracker.com/story/show/186144223

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
