### PR TITLE
MassHealth API Hotfix

### DIFF
--- a/app/models/health/soap/mass_health.rb
+++ b/app/models/health/soap/mass_health.rb
@@ -116,7 +116,7 @@ module Health::Soap
 
     # Parse the response. Generally, MassHealth responds with a multipart, so we use the Mail parser to decode the message
     private def parse_result(result)
-      body = result.body_str
+      body = result.body_str.lstrip # Remove any leading whitespace in the body
       if body[0..1] == '--'
         header = "Content-Type: multipart/alternative; boundary=\"#{body.lines.first.strip[2..]}\"\r\n\r\n"
       else


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Strip leading whitespace from start of MassHealth SOAP response that has appeared. Once deployed, testing would involve triggering an 834 API download.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
