### PR TITLE
Only validate required enrollment CoC on HoH

### DIFF
--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/hmis_csv_validation/non_blank_validation_hoh.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/hmis_csv_validation/non_blank_validation_hoh.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class HmisCsvImporter::HmisCsvValidation::NonBlankValidationHoh < HmisCsvImporter::HmisCsvValidation::Validation
+  def self.check_validity!(item, column)
+    value = item[column]
+    return if value.present?
+    return unless item['RelationshipToHoH'] == 1
+
+    new(
+      importer_log_id: item['importer_log_id'],
+      source_id: item['source_id'],
+      source_type: item['source_type'],
+      status: "A value is required for #{column}",
+      validated_column: column,
+    )
+  end
+
+  def self.title
+    'Missing required value for HoH'
+  end
+end

--- a/drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb
+++ b/drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe 'Validate import files', type: :model do
   it 'includes expected enrollments validations' do
     aggregate_failures 'validating' do
       expect(HmisCsvImporter::HmisCsvValidation::InclusionInSet.where("source_type LIKE '%Enrollment'").count).to eq(4)
-      expect(HmisCsvImporter::HmisCsvValidation::NonBlankValidation.where("source_type LIKE '%Enrollment'").count).to eq(3)
+      expect(HmisCsvImporter::HmisCsvValidation::NonBlankValidation.where("source_type LIKE '%Enrollment'").count).to eq(2)
     end
   end
 

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/importer/enrollment.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/importer/enrollment.rb
@@ -112,7 +112,7 @@ module HmisCsvTwentyTwentyFour::Importer
         ],
         EnrollmentCoC: [
           {
-            class: HmisCsvImporter::HmisCsvValidation::NonBlankValidation,
+            class: HmisCsvImporter::HmisCsvValidation::NonBlankValidationHoh,
           },
           {
             class: HmisCsvImporter::HmisCsvValidation::InclusionInSet,


### PR DESCRIPTION
## Description

This changes makes it so that we only call out Enrollment.EnrollmentCoC as a missing element for the HoH records.

## Type of change
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
