### PR TITLE
Confidentialize project name if user only has limited access

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -187,10 +187,15 @@ module Types
 
     field :move_in_addresses, [HmisSchema::ClientAddress], null: false
 
+    # Summary of ALL open enrollments that this client currently has.
+    # This is different from the "summary_fields" which are governed by a different
+    # permission ('can_view_limited_enrollment_details').
     def open_enrollment_summary
-      return [] unless current_user.can_view_open_enrollment_summary_for?(object)
+      return [] unless current_permission?(permission: :can_view_open_enrollment_summary, entity: object)
 
       client = load_ar_association(object, :client)
+      # There is no "viewable_by" check on the enrollments, because this permission
+      # grants full access regardless of enrollment/project visibility.
       load_ar_association(client, :enrollments).where.not(id: object.id).open_including_wip
     end
 
@@ -218,6 +223,8 @@ module Types
 
     # Needed because limited access viewers cannot resolve the project
     def project_name
+      return Hmis::Hud::Project::CONFIDENTIAL_PROJECT_NAME if project&.confidential && !current_permission?(permission: :can_view_enrollment_details, entity: object)
+
       project&.project_name
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment_summary.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment_summary.rb
@@ -10,7 +10,7 @@ module Types
     field :can_view_enrollment, Boolean, null: false
 
     def project_name
-      return 'Confidential Project' if project.confidential
+      return Hmis::Hud::Project::CONFIDENTIAL_PROJECT_NAME if project.confidential && !can_view_enrollment
 
       project.project_name
     end
@@ -28,7 +28,7 @@ module Types
     end
 
     def can_view_enrollment
-      current_user.can_view_enrollment_details_for?(object)
+      current_permission?(permission: :can_view_enrollment_details, entity: object)
     end
 
     def project

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -11,6 +11,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
 
   self.table_name = :Project
   self.sequence_name = "public.\"#{table_name}_id_seq\""
+  CONFIDENTIAL_PROJECT_NAME = 'Confidential Project'.freeze
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :organization, **hmis_relation(:OrganizationID, 'Organization')

--- a/drivers/hmis/spec/factories/hmis/hud/enrollments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/enrollments.rb
@@ -27,9 +27,12 @@ FactoryBot.define do
       ]
       dates[n % 5].to_date
     end
-    # after(:build) do |enrollment|
-    #   enrollment.data_source = enrollment.project.data_source
-    # end
+    transient do
+      exit_date { nil }
+    end
+    after(:create) do |enrollment, evaluator|
+      enrollment.exit = create(:hmis_hud_exit, exit_date: evaluator.exit_date, enrollment: enrollment, data_source: enrollment.data_source, client: enrollment.client) if evaluator.exit_date
+    end
   end
 
   factory :hmis_hud_wip_enrollment, parent: :hmis_hud_enrollment do

--- a/drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb
@@ -1,0 +1,94 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  include_context 'hmis base setup'
+
+  let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+
+  # Enrollments at p1 (2 open, 1 closed)
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+  let!(:e1_dup) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+  let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, exit_date: 1.week.ago }
+
+  let!(:p2) { create :hmis_hud_project, data_source: ds1 }
+  # Enrollments at p2 (1 open, 1 closed)
+  let!(:e3) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p2, client: c1 }
+  let!(:e4) { create :hmis_hud_enrollment, data_source: ds1, project: p2, client: c1, exit_date: 1.week.ago }
+
+  let!(:p3) { create :hmis_hud_project, data_source: ds1, confidential: true }
+  # Enrollments at p3 (1 open, confidential)
+  let!(:e5) { create :hmis_hud_enrollment, data_source: ds1, project: p3, client: c1 }
+
+  # canary values
+  let!(:e6) { create :hmis_hud_enrollment, data_source: ds1, project: p1 }
+  let!(:e7) { create :hmis_hud_enrollment, data_source: ds1, project: p2 }
+
+  # Give user full access to p1
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+  # Give user some limited access to p3
+  let!(:access_control2) { create_access_control(hmis_user, p3, with_permission: :can_view_clients) }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  describe 'Open enrollment summary' do
+    let(:query) do
+      <<~GRAPHQL
+        query TestQuery($id: ID!) {
+          enrollment(id: $id) {
+            id
+            openEnrollmentSummary {
+              id
+              entryDate
+              projectName
+              canViewEnrollment
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def perform_query(id = e1.id)
+      response, result = post_graphql(id: id) { query }
+      expect(response.status).to eq(200), result.inspect
+      enrollment = result.dig('data', 'enrollment')
+      expect(enrollment['id']).to be_present
+      result.dig('data', 'enrollment', 'openEnrollmentSummary')
+    end
+
+    it 'resolves nothing if user does not have permission' do
+      remove_permissions(access_control, :can_view_open_enrollment_summary)
+      results = perform_query
+      expect(results).to be_empty
+    end
+
+    it 'resolves correct enrollment summary' do
+      results = perform_query
+      expect(results).to contain_exactly(
+        a_hash_including('id' => e1_dup.id.to_s, 'projectName' => p1.project_name, 'canViewEnrollment' => true),
+        a_hash_including('id' => e3.id.to_s, 'projectName' => p2.project_name, 'canViewEnrollment' => false),
+        a_hash_including('id' => e5.id.to_s, 'projectName' => Hmis::Hud::Project::CONFIDENTIAL_PROJECT_NAME, 'canViewEnrollment' => false),
+      )
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## Description

* Hide confidential project names for users that only have "limited access" to view the enrollment.
* Add tests for Open Enrollment Summary

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
