### PR TITLE
Collect disabilities at annuals, update R17 rule

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/assessments/base_annual.json
+++ b/drivers/hmis/lib/form_data/allegheny/assessments/base_annual.json
@@ -1,0 +1,19 @@
+{
+  "item": [
+    {
+      "fragment": "#information_date"
+    },
+    {
+      "fragment": "#income_and_sources"
+    },
+    {
+      "fragment": "#non_cash_benefits"
+    },
+    {
+      "fragment": "#health_insurance"
+    },
+    {
+      "fragment": "#disability"
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/default/fragments/r17_project_completion_status.json
+++ b/drivers/hmis/lib/form_data/default/fragments/r17_project_completion_status.json
@@ -10,19 +10,21 @@
         "_comment": "HHS: RHY – Collection required for all components except for Street Outreach and BCP-Prevention",
         "parts": [
           {
-            "variable": "projectFunders",
+            "variable": "projectFunderComponents",
             "operator": "INCLUDE",
-            "value": 23
+            "value": "HHS: RHY"
           },
           {
-            "variable": "projectFunders",
-            "operator": "INCLUDE",
-            "value": 24
+            "variable": "projectType",
+            "operator": "NOT_EQUAL",
+            "_comment": "street outreach",
+            "value": 4
           },
           {
-            "variable": "projectFunders",
-            "operator": "INCLUDE",
-            "value": 26
+            "variable": "projectType",
+            "operator": "NOT_EQUAL",
+            "_comment": "prevention",
+            "value": 12
           }
         ]
       },

--- a/drivers/hmis/lib/form_data/springfield/assessments/base_annual.json
+++ b/drivers/hmis/lib/form_data/springfield/assessments/base_annual.json
@@ -1,0 +1,19 @@
+{
+  "item": [
+    {
+      "fragment": "#information_date"
+    },
+    {
+      "fragment": "#income_and_sources"
+    },
+    {
+      "fragment": "#non_cash_benefits"
+    },
+    {
+      "fragment": "#health_insurance"
+    },
+    {
+      "fragment": "#disability"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

* While disabilities are not required to be collected at annuals, they are collected for both installations. Not including it could potentially hide data that's there.
* R17 had an incorrect implementation of RHY funding rule. 

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
