### PR TITLE
Homepage without database hits

### DIFF
--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -20,6 +20,7 @@ module Admin
 
     def create
       @link = link_scope.create(link_params)
+      link_scope.invalidate_cache
       respond_with(@link, location: admin_links_path)
     end
 
@@ -28,11 +29,13 @@ module Admin
 
     def update
       @link.update(link_params)
+      link_scope.invalidate_cache
       respond_with(@link, location: admin_links_path)
     end
 
     def destroy
       @link.destroy
+      link_scope.invalidate_cache
       respond_with(@link, location: admin_links_path)
     end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -11,6 +11,10 @@ class Link < ApplicationRecord
     @cache[location] ||= where(location: location)
   end
 
+  def self.invalidate_cache
+    @cache = nil
+  end
+
   def available_locations
     {
       'Footer' => 'footer',

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -5,8 +5,10 @@
 ###
 
 class Link < ApplicationRecord
-  scope :for, ->(location) do
-    where(location: location)
+  def self.for(location)
+    @cache ||= {}
+
+    @cache[location] ||= where(location: location)
   end
 
   def available_locations


### PR DESCRIPTION
## Description

We think that slow probe times are due to database load, and the probes hit the home page. 

I'm not sure how frequently the links table changes, so we could use redis or some other preferred way of memoizing in this application.

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
