### PR TITLE
Fix annual reminder bug for newly added hhm

### DIFF
--- a/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
@@ -48,22 +48,22 @@ module Hmis
       end
 
       def earliest_entry_date(enrollment)
-        @earliest_entry_date_by_household_id ||= enrollments
-          .group_by(&:household_id)
-          .map do |household_id, group|
+        @earliest_entry_date_by_household_id ||= enrollments.
+          group_by(&:household_id).
+          map do |household_id, group|
             min_entry = group.map { |e| e.entry_date&.to_date }.compact.min
             [household_id, min_entry]
-          end
-          .to_h
+          end.
+          to_h
         @earliest_entry_date_by_household_id[enrollment.household_id]
       end
 
       def last_assessment_date(enrollment:, stages:, wip:)
         # load all the assessments we might need
-        @all_assessments ||= Hmis::Hud::CustomAssessment
-          .where(enrollment_id: enrollments.map(&:enrollment_id), data_source_id: project.data_source_id)
-          .order(assessment_date: :desc)
-          .group_by(&:enrollment_id)
+        @all_assessments ||= Hmis::Hud::CustomAssessment.
+          where(enrollment_id: enrollments.map(&:enrollment_id), data_source_id: project.data_source_id).
+          order(assessment_date: :desc).
+          group_by(&:enrollment_id)
 
         assessments = @all_assessments[enrollment.enrollment_id]
         return unless assessments
@@ -92,6 +92,9 @@ module Hmis
         hoh_anniversary = hoh_entered_on.change(year: today.year)
         start_date = hoh_anniversary - window
         due_date = hoh_anniversary + window
+
+        # client entered after the HoH anniversary
+        return if enrollment.entry_date > hoh_anniversary
 
         # client exited before the HoH anniversary
         return if enrollment.exit_date && enrollment.exit_date < hoh_anniversary
@@ -174,10 +177,10 @@ module Hmis
         cadence = project.ProjectType == 14 ? 90 : nil
         return unless cadence
 
-        latest_living_situation_on = enrollment
-          .current_living_situations
-          .max_by(&:InformationDate)
-          &.InformationDate
+        latest_living_situation_on = enrollment.
+          current_living_situations.
+          max_by(&:InformationDate)&.
+          InformationDate
 
         due_date = latest_living_situation_on ? latest_living_situation_on + cadence : enrollment.entry_date
         return if due_date > today


### PR DESCRIPTION
## Description

Household members that were added _after_ the anniversary date do not need an annual. [PT story](https://www.pivotaltracker.com/story/show/186505298)

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
