### PR TITLE
Ignore deleted annuals in Annual Due filter

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
@@ -113,11 +113,12 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
             and(cas_t[:data_source_id].eq(e_t[:data_source_id])).
             and(cas_t[:data_collection_stage]).eq(5). # Annual
             and(cas_t[:wip]).eq(false).
+            and(cas_t[:DateDeleted]).eq(nil).
             and(annual_in_range),
           ).join_sources,
         ).
         # Earliest entry in household was more than a year ago
-        where(hh_t[:earliest_entry].lteq(Date.today - 11.months)).
+        where(hh_t[:earliest_entry].lteq(Date.current - 11.months)).
         # Household is not fully exited
         where(hh_t[:latest_exit].eq(nil)).
         # Client entered household before anniversary date


### PR DESCRIPTION
## Description

bug fix with regression test. related: https://github.com/greenriver/hmis-warehouse/pull/3698

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
