### PR TITLE
Enforce SHE cleanup after 2022->2024 migration

### DIFF
--- a/app/models/grda_warehouse/place.rb
+++ b/app/models/grda_warehouse/place.rb
@@ -43,6 +43,7 @@ module GrdaWarehouse
       place
     rescue StandardError => e
       send_single_notification("Error contacting the OSM Nominatim API.: #{e.message}", 'NominatimWarning')
+      Sentry.capture_exception(e)
     end
 
     def self.nominatim_lookup(query, city, state, postalcode, country)

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/config/initializers/hud_twenty_twenty_two_to_twenty_twenty_four_feature.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/config/initializers/hud_twenty_twenty_two_to_twenty_twenty_four_feature.rb
@@ -29,11 +29,11 @@ Rails.application.reloader.to_prepare do
     return if GrdaWarehouse::Hud::HmisParticipation.exists? || GrdaWarehouse::Hud::CeParticipation.exists?
 
     HudTwentyTwentyTwoToTwentyTwentyFour::DbTransformer.up
-  end
 
-  # Any exit record that has a new destination invalidates the cached one on the ServiceHistoryEnrollment record
-  # queue those up for re-processing
-  Rails.application.config.queued_tasks[:hud_twenty_twenty_two_to_twenty_twenty_four_invalidate_she] = -> do
+    # After the migration to FY2024, do some cleanup
+
+    # Any exit record that has a new destination invalidates the cached one on the ServiceHistoryEnrollment record
+    # queue those up for re-processing
     she_t = GrdaWarehouse::ServiceHistoryEnrollment.arel_table
     ex_t = GrdaWarehouse::Hud::Exit.arel_table
     GrdaWarehouse::Hud::Enrollment.joins(:exit, :service_history_enrollment).where(she_t[:destination].not_eq(ex_t[:Destination])).invalidate_processing!


### PR DESCRIPTION
## Description

Items that need changing for deployment of FY2024.

* We originally deployed without the SHE cleanup, so it had to be a separate task.  It needs to run *after* the 2022 -> 2024 migration, so this explicitly forces that.
* Attempt to capture failures on Nominatim API

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
