### PR TITLE
Add records missing from merge

### DIFF
--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -222,9 +222,12 @@ module Hmis
         Hmis::Hud::AssessmentQuestion,
         Hmis::Hud::AssessmentResult,
         Hmis::Hud::CurrentLivingSituation,
+        Hmis::Hud::CustomAssessment,
+        Hmis::Hud::CustomCaseNote,
         Hmis::Hud::CustomClientAddress,
         Hmis::Hud::CustomClientContactPoint,
         # Hmis::Hud::CustomClientName,      # Handled in separate method
+        Hmis::Hud::CustomService,
         Hmis::Hud::Disability,
         Hmis::Hud::EmploymentEducation,
         Hmis::Hud::Enrollment,


### PR DESCRIPTION
## Description

HMIS client merge was leaving dangling assessments, case notes, and custom services. I have already done the data-cleanup to correct those dangling records in production environments.

I included the cleanup function, because this is bound to happen again, given the brittleness of maintaining a list of records in `Hmis::MergeClientsJob`.

https://www.pivotaltracker.com/story/show/186353520

https://green-river.sentry.io/issues/4576840813/?alert_rule_id=14757490&alert_type=issue&notification_uuid=b0196c47-2fb2-4471-88e2-395583f1025f&project=4504006381273088&referrer=slack

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
