### PR TITLE
Don't try to merge with deleted clients

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -113,10 +113,8 @@ module HmisExternalApis::AcHmis
     end
 
     def merge_clients_by_mci_unique_id
-      e_t = HmisExternalApis::ExternalId.arel_table
-
       self.merge_sets = HmisExternalApis::ExternalId.
-        where(e_t[:source_type].eq('Hmis::Hud::Client')).
+        joins(:client). # join to ensure we're not pulling in any ExternalIds for deleted clients
         where(namespace: NAMESPACE).
         group(:value).
         having('count(*) > 1').


### PR DESCRIPTION
## Description

Fixes a bug where ExternalIds for deleted clients would be considered for merge

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
