### PR TITLE
Ensure that client_ages[base_count_sym] is defined

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/age_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/age_calculations.rb
@@ -222,11 +222,11 @@ module
     private def client_ages
       @client_ages ||= Rails.cache.fetch(age_cache_key, expires_in: expiration_length) do
         {}.tap do |clients|
+          clients[base_count_sym] ||= {}
           report_scope.joins(:client).order(first_date_in_program: :desc).
             distinct.
             pluck(:client_id, age_calculation, :first_date_in_program).
             each do |client_id, age, _|
-              clients[base_count_sym] ||= {}
               clients[base_count_sym][client_id] ||= age
             end
           available_coc_codes.each do |coc_code|


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

If there were no clients in the report, `client_ages[base_count_sym]` was unexpectedly returning `nil`.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
