### PR TITLE
Use a more appropriate label method for path referrals

### DIFF
--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -626,7 +626,7 @@ module HudUtility2024
       },
       161 => {
         list: ::HudUtility2024.path_referral_options,
-        label_method: :path_referral_options,
+        label_method: :path_referral,
       },
       200 => {
         list: ::HudUtility2024.bed_night_options,


### PR DESCRIPTION
## Description

This fixes an issue where the service roll-up can't load when a path referral is included

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
