### PR TITLE
Patch unit creation user_id

### DIFF
--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -24,7 +24,7 @@ module Mutations
       return { errors: errors.errors } if errors.any?
 
       # Create Units
-      common = { user_id: hmis_user.user_id, created_at: Time.now, updated_at: Time.now }
+      common = { user_id: current_user.id, created_at: Time.now, updated_at: Time.now }
       units = (1..input.count).map do
         Hmis::Unit.new(
           project_id: project.id,

--- a/drivers/hmis/app/graphql/mutations/update_units.rb
+++ b/drivers/hmis/app/graphql/mutations/update_units.rb
@@ -18,7 +18,7 @@ module Mutations
       return { units: [], errors: [HmisErrors::Error.new(:project_id, :not_allowed)] } unless current_user.permissions_for?(project, :can_manage_inventory)
 
       units = project.units.where(id: unit_ids)
-      units.update_all(name: name, user_id: hmis_user.user_id, updated_at: Time.now)
+      units.update_all(name: name, user_id: current_user.id, updated_at: Time.now)
 
       { units: units, errors: [] }
     end


### PR DESCRIPTION
## Description

Patch bug in unit creation where we incorrectly stored HUD User UserID instead of the application user id.

PT: https://www.pivotaltracker.com/story/show/186428559

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
