### PR TITLE
Prevent deleting enrollment if intakes still exist

### DIFF
--- a/drivers/hmis/app/graphql/mutations/delete_assessment.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_assessment.rb
@@ -50,7 +50,7 @@ module Mutations
             record.enrollment&.accept_referral!(current_user: current_user) if record.exit? && !is_wip
 
             # Deleting the Intake Assessment deletes the enrollment
-            record.enrollment&.destroy! if record.intake?
+            record.enrollment&.destroy! if record.intake? && !record.enrollment&.intake_assessment&.present?
           end,
         )
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

When deleting an intake assessment, prevents deleting the enrollment if other intakes still exist for that enrollment

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
