### PR TITLE
Patch CustomClientAddress Enrollment relation

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
@@ -37,6 +37,8 @@ class Hmis::Hud::CustomClientAddress < Hmis::Hud::Base
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :AddressID]
 
+  validates_presence_of :EnrollmentID, if: :enrollment_address_type
+
   scope :active, ->(date = Date.current) do
     left_outer_joins(:active_range).where(Hmis::ActiveRange.arel_active_on(date))
   end
@@ -85,7 +87,6 @@ class Hmis::Hud::CustomClientAddress < Hmis::Hud::Base
     enrollment_move_in_type?
   end
 
-  # maybe there's a list of states somewhere else we can use?
   USA_STATES = ['AK', 'AL', 'AR', 'AS', 'AZ', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'GU', 'HI', 'IA', 'ID', 'IL', 'IN', 'KS', 'KY', 'LA', 'MA', 'MD', 'ME', 'MI', 'MN', 'MO', 'MP', 'MS', 'MT', 'NC', 'ND', 'NE', 'NH', 'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VA', 'VI', 'VT', 'WA', 'WI', 'WV', 'WY'].freeze
   with_options(if: :validate_required_fields?) do
     validates :line1, presence: true

--- a/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
@@ -32,7 +32,7 @@ class Hmis::Hud::CustomClientAddress < Hmis::Hud::Base
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
-  belongs_to :enrollment, **hmis_relation(:PersonalID, 'Enrollment'), optional: true
+  belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :AddressID]


### PR DESCRIPTION
## Description

Fix issue where the `CustomClientAddress.enrollment` relation wasn't set up correctly.

NOTE: when resolving move-in addresses in the frontend, we [load](https://github.com/greenriver/hmis-warehouse/blob/0cc2bed56904cdf1daf7667bc411efe101596e01/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb#L329) move-in addresses using the [move_in_addresses relation on Enrollment](https://github.com/greenriver/hmis-warehouse/blob/0cc2bed56904cdf1daf7667bc411efe101596e01/drivers/hmis/app/models/hmis/hud/enrollment.rb#L34-L40), which is correctly configured. So there has not been any exposure of move-in addresses in the wrong places.

There are regression tests in this pr https://github.com/greenriver/hmis-warehouse/pull/3737 which is where I found the issue.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
