### PR TITLE
Delete ExternalIDs when client is deleted

### DIFF
--- a/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/client_extension.rb
@@ -12,7 +12,7 @@ module HmisExternalApis
         include ExternallyIdentifiedMixin
 
         included do
-          has_many :external_ids, class_name: 'HmisExternalApis::ExternalId', as: :source
+          has_many :external_ids, class_name: 'HmisExternalApis::ExternalId', as: :source, dependent: :destroy
           has_many :external_referral_household_members, class_name: 'HmisExternalApis::AcHmis::ReferralHouseholdMember', dependent: :destroy, inverse_of: :client
           has_many :ac_hmis_mci_ids,
                    -> { where(namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID) },
@@ -37,9 +37,9 @@ module HmisExternalApis
 
           # remove referrals where this client is the the HOH
           def destroy_hoh_external_referrals
-            HmisExternalApis::AcHmis::Referral
-              .where(id: external_referral_household_members.heads_of_households.select(:referral_id))
-              .each(&:destroy!)
+            HmisExternalApis::AcHmis::Referral.
+              where(id: external_referral_household_members.heads_of_households.select(:referral_id)).
+              each(&:destroy!)
           end
 
           # Used by ClientSearch concern


### PR DESCRIPTION
## Description

When a client is deleted, its associated ExternalIds (MCI and MCI Unique, for now) should be deleted as well.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
