### PR TITLE
185505938 link prevention assessment report 2

### DIFF
--- a/drivers/hmis/app/controllers/hmis/reports_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/reports_controller.rb
@@ -3,8 +3,7 @@
 #
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
-
-module AcHmis
+module Hmis
   class ReportsController < Hmis::BaseController
     def prevention_assessment_report
       referral_id = params[:referral_id]

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -13,13 +13,6 @@ BostonHmis::Application.routes.draw do
 
   # Routes for the HMIS API
   if ENV['ENABLE_HMIS_API'] == 'true'
-    namespace :ac_hmis do
-      get 'prevention_assessment_report/:referral_id',
-          to: 'reports#prevention_assessment_report',
-          as: 'ac_hmis_prevention_assessment_report',
-          defaults: { format: 'pdf' }
-    end
-
     namespace :hmis, defaults: { format: :json } do
       devise_for :users, class_name: 'Hmis::User',
                          skip: [:registrations, :invitations, :passwords, :confirmations, :unlocks, :password_expired],
@@ -35,6 +28,11 @@ BostonHmis::Application.routes.draw do
           get '/users/auth/okta/callback' => 'users/omniauth_callbacks#okta' if ENV['HMIS_OKTA_CLIENT_ID']
         end
       end
+
+      get 'ac/prevention_assessment_report/:referral_id',
+          to: 'reports#prevention_assessment_report',
+          as: 'ac_prevention_assessment_report',
+          defaults: { format: 'pdf' }
 
       get 'theme', to: 'theme#index', defaults: { format: :json }
       get 'themes', to: 'theme#list', defaults: { format: :json }


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adjusts the routes for the LINK prevention assessment report to use the `/hmis` namespace.

Relies on frontend PR: https://github.com/greenriver/hmis-frontend/pull/576

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
