### PR TITLE
fix repeated inclusion of acts-as-paranoid

### DIFF
--- a/app/models/concerns/hmis_structure/affiliation.rb
+++ b/app/models/concerns/hmis_structure/affiliation.rb
@@ -10,7 +10,7 @@ module HmisStructure::Affiliation
 
   included do
     self.hud_key = :AffiliationID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/assessment.rb
+++ b/app/models/concerns/hmis_structure/assessment.rb
@@ -10,7 +10,7 @@ module HmisStructure::Assessment
 
   included do
     self.hud_key = :AssessmentID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/assessment_question.rb
+++ b/app/models/concerns/hmis_structure/assessment_question.rb
@@ -10,7 +10,7 @@ module HmisStructure::AssessmentQuestion
 
   included do
     self.hud_key = :AssessmentQuestionID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/assessment_result.rb
+++ b/app/models/concerns/hmis_structure/assessment_result.rb
@@ -10,7 +10,7 @@ module HmisStructure::AssessmentResult
 
   included do
     self.hud_key = :AssessmentResultID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/ce_participation.rb
+++ b/app/models/concerns/hmis_structure/ce_participation.rb
@@ -10,7 +10,7 @@ module HmisStructure::CeParticipation
 
   included do
     self.hud_key = :CEParticipationID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/client.rb
+++ b/app/models/concerns/hmis_structure/client.rb
@@ -13,7 +13,7 @@ module HmisStructure::Client
     self.ignored_columns += [:search_name_full, :search_name_last]
     self.hud_key = :PersonalID
     self.additional_upsert_columns = [:demographic_dirty]
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/current_living_situation.rb
+++ b/app/models/concerns/hmis_structure/current_living_situation.rb
@@ -10,7 +10,7 @@ module HmisStructure::CurrentLivingSituation
 
   included do
     self.hud_key = :CurrentLivingSitID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/disability.rb
+++ b/app/models/concerns/hmis_structure/disability.rb
@@ -10,7 +10,7 @@ module HmisStructure::Disability
 
   included do
     self.hud_key = :DisabilitiesID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/employment_education.rb
+++ b/app/models/concerns/hmis_structure/employment_education.rb
@@ -10,7 +10,7 @@ module HmisStructure::EmploymentEducation
 
   included do
     self.hud_key = :EmploymentEducationID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/enrollment.rb
+++ b/app/models/concerns/hmis_structure/enrollment.rb
@@ -12,7 +12,7 @@ module HmisStructure::Enrollment
     self.hud_key = :EnrollmentID
     self.conflict_target = [:data_source_id, connection.quote_column_name(:EnrollmentID), connection.quote_column_name(:PersonalID)]
     self.additional_upsert_columns = [:processed_as]
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
 
     alias_attribute :relationship_to_hoh, :RelationshipToHoH
     alias_attribute :disabled_hoh, :DisabledHoH

--- a/app/models/concerns/hmis_structure/enrollment_coc.rb
+++ b/app/models/concerns/hmis_structure/enrollment_coc.rb
@@ -10,7 +10,7 @@ module HmisStructure::EnrollmentCoc
 
   included do
     self.hud_key = :EnrollmentCoCID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/event.rb
+++ b/app/models/concerns/hmis_structure/event.rb
@@ -10,7 +10,7 @@ module HmisStructure::Event
 
   included do
     self.hud_key = :EventID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/exit.rb
+++ b/app/models/concerns/hmis_structure/exit.rb
@@ -10,7 +10,7 @@ module HmisStructure::Exit
 
   included do
     self.hud_key = :ExitID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/funder.rb
+++ b/app/models/concerns/hmis_structure/funder.rb
@@ -10,7 +10,7 @@ module HmisStructure::Funder
 
   included do
     self.hud_key = :FunderID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/health_and_dv.rb
+++ b/app/models/concerns/hmis_structure/health_and_dv.rb
@@ -10,7 +10,7 @@ module HmisStructure::HealthAndDv
 
   included do
     self.hud_key = :HealthAndDVID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/hmis_participation.rb
+++ b/app/models/concerns/hmis_structure/hmis_participation.rb
@@ -10,7 +10,7 @@ module HmisStructure::HmisParticipation
 
   included do
     self.hud_key = :HMISParticipationID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/income_benefit.rb
+++ b/app/models/concerns/hmis_structure/income_benefit.rb
@@ -10,7 +10,7 @@ module HmisStructure::IncomeBenefit
 
   included do
     self.hud_key = :IncomeBenefitsID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/inventory.rb
+++ b/app/models/concerns/hmis_structure/inventory.rb
@@ -10,7 +10,7 @@ module HmisStructure::Inventory
 
   included do
     self.hud_key = :InventoryID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/organization.rb
+++ b/app/models/concerns/hmis_structure/organization.rb
@@ -10,7 +10,7 @@ module HmisStructure::Organization
 
   included do
     self.hud_key = :OrganizationID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/project.rb
+++ b/app/models/concerns/hmis_structure/project.rb
@@ -10,7 +10,7 @@ module HmisStructure::Project
 
   included do
     self.hud_key = :ProjectID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/project_coc.rb
+++ b/app/models/concerns/hmis_structure/project_coc.rb
@@ -10,7 +10,7 @@ module HmisStructure::ProjectCoc
 
   included do
     self.hud_key = :ProjectCoCID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/service.rb
+++ b/app/models/concerns/hmis_structure/service.rb
@@ -10,7 +10,7 @@ module HmisStructure::Service
 
   included do
     self.hud_key = :ServicesID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/user.rb
+++ b/app/models/concerns/hmis_structure/user.rb
@@ -10,7 +10,7 @@ module HmisStructure::User
 
   included do
     self.hud_key = :UserID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods

--- a/app/models/concerns/hmis_structure/youth_education_status.rb
+++ b/app/models/concerns/hmis_structure/youth_education_status.rb
@@ -10,7 +10,7 @@ module HmisStructure::YouthEducationStatus
 
   included do
     self.hud_key = :YouthEducationStatusID
-    acts_as_paranoid(column: :DateDeleted)
+    acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
   end
 
   module ClassMethods


### PR DESCRIPTION
## Description

Fix repeated inclusion of acts_as_paranoid. This removes redundant conditions in the SQL from Active Record models in the HMIS. There should be no difference in functionality, this is just a housekeeping change. 

The act_as_paranoid module is included from both the hud model concerns in `app/models/concerns/hmis_structure` and from Hmis::Hud::Base. This PR changes the concerns to conditionally include acts_as_paranoid via [the same mechanism as the gem itself](https://github.com/rubysherpas/paranoia/blob/a0b7632ae14c939b18470f2e1f5fc621e62f678c/lib/paranoia.rb#L243C7-L243C45). This seemed like the safest way to correct this behavior.

Example to illustrate the change:
```
# before
> Hmis::Hud::Project.count
   (61.7ms)  SELECT COUNT(*) FROM "Project" WHERE "Project"."DateDeleted" IS NULL AND "Project"."DateDeleted" IS NULL /*application:BostonHmis*/
# after
> Hmis::Hud::Project.count
   (2.1ms)  SELECT COUNT(*) FROM "Project" WHERE "Project"."DateDeleted" IS NULL /*application:BostonHmis*/

```

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
