### PR TITLE
Adds support for bluegreen deployments

### DIFF
--- a/app/models/health/agency_performance.rb
+++ b/app/models/health/agency_performance.rb
@@ -199,12 +199,19 @@ module Health
 
     def with_required_wellcare_visit
       anchor = [@range.last, Date.current].min
-      @with_required_wellcare_visit ||= ClaimsReporting::MedicalClaim.
-        annual_well_care_visits.
-        service_in(anchor - WELLCARE_WINDOW ... anchor).
-        joins(:patient).
-        where(hp_t[:id].in(patient_ids)).
-        pluck(hp_t[:id]).uniq
+      @with_required_wellcare_visit ||=
+        begin
+          set = Set.new
+          patient_ids.each_slice(100).each do |patient_id_slice|
+            set << ClaimsReporting::MedicalClaim.
+              annual_well_care_visits.
+              service_in(anchor - WELLCARE_WINDOW ... anchor).
+              joins(:patient).
+              where(hp_t[:id].in(patient_id_slice)).
+              pluck(hp_t[:id])
+          end
+          set.to_a
+        end
     end
   end
 end

--- a/app/models/health/release_form.rb
+++ b/app/models/health/release_form.rb
@@ -37,7 +37,7 @@ module Health
     scope :recent, -> { order(signature_on: :desc).limit(1) }
     scope :reviewed, -> { where.not(reviewed_by_id: nil) }
     scope :valid, -> do
-      parent_ids = Health::ReleaseFormFile.where.not(parent_id: nil).pluck(:parent_id)
+      parent_ids = Health::ReleaseFormFile.where.not(parent_id: nil).select(:parent_id)
       where.not(file_location: [nil, '']).
         or(where(id: parent_ids))
     end

--- a/app/models/health/team_performance.rb
+++ b/app/models/health/team_performance.rb
@@ -165,12 +165,20 @@ module Health
 
     def with_required_wellcare_visit
       anchor = [@range.last, Date.current].min
-      @with_required_wellcare_visit ||= ClaimsReporting::MedicalClaim.
-        annual_well_care_visits.
-        service_in(anchor - WELLCARE_WINDOW... anchor).
-        joins(:patient).
-        where(hp_t[:id].in(patient_ids)).
-        pluck(hp_t[:id]).uniq
+      @with_required_wellcare_visit ||=
+        begin
+          set = Set.new
+          patient_ids.each_slice(100).each do |patient_id_slice|
+            set << ClaimsReporting::MedicalClaim.
+              annual_well_care_visits.
+              service_in(anchor - WELLCARE_WINDOW... anchor).
+              joins(:patient).
+              where(hp_t[:id].in(patient_id_slice)).
+              pluck(hp_t[:id])
+          end
+
+          set.to_a
+        end
     end
   end
 end

--- a/bin/test-bg
+++ b/bin/test-bg
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+# Runs with
+# Get target_group_name from secrets yaml
+# aws-vault exec $VAULT_PROFILE -- docker compose run --no-deps --entrypoint='' --rm web bundle exec rails runner ./bin/test-bg
+# aws-vault exec $VAULT_PROFILE -- docker compose run --no-deps --entrypoint='' --rm web bundle exec rails runner ./bin/test-bg
+
+require_relative '../config/deploy/docker/lib/blue_green'
+
+ENV['RAILS_LOG_TO_STDOUT'] = 'true'
+
+class BlueGreenTest
+  attr_accessor :results
+
+  def initialize
+    self.results = {}
+  end
+
+  def test_sample
+    secrets = YAML.load_file("config/deploy/docker/assets/secret.deploy.values.yml", aliases: true)
+    target_group_names = secrets.dig('warehouse').values.map { |x| x.first && x.first[:target_group_name] }.compact
+
+    sample = target_group_names.sample(3)
+    sample << 'qa-warehouse-staging-ecs'
+    sample << 'qa-hmis-fe-hmis-staging-ecs'
+    sample.uniq!
+
+    sample.each do |target_group_name|
+      test_one(target_group_name)
+    end
+
+    ap(results)
+  end
+
+  def test_one(target_group_name)
+    bg = BlueGreen.new(target_group_name)
+    bg.check!
+
+    results.merge!(
+      {
+        target_group_name => {
+          chossen: bg.target_group_to_deploy_to.target_group_arn,
+          preview: bg.preview_target_group&.target_group_arn,
+          stable: bg.stable_target_group.target_group_arn,
+          bg_listener_rules: bg.listener_rules_summary,
+        },
+      },
+    )
+  end
+end
+
+BlueGreenTest.new.test_sample

