### PR TITLE
Speed up project queries by skipping unnecessary viewable_by queries

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
@@ -41,8 +41,8 @@ module Types
 
       private
 
-      def scoped_enrollments(scope, sort_order: :most_recent, filters: nil)
-        scope = scope.viewable_by(current_user)
+      def scoped_enrollments(scope, sort_order: :most_recent, filters: nil, dangerous_skip_permission_check: false)
+        scope = scope.viewable_by(current_user) unless dangerous_skip_permission_check
         scope = scope.apply_filters(filters) if filters.present?
         scope = scope.sort_by_option(sort_order) if sort_order.present?
         scope

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_households.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_households.rb
@@ -33,8 +33,8 @@ module Types
 
       private
 
-      def scoped_households(scope, sort_order: :most_recent, filters: nil)
-        scope = scope.viewable_by(current_user)
+      def scoped_households(scope, sort_order: :most_recent, filters: nil, dangerous_skip_permission_check: false)
+        scope = scope.viewable_by(current_user) unless dangerous_skip_permission_check
         scope = scope.apply_filters(filters) if filters.present?
         scope = scope.sort_by_option(sort_order) if sort_order.present?
         scope

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_services.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_services.rb
@@ -33,8 +33,8 @@ module Types
 
       private
 
-      def scoped_services(scope, sort_order: :date_provided, filters: nil)
-        scope = scope.viewable_by(current_user)
+      def scoped_services(scope, sort_order: :date_provided, filters: nil, dangerous_skip_permission_check: false)
+        scope = scope.viewable_by(current_user) unless dangerous_skip_permission_check
         scope = scope.apply_filters(filters) if filters.present?
         scope = scope.sort_by_option(sort_order) if sort_order.present?
         scope

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -101,9 +101,9 @@ module Types
     end
 
     def enrollments(**args)
-      return Hmis::Hud::Enrollment.none unless current_user.can_view_enrollment_details_for?(object)
+      return unless current_user.can_view_enrollment_details_for?(object)
 
-      resolve_enrollments(object.enrollments_including_wip, **args)
+      resolve_enrollments(object.enrollments_including_wip, dangerous_skip_permission_check: true, **args)
     end
 
     def organization
@@ -115,7 +115,9 @@ module Types
     end
 
     def services(**args)
-      resolve_services(**args)
+      return unless current_user.can_view_enrollment_details_for?(object)
+
+      resolve_services(**args, dangerous_skip_permission_check: true)
     end
 
     def residential_affiliation_projects
@@ -156,7 +158,9 @@ module Types
     end
 
     def households(**args)
-      resolve_households(object.households_including_wip, **args)
+      return unless current_user.can_view_enrollment_details_for?(object)
+
+      resolve_households(object.households_including_wip, **args, dangerous_skip_permission_check: true)
     end
 
     def referral_requests(**args)

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -101,6 +101,7 @@ module Types
     end
 
     def enrollments(**args)
+      # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
       return unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_enrollments(object.enrollments_including_wip, dangerous_skip_permission_check: true, **args)
@@ -115,6 +116,7 @@ module Types
     end
 
     def services(**args)
+      # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
       return unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_services(**args, dangerous_skip_permission_check: true)
@@ -158,6 +160,7 @@ module Types
     end
 
     def households(**args)
+      # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
       return unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_households(object.households_including_wip, **args, dangerous_skip_permission_check: true)


### PR DESCRIPTION
## Description

When resolving records on Project, skip the viewable_by scope, since all the permissions are project-based.

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
