### PR TITLE
Only resolve limited-access enrollments when requested

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -683,7 +683,7 @@ type Client {
   dobDataQuality: DOBDataQuality!
   emailAddresses: [ClientContactPoint!]!
   employmentEducations(limit: Int, offset: Int): EmploymentEducationsPaginated!
-  enrollments(filters: EnrollmentsForClientFilterOptions, limit: Int, offset: Int, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
+  enrollments(filters: EnrollmentsForClientFilterOptions, includeEnrollmentsWithLimitedAccess: Boolean, limit: Int, offset: Int, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
   externalIds: [ExternalIdentifier!]!
   files(limit: Int, offset: Int, sortOrder: FileSortOption): FilesPaginated!
   firstName: String

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -72,7 +72,10 @@ module Types
     field :phone_numbers, [HmisSchema::ClientContactPoint], null: false
     field :email_addresses, [HmisSchema::ClientContactPoint], null: false
     field :hud_chronic, Boolean, null: true
-    enrollments_field filter_args: { omit: [:search_term, :bed_night_on_date], type_name: 'EnrollmentsForClient' }
+    enrollments_field filter_args: { omit: [:search_term, :bed_night_on_date], type_name: 'EnrollmentsForClient' } do
+      # Option to include enrollments that the user has "limited" access to
+      argument :include_enrollments_with_limited_access, Boolean, required: false
+    end
     income_benefits_field
     disabilities_field
     health_and_dvs_field
@@ -154,7 +157,11 @@ module Types
       collection.hmis_identifiers + collection.mci_identifiers
     end
 
+    # Resolve enrollments that the current user has ANY access to (limited or detailed access)
     def enrollments(**args)
+      include_limited_access = args.delete(:include_enrollments_with_limited_access)
+      return resolve_enrollments(object.enrollments, **args) unless include_limited_access
+
       # If current user has "detailed" access to any enrollment for this client, then we also resolve
       # "limited access" enrollments (if permitted). The purpose is to show additional enrollment history
       # for "my" clients, but not for other clients in the system that I can see.

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -157,7 +157,6 @@ module Types
       collection.hmis_identifiers + collection.mci_identifiers
     end
 
-    # Resolve enrollments that the current user has ANY access to (limited or detailed access)
     def enrollments(**args)
       include_limited_access = args.delete(:include_enrollments_with_limited_access)
       return resolve_enrollments(object.enrollments, **args) unless include_limited_access


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Change the logic for the `client.enrollments` field so that it only resolves "limited access" enrollments if specified using the `includeEnrollmentsWithLimitedAccess` argument.

This is desired because we want to show those in the Client Enrollments table, but elsewhere in the application we only want to request enrollments that the user has detailed access to (For example when populating the Previously Associated Members table).

I made this an argument rather than a table "filter" because it's not needed as a table filter and it's not applicable to resolving enrollments on anywhere other than Clients. 


HMIS PR: https://github.com/greenriver/hmis-frontend/pull/596

**This fixes a bug where** the Edit Household page would crash when attempting to populate the "previous members" table if those enrollments were at other projects where the current user only has limited access to view their existence. [ticket](https://www.pivotaltracker.com/n/projects/2591838/stories/186727788)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