--- a/config/deploy/docker/lib/blue_green.rb
+++ b/config/deploy/docker/lib/blue_green.rb
@@ -1,0 +1,150 @@
+require 'aws-sdk-elasticloadbalancingv2'
+
+# This class helps coordinate with the HMIS frontend (if one exists) to make
+# both systems go live at roughly the same time.
+#
+# If there is only one target group, this should behave like it did previously.
+class BlueGreen
+  attr_accessor :target_group_name
+
+  def initialize(target_group_name)
+    self.target_group_name = target_group_name
+  end
+
+  # Deploy to preview if bluegreen is set up, otherwise deploy to the only
+  # target group available
+  def target_group_to_deploy_to
+    return target_groups[0] if target_groups.length == 1
+
+    stable_target_group_empty? and puts "[WARN] Looks like this is your first deployment. It won't go live until you deploy the HMIS front-end"
+
+    puts '[INFO] Deploying to the preview target group since bluegreen is detected'
+
+    if ENV['DEPLOY_TO_STABLE'] == 'true'
+      stable_target_group
+    else
+      preview_target_group
+    end
+  end
+
+  def check!
+    # raise 'target groups are not properly labeled yet. Deploy the HMIS front-end and try again' if preview_target_group_arn.nil? && target_groups.length > 1
+
+    raise "You shouldn't have zero target groups for #{target_group_name}" if target_groups.empty?
+
+    raise "You shouldn't have more than 2 target groups" if target_groups.length > 2
+
+    return unless target_groups.length == 2
+
+    # For bluegreen enabled deployments there are more checks
+    raise 'The number of target groups should match the number of listener rules when bluegreen is enabled' if listener_rules.length != 2 && !preview_target_group_arn.nil?
+
+    preview = listener_rules.find { |lr| lr.blue_green_state == 'preview' }
+    stable = listener_rules.reject { |lr| lr.blue_green_state == 'preview' }.first
+    listener_rule_not_sane = preview.priority.to_i > stable.priority.to_i
+    raise 'The preview listener rule should have a smaller priority number (i.e. higher priority)' if listener_rule_not_sane
+  end
+
+  def preview_target_group
+    target_groups.find { |tg| tg.blue_green_state == 'preview' }
+  end
+
+  def stable_target_group
+    target_groups.find { |tg| tg.blue_green_state == 'stable' || tg.blue_green_state.nil? }
+  end
+
+  def listener_rules_summary
+    listener_rules.map do |lr|
+      condition_that_matters = lr.conditions.select(&:http_header_config).map(&:http_header_config).map { |x| { x.http_header_name => x.values.first } }.first
+      {
+        target_group: lr.actions.first.target_group_arn,
+        priority: lr.priority,
+        conditions: condition_that_matters,
+      }
+    end
+  end
+
+  private
+
+  def stable_target_group_empty?
+    resp = elbv2.describe_target_health(target_group_arn: stable_target_group.target_group_arn)
+
+    resp.target_health_descriptions.empty?
+  end
+
+  def listener_rules
+    return @listener_rules unless @listener_rules.nil?
+
+    listener_arn = target_group_name.match?(/ost/) ? ENV.fetch('ALTERNATE_LISTENER_ARN') : ENV.fetch('LISTENER_ARN')
+    results = elbv2.describe_rules(listener_arn: listener_arn)
+
+    @listener_rules = []
+
+    results.each do |page|
+      @listener_rules += page.rules.filter_map do |lr|
+        resp = elbv2.describe_tags(resource_arns: [lr.rule_arn])
+        tags = tags_as_hash(resp.tag_descriptions[0].tags)
+
+        relevant = tags['BlueGreenGroup'] == target_group_name
+
+        if relevant
+          lr.define_singleton_method(:tags) { tags }
+          lr.define_singleton_method(:blue_green_group) { tags['BlueGreenGroup'] }
+          lr.define_singleton_method(:blue_green_state) { tags['BlueGreenState'] }
+          lr
+        end
+      end
+    end
+
+    @listener_rules
+  end
+
+  # Relevant target groups annotated with bluegreen information and tags
+  def target_groups
+    return @target_groups unless @target_groups.nil?
+
+    results = elbv2.describe_target_groups
+
+    @target_groups = []
+
+    results.each do |page|
+      @target_groups += page.target_groups.filter_map do |tg|
+        # This speeds thing up since all the relevant target groups start with
+        # the same characters
+        next unless tg.target_group_name.start_with?(target_group_name[0..5])
+
+        resp = elbv2.describe_tags(resource_arns: [tg.target_group_arn])
+        tags = tags_as_hash(resp.tag_descriptions[0].tags)
+
+        relevant = tags['BlueGreenGroup'] == target_group_name || tg.target_group_name == target_group_name
+
+        if relevant
+          tg.define_singleton_method(:tags) { tags }
+          tg.define_singleton_method(:blue_green_group) { tags['BlueGreenGroup'] }
+          tg.define_singleton_method(:blue_green_state) { tags['BlueGreenState'] }
+          tg
+        end
+      end
+    end
+
+    @target_groups
+  end
+
+  def elbv2
+    Aws::ElasticLoadBalancingV2::Client.new
+  end
+
+  def tags_as_hash(tags)
+    tags.map do |t|
+      [t.key, t.value]
+    end.to_h
+  end
+end
+
+if ENV['RUN'] == 'true'
+  qa = BlueGreen.new('qa-warehouse-staging-ecs')
+  qa.check!
+
+  hmis = BlueGreen.new('qa-hmis-fe-hmis-staging-ecs')
+  hmis.check!
+end

