### PR TITLE
Avoid StaleObjectError with update_columns

### DIFF
--- a/app/models/concerns/hud_concerns/enrollment.rb
+++ b/app/models/concerns/hud_concerns/enrollment.rb
@@ -40,7 +40,8 @@ module HudConcerns::Enrollment
     end
 
     def invalidate_processing!
-      update(processed_as: nil, processed_hash: nil)
+      # use update_columns to avoid stale object errors when this method is called from Service after_commit hooks
+      update_columns(processed_as: nil, processed_hash: nil)
     end
   end
 end


### PR DESCRIPTION
## Description

Theron's fix from PR https://github.com/greenriver/hmis-warehouse/pull/3750#discussion_r1412912206. Opening against 94 since we're seeing it on Sentry.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
