### PR TITLE
Add contact info to default enrollment form

### DIFF
--- a/drivers/hmis/lib/form_data/default/records/new_client_enrollment.json
+++ b/drivers/hmis/lib/form_data/default/records/new_client_enrollment.json
@@ -12,6 +12,9 @@
     },
     {
       "fragment": "#client_demographics"
+    },
+    {
+      "fragment": "#client_contact_information"
     }
   ]
 }


### PR DESCRIPTION
## Description

My default, support collecting contact information at time of enrollment. This is already enabled in one installation, just enabling it in another by making it the default. I don't see any reason why it shouldn't be the default.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