--- a/db/health/migrate/20240318191704_add_indexes.rb
+++ b/db/health/migrate/20240318191704_add_indexes.rb
@@ -1,0 +1,7 @@
+class AddIndexes < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_index :medications, :patient_id
+    end
+  end
+end

--- a/db/health_structure.sql
+++ b/db/health_structure.sql
@@ -8364,6 +8364,13 @@ CREATE INDEX index_loaded_ed_ip_visits_on_updated_at ON public.loaded_ed_ip_visi
 
 
 --
+-- Name: index_medications_on_patient_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_medications_on_patient_id ON public.medications USING btree (patient_id);
+
+
+--
 -- Name: index_member_status_report_patients_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9275,6 +9282,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230807201621'),
 ('20230814153918'),
 ('20230816173812'),
-('20240126184731');
+('20240126184731'),
+('20240318191704');
 
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -59,6 +59,8 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :services, through: :enrollments_including_wip
   has_many :custom_services, through: :enrollments_including_wip
 
+  accepts_nested_attributes_for :affiliations, allow_destroy: true
+
   # FIXME: joining services through enrollments confounds postgres. On larger projects, the query might take many
   # minutes. It needs optimization; for now we use a class method instead of a AR association
   # has_many :hmis_services, through: :enrollments_including_wip

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/base_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/base_loader.rb
@@ -110,9 +110,9 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     def yn_boolean(str)
       case str
-      when /^(y|yes)$/i
+      when /^(t|y|yes)$/i
         true
-      when /^(n|no)$/i
+      when /^(f|n|no)$/i
         false
       when '.'
         # for element 12180 in the HAT, the dot appears to mean 'true'
@@ -164,7 +164,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     def placeholder_service_category
       @placeholder_service_category ||= Hmis::Hud::CustomServiceCategory.where(data_source: data_source, name: 'placeholder service category').first_or_create! do |cat|
-        cat.UserID = system_hud_user.id
+        cat.UserID = system_hud_user.user_id
       end
     end
 
@@ -210,9 +210,9 @@ module HmisExternalApis::TcHmis::Importers::Loaders
       end
     end
 
-    def log_skipped_row(row, field:)
+    def log_skipped_row(row, field:, prefix: nil)
       value = row.field_value(field)
