### PR TITLE
Move data warehouse upload to a different schedule

### DIFF
--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -346,6 +346,11 @@ namespace :grda_warehouse do
   desc 'Process Recurring HMIS Exports'
   task process_recurring_hmis_exports: [:environment] do
     GrdaWarehouse::Tasks::ProcessRecurringHmisExports.new.run!
+
+    if HmisEnforcement.hmis_enabled? && GrdaWarehouse::DataSource.hmis.exists? && RailsDrivers.loaded.include?(:hmis_external_apis)
+      # Upload HMIS Export and Client MCI mapping to the AC Data Warehouse
+      Rake::Task['driver:hmis_external_apis:export:ac_clients'].invoke
+    end
   end
 
   desc 'Process location data'

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -9,8 +9,6 @@ namespace :import do
       tasks << 'driver:hmis_external_apis:import:ac_clients_with_active_referrals' if RailsDrivers.loaded.include?(:hmis_external_apis)
       # Fetch recent client changes from AC Data Warehouse to get MCI Unique IDs
       tasks << 'driver:hmis_external_apis:import:ac_warehouse_changes' if RailsDrivers.loaded.include?(:hmis_external_apis)
-      # Upload Client and HMIS data to AC Data Warehouse
-      tasks << 'driver:hmis_external_apis:export:ac_clients' if RailsDrivers.loaded.include?(:hmis_external_apis)
     end
 
     tasks << 'eto:import:demographics_and_touch_points'


### PR DESCRIPTION
## Description

Move the Data Warehouse upload to a different schedule. I don't like the idea of it occurring at the same time as the MPER import and the Data Warehouse changes job which merges clients.

This schedule runs at `DAILY_EXPORT_SCHEDULE` or `DAILY_SCHEDULE - 2h`

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
