### PR TITLE
Don't log PDF result in ExternalRequestLog

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/oauth_client_logger.rb
@@ -25,7 +25,16 @@ module HmisExternalApis
         update_log_record(record, { response: "#{e.class.name}: #{e.message || 'Unknown error'}", http_status: 400 })
         raise
       end
-      update_log_record(record, { content_type: result.content_type, response: result.body, http_status: result.status }) if result
+
+      if result
+        attrs = {
+          content_type: result.content_type,
+          response: result.content_type == 'application/pdf' ? 'pdf' : result.body&.truncate(5000),
+          http_status: result.status,
+        }
+        update_log_record(record, attrs)
+      end
+
       [result, record]
     end
 


### PR DESCRIPTION
## Description

* Don't log `result.body` in the request log for PDF responses (relates to https://www.pivotaltracker.com/n/projects/2591838/stories/185505938)
* Truncate result when it is logged

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
