### PR TITLE
Generate homelessness ICD10 codes from THRIVEs as well as SSMs

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -1338,8 +1338,7 @@ module Health
     end
 
     def sdoh_icd10_codes
-      # TODO: Replace with THRIVE
-      homelessness_unspecified = recent_ssm_form&.housing_score&.in?([1, 2])
+      homelessness_unspecified = recent_hrsn_screening&.instrument&.positive_for_homelessness?
 
       [].tap do |codes|
         codes << 'Z5900' if homelessness_unspecified

--- a/app/models/health/self_sufficiency_matrix_form.rb
+++ b/app/models/health/self_sufficiency_matrix_form.rb
@@ -450,6 +450,10 @@ module Health
       SECTIONS.keys.map { |key| send("#{key}_score") }.any? { |answer| answer.in?(1..4) }
     end
 
+    def positive_for_homelessness?
+      housing_score&.in?([1, 2])
+    end
+
     def encounter_report_details
       {
         source: 'Warehouse',

--- a/drivers/health_thrive_assessment/app/models/health_thrive_assessment/assessment.rb
+++ b/drivers/health_thrive_assessment/app/models/health_thrive_assessment/assessment.rb
@@ -52,6 +52,10 @@ module HealthThriveAssessment
         interested_in_education?
     end
 
+    def positive_for_homelessness?
+      homeless?
+    end
+
     enum reporter: {
       patient: 10,
       caregiver: 20,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

MassHealth wants the ICD 10 code Z59.00 attached to the SDOH positive screenings when a patient is identified by the screener as homeless. This had been done for SSMs, but never finalized for THRIVEs.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)
- [X] Code clean-up / housekeeping

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
