### PR TITLE
CsvTransformer default to NBN when missing TrackingMethod

### DIFF
--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects/Project.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects/Project.csv
@@ -1,2 +1,2 @@
 ﻿ProjectID,OrganizationID,ProjectName,ProjectCommonName,OperatingStartDate,OperatingEndDate,ContinuumProject,ProjectType,HousingType,ResidentialAffiliation,TrackingMethod,HMISParticipatingProject,TargetPopulation,HOPWAMedAssistedLivingFac,PITCount,Walkin,DateCreated,DateUpdated,UserID,DateDeleted,ExportID
-1000,127,Project 1000,Project 1000,2018-07-01,9999-12-31,1,6,,1,,1,,2,,0,2018-07-02 09:07:00,2023-04-29 08:04:50,SYS,,ABCDEFGHIJKLMNO20230404
+1000,127,Project 1000,Project 1000,2018-07-01,9999-12-31,1,1,,1,,1,,2,,0,2018-07-02 09:07:00,2023-04-29 08:04:50,SYS,,ABCDEFGHIJKLMNO20230404

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::ProjectsImporter, type: :mod
     end
 
     expect(GrdaWarehouse::Hud::Project.count).to eq(1)
+    expect(GrdaWarehouse::Hud::Project.first.project_type).to eq(1)
     expect(GrdaWarehouse::Hud::Funder.count).to eq(1)
     expect(GrdaWarehouse::Hud::Organization.count).to eq(1)
     expect(GrdaWarehouse::Hud::Inventory.count).to eq(20)

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/project/update_project_type.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/project/update_project_type.rb
@@ -10,6 +10,8 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::Project
       project_type = if row['ProjectType'].to_i == 1
         if row['TrackingMethod'].to_i == 3
           1
+        elsif row['TrackingMethod'].nil?
+          1 # Default to NBN if TrackingMethod is missing
         else
           0
         end


### PR DESCRIPTION
## Description

**Old behavior**: If a row in a 2022 file has ProjectType 1 and TrackingMethod is empty, change the ProjectType to 0 (Entry/Exit)
**New behavior**: If a row in a 2022 file has ProjectType 1 and TrackingMethod is empty, keep the ProjectType as 1 (NBN)

Support request: https://www.pivotaltracker.com/story/show/186466712


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
