### PR TITLE
Stop storing Enrollment WIP status in instance variable

### DIFF
--- a/drivers/hmis/app/models/hmis/entity_access_loader_factory.rb
+++ b/drivers/hmis/app/models/hmis/entity_access_loader_factory.rb
@@ -35,7 +35,7 @@ class Hmis::EntityAccessLoaderFactory
   # @yieldreturn [#resolved, nil] the association (record.association)
   # @return [Array<Hmis::BaseLoader, #entity>]
   def perform(entity, &block)
-    raise 'Cannot resolve assocation for unpersisted record' unless entity.persisted?
+    raise "Cannot resolve assocation for unpersisted record of type #{entity.class.name}" unless entity.persisted?
 
     resolve_entity(entity, safety: 0, &block)
   end
@@ -85,7 +85,7 @@ class Hmis::EntityAccessLoaderFactory
 
     return nil unless resolved
 
-    raise 'Cannot resolve assocation for unpersisted record' unless resolved.persisted?
+    raise "Cannot resolve assocation for unpersisted record of type #{resolved.class.name}" unless resolved.persisted?
 
     resolve_entity(resolved, safety: safety + 1, &block)
   end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -302,8 +302,7 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   end
 
   def in_progress?
-    @in_progress = project_id.nil? if @in_progress.nil?
-    @in_progress
+    project_id.nil?
   end
 
   def exit_in_progress?


### PR DESCRIPTION
## Description

Fix a big that I think was introduced in  https://github.com/greenriver/hmis-warehouse/pull/3682 maybe from introducing `GraphqlPermissionChecker` concern. I don't quite understand why that surfaced this issue, but its the only recent relevant code change that this directly touches. The entity resolver was evaluating `enrollment.in_progress?` to `true` even though it wasn't, and then trying to resolve a WIP record that didnt exist.

Sentry: https://green-river.sentry.io/issues/4596336383/?project=4503977346662400&query=is%3Aunresolved+Cannot+resolve+assocation+for+unpersiste&referrer=issue-stream&statsPeriod=14d&stream_index=0

**How to reproduce the bug on release-91**: enroll a new household with 2+ members. Perform the intake assessments and submit them together. The linked sentry error will occur.


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
