### PR TITLE
Universe members performance - hot fix

### DIFF
--- a/app/models/hud_reports/report_cell.rb
+++ b/app/models/hud_reports/report_cell.rb
@@ -115,7 +115,9 @@ module HudReports
       # joins don't work for polymorphic associations since it could join multiple tables.
       # However, for a given report cell, all of the universe members must be in the same table
       # and we can compute the name based on a single member.
-      universe_table_name = universe_members.first.universe_membership.class.arel_table
+      # NOTE: need to specify order by report_cell_id or the postgres planner gets really unhappy when
+      # the universe members table gets large
+      universe_table_name = universe_members.order(:report_cell_id).first.universe_membership.class.arel_table
       members_table = universe_members.arel_table
 
       table_join = members_table.join(universe_table_name).on(members_table[:universe_membership_id].eq(universe_table_name[:id]))


### PR DESCRIPTION
## Description

This fixes a performance bug where Rails is conducting a `find` which it, by default, injects an `order by id` even if the `id` isn't necessary.  Postgres then needs to do an index scan for the sort against the index on the `id` column even though sorting a `limit` 1 in this case has no effect on the result.  Moving the sort to the same column as the where clause, allows the query planner to use the same index for the lookup and the search.  This takes the query time (against a table of ~300,000,000 records from ~1 minute down to sub 0.1ms.

Before:
<img width="960" alt="Screenshot 2023-10-18 at 9 18 44 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/a1318e56-c633-42c0-b56f-3815a0b378f4">

After:
<img width="932" alt="Screenshot 2023-10-18 at 9 18 36 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/a3a2aedb-6fc6-49ac-9160-6d93a794b72a">

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
