### PR TITLE
Only show Superset if a reasonable doorkeeper application has been setup

### DIFF
--- a/app/models/grda_warehouse/warehouse_reports/report_definition.rb
+++ b/app/models/grda_warehouse/warehouse_reports/report_definition.rb
@@ -1355,11 +1355,11 @@ module GrdaWarehouse::WarehouseReports
       end
 
       # Don't enable this report in production yet
-      if RailsDrivers.loaded.include?(:superset) && ! Rails.env.production?
+      if RailsDrivers.loaded.include?(:superset) && Superset.available?
         r_list['Performance'] << {
           url: 'superset/warehouse_reports/reports',
           name: 'Launch Superset',
-          description: 'An integration with the Apache Superset business inteligence tool.',
+          description: 'An integration with the Apache Superset business intelligence tool.',
           limitable: true,
           health: false,
         }

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -9,4 +9,9 @@ module Superset
     tokens = [tokens[0], 'superset', tokens[1..]].flatten
     'https://' + ENV.fetch('SUPERSET_FQDN', tokens.join('.'))
   end
+
+  def self.available?
+    a_t = Doorkeeper::Application.arel_table
+    Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
+  end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Show the superset "report" with a link to superset if the doorkeeper application has been setup in a reasonable way.

## Type of change
[//]: # 'remove options that are not relevant'

- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
