### PR TITLE
Add root enabledFeatures query

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -683,6 +683,7 @@ type Client {
   dobDataQuality: DOBDataQuality!
   emailAddresses: [ClientContactPoint!]!
   employmentEducations(limit: Int, offset: Int): EmploymentEducationsPaginated!
+  enabledFeatures: [ClientDashboardFeature!]!
   enrollments(filters: EnrollmentsForClientFilterOptions, includeEnrollmentsWithLimitedAccess: Boolean, limit: Int, offset: Int, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
   externalIds: [ExternalIdentifier!]!
   files(limit: Int, offset: Int, sortOrder: FileSortOption): FilesPaginated!
@@ -907,6 +908,11 @@ enum ClientContactPointUse {
   Work
   """
   work
+}
+
+enum ClientDashboardFeature {
+  CASE_NOTE
+  FILE
 }
 
 input ClientFilterOptions {
@@ -8158,11 +8164,6 @@ type Query {
   clientSearch(filters: ClientFilterOptions, input: ClientSearchInput!, limit: Int, offset: Int, sortOrder: ClientSortOption): ClientsPaginated!
   currentUser: ApplicationUser
   deniedPendingReferralPostings(limit: Int, offset: Int): ReferralPostingsPaginated!
-
-  """
-  Data collection features that are enabled for ANY project (e.g. Current Living Situations, Events, Case Notes)
-  """
-  enabledFeatures: [DataCollectionFeatureRole!]!
 
   """
   Enrollment lookup

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8160,6 +8160,11 @@ type Query {
   deniedPendingReferralPostings(limit: Int, offset: Int): ReferralPostingsPaginated!
 
   """
+  Data collection features that are enabled for ANY project (e.g. Current Living Situations, Events, Case Notes)
+  """
+  enabledFeatures: [DataCollectionFeatureRole!]!
+
+  """
   Enrollment lookup
   """
   enrollment(id: ID!): Enrollment

--- a/drivers/hmis/app/graphql/types/forms/enums/client_dashboard_feature.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/client_dashboard_feature.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class Forms::Enums::ClientDashboardFeature < Types::BaseEnum
+    graphql_name 'ClientDashboardFeature'
+
+    value 'CASE_NOTE'
+    value 'FILE'
+  end
+end

--- a/drivers/hmis/app/graphql/types/forms/enums/client_dashboard_feature.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/client_dashboard_feature.rb
@@ -4,8 +4,6 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# frozen_string_literal: true
-
 module Types
   class Forms::Enums::ClientDashboardFeature < Types::BaseEnum
     graphql_name 'ClientDashboardFeature'

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -128,7 +128,7 @@ module Types
     )
 
     field :image, HmisSchema::ClientImage, null: true
-
+    field :enabled_features, [Types::Forms::Enums::ClientDashboardFeature], null: false
     access_field do
       can :view_partial_ssn
       can :view_full_ssn
@@ -296,6 +296,22 @@ module Types
       return unless current_user.can_merge_clients?
 
       object.merge_audits.order(merged_at: :desc)
+    end
+
+    # This query is used to determine which features to show on the Client Dashboard (for example, the read-only Case Notes tab).
+    #
+    # This first version is global. In other words it resolves the same thing for every client.
+    # In the future this will probably be client-specific, either based on some configuration, or based on the projects that the client is enrolled at.
+    # Specifically for indicating whether certain "Enrollment-optional records" (File, Case Note) should be collectable on the Client Dashbord vs on the Enrollment Dashboard (in the future).
+    def enabled_features
+      client_dashboard_feature_roles = Types::Forms::Enums::ClientDashboardFeature.values.keys
+
+      # Just checks if there are ANY active Instances for each role.
+      # It's possible there could be instances that exist but don't apply to any projects, but we don't bother checking for that.
+      Hmis::Form::Instance.active.
+        joins(:definition).
+        where(Hmis::Form::Definition.arel_table[:role].in(client_dashboard_feature_roles)).
+        pluck(:role).uniq
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -389,5 +389,17 @@ module Types
 
       Hmis::AutoExitConfig.all
     end
+
+    # This query is used to determine which features to show on the Client Dashboard (for example, the read-only Case Notes tab).
+    # It just checks if there are active Instances for each role type (e.g. Case Note).
+    # It's possible there could be instances that exist but don't apply to any projects, but don't bother checking for that.
+    #
+    # Note: this will need to change if/when we want to support specific rules indicating whether certain "Enrollment-optional records" (File, Case Note)
+    # should be collectable on the Client Dashbord vs on the Enrollment Dashboard.
+    field :enabled_features, [Types::Forms::Enums::DataCollectionFeatureRole], null: false, description: 'Features that are enabled for ANY project in the Data Source'
+    def enabled_features
+      feature_roles = Hmis::Form::Definition::DATA_COLLECTION_FEATURE_ROLES
+      Hmis::Form::Instance.active.joins(:definition).where(fd_t[:role].in(feature_roles)).pluck(:role).uniq
+    end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -389,17 +389,5 @@ module Types
 
       Hmis::AutoExitConfig.all
     end
-
-    # This query is used to determine which features to show on the Client Dashboard (for example, the read-only Case Notes tab).
-    # It just checks if there are active Instances for each role type (e.g. Case Note).
-    # It's possible there could be instances that exist but don't apply to any projects, but don't bother checking for that.
-    #
-    # Note: this will need to change if/when we want to support specific rules indicating whether certain "Enrollment-optional records" (File, Case Note)
-    # should be collectable on the Client Dashbord vs on the Enrollment Dashboard.
-    field :enabled_features, [Types::Forms::Enums::DataCollectionFeatureRole], null: false, description: 'Features that are enabled for ANY project in the Data Source'
-    def enabled_features
-      feature_roles = Hmis::Form::Definition::DATA_COLLECTION_FEATURE_ROLES
-      Hmis::Form::Instance.active.joins(:definition).where(fd_t[:role].in(feature_roles)).pluck(:role).uniq
-    end
   end
 end


### PR DESCRIPTION
## Description

Simple query that resolves the list of "features" that are enabled for the client dashboard.

This is going to need some tweaking to support the more complex configurability that we'll need. But for now this is a simple approach to deciding whether to show the read-only Case Notes on the Client Dashboard.

For installations that don't use Case Notes anywhere, this will hide the Case Notes tab from the Client dash.

Frontend PR: https://github.com/greenriver/hmis-frontend/pull/603

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
