### PR TITLE
Add more HMIS admin permissions

### DIFF
--- a/db/migrate/20231017185729_add_hmis_admin_perms.rb
+++ b/db/migrate/20231017185729_add_hmis_admin_perms.rb
@@ -1,0 +1,12 @@
+class AddHmisAdminPerms < ActiveRecord::Migration[6.1]
+  def up
+    Hmis::Role.ensure_permissions_exist
+    Hmis::Role.reset_column_information
+  end
+
+  def down
+    remove_column :hmis_roles, :can_merge_clients
+    remove_column :hmis_roles, :can_split_households
+    remove_column :hmis_roles, :can_transfer_enrollments
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -742,7 +742,10 @@ CREATE TABLE public.hmis_roles (
     can_enroll_clients boolean DEFAULT false,
     can_view_open_enrollment_summary boolean DEFAULT false,
     can_view_project boolean DEFAULT false,
-    can_view_hud_chronic_status boolean DEFAULT false
+    can_view_hud_chronic_status boolean DEFAULT false,
+    can_merge_clients boolean DEFAULT false,
+    can_split_households boolean DEFAULT false,
+    can_transfer_enrollments boolean DEFAULT false
 );
 
 
@@ -4045,6 +4048,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230916124819'),
 ('20230918231940'),
 ('20230923000619'),
-('20230927131152');
+('20230927131152'),
+('20231017185729');
 
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2789,6 +2789,7 @@ type Enrollment {
 type EnrollmentAccess {
   canDeleteEnrollments: Boolean!
   canEditEnrollments: Boolean!
+  canSplitHouseholds: Boolean!
   id: ID!
 }
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -599,6 +599,7 @@ type Client {
 }
 
 type ClientAccess {
+  canAuditClients: Boolean!
   canDeleteAssessments: Boolean!
   canDeleteClient: Boolean!
   canDeleteEnrollments: Boolean!
@@ -7733,6 +7734,9 @@ type QueryAccess {
   canManageInventory: Boolean!
   canManageOutgoingReferrals: Boolean!
   canManageOwnClientFiles: Boolean!
+  canMergeClients: Boolean!
+  canSplitHouseholds: Boolean!
+  canTransferEnrollments: Boolean!
   canViewAnyConfidentialClientFiles: Boolean!
   canViewAnyNonconfidentialClientFiles: Boolean!
   canViewClients: Boolean!

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -137,6 +137,7 @@ module Types
       can :manage_own_client_files
       can :view_any_nonconfidential_client_files
       can :view_any_confidential_client_files
+      can :audit_clients
     end
 
     def external_ids

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -145,6 +145,7 @@ module Types
     access_field do
       can :edit_enrollments
       can :delete_enrollments
+      can :split_households
     end
     custom_data_elements_field
 

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -316,6 +316,33 @@ class Hmis::Role < ::ApplicationRecord
           'Audit History',
         ],
       },
+      can_merge_clients: {
+        description: 'Grants the ability to merge and split client records',
+        administrative: true,
+        access: [:editable],
+        categories: [
+          'Administrative',
+          'Client Access',
+        ],
+      },
+      can_split_households: {
+        description: 'Grants the ability to merge and split households',
+        administrative: true,
+        access: [:editable],
+        categories: [
+          'Administrative',
+          'Enrollments',
+        ],
+      },
+      can_transfer_enrollments: {
+        description: 'Grants the ability to transfer enrollments between projects',
+        administrative: true,
+        access: [:editable],
+        categories: [
+          'Administrative',
+          'Enrollments',
+        ],
+      },
     }
   end
 end


### PR DESCRIPTION
## Description

Adds 3 more HMIS admin permissions:
1. Can merge clients. Globally applied. (feature not yet implemented)
2. Can split households. Applied at the project-level. (feature not yet implemented)
3. Can transfer enrollments between projects. Globally applied. (feature not yet implemented)

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
