### PR TITLE
Fix for cohorts timing out if there are too many clients

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -56,8 +56,9 @@ class CohortsController < ApplicationController
     params[:population] ||= 'Active Clients'
     load_cohort_names
     @cohort = cohort_scope.find(cohort_id)
-    # leave off the pagination here and return all the data
-    @cohort_clients = @cohort.search_clients(population: params[:population], user: current_user)
+    # Just fetch one client so the UI works, but we really are just using @cohort_clients in this context
+    # to determine if there is anyone on the page we're looking at
+    @cohort_clients = @cohort.search_clients(population: params[:population], user: current_user).limit(1)
     # redirect_to cohorts_path(population: ) if @cohort.needs_client_search?
     @cohort_client_updates = @cohort.cohort_clients.select(:id, :updated_at).map { |m| [m.id, m.updated_at.to_i] }.to_h
     @population = params[:population]


### PR DESCRIPTION
## Description

Prevent loading all cohort clients (with preloads) just to determine if we have at least one person on the page.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
