### PR TITLE
Fix RRH Sub Type not showing on Project form

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/project_details.json
+++ b/drivers/hmis/lib/form_data/default/fragments/project_details.json
@@ -31,7 +31,7 @@
             {
               "question": "2.02.6",
               "operator": "EQUAL",
-              "answer_code": "RRH"
+              "answer_code": "PH_RRH"
             }
           ]
         },


### PR DESCRIPTION
## Description

Fix issue where RRH SubType question doesn't show up. This regression occurred when the ProjectType enums changed.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x]  I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
