### PR TITLE
Don't remind about annual assessments that are due in the future

### DIFF
--- a/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
@@ -86,11 +86,14 @@ module Hmis
 
         hoh_entered_on = normalize_yoy_date(hoh_entered_on)
         window = 30.days
-        # not due for an assessment yet
+        # not due for an assessment yet (household entered <11 months ago)
         return if today < (hoh_entered_on + (1.year - window))
 
         # Find the closest HOH entry anniversary
         hoh_anniversary = hoh_entered_on + ((today - hoh_entered_on) / Time.days_in_year).round.years
+
+        # not due for an assessment yet (next due period is in the future)
+        return if today < (hoh_anniversary - window)
 
         start_date = hoh_anniversary - window
         due_date = hoh_anniversary + window

--- a/drivers/hmis/spec/models/hmis/reminder_spec.rb
+++ b/drivers/hmis/spec/models/hmis/reminder_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Hmis::Reminders::ReminderGenerator, type: :model do
     # Entry date: 1/15/2020
     # Expected due period: 12/15/2023-2/14/2024
     [
-      Time.local(2023, 12, 16), # within first half of due period
+      Time.local(2023, 12, 17), # within first half of due period
       Time.local(2024, 1, 20), # within second half of due period
       Time.local(2024, 2, 30), # after due period (should still show up as overdue)
     ].each do |local_time|
@@ -79,6 +79,15 @@ RSpec.describe Hmis::Reminders::ReminderGenerator, type: :model do
           expect(res.size).to eq(1)
           expect(res.first.due_date).to eq(Time.local(2024, 1, 14)), local_time.inspect
         end
+      end
+    end
+
+    it 'does not remind if the next annual is due in the future (a.k.a. last annual period is >6mo ago)' do
+      travel_to Time.local(2023, 12, 20) do
+        enrollment.update(entry_date: Time.local(2022, 6, 10))
+        # next upcoming due date is May 2024. No reminder because it's too far in the future.
+        res = reminders_for(enrollment, topic: 'annual_assessment')
+        expect(res).to be_empty
       end
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

We recently made a change for annual reminders to make it so it reminds about the "closest" annual due period, rather than just the one for the current year. We need this additional check to ensure we aren't reminding about annuals that are due far in the future.

We still don't remind about past-due annuals that are more than 6 months over due. 

https://www.pivotaltracker.com/story/show/186721204

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
