### PR TITLE
Support "limited" enrollment access (field-level authorization)

### DIFF
--- a/db/migrate/20231030184613_add_limited_enrollment_perm.rb
+++ b/db/migrate/20231030184613_add_limited_enrollment_perm.rb
@@ -1,0 +1,10 @@
+class AddLimitedEnrollmentPerm < ActiveRecord::Migration[6.1]
+  def up
+    Hmis::Role.ensure_permissions_exist
+    Hmis::Role.reset_column_information
+  end
+
+  def down
+    remove_column :hmis_roles, :can_view_limited_enrollment_details
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -745,7 +745,8 @@ CREATE TABLE public.hmis_roles (
     can_view_hud_chronic_status boolean DEFAULT false,
     can_merge_clients boolean DEFAULT false,
     can_split_households boolean DEFAULT false,
-    can_transfer_enrollments boolean DEFAULT false
+    can_transfer_enrollments boolean DEFAULT false,
+    can_view_limited_enrollment_details boolean DEFAULT false
 );
 
 
@@ -4051,6 +4052,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230923000619'),
 ('20230927131152'),
 ('20231009120833'),
-('20231017185729');
+('20231017185729'),
+('20231030184613');
 
 

--- a/drivers/hmis/app/graphql/concerns/graphql_permission_checker.rb
+++ b/drivers/hmis/app/graphql/concerns/graphql_permission_checker.rb
@@ -1,0 +1,22 @@
+module GraphqlPermissionChecker
+  extend ActiveSupport::Concern
+
+  # Does the current user have the given permission on entity?
+  #
+  # @param permission [Symbol] :can_do_foo
+  # @param entity [#record] Client, project, etc
+  private def current_permission_for_context?(context, permission:, entity:)
+    current_user = context[:current_user]
+    return false unless current_user&.present?
+
+    # Just return false if we don't have this permission at all for anything
+    return false unless current_user.send("#{permission}?")
+
+    loader, subject = current_user.entity_access_loader_factory(entity) do |record, association|
+      context.dataloader.with(Sources::ActiveRecordAssociation, association, nil).load(record)
+    end
+    raise "Missing loader for #{entity.class.name}##{entity.id}" unless loader
+
+    context.dataloader.with(Sources::UserEntityAccessSource, loader).load([subject, permission])
+  end
+end

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2811,6 +2811,7 @@ type Enrollment {
   prisonDischarge: NoYesMissing
   project: Project!
   projectName: String!
+  projectType: ProjectType
   reasonNoServices: ReasonNoServices
   reasonNotEnrolled: ReasonNotEnrolled
   referralSource: ReferralSource

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2838,6 +2838,7 @@ type EnrollmentAccess {
   canDeleteEnrollments: Boolean!
   canEditEnrollments: Boolean!
   canSplitHouseholds: Boolean!
+  canViewEnrollmentDetails: Boolean!
   id: ID!
 }
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -2802,6 +2802,7 @@ type Enrollment {
   moveInDate: ISO8601Date
   numUnitsAssignedToHousehold: Int!
   openEnrollmentSummary: [EnrollmentSummary!]!
+  organizationName: String!
   percentAmi: PercentAMI
   physicalDisabilityFam: NoYesMissing
   preferredLanguage: PreferredLanguage
@@ -2809,6 +2810,7 @@ type Enrollment {
   previousStreetEssh: NoYesMissing
   prisonDischarge: NoYesMissing
   project: Project!
+  projectName: String!
   reasonNoServices: ReasonNoServices
   reasonNotEnrolled: ReasonNotEnrolled
   referralSource: ReferralSource
@@ -7852,6 +7854,7 @@ type QueryAccess {
   canViewEnrollmentDetails: Boolean!
   canViewFullSsn: Boolean!
   canViewHudChronicStatus: Boolean!
+  canViewLimitedEnrollmentDetails: Boolean!
   canViewOpenEnrollmentSummary: Boolean!
   canViewPartialSsn: Boolean!
   canViewProject: Boolean!

--- a/drivers/hmis/app/graphql/types/base_field.rb
+++ b/drivers/hmis/app/graphql/types/base_field.rb
@@ -9,8 +9,8 @@ module Types
     include GraphqlPermissionChecker
     argument_class Types::BaseArgument
 
-    def initialize(*args, default_value: nil, permission: nil, **kwargs, &block)
-      @permissions = Array.wrap(permission)
+    def initialize(*args, default_value: nil, permissions: nil, **kwargs, &block)
+      @permissions = Array.wrap(permissions)
 
       super(*args, **kwargs, &block)
 
@@ -25,7 +25,7 @@ module Types
     # Field-level authorization
     # https://graphql-ruby.org/authorization/authorization.html#field-authorization
     def authorized?(object, args, ctx)
-      # if `permission:` was given, then require the current user to have the specified permissions on the object
+      # if `permissions:` was given, then require the current user to have the specified permissions on the object
       base_authorized = super(object, args, ctx)
       if @permissions.any?
         base_authorized && @permissions.all? do |perm|

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -151,7 +151,9 @@ module Types
     end
 
     def enrollments(**args)
-      resolve_enrollments(**args)
+      # Scope client enrollments that this user has full OR limited access to
+      scope = object.enrollments.viewable_by(current_user, include_limited_access_enrollments: true)
+      resolve_enrollments(scope, **args, dangerous_skip_permission_check: true)
     end
 
     def income_benefits(**args)

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -151,8 +151,12 @@ module Types
     end
 
     def enrollments(**args)
-      # Scope client enrollments that this user has full OR limited access to
-      scope = object.enrollments.viewable_by(current_user, include_limited_access_enrollments: true)
+      # If current user has "detailed" access to any enrollment for this client, then we also resolve
+      # "limited access" enrollments (if permitted). The purpose is to show additional enrollment history
+      # for "my" clients, but not for other clients in the system that I can see.
+      # This would need to change if we wanted to support the ability to see limited enrollment details for all clients.
+      has_some_detailed_access = current_permission?(permission: :can_view_enrollment_details, entity: object)
+      scope = object.enrollments.viewable_by(current_user, include_limited_access_enrollments: has_some_detailed_access)
       resolve_enrollments(scope, **args, dangerous_skip_permission_check: true)
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -35,7 +35,7 @@ module Types
     # to other Enrollments.
     def self.field(name, type = nil, **kwargs)
       # See Types::BaseField `authorized?` function.
-      super(name, type, permission: :can_view_enrollment_details, **kwargs)
+      super(name, type, permissions: :can_view_enrollment_details, **kwargs)
     end
 
     # Add a separate "field" function to use for summary fields which are visible
@@ -44,7 +44,7 @@ module Types
     # No field-level authorization is needed here, because the enrollment necessarily
     # has some level of visibility if it's being resolved.
     def self.summary_field(name, type = nil, **kwargs)
-      field(name, type, **kwargs, permission: nil)
+      field(name, type, **kwargs, permissions: nil)
     end
 
     available_filter_options do
@@ -71,7 +71,7 @@ module Types
     summary_field :relationship_to_ho_h, HmisSchema::Enums::Hud::RelationshipToHoH, null: false, default_value: 99
     # Override permission requirement for the access object. This is necessary so the frontend
     # knows whether its safe to link to the full enrollment dashboard for a given enrollment.
-    access_field permission: nil do
+    access_field permissions: nil do
       can :view_enrollment_details
       can :edit_enrollments
       can :delete_enrollments

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -27,14 +27,10 @@ module Types
       Hmis::Hud::Enrollment.hmis_configuration(version: '2024')
     end
 
-    def self.enrollment_detail_perms
-      [:can_view_enrollment_details, :can_view_project]
-    end
-
     # Special field function to perform field-level authorization, to ensure that user has Detail-level access to this Enrollment.
     # If user lacks sufficient access, field is resolved as null. See Types::BaseField `authorized?` function.
     def self.detail_field(name, type = nil, **kwargs)
-      field(name, type, **kwargs, require_permissions: enrollment_detail_perms)
+      field(name, type, **kwargs, permission: :can_view_enrollment_details)
     end
 
     available_filter_options do
@@ -70,19 +66,19 @@ module Types
     detail_field :household, HmisSchema::Household, null: false
     detail_field :household_size, Integer, null: false
     # Associated records (detail-access)
-    assessments_field require_permissions: enrollment_detail_perms
-    events_field require_permissions: enrollment_detail_perms
-    services_field filter_args: { omit: [:project, :project_type], type_name: 'ServicesForEnrollment' }, require_permissions: enrollment_detail_perms
-    custom_case_notes_field require_permissions: enrollment_detail_perms
-    files_field require_permissions: enrollment_detail_perms
-    ce_assessments_field require_permissions: enrollment_detail_perms
-    income_benefits_field require_permissions: enrollment_detail_perms
-    disabilities_field require_permissions: enrollment_detail_perms
-    health_and_dvs_field require_permissions: enrollment_detail_perms
-    youth_education_statuses_field require_permissions: enrollment_detail_perms
-    employment_educations_field require_permissions: enrollment_detail_perms
-    current_living_situations_field require_permissions: enrollment_detail_perms
-    custom_data_elements_field require_permissions: enrollment_detail_perms
+    assessments_field permission: :can_view_enrollment_details
+    events_field permission: :can_view_enrollment_details
+    services_field filter_args: { omit: [:project, :project_type], type_name: 'ServicesForEnrollment' }, permission: :can_view_enrollment_details
+    custom_case_notes_field permission: :can_view_enrollment_details
+    files_field permission: :can_view_enrollment_details
+    ce_assessments_field permission: :can_view_enrollment_details
+    income_benefits_field permission: :can_view_enrollment_details
+    disabilities_field permission: :can_view_enrollment_details
+    health_and_dvs_field permission: :can_view_enrollment_details
+    youth_education_statuses_field permission: :can_view_enrollment_details
+    employment_educations_field permission: :can_view_enrollment_details
+    current_living_situations_field permission: :can_view_enrollment_details
+    custom_data_elements_field permission: :can_view_enrollment_details
     # 3.16.1
     detail_field :enrollment_coc, String, null: true
     # 3.08
@@ -133,7 +129,7 @@ module Types
     detail_field :insufficient_income, HmisSchema::Enums::Hud::NoYesMissing, null: true
     detail_field :incarcerated_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
     # V6
-    detail_field :vamc_station, HmisSchema::Enums::Hud::VamcStationNumber, null: true, require_permissions: [:can_view_enrollment_details, :can_view_project]
+    detail_field :vamc_station, HmisSchema::Enums::Hud::VamcStationNumber, null: true
     # V7
     detail_field :target_screen_reqd, HmisSchema::Enums::Hud::NoYesMissing, null: true
     detail_field :time_to_housing_loss, HmisSchema::Enums::Hud::TimeToHousingLoss, null: true

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -27,10 +27,24 @@ module Types
       Hmis::Hud::Enrollment.hmis_configuration(version: '2024')
     end
 
-    # Special field function to perform field-level authorization, to ensure that user has Detail-level access to this Enrollment.
-    # If user lacks sufficient access, field is resolved as null. See Types::BaseField `authorized?` function.
-    def self.detail_field(name, type = nil, **kwargs)
-      field(name, type, **kwargs, permission: :can_view_enrollment_details)
+    # Override the "field" function to perform field-level authorization.
+    # If user lacks sufficient access, the field will be resolved as null.
+    #
+    # This is necessary because the user may have access to view
+    # "full" enrollment details for some Enrollments, but only "limited" access
+    # to other Enrollments.
+    def self.field(name, type = nil, **kwargs)
+      # See Types::BaseField `authorized?` function.
+      super(name, type, permission: :can_view_enrollment_details, **kwargs)
+    end
+
+    # Add a separate "field" function to use for summary fields which are visible
+    # to users with "can_view_limited_enrollment_details".
+    #
+    # No field-level authorization is needed here, because the enrollment necessarily
+    # has some level of visibility if it's being resolved.
+    def self.summary_field(name, type = nil, **kwargs)
+      field(name, type, **kwargs, permission: nil)
     end
 
     available_filter_options do
@@ -43,133 +57,133 @@ module Types
 
     description 'HUD Enrollment'
 
-    # LIMITED ACCESS FIELDS. These fields are visible with `can_view_limited_enrollment_details` permission (or `can_view_enrollment_details` + `can_view_project` perms).
-    field :id, ID, null: false
-    field :lock_version, Integer, null: false
-    field :project_name, String, null: false
-    field :project_type, Types::HmisSchema::Enums::ProjectType, null: true
-    field :organization_name, String, null: false
-    field :entry_date, GraphQL::Types::ISO8601Date, null: false
-    field :exit_date, GraphQL::Types::ISO8601Date, null: true
-    field :status, HmisSchema::Enums::EnrollmentStatus, null: false
-    field :client, HmisSchema::Client, null: false
-    field :in_progress, Boolean, null: false
-    field :relationship_to_ho_h, HmisSchema::Enums::Hud::RelationshipToHoH, null: false, default_value: 99
-
-    # DETAILED ACCESS FIELDS. These fields are visible with `can_view_enrollment_details` + `can_view_project` permissions.
-    # For non-nullable fields, an error will be thrown if the client tries to query them for a Limited-access enrollment.
-    # For nullable fields, they will be resolved as null for Limited-access enrollments.
-    detail_field :project, Types::HmisSchema::Project, null: false
-    detail_field :exit_destination, Types::HmisSchema::Enums::Hud::Destination, null: true
-    detail_field :household_id, ID, null: false
-    detail_field :household_short_id, ID, null: false
-    detail_field :household, HmisSchema::Household, null: false
-    detail_field :household_size, Integer, null: false
-    # Associated records (detail-access)
-    assessments_field permission: :can_view_enrollment_details
-    events_field permission: :can_view_enrollment_details
-    services_field filter_args: { omit: [:project, :project_type], type_name: 'ServicesForEnrollment' }, permission: :can_view_enrollment_details
-    custom_case_notes_field permission: :can_view_enrollment_details
-    files_field permission: :can_view_enrollment_details
-    ce_assessments_field permission: :can_view_enrollment_details
-    income_benefits_field permission: :can_view_enrollment_details
-    disabilities_field permission: :can_view_enrollment_details
-    health_and_dvs_field permission: :can_view_enrollment_details
-    youth_education_statuses_field permission: :can_view_enrollment_details
-    employment_educations_field permission: :can_view_enrollment_details
-    current_living_situations_field permission: :can_view_enrollment_details
-    custom_data_elements_field permission: :can_view_enrollment_details
-    # 3.16.1
-    detail_field :enrollment_coc, String, null: true
-    # 3.08
-    detail_field :disabling_condition, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true, default_value: 99
-    # 3.13.1
-    detail_field :date_of_engagement, GraphQL::Types::ISO8601Date, null: true
-    # 3.20.1
-    detail_field :move_in_date, GraphQL::Types::ISO8601Date, null: true
-    # 3.917
-    detail_field :living_situation, HmisSchema::Enums::Hud::PriorLivingSituation
-    detail_field :rental_subsidy_type, Types::HmisSchema::Enums::Hud::RentalSubsidyType
-    detail_field :length_of_stay, HmisSchema::Enums::Hud::ResidencePriorLengthOfStay
-    detail_field :los_under_threshold, HmisSchema::Enums::Hud::NoYesMissing
-    detail_field :previous_street_essh, HmisSchema::Enums::Hud::NoYesMissing
-    detail_field :date_to_street_essh, GraphQL::Types::ISO8601Date
-    detail_field :times_homeless_past_three_years, HmisSchema::Enums::Hud::TimesHomelessPastThreeYears
-    detail_field :months_homeless_past_three_years, HmisSchema::Enums::Hud::MonthsHomelessPastThreeYears
-    # P3
-    detail_field :date_of_path_status, GraphQL::Types::ISO8601Date, null: true
-    detail_field :client_enrolled_in_path, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :reason_not_enrolled, HmisSchema::Enums::Hud::ReasonNotEnrolled, null: true
-    # V4
-    detail_field :percent_ami, HmisSchema::Enums::Hud::PercentAMI, null: true
-    # R1
-    detail_field :referral_source, HmisSchema::Enums::Hud::ReferralSource, null: true
-    detail_field :count_outreach_referral_approaches, Integer, null: true
-    # R2
-    detail_field :date_of_bcp_status, GraphQL::Types::ISO8601Date, null: true
-    detail_field :eligible_for_rhy, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :reason_no_services, HmisSchema::Enums::Hud::ReasonNoServices, null: true
-    detail_field :runaway_youth, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
-    # R3
-    detail_field :sexual_orientation, HmisSchema::Enums::Hud::SexualOrientation, null: true
-    detail_field :sexual_orientation_other, String, null: true
-    # R11
-    detail_field :former_ward_child_welfare, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
-    detail_field :child_welfare_years, HmisSchema::Enums::Hud::RHYNumberofYears, null: true
-    detail_field :child_welfare_months, Integer, null: true
-    # R12
-    detail_field :former_ward_juvenile_justice, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
-    detail_field :juvenile_justice_years, HmisSchema::Enums::Hud::RHYNumberofYears, null: true
-    detail_field :juvenile_justice_months, Integer, null: true
-    # R13
-    detail_field :unemployment_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :mental_health_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :physical_disability_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :alcohol_drug_use_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :insufficient_income, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :incarcerated_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    # V6
-    detail_field :vamc_station, HmisSchema::Enums::Hud::VamcStationNumber, null: true
-    # V7
-    detail_field :target_screen_reqd, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :time_to_housing_loss, HmisSchema::Enums::Hud::TimeToHousingLoss, null: true
-    detail_field :annual_percent_ami, HmisSchema::Enums::Hud::AnnualPercentAMI, null: true
-    detail_field :literal_homeless_history, HmisSchema::Enums::Hud::LiteralHomelessHistory, null: true
-    detail_field :client_leaseholder, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :hoh_leaseholder, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :subsidy_at_risk, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :eviction_history, HmisSchema::Enums::Hud::EvictionHistory, null: true
-    detail_field :criminal_record, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :incarcerated_adult, HmisSchema::Enums::Hud::IncarceratedAdult, null: true
-    detail_field :prison_discharge, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :sex_offender, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :disabled_hoh, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :current_pregnant, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :single_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :dependent_under6, HmisSchema::Enums::Hud::DependentUnder6, null: true
-    detail_field :hh5_plus, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :coc_prioritized, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    detail_field :hp_screening_score, Integer, null: true
-    detail_field :threshold_score, Integer, null: true
-    # C4
-    detail_field :translation_needed, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
-    detail_field :preferred_language, HmisSchema::Enums::Hud::PreferredLanguage, null: true
-    detail_field :preferred_language_different, String, null: true
-
-    detail_field :intake_assessment, HmisSchema::Assessment, null: true
-    detail_field :exit_assessment, HmisSchema::Assessment, null: true
-    access_field do
+    # SUMMARY FIELDS. These fields are visible with `can_view_limited_enrollment_details` permission.
+    summary_field :id, ID, null: false
+    summary_field :lock_version, Integer, null: false
+    summary_field :project_name, String, null: false
+    summary_field :project_type, Types::HmisSchema::Enums::ProjectType, null: true
+    summary_field :organization_name, String, null: false
+    summary_field :entry_date, GraphQL::Types::ISO8601Date, null: false
+    summary_field :exit_date, GraphQL::Types::ISO8601Date, null: true
+    summary_field :status, HmisSchema::Enums::EnrollmentStatus, null: false
+    summary_field :client, HmisSchema::Client, null: false
+    summary_field :in_progress, Boolean, null: false
+    summary_field :relationship_to_ho_h, HmisSchema::Enums::Hud::RelationshipToHoH, null: false, default_value: 99
+    # Override permission requirement for the access object. This is necessary so the frontend
+    # knows whether its safe to link to the full enrollment dashboard for a given enrollment.
+    access_field permission: nil do
       can :view_enrollment_details
       can :edit_enrollments
       can :delete_enrollments
       can :split_households
     end
 
-    detail_field :current_unit, HmisSchema::Unit, null: true
-    detail_field :num_units_assigned_to_household, Integer, null: false, default_value: 0
-    detail_field :reminders, [HmisSchema::Reminder], null: false
-    detail_field :open_enrollment_summary, [HmisSchema::EnrollmentSummary], null: false
-    detail_field :last_bed_night_date, GraphQL::Types::ISO8601Date, null: true
+    # FULL ACCESS FIELDS. All fields below this line require `can_view_enrollment_details` perm, because they use the overridden 'field' class method.
+    field :project, Types::HmisSchema::Project, null: false
+    field :exit_destination, Types::HmisSchema::Enums::Hud::Destination, null: true
+    field :household_id, ID, null: false
+    field :household_short_id, ID, null: false
+    field :household, HmisSchema::Household, null: false
+    field :household_size, Integer, null: false
+    # Associated records. These automatically require the "can_view_enrollment_details" permission
+    # because they use the overridden 'field' class method.
+    assessments_field
+    events_field
+    services_field filter_args: { omit: [:project, :project_type], type_name: 'ServicesForEnrollment' }
+    custom_case_notes_field
+    files_field
+    ce_assessments_field
+    income_benefits_field
+    disabilities_field
+    health_and_dvs_field
+    youth_education_statuses_field
+    employment_educations_field
+    current_living_situations_field
+    custom_data_elements_field
+    # 3.16.1
+    field :enrollment_coc, String, null: true
+    # 3.08
+    field :disabling_condition, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true, default_value: 99
+    # 3.13.1
+    field :date_of_engagement, GraphQL::Types::ISO8601Date, null: true
+    # 3.20.1
+    field :move_in_date, GraphQL::Types::ISO8601Date, null: true
+    # 3.917
+    field :living_situation, HmisSchema::Enums::Hud::PriorLivingSituation
+    field :rental_subsidy_type, Types::HmisSchema::Enums::Hud::RentalSubsidyType
+    field :length_of_stay, HmisSchema::Enums::Hud::ResidencePriorLengthOfStay
+    field :los_under_threshold, HmisSchema::Enums::Hud::NoYesMissing
+    field :previous_street_essh, HmisSchema::Enums::Hud::NoYesMissing
+    field :date_to_street_essh, GraphQL::Types::ISO8601Date
+    field :times_homeless_past_three_years, HmisSchema::Enums::Hud::TimesHomelessPastThreeYears
+    field :months_homeless_past_three_years, HmisSchema::Enums::Hud::MonthsHomelessPastThreeYears
+    # P3
+    field :date_of_path_status, GraphQL::Types::ISO8601Date, null: true
+    field :client_enrolled_in_path, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :reason_not_enrolled, HmisSchema::Enums::Hud::ReasonNotEnrolled, null: true
+    # V4
+    field :percent_ami, HmisSchema::Enums::Hud::PercentAMI, null: true
+    # R1
+    field :referral_source, HmisSchema::Enums::Hud::ReferralSource, null: true
+    field :count_outreach_referral_approaches, Integer, null: true
+    # R2
+    field :date_of_bcp_status, GraphQL::Types::ISO8601Date, null: true
+    field :eligible_for_rhy, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :reason_no_services, HmisSchema::Enums::Hud::ReasonNoServices, null: true
+    field :runaway_youth, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    # R3
+    field :sexual_orientation, HmisSchema::Enums::Hud::SexualOrientation, null: true
+    field :sexual_orientation_other, String, null: true
+    # R11
+    field :former_ward_child_welfare, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :child_welfare_years, HmisSchema::Enums::Hud::RHYNumberofYears, null: true
+    field :child_welfare_months, Integer, null: true
+    # R12
+    field :former_ward_juvenile_justice, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :juvenile_justice_years, HmisSchema::Enums::Hud::RHYNumberofYears, null: true
+    field :juvenile_justice_months, Integer, null: true
+    # R13
+    field :unemployment_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :mental_health_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :physical_disability_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :alcohol_drug_use_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :insufficient_income, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :incarcerated_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    # V6
+    field :vamc_station, HmisSchema::Enums::Hud::VamcStationNumber, null: true
+    # V7
+    field :target_screen_reqd, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :time_to_housing_loss, HmisSchema::Enums::Hud::TimeToHousingLoss, null: true
+    field :annual_percent_ami, HmisSchema::Enums::Hud::AnnualPercentAMI, null: true
+    field :literal_homeless_history, HmisSchema::Enums::Hud::LiteralHomelessHistory, null: true
+    field :client_leaseholder, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :hoh_leaseholder, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :subsidy_at_risk, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :eviction_history, HmisSchema::Enums::Hud::EvictionHistory, null: true
+    field :criminal_record, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :incarcerated_adult, HmisSchema::Enums::Hud::IncarceratedAdult, null: true
+    field :prison_discharge, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :sex_offender, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :disabled_hoh, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :current_pregnant, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :single_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :dependent_under6, HmisSchema::Enums::Hud::DependentUnder6, null: true
+    field :hh5_plus, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :coc_prioritized, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :hp_screening_score, Integer, null: true
+    field :threshold_score, Integer, null: true
+    # C4
+    field :translation_needed, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :preferred_language, HmisSchema::Enums::Hud::PreferredLanguage, null: true
+    field :preferred_language_different, String, null: true
+
+    field :intake_assessment, HmisSchema::Assessment, null: true
+    field :exit_assessment, HmisSchema::Assessment, null: true
+    field :current_unit, HmisSchema::Unit, null: true
+    field :num_units_assigned_to_household, Integer, null: false, default_value: 0
+    field :reminders, [HmisSchema::Reminder], null: false
+    field :open_enrollment_summary, [HmisSchema::EnrollmentSummary], null: false
+    field :last_bed_night_date, GraphQL::Types::ISO8601Date, null: true
 
     def open_enrollment_summary
       return [] unless current_user.can_view_open_enrollment_summary_for?(object)
@@ -200,17 +214,17 @@ module Types
       end
     end
 
-    # Independent ProjectName field is needed because limited access viewers cannot resolve the project
+    # Needed because limited access viewers cannot resolve the project
     def project_name
       project&.project_name
     end
 
-    # Independent ProjectType field is needed because limited access viewers cannot resolve the project
+    # Needed because limited access viewers cannot resolve the project
     def project_type
       project&.project_type
     end
 
-    # Independent OrganizationName field is needed because limited access viewers cannot resolve the project
+    # Needed because limited access viewers cannot resolve the project
     def organization_name
       load_ar_association(project, :organization).organization_name
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
@@ -15,6 +15,7 @@ module Types
         def assessments_field(name = :assessments, description = nil, filter_args: {}, **override_options, &block)
           default_field_options = { type: HmisSchema::Assessment.page_type, null: false, description: description }
           field_options = default_field_options.merge(override_options)
+
           field(name, **field_options) do
             argument :sort_order, Types::HmisSchema::AssessmentSortOption, required: false
             argument :in_progress, GraphQL::Types::Boolean, required: false

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -93,16 +93,13 @@ module Types
     field :data_collection_features, [Types::HmisSchema::DataCollectionFeature], null: false, description: 'Occurrence Point data collection features that are enabled for this Project (e.g. Current Living Situations, Events)'
     field :occurrence_point_forms, [Types::HmisSchema::OccurrencePointForm], null: false, method: :occurrence_point_form_instances, description: 'Forms for individual data elements that are collected at occurrence for this Project (e.g. Move-In Date)'
 
-    # TODO: resolve related HMISParticipation records
-    # TODO: resolve related CEParticipation records
-
     def hud_id
       object.project_id
     end
 
     def enrollments(**args)
       # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
-      return unless current_user.can_view_enrollment_details_for?(object)
+      raise 'access denied' unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_enrollments(object.enrollments_including_wip, dangerous_skip_permission_check: true, **args)
     end
@@ -117,7 +114,7 @@ module Types
 
     def services(**args)
       # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
-      return unless current_user.can_view_enrollment_details_for?(object)
+      raise 'access denied' unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_services(**args, dangerous_skip_permission_check: true)
     end
@@ -161,7 +158,7 @@ module Types
 
     def households(**args)
       # Skipping permission checks below for performance. Ensure the user can access enrollment details for this project here, and don't re-check.
-      return unless current_user.can_view_enrollment_details_for?(object)
+      raise 'access denied' unless current_user.can_view_enrollment_details_for?(object)
 
       resolve_households(object.households_including_wip, **args, dangerous_skip_permission_check: true)
     end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -113,12 +113,12 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     return none unless user.permissions?(:can_view_enrollment_details, :can_view_limited_enrollment_details, mode: 'any')
 
     # Projects where the user has full enrollment access
-    full_acccess_project_ids = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all').pluck(:id, :ProjectID)
+    full_access_project_ids = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all').pluck(:id, :ProjectID)
     # Projects where the user has limited enrollment access
-    limited_acccess_project_ids = Hmis::Hud::Project.with_access(user, :can_view_limited_enrollment_details).pluck(:id, :ProjectID)
+    limited_access_project_ids = Hmis::Hud::Project.with_access(user, :can_view_limited_enrollment_details).pluck(:id, :ProjectID)
 
-    viewable_wip = wip_t[:project_id].in(full_acccess_project_ids.map(&:first) + limited_acccess_project_ids.map(&:first))
-    viewable_enrollment = e_t[:ProjectID].in(full_acccess_project_ids.map(&:second) + limited_acccess_project_ids.map(&:second))
+    viewable_wip = wip_t[:project_id].in(full_access_project_ids.map(&:first) + limited_access_project_ids.map(&:first))
+    viewable_enrollment = e_t[:ProjectID].in(full_access_project_ids.map(&:second) + limited_access_project_ids.map(&:second))
 
     left_outer_joins(:wip).where(viewable_wip.or(viewable_enrollment))
   end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -104,10 +104,23 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     left_outer_joins(:wip).where(viewable_wip.or(viewable_enrollment))
   end
 
-  # hide previous declaration of :viewable_by, we'll use this one
-  # A user can see any enrollment associated with a project they can view
-  replace_scope :viewable_by, ->(user) do
-    with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all')
+  # Enrollments that this user has access to. By default, only returns enrollments that the user has full
+  # access to (can_view_enrollment_details).
+  #
+  # Note: use "replace_scope" hide previous declaration of :viewable_by
+  replace_scope :viewable_by, ->(user, include_limited_access_enrollments: false) do
+    return with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all') unless include_limited_access_enrollments
+    return none unless user.permissions?(:can_view_enrollment_details, :can_view_limited_enrollment_details, mode: 'any')
+
+    # Projects where the user has full enrollment access
+    full_acccess_project_ids = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all').pluck(:id, :ProjectID)
+    # Projects where the user has limited enrollment access
+    limited_acccess_project_ids = Hmis::Hud::Project.with_access(user, :can_view_limited_enrollment_details).pluck(:id, :ProjectID)
+
+    viewable_wip = wip_t[:project_id].in(full_acccess_project_ids.map(&:first) + limited_acccess_project_ids.map(&:first))
+    viewable_enrollment = e_t[:ProjectID].in(full_acccess_project_ids.map(&:second) + limited_acccess_project_ids.map(&:second))
+
+    left_outer_joins(:wip).where(viewable_wip.or(viewable_enrollment))
   end
 
   # Free-text search for Enrollment

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -236,6 +236,14 @@ class Hmis::Role < ::ApplicationRecord
           'Enrollments',
         ],
       },
+      can_view_limited_enrollment_details: {
+        description: 'Grants access to view limited information about an enrollment, including: entry date, exit date, project name, project type, move-in date, and last bed night date.',
+        administrative: false,
+        access: [:viewable],
+        categories: [
+          'Enrollments',
+        ],
+      },
       can_view_open_enrollment_summary: {
         description: 'Grants access to view minimal information (entry date, project name, move-in date) for all open enrollments for a given client, regardless of whether the user can see those other projects.',
         administrative: false,

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect do
         _, result = post_graphql(**variables) { query }
         expect(result.dig('data', 'client', 'enrollments', 'nodes').size).to eq(enrollments.size)
-      end.to perform_under(150).ms
+      end.to perform_under(200).ms
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect do
         _, result = post_graphql(**variables) { query }
         expect(result.dig('data', 'client', 'enrollments', 'nodes').size).to eq(enrollments.size)
-      end.to perform_under(200).ms
+      end.to perform_under(250).ms
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_spec.rb
@@ -9,64 +9,24 @@ require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
 RSpec.describe Hmis::GraphqlController, type: :request do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   include_context 'hmis base setup'
   let!(:access_control) { create_access_control(hmis_user, p1) }
   let!(:c1) { create :hmis_hud_client, data_source: ds1 }
   let!(:c2) { create :hmis_hud_client, data_source: ds1 }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
-  let!(:e2_wip) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+  let!(:e2_wip) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c1 }
 
   describe 'project query' do
     before(:each) do
       hmis_login(user)
-      e2_wip.save_in_progress
     end
 
     let(:query) do
       <<~GRAPHQL
-        query GetProject($id: ID!) {
-          project(id: $id) {
+        query GetClient($id: ID!, $status: [EnrollmentFilterOptionStatus!]) {
+          client(id: $id) {
             id
-            enrollments(limit: 10, offset: 0) {
-              nodesCount
-              nodes {
-                id
-              }
-            }
-          }
-        }
-      GRAPHQL
-    end
-
-    let(:wip_only_query) do
-      <<~GRAPHQL
-        query GetProject($id: ID!) {
-          project(id: $id) {
-            id
-            enrollments(limit: 10, offset: 0, filters: { status: [INCOMPLETE] }) {
-              nodesCount
-              nodes {
-                id
-              }
-            }
-          }
-        }
-      GRAPHQL
-    end
-
-    let(:non_wip_query) do
-      <<~GRAPHQL
-        query GetProject($id: ID!) {
-          project(id: $id) {
-            id
-            enrollments(limit: 10, offset: 0, filters: { status: [ACTIVE, EXITED] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: $status }) {
               nodesCount
               nodes {
                 id
@@ -78,29 +38,30 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
 
     it 'resolves WIP and non-WIP by default' do
-      response, result = post_graphql(id: p1.id) { query }
+      response, result = post_graphql(id: c1.id) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
-        enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
+        expect(response.status).to eq(200), result.inspect
+        enrollments = result.dig('data', 'client', 'enrollments', 'nodes').map { |n| n['id'] }
         expect(enrollments.size).to eq(2)
+        expect(enrollments).to contain_exactly(e1.id.to_s, e2_wip.id.to_s)
       end
     end
 
-    it 'applies WIP-only limit' do
-      response, result = post_graphql(id: p1.id) { wip_only_query }
+    it 'applies WIP-only filter' do
+      response, result = post_graphql(id: c1.id, status: ['INCOMPLETE']) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
-        enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
+        expect(response.status).to eq(200), result.inspect
+        enrollments = result.dig('data', 'client', 'enrollments', 'nodes')
         expect(enrollments.size).to eq(1)
         expect(enrollments[0]['id']).to eq(e2_wip.id.to_s)
       end
     end
 
-    it 'applies non-WIP-only limit' do
-      response, result = post_graphql(id: p1.id) { non_wip_query }
+    it 'applies non-WIP-only filter' do
+      response, result = post_graphql(id: c1.id, status: ['ACTIVE', 'EXITED']) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
-        enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
+        expect(response.status).to eq(200), result.inspect
+        enrollments = result.dig('data', 'client', 'enrollments', 'nodes')
         expect(enrollments.size).to eq(1)
         expect(enrollments[0]['id']).to eq(e1.id.to_s)
       end

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
@@ -21,14 +21,17 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:c1) { create :hmis_hud_client, data_source: ds1 }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
   let!(:s1) { create :hmis_hud_service, data_source: ds1, enrollment: e1, client: c1 }
+  let!(:a1) { create :hmis_hud_assessment, data_source: e1.data_source, enrollment: e1, client: c1 }
 
   # override base setup
   let!(:cst1) { create :hmis_custom_service_type_for_hud_service, data_source: ds1, custom_service_category: csc1, user: u1 }
 
   # canary values
   let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1 }
-  let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p2, client: c1 }
+  let!(:access_control2) { create_access_control(hmis_user, p2, with_permission: :can_view_clients) }
+  let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p2, client: c1, sexual_orientation: 2 }
   let!(:s2) { create :hmis_hud_service, data_source: ds1, enrollment: e2, client: c1 }
+  let!(:a2) { create :hmis_hud_assessment, data_source: e1.data_source, enrollment: e2, client: c1 }
 
   before(:each) do
     hmis_login(user)
@@ -43,6 +46,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             enrollments(limit: 10, offset: 0) {
               nodes {
                 id
+                entryDate # limited-access
+                projectName # limited-access
+                sexualOrientation # detail-access
               }
             }
             services(limit: 10, offset: 0) {
@@ -57,19 +63,97 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     it 'resolves only services and enrollments at visible projects' do
       response, result = post_graphql(id: c1.id) { query }
-      expect(response.status).to eq 200
+      expect(response.status).to eq(200), result.inspect
 
       aggregate_failures 'checking response' do
         [e1].map(&:id).map(&:to_s).tap do |expected|
           expect(expected.size).to eq 1
           enrollments = result.dig('data', 'client', 'enrollments', 'nodes')
-          expect(enrollments.map { |r| r.fetch('id') }).to eq(expected)
+          expect(enrollments.map { |r| r.fetch('id') }).to contain_exactly(*expected)
         end
         c1.hmis_services.where(enrollment_id: e1.enrollment_id).map(&:id).map(&:to_s).tap do |expected|
           expect(expected.size).to eq 1
           services = result.dig('data', 'client', 'services', 'nodes')
-          expect(services.map { |r| r.fetch('id') }).to eq(expected)
+          expect(services.map { |r| r.fetch('id') }).to contain_exactly(*expected)
         end
+      end
+    end
+
+    it 'resolves enrollment where user has limited access (but not services)' do
+      create_access_control(hmis_user, p2, with_permission: :can_view_limited_enrollment_details)
+
+      response, result = post_graphql(id: c1.id) { query }
+      expect(response.status).to eq(200), result.inspect
+
+      aggregate_failures 'checking response' do
+        [e1, e2].map(&:id).map(&:to_s).tap do |expected|
+          expect(expected.size).to eq 2
+          enrollments = result.dig('data', 'client', 'enrollments', 'nodes')
+          expect(enrollments.map { |r| r.fetch('id') }).to contain_exactly(*expected)
+
+          # enrollment details should not be present on limited enrollment (e2)
+          resolved_e2 = enrollments.find { |e| e['id'] == e2.id.to_s }
+          expect(e2.sexual_orientation).to be_present
+          expect(resolved_e2['sexualOrientation']).to be_nil # redacted due to permissions
+          expect(resolved_e2['entryDate']).to be_present
+          expect(resolved_e2['projectName']).to be_present
+        end
+
+        # Only resolves services for e1
+        c1.hmis_services.where(enrollment_id: e1.enrollment_id).map(&:id).map(&:to_s).tap do |expected|
+          expect(expected.size).to eq 1
+          services = result.dig('data', 'client', 'services', 'nodes')
+          expect(services.map { |r| r.fetch('id') }).to contain_exactly(*expected)
+        end
+      end
+    end
+
+    describe 'resolving limited-access enrollments' do
+      let!(:limited_access_control) { create_access_control(hmis_user, p2, with_permission: :can_view_limited_enrollment_details) }
+      let(:query_with_project) do
+        <<~GRAPHQL
+          query TestQuery($id: ID!) {
+            client(id: $id) {
+              id
+              enrollments(limit: 10, offset: 0) {
+                nodes {
+                  id
+                  project { # detail-access non-nullable, will error
+                    id
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      let(:query_with_assessments) do
+        <<~GRAPHQL
+          query TestQuery($id: ID!) {
+            client(id: $id) {
+              id
+              enrollments(limit: 10, offset: 0) {
+                nodes {
+                  id
+                  assessments { # detail-access non-nullable, will error
+                    nodes {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      it 'errors if attempting to resolve project on a limited-access enrollment' do
+        expect { post_graphql(id: c1.id) { query_with_project } }.to raise_error(StandardError)
+      end
+
+      it 'errors if attempting to resolve assessments on a limited-access enrollment' do
+        expect { post_graphql(id: c1.id) { query_with_assessments } }.to raise_error(StandardError)
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
@@ -48,8 +48,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             enrollments(limit: 10, offset: 0) {
               nodes {
                 id
-                entryDate # limited-access
-                projectName # limited-access
+                entryDate # summary-access
+                projectName # summary-access
+                access {
+                  canViewEnrollmentDetails # summary-access
+                }
                 sexualOrientation # detail-access
               }
             }
@@ -99,6 +102,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect(resolved_e2['sexualOrientation']).to be_nil # redacted due to permissions
           expect(resolved_e2['entryDate']).to be_present
           expect(resolved_e2['projectName']).to be_present
+          expect(resolved_e2['access']['canViewEnrollmentDetails']).to eq(false)
         end
 
         # Only resolves services for e1

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   describe 'Client lookup' do
     it 'should resolve no related records if user does not have view access' do
-      remove_permissions(access_control, :can_view_enrollment_details)
+      remove_permissions(access_control, :can_view_enrollment_details, :can_view_limited_enrollment_details)
       response, result = post_graphql(id: c1.id) { client_query }
       expect(response.status).to eq 200
       client = result.dig('data', 'client')

--- a/drivers/hmis/spec/requests/hmis/project_enrollments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollments_spec.rb
@@ -9,64 +9,24 @@ require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
 RSpec.describe Hmis::GraphqlController, type: :request do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   include_context 'hmis base setup'
   let!(:access_control) { create_access_control(hmis_user, p1) }
   let!(:c1) { create :hmis_hud_client, data_source: ds1 }
   let!(:c2) { create :hmis_hud_client, data_source: ds1 }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
-  let!(:e2_wip) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+  let!(:e2_wip) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c1 }
 
   describe 'project query' do
     before(:each) do
       hmis_login(user)
-      e2_wip.save_in_progress
     end
 
     let(:query) do
       <<~GRAPHQL
-        query GetProject($id: ID!) {
+        query GetProject($id: ID!, $status: [EnrollmentFilterOptionStatus!]) {
           project(id: $id) {
             id
-            enrollments(limit: 10, offset: 0) {
-              nodesCount
-              nodes {
-                id
-              }
-            }
-          }
-        }
-      GRAPHQL
-    end
-
-    let(:wip_only_query) do
-      <<~GRAPHQL
-        query GetProject($id: ID!) {
-          project(id: $id) {
-            id
-            enrollments(limit: 10, offset: 0, filters: { status: [INCOMPLETE] }) {
-              nodesCount
-              nodes {
-                id
-              }
-            }
-          }
-        }
-      GRAPHQL
-    end
-
-    let(:non_wip_query) do
-      <<~GRAPHQL
-        query GetProject($id: ID!) {
-          project(id: $id) {
-            id
-            enrollments(limit: 10, offset: 0, filters: { status: [ACTIVE, EXITED] }) {
+            enrollments(limit: 10, offset: 0, filters: { status: $status }) {
               nodesCount
               nodes {
                 id
@@ -80,26 +40,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'resolves WIP and non-WIP by default' do
       response, result = post_graphql(id: p1.id) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
-        enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
+        expect(response.status).to eq(200), result.inspect
+        enrollments = result.dig('data', 'project', 'enrollments', 'nodes').map { |n| n['id'] }
         expect(enrollments.size).to eq(2)
+        expect(enrollments).to contain_exactly(e1.id.to_s, e2_wip.id.to_s)
       end
     end
 
-    it 'applies WIP-only limit' do
-      response, result = post_graphql(id: p1.id) { wip_only_query }
+    it 'applies WIP-only filter' do
+      response, result = post_graphql(id: p1.id, status: ['INCOMPLETE']) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
+        expect(response.status).to eq(200), result.inspect
         enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
         expect(enrollments.size).to eq(1)
         expect(enrollments[0]['id']).to eq(e2_wip.id.to_s)
       end
     end
 
-    it 'applies non-WIP-only limit' do
-      response, result = post_graphql(id: p1.id) { non_wip_query }
+    it 'applies non-WIP-only filter' do
+      response, result = post_graphql(id: p1.id, status: ['ACTIVE', 'EXITED']) { query }
       aggregate_failures 'checking response' do
-        expect(response.status).to eq 200
+        expect(response.status).to eq(200), result.inspect
         enrollments = result.dig('data', 'project', 'enrollments', 'nodes')
         expect(enrollments.size).to eq(1)
         expect(enrollments[0]['id']).to eq(e1.id.to_s)

--- a/drivers/hmis/spec/support/graphql_helpers.rb
+++ b/drivers/hmis/spec/support/graphql_helpers.rb
@@ -68,7 +68,7 @@ module GraphqlHelpers
   def expect_gql_error(arr, message: nil)
     response, result = arr
     error_message = result.dig('errors', 0, 'message')
-    expect(response.status).to eq 500
+    expect(response.status).to eq(500), result.inspect
     expect(error_message).to be_present
     expect(error_message).to eq(message) if message.present?
   end


### PR DESCRIPTION
## Description

Support "limited" enrollment access. This type of access lets you see the existence of the enrollment plus some limited information about it: Entry date, exit date, project/org name, project type, enrollment period, relationship to hoh, move-in date, and last bed night date.

I implemented this using field level authorization on the GQL Enrollment type. The majority of fields require the `can_view_enrollment_details` permission, but some fields can resolve with `can_view_limited_enrollment_details`.

Here is an example of the UI. This is an example client dashboard where the user only has permission to view enrollment details at Chestnut Grove organization, but is permitted to see limited enrollment details for enrollments at other projects.

https://www.pivotaltracker.com/n/projects/2591838/stories/186304198

Frontend PR: https://github.com/greenriver/hmis-frontend/pull/542

<img width="1139" alt="Screenshot 2023-10-30 at 5 19 08 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/d1602789-eb7b-4531-90b4-e58dc768d8cf">


## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
