### PR TITLE
Fix incorrect form logic for HousingType

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/project_details.json
+++ b/drivers/hmis/lib/form_data/default/fragments/project_details.json
@@ -130,7 +130,7 @@
         {
           "question": "2.02.A",
           "operator": "EQUAL",
-          "answer_code": "RRH_SERVICES_ONLY"
+          "answer_code": "RRH_HOUSING_WITH_OR_WITHOUT_SERVICES"
         }
       ]
     },


### PR DESCRIPTION
## Description

https://files.hudexchange.info/resources/documents/HMIS-Data-Dictionary-2024.pdf
<img width="328" alt="Screenshot 2023-11-20 at 4 00 48 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/2495cdb8-6717-4b51-b395-f1de7735264f">

We had the logic backwards on this one. For RRH, the HousingType question should be shown if the sub-type is RRH_HOUSING_WITH_OR_WITHOUT_SERVICES (2).

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
