### PR TITLE
186645293 hmis deduplicate mci ids on merge

### DIFF
--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -199,8 +199,9 @@ module Hmis
 
     def merge_mci_ids
       mci_ids = HmisExternalApis::AcHmis::Mci.external_ids
-      # merge ids
+      current_ids_for_retained_client = mci_ids.where(source: client_to_retain).pluck(:value)
       records_by_value = mci_ids.where(source: clients_needing_reference_updates).
+        where.not(value: current_ids_for_retained_client).
         order(:id).reverse.index_by(&:value) # de-duplicate by value, take first id
 
       mci_ids.where(id: records_by_value.values.map(&:id)).


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[Bugfix MCI IDs are duplicated on client merge
](https://www.pivotaltracker.com/story/show/186645293)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
