### PR TITLE
186387448-fix-invalid-session-handling

### DIFF
--- a/lib/devise/custom_auth_failure.rb
+++ b/lib/devise/custom_auth_failure.rb
@@ -7,7 +7,7 @@
 class CustomAuthFailure < Devise::FailureApp
   def respond
     if scope == :hmis_user
-      return json_error_response if request.content_type == 'application/json'
+      return json_error_response if request.content_type == 'application/json' || request.format == :json
 
       return redirect_to_hmis if ENV['HMIS_OKTA_CLIENT_ID'].present?
     end

--- a/lib/devise/custom_auth_failure.rb
+++ b/lib/devise/custom_auth_failure.rb
@@ -7,9 +7,9 @@
 class CustomAuthFailure < Devise::FailureApp
   def respond
     if scope == :hmis_user
-      return redirect_to_hmis if ENV['HMIS_OKTA_CLIENT_ID'].present?
+      return json_error_response if request.content_type == 'application/json'
 
-      return json_error_response if request.format == :json
+      return redirect_to_hmis if ENV['HMIS_OKTA_CLIENT_ID'].present?
     end
     super
   end


### PR DESCRIPTION
## Description
[Fix invalid session handling](https://www.pivotaltracker.com/story/show/186387448)

When a session is invalid (a user signed in via another browser), an API request is not handled correctly. Right now we redirect, causing our JSON request to return HTML which it can't parse. This corrects the error handler to return a 401 instead so the client can invalidate the local state.

## testing:
sign in in one browser, then sign in a second browser or incognito session. Return the first browser and navigate to a page that makes a network request. You should see "Your session has ended: You may have signed out in another window. Click OK to log in again." You should be able to continue and sign in again.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
