### PR TITLE
health check much lighter weight. Removes lots of log noise too.

### DIFF
--- a/app/controllers/system_status_controller.rb
+++ b/app/controllers/system_status_controller.rb
@@ -4,9 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class SystemStatusController < ApplicationController
-  skip_before_action :authenticate_user!
-
+class SystemStatusController < ActionController::Base
   def exception
     raise 'A forced exception for testing purposes.'
   end
@@ -17,19 +15,9 @@ class SystemStatusController < ApplicationController
     render status: 200, plain: 'Ping'
   end
 
-  # Provide a path for nagios or other system checker to determine if the system is
-  # operational
+  # minimal health check
   def operational
-    user_count = User.all.count
-    data_source_count = GrdaWarehouse::DataSource.count
-    patient_count = Health::Patient.count
-    if user_count.present? && data_source_count.present? && patient_count.present?
-      Rails.logger.info 'Operating system is operational'
-      render plain: 'OK'
-    else
-      Rails.logger.info 'Operating system is not operational'
-      render status: 500, plain: 'FAIL'
-    end
+    render plain: 'OK'
   end
 
   def cache_status


### PR DESCRIPTION
## Description

Makes health check more minimal to try to prevent flapping of the target group targets. Removes log noise.

Test via `system_status/operational` endpoint and `system_status/details` endpoint.


## Type of change
- [x] Bug fix. Non-responsive databases shouldn't cause the app to be stopped and started.


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
