### PR TITLE
Confirm DJ are worked off in tests

### DIFF
--- a/app/jobs/test_empty_job.rb
+++ b/app/jobs/test_empty_job.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class TestEmptyJob < BaseJob
+  def perform
+    Rails.logger.info 'TestEmptyJob started'
+    Rails.logger.info 'TestEmptyJob completed'
+  end
+
+  def max_attempts
+    1
+  end
+end

--- a/app/models/access_group.rb
+++ b/app/models/access_group.rb
@@ -82,7 +82,7 @@ class AccessGroup < ApplicationRecord
 
   def self.delayed_system_group_maintenance(group: nil)
     delay.maintain_system_groups_no_named_arguments(group)
-    Delayed::Worker.new.work_off if Rails.env.test?
+    Delayed::Worker.new.work_off(1_000) if Rails.env.test?
   end
 
   def self.maintain_system_groups_no_named_arguments(group)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -93,7 +93,7 @@ class Collection < ApplicationRecord
 
   def self.delayed_system_group_maintenance(group: nil)
     delay.maintain_system_groups_no_named_arguments(group)
-    Delayed::Worker.new.work_off if Rails.env.test?
+    Delayed::Worker.new.work_off(1_000) if Rails.env.test?
   end
 
   def self.maintain_system_groups_no_named_arguments(group)

--- a/spec/factories/test_jobs.rb
+++ b/spec/factories/test_jobs.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :test_job do
+  end
+end

--- a/spec/models/test_empty_job_spec.rb
+++ b/spec/models/test_empty_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe TestEmptyJob, type: :model do
+  describe 'when more than 100 jobs' do
+    before do
+      222.times do
+        Delayed::Job.enqueue TestEmptyJob.new
+      end
+    end
+
+    it 'works off all jobs when looping' do
+      expect(Delayed::Job.where(failed_at: nil).count).to be > 100
+      Delayed::Worker.new.work_off while Delayed::Job.where(failed_at: nil).count > 0
+      expect(Delayed::Job.where(failed_at: nil).count).to eq(0)
+      # No failed jobs
+      expect(Delayed::Job.count).to eq(0)
+    end
+
+    it 'works off all jobs when told to work off 1,000' do
+      expect(Delayed::Job.where(failed_at: nil).count).to be > 100
+      Delayed::Worker.new.work_off(1_000)
+      expect(Delayed::Job.where(failed_at: nil).count).to eq(0)
+      # No failed jobs
+      expect(Delayed::Job.count).to eq(0)
+    end
+  end
+end

--- a/spec/support/hmis_csv_fixtures.rb
+++ b/spec/support/hmis_csv_fixtures.rb
@@ -62,7 +62,7 @@ module HmisCsvFixtures
     GrdaWarehouse::Tasks::ServiceHistory::Enrollment.batch_process_unprocessed!
     AccessGroup.maintain_system_groups
     AccessGroup.where(name: 'All Data Sources').first.add(user)
-    Delayed::Worker.new.work_off
+    Delayed::Worker.new.work_off while Delaye::Job.where(failed_at: nil).count > 0
   end
 
   def cleanup_hmis_csv_fixtures

--- a/spec/support/hmis_csv_fixtures.rb
+++ b/spec/support/hmis_csv_fixtures.rb
@@ -62,7 +62,7 @@ module HmisCsvFixtures
     GrdaWarehouse::Tasks::ServiceHistory::Enrollment.batch_process_unprocessed!
     AccessGroup.maintain_system_groups
     AccessGroup.where(name: 'All Data Sources').first.add(user)
-    Delayed::Worker.new.work_off while Delaye::Job.where(failed_at: nil).count > 0
+    Delayed::Worker.new.work_off while Delayed::Job.where(failed_at: nil).count > 0
   end
 
   def cleanup_hmis_csv_fixtures


### PR DESCRIPTION
## Description

This adds tests to show two mechanisms of ensuring all jobs in the queue are worked off before proceeding during tests

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
