### PR TITLE
Add hmis_group_viewable_entities table

### DIFF
--- a/db/views/hmis_group_viewable_entity_projects_v02.sql
+++ b/db/views/hmis_group_viewable_entity_projects_v02.sql
@@ -1,0 +1,50 @@
+-- rails generate scenic:view hmis_group_viewable_entity_projects --replace
+(
+  -- projects
+  SELECT
+    "hmis_group_viewable_entities"."id" AS group_viewable_entity_id,
+    NULL as organization_id,
+    "hmis_group_viewable_entities"."entity_id" AS project_id
+  FROM
+    "hmis_group_viewable_entities"
+  WHERE
+    "hmis_group_viewable_entities"."entity_type" = 'Hmis::Hud::Project'
+    AND "hmis_group_viewable_entities"."deleted_at" IS NULL
+)
+UNION
+(
+  -- projects through organization
+  SELECT
+    "hmis_group_viewable_entities"."id" AS group_viewable_entity_id,
+    "Organization"."id" AS organization_id,
+    "Project"."id" AS project_id
+  FROM
+    "hmis_group_viewable_entities"
+    INNER JOIN "Organization" ON "Organization"."DateDeleted" IS NULL
+    AND "Organization"."id" = "hmis_group_viewable_entities"."entity_id"
+    INNER JOIN "Project" ON "Project"."DateDeleted" IS NULL
+    AND "Organization"."data_source_id" = "Project"."data_source_id"
+    AND "Organization"."OrganizationID" = "Project"."OrganizationID"
+  WHERE
+    "hmis_group_viewable_entities"."entity_type" = 'Hmis::Hud::Organization'
+    AND "hmis_group_viewable_entities"."deleted_at" IS NULL
+)
+UNION
+(
+  -- projects and organization through data_source
+  SELECT
+    "hmis_group_viewable_entities"."id" AS group_viewable_entity_id,
+    "Organization"."id" as organization_id,
+    "Project"."id" AS project_id
+  FROM
+    "hmis_group_viewable_entities"
+    INNER JOIN "data_sources" ON "data_sources"."deleted_at" IS NULL
+    AND "data_sources"."id" = "hmis_group_viewable_entities"."entity_id"
+    LEFT JOIN "Project" ON "Project"."DateDeleted" IS NULL
+    AND "data_sources"."id" = "Project"."data_source_id"
+    LEFT JOIN "Organization" ON "Organization"."DateDeleted" IS NULL
+    AND "data_sources"."id" = "Organization"."data_source_id"
+  WHERE
+    "hmis_group_viewable_entities"."entity_type" = 'GrdaWarehouse::DataSource'
+    AND "hmis_group_viewable_entities"."deleted_at" IS NULL
+)

--- a/db/warehouse/migrate/20231103151804_add_hmis_group_viewable_entities.rb
+++ b/db/warehouse/migrate/20231103151804_add_hmis_group_viewable_entities.rb
@@ -1,0 +1,9 @@
+class AddHmisGroupViewableEntities < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hmis_group_viewable_entities do |t|
+      t.references :entity, polymorphic: true, null: false
+      t.references :collection, null: false
+      t.datetime :deleted_at
+    end
+  end
+end

--- a/db/warehouse/migrate/20231103153556_update_hmis_group_viewable_entity_projects_to_version_2.rb
+++ b/db/warehouse/migrate/20231103153556_update_hmis_group_viewable_entity_projects_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateHmisGroupViewableEntityProjectsToVersion2 < ActiveRecord::Migration[6.1]
+  def change
+    update_view :hmis_group_viewable_entity_projects, version: 2, revert_to_version: 1
+  end
+end

--- a/db/warehouse/migrate/20231103154939_migrate_hmis_viewable_entities.rb
+++ b/db/warehouse/migrate/20231103154939_migrate_hmis_viewable_entities.rb
@@ -1,0 +1,32 @@
+class MigrateHmisViewableEntities < ActiveRecord::Migration[6.1]
+  def change
+    # Migrate records from GrdaWarehouse::GroupViewableEntity to Hmis::GroupViewableEntity
+    # NOTE: this only migrates Viewable Entities for Projects and Organiations.
+    # If there were any HMIS AccesGroups that contained _data sources_, they will need to
+    # be manually updated in the UI.
+
+    entity_types = [
+      'Hmis::Hud::Organization',
+      'Hmis::Hud::Project',
+    ]
+    rows_to_migrate = GrdaWarehouse::GroupViewableEntity.where(entity_type: entity_types)
+    if rows_to_migrate.exists?
+      attributes = rows_to_migrate.map do |gve|
+        {
+          collection_id: gve.access_group_id,
+          entity_id: gve.entity_id,
+          entity_type: gve.entity_type,
+        }
+      end
+
+      Hmis::GroupViewableEntity.transaction do
+        result = Hmis::GroupViewableEntity.import(attributes)
+        raise "Failed to import HMIS group viewable entities: #{result.failed_instances}" if result.failed_instances.any?
+
+        # Delete from warehouse table
+        # Commenting out, we can do this later after verifying a successful migration
+        # rows_to_migrate.update_all(deleted_at: Time.current)
+      end
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -162,115 +162,225 @@ $_$;
 CREATE FUNCTION public.service_history_service_insert_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
+
       BEGIN
+
       IF  ( NEW.date BETWEEN DATE '2050-01-01' AND DATE '2050-12-31' ) THEN
+
             INSERT INTO service_history_services_2050 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2049-01-01' AND DATE '2049-12-31' ) THEN
+
             INSERT INTO service_history_services_2049 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2048-01-01' AND DATE '2048-12-31' ) THEN
+
             INSERT INTO service_history_services_2048 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2047-01-01' AND DATE '2047-12-31' ) THEN
+
             INSERT INTO service_history_services_2047 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2046-01-01' AND DATE '2046-12-31' ) THEN
+
             INSERT INTO service_history_services_2046 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2045-01-01' AND DATE '2045-12-31' ) THEN
+
             INSERT INTO service_history_services_2045 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2044-01-01' AND DATE '2044-12-31' ) THEN
+
             INSERT INTO service_history_services_2044 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2043-01-01' AND DATE '2043-12-31' ) THEN
+
             INSERT INTO service_history_services_2043 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2042-01-01' AND DATE '2042-12-31' ) THEN
+
             INSERT INTO service_history_services_2042 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2041-01-01' AND DATE '2041-12-31' ) THEN
+
             INSERT INTO service_history_services_2041 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2040-01-01' AND DATE '2040-12-31' ) THEN
+
             INSERT INTO service_history_services_2040 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2039-01-01' AND DATE '2039-12-31' ) THEN
+
             INSERT INTO service_history_services_2039 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2038-01-01' AND DATE '2038-12-31' ) THEN
+
             INSERT INTO service_history_services_2038 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2037-01-01' AND DATE '2037-12-31' ) THEN
+
             INSERT INTO service_history_services_2037 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2036-01-01' AND DATE '2036-12-31' ) THEN
+
             INSERT INTO service_history_services_2036 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2035-01-01' AND DATE '2035-12-31' ) THEN
+
             INSERT INTO service_history_services_2035 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2034-01-01' AND DATE '2034-12-31' ) THEN
+
             INSERT INTO service_history_services_2034 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2033-01-01' AND DATE '2033-12-31' ) THEN
+
             INSERT INTO service_history_services_2033 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2032-01-01' AND DATE '2032-12-31' ) THEN
+
             INSERT INTO service_history_services_2032 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2031-01-01' AND DATE '2031-12-31' ) THEN
+
             INSERT INTO service_history_services_2031 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2030-01-01' AND DATE '2030-12-31' ) THEN
+
             INSERT INTO service_history_services_2030 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2029-01-01' AND DATE '2029-12-31' ) THEN
+
             INSERT INTO service_history_services_2029 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2028-01-01' AND DATE '2028-12-31' ) THEN
+
             INSERT INTO service_history_services_2028 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2027-01-01' AND DATE '2027-12-31' ) THEN
