### PR TITLE
Fix valid_options for GenderNone

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/importer/client.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/importer/client.rb
@@ -123,7 +123,7 @@ module HmisCsvTwentyTwentyFour::Importer
         GenderNone: [
           {
             class: HmisCsvImporter::HmisCsvValidation::InclusionInSet,
-            arguments: { valid_options: HudUtility2024.no_yes_options.keys.map(&:to_s).freeze },
+            arguments: { valid_options: HudUtility2024.race_gender_none_options.keys.map(&:to_s).freeze },
           },
         ],
         AmIndAKNative: [


### PR DESCRIPTION
## Description

I noticed some validation errors when importing 2024 files that said `Expected 9 to be included in ["0", "1"] for GenderNone`. Update the expected list to `["8", "9", "99"]`

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
