### PR TITLE
Allow managing internal referrals if LINK connection turned off

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
@@ -14,20 +14,19 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(input:)
-      handle_error('connection not configured') unless HmisExternalApis::AcHmis::LinkApi.enabled?
       # the front-end doesn't block submission if there are empty required fields, handle it here
       errors = basic_validation(input)
       return { errors: errors } if errors.any?
 
-      enrollment = Hmis::Hud::Enrollment
-        .viewable_by(current_user)
-        .find_by(id: input.enrollment_id)
+      enrollment = Hmis::Hud::Enrollment.
+        viewable_by(current_user).
+        find_by(id: input.enrollment_id)
       handle_error('enrollment not found') unless enrollment
       handle_error('access denied') unless current_user.can_manage_outgoing_referrals_for?(enrollment.project)
 
-      project = Hmis::Hud::Project
-        .viewable_by(current_user)
-        .find_by(id: input.project_id)
+      project = Hmis::Hud::Project.
+        viewable_by(current_user).
+        find_by(id: input.project_id)
       handle_error('project not found') unless project
 
       errors = validate_unit_type(project, input)

--- a/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/update_referral_posting.rb
@@ -15,10 +15,9 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:, input:)
-      handle_error('connection not configured') unless HmisExternalApis::AcHmis::LinkApi.enabled?
-
       posting = HmisExternalApis::AcHmis::ReferralPosting.active.viewable_by(current_user).find(id)
       handle_error('referral not found') unless posting
+      handle_error('connection not configured') if posting.from_link? && !HmisExternalApis::AcHmis::LinkApi.enabled?
 
       errors = HmisErrors::Errors.new
 

--- a/drivers/hmis_external_apis/extensions/hmis/hud/enrollment_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/enrollment_extension.rb
@@ -19,11 +19,12 @@ module HmisExternalApis
 
           def accept_referral!(current_user:)
             return unless head_of_household?
-            return unless HmisExternalApis::AcHmis::LinkApi.enabled?
 
             # Posting can only be accepted if it is AcceptedPending or Closed (if re-opening exited enrollment)
             posting = source_postings.find_by(status: ['accepted_pending_status', 'closed_status'])
             return unless posting.present?
+
+            raise 'connection not configured' if posting.from_link? && !HmisExternalApis::AcHmis::LinkApi.enabled?
 
             posting.status = 20 # accepted
             posting.referral_result = 1 # successful result
@@ -44,10 +45,11 @@ module HmisExternalApis
 
           def close_referral!(current_user:)
             return unless head_of_household?
-            return unless HmisExternalApis::AcHmis::LinkApi.enabled?
 
             posting = source_postings.find_by(status: 'accepted_status')
             return unless posting.present?
+
+            raise 'connection not configured' if posting.from_link? && !HmisExternalApis::AcHmis::LinkApi.enabled?
 
             # Note: doesn't use a transaction because the caller, save_submitted_assessment!, already calls it in a transaction
             posting.status = 13 # closed


### PR DESCRIPTION
## Description

Requested behavior for training environment: allow "internal" referrals to function even if LINK connection is disabled

## Type of change
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
