### PR TITLE
Only show audit history for changes to HMIS record

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -269,7 +269,7 @@ module Types
       contact_ids = object.contact_points.with_deleted.pluck(:id)
 
       v_t = GrPaperTrail::Version.arel_table
-      client_changes = v_t[:item_id].eq(object.id).and(v_t[:item_type].in(['Hmis::Hud::Client', 'GrdaWarehouse::Hud::Client']))
+      client_changes = v_t[:item_id].eq(object.id).and(v_t[:item_type].eq('Hmis::Hud::Client'))
       address_changes = v_t[:item_id].in(address_ids).and(v_t[:item_type].eq('Hmis::Hud::CustomClientAddress'))
       name_changes = v_t[:item_id].in(name_ids).and(v_t[:item_type].eq('Hmis::Hud::CustomClientName'))
       contact_changes = v_t[:item_id].in(contact_ids).and(v_t[:item_type].eq('Hmis::Hud::CustomClientContactPoint'))


### PR DESCRIPTION
## Description

Client Audit History should only show changes to `Hmis::Hud::Client` records, since those are changes made in the HMIS.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
