### PR TITLE
Source hash updates on client save

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -356,7 +356,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   # A tool to batch reset all source hashes for a particular data source
-  def self.reset_source_hashes(data_source_id)
+  def self.reset_source_hashes!(data_source_id)
     where(data_source_id: data_source_id).find_in_batches do |batch|
       original_hashes = batch.map(&:source_hash)
       batch.each(&:set_source_hash)

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -83,6 +83,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   attr_accessor :image_blob_id
   after_create :warehouse_identify_duplicate_clients
   after_update :warehouse_match_existing_clients
+  before_save :set_source_hash
   after_save do
     current_image_blob = ActiveStorage::Blob.find_by(id: image_blob_id)
     self.image_blob_id = nil
@@ -344,4 +345,31 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   include RailsDrivers::Extensions
+
+  # The warehouse uses the source hash to determine if the record has changed and to maintain the
+  # associated warehouse record for reporting.
+  # This gets called during a pre-commit hook
+  def set_source_hash
+    hmis_keys = self.class.hmis_configuration(version: '2024').keys
+    hmis_data = slice(*hmis_keys)
+    self.source_hash = Digest::SHA256.hexdigest(hmis_data.except(:ExportID).to_s)
+  end
+
+  # A tool to batch reset all source hashes for a particular data source
+  def self.reset_source_hashes(data_source_id)
+    where(data_source_id: data_source_id).find_in_batches do |batch|
+      original_hashes = batch.map(&:source_hash)
+      batch.each(&:set_source_hash)
+      batch.reject!.with_index { |c, i| c.source_hash == original_hashes[i] }
+      puts "Updating #{batch.size} client source hashes"
+      next unless batch.size.positive?
+
+      import!(
+        batch,
+        validate: false,
+        timestamps: false,
+        on_duplicate_key_update: { conflict_target: [:id], columns: [:source_hash] },
+      )
+    end
+  end
 end

--- a/drivers/hmis/spec/models/hmis/hud/client_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/client_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Hmis::Hud::Client, type: :model do
 
   include_context 'hmis base setup'
 
+  describe 'source_hash checks' do
+    let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1, FirstName: 'Jelly', LastName: 'Bean' }
+    it 'should exist when a new record is created, and change when updated' do
+      initial_source_hash = c2.source_hash
+      expect(initial_source_hash).to be_present
+      c2.update!(FirstName: 'Jelly2')
+      expect(initial_source_hash).not_to eq(c2.reload.source_hash)
+    end
+  end
   describe 'matching_search_term scope' do
     let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1, FirstName: 'Jelly', LastName: 'Bean' }
     let!(:c3) { create :hmis_hud_client, data_source: ds1, user: u1, FirstName: 'Zoo', LastName: 'Jelly' }
@@ -88,9 +97,9 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       expect do
         client.destroy!
         client.reload
-      end
-        .to not_change(client, :data_source)
-        .and not_change(client, :user)
+      end.
+        to not_change(client, :data_source).
+        and not_change(client, :user)
     end
 
     it 'destroys dependent data' do
@@ -103,10 +112,10 @@ RSpec.describe Hmis::Hud::Client, type: :model do
       expect do
         client.destroy!
         client.reload
-      end
-        .to change(client, :enrollments).to([])
-        .and change(client, :external_referral_household_members).to([])
-        .and change(HmisExternalApis::AcHmis::Referral, :count).to(0)
+      end.
+        to change(client, :enrollments).to([]).
+        and change(client, :external_referral_household_members).to([]).
+        and change(HmisExternalApis::AcHmis::Referral, :count).to(0)
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This sets the source_hash column of a client when the client is changed in the HMIS.  This column is used to determine which source clients have changed, and therefore need demographic updates for warehouse reporting.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
