### PR TITLE
Enable move in address collection by default

### DIFF
--- a/drivers/hmis/lib/form_data/default/occurrence_point_forms/move_in_date.json
+++ b/drivers/hmis/lib/form_data/default/occurrence_point_forms/move_in_date.json
@@ -26,6 +26,25 @@
           "offset": 7
         }
       ]
+    },
+    {
+      "type": "OBJECT",
+      "component": "ADDRESS",
+      "repeats": false,
+      "required": true,
+      "link_id": "moveInAddresses",
+      "mapping": {
+        "record_type": "ENROLLMENT",
+        "field_name": "moveInAddresses"
+      },
+      "text": "Move in address",
+      "enable_when": [
+        {
+          "question": "3.20",
+          "operator": "EXISTS",
+          "answer_boolean": true
+        }
+      ]
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/springfield/occurrence_point_forms/move_in_date.json
+++ b/drivers/hmis/lib/form_data/springfield/occurrence_point_forms/move_in_date.json
@@ -1,6 +1,7 @@
 {
   "item": [
     {
+      "_comment": "override that does not collect move-in address",
       "link_id": "3.20",
       "type": "DATE",
       "text": "Move-in Date",
@@ -24,25 +25,6 @@
           "type": "MAX",
           "value_local_constant": "$today",
           "offset": 7
-        }
-      ]
-    },
-    {
-      "type": "OBJECT",
-      "component": "ADDRESS",
-      "repeats": false,
-      "required": true,
-      "link_id": "moveInAddresses",
-      "mapping": {
-        "record_type": "ENROLLMENT",
-        "field_name": "moveInAddresses"
-      },
-      "text": "Move in address",
-      "enable_when": [
-        {
-          "question": "3.20",
-          "operator": "EXISTS",
-          "answer_boolean": true
         }
       ]
     }


### PR DESCRIPTION
## Description

Make it the default behavior to collect an address when recording move-in date. This is just to let us test on QA.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
