### PR TITLE
Always show Open In HMIS link for HMIS clients

### DIFF
--- a/app/views/clients/_demographic_row.haml
+++ b/app/views/clients/_demographic_row.haml
@@ -24,12 +24,12 @@
     - if authoritative_data_source_ids.include?(client.data_source_id) && !client.data_source.hmis? && can_create_clients?
       = link_to 'Edit', polymorphic_path([:edit] + source_client_path_generator, id: client.id), class: 'btn btn-sm btn-secondary', data: {loads_in_pjax_modal: true}
   %td.text-right
+    - if client.data_source.hmis?
+      .mb-2.text-teeny
+        %a{href: client.data_source.hmis_url_for(client), target: :blank}
+          Open in HMIS
+          %i.icon-link-ext
     - if @client.hmis_source_visible_by?(current_user) && (!authoritative_data_source_ids.include?(client.data_source_id) || client.data_source.hmis?)
-      - if client.data_source.hmis?
-        .mb-2.text-teeny
-          %a{href: client.data_source.hmis_url_for(client), target: :blank}
-            Open in HMIS
-            %i.icon-link-ext
       = link_to 'HMIS Client', source_datum_path(client.id, type: 'Client'), class: 'btn btn-xs btn-secondary btn-muted btn-hmis mb-2'
       .text-teeny.font-weight-light
         .text-nowrap


### PR DESCRIPTION
## Description

Always show HMIS link on HMIS client demographic row.

Currently it is gated by `hmis_source_visible_by` which requires administrative permissions like editing data sources and uploading HUD zips. That does not seems necessary.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
