### PR TITLE
Transformation to display audit history for disability correctly

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1165,6 +1165,53 @@ enum CmExitReason {
   VETERAN_TOO_ILL_TO_PARTICIPATE_AT_THIS_TIME
 }
 
+enum CompleteDisabilityResponse {
+  """
+  Alcohol use disorder
+  """
+  ALCOHOL_USE_DISORDER
+
+  """
+  Both alcohol and drug use disorders
+  """
+  BOTH_ALCOHOL_AND_DRUG_USE_DISORDERS
+
+  """
+  Client doesn't know
+  """
+  CLIENT_DOESN_T_KNOW
+
+  """
+  Client prefers not to answer
+  """
+  CLIENT_PREFERS_NOT_TO_ANSWER
+
+  """
+  Data not collected
+  """
+  DATA_NOT_COLLECTED
+
+  """
+  Drug use disorder
+  """
+  DRUG_USE_DISORDER
+
+  """
+  Invalid Value
+  """
+  INVALID
+
+  """
+  No
+  """
+  NO
+
+  """
+  Yes
+  """
+  YES
+}
+
 enum Component {
   """
   Client Address input
@@ -2583,7 +2630,7 @@ type Disability {
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
-  disabilityResponse: DisabilityResponse!
+  disabilityResponse: CompleteDisabilityResponse!
   disabilityType: DisabilityType!
   enrollment: Enrollment!
   id: ID!

--- a/drivers/hmis/app/graphql/types/hmis_schema/disability.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/disability.rb
@@ -19,7 +19,7 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :information_date, GraphQL::Types::ISO8601Date, null: true
     field :disability_type, HmisSchema::Enums::Hud::DisabilityType, null: false, default_value: Types::BaseEnum::INVALID_VALUE
-    field :disability_response, HmisSchema::Enums::Hud::DisabilityResponse, null: false, default_value: 99
+    field :disability_response, HmisSchema::Enums::CompleteDisabilityResponse, null: false, default_value: 99
     field :indefinite_and_impairs, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
     field :data_collection_stage, HmisSchema::Enums::Hud::DataCollectionStage, null: false, default_value: Types::BaseEnum::INVALID_VALUE
     hud_field :t_cell_count_available, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
@@ -35,6 +35,15 @@ module Types
 
     def client
       load_ar_association(object, :client)
+    end
+
+    def disability_response
+      # Special case for Substance Use "1" which means Alcohol Use Disorder (as opposed to 'Yes' for others)
+      if object.substance_use_type? && object.disability_response == 1
+        Types::HmisSchema::Enums::CompleteDisabilityResponse::SUBSTANCE_USE_1_OVERRIDE_VALUE
+      else
+        object.disability_response
+      end
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/complete_disability_response.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/complete_disability_response.rb
@@ -1,0 +1,27 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::Enums::CompleteDisabilityResponse < Types::BaseEnum
+    graphql_name 'CompleteDisabilityResponse'
+    # Used for Disability.DisabiltiyResponse field. It is a combination of DisabilityResponse+NoYesMissing enums,
+    # with a special fake value for ALCOHOL_USE_DISORDERS which is the only one that overlaps with a different label.
+
+    SUBSTANCE_USE_1_OVERRIDE_VALUE = 10
+
+    value 'NO', 'No', value: 0
+    value 'YES', 'Yes', value: 1
+    value 'ALCOHOL_USE_DISORDER', 'Alcohol use disorder', value: SUBSTANCE_USE_1_OVERRIDE_VALUE # The HUD value is 1.
+    value 'DRUG_USE_DISORDER', 'Drug use disorder', value: 2
+    value 'BOTH_ALCOHOL_AND_DRUG_USE_DISORDERS', 'Both alcohol and drug use disorders', value: 3
+    value 'CLIENT_DOESN_T_KNOW', 'Client doesn\'t know', value: 8
+    value 'CLIENT_PREFERS_NOT_TO_ANSWER', 'Client prefers not to answer', value: 9
+    value 'DATA_NOT_COLLECTED', 'Data not collected', value: 99
+    invalid_value
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/complete_disability_response.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/complete_disability_response.rb
@@ -12,7 +12,7 @@ module Types
     # Used for Disability.DisabiltiyResponse field. It is a combination of DisabilityResponse+NoYesMissing enums,
     # with a special fake value for ALCOHOL_USE_DISORDERS which is the only one that overlaps with a different label.
 
-    SUBSTANCE_USE_1_OVERRIDE_VALUE = 10
+    SUBSTANCE_USE_1_OVERRIDE_VALUE = 1000
 
     value 'NO', 'No', value: 0
     value 'YES', 'Yes', value: 1

--- a/drivers/hmis/app/models/hmis/hud/disability.rb
+++ b/drivers/hmis/app/models/hmis/hud/disability.rb
@@ -16,4 +16,8 @@ class Hmis::Hud::Disability < Hmis::Hud::Base
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
+  def substance_use_type?
+    disability_type == 10
+  end
 end


### PR DESCRIPTION
## Description

Fixes a bug where Disability Response "Yes" was always showing up in the Audit UI as "Alcohol Use Disorder", even for non-Substance Use disability types.

This approach uses a new enum that is a union of 1.8 and 4.10.2.
<img width="581" alt="Screenshot 2024-01-04 at 10 24 29 AM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/de192fb2-0a13-4826-89f0-087404dd3f4b">


It also includes a change in the Audit Event resolver for Enrollment-related records, in order to override the "1" so that it will be displayed using the correct enum label. This could have been done on the frontend instead, but this felt cleaner because the all of the logic is contained to the backend (As opposed to spread across both).

<img width="1428" alt="Screenshot 2024-01-04 at 10 25 53 AM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/117d51e0-477d-41c8-9061-6ec0cb8c22ee">


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
