### PR TITLE
Fix bug when client enrolled twice in household

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -177,8 +177,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
     case assessment_role.to_sym
     when :INTAKE, :EXIT
-      # Ensure we only return 1 assessment per person
-      household_assessments.index_by(&:personal_id).values
+      household_assessments
     when :ANNUAL
       # If we have a source, find annuals "near" it (within threshold)
       # If we don't have a source, that means this is a new annual. Include any annuals from the past 3 months.

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -177,12 +177,13 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
     case assessment_role.to_sym
     when :INTAKE, :EXIT
-      household_assessments
+      # Ensure we only return 1 assessment per enrollment
+      household_assessments.index_by(&:enrollment_id).values
     when :ANNUAL
       # If we have a source, find annuals "near" it (within threshold)
       # If we don't have a source, that means this is a new annual. Include any annuals from the past 3 months.
       source_date = source_assessment&.assessment_date || Date.current
-      household_assessments.group_by(&:personal_id).
+      household_assessments.group_by(&:enrollment_id).
         map do |_, assmts|
           nearest_assmt = assmts.min_by { |a| (source_date - a.assessment_date).abs }
           distance_in_days = (source_date - nearest_assmt.assessment_date).to_i.abs


### PR DESCRIPTION
## Description

Follow-up to https://github.com/greenriver/hmis-warehouse/pull/3626 to fix bug found in QA. Household intake/exit workflow view should show intakes/exits for all enrollments, even if some are for the same client.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
