### PR TITLE
fix bug in demographic report excel export when calculating percentages of coc data for age, gender, & race

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/age_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/age_calculations.rb
@@ -159,7 +159,7 @@ module
       total_count = mask_small_population(client_ages[coc_code].count)
       return 0 if total_count.zero?
 
-      of_type = age_count(type)
+      of_type = age_count(type, coc_code)
       return 0 if of_type.zero?
 
       ((of_type.to_f / total_count) * 100)

--- a/drivers/core_demographics_report/app/models/core_demographics_report/gender_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/gender_calculations.rb
@@ -29,7 +29,7 @@ module
       total_count = mask_small_population(client_genders_and_ages[coc_code].count)
       return 0 if total_count.zero?
 
-      of_type = gender_count(type)
+      of_type = gender_count(type, coc_code)
       return 0 if of_type.zero?
 
       ((of_type.to_f / total_count) * 100)

--- a/drivers/core_demographics_report/app/models/core_demographics_report/race_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/race_calculations.rb
@@ -33,7 +33,7 @@ module
       total_count = mask_small_population(client_races[coc_code].count)
       return 0 if total_count.zero?
 
-      of_type = race_count(type)
+      of_type = race_count(type, coc_code)
       return 0 if of_type.zero?
 
       ((of_type.to_f / total_count) * 100)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a bug with the demographic summary report excel export where percentages for CoC data in the age, gender, and race sections were being calculated incorrectly.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
