### PR TITLE
Allow deleting WIP enrollments with can_edit_enrollments

### DIFF
--- a/drivers/hmis/app/graphql/mutations/delete_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_assessment.rb
@@ -50,7 +50,7 @@ module Mutations
             record.enrollment&.accept_referral!(current_user: current_user) if record.exit? && !is_wip
 
             # Deleting the Intake Assessment deletes the enrollment
-            record.enrollment&.destroy if record.intake?
+            record.enrollment&.destroy! if record.intake?
           end,
         )
 

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -13,12 +13,17 @@ module Mutations
     def resolve(id:)
       enrollment = Hmis::Hud::Enrollment.viewable_by(current_user).find_by(id: id)
       raise HmisErrors::ApiError, 'Record not found' unless enrollment.present?
-      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
+      # WIP Enrollments can be deleted if user has "can_edit_enrollments" access for this project
+      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(enrollment, :can_edit_enrollments)
 
       errors = []
       if enrollment.in_progress?
         enrollment.destroy
       else
+        # Deleting non-WIP Enrollments requires can_delete_enrollments. Currently not supported via this mutation, though.
+        # See DeleteAssessment mutation for deletiong of non-WIP enrollments.
+        raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
+
         errors << HmisErrors::Error.new(:base, full_message: 'Completed enrollments can not be deleted. Please exit the client instead.')
       end
 

--- a/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_enrollment.rb
@@ -18,12 +18,9 @@ module Mutations
 
       errors = []
       if enrollment.in_progress?
-        enrollment.destroy
+        enrollment.destroy!
       else
-        # Deleting non-WIP Enrollments requires can_delete_enrollments. Currently not supported via this mutation, though.
-        # See DeleteAssessment mutation for deletiong of non-WIP enrollments.
-        raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(enrollment, :can_delete_enrollments)
-
+        # Deleting non-WIP Enrollments requires can_delete_enrollments, and can only occur via DeleteAssessment mutation (deleting intake)
         errors << HmisErrors::Error.new(:base, full_message: 'Completed enrollments can not be deleted. Please exit the client instead.')
       end
 

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -124,7 +124,7 @@ class Hmis::Role < ::ApplicationRecord
           'Projects',
         ],
       },
-      can_manage_inventory: {
+      can_manage_inventory: { # TODO: should be renamed to "can manage units"
         description: 'Ability to manage bed and unit capacity in the project',
         administrative: false,
         access: [:editable],
@@ -229,7 +229,7 @@ class Hmis::Role < ::ApplicationRecord
         ],
       },
       can_view_enrollment_details: {
-        description: 'Grants access to view enrollments',
+        description: 'Grants access to view enrollment details, including related records such as Assessments, Services, Current Living Situations, and more.',
         administrative: false,
         access: [:viewable],
         categories: [
@@ -245,7 +245,7 @@ class Hmis::Role < ::ApplicationRecord
         ],
       },
       can_edit_enrollments: {
-        description: 'Grants access to edit enrollments',
+        description: 'Grants access to edit enrollments, including: adding and removing household members, performing assessments, recording services, and creating and editing any other Enrollment-related records.',
         administrative: false,
         access: [:editable],
         categories: [

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -10,16 +10,11 @@ require_relative '../../support/hmis_base_setup'
 
 RSpec.describe Hmis::GraphqlController, type: :request do
   include_context 'hmis base setup'
-  let!(:access_control) { create_access_control(hmis_user, p1) }
+  let!(:access_control) { create_access_control(hmis_user, p1, with_permission: [:can_view_project, :can_view_enrollment_details, :can_view_clients]) }
   let(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
   let(:c2) { create :hmis_hud_client, data_source: ds1, user: u1 }
-  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, relationship_to_ho_h: 1, household_id: '1', user: u1 }
-  let!(:e2) do
-    enrollment = create(:hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, relationship_to_ho_h: 2, household_id: '1', user: u1)
-    enrollment.save_in_progress
-    enrollment
-  end
-  let(:new_entry_date) { Date.today - 7.days }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, relationship_to_ho_h: 1 }
+  let!(:e2) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c2, relationship_to_ho_h: 2, household_id: e1.household_id }
 
   before(:each) do
     hmis_login(user)
@@ -43,40 +38,42 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
-  it 'should not delete an enrollment that is not in progress' do
-    response, result = post_graphql(input: { id: e1.id }) { mutation }
-
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
-      errors = result.dig('data', 'deleteEnrollment', 'errors')
-      expect(enrollment).to be_present
-      expect(errors).to contain_exactly(include('fullMessage' => 'Completed enrollments can not be deleted. Please exit the client instead.'))
-      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
-        have_attributes(id: e1.id),
-        have_attributes(id: e2.id),
-      )
-    end
+  def perform_mutation(enrollment)
+    response, result = post_graphql(input: { id: enrollment.id }) { mutation }
+    expect(response.status).to eq 200
+    enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
+    errors = result.dig('data', 'deleteEnrollment', 'errors')
+    [enrollment, errors]
   end
 
-  it 'should delete an enrollment that is in progress' do
-    response, result = post_graphql(input: { id: e2.id }) { mutation }
+  it 'should not allow deleting non-WIP enrollments, even if user has permission to' do
+    # give user permission to edit/delete
+    add_permissions(access_control, :can_edit_enrollments, :can_delete_enrollments)
 
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 200
-      enrollment = result.dig('data', 'deleteEnrollment', 'enrollment')
-      errors = result.dig('data', 'deleteEnrollment', 'errors')
-      expect(enrollment).to be_present
-      expect(errors).to be_empty
-      expect(Hmis::Hud::Enrollment.all).to contain_exactly(
-        have_attributes(id: e1.id),
-      )
-    end
+    enrollment, errors = perform_mutation(e1)
+
+    expect(enrollment).to be_present
+    expect(errors).to contain_exactly(include('fullMessage' => 'Completed enrollments can not be deleted. Please exit the client instead.'))
+    expect(e1.reload).not_to be_deleted
+    expect(e2.reload).not_to be_deleted
   end
 
-  it 'should throw error if unauthorized' do
-    remove_permissions(access_control, :can_delete_enrollments)
+  it 'should allow deleting WIP enrollments' do
+    add_permissions(access_control, :can_edit_enrollments)
+    enrollment, errors = perform_mutation(e2)
+    expect(enrollment).to be_present
+    expect(errors).to be_empty
+    expect(e1.reload).not_to be_deleted
+    expect(e2.reload).to be_deleted
+  end
+
+  it 'should throw error if unauthorized (WIP and non-WIP, no access to edit enrollments)' do
+    expect_gql_error post_graphql(input: { id: e1.id }) { mutation }
     expect_gql_error post_graphql(input: { id: e2.id }) { mutation }
+  end
+  it 'should throw error if unauthorized (non-WIP, no access to delete enrollments)' do
+    add_permissions(access_control, :can_edit_enrollments)
+    expect_gql_error post_graphql(input: { id: e1.id }) { mutation }
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb
@@ -71,10 +71,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect_gql_error post_graphql(input: { id: e1.id }) { mutation }
     expect_gql_error post_graphql(input: { id: e2.id }) { mutation }
   end
-  it 'should throw error if unauthorized (non-WIP, no access to delete enrollments)' do
-    add_permissions(access_control, :can_edit_enrollments)
-    expect_gql_error post_graphql(input: { id: e1.id }) { mutation }
-  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
## Description

This was the agreed-upon behavior for "can edit enrollments", but it was not implemented correctly.

Bug: users who have "can edit enrollments" are able to add household members, but they cannot remove WIP household members if they accidentally added the wrong person.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
