### PR TITLE
Adjust prior living situation values in Q26i to 2024 spec

### DIFF
--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/question_twenty_six.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/question_twenty_six.rb
@@ -199,7 +199,7 @@ module HudPathReport::Generators::Fy2024
         query = query.or(a_t[:length_of_stay].eq(nil)) if v == 99
         [
           HudUtility2024.length_of_stays[v],
-          a_t[:prior_living_situation].in([1, 16]).and(query),
+          a_t[:prior_living_situation].in([101, 116]).and(query),
         ]
       end.to_h
       h['Total'] = :total


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Prior living situations for Q26i were still pre-2024 values.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
