### PR TITLE
Support re-enrollment in household

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -212,8 +212,7 @@ module Types
     end
 
     def household_size
-      # FIXME: N+1
-      household.clients.distinct.size
+      load_ar_association(household, :enrollments).map(&:personal_id).uniq.size
     end
 
     def in_progress

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -212,7 +212,8 @@ module Types
     end
 
     def household_size
-      load_ar_association(household, :enrollments).size
+      # FIXME: how to avoid N+1 here?
+      household.clients.distinct.size
     end
 
     def in_progress

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -212,7 +212,7 @@ module Types
     end
 
     def household_size
-      # FIXME: how to avoid N+1 here?
+      # FIXME: N+1
       household.clients.distinct.size
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -33,7 +33,8 @@ module Types
     end
 
     def household_size
-      enrollments.size
+      # FIXME: N+1
+      clients.distinct.size
     end
 
     def enrollments

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -33,8 +33,7 @@ module Types
     end
 
     def household_size
-      # FIXME: N+1
-      clients.distinct.size
+      enrollments.map(&:personal_id).uniq.size
     end
 
     def enrollments

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -81,13 +81,11 @@ module Types
     end
 
     def household_members
-      # FIXME: N+1? This is called in batch for referral posting table
-      referral.household_members
+      load_ar_association(referral, :household_members)
     end
 
     def household_size
-      # FIXME: N+1? This is called in batch for referral posting table
-      household_members.size
+      household_members.map(&:client_id).uniq.size
     end
 
     def hud_chronic

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -80,10 +80,12 @@ module Types
     end
 
     def household_members
+      # FIXME: N+1? This is called in batch for referral posting table
       referral.household_members
     end
 
     def household_size
+      # FIXME: N+1? This is called in batch for referral posting table
       household_members.size
     end
 

--- a/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
@@ -35,9 +35,9 @@ class Hmis::Hud::Validators::EnrollmentValidator < Hmis::Hud::Validators::BaseVa
   end
 
   def self.find_conflict_severity(enrollment)
-    conflict_scope = Hmis::Hud::Enrollment
-      .where(personal_id: enrollment.personal_id, data_source_id: enrollment.data_source_id)
-      .with_conflicting_dates(project: enrollment.project, range: enrollment.entry_date...enrollment.exit_date)
+    conflict_scope = Hmis::Hud::Enrollment.
+      where(personal_id: enrollment.personal_id, data_source_id: enrollment.data_source_id).
+      with_conflicting_dates(project: enrollment.project, range: enrollment.entry_date...enrollment.exit_date)
 
     if enrollment.persisted?
       # If the entry date is being changed on an EXISTING enrollment, and it overlaps with another one, it should be a warning
@@ -93,9 +93,9 @@ class Hmis::Hud::Validators::EnrollmentValidator < Hmis::Hud::Validators::BaseVa
       is_hoh = record.head_of_household?
       has_hoh = household_members.any?(&:head_of_household?)
       # Error: client is already a member of this household
-      already_in_household = household_members.where(personal_id: record.personal_id).exists?
-      errors.add :base, :invalid, full_message: duplicate_member_full_message if already_in_household
-      return errors.errors if already_in_household
+      already_enrolled = household_members.open_on_date.where(personal_id: record.personal_id).exists?
+      errors.add :base, :invalid, full_message: duplicate_member_full_message if already_enrolled
+      return errors.errors if already_enrolled
 
       # Error: adding second HoH to existing hh
       errors.add :relationship_to_hoh, :invalid, full_message: one_hoh_full_message if is_hoh && has_hoh

--- a/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
@@ -127,14 +127,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'minimizes n+1 queries' do
       expect do
         _, result = post_graphql(**variables) { query }
-        expect(result.dig('data', 'project', 'households', 'nodes').size).to eq(enrollments.size)
+        expect(result.dig('data', 'project', 'households', 'nodes').size).to eq(enrollments.size), result.inspect
       end.to make_database_queries(count: 10..30)
     end
 
     it 'is responsive' do
       expect do
         _, result = post_graphql(**variables) { query }
-        expect(result.dig('data', 'project', 'households', 'nodes').size).to eq(enrollments.size)
+        expect(result.dig('data', 'project', 'households', 'nodes').size).to eq(enrollments.size), result.inspect
       end.to perform_under(300).ms
     end
 
@@ -152,7 +152,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       it 'should only return a household once if there are both WIP and completed members' do
         _, result = post_graphql({ id: p2.id.to_s, filters: { status: ['ACTIVE', 'INCOMPLETE'] } }) { query }
         expect(Hmis::Hud::Household.where(household_id: '1').count).to eq(1)
-        expect(result.dig('data', 'project', 'households', 'nodes').count).to eq(1)
+        expect(result.dig('data', 'project', 'households', 'nodes').count).to eq(1), result.inspect
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             ... on Enrollment {
               id
               inProgress
+              householdSize
             }
             ... on CurrentLivingSituation {
               id
@@ -478,6 +479,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       errors = result.dig('data', 'submitForm', 'errors')
       expect(response.status).to eq(200), result&.inspect
       expect(errors).to be_empty
+      household_size = result.dig('data', 'submitForm', 'record', 'householdSize')
+      expect(household_size).to eq(2) # household size is 2 even though it contains 3 enrollments
     end
 
     it 'should warn if client already enrolled' do


### PR DESCRIPTION
## Description

Support re-enrolling a household member that has been previously exited form a household. Update "household size" counts to consider uniq members rather than uniq enrollments.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
