### PR TITLE
Add papertrail to roles tables

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -5,6 +5,9 @@
 ###
 
 class Role < ApplicationRecord
+  acts_as_paranoid
+  has_paper_trail
+
   include UserPermissionCache
 
   # Keep for health roles

--- a/db/migrate/20231116185857_make_roles_tables_paranoid.rb
+++ b/db/migrate/20231116185857_make_roles_tables_paranoid.rb
@@ -1,0 +1,5 @@
+class MakeRolesTablesParanoid < ActiveRecord::Migration[6.1]
+  def change
+    add_column :roles, :deleted_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1670,7 +1670,8 @@ CREATE TABLE public.roles (
     can_edit_theme boolean DEFAULT false,
     system boolean DEFAULT false NOT NULL,
     can_edit_collections boolean DEFAULT false,
-    can_publish_reports boolean DEFAULT false
+    can_publish_reports boolean DEFAULT false,
+    deleted_at timestamp without time zone
 );
 
 
@@ -4168,6 +4169,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20231017185729'),
 ('20231023000619'),
 ('20231030184613'),
-('20231103165752');
+('20231103165752'),
+('20231116185857');
 
 

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -6,7 +6,8 @@
 
 class Hmis::Role < ::ApplicationRecord
   self.table_name = :hmis_roles
-  # Warehouse roles do not have a paper trail, so neither do these
+  acts_as_paranoid
+  has_paper_trail
 
   has_many :access_controls, class_name: '::Hmis::AccessControl', inverse_of: :role
   has_many :users, through: :access_controls


### PR DESCRIPTION
## Description

* Track role changes in PaperTrail in HMIS and Warehouse
* Make Warehouse roles acts as paranoid

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
