### PR TITLE
Fix test failure due to date roll over

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
@@ -100,7 +100,7 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
       last_year_annual_in_range = start_date.gt(today).and(cas_t[:assessment_date].gteq(last_start_date).and(cas_t[:assessment_date].lteq(last_end_date)))
       annual_in_range = this_year_annual_in_range.or(last_year_annual_in_range)
 
-      # Clause for checking whether an Enrollment's Entry Date falls before the "anniverary". There are due cases because the anniversary may be this year or last year.
+      # Clause for checking whether an Enrollment's Entry Date falls before the "anniverary". There are two cases because the anniversary may be this year or last year.
       this_year_entered_before_anniversary = start_date.lteq(today).and(e_t[:entry_date].lt(Arel.sql(anniversary_date)))
       last_year_entered_before_anniversary = start_date.gt(today).and(e_t[:entry_date].lt(Arel.sql(last_year_anniversary_date)))
       entered_before_anniversary = this_year_entered_before_anniversary.or(last_year_entered_before_anniversary)

--- a/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/enrollment_filter.rb
@@ -95,7 +95,7 @@ class Hmis::Filter::EnrollmentFilter < Hmis::Filter::BaseFilter
         #{last_year_anniversary_date} + interval '30 days'
       SQL
 
-      # Clause for checking whether an Assessment falls within the "due period". There are due cases because the due period may be this year or last year.
+      # Clause for checking whether an Assessment falls within the "due period". There are two cases because the due period may be this year or last year.
       this_year_annual_in_range = start_date.lteq(today).and(cas_t[:assessment_date].gteq(start_date).and(cas_t[:assessment_date].lteq(end_date)))
       last_year_annual_in_range = start_date.gt(today).and(cas_t[:assessment_date].gteq(last_start_date).and(cas_t[:assessment_date].lteq(last_end_date)))
       annual_in_range = this_year_annual_in_range.or(last_year_annual_in_range)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The year roll-over exposed an issue in graphql household search filter. It's using the db current_date which no-longer matches the test  date (set via  time-cop)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
