### PR TITLE
Use cleaned user_id for last user from versions

### DIFF
--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -62,7 +62,7 @@ module Types
       latest_version = versions.last # db-ordered so we choose the last record
       return unless latest_version
 
-      last_user_id = latest_version.true_user_id || latest_version.clean_user_id
+      last_user_id = latest_version.clean_true_user_id || latest_version.clean_user_id
       return unless last_user_id
 
       load_ar_scope(scope: Hmis::User.with_deleted, id: last_user_id)

--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -57,9 +57,12 @@ module Types
       refinement = GrdaWarehouse.paper_trail_versions.
         where.not(whodunnit: nil). # note, filter is okay here since it is constant with respect to object
         order(:created_at, :id).
-        select(:id, :whodunnit, :item_id, :item_type) # select only fields we need for performance
+        select(:id, :whodunnit, :item_id, :item_type, :user_id, :true_user_id) # select only fields we need for performance
       versions = load_ar_association(object, :versions, scope: refinement)
-      last_user_id = versions.last&.clean_user_id # db-ordered so we choose the last record
+      latest_version = versions.last # db-ordered so we choose the last record
+      return unless latest_version
+
+      last_user_id = latest_version.true_user_id || latest_version.clean_user_id
       return unless last_user_id
 
       load_ar_scope(scope: Hmis::User.with_deleted, id: last_user_id)

--- a/drivers/hmis/app/graphql/types/base_object.rb
+++ b/drivers/hmis/app/graphql/types/base_object.rb
@@ -59,8 +59,8 @@ module Types
         order(:created_at, :id).
         select(:id, :whodunnit, :item_id, :item_type) # select only fields we need for performance
       versions = load_ar_association(object, :versions, scope: refinement)
-      last_user_id = versions.last&.whodunnit # db-ordered so we choose the last record
-      return unless last_user_id && last_user_id =~ /\A[0-9]+\z/
+      last_user_id = versions.last&.clean_user_id # db-ordered so we choose the last record
+      return unless last_user_id
 
       load_ar_scope(scope: Hmis::User.with_deleted, id: last_user_id)
     end


### PR DESCRIPTION
## Description

`load_last_user_from_versions` is used to resolve the user that most recently touched the given record. use the new method that provides a "cleaned" version of the numeric user id for the true user.
## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
