### PR TITLE
Add diagnosis code pointers to screenings when appropriate

### DIFF
--- a/app/models/health/claim.rb
+++ b/app/models/health/claim.rb
@@ -147,11 +147,12 @@ module Health
               b.CLM pr.id, '0', nil, nil, b.composite('11', 'B', '1'), 'Y', 'A', 'Y', 'Y'
               hi_codes = [b.composite('ABK', 'Z139')] # Encounter for screening, unspecified
               hi_codes += patient.sdoh_icd10_codes.map { |code| b.composite('ABF', code) } if qas.any? { |qa| qa.activity == 'sdoh_positive' }
+              diag_ptrs = ('1' .. hi_codes.count.to_s).to_a
               b.HI(*hi_codes)
               qa_batch.each do |qa|
                 @lx += 1
                 b.LX @lx
-                b.SV1 b.composite('HC', *qa.procedure_code.split(component_element_separator), *qa.modifiers), '0', 'UN', '1', nil, nil, b.composite('1')
+                b.SV1 b.composite('HC', *qa.procedure_code.split(component_element_separator), *qa.modifiers), '0', 'UN', '1', nil, nil, b.composite(*diag_ptrs)
                 b.DTP '472', 'D8', qa.date_of_activity.strftime('%Y%m%d')
               end
             end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

MassHealth tells us that the secondary diagnosis code for homelessness in screening QAs needs to be referenced in
the diagnosis code pointers field of the SV1.

This is not easily tested without tools to explore the generated EDI, so this was bench tested with the `claim_spec.rb`
smoke test, and an  online EDI parser (https://www.stedi.com/edi/inspector)

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
