### PR TITLE
Support custom client detail forms

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3908,6 +3908,11 @@ enum FormRole {
   CLIENT
 
   """
+  Client detail
+  """
+  CLIENT_DETAIL
+
+  """
   Current living situation
   """
   CURRENT_LIVING_SITUATION
@@ -8192,6 +8197,11 @@ type Query {
   Client lookup
   """
   client(id: ID!): Client
+
+  """
+  Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form)
+  """
+  clientDetailForms: [OccurrencePointForm!]!
 
   """
   Client omnisearch

--- a/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
@@ -26,12 +26,10 @@ module Types
     end
 
     def definition(parent:)
-      raise 'Resolving on something other than project' unless parent.is_a?(Hmis::Hud::Project)
-
       definition = load_ar_association(object, :definition)
       raise "Unable to load definition for instance: #{object.id}" unless definition.present?
 
-      definition.filter_context = { project: parent }
+      definition.filter_context = { project: parent } if parent.is_a?(Hmis::Hud::Project)
       definition
     end
   end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -389,5 +389,11 @@ module Types
 
       Hmis::AutoExitConfig.all
     end
+
+    field :client_detail_forms, [Types::HmisSchema::OccurrencePointForm], null: false, description: 'Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form)'
+    def client_detail_forms
+      # No authorization required, this just resolving application configuration
+      Hmis::Form::Instance.active.with_role(:CLIENT_DETAIL)
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -62,6 +62,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     *DATA_COLLECTION_FEATURE_ROLES,
     *STATIC_FORM_ROLES,
     :OCCURRENCE_POINT,
+    :CLIENT_DETAIL,
     # Other/misc forms
     :FILE, # should maybe be considered a data collection feature, but different becase its at Client-level (not Project)
   ].freeze
@@ -144,6 +145,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
       **ENROLLMENT_CONFIG,
       permission: [:can_edit_clients, :can_edit_enrollments],
     },
+    CLIENT_DETAIL: {
+      owner_class: Hmis::Hud::Client,
+      permission: :can_edit_clients,
+    },
   }.freeze
 
   FORM_DATA_COLLECTION_STAGES = {
@@ -173,6 +178,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     return none unless instance_scope.present?
 
     where(identifier: instance_scope.pluck(:definition_identifier))
+  end
+
+  scope :active, -> do
+    joins(:instance).merge(Hmis::Form::Instance.active)
   end
 
   scope :for_service_type, ->(service_type) do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add a new form role called `CLIENT_DETAIL`. This is used for resolving custom fields on the Client that should be present (and possibly editable) on the Client Dashboard. See frontend PR for a screenshot.

The client detail forms are resolved globally. For now they are the same for all clients.

https://github.com/greenriver/hmis-frontend/pull/605

## How to test

1. Create a custom data element for client: `Hmis::Hud::CustomDataElementDefinition.create!(owner_type: "Hmis::Hud::Client", field_type: "string", key: :favorite_color, label: "Favorite Color", data_source_id: 1 (hmis), UserID: "1")`
2. Create a form definition to collect that data element. (`admin/forms` => "New Definition"). Give it a title and identifier, and choose role "Client Detail". If the title matches your cded title ("Favorite Color") the title won't show up twice in the ui.
```
{
  "item": [
    {
      "text": "Favorite Color",
      "type": "CHOICE",
      "link_id": "color-1",
      "mapping": {
        "record_type": "CLIENT",
        "custom_field_key": "favorite_color"
      },
      "pick_list_options": [
        {
          "code": "Red"
        },
        {
          "code": "Yellow"
        }
      ]
    }
  ]
}
```
3. Add a form rule (`/admin/forms/<id>` click "new rule") it can be empty as long as it is set to `active: true`. The other rules are project/enrollment-based and won't make any difference. Maybe in the future we want to be able to configure visibility based on client age or something, but I didn't implement that here.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
