### PR TITLE
CAS sync no pathways

### DIFF
--- a/app/models/concerns/cas_client_data.rb
+++ b/app/models/concerns/cas_client_data.rb
@@ -203,8 +203,9 @@ module CasClientData
         # current requirement:
         # 1. an ongoing enrollment at a project in the chosen group (if no group, just an ongoing enrollment)
         # 2. a release of some sort on file
-        # 3. Pathways or Transfer assessment on file (currently no date range restriction)
-        project_group_scope.exists? && any_release_on_file? && most_recent_pathways_or_rrh_assessment_for_destination.present?
+        # ~3.~ Pathways or Transfer assessment on file (currently no date range restriction) (Removed by request 11/23/23)
+        # project_group_scope.exists? && any_release_on_file? && most_recent_pathways_or_rrh_assessment_for_destination.present?
+        project_group_scope.exists? && any_release_on_file?
       else
         raise NotImplementedError
       end

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -23,7 +23,7 @@ module GrdaWarehouse
         'All clients with a release on file' => :release_present,
         'Active clients within range' => :active_clients,
         'Clients in project group' => :project_group,
-        'Boston (in a project group, with a release' => :boston,
+        'Boston (in a project group, with a release)' => :boston,
       }
     end
 

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -23,7 +23,7 @@ module GrdaWarehouse
         'All clients with a release on file' => :release_present,
         'Active clients within range' => :active_clients,
         'Clients in project group' => :project_group,
-        'Boston (in a project group, with a release, and a Pathways assessment)' => :boston,
+        'Boston (in a project group, with a release' => :boston,
       }
     end
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -362,8 +362,9 @@ module GrdaWarehouse::Hud
           enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.ongoing.in_project(project_ids)
           scope = scope.where(id: enrollment_scope.select(:client_id))
         end
-        # with a Pathways assessment
-        scope.where(id: joins(source_clients: :most_recent_pathways_or_rrh_assessment).select(:id))
+        # with a Pathways assessment (removed by request 11/23/23)
+        # scope.where(id: joins(source_clients: :most_recent_pathways_or_rrh_assessment).select(:id))
+        scope
       else
         raise NotImplementedError
       end


### PR DESCRIPTION
## Description

Removes the requirement for a Pathways assessment from Boston's CAS sync method.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
