### PR TITLE
186632025 annuals due bug

### DIFF
--- a/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
@@ -89,7 +89,9 @@ module Hmis
         # not due for an assessment yet
         return if today < (hoh_entered_on + (1.year - window))
 
-        hoh_anniversary = hoh_entered_on.change(year: today.year)
+        # Find the closest HOH entry anniversary
+        hoh_anniversary = hoh_entered_on + ((today - hoh_entered_on) / Time.days_in_year).round.years
+
         start_date = hoh_anniversary - window
         due_date = hoh_anniversary + window
 

--- a/drivers/hmis/spec/models/hmis/reminder_spec.rb
+++ b/drivers/hmis/spec/models/hmis/reminder_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Hmis::Reminders::ReminderGenerator, type: :model do
 
   def reminders_for(_enrollment, topic:)
     project = p1
-    Hmis::Reminders::ReminderGenerator
-      .perform(project: project, enrollments: project.enrollments_including_wip)
-      .filter { |r| r.topic == topic }
+    Hmis::Reminders::ReminderGenerator.
+      perform(project: project, enrollments: project.enrollments_including_wip).
+      filter { |r| r.topic == topic }
   end
 
   describe 'with an enrollment due for annual assessment' do
@@ -29,6 +29,59 @@ RSpec.describe Hmis::Reminders::ReminderGenerator, type: :model do
     it 'reminds about annual assessment' do
       expect(reminders_for(enrollment, topic: 'annual_assessment').size).to eq(1)
     end
+
+    it 'reminds about annual assessment where period overlaps the new year' do
+      travel_to Time.local(2023, 12, 6) do
+        enrollment.update(entry_date: Time.local(2023, 1, 3))
+        res = reminders_for(enrollment, topic: 'annual_assessment')
+        expect(res.size).to eq(1)
+        expect(res.first.due_date).to eq(Time.local(2024, 2, 2))
+      end
+    end
+
+    it 'reminds about annual assessment where period overlaps the new year (multiple years ago)' do
+      travel_to Time.local(2023, 12, 6) do
+        enrollment.update(entry_date: Time.local(2020, 1, 3))
+        res = reminders_for(enrollment, topic: 'annual_assessment')
+        expect(res.size).to eq(1)
+        expect(res.first.due_date).to eq(Time.local(2024, 2, 2))
+      end
+    end
+
+    # Entry date: 1/15/2020
+    # Expected due period: 12/15/2023-2/14/2024
+    [
+      Time.local(2023, 12, 16), # within first half of due period
+      Time.local(2024, 1, 20), # within second half of due period
+      Time.local(2024, 2, 30), # after due period (should still show up as overdue)
+    ].each do |local_time|
+      it "reminds about annual assessment where household entered in January (current date: #{local_time})" do
+        travel_to local_time do
+          enrollment.update(entry_date: Time.local(2020, 1, 15))
+          res = reminders_for(enrollment, topic: 'annual_assessment')
+          expect(res.size).to eq(1)
+          expect(res.first.due_date).to eq(Time.local(2024, 2, 14)), local_time.inspect
+        end
+      end
+    end
+
+    # Entry date: 12/15/2020
+    # Expected due period: 11/15/2023-1/14/2024
+    [
+      Time.local(2023, 11, 16), # within first half of due period
+      Time.local(2024, 1, 6), # within second half of due period
+      Time.local(2024, 1, 30), # after due period (should still show up as overdue)
+    ].each do |local_time|
+      it "reminds about annual assessment where household entered in December (current date: #{local_time})" do
+        travel_to local_time do
+          enrollment.update(entry_date: Time.local(2020, 12, 15))
+          res = reminders_for(enrollment, topic: 'annual_assessment')
+          expect(res.size).to eq(1)
+          expect(res.first.due_date).to eq(Time.local(2024, 1, 14)), local_time.inspect
+        end
+      end
+    end
+
     describe 'with annual assessment completed' do
       before(:each) do
         create(:hmis_custom_assessment, data_collection_stage: 5, assessment_date: today, enrollment: enrollment, data_source: ds1)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Updates the logic of the reminder generator to use the closest anniversary date rather than `date.today`

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
