### PR TITLE
Task for seeding e2e data

### DIFF
--- a/drivers/hmis/lib/tasks/setup.rake
+++ b/drivers/hmis/lib/tasks/setup.rake
@@ -36,15 +36,15 @@ end
 desc 'Seed E2E HMIS test data'
 task seed_e2e: [:environment, 'log:info_to_stdout'] do
   next if Rails.env =~ /production|staging/
-
-  system_user = Hmis::Hud::User.system_user(data_source_id: hmis_ds.id)
-
+  
   # Find or create HMIS DS
   hmis_ds = GrdaWarehouse::DataSource.source.where(hmis: ENV['HMIS_HOSTNAME']).first_or_create! do |ds|
     ds.name = 'HMIS'
     ds.short_name = 'HMIS'
     ds.authoritative = true
   end
+
+  system_user = Hmis::Hud::User.system_user(data_source_id: hmis_ds.id)
 
   # Find or create Test Organization
   test_org = Hmis::Hud::Organization.where(data_source: hmis_ds, organization_name: 'E2E Test Organization').

--- a/drivers/hmis/lib/tasks/setup.rake
+++ b/drivers/hmis/lib/tasks/setup.rake
@@ -36,7 +36,7 @@ end
 desc 'Seed E2E HMIS test data'
 task seed_e2e: [:environment, 'log:info_to_stdout'] do
   next if Rails.env =~ /production|staging/
-  
+
   # Find or create HMIS DS
   hmis_ds = GrdaWarehouse::DataSource.source.where(hmis: ENV['HMIS_HOSTNAME']).first_or_create! do |ds|
     ds.name = 'HMIS'

--- a/drivers/hmis/lib/tasks/setup.rake
+++ b/drivers/hmis/lib/tasks/setup.rake
@@ -31,3 +31,62 @@ task migrate_assessments: [:environment, 'log:info_to_stdout'] do
     Hmis::MigrateAssessmentsJob.perform_later(data_source_id: id)
   end
 end
+
+# Seed user, org, and project to use with HMIS E2E Cypress tests
+desc 'Seed E2E HMIS test data'
+task seed_e2e: [:environment, 'log:info_to_stdout'] do
+  next if Rails.env =~ /production|staging/
+
+  system_user = Hmis::Hud::User.system_user(data_source_id: hmis_ds.id)
+
+  # Find or create HMIS DS
+  hmis_ds = GrdaWarehouse::DataSource.source.where(hmis: ENV['HMIS_HOSTNAME']).first_or_create! do |ds|
+    ds.name = 'HMIS'
+    ds.short_name = 'HMIS'
+    ds.authoritative = true
+  end
+
+  # Find or create Test Organization
+  test_org = Hmis::Hud::Organization.where(data_source: hmis_ds, organization_name: 'E2E Test Organization').
+    first_or_create!(victim_service_provider: 0, user: system_user)
+  test_org.projects.destroy_all # destroy all projects in org
+  # Create Test Project
+  Hmis::Hud::Project.create!(
+    data_source_id: hmis_ds.id,
+    organization_id: test_org.organization_id,
+    project_name: 'E2E Test Project',
+    user: system_user,
+    operating_start_date: 1.year.ago,
+    project_type: 1, # ES NBN
+    continuum_project: 0,
+  )
+
+  # Find or create Test User
+  e2e_email = 'e2e@example.com' # Do not change! frontend e2e tests rely on it
+  e2e_pw = 'e2e-test-user' # Do not change! frontend e2e tests rely on it
+  user = User.where(email: e2e_email).first_or_initialize(
+    first_name: 'E2E Test',
+    last_name: 'User',
+    password: e2e_pw,
+    confirmed_at: Time.current,
+  )
+  user.agency_id = Agency.where(name: 'Sample Agency').first_or_create!.id
+  user.save!
+
+  # Find or create Role
+  role = Hmis::Role.where(name: 'E2E Test Role').first_or_initialize
+  # Grant all permissions
+  Hmis::Role.permissions_with_descriptions.keys.each do |perm|
+    role.assign_attributes(perm => true)
+  end
+  role.save!
+
+  # Find or create Access Group (Collection) with access to test org
+  access_group = Hmis::AccessGroup.where(name: 'E2E Test Collection').first_or_create!
+  access_group.add_viewable(test_org)
+  # Find or create User Group
+  user_group = Hmis::UserGroup.where(name: 'E2E Test Users').first_or_create!
+  user_group.add(user)
+  # Find or create ACL
+  Hmis::AccessControl.where(role: role, access_group: access_group, user_group: user_group).first_or_create!
+end


### PR DESCRIPTION
## Description

Add task for seeding e2e data (including a user) that will be used by HMIS cypress e2e tests. For now, its for local use. Once we have these running on CI (on the frontend repo), we will run this seed to prepare the db for tests.

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
