### PR TITLE
More assessment patches

### DIFF
--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/disability_rule.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/disability_rule.json
@@ -494,11 +494,6 @@
         {
           "variable": "projectId",
           "operator": "EQUAL",
-          "value": "785"
-        },
-        {
-          "variable": "projectId",
-          "operator": "EQUAL",
           "value": "660"
         },
         {
@@ -530,11 +525,6 @@
           "variable": "projectId",
           "operator": "EQUAL",
           "value": "746"
-        },
-        {
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "751"
         },
         {
           "variable": "projectId",

--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/youth_program_rules.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/youth_program_rules.json
@@ -1,6 +1,6 @@
 [
   {
-    "link_id": "C3",
+    "link_id": "c3-youth-education-status",
     "rule": {
       "operator": "ANY",
       "parts": [


### PR DESCRIPTION
- Stop collecting HIV/AIDS for a couple programs
- Fix incorrect link id that was causing C3 patches not to be applied 