### PR TITLE
Double the web cpu request, reduce deploy cpu, and increase DJ by 50%.

### DIFF
--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -39,11 +39,6 @@ class Deployer
 
   attr_accessor :web_options
 
-  # github actions or other CI builds the image, so when true, don't try to
-  # build locally and push (which can be slow).
-  attr_accessor :assume_ci_build
-  attr_accessor :push_allowed
-
   # The fully-qualified domain name of the application
   # We use this so we can get data from the app about the deployment state
   attr_accessor :fqdn
@@ -52,22 +47,23 @@ class Deployer
 
   attr_accessor :service_registry_arns
 
-  def initialize(target_group_name:, assume_ci_build: true, secrets_arn:, execution_role:, task_role:, dj_options: nil, web_options:, registry_id:, repo_name:, fqdn:, service_registry_arns:) # rubocop:disable Metrics/ParameterLists
-    self.service_registry_arns    = service_registry_arns
+  attr_accessor :args
+
+  def initialize(args)
+    self.service_registry_arns    = args.fetch(:service_registry_arns)
     self.cluster                  = _cluster_name
-    self.target_group_name        = target_group_name
-    self.assume_ci_build          = assume_ci_build
-    self.secrets_arn              = secrets_arn
-    self.execution_role           = execution_role
-    self.task_role                = task_role
-    self.dj_options               = dj_options || []
-    self.fqdn                     = fqdn
-    self.push_allowed             = true
-    self.web_options              = web_options
-    self.registry_id              = registry_id
-    self.repo_name                = repo_name
+    self.target_group_name        = args.fetch(:target_group_name)
+    self.secrets_arn              = args.fetch(:secrets_arn)
+    self.execution_role           = args.fetch(:execution_role)
+    self.task_role                = args.fetch(:task_role)
+    self.dj_options               = args.fetch(:dj_options, [])
+    self.fqdn                     = args.fetch(:fqdn)
+    self.web_options              = args.fetch(:web_options)
+    self.registry_id              = args.fetch(:registry_id)
+    self.repo_name                = args.fetch(:repo_name)
     self.variant                  = 'web'
     self.version                  = `git rev-parse --short=9 HEAD`.chomp
+    self.args                     = OpenStruct.new(args)
 
     Dir.chdir(_root)
   end
@@ -143,6 +139,7 @@ class Deployer
         web_options: web_options,
         capacity_providers: _capacity_providers,
         service_registry_arns: service_registry_arns,
+        args: args,
       )
   end
 

--- a/config/deploy/docker/lib/roll_out.rb
+++ b/config/deploy/docker/lib/roll_out.rb
@@ -35,11 +35,11 @@ class RollOut
   attr_accessor :web_options
   attr_accessor :only_check_ram
   attr_accessor :service_registry_arns
+  attr_accessor :args
 
   include SharedLogic
   include AwsSdkHelpers::Helpers
 
-  # FIXME: cpu shares as parameter
   # FIXME: log level as parameter
 
   DEFAULT_SOFT_WEB_RAM_MB = 1800
@@ -52,7 +52,7 @@ class RollOut
 
   DEFAULT_CPU_SHARES = 256
 
-  def initialize(image_base:, target_group_name:, target_group_arn:, secrets_arn:, execution_role:, task_role:, dj_options: nil, web_options:, fqdn:, capacity_providers:, service_registry_arns:) # rubocop:disable Metrics/ParameterLists
+  def initialize(args:, image_base:, target_group_name:, target_group_arn:, secrets_arn:, execution_role:, task_role:, dj_options: nil, web_options:, fqdn:, capacity_providers:, service_registry_arns:) # rubocop:disable Metrics/ParameterLists
     self.cluster                  = _cluster_name
     self.image_base               = image_base
     self.secrets_arn              = secrets_arn
@@ -65,6 +65,7 @@ class RollOut
     self.status_uri               = URI("https://#{fqdn}/system_status/details")
     self.only_check_ram           = false
     self.service_registry_arns    = service_registry_arns || {}
+    self.args                     = args
     @capacity_providers           = capacity_providers
 
     puts '[WARN] You should specify a web service registry ARN value for service discovery (Cloud Map)' if service_registry_arns['web'].nil?
@@ -176,6 +177,7 @@ class RollOut
       soft_mem_limit_mb: DEFAULT_SOFT_RAM_MB,
       image: image_base + '--deploy',
       name: name,
+      cpu_shares: args.dig(:cpu_shares, :deploy),
       command: ['bin/deploy_tasks.sh'],
     )
 
@@ -190,6 +192,7 @@ class RollOut
     _register_task!(
       soft_mem_limit_mb: DEFAULT_SOFT_DJ_RAM_MB.call(target_group_name),
       image: image_base + '--base',
+      cpu_shares: args.dig(:cpu_shares, :cron),
       name: name,
       # command: ['echo', 'workerhere'],
     )
@@ -202,6 +205,7 @@ class RollOut
       soft_mem_limit_mb: DEFAULT_SOFT_RAM_MB,
       image: image_base + '--base',
       name: name,
+      cpu_shares: args.dig(:cpu_shares, :workoff),
       command: ['rake', 'jobs:workoff'],
     )
 
@@ -225,6 +229,7 @@ class RollOut
       soft_mem_limit_mb: soft_mem_limit_mb,
       image: image_base + '--base',
       environment: environment,
+      cpu_shares: args.dig(:cpu_shares, :web),
       health_check: {
         start_period: 15,   # seconds
         interval: (60 * 5), # seconds (5 minutes)
@@ -305,6 +310,7 @@ class RollOut
       soft_mem_limit_mb: soft_mem_limit_mb,
       image: image_base + '--base',
       name: name,
+      cpu_shares: args.dig(:cpu_shares, :dj),
       environment: environment,
       docker_labels: {
         'role' => 'jobs',
@@ -372,7 +378,19 @@ class RollOut
     # instance. Any unused get divided up at the same ratio as all the
     # containers running.
     # Increase this to limit number of containers on a box if there are cpu capacity issues.
-    cpu_shares ||= DEFAULT_CPU_SHARES
+    if cpu_shares.nil?
+      cpu_shares = DEFAULT_CPU_SHARES
+    else
+      aka = (cpu_shares / 1024.0).round(3)
+      puts "[INFO] Setting cpu shares to #{cpu_shares} (#{aka} vCPU) for #{name} task #{target_group_name}"
+      if cpu_shares % 2**7 != 0
+        puts '[FATAL] cpu shares was not divisible by 128'
+        exit 1
+      elsif cpu_shares < 128
+        puts '[FATAL] cpu shares was too small'
+        exit 1
+      end
+    end
 
     memory_multiplier = RAM_OVERCOMMIT_MULTIPLIER.call(target_group_name)
 


### PR DESCRIPTION
## Description

This lets us configure CPU requests (shares) for ECS services. I'll change the secrets yaml after this is merged to lock in the values for QA, but we need this merged and deployed everywhere before we can start setting the values for all the other environments.

## Testing and Docs

With this PR, we'll be able to add sections like this to the secrets yaml. I'll test QA with and without this and make sure it works as expected.
```
  :cpu_shares:
    :workoff: 256
    :cron: 256
    :web: 1024
    :deploy: 128
    :dj: 384
```


## Type of change
- [x] reliability improvement

## checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
