### PR TITLE
Log true user as whodunnit when impersonating

### DIFF
--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -46,7 +46,11 @@ class Hmis::BaseController < ActionController::Base
 
   # PaperTrail whodunnit (set in ApplicationController) uses this method to determine the label to be stored
   def user_for_paper_trail
-    current_hmis_user&.id
+    return 'unauthenticated' unless current_hmis_user.present?
+    return current_hmis_user.id unless true_user.present?
+    return current_hmis_user.id if true_user == current_hmis_user
+
+    "#{true_user.id} as #{current_hmis_user.id}"
   end
 
   def set_app_user_header

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -47,10 +47,9 @@ class Hmis::BaseController < ActionController::Base
   # PaperTrail whodunnit (set in ApplicationController) uses this method to determine the label to be stored
   def user_for_paper_trail
     return 'unauthenticated' unless current_hmis_user.present?
-    return current_hmis_user.id unless true_user.present?
-    return current_hmis_user.id if true_user == current_hmis_user
+    return current_hmis_user.id unless impersonating?
 
-    "#{true_user.id} as #{current_hmis_user.id}"
+    "#{true_hmis_user.id} as #{current_hmis_user.id}"
   end
 
   def set_app_user_header

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -46,11 +46,16 @@ module Types
     end
 
     def user
+      return unless object.whodunnit
       # 'unauthenticated' matches user_for_paper_trail in ApplicationController.
       # This happens when a Job updates records, which we should display as System changes.
       return User.system_user if object.whodunnit == 'unauthenticated'
 
-      Hmis::User.find_by(id: object.whodunnit)
+      # If user was impersonating, return the true user only. If someone performed the action while impersonating, whodunnit stores as '1 as 2' where 1 is the true user.
+      user_id = object.whodunnit.sub(/ as [0-9]+$/, '')
+      return unless user_id.to_i.to_s == user_id
+
+      Hmis::User.find_by(id: user_id)
     end
 
     def object_changes


### PR DESCRIPTION
## Description

Update the HMIS to match the Warehouse behavior when it comes to `whodunnit` logging during impersonation.

I followed all the same conventions of the warehouse (like using "unauthenticated") just for consistency's sake.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