-      log_info "#{row.context} could not resolve \"#{field}\":\"#{value}\""
+      log_info "#{row.context} #{prefix} could not resolve \"#{field}\":\"#{value}\""
     end
 
     def log_processed_result(name: nil, expected:, actual:)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
@@ -107,7 +107,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           CustomAssessmentID: row_assessment_id(row),
           EnrollmentID: enrollment_id,
           PersonalID: personal_id,
-          UserID: system_hud_user.id,
+          UserID: system_hud_user.user_id,
           AssessmentDate: row_assessment_date(row),
           DataCollectionStage: 99,
           wip: false,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
@@ -41,6 +41,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     private def process_file(filename)
       create_service_types
+      create_cdeds
       rows = @reader.rows(filename: filename, header_row_number: 2, field_id_row_number: nil).to_a
       extrapolate_missing_enrollment_ids(rows, enrollment_id_field: ENROLLMENT_ID)
 
@@ -58,8 +59,21 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
       configs.values.each do |value|
         Hmis::Hud::CustomServiceType.where(data_source_id: data_source.id).where(name: value.fetch(:service_type)).first_or_create! do |st|
-          st.UserID = system_hud_user.id
+          st.UserID = system_hud_user.user_id
           st.custom_service_category_id = placeholder_service_category.id
+        end
+      end
+    end
+
+    private def create_cdeds
+      configs.each_value do |config|
+        config[:elements].each_value do |element_config|
+          cde_helper.find_or_create_cded(
+            owner_type: service_class.name,
+            key: element_config.fetch(:key),
+            field_type: element_config.fetch(:field_type, 'string'),
+            repeats: element_config[:repeats],
+          )
         end
       end
     end
@@ -100,8 +114,8 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           response_id = row.field_value(RESPONSE_ID, required: true)
           expected.add(response_id)
 
-          row_field_value = row.field_value(TOUCHPOINT_NAME, required: true)
-          config = configs[row_field_value]
+          touch_point_name = row.field_value(TOUCHPOINT_NAME, required: true)
+          config = configs[touch_point_name]
           if config.blank?
             log_skipped_row(row, field: TOUCHPOINT_NAME)
             next
@@ -117,7 +131,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           row_field_value = row_enrollment_id(row)
           enrollment = row_field_value ? enrollments[row_field_value] : nil
           if enrollment.blank?
-            log_skipped_row(row, field: ENROLLMENT_ID)
+            log_skipped_row(row, field: ENROLLMENT_ID, prefix: touch_point_name)
             next
           end
 
@@ -125,7 +139,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             CustomServiceID: generate_service_id(config, row),
             EnrollmentID: enrollment.EnrollmentID,
             PersonalID: enrollment.PersonalID,
-            UserID: system_hud_user.id,
+            UserID: system_hud_user.user_id,
             DateProvided: row_date_provided(row),
             data_source_id: data_source.id,
             custom_service_type_id: service_type_id,
@@ -140,10 +154,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           service_field = config[:service_fields][row.field_value(QUESTION)]
           next unless service_field.present? # Don't log this, if there is a problem, we will find it in create_records
 
-          row_value = row.field_value(ANSWER)
-          value = row_value ? service_field[:cleaner].call(row_value) : nil
-
-          services[response_id][service_field[:key]] = value
+          services[response_id][service_field[:key]] = cleaned_row_answer(row, service_field)
         end
       end
       log_processed_result(name: 'create services', expected: expected.size, actual: result.size)
@@ -152,6 +163,13 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     private def generate_service_id(config, row)
       "#{config[:id_prefix]}-#{row.field_value(RESPONSE_ID)}"
+    end
+
+    def cleaned_row_answer(row, service_field)
+      row_value = row.field_value(ANSWER)
+      return nil unless row_value
+
+      service_field[:cleaner] ? service_field[:cleaner].call(row_value) : row_value
     end
 
     def row_question_value(row)
@@ -173,11 +191,11 @@ module HmisExternalApis::TcHmis::Importers::Loaders
       records = [].tap do |cdes|
         rows.each do |row|
           expected += 1
