### PR TITLE
186522571 bugfix audit history

### DIFF
--- a/app/models/grda_warehouse/version.rb
+++ b/app/models/grda_warehouse/version.rb
@@ -7,5 +7,13 @@
 module GrdaWarehouse
   class Version < GrdaWarehouseBase
     include PaperTrail::VersionConcern
+
+    # overlay object changes onto object
+    def object_with_changes
+      # create events have object_changes and a nil object
+      result = object&.dup || {}
+      result.merge!(object_changes.transform_values(&:last)) if object_changes.present?
+      result
+    end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -93,23 +93,16 @@ module Types
       transform_changes: ->(version, changes) do
         result = changes
         [
-          ['race', Hmis::Hud::Client.race_enum_map, :RaceNone],
-          ['gender', Hmis::Hud::Client.gender_enum_map, :GenderNone],
+          ['race', Hmis::Hud::Client.race_enum_map, 'RaceNone'],
+          ['gender', Hmis::Hud::Client.gender_enum_map, 'GenderNone'],
         ].each do |input_field, enum_map, none_field|
           relevant_fields = [*enum_map.base_members.map { |member| member[:key].to_s }, none_field.to_s, input_field]
           next unless changes.slice(*relevant_fields).present?
 
           result = result.except(*relevant_fields)
-          old_client = version.reify
 
-          # Reify the next version to get next values; If no next version, then we're at the latest update and the current object will have the next values
-          new_client =  version.next&.reify || version.item
-
-          old_value = { input_field => nil }
-          new_value = { input_field => nil }
-
-          old_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(old_client, input_field, enum_map, none_field) if old_client.present?
-          new_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(new_client, input_field, enum_map, none_field) if new_client.present?
+          old_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(changes, 0, input_field, enum_map, none_field)
+          new_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(changes, 1, input_field, enum_map, none_field)
 
           result = result.merge(input_field => [old_value[input_field], new_value[input_field]])
         end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -101,15 +101,18 @@ module Types
 
           result = result.except(*relevant_fields)
 
-          # TODO need to incorporate version.object
-          delta = [0, 1].map do |idx|
-            none_value = changes.dig(none_field, idx)
-            if none_value
-              [non_value]
-            else
+          # delta = [[old], [new]]
+          delta = [
+            version.object || {},
+            changes.transform_values(&:last),
+          ].map do |doc|
+            none_value = doc[none_field]
+            if none_value.nil? || none_value.zero?
               enum_map.base_members.
-                filter { |item| changes.dig(item[:key].to_s, idx) == 1 }.
+                filter { |item| doc[item[:key].to_s] == 1 }.
                 map { |item| item[:value] }
+            else
+              [none_value]
             end
           end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -104,7 +104,7 @@ module Types
           # delta = [[old], [new]]
           delta = [
             version.object || {},
-            changes.transform_values(&:last),
+            version.object_with_changes,
           ].map do |doc|
             none_value = doc[none_field]
             if none_value.nil? || none_value.zero?

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -101,10 +101,19 @@ module Types
 
           result = result.except(*relevant_fields)
 
-          old_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(changes, 0, input_field, enum_map, none_field)
-          new_value = Hmis::Hud::Processors::ClientProcessor.multi_fields_to_input(changes, 1, input_field, enum_map, none_field)
+          # TODO need to incorporate version.object
+          delta = [0, 1].map do |idx|
+            none_value = changes.dig(none_field, idx)
+            if none_value
+              [non_value]
+            else
+              enum_map.base_members.
+                filter { |item| changes.dig(item[:key].to_s, idx) == 1 }.
+                map { |item| item[:value] }
+            end
+          end
 
-          result = result.merge(input_field => [old_value[input_field], new_value[input_field]])
+          result = result.merge(input_field => delta)
         end
 
         # Drop excluded fields

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -87,17 +87,6 @@ module Hmis::Hud::Processors
       )
     end
 
-    def self.multi_fields_to_input(changes, idx, input_field, enum_map, none_field)
-      none_value = changes.dig(none_field, idx)
-      return { input_field => [none_value] } if none_value.present?
-
-      {
-        input_field => enum_map.base_members.
-          select { |item| changes.dig(item[:key].to_s, idx) == 1 }.
-          map { |item| item[:value] },
-      }
-    end
-
     def self.input_to_multi_fields(input_field, enum_map, not_collected_key, none_field)
       result = {}
       return result if input_field.nil?

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -87,13 +87,13 @@ module Hmis::Hud::Processors
       )
     end
 
-    def self.multi_fields_to_input(client, input_field, enum_map, none_field)
-      none_value = client.send(none_field)
+    def self.multi_fields_to_input(changes, idx, input_field, enum_map, none_field)
+      none_value = changes.dig(none_field, idx)
       return { input_field => [none_value] } if none_value.present?
 
       {
         input_field => enum_map.base_members.
-          select { |item| client.send(item[:key]) == 1 }.
+          select { |item| changes.dig(item[:key].to_s, idx) == 1 }.
           map { |item| item[:value] },
       }
     end

--- a/drivers/hmis/spec/requests/hmis/client_audit_history.rb
+++ b/drivers/hmis/spec/requests/hmis/client_audit_history.rb
@@ -8,12 +8,36 @@ require 'rails_helper'
 require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
-RSpec.describe Hmis::GraphqlController, type: :request do
+RSpec.describe 'Client Audit History Query', type: :request do
   include_context 'hmis base setup'