+
             INSERT INTO service_history_services_2027 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2026-01-01' AND DATE '2026-12-31' ) THEN
+
             INSERT INTO service_history_services_2026 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2025-01-01' AND DATE '2025-12-31' ) THEN
+
             INSERT INTO service_history_services_2025 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2024-01-01' AND DATE '2024-12-31' ) THEN
+
             INSERT INTO service_history_services_2024 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2023-01-01' AND DATE '2023-12-31' ) THEN
+
             INSERT INTO service_history_services_2023 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2022-01-01' AND DATE '2022-12-31' ) THEN
+
             INSERT INTO service_history_services_2022 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2021-01-01' AND DATE '2021-12-31' ) THEN
+
             INSERT INTO service_history_services_2021 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2020-01-01' AND DATE '2020-12-31' ) THEN
+
             INSERT INTO service_history_services_2020 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2019-01-01' AND DATE '2019-12-31' ) THEN
+
             INSERT INTO service_history_services_2019 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2018-01-01' AND DATE '2018-12-31' ) THEN
+
             INSERT INTO service_history_services_2018 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2017-01-01' AND DATE '2017-12-31' ) THEN
+
             INSERT INTO service_history_services_2017 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2016-01-01' AND DATE '2016-12-31' ) THEN
+
             INSERT INTO service_history_services_2016 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2015-01-01' AND DATE '2015-12-31' ) THEN
+
             INSERT INTO service_history_services_2015 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2014-01-01' AND DATE '2014-12-31' ) THEN
+
             INSERT INTO service_history_services_2014 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2013-01-01' AND DATE '2013-12-31' ) THEN
+
             INSERT INTO service_history_services_2013 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2012-01-01' AND DATE '2012-12-31' ) THEN
+
             INSERT INTO service_history_services_2012 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2011-01-01' AND DATE '2011-12-31' ) THEN
+
             INSERT INTO service_history_services_2011 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2010-01-01' AND DATE '2010-12-31' ) THEN
+
             INSERT INTO service_history_services_2010 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2009-01-01' AND DATE '2009-12-31' ) THEN
+
             INSERT INTO service_history_services_2009 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2008-01-01' AND DATE '2008-12-31' ) THEN
+
             INSERT INTO service_history_services_2008 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2007-01-01' AND DATE '2007-12-31' ) THEN
+
             INSERT INTO service_history_services_2007 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2006-01-01' AND DATE '2006-12-31' ) THEN
+
             INSERT INTO service_history_services_2006 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2005-01-01' AND DATE '2005-12-31' ) THEN
+
             INSERT INTO service_history_services_2005 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2004-01-01' AND DATE '2004-12-31' ) THEN
+
             INSERT INTO service_history_services_2004 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2003-01-01' AND DATE '2003-12-31' ) THEN
+
             INSERT INTO service_history_services_2003 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2002-01-01' AND DATE '2002-12-31' ) THEN
+
             INSERT INTO service_history_services_2002 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2001-01-01' AND DATE '2001-12-31' ) THEN
+
             INSERT INTO service_history_services_2001 VALUES (NEW.*);
+
          ELSIF  ( NEW.date BETWEEN DATE '2000-01-01' AND DATE '2000-12-31' ) THEN
+
             INSERT INTO service_history_services_2000 VALUES (NEW.*);
-        
+
+
+
       ELSE
+
         INSERT INTO service_history_services_remainder VALUES (NEW.*);
+
         END IF;
+
         RETURN NULL;
+
     END;
+
     $$;
 
 
