### PR TITLE
Raise exceptions for bad states from SubmitHouseholdAssessments, warn about dup updates/annuals

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -113,6 +113,14 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
     data_collection_stage == 3
   end
 
+  def annual?
+    data_collection_stage == 5
+  end
+
+  def update?
+    data_collection_stage == 2
+  end
+
   def save_submitted_assessment!(current_user:, as_wip: false)
     Hmis::Hud::CustomAssessment.transaction do
       # Save FormProcessor to save wip values and/or related records

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -43,6 +43,11 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_many :assessments, **hmis_enrollment_relation('Assessment'), inverse_of: :enrollment, dependent: :destroy
   # Custom Assessments
   has_many :custom_assessments, **hmis_enrollment_relation('CustomAssessment'), inverse_of: :enrollment, dependent: :destroy
+  has_one :intake_assessment, -> { intakes }, **hmis_enrollment_relation('CustomAssessment')
+  has_one :exit_assessment, -> { exits }, **hmis_enrollment_relation('CustomAssessment')
+  has_many :update_assessments, -> { updates }, **hmis_enrollment_relation('CustomAssessment')
+  has_many :annual_assessments, -> { annuals }, **hmis_enrollment_relation('CustomAssessment')
+  has_many :post_exit_assessments, -> { post_exits }, **hmis_enrollment_relation('CustomAssessment')
 
   # Files
   has_many :files, class_name: '::Hmis::File', dependent: :destroy, inverse_of: :enrollment
@@ -273,14 +278,6 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
       wip&.destroy
       save!
     end
-  end
-
-  def intake_assessment
-    custom_assessments.intakes.first
-  end
-
-  def exit_assessment
-    custom_assessments.exits.first
   end
 
   def in_progress?

--- a/drivers/hmis/app/models/hmis/hud/validators/custom_assessment_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/custom_assessment_validator.rb
@@ -5,6 +5,14 @@
 ###
 
 class Hmis::Hud::Validators::CustomAssessmentValidator < Hmis::Hud::Validators::BaseValidator
+  def self.already_has_annual_full_message(date)
+    "Client already has an annual assessment on the same date (#{date.strftime('%m/%d/%Y')})"
+  end
+
+  def self.already_has_update_full_message(date)
+    "Client already has an update assessment on the same date (#{date.strftime('%m/%d/%Y')})"
+  end
+
   # Validate assessment date
   def self.validate_assessment_date(assessment, household_members: nil, options: {})
     date = assessment.assessment_date
@@ -47,6 +55,21 @@ class Hmis::Hud::Validators::CustomAssessmentValidator < Hmis::Hud::Validators::
 
     # Add Exit Date validations if this is an intake assessment
     errors.push(*Hmis::Hud::Validators::ExitValidator.validate_exit_date(enrollment.exit, household_members: household_members, options: options)) if assessment.exit?
+
+    # HUD Annual/Update assessment date validations
+    if assessment.annual?
+      other_annual_dates = enrollment.annual_assessments.where.not(id: assessment.id).pluck(:assessment_date)
+      # Warning: shouldn't have 2 annuals on the same day.
+      # This could probably be an error, but, the user doesnt necessarily have access to delete the dup. Can make it a hard stop later if desired.
+      errors.add :assessment_date, :invalid, severity: :warning, full_message: already_has_annual_full_message(date), **options if other_annual_dates.include?(date)
+      # TODO: warn if annual is close to another annual?
+      # TODO: warn about relationship to other annuals dates?
+
+    elsif assessment.update?
+      other_update_dates = enrollment.update_assessments.where.not(id: assessment.id).pluck(:assessment_date)
+      # Warning: shouldn't have 2 updates on the same day
+      errors.add :assessment_date, :invalid, severity: :warning, full_message: already_has_update_full_message(date), **options if other_update_dates.include?(date)
+    end
 
     errors.deduplicate! # Drop any duplicates from entry/exit and default
     errors.errors

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
@@ -177,16 +177,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         submissions: @wip_assessment_ids,
         confirmed: true,
       }
-      response, result = post_graphql(input: input) { mutation }
-      assessments = result.dig('data', 'submitHouseholdAssessments', 'assessments')
-      errors = result.dig('data', 'submitHouseholdAssessments', 'errors')
-
-      aggregate_failures 'checking response' do
-        expect(response.status).to eq(200), result&.inspect
-        expect(assessments).to be_nil
-        expect(errors.size).to eq(1)
-        expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'Assessments must all belong to the same household.')])
-      end
+      expect_gql_error post_graphql(input: input) { mutation }
     end
   end
 


### PR DESCRIPTION
## Description

* raise exceptions when submitting household assessments for bad states we don't expect, so we can track them in Sentry
* warn if there are 2 updates or annuals with the same date

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
