### PR TITLE
Fix bug in numUnitsAssignedToHousehold

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -266,9 +266,8 @@ module Types
     # ALERT: n+1, dont use when resolving multiple enrollments
     def num_units_assigned_to_household
       object.household_members.
-        joins(:current_unit).
-        pluck(Hmis::Unit.arel_table[:id]).
-        uniq.size
+        map { |hhm| hhm.current_unit&.id }.
+        compact.uniq.size
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -299,8 +299,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       unit2 = create(:hmis_unit, project: p1)
       e3 = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id)
       create(:hmis_unit_occupancy, unit: unit2, enrollment: e3, start_date: e3.entry_date)
-      e4 = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id)
-      create(:hmis_unit_occupancy, unit: unit2, enrollment: e4, start_date: e4.entry_date)
+      e4 = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: e1.household_id, entry_date: 2.weeks.ago)
+      create(:hmis_unit_occupancy, unit: unit2, enrollment: e4, start_date: e4.entry_date + 2.days)
+      # previous occupancy in another unit should not be counted
+      create(:hmis_unit_occupancy, enrollment: e4, start_date: e4.entry_date, end_date: e4.entry_date + 2.day)
 
       response, result = post_graphql(id: e1.id) { enrollment_query }
       expect(response.status).to eq 200


### PR DESCRIPTION
## Description

Fix a bug where previously occupied units were being included in the unit count. Includes regression test

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
