### PR TITLE
Resolve enum values on Enrollment Audit History

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9005,9 +9005,11 @@ type Service {
   id: ID!
   movingOnOtherType: String
   otherTypeProvided: String
+  recordType: RecordType
   referralOutcome: PATHReferralOutcome
   serviceType: ServiceType!
   subTypeProvided: ServiceSubTypeProvided
+  typeProvided: ServiceTypeProvided
   user: ApplicationUser
 }
 

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -64,6 +64,8 @@ module Types
         return 'Phone Number' if item_attributes['system'] == 'phone'
 
         'Contact Information'
+      when 'Hmis::Hud::Disability'
+        HudUtility2024.disability_type(item_attributes['DisabilityType']) || 'Disability'
       # TODO: Add back CDE label more efficiently? The below causes N+1, and doesn't work for CDE destroy actions.
       # We could look at `item_attributes['data_element_definition_id']` to determine the label, but it would still be N+1.
       # when 'Hmis::Hud::CustomDataElement'

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -69,9 +69,7 @@ module Types
       # when 'Hmis::Hud::CustomDataElement'
       #   changed_record&.data_element_definition&.label
       else
-        object.item_type.demodulize.
-          gsub(/^CustomClient/, ''). # Address, Contact Point
-          gsub(/^Custom/, ''). # Service, Assessment
+        object.item_type.demodulize.gsub(/^Custom(Client)?/, '').
           underscore.humanize.titleize
       end
     end

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -64,8 +64,10 @@ module Types
         return 'Phone Number' if item_attributes['system'] == 'phone'
 
         'Contact Information'
-      when 'Hmis::Hud::CustomDataElement'
-        changed_record&.data_element_definition&.label # can we do this without N+1?
+      # TODO: Add back CDE label more efficiently? The below causes N+1, and doesn't work for CDE destroy actions.
+      # We could look at `item_attributes['data_element_definition_id']` to determine the label, but it would still be N+1.
+      # when 'Hmis::Hud::CustomDataElement'
+      #   changed_record&.data_element_definition&.label
       else
         object.item_type.demodulize.
           gsub(/^CustomClient/, ''). # Address, Contact Point

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -140,7 +140,7 @@ module Types
         [Hmis::Hud::CustomDataElement],
         [Hmis::Hud::CustomCaseNote],
       ].map do |klass, name|
-        { code: klass.sti_name, label: name || klass.name.demodulize }
+        { code: klass.sti_name, label: name || klass.name.demodulize.gsub(/^Custom(Client)?/, '').titleize }
       end.sort_by { |h| h[:label] }
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -192,7 +192,7 @@ module Types
     field :move_in_addresses, [HmisSchema::ClientAddress], null: false
 
     # fields should match our DB casing, consult schema to see determine appropriate casing
-    EXCLUDED_HISTORY_FIELDS = ['id', 'DateCreated', 'DateUpdated', 'DateDeleted'].to_set.freeze
+    EXCLUDED_HISTORY_FIELDS = ['id', 'DateCreated', 'DateUpdated', 'DateDeleted', 'owner_type'].to_set.freeze
     audit_history_field(
       transform_changes: ->(_version, changes) {
         # Drop excluded fields

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -192,7 +192,7 @@ module Types
     field :move_in_addresses, [HmisSchema::ClientAddress], null: false
 
     # fields should match our DB casing, consult schema to see determine appropriate casing
-    EXCLUDED_HISTORY_FIELDS = ['id', 'DateCreated', 'DateUpdated', 'DateDeleted', 'owner_type'].to_set.freeze
+    EXCLUDED_HISTORY_FIELDS = ['id', 'DateCreated', 'DateUpdated', 'DateDeleted', 'owner_type', 'enrollment_address_type'].to_set.freeze
     audit_history_field(
       transform_changes: ->(_version, changes) {
         # Drop excluded fields

--- a/drivers/hmis/app/graphql/types/hmis_schema/service.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/service.rb
@@ -42,6 +42,9 @@ module Types
     hud_field :sub_type_provided, HmisSchema::Enums::ServiceSubTypeProvided
     hud_field :referral_outcome, HmisSchema::Enums::Hud::PATHReferralOutcome
 
+    field :record_type, HmisSchema::Enums::Hud::RecordType, null: true
+    field :type_provided, HmisSchema::Enums::ServiceTypeProvided, null: true
+
     def type_provided
       [object.record_type, object.type_provided].join(':')
     end

--- a/drivers/hmis/app/models/hmis/filter/paper_trail_version_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/paper_trail_version_filter.rb
@@ -9,6 +9,7 @@ class Hmis::Filter::PaperTrailVersionFilter < Hmis::Filter::BaseFilter
     filters = input
     scope = ensure_scope(scope)
     scope = scope.where(user_id: filters.user) if filters&.user&.present?
+    # FIXME: filtering by `Service` only turns up HUD Services, not Custom Services
     scope = scope.where(item_type: filters.audit_event_record_type) if filters&.audit_event_record_type&.present?
     scope
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Follow-up to https://github.com/greenriver/hmis-warehouse/pull/3750 to resolve enum values (where appropriate) for audit changes. Includes...

* Try to resolve GQL Enum values where possible. For example, resolve `"YES"` instead of `1` in the change array.
* Add some more user-friendly names for the record type column, like "phone number" and "email address" instead of "contact point"
* Fix an issue with how we were displaying "Move-in address". The previous approach only worked when looking at an `update` or `destroy` record, not a `create` record. I added the `item_attributes` helper which can be used to refer to attributes that aren't expected to change. Feels a bit messy but it gives the desired results in the UI.


#### QA:
* With frontend https://github.com/greenriver/hmis-frontend/pull/577
* Add/edit/delete move-in address
* Add/edit/delete email address
* Add/edit/delete custom data element, like rental assistance end date
* Add/edit/delete HUD service
* Add/edit/delete custom service
* Add/edit/delete CLS
* Add/edit/delete income on an assessment
* Ensure client and enrollment audit interfaces look reasonable for all of the above

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