-          row_field_value = row.field_value(TOUCHPOINT_NAME)
-          config = configs[row_field_value]
+          touch_point_name = row.field_value(TOUCHPOINT_NAME)
+          config = configs[touch_point_name]
           next if config.blank?
 
-          seen.add(row_field_value)
+          seen.add(touch_point_name)
 
           row_field_value = row_question_value(row)
           if config[:service_fields].keys.include?(row_field_value)
@@ -188,7 +206,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
           element = config[:elements][row_field_value]
           if element.blank?
-            log_skipped_row(row, field: QUESTION)
+            log_skipped_row(row, field: QUESTION, prefix: touch_point_name)
             next
           end
 
@@ -199,8 +217,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           actual += 1
 
           key = element[:key]
-          row_value = row.field_value(ANSWER)
-          answer = row_value ? element[:cleaner].call(row_value) : nil
+          answer = cleaned_row_answer(row, element)
           Array.wrap(answer).each do |value|
             cdes << cde_helper.new_cde_record(value: value, owner_type: service_class.name, owner_id: service.id, definition_key: key)
           end
@@ -226,14 +243,15 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Number of Pantry Bags' => {
               key: :food_service_pantry_bags_quantity,
               cleaner: ->(quantity) { quantity.to_i },
+              field_type: :integer,
             },
             'Number of people in the household' => {
               key: :food_service_household_size,
               cleaner: ->(size) { size.to_i },
+              field_type: :integer,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -243,6 +261,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Cost' => {
               key: :FAAmount,
               cleaner: ->(amount) { amount.to_f },
+              field_type: :float,
             },
           },
           id_prefix: 'transport',
@@ -253,15 +272,14 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             },
             'Value' => {
               key: :transportation_type,
-              cleaner: ->(type) { type },
             },
             'Quantity' => {
               key: :transportation_quantity,
               cleaner: ->(quantity) { quantity.to_i },
+              field_type: :integer,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -277,14 +295,15 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Items' => {
               key: :baby_supplies_items,
               cleaner: ->(items) { items.split('|') },
+              repeats: true,
             },
             'Quantity' => {
               key: :baby_supplies_quantity,
               cleaner: ->(quantity) { quantity.to_i },
+              field_type: :integer,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -298,19 +317,15 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           },
           id_prefix: 'goods',
           elements: {
-            elements: {
-              'Contact Location/Method' => {
-                key: :service_contact_location,
-                cleaner: ->(location) { normalize_location(location) },
-              },
-              'Value' => {
-                key: :financial_assistance_type,
-                cleaner: ->(type) { type },
-              },
-              'Case Notes' => {
-                key: :service_notes,
-                cleaner: ->(note) { note },
-              },
+            'Contact Location/Method' => {
+              key: :service_contact_location,
+              cleaner: ->(location) { normalize_location(location) },
+            },
+            'Value' => {
+              key: :financial_assistance_type,
+            },
+            'Case Notes' => {
+              key: :service_note,
             },
           },
         },
@@ -322,14 +337,13 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Time Spent' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
             },
             '.' => { # label in eto is just a period
               key: :service_benefits_contact_attempt,
-              cleaner: ->(type) { type },
             },
             'Notes:' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -340,15 +354,26 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           elements: {
             'Service' => {
               key: :service_benefits_type,
-              cleaner: ->(type) { type },
             },
             'Time Spent total time spend working with the client in person or on their behalf.' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
+            },
+            'Monthly SSI/SSDI Payment/Retirement' => {
+              key: :service_benefits_ssi,
+              field_type: :float,
+            },
+            'Lump Payment' => {
+              key: :service_lump_payment,
+              field_type: :float,
+            },
+            'SNAPS Amount' => {
+              key: :service_snaps_amount,
+              field_type: :float,
             },
             'Note' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -366,8 +391,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
               cleaner: ->(type) { normalize_contact(type) },
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -376,13 +400,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           service_fields: {},
           id_prefix: 'dh-cm',
           elements: {
-            # FIXME: the full label that comes through from ETO for 'Contact Location/Method' is below. Maybe we can split labels by newline and drop the rest before trying to match?
-            # "Service Location
-
-            # Residential (if the service was provided in the clients home/apartment/ etc)
-            # Non-residential (If the service was provided in any other shelterd place but their home)
-            # Place not meant for habitation (Unsheltered place -under bridge, camp sides, on the streets, outside, etc -)"
-            'Service Location' => { # FIXME
+            'Service Location' => {
               key: :service_contact_location,
               cleaner: ->(location) { normalize_location(location) },
             },
@@ -393,10 +411,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Time Spent' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -412,10 +430,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Value' => {
               key: :service_drug_tests_provided,
               cleaner: ->(tests) { tests.split('|') },
+              repeats: true,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -433,8 +451,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
               cleaner: ->(time) { parse_duration(time) },
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -450,10 +467,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Time Spend' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -469,10 +486,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             'Value' => {
               key: :medication_supervision_value,
               cleaner: ->(value) { yn_boolean(value) },
+              field_type: :boolean,
             },
             'Case Notes' => {
-              key: :service_notes,
-              cleaner: ->(note) { note },
+              key: :service_note,
             },
           },
         },
