### PR TITLE
Installation-specific form to show # assigned units on enrollment dashboard

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/occurrence_point_forms/num_assigned_units.json
+++ b/drivers/hmis/lib/form_data/allegheny/occurrence_point_forms/num_assigned_units.json
@@ -1,0 +1,14 @@
+{
+  "item": [
+    {
+      "type": "INTEGER",
+      "link_id": "num-assigned-units",
+      "text": "Number of Units Assigned to Household",
+      "read_only": true,
+      "mapping": {
+        "record_type": "ENROLLMENT",
+        "field_name": "numUnitsAssignedToHousehold"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Requested feature to show number of units assigned to household on dashboard

https://www.pivotaltracker.com/story/show/186144223

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue



<img width="766" alt="Screenshot 2023-09-29 at 5 44 30 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/4621970c-8c00-4d1c-acff-641504b3c99c">


