### PR TITLE
Use true user in HMIS activity log

### DIFF
--- a/drivers/hmis/app/controllers/hmis/graphql_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/graphql_controller.rb
@@ -118,9 +118,8 @@ module Hmis
     end
 
     def graphql_activity_log(gql_param)
-      TodoOrDie('Update to true_hmis_user after #3672', by: Date.new(2023, 12, 1))
       {
-        user_id: current_hmis_user.id, # FIXME: true_user if masquerading
+        user_id: true_hmis_user.id,
         data_source_id: current_hmis_user.hmis_data_source_id,
         ip_address: request.remote_ip&.to_s,
         session_hash: session.id&.to_s,


### PR DESCRIPTION
## Description

When someone is impersonating, log the true user in the HMIS Activiy Log

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