+
+  subject(:query) do
+    <<~GRAPHQL
+      query GetClient($id: ID!) {
+        client(id: $id) {
+          id
+          auditHistory(limit: 10, offset: 0) {
+            nodes {
+              id
+              createdAt
+              event
+              objectChanges
+              recordName
+              recordId
+              user {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+  end
+
   let!(:access_control) do
     create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
   end
-  let!(:c1) { create :hmis_hud_client, data_source: ds1, Man: 1, Questioning: 0, RaceNone: nil, HispanicLatinaeo: nil }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
 
   before(:all) do
@@ -24,46 +48,36 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     PaperTrail.enabled = @paper_trail_was
   end
 
-  describe 'client with paper trail enabled' do
-    before(:each) do
-      hmis_login(user)
-    end
+  before(:each) { hmis_login(user) }
 
-    let(:query) do
-      <<~GRAPHQL
-        query GetClient($id: ID!) {
-          client(id: $id) {
-            id
-            auditHistory(limit: 10, offset: 0) {
-              nodes {
-                id
-                createdAt
-                event
-                objectChanges
-                recordName
-                recordId
-                user {
-                  id
-                  name
-                }
-              }
-            }
-          }
-        }
-      GRAPHQL
-    end
+  def run_query(id:)
+    response, result = post_graphql(id: id) { query }
+    expect(response.status).to eq(200), result.inspect
+    result.dig('data', 'client', 'auditHistory', 'nodes')
+  end
 
-    it 'resolves audit history' do
-      c1.update!(Man: 0, Questioning: 1)
-      c1.update!(HispanicLatinaeo: 1)
-      response, result = post_graphql(id: c1.id) { query }
-      aggregate_failures 'checking response' do
-        expect(response.status).to eq(200), result.inspect
-        records = result.dig('data', 'client', 'auditHistory', 'nodes')
-        expect(records.size).to eq(3)
+  context 'client record with two genders' do
+    let!(:c1) { create :hmis_hud_client, data_source: ds1, Man: 1, CulturallySpecific: 1 }
+    context 'changing to one gender' do
+      before(:each) { c1.update!(Man: 0) }
+      it 'reports change' do
+        records = run_query(id: c1.id)
+        expect(records.size).to eq(2)
+        expect(records.dig(0, 'objectChanges', 'gender', 'values')).to eq([['MAN', 'CULTURALLY_SPECIFIC'], ['CULTURALLY_SPECIFIC']])
+        expect(records.dig(1, 'objectChanges', 'gender', 'values')).to eq([nil, ['MAN', 'CULTURALLY_SPECIFIC']])
+      end
+    end
+  end
+
+  context 'client record with no race' do
+    let!(:c1) { create :hmis_hud_client, data_source: ds1, RaceNone: nil, HispanicLatinaeo: nil }
+    context 'changing to one race' do
+      before(:each) { c1.update!(HispanicLatinaeo: 1) }
+      it 'reports change' do
+        records = run_query(id: c1.id)
+        expect(records.size).to eq(2)
         expect(records.dig(0, 'objectChanges', 'race', 'values')).to eq([nil, ['HISPANIC_LATINAEO']])
-        expect(records.dig(1, 'objectChanges', 'gender', 'values')).to eq([['MAN'], ['QUESTIONING']])
-        expect(records.dig(2, 'objectChanges', 'gender', 'values')).to eq([nil, ['MAN']]) # create
+        expect(records.dig(1, 'objectChanges', 'race', 'values')).to be_nil
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/client_audit_history.rb
+++ b/drivers/hmis/spec/requests/hmis/client_audit_history.rb
@@ -13,7 +13,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:access_control) do
     create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
   end
-  let!(:c1) { create :hmis_hud_client, data_source: ds1, Man: 1, Questioning: 0 }
+  let!(:c1) { create :hmis_hud_client, data_source: ds1, Man: 1, Questioning: 0, RaceNone: nil, HispanicLatinaeo: nil }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
 
   before(:all) do
@@ -55,13 +55,15 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     it 'resolves audit history' do
       c1.update!(Man: 0, Questioning: 1)
+      c1.update!(HispanicLatinaeo: 1)
       response, result = post_graphql(id: c1.id) { query }
       aggregate_failures 'checking response' do
         expect(response.status).to eq(200), result.inspect
         records = result.dig('data', 'client', 'auditHistory', 'nodes')
-        expect(records.size).to eq(2)
-        expect(records.dig(0, 'objectChanges', 'gender', 'values')).to eq([['MAN'], ['QUESTIONING']])
-        expect(records.dig(1, 'objectChanges', 'gender', 'values')).to eq([nil, ['MAN']])
+        expect(records.size).to eq(3)
+        expect(records.dig(0, 'objectChanges', 'race', 'values')).to eq([nil, ['HISPANIC_LATINAEO']])
+        expect(records.dig(1, 'objectChanges', 'gender', 'values')).to eq([['MAN'], ['QUESTIONING']])
+        expect(records.dig(2, 'objectChanges', 'gender', 'values')).to eq([nil, ['MAN']]) # create
       end
     end
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[Bugfix for 186522571](https://www.pivotaltracker.com/story/show/186522571)

Fix bug in audit reporting around client race/gender changes. I believe this was because version.reify changes version.item unexpectedly. Rather than reifing, I think we can use the changes directly since these fields are simple integer codes

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
