### PR TITLE
Increase MCI timeout, add additional logging/error handling for MCI & LINK

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
@@ -113,6 +113,7 @@ module Mutations
       # Contact date should only be present when changing to AcceptedPending or DeniedPending
       contact_date = ['accepted_pending_status', 'denied_pending_status'].include?(posting.status) ? Time.current : nil
 
+      Rails.logger.info "Updating status in LINK for posting #{posting.identifier} from posting form"
       HmisExternalApis::AcHmis::UpdateReferralPostingJob.perform_now(
         posting_id: posting.identifier,
         posting_status_id: posting.status_before_type_cast,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
@@ -29,24 +29,24 @@ module HmisExternalApis::AcHmis
     end
 
     def create_referral_request(payload)
-      conn.post('Referral/ReferralRequest', format_payload(payload))
-        .then { |r| handle_error(r) }
+      conn.post('Referral/ReferralRequest', format_payload(payload)).
+        then { |r| handle_error(r) }
     end
 
     def void_referral_request(referral_request_id:, requested_by:)
       payload = format_payload({ is_void: true, requested_by: requested_by })
-      conn.patch("Referral/ReferralRequest/#{referral_request_id}", payload)
-        .then { |r| handle_error(r) }
+      conn.patch("Referral/ReferralRequest/#{referral_request_id}", payload).
+        then { |r| handle_error(r) }
     end
 
     def update_unit_capacity(payload)
-      conn.patch('Unit/Capacity', format_payload(payload))
-        .then { |r| handle_error(r) }
+      conn.patch('Unit/Capacity', format_payload(payload)).
+        then { |r| handle_error(r) }
     end
 
     def update_referral_posting_status(payload)
-      conn.patch('Referral/PostingStatus', format_payload(payload, id_variant: 'Id'))
-        .then { |r| handle_error(r) }
+      conn.patch('Referral/PostingStatus', format_payload(payload, id_variant: 'Id')).
+        then { |r| handle_error(r) }
     end
 
     def active_referral_mci_ids

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_connection.rb
@@ -79,6 +79,13 @@ module HmisExternalApis
         url: url,
         request_log: request_log,
       )
+    rescue OAuth2::TimeoutError, OAuth2::ConnectionError => e
+      OauthClientResult.new(
+        body: e.message.presence || 'Unknown Error',
+        error: try_parse_json(e.message) || e.message.presence || 'Unknown Error',
+        error_type: e.class.name,
+        request_log: request_log,
+      )
     rescue OAuth2::Error => e
       OauthClientResult.new(
         body: result&.body || e.message,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
@@ -16,8 +16,6 @@ module HmisExternalApis
         requested_at: Time.current,
         response: 'pending', # can't be null
       )
-      # Capture logging to stdout too, because ExternalRequestLog creation is sometimes being rolled back in transactions
-      Rails.logger.info "ExternalRequestLog request captured: URL:#{url}, PAYLOAD:#{payload || ''}"
 
       result = nil
       begin
@@ -37,8 +35,8 @@ module HmisExternalApis
     end
 
     def update_log_record(record, attrs)
-      # Capture logging to stdout too, because ExternalRequestLog update is sometimes being rolled back in transactions
-      Rails.logger.info "ExternalRequestLog #{record.id} result captured: #{attrs}"
+      # Capture logging to stdout too, because ExternalRequestLog is sometimes being rolled back in transactions
+      Rails.logger.info "ExternalRequestLog captured: URL:#{record.url}, REQUEST:#{record.payload}, RESPONSE:#{attrs}"
       record.update!(attrs)
     end
   end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
@@ -16,6 +16,9 @@ module HmisExternalApis
         requested_at: Time.current,
         response: 'pending', # can't be null
       )
+      # Capture logging to stdout too, because ExternalRequestLog creation is sometimes being rolled back in transactions
+      Rails.logger.info "ExternalRequestLog request captured: URL:#{url}, PAYLOAD:#{payload || ''}"
+
       result = nil
       begin
         result = yield
@@ -34,6 +37,8 @@ module HmisExternalApis
     end
 
     def update_log_record(record, attrs)
+      # Capture logging to stdout too, because ExternalRequestLog update is sometimes being rolled back in transactions
+      Rails.logger.info "ExternalRequestLog #{record.id} result captured: #{attrs}"
       record.update!(attrs)
     end
   end


### PR DESCRIPTION
## Description

* Increase MCI timeout to 10 seconds
* Handle [oauth connection and timeout errors](https://gitlab.com/oauth-xx/oauth2/-/blob/main/lib/oauth2/client.rb#L12) so that users get accurate message about the failure, and so that we store more managable information in the ExternalRequestLog
* Add more stdout logging for LINK since some ExternalRequestLogs are swallowed by failed transactions

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
