### PR TITLE
Resolve HUD Chronic on referred hoh, check perms on project

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -7837,6 +7837,7 @@ type ReferralPosting {
   hohName: String!
   householdMembers: [ReferralHouseholdMember!]!
   householdSize: Int!
+  hudChronic: Boolean
   id: ID!
   needsWheelchairAccessibleUnit: Boolean
   organization: Organization

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -16,6 +16,7 @@ module Types
     field :referred_by, String, null: false
     field :referral_notes, String
     field :chronic, Boolean
+    field :hud_chronic, Boolean
     field :score, Integer
     field :needs_wheelchair_accessible_unit, Boolean
 
@@ -85,6 +86,19 @@ module Types
 
     def household_size
       household_members.size
+    end
+
+    def hud_chronic
+      # HUD Chronic status for the client that was referred as HoH
+      referred_hoh_client = hoh_member&.client
+      return unless referred_hoh_client.present?
+
+      # Users can see HUD Chronic status for clients being referred to their program, even if the client isn't enrolled yet.
+      # That's why the "entity" is project and not client.
+      return unless current_permission?(permission: :can_view_hud_chronic_status, entity: project)
+
+      # client.hud_chronic causes n+1 queries, only use when resolving 1 posting
+      !!referred_hoh_client.hud_chronic?(scope: referred_hoh_client.enrollments)
     end
 
     def referred_from


### PR DESCRIPTION
## Description

- If a user has permission to see HUD Chronic details within their program, they should be able to see it on clients that are assigned to their program even if they're not enrolled yet.
- Also fixes bug where Referral Detail page was not showing the HUD Chronic status for Assigned referrals, because it was going through the enrollment to find the client (which didnt exist yet). Use ReferralHouseholdMembers instead

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