@@ -2993,8 +3103,8 @@ ALTER SEQUENCE public.api_client_data_source_ids_id_seq OWNED BY public.api_clie
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -6247,9 +6357,6 @@ CREATE TABLE public.cohort_tabs (
     cohort_id bigint NOT NULL,
     name character varying,
     rules jsonb,
-    "order" integer DEFAULT 0 NOT NULL,
-    permissions jsonb DEFAULT '[]'::jsonb NOT NULL,
-    base_scope character varying DEFAULT 'current_scope'::character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone
@@ -7190,7 +7297,7 @@ ALTER SEQUENCE public.enrollment_change_histories_id_seq OWNED BY public.enrollm
 
 CREATE TABLE public.enrollment_extras (
     id integer NOT NULL,
-    enrollment_id integer,
+    enrollment_id integer NOT NULL,
     vispdat_grand_total integer,
     vispdat_added_at date,
     vispdat_started_at date,
@@ -17462,14 +17569,14 @@ CREATE TABLE public.hmis_dqt_clients (
     overlapping_nbn integer,
     overlapping_pre_move_in integer,
     overlapping_post_move_in integer,
-    ch_at_most_recent_entry boolean DEFAULT false,
-    ch_at_any_entry boolean DEFAULT false,
     veteran_status integer,
     ssn character varying,
     ssn_data_quality integer,
     name_data_quality integer,
     ethnicity integer,
     reporting_age integer,
+    ch_at_most_recent_entry boolean DEFAULT false,
+    ch_at_any_entry boolean DEFAULT false,
     woman integer,
     man integer,
     culturally_specific integer,
@@ -17596,7 +17703,6 @@ CREATE TABLE public.hmis_dqt_enrollments (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone,
     project_type integer,
-    ch_at_entry boolean DEFAULT false,
     project_id integer,
     household_type character varying,
     household_min_age integer,
@@ -17622,19 +17728,20 @@ CREATE TABLE public.hmis_dqt_enrollments (
     cash_income_as_expected_at_entry boolean DEFAULT false,
     cash_income_as_expected_at_annual boolean DEFAULT false,
     cash_income_as_expected_at_exit boolean DEFAULT false,
-    ncb_from_any_source_at_entry integer,
-    ncb_from_any_source_at_annual integer,
-    ncb_from_any_source_at_exit integer,
+    ncb_from_any_source_at_entry boolean DEFAULT false,
+    ncb_from_any_source_at_annual boolean DEFAULT false,
+    ncb_from_any_source_at_exit boolean DEFAULT false,
     ncb_as_expected_at_entry boolean DEFAULT false,
     ncb_as_expected_at_annual boolean DEFAULT false,
     ncb_as_expected_at_exit boolean DEFAULT false,
-    insurance_from_any_source_at_entry integer,
-    insurance_from_any_source_at_annual integer,
-    insurance_from_any_source_at_exit integer,
+    insurance_from_any_source_at_entry boolean DEFAULT false,
+    insurance_from_any_source_at_annual boolean DEFAULT false,
+    insurance_from_any_source_at_exit boolean DEFAULT false,
     insurance_as_expected_at_entry boolean DEFAULT false,
     insurance_as_expected_at_annual boolean DEFAULT false,
     insurance_as_expected_at_exit boolean DEFAULT false,
     disability_at_entry_collected boolean DEFAULT false,
+    ch_at_entry boolean DEFAULT false,
     previous_street_es_sh integer,
     entry_date_entered_at timestamp without time zone,
     exit_date_entered_at timestamp without time zone,
@@ -18277,31 +18384,35 @@ ALTER SEQUENCE public.hmis_forms_id_seq OWNED BY public.hmis_forms.id;
 
 
 --
--- Name: project_groups; Type: TABLE; Schema: public; Owner: -
+-- Name: hmis_group_viewable_entities; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.project_groups (
-    id integer NOT NULL,
-    name character varying NOT NULL,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
-    deleted_at timestamp without time zone,
-    options jsonb DEFAULT '{}'::jsonb
-);
-
-
---
--- Name: project_project_groups; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.project_project_groups (
-    id integer NOT NULL,
-    project_group_id integer,
-    project_id integer,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
+CREATE TABLE public.hmis_group_viewable_entities (
+    id bigint NOT NULL,
+    entity_type character varying,
+    entity_id bigint,
+    collection_id bigint,
     deleted_at timestamp without time zone
 );
+
+
+--
+-- Name: hmis_group_viewable_entities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.hmis_group_viewable_entities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: hmis_group_viewable_entities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.hmis_group_viewable_entities_id_seq OWNED BY public.hmis_group_viewable_entities.id;
 
 
 --
@@ -18309,37 +18420,28 @@ CREATE TABLE public.project_project_groups (
 --
 
 CREATE VIEW public.hmis_group_viewable_entity_projects AS
- SELECT group_viewable_entities.id AS group_viewable_entity_id,
+ SELECT hmis_group_viewable_entities.id AS group_viewable_entity_id,
     NULL::integer AS organization_id,
-    group_viewable_entities.entity_id AS project_id
-   FROM public.group_viewable_entities
-  WHERE (((group_viewable_entities.entity_type)::text = 'Hmis::Hud::Project'::text) AND (group_viewable_entities.deleted_at IS NULL))
+    hmis_group_viewable_entities.entity_id AS project_id
+   FROM public.hmis_group_viewable_entities
+  WHERE (((hmis_group_viewable_entities.entity_type)::text = 'Hmis::Hud::Project'::text) AND (hmis_group_viewable_entities.deleted_at IS NULL))
 UNION
- SELECT group_viewable_entities.id AS group_viewable_entity_id,
+ SELECT hmis_group_viewable_entities.id AS group_viewable_entity_id,
     "Organization".id AS organization_id,
     "Project".id AS project_id
-   FROM ((public.group_viewable_entities
-     JOIN public."Organization" ON ((("Organization"."DateDeleted" IS NULL) AND ("Organization".id = group_viewable_entities.entity_id))))
+   FROM ((public.hmis_group_viewable_entities
+     JOIN public."Organization" ON ((("Organization"."DateDeleted" IS NULL) AND ("Organization".id = hmis_group_viewable_entities.entity_id))))
      JOIN public."Project" ON ((("Project"."DateDeleted" IS NULL) AND ("Organization".data_source_id = "Project".data_source_id) AND (("Organization"."OrganizationID")::text = ("Project"."OrganizationID")::text))))
-  WHERE (((group_viewable_entities.entity_type)::text = 'Hmis::Hud::Organization'::text) AND (group_viewable_entities.deleted_at IS NULL))
+  WHERE (((hmis_group_viewable_entities.entity_type)::text = 'Hmis::Hud::Organization'::text) AND (hmis_group_viewable_entities.deleted_at IS NULL))
 UNION
- SELECT group_viewable_entities.id AS group_viewable_entity_id,
+ SELECT hmis_group_viewable_entities.id AS group_viewable_entity_id,
     "Organization".id AS organization_id,
     "Project".id AS project_id
-   FROM (((public.group_viewable_entities
-     JOIN public.data_sources ON (((data_sources.deleted_at IS NULL) AND (data_sources.id = group_viewable_entities.entity_id))))
+   FROM (((public.hmis_group_viewable_entities
+     JOIN public.data_sources ON (((data_sources.deleted_at IS NULL) AND (data_sources.id = hmis_group_viewable_entities.entity_id))))
      LEFT JOIN public."Project" ON ((("Project"."DateDeleted" IS NULL) AND (data_sources.id = "Project".data_source_id))))
      LEFT JOIN public."Organization" ON ((("Organization"."DateDeleted" IS NULL) AND (data_sources.id = "Organization".data_source_id))))
-  WHERE (((group_viewable_entities.entity_type)::text = 'GrdaWarehouse::DataSource'::text) AND (group_viewable_entities.deleted_at IS NULL))
-UNION
- SELECT group_viewable_entities.id AS group_viewable_entity_id,
-    NULL::integer AS organization_id,
-    "Project".id AS project_id
-   FROM (((public.group_viewable_entities
-     JOIN public.project_groups ON (((project_groups.deleted_at IS NULL) AND (project_groups.id = group_viewable_entities.entity_id))))
-     JOIN public.project_project_groups ON ((project_project_groups.project_group_id = project_groups.id)))
-     JOIN public."Project" ON ((("Project"."DateDeleted" IS NULL) AND ("Project".id = project_project_groups.project_id))))
-  WHERE (((group_viewable_entities.entity_type)::text = 'GrdaWarehouse::ProjectGroup'::text) AND (group_viewable_entities.deleted_at IS NULL));
+  WHERE (((hmis_group_viewable_entities.entity_type)::text = 'GrdaWarehouse::DataSource'::text) AND (hmis_group_viewable_entities.deleted_at IS NULL));
 
 
 --
@@ -18479,7 +18581,7 @@ CREATE VIEW public.hmis_services AS
     "Services"."EnrollmentID",
     "Services"."PersonalID",
     "Services"."DateProvided",
-    "Services"."UserID",
+    ("Services"."UserID")::character varying AS "UserID",
     "Services"."DateCreated",
     "Services"."DateUpdated",
     "Services"."DateDeleted",
@@ -18878,6 +18980,12 @@ CREATE TABLE public.homeless_summary_report_clients (
     spm_adults_with_children_where_parenting_adult_18_to_24__a_n_h_ integer,
     spm_adults_with_children_where_parenting_adult_18_to_24__n_n_h_ integer,
     spm_adults_with_children_where_parenting_adult_18_to_24__h_n_h_ integer,
+    spm_all_persons__mid_east_n_afric integer,
+    spm_without_children__mid_east_n_ integer,
+    spm_with_children__mid_east_n_afr integer,
+    spm_only_children__mid_east_n_afr integer,
+    spm_without_children_and_fifty_fi integer,
+    spm_adults_with_children_where_pa integer,
     spm_all_persons__mid_east_n_african integer,
     spm_all_persons__hispanic_latinaeo integer,
     spm_without_children__mid_east_n_african integer,
@@ -21221,33 +21329,6 @@ ALTER SEQUENCE public.non_hmis_uploads_id_seq OWNED BY public.non_hmis_uploads.i
 
 
 --
--- Name: organization_47_tes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.organization_47_tes (
-    source_id integer
-);
-
-
---
--- Name: organization_48_tes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.organization_48_tes (
-    source_id integer
-);
-
-
---
--- Name: organization_49_tes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.organization_49_tes (
-    source_id integer
-);
-
-
---
 -- Name: performance_measurement_goals; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -21381,9 +21462,7 @@ CREATE TABLE public.places (
     updated_at timestamp(6) without time zone NOT NULL,
     city character varying,
     state character varying,
-    zipcode character varying,
-    lat double precision,
-    lon double precision
+    zipcode character varying
 );
 
 
@@ -21763,6 +21842,20 @@ ALTER SEQUENCE public.project_data_quality_id_seq OWNED BY public.project_data_q
 
 
 --
+-- Name: project_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_groups (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    deleted_at timestamp without time zone,
+    options jsonb DEFAULT '{}'::jsonb
+);
+
+
+--
 -- Name: project_groups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -21942,6 +22035,20 @@ CREATE SEQUENCE public.project_pass_fails_projects_id_seq
 --
 
 ALTER SEQUENCE public.project_pass_fails_projects_id_seq OWNED BY public.project_pass_fails_projects.id;
+
+
+--
+-- Name: project_project_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_project_groups (
+    id integer NOT NULL,
+    project_group_id integer,
+    project_id integer,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone,
+    deleted_at timestamp without time zone
+);
 
 
 --
@@ -24563,6 +24670,7 @@ CREATE TABLE public.system_pathways_enrollments (
     final_enrollment boolean DEFAULT false NOT NULL,
     move_in_date date,
     days_to_move_in integer,
+    days_to_exit_after_move_in integer,
     chronic_at_entry boolean,
     disabling_condition integer
 );
@@ -27964,6 +28072,13 @@ ALTER TABLE ONLY public.hmis_form_processors ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.hmis_forms ALTER COLUMN id SET DEFAULT nextval('public.hmis_forms_id_seq'::regclass);
+
+
+--
+-- Name: hmis_group_viewable_entities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hmis_group_viewable_entities ALTER COLUMN id SET DEFAULT nextval('public.hmis_group_viewable_entities_id_seq'::regclass);
 
 
 --
@@ -31761,6 +31876,14 @@ ALTER TABLE ONLY public.hmis_forms
 
 
 --
+-- Name: hmis_group_viewable_entities hmis_group_viewable_entities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hmis_group_viewable_entities
+    ADD CONSTRAINT hmis_group_viewable_entities_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: hmis_import_configs hmis_import_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -32425,14 +32548,6 @@ ALTER TABLE ONLY public.report_tokens
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
 -- Name: secure_files secure_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -32908,90 +33023,6 @@ CREATE INDEX "Disabilities_DateDeleted_idx" ON public."Disabilities" USING btree
 
 
 --
--- Name: Enrollment_2735; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_2735" ON public."Enrollment" USING btree ("ProjectID", "HouseholdID");
-
-
---
--- Name: Enrollment_3085; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_3085" ON public."Enrollment" USING btree ("PreviousStreetESSH", "LengthOfStay");
-
-
---
--- Name: Enrollment_34e3; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_34e3" ON public."Enrollment" USING btree ("EnrollmentID", "ProjectID", "EntryDate");
-
-
---
--- Name: Enrollment_42af; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_42af" ON public."Enrollment" USING btree ("ProjectID");
-
-
---
--- Name: Enrollment_42d5; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_42d5" ON public."Enrollment" USING btree ("DateUpdated");
-
-
---
--- Name: Enrollment_4337; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_4337" ON public."Enrollment" USING btree ("EnrollmentID");
-
-
---
--- Name: Enrollment_5328; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_5328" ON public."Enrollment" USING btree ("HouseholdID");
-
-
---
--- Name: Enrollment_603f; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_603f" ON public."Enrollment" USING btree ("PersonalID");
-
-
---
--- Name: Enrollment_634d; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_634d" ON public."Enrollment" USING btree ("ExportID");
-
-
---
--- Name: Enrollment_c548; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_c548" ON public."Enrollment" USING btree ("EnrollmentID", "PersonalID");
-
-
---
--- Name: Enrollment_d381; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_d381" ON public."Enrollment" USING btree ("DateCreated");
-
-
---
--- Name: Enrollment_f3a2; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX "Enrollment_f3a2" ON public."Enrollment" USING btree ("DateDeleted");
-
-
---
 -- Name: IncomeBenefits_DateDeleted_data_source_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -33160,13 +33191,6 @@ CREATE INDEX client_personal_id ON public."Client" USING btree ("PersonalID");
 
 
 --
--- Name: coc_code_test; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX coc_code_test ON public."EnrollmentCoC" USING btree ("CoCCode");
-
-
---
 -- Name: computed_project_type_rsh_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -33244,6 +33268,13 @@ CREATE UNIQUE INDEX ds_ceparticipation_idx ON public."CEParticipation" USING btr
 
 
 --
+-- Name: ds_email_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ds_email_idx ON public."User" USING btree (data_source_id, "UserEmail");
+
+
+--
 -- Name: ds_hmisparticipation_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -33304,13 +33335,6 @@ CREATE INDEX employment_education_export_id ON public."EmploymentEducation" USIN
 --
 
 CREATE UNIQUE INDEX en_en_id_p_id_ds_id ON public."Enrollment" USING btree ("EnrollmentID", "PersonalID", data_source_id);
-
-
---
--- Name: en_tt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX en_tt ON public.hmis_2022_enrollments USING btree ("EnrollmentID", "PersonalID", importer_log_id, data_source_id);
 
 
 --
@@ -52256,6 +52280,20 @@ CREATE INDEX index_hmis_forms_on_name ON public.hmis_forms USING btree (name);
 
 
 --
+-- Name: index_hmis_group_viewable_entities_on_collection_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hmis_group_viewable_entities_on_collection_id ON public.hmis_group_viewable_entities USING btree (collection_id);
+
+
+--
+-- Name: index_hmis_group_viewable_entities_on_entity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hmis_group_viewable_entities_on_entity ON public.hmis_group_viewable_entities USING btree (entity_type, entity_id);
+
+
+--
 -- Name: index_hmis_import_configs_on_data_source_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -53100,13 +53138,6 @@ CREATE INDEX index_performance_metrics_clients_on_report_id ON public.performanc
 --
 
 CREATE INDEX index_performance_metrics_clients_on_updated_at ON public.performance_metrics_clients USING btree (updated_at);
-
-
---
--- Name: index_places_on_lat_and_lon; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_places_on_lat_and_lon ON public.places USING btree (lat, lon);
 
 
 --
@@ -57681,13 +57712,6 @@ CREATE UNIQUE INDEX test_shs ON public.service_history_services_2000 USING btree
 
 
 --
--- Name: tt; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX tt ON public.hmis_2022_exits USING btree ("EnrollmentID", "PersonalID", importer_log_id, data_source_id);
-
-
---
 -- Name: tx_id_ds_id_ft_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -57779,6 +57803,13 @@ CREATE UNIQUE INDEX unique_index_ensuring_one_key_per_record_type ON public."Cus
 
 
 --
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
+
+
+--
 -- Name: unk_Geography; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -57804,13 +57835,6 @@ CREATE UNIQUE INDEX "unk_Project" ON public."Project" USING btree (data_source_i
 --
 
 CREATE UNIQUE INDEX "unk_Site" ON public."Geography" USING btree (data_source_id, "GeographyID");
-
-
---
--- Name: users_ds_email_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX users_ds_email_idx ON public."User" USING btree ("UserEmail", data_source_id);
 
 
 --
@@ -58915,22 +58939,6 @@ CREATE RULE attempt_client_searchable_names_up AS
 
 
 --
--- Name: hmis_group_viewable_entity_projects attempt_hmis_group_viewable_entity_projects_del; Type: RULE; Schema: public; Owner: -
---
-
-CREATE RULE attempt_hmis_group_viewable_entity_projects_del AS
-    ON DELETE TO public.hmis_group_viewable_entity_projects DO INSTEAD NOTHING;
-
-
---
--- Name: hmis_group_viewable_entity_projects attempt_hmis_group_viewable_entity_projects_up; Type: RULE; Schema: public; Owner: -
---
-
-CREATE RULE attempt_hmis_group_viewable_entity_projects_up AS
-    ON UPDATE TO public.hmis_group_viewable_entity_projects DO INSTEAD NOTHING;
-
-
---
 -- Name: hmis_households attempt_hmis_households_del; Type: RULE; Schema: public; Owner: -
 --
 
@@ -59696,13 +59704,1006 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20160727190957'),
+('20160729135359'),
+('20160729183141'),
+('20160816131814'),
+('20160816173101'),
+('20160818180405'),
+('20160823130251'),
+('20160823144637'),
+('20160824150416'),
+('20160826140306'),
+('20160902162623'),
+('20160902185045'),
+('20160910000538'),
+('20160913132444'),
+('20160913152926'),
+('20160913155401'),
+('20160913160306'),
+('20160913161311'),
+('20160914185810'),
+('20160919210259'),
+('20160919212545'),
+('20160922142402'),
+('20160922162359'),
+('20160922185930'),
+('20160923113802'),
+('20160926002900'),
+('20160926145351'),
+('20160926170204'),
+('20160927134516'),
+('20160927183151'),
+('20160927184003'),
+('20160927202506'),
+('20160927202843'),
+('20160927203650'),
+('20160927205852'),
+('20160928125517'),
+('20160928140906'),
+('20160928202720'),
+('20160929010237'),
+('20160929153319'),
+('20160930142027'),
+('20161004181613'),
+('20161006180229'),
+('20161007160124'),
+('20161007182409'),
+('20161011135522'),
+('20161017193504'),
+('20161019122336'),
+('20161019181914'),
+('20161020175933'),
+('20161021142349'),
+('20161021185201'),
+('20161024205300'),
+('20161025142716'),
+('20161027160241'),
+('20161027173838'),
+('20161029184725'),
+('20161030141156'),
+('20161102131838'),
+('20161102194513'),
+('20161103173010'),
+('20161104131304'),
+('20161108150033'),
+('20161109173403'),
+('20161111194734'),
+('20161111200331'),
+('20161111205557'),
+('20161111210852'),
+('20161111214343'),
+('20161115160857'),
+('20161115163024'),
+('20161115173437'),
+('20161115181519'),
+('20161115194005'),
+('20161117042632'),
+('20161117211439'),
+('20161121134639'),
+('20161122193356'),
+('20161122205922'),
+('20161122212446'),
+('20161123145006'),
+('20161128164214'),
+('20161212154456'),
+('20161213184140'),
+('20161222172617'),
+('20161223181314'),
+('20161228184803'),
+('20161229150159'),
+('20170110183158'),
+('20170210211420'),
+('20170314123357'),
+('20170420193254'),
+('20170505131647'),
+('20170505135248'),
+('20170508001011'),
+('20170508003906'),
+('20170509183056'),
+('20170510131916'),
+('20170518194049'),
+('20170526142051'),
+('20170526162435'),
+('20170530203255'),
+('20170531152936'),
+('20170602183611'),
+('20170602235909'),
+('20170604225122'),
+('20170605004541'),
+('20170605011844'),
+('20170607195038'),
+('20170609162811'),
+('20170619211924'),
+('20170620000812'),
+('20170620013208'),
+('20170622125121'),
+('20170626133126'),
+('20170705125336'),
+('20170706145106'),
+('20170712174621'),
+('20170712182033'),
+('20170714172533'),
+('20170714195436'),
+('20170716180758'),
+('20170716202346'),
+('20170718132138'),
+('20170719172444'),
+('20170726140915'),
+('20170727231741'),
+('20170728151813'),
+('20170728201723'),
+('20170801120635'),
+('20170809173044'),
+('20170815174824'),
+('20170816175326'),
+('20170816205625'),
+('20170817150519'),
+('20170818140329'),
+('20170829131400'),
+('20170830171507'),
+('20170904132001'),
+('20170904140427'),
+('20170904202838'),
+('20170905122913'),
+('20170905122914'),
+('20170905122915'),
+('20170905122916'),
+('20170905122917'),
+('20170905122918'),
+('20170905183117'),
+('20170905202251'),
+('20170905202611'),
+('20170906161906'),
+('20170911124040'),
+('20170911194951'),
+('20170912134710'),
+('20170913192945'),
+('20170918135821'),
+('20170921201252'),
+('20170922193229'),
+('20170922200507'),
+('20170924001510'),
+('20170924005724'),
+('20170924193906'),
+('20170925000145'),
+('20170926124009'),
+('20170926200356'),
+('20170927194653'),
+('20170928185422'),
+('20170928191904'),
+('20170929193327'),
+('20170930184143'),
+('20171003122627'),
+('20171005191828'),
+('20171016191359'),
+('20171019085351'),
+('20171019143151'),
+('20171020131243'),
+('20171021194831'),
+('20171023175038'),
+('20171023194703'),
+('20171024123740'),
+('20171024180819'),
+('20171025165617'),
+('20171026122017'),
+('20171026152842'),
+('20171027031033'),
+('20171102134710'),
+('20171103003947'),
+('20171103134010'),
+('20171103154925'),
+('20171106005358'),
+('20171106211934'),
+('20171108195513'),
+('20171110180121'),
+('20171111032952'),
+('20171111190457'),
+('20171113134728'),
+('20171113142927'),
+('20171113182656'),
+('20171114132110'),
+('20171115182249'),
+('20171115193025'),
+('20171116155352'),
+('20171116184557'),
+('20171127191122'),
+('20171127203632'),
+('20171127234210'),
+('20171128161058'),
+('20171129131811'),
+('20171129172903'),
+('20171201180334'),
+('20171201180412'),
+('20171204161239'),
+('20171204180630'),
+('20171205135225'),
+('20171206131931'),
+('20171208151137'),
+('20171211131328'),
+('20171211142747'),
+('20171211194546'),
+('20171212182935'),
+('20171213002710'),
+('20171213002924'),
+('20171215203448'),
+('20171218211735'),
+('20171219160943'),
+('20171222140958'),
+('20171222142957'),
+('20171222143540'),
+('20171222151018'),
+('20180114165737'),
+('20180114181159'),
+('20180115165003'),
+('20180115195008'),
+('20180117210259'),
+('20180120142315'),
+('20180120145651'),
+('20180120184755'),
+('20180122135635'),
+('20180122190528'),
+('20180123145547'),
+('20180123151137'),
+('20180125214133'),
+('20180126184544'),
+('20180126212658'),
+('20180126230757'),
+('20180127151221'),
+('20180129211310'),
+('20180129222234'),
+('20180130173319'),
+('20180203202523'),
+('20180205134947'),
+('20180205160021'),
+('20180206132151'),
+('20180206132418'),
+('20180206132549'),
+('20180206211300'),
+('20180209140514'),
+('20180209145558'),
+('20180211182226'),
+('20180211191923'),
+('20180212154518'),
+('20180213132145'),
+('20180213133619'),
+('20180215212401'),
+('20180216221704'),
+('20180218004200'),
+('20180218194158'),
+('20180218195838'),
+('20180219003427'),
+('20180219011911'),
+('20180219213751'),
+('20180221172154'),
+('20180221200920'),
+('20180222132714'),
+('20180223131630'),
+('20180226181023'),
+('20180227184226'),
+('20180228134319'),
+('20180228202408'),
+('20180302005549'),
+('20180303012057'),
+('20180304020707'),
+('20180307184913'),
+('20180309152824'),
+('20180309161833'),
+('20180309194413'),
+('20180309200416'),
+('20180313170616'),
+('20180314121340'),
+('20180319204410'),
+('20180326140546'),
+('20180330145925'),
+('20180408102020'),
+('20180410081403'),
+('20180424182721'),
+('20180424185646'),
+('20180424190544'),
+('20180425140146'),
+('20180510001923'),
+('20180510002556'),
+('20180510130324'),
+('20180516130234'),
+('20180516133454'),
+('20180521173754'),
+('20180528152133'),
+('20180528155555'),
+('20180528174021'),
+('20180529122603'),
+('20180605164543'),
+('20180613193551'),
+('20180614004301'),
+('20180615232905'),
+('20180616123004'),
+('20180617111542'),
+('20180617130414'),
+('20180626134714'),
+('20180626140358'),
+('20180628035131'),
+('20180707180119'),
+('20180707183425'),
+('20180709173131'),
+('20180710174412'),
+('20180710195222'),
+('20180713143703'),
+('20180716142944'),
+('20180716175514'),
+('20180716181552'),
+('20180718152629'),
+('20180723180257'),
+('20180731125029'),
+('20180801185645'),
+('20180810142730'),
+('20180810175903'),
+('20180813144056'),
+('20180814144715'),
+('20180815162429'),
+('20180831171525'),
+('20180909174113'),
+('20180910121905'),
+('20180910130909'),
+('20180912121943'),
+('20180912154937'),
+('20180914235727'),
+('20180917204430'),
+('20180919135034'),
+('20181001174159'),
+('20181001180812'),
+('20181001193048'),
+('20181005171232'),
+('20181005172849'),
+('20181010193431'),
+('20181012130754'),
+('20181015132913'),
+('20181015132958'),
+('20181019160628'),
+('20181019182438'),
+('20181019185052'),
+('20181022144551'),
+('20181026125946'),
+('20181030142001'),
+('20181031151924'),
+('20181107183718'),
+('20181107184057'),
+('20181107184157'),
+('20181107184258'),
+('20181119165528'),
+('20181206135841'),
+('20181206195139'),
+('20181207011350'),
+('20181210141734'),
+('20181218184800'),
+('20181219184841'),
+('20181227145018'),
+('20190107135250'),
+('20190108133610'),
+('20190110145430'),
+('20190110205705'),
+('20190111154442'),
+('20190111162407'),
+('20190114175107'),
+('20190129175440'),
+('20190129193710'),
+('20190129193718'),
+('20190129193734'),
+('20190130141818'),
+('20190201172226'),
+('20190204194825'),
+('20190208173854'),
+('20190209204636'),
+('20190211182446'),
+('20190211212757'),
+('20190215151428'),
+('20190215174811'),
+('20190216193115'),
+('20190221211525'),
+('20190225173734'),
+('20190228151509'),
+('20190306011413'),
+('20190307205203'),
+('20190313191758'),
+('20190314233300'),
+('20190315202420'),
+('20190319174002'),
+('20190320132816'),
+('20190320135300'),
+('20190321154235'),
+('20190322182648'),
+('20190324204257'),
+('20190325205709'),
+('20190327174322'),
+('20190328135601'),
+('20190328183719'),
+('20190328201651'),
+('20190329122650'),
+('20190408180044'),
+('20190423144729'),
+('20190424185158'),
+('20190424194714'),
+('20190501154934'),
+('20190502150143'),
+('20190507184540'),
+('20190508181020'),
+('20190509161703'),
+('20190510123307'),
+('20190512175652'),
+('20190531005415'),
+('20190603155216'),
+('20190603192544'),
+('20190603204753'),
+('20190604164934'),
+('20190605121550'),
+('20190605153143'),
+('20190605155107'),
+('20190606000839'),
+('20190606111838'),
+('20190611020510'),
+('20190612194424'),
+('20190614132143'),
+('20190617141627'),
+('20190617154412'),
+('20190701175345'),
+('20190701203722'),
+('20190701203738'),
+('20190705192539'),
+('20190709170452'),
+('20190710202403'),
+('20190712190215'),
+('20190715191354'),
+('20190715195832'),
+('20190715203906'),
+('20190715371835'),
+('20190717171417'),
+('20190719141740'),
+('20190725172606'),
+('20190725183917'),
+('20190725205710'),
+('20190726191455'),
+('20190726201314'),
+('20190730141425'),
+('20190801130133'),
+('20190801131014'),
+('20190802121551'),
+('20190805172310'),
+('20190808155531'),
+('20190814011156'),
+('20190814174740'),
+('20190814194736'),
+('20190814195700'),
+('20190814202518'),
+('20190816160117'),
+('20190819235806'),
+('20190820145158'),
+('20190821163752'),
+('20190821200216'),
+('20190823150100'),
+('20190823175037'),
+('20190902140838'),
+('20190909171338'),
+('20190913131118'),
+('20190916192050'),
+('20190917000129'),
+('20190917001135'),
+('20190917172920'),
+('20190918132924'),
+('20190918191348'),
+('20190918204616'),
+('20190919153540'),
+('20190919164531'),
+('20190919211227'),
+('20190923153128'),
+('20190924134442'),
+('20190927193254'),
+('20191007155052'),
+('20191011124048'),
+('20191014144407'),
+('20191017122329'),
+('20191017141927'),
+('20191021192058'),
+('20191025130319'),
+('20191029172244'),
+('20191101143044'),
+('20191101171753'),
+('20191102185935'),
+('20191104145557'),
+('20191106135508'),
+('20191107212914'),
+('20191111144437'),
+('20191112142922'),
+('20191114212804'),
+('20191115192256'),
+('20191120171159'),
+('20191205155752'),
+('20191216210204'),
+('20191219154817'),
+('20191223133641'),
+('20191223141858'),
+('20191223161021'),
+('20191223203007'),
+('20191227161033'),
+('20200106005041'),
+('20200106010648'),
+('20200106161751'),
+('20200106175129'),
+('20200108174617'),
+('20200108184052'),
+('20200110150204'),
+('20200114154449'),
+('20200120191326'),
+('20200205010344'),
+('20200207165957'),
+('20200211150300'),
+('20200211154527'),
+('20200212140919'),
+('20200214200455'),
+('20200217152806'),
+('20200217194551'),
+('20200219175547'),
+('20200221194355'),
+('20200225181344'),
+('20200225181450'),
+('20200225190151'),
+('20200302164716'),
+('20200303174258'),
+('20200303183252'),
+('20200304153159'),
+('20200306172853'),
+('20200307210926'),
+('20200310141315'),
+('20200312175312'),
+('20200319123357'),
+('20200324151503'),
+('20200325181533'),
+('20200325200620'),
+('20200326183628'),
+('20200326203618'),
+('20200327143205'),
+('20200327203519'),
+('20200328122019'),
+('20200328124124'),
+('20200402121258'),
+('20200408133149'),
+('20200414121843'),
+('20200415124657'),
+('20200417164547'),
+('20200420123748'),
+('20200420144827'),
+('20200421121604'),
+('20200424152842'),
+('20200424202136'),
+('20200429142723'),
+('20200430124823'),
+('20200430173113'),
+('20200504140400'),
+('20200506181929'),
+('20200506195939'),
+('20200514185800'),
+('20200518125929'),
+('20200519175104'),
+('20200530134853'),
+('20200608183800'),
+('20200617123752'),
+('20200625130802'),
+('20200627165150'),
+('20200628001355'),
+('20200628002641'),
+('20200628153252'),
+('20200629153416'),
+('20200629180206'),
+('20200630152328'),
+('20200701150708'),
+('20200701171520'),
+('20200701192839'),
+('20200702125231'),
+('20200703025438'),
+('20200703154239'),
+('20200703154409'),
+('20200703223937'),
+('20200703234840'),
+('20200706171817'),
+('20200706180800'),
+('20200706193249'),
+('20200713203505'),
+('20200716132417'),
+('20200718194102'),
+('20200719235413'),
+('20200721190101'),
+('20200722194242'),
+('20200722200713'),
+('20200723143000'),
+('20200723144121'),
+('20200723172609'),
+('20200723204046'),
+('20200724153536'),
+('20200724173742'),
+('20200724180227'),
+('20200729203440'),
+('20200731143840'),
+('20200731181511'),
+('20200806183758'),
+('20200812144640'),
+('20200812153339'),
+('20200814173200'),
+('20200821185026'),
+('20200824174347'),
+('20200826165713'),
+('20200827130841'),
+('20200827224602'),
+('20200831151807'),
+('20200831193024'),
+('20200901201024'),
+('20200903133437'),
+('20200904191736'),
+('20200910142617'),
+('20200914190210'),
+('20200915230624'),
+('20200916144557'),
+('20200916195351'),
+('20200917185233'),
+('20200917193037'),
+('20200921194630'),
+('20200922192121'),
+('20200923184619'),
+('20200925172414'),
+('20200925201420'),
+('20200927201419'),
+('20200928194005'),
+('20200929203230'),
+('20201001171704'),
+('20201006134420'),
+('20201006194015'),
+('20201008204557'),
+('20201009165424'),
+('20201019193328'),
+('20201020181913'),
+('20201023130124'),
+('20201027200503'),
+('20201030145808'),
+('20201104133922'),
+('20201104182139'),
+('20201104183517'),
+('20201109142122'),
+('20201110201513'),
+('20201111165550'),
+('20201116211113'),
+('20201125130708'),
+('20201201162902'),
+('20201202135347'),
+('20201203140706'),
+('20201208140125'),
+('20201208210326'),
+('20201209163906'),
+('20201211142334'),
+('20201211213255'),
+('20201216164355'),
+('20201218132535'),
+('20201218134107'),
+('20201218180004'),
+('20201223180342'),
+('20210106173839'),
+('20210106195019'),
+('20210111123325'),
+('20210113151049'),
+('20210116192833'),
+('20210118133014'),
+('20210118160904'),
+('20210125151501'),
+('20210201195631'),
+('20210204141807'),
+('20210209182423'),
+('20210216125622'),
+('20210217173551'),
+('20210217202610'),
+('20210223011452'),
+('20210225144651'),
+('20210303180023'),
+('20210303181117'),
+('20210303200052'),
+('20210305204708'),
+('20210312200044'),
+('20210325202706'),
+('20210330124825'),
+('20210413143040'),
+('20210422191627'),
+('20210426165914'),
+('20210427184522'),
+('20210428193540'),
+('20210503165055'),
+('20210505010944'),
+('20210507180711'),
+('20210507180738'),
+('20210507180809'),
+('20210510182341'),
+('20210513185514'),
+('20210514154843'),
+('20210515142741'),
+('20210517144348'),
+('20210520184416'),
+('20210526182148'),
+('20210527140359'),
+('20210601135719'),
+('20210601173704'),
+('20210603121547'),
+('20210603143037'),
+('20210604155334'),
+('20210615131534'),
+('20210616181054'),
+('20210616193735'),
+('20210622171720'),
+('20210623184626'),
+('20210623184729'),
+('20210623195645'),
+('20210625231326'),
+('20210630201802'),
+('20210702143811'),
+('20210702144442'),
+('20210707122337'),
+('20210707172124'),
+('20210707190613'),
+('20210707193633'),
+('20210708183958'),
+('20210708192452'),
+('20210714131449'),
+('20210716144139'),
+('20210717154701'),
+('20210722155210'),
+('20210723161722'),
+('20210726155740'),
+('20210727134415'),
+('20210729175328'),
+('20210729201521'),
+('20210806202832'),
+('20210809124146'),
+('20210809130851'),
+('20210809154208'),
+('20210809184745'),
+('20210810182752'),
+('20210813121134'),
+('20210819132406'),
+('20210819133035'),
+('20210823203031'),
+('20210825182548'),
+('20210830150500'),
+('20210901200255'),
+('20210902113909'),
+('20210902134959'),
+('20210903113401'),
+('20210904021301'),
+('20210906163956'),
+('20210909160929'),
+('20210910113307'),
+('20210910133606'),
+('20210916194101'),
+('20210917140612'),
+('20210920132236'),
+('20210920200621'),
+('20210923202947'),
+('20210926190212'),
+('20210927130613'),
+('20210927133554'),
+('20210929182410'),
+('20210930135501'),
+('20211001135131'),
+('20211001160706'),
+('20211004174014'),
+('20211009183833'),
+('20211011191547'),
+('20211013135958'),
+('20211015172536'),
+('20211018183403'),
+('20211019154744'),
+('20211019164536'),
+('20211020130447'),
+('20211023193009'),
+('20211027185505'),
+('20211101203339'),
+('20211102203208'),
+('20211103235413'),
+('20211108203857'),
+('20211109161950'),
+('20211110005810'),
+('20211115191349'),
+('20211117145404'),
+('20211117181217'),
+('20211118175318'),
+('20211119184203'),
+('20211129122357'),
+('20211202160059'),
+('20211208153720'),
+('20211208155347'),
+('20211218202811'),
+('20211220163817'),
+('20211220204231'),
+('20211221151552'),
+('20211223134654'),
+('20211229164804'),
+('20211230201245'),
+('20220101180956'),
+('20220102193048'),
+('20220114140723'),
+('20220126164546'),
+('20220126182806'),
+('20220127153246'),
+('20220127200317'),
+('20220128203412'),
+('20220201213104'),
+('20220204163115'),
+('20220208180300'),
+('20220210132610'),
+('20220211001613'),
+('20220214202202'),
+('20220216204506'),
+('20220302145218'),
+('20220302154833'),
+('20220308185943'),
+('20220308193503'),
+('20220311161639'),
+('20220312204503'),
+('20220316160839'),
+('20220317185834'),
+('20220322185532'),
+('20220328122746'),
+('20220331180748'),
+('20220411150736'),
+('20220413144557'),
+('20220415192223'),
+('20220427144200'),
+('20220511171233'),
+('20220512174700'),
+('20220516171135'),
+('20220523123830'),
+('20220525125953'),
+('20220526203313'),
+('20220527144703'),
+('20220527144717'),
+('20220527191834'),
+('20220601122623'),
+('20220604181405'),
+('20220607155407'),
+('20220610173543'),
+('20220612161111'),
+('20220617180748'),
+('20220621180929'),
+('20220628162723'),
+('20220630151129'),
+('20220712164926'),
+('20220713150217'),
+('20220714190911'),
+('20220715194241'),
+('20220718185442'),
+('20220801135734'),
+('20220804160252'),
+('20220811205630'),
+('20220812193159'),
+('20220815134022'),
+('20220815140216'),
+('20220816194756'),
+('20220816204223'),
+('20220816205217'),
+('20220817193604'),
+('20220818155829'),
+('20220818173333'),
+('20220819184832'),
+('20220822182146'),
+('20220824150945'),
+('20220824155726'),
+('20220824194239'),
+('20220824202625'),
+('20220825131554'),
+('20220826123607'),
+('20220830131900'),
+('20220830142632'),
+('20220831183303'),
+('20220901142553'),
+('20220901202643'),
+('20220906182407'),
+('20220915132815'),
+('20220915133927'),
+('20220915141020'),
+('20220916152205'),
+('20220916182057'),
+('20220916234039'),
+('20220919161059'),
+('20220919185042'),
+('20220920192149'),
+('20220921141010'),
+('20220921182035'),
+('20220925175719'),
+('20220928132603'),
+('20220928150112'),
+('20220928164029'),
+('20220930194814'),
+('20221006193112'),
+('20221007152924'),
+('20221013195245'),
+('20221014144316'),
+('20221017180229'),
+('20221018164204'),
+('20221019122456'),
+('20221019182810'),
+('20221020113634'),
+('20221021205724'),
+('20221028172017'),
+('20221102194234'),
+('20221103144659'),
+('20221103201310'),
+('20221104134752'),
+('20221107144111'),
+('20221108134143'),
+('20221109155552'),
+('20221110133236'),
+('20221115123832'),
+('20221115211004'),
+('20221116185411'),
+('20221124002729'),
+('20221126145518'),
+('20221207171030'),
+('20221209131957'),
+('20221220180133'),
+('20221220184746'),
+('20221223202329'),
+('20230105155630'),
+('20230105155655'),
+('20230107220752'),
+('20230108133748'),
+('20230109173226'),
+('20230110174657'),
+('20230112142317'),
+('20230119123843'),
+('20230123010327'),
+('20230124195245'),
 ('20230127151606'),
+('20230127200801'),
+('20230206142754'),
+('20230207151644'),
+('20230214194841'),
+('20230227195221'),
+('20230301172341'),
+('20230303154815'),
+('20230303181248'),
+('20230307143837'),
+('20230309205059'),
+('20230313122300'),
+('20230313152950'),
+('20230319133739'),
+('20230320131930'),
+('20230322183901'),
+('20230322220754'),
+('20230327202808'),
+('20230328171436'),
+('20230403144801'),
+('20230406154235'),
+('20230406183420'),
+('20230407164611'),
 ('20230410202101'),
+('20230411193836'),
+('20230412163545'),
+('20230412191455'),
+('20230414130229'),
+('20230414152958'),
+('20230417122614'),
+('20230418163934'),
+('20230419162140'),
+('20230419165219'),
+('20230419190654'),
+('20230420164514'),
+('20230424194313'),
+('20230426175101'),
+('20230428141601'),
+('20230428145659'),
+('20230428155418'),
 ('20230428203604'),
 ('20230428203806'),
 ('20230428210859'),
+('20230429185311'),
 ('20230429212740'),
+('20230429224702'),
 ('20230501183045'),
+('20230502175218'),
+('20230503155642'),
+('20230503161258'),
 ('20230504131726'),
 ('20230504152750'),
 ('20230505150822'),
@@ -59815,8 +60816,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231020151224'),
 ('20231021205059'),
 ('20231028140507'),
-('20231028230227'),
-('20231028231546'),
-('20231030140507');
+('20231030140507'),
+('20231103151804'),
+('20231103153556'),
+('20231103154939');
 
 

--- a/drivers/hmis/app/models/hmis/data_source_access_loader.rb
+++ b/drivers/hmis/app/models/hmis/data_source_access_loader.rb
@@ -13,10 +13,10 @@ class Hmis::DataSourceAccessLoader < Hmis::BaseAccessLoader
     validate_items(items, GrdaWarehouse::DataSource)
     entity_ids = items.map { |i| i.first.id }.compact.uniq
 
-    access_group_ids_by_client_id = Hmis::GroupViewableEntity.data_sources
-      .where(entity_id: entity_ids)
-      .pluck('group_viewable_entities.entity_id', 'group_viewable_entities.access_group_id')
-      .group_by(&:shift).transform_values(&:flatten)
+    access_group_ids_by_client_id = Hmis::GroupViewableEntity.data_sources.
+      where(entity_id: entity_ids).
+      pluck(:entity_id, :collection_id).
+      group_by(&:shift).transform_values(&:flatten)
 
     items.map do |entity, permission|
       access_group_ids = access_group_ids_by_client_id[entity.id] || []

--- a/drivers/hmis/app/models/hmis/hud/client_access_loader.rb
+++ b/drivers/hmis/app/models/hmis/hud/client_access_loader.rb
@@ -15,17 +15,17 @@ class Hmis::Hud::ClientAccessLoader < Hmis::BaseAccessLoader
 
     group_view_t = Hmis::GroupViewableEntity.arel_table
     client_project_t = Hmis::Hud::ClientProject.arel_table
-    orphan_client_ids = Hmis::Hud::Client
-      .left_outer_joins(:client_projects)
-      .where(id: client_ids)
-      .where(client_project_t[:project_id].eq(nil))
-      .pluck(arel.c_t[:id])
+    orphan_client_ids = Hmis::Hud::Client.
+      left_outer_joins(:client_projects).
+      where(id: client_ids).
+      where(client_project_t[:project_id].eq(nil)).
+      pluck(arel.c_t[:id])
 
-    access_group_ids_by_client_id = Hmis::Hud::Project
-      .joins(:client_projects, :group_viewable_entities)
-      .where(client_project_t[:client_id].in(client_ids - orphan_client_ids))
-      .pluck(client_project_t[:client_id], group_view_t[:access_group_id])
-      .group_by(&:shift).transform_values(&:flatten)
+    access_group_ids_by_client_id = Hmis::Hud::Project.
+      joins(:client_projects, :group_viewable_entities).
+      where(client_project_t[:client_id].in(client_ids - orphan_client_ids)).
+      pluck(client_project_t[:client_id], group_view_t[:collection_id]).
+      group_by(&:shift).transform_values(&:flatten)
 
     orphan_client_ids = orphan_client_ids.to_set
     items.map do |item|

--- a/drivers/hmis/app/models/hmis/hud/organization_access_loader.rb
+++ b/drivers/hmis/app/models/hmis/hud/organization_access_loader.rb
@@ -13,11 +13,11 @@ class Hmis::Hud::OrganizationAccessLoader < Hmis::BaseAccessLoader
     validate_items(items, Hmis::Hud::Organization)
     organization_ids = items.map { |i| i.first.id }.compact.uniq
 
-    access_group_ids_by_organization_id = Hmis::Hud::Organization
-      .where(id: organization_ids)
-      .joins(:group_viewable_entities)
-      .pluck(arel.o_t[:id], 'group_viewable_entities.access_group_id')
-      .group_by(&:shift).transform_values(&:flatten)
+    access_group_ids_by_organization_id = Hmis::Hud::Organization.
+      where(id: organization_ids).
+      joins(:group_viewable_entities).
+      pluck(arel.o_t[:id], 'hmis_group_viewable_entities.collection_id').
+      group_by(&:shift).transform_values(&:flatten)
 
     items.map do |item|
       organization, permission = item

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -77,7 +77,6 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     ids = user.viewable_projects.pluck(:id)
     ids += user.viewable_organizations.joins(:projects).pluck(p_t[:id])
     ids += user.viewable_data_sources.joins(:projects).pluck(p_t[:id])
-    ids += user.viewable_project_access_groups.joins(:projects).pluck(p_t[:id])
 
     where(id: ids, data_source_id: user.hmis_data_source_id)
   end
@@ -90,7 +89,6 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     ids = user.entities_with_permissions(Hmis::Hud::Project, *permissions, **kwargs).pluck(:id)
     ids += user.entities_with_permissions(Hmis::Hud::Organization, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
     ids += user.entities_with_permissions(GrdaWarehouse::DataSource, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
-    ids += user.entities_with_permissions(GrdaWarehouse::ProjectAccessGroup, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
 
     where(id: ids, data_source_id: user.hmis_data_source_id)
   end

--- a/drivers/hmis/app/models/hmis/hud/project_access_loader.rb
+++ b/drivers/hmis/app/models/hmis/hud/project_access_loader.rb
@@ -13,11 +13,11 @@ class Hmis::Hud::ProjectAccessLoader < Hmis::BaseAccessLoader
     validate_items(items, Hmis::Hud::Project)
     project_ids = items.map { |i| i.first.id }.uniq
 
-    access_group_ids_by_project_id = Hmis::Hud::Project
-      .joins(:group_viewable_entities)
-      .where(id: project_ids)
-      .pluck(arel.p_t[:id], 'group_viewable_entities.access_group_id')
-      .group_by(&:shift).transform_values(&:flatten)
+    access_group_ids_by_project_id = Hmis::Hud::Project.
+      joins(:group_viewable_entities).
+      where(id: project_ids).
+      pluck(arel.p_t[:id], 'hmis_group_viewable_entities.collection_id').
+      group_by(&:shift).transform_values(&:flatten)
 
     items.map do |item|
       project, permission = item

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -127,7 +127,7 @@ class Hmis::User < ApplicationRecord
     access_group_ids = access_controls.where(role_id: roles_with_permission).pluck(:access_group_id)
 
     entity_ids = Hmis::GroupViewableEntity.where(
-      access_group_id: access_group_ids,
+      collection_id: access_group_ids,
       entity_type: model.sti_name,
     ).select(:entity_id)
 
@@ -149,10 +149,6 @@ class Hmis::User < ApplicationRecord
 
   def viewable_projects
     viewable Hmis::Hud::Project
-  end
-
-  def viewable_project_access_groups
-    viewable GrdaWarehouse::ProjectAccessGroup
   end
 
   def viewable_project_ids
@@ -186,10 +182,6 @@ class Hmis::User < ApplicationRecord
 
   def editable_projects
     editable Hmis::Hud::Project
-  end
-
-  def editable_project_access_groups
-    editable GrdaWarehouse::ProjectAccessGroup
   end
 
   def editable_project_ids

--- a/drivers/hmis/app/views/hmis_admin/groups/_viewable_entities.haml
+++ b/drivers/hmis/app/views/hmis_admin/groups/_viewable_entities.haml
@@ -19,7 +19,7 @@
       = render 'entity_column', entity: @organizations, f: f
       -# Add back once we have support for Hmis Project Groups.
       -# = render 'entity_column', entity: @project_access_groups, f: f
-      = render 'entity_column', entity: @projects, associations: [:data_source, :organization, :project_access_group], f: f
+      = render 'entity_column', entity: @projects, associations: [:data_source, :organization], f: f
 
 - content_for :page_js do
   :javascript

--- a/drivers/hmis/doc/PERMISSIONS.md
+++ b/drivers/hmis/doc/PERMISSIONS.md
@@ -40,7 +40,6 @@ When checking if a user has permission on a given entity, each type of entity re
 - `Hmis::Hud::Project`
 - `Hmis::Hud::Organization`
 - `GrdaWarehouse::DataSource`
-- `GrdaWarehouse::ProjectAccessGroup`
 
 Once the permissions base is determined, the permission check involves determining whether the user is connected to an `AccessControl` that meets the following conditions:
 


### PR DESCRIPTION
## Description

Add `hmis_group_viewable_entities` table to back the `Hmis::GroupViewableEntity` model, which war previosly backed by the `group_viewable_entities` table (shared with warehouse). Includes a migration to migrate HMIS group viewable entities  to the new table.


Comments:
* I set up the new table with column name `collection_id` instead of `access_group_id`, since I'd like to eventually make the naming fully consistent with the warehouse. 
* I removed the unused references to `GrdaWarehouse::ProjectAccessGroup` in HMIS access code as well, so I didn't have to deal with making an exception for it (when its nonexistent). We are not planning to share project groups across the system, there is a separate work item for adding HMIS Project Groups https://www.pivotaltracker.com/story/show/186150161.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
