### PR TITLE
Use destination id for lookup in WarehouseChangesJob

### DIFF
--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -9,13 +9,13 @@ require 'rails_helper'
 RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   let(:user) { create(:user) }
   let(:job) { HmisExternalApis::AcHmis::WarehouseChangesJob.new }
-  let!(:client) { create(:hmis_hud_client, PersonalID: '1000019089', data_source: data_source) }
   let(:data_source) { create(:hmis_data_source, name: 'HMIS', authoritative: true) }
+  let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: data_source) }
   let(:default_record) do
     {
       'srcSysKey' => 123,
       'srcSysDesc' => 'Master Client Index (MCI)',
-      'clientId' => '1000019089',
+      'clientId' => client.warehouse_id.to_s,
       'mciUniqId' => 1_000_119_810,
       'firstName' => 'first',
       'middleName' => nil,


### PR DESCRIPTION
## Description

Follow-up to https://github.com/greenriver/hmis-warehouse/pull/3543

Our source Client ID is the destination id, so that is what we are receiving back from the warehouse changes API.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
