### PR TITLE
Carrierwave CVE Fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,11 +300,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    carrierwave (1.3.2)
+    carrierwave (1.3.4)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-      ssrf_filter (~> 1.0)
+      ssrf_filter (~> 1.0, < 1.1.0)
     carrierwave-i18n (0.2.0)
     caxlsx (3.3.0)
       htmlentities (~> 4.3, >= 4.3.4)
@@ -553,9 +553,9 @@ GEM
       ruby2_keywords (~> 0.0.2)
     memory_profiler (1.0.0)
     method_source (1.0.0)
-    mime-types (3.4.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
+    mime-types-data (3.2023.1003)
     mimemagic (0.4.3)
       nokogiri (~> 1)
       rake
@@ -563,7 +563,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
-    minitest (5.19.0)
+    minitest (5.20.0)
     minitest-reporters (1.4.3)
       ansi
       builder
@@ -879,7 +879,7 @@ GEM
     sshkit (1.21.3)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    ssrf_filter (1.0.7)
+    ssrf_filter (1.0.8)
     stackprof (0.2.17)
     strong_migrations (1.4.4)
       activerecord (>= 5.2)
@@ -966,7 +966,7 @@ GEM
       anyway_config (>= 1.3, < 3)
       railties
       yabeda (~> 0.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   aarch64-linux

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -18,6 +18,7 @@ CarrierWave.configure do |config|
   end
 end
 
+# FIX for CVE-2023-49090
 module CarrierWave
   module Uploader
     module ContentTypeWhitelist

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -17,3 +17,15 @@ CarrierWave.configure do |config|
     }
   end
 end
+
+module CarrierWave
+  module Uploader
+    module ContentTypeWhitelist
+      private
+
+      def whitelisted_content_type?(content_type)
+        Array(content_type_whitelist).any? { |item| content_type =~ /\A#{item}/ }
+      end
+    end
+  end
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -26,8 +26,6 @@ module CarrierWave
       private
 
       def whitelisted_content_type?(content_type)
-
-
         Array(content_type_whitelist).any? { |item| content_type =~ /\A#{item}/ }
       end
     end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -19,12 +19,15 @@ CarrierWave.configure do |config|
 end
 
 # FIX for CVE-2023-49090
+raise unless Gem.loaded_specs['carrierwave'].version.to_s == '1.3.4'
 module CarrierWave
   module Uploader
     module ContentTypeWhitelist
       private
 
       def whitelisted_content_type?(content_type)
+
+
         Array(content_type_whitelist).any? { |item| content_type =~ /\A#{item}/ }
       end
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This implements the suggested work-around for Carrier wave for CVE-2023-49090 since no 1.x version is provided.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
