### PR TITLE
HMIS Participation Cleanup

### DIFF
--- a/db/warehouse/migrate/20231226194235_adjust_hmis_participation.rb
+++ b/db/warehouse/migrate/20231226194235_adjust_hmis_participation.rb
@@ -1,0 +1,9 @@
+class AdjustHmisParticipation < ActiveRecord::Migration[6.1]
+  def up
+    # The spec doesn't allow nil or 99, which we had incorrectly copied from the 2022 fields (which did allow them)
+    GrdaWarehouse::Hud::HmisParticipation.
+      where(GrdaWarehouse::Hud::HmisParticipation.arel_table[:HMISParticipationID].matches('GR-%', nil, true)).
+      where(HMISParticipationType: [nil, 99]).
+      update_all(HMISParticipationType: 0)
+  end
+end

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/hmis_participation/create_hmis_participation.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/hmis_participation/create_hmis_participation.rb
@@ -20,7 +20,7 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::HmisParticipation
       @victim_service_providers ||= {}.tap do |h|
         reference(:organization) do |row|
           key = "#{row['OrganizationID']}_ds_#{row['data_source_id']}"
-          h[key] = row['VictimServiceProvider']
+          h[key] = row['VictimServiceProvider'].to_i
         end
       end
     end
@@ -29,11 +29,10 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::HmisParticipation
       @parse_projects ||= [].tap do |arr|
         reference(:project) do |row|
           participation_id = "GR-#{row['ProjectID']}"[0..31]
-
           key = "#{row['OrganizationID']}_ds_#{row['data_source_id']}"
           participation_type = if victim_service_providers[key] == 1
             2 # Flag VSPs as CD
-          elsif row['HMISParticipatingProject'] == 1
+          elsif row['HMISParticipatingProject'].to_i == 1
             1 # Copy participating from project to new record
           else
             0 # 0, nil, or 99 are non-participating

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/hmis_participation/create_hmis_participation.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/app/models/hud_twenty_twenty_two_to_twenty_twenty_four/hmis_participation/create_hmis_participation.rb
@@ -32,9 +32,11 @@ module HudTwentyTwentyTwoToTwentyTwentyFour::HmisParticipation
 
           key = "#{row['OrganizationID']}_ds_#{row['data_source_id']}"
           participation_type = if victim_service_providers[key] == 1
-            2
+            2 # Flag VSPs as CD
+          elsif row['HMISParticipatingProject'] == 1
+            1 # Copy participating from project to new record
           else
-            row['HMISParticipatingProject']
+            0 # 0, nil, or 99 are non-participating
           end
 
           timestamp = row['DateUpdated']


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

- Adjust migrator to generate 0 instead  copying existing value if a project is not flagged as participating as null and 99 are
no longer acceptable values per the spec, and clean up any nulls or 99s from past migrations.
- Remove the generated participation records if there are real ones as they will likely conflict with records from an external HMIS.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [X] New feature (adds functionality)
- [X] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
