### PR TITLE
Dont hide acl filter when no results

### DIFF
--- a/drivers/hmis/app/views/hmis_admin/access_controls/index.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/index.haml
@@ -9,8 +9,8 @@
   = link_to new_hmis_admin_access_control_path, class: 'btn btn-primary mb-2' do
     %span.icon-plus
     Create a new Access Control
+= render 'filter'
 - if @pagy.count.positive?
-  = render 'filter'
   = render 'common/pagination_top', item_name: 'access control list'
   .table-responsive
     %table.table.table-striped


### PR DESCRIPTION
## Description

Bug: filter was hidden if there were no results

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