@@ -483,11 +500,11 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           elements: {
             'Service Location' => {
               key: :service_location_text,
-              cleaner: ->(service_location) { service_location },
             },
             'Time Spent' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
             },
           },
         },
@@ -501,21 +518,26 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           },
           id_prefix: 'cm-notes',
           elements: {
-            'Contact Location/Method' => {
+            'Service Location' => {
               key: :service_contact_location,
               cleaner: ->(location) { normalize_location(location) },
             },
             'Time Spent' => {
               key: :service_time_spent,
               cleaner: ->(time) { parse_duration(time) },
+              field_type: :integer,
             },
             'Type of Contact' => {
               key: :service_contact_type,
               cleaner: ->(type) { normalize_contact(type) },
             },
-            'When We Love Services Provided' => {
+            'When We Love: Services Provided' => {
               key: :services_provided_when_we_love,
               cleaner: ->(services) { services.split('|') },
+              repeats: true,
+            },
+            'Case Notes' => {
+              key: :service_note,
             },
           },
         },
@@ -538,10 +560,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           'Time Spent on Contact' => {
             key: :service_time_spent,
             cleaner: ->(time) { parse_duration(time) },
+            field_type: :integer,
           },
           'Case Notes' => {
-            key: :service_notes,
-            cleaner: ->(note) { note },
+            key: :service_note,
           },
         },
       }.dup.freeze

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/meals_services_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/meals_services_loader.rb
@@ -82,10 +82,10 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           EnrollmentID: enrollment_id,
           PersonalID: personal_id,
           DateProvided: date_provided,
-          UserID: system_hud_user.id,
+          UserID: system_hud_user.user_id,
           data_source_id: data_source.id,
           custom_service_type_id: service_type.id,
-          service_name: service_type,
+          service_name: service_type.name,
           DateCreated: today,
           DateUpdated: today,
           FAAmount: nil,
@@ -98,8 +98,9 @@ module HmisExternalApis::TcHmis::Importers::Loaders
     end
 
     def create_service_type
-      Hmis::Hud::CustomServiceType.where(data_source: data_source).where(name: service_type_name).first_or_create! do |st|
-        st.UserID = system_hud_user.id
+      service_name = service_type_name.split(' ').last # drop 1A-SA prefix
+      Hmis::Hud::CustomServiceType.where(data_source: data_source).where(name: service_name).first_or_create! do |st|
+        st.UserID = system_hud_user.user_id
         st.custom_service_category_id = placeholder_service_category.id
       end
     end


### PR DESCRIPTION
## Description

- orchestrated via argo rollouts on the EKS side in the HMIS frontend
- if there's only one target group, the behavior should remain the same
- if there's two target groups (i.e. bluegreen is set up), then it deploys to the preview target group. It will not be immediately live.
- Deployers need to set LISTENER_ARN and ALTERNATE_LISTENER_ARN in their `.env.local` file. Talk to DevOps for the values. It's the ECS https listener and the one for a single installation.
- Blue/Green is turned off at the target group / listener rule level so this PR shouldn't have any real affect. It just lets us turn on blue/green when we have it working on the front end.

## Type of change

- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
