### PR TITLE
Stop validation CustomAssessment as a CEAssessment

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/validators/custom_assessment_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/custom_assessment_validator.rb
@@ -5,22 +5,6 @@
 ###
 
 class Hmis::Hud::Validators::CustomAssessmentValidator < Hmis::Hud::Validators::BaseValidator
-  IGNORED = [
-    :ExportID,
-    :DateCreated,
-    :DateUpdated,
-    # CE fields are not present on the custom assessment
-    :AssessmentID,
-    :AssessmentLocation,
-    :AssessmentType,
-    :AssessmentLevel,
-    :PrioritizationStatus,
-  ].freeze
-
-  def configuration
-    Hmis::Hud::CustomAssessment.hmis_configuration(version: '2024').except(*IGNORED)
-  end
-
   # Validate assessment date
   def self.validate_assessment_date(assessment, household_members: nil, options: {})
     date = assessment.assessment_date

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -56,9 +56,9 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
     let!(:assessment) { create(:hmis_custom_assessment, data_source: ds1, enrollment: e1) }
 
     def apply_assessment_date(date)
-      assessment.update(assessment_date: date)
-      assessment.enrollment.update(entry_date: date) if assessment.intake?
-      assessment.enrollment.exit.update(exit_date: date) if assessment.exit?
+      assessment.assessment_date = date
+      assessment.enrollment.entry_date = date if assessment.intake?
+      assessment.enrollment.exit.exit_date = date if assessment.exit?
     end
 
     [:INTAKE, :UPDATE, :ANNUAL, :EXIT].each do |role|


### PR DESCRIPTION
## Description

I dont know why we set it up like this but it doesn't make sense. CustomAssessment doesnt need to be validating using the CE Assessment structure. Remove

## Type of change
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
