### PR TITLE
Ignore cp1 for initial assessments

### DIFF
--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -373,7 +373,9 @@ module Health
       return false unless cp1?
 
       # Only the most recent PCTP needs review
-      patient.pctp_careplans.sorted.first&.instrument&.id == id
+      return false unless patient.recent_pctp_careplan&.instrument == self
+
+      careplan.careplan_sent_on.blank?
     end
 
     def compact_future_issues

--- a/app/models/health/careplan.rb
+++ b/app/models/health/careplan.rb
@@ -368,13 +368,16 @@ module Health
       ! cp1?
     end
 
+    # For the transition between CP1 and CP2, MH allowed careplans in development
+    # at the time of the transition to be carried forward after a review.
     def needs_rereview?
       # Only CP1 careplans need to be reviewed for CP2
       return false unless cp1?
 
-      # Only the most recent PCTP needs review
+      # Only the most recent PCTP can need review
       return false unless patient.recent_pctp_careplan&.instrument == self
 
+      # Once sent to the PCP, the careplan is completed.
       careplan.careplan_sent_on.blank?
     end
 

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -113,6 +113,10 @@ module Health
     end, class_name: 'Health::CaAssessment'
 
     has_many :pctp_careplans
+    has_many :cp2_careplans, -> do
+      merge(Health::PctpCareplan.cp2)
+    end, class_name: 'Health::PctpCareplan'
+
     has_one :recent_pctp_careplan, -> do
       merge(Health::PctpCareplan.recent)
     end, class_name: 'Health::PctpCareplan'
@@ -411,22 +415,22 @@ module Health
     end
 
     scope :has_intake, -> do
-      where(id: Health::PctpCareplan.sent.select(:patient_id))
+      where(id: Health::PctpCareplan.cp2.sent.select(:patient_id))
     end
 
     scope :intake_required, -> do
-      where.not(id: Health::PctpCareplan.sent.select(:patient_id)).
-        or(where(id: where.missing(:pctp_careplans).select(:id)))
+      where.not(id: Health::PctpCareplan.cp2.sent.select(:patient_id)).
+        or(where(id: where.missing(:cp2_careplans).select(:id)))
     end
 
     scope :needs_renewal, ->(on: Date.current.end_of_month) do
       joins(:recent_pctp_careplan).
-        merge(Health::PctpCareplan.recent.sent_within(.. on - 335.days)) # 1 year - 30 days
+        merge(Health::PctpCareplan.recent.cp2.sent_within(.. on - 335.days)) # 1 year - 30 days
     end
 
     scope :overdue_for_renewal, ->(on: Date.current.end_of_month) do
       joins(:recent_pctp_careplan).
-        merge(Health::PctpCareplan.recent.sent_within(.. on - 365.days)) # 1 year
+        merge(Health::PctpCareplan.recent.cp2.sent_within(.. on - 365.days)) # 1 year
     end
 
     # For now, all patients are visible to all health users

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -402,6 +402,17 @@ module Health
       where(id: without_intake_query).or(where(id: with_intake_query))
     end
 
+    # Intake Scopes
+    #
+    # To receive services from the the MH CP program, a patient must complete
+    # the assessment process at the beginning of the program, and then again
+    # annually.
+    #
+    # The first asessment is the "intake", and only assessments for the current
+    # CP program are considered. This means that when a CP1 careplan expires,
+    # the patient is not considered enrolled in CP2, and needs an intake rather
+    # than a renewal.
+
     scope :needs_intake, ->(on: Date.current) do
       intake_due(on: on).or(intake_overdue(on: on))
     end

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -444,6 +444,8 @@ module Health
         merge(Health::PctpCareplan.recent.cp2.sent_within(.. on - 365.days)) # 1 year
     end
 
+    # End Intake Scopes
+
     # For now, all patients are visible to all health users
     # BUT, all patients must have a referral
     scope :viewable_by_user, ->(user) do

--- a/app/models/health/pctp_careplan.rb
+++ b/app/models/health/pctp_careplan.rb
@@ -39,6 +39,14 @@ module Health
       left_joins(:v1, :v2)
     end
 
+    scope :cp1, -> do
+      joins(:v1)
+    end
+
+    scope :cp2, -> do
+      joins(:v2)
+    end
+
     scope :recent, -> do
       one_for_column([:created_at, :instrument_id], source_arel_table: arel_table, group_on: :patient_id)
     end
@@ -127,8 +135,10 @@ module Health
     # # @return [Boolean] True if the careplan is expired
     def expired?
       return false unless expires_on.present?
+      return false unless expires_on < Date.current
 
-      expires_on < Date.current
+      # When CP1 careplans reach their expiration date, they are archived, not expired
+      !instrument.cp1?
     end
   end
 end

--- a/app/models/health/pctp_careplan.rb
+++ b/app/models/health/pctp_careplan.rb
@@ -131,8 +131,10 @@ module Health
       active? && expires_on - 1.month < Date.current
     end
 
-    # A Careplan has expired if the expiration date is in the past
-    # # @return [Boolean] True if the careplan is expired
+    # A Careplan has expired if the expiration date is in the past except for careplans
+    # from prior CP programs, which need to be replaced instead of reviewed.
+    #
+    # @return [Boolean] True if the careplan is expired
     def expired?
       return false unless expires_on.present?
       return false unless expires_on < Date.current

--- a/app/models/health/pctp_careplan.rb
+++ b/app/models/health/pctp_careplan.rb
@@ -132,7 +132,7 @@ module Health
     end
 
     # A Careplan has expired if the expiration date is in the past except for careplans
-    # from prior CP programs, which need to be replaced instead of reviewed.
+    # from prior CP programs, which need to be replaced instead of renewed.
     #
     # @return [Boolean] True if the careplan is expired
     def expired?


### PR DESCRIPTION
## Description

Change the logic so that an expiring CP1 careplan does not need to be "renewed", instead, they patient needs an intake into CP2.

## Type of change
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
