### PR TITLE
Hide static forms from the form ui

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -363,7 +363,7 @@ module Types
       raise 'Access denied' unless current_user.can_configure_data_collection?
 
       # TODO: add ability to sort and filter definitions
-      Hmis::Form::Definition.all
+      Hmis::Form::Definition.non_static.order(updated_at: :desc)
     end
 
     form_rules_field

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -180,6 +180,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     where(identifier: instance_scope.pluck(:definition_identifier))
   end
 
+  scope :non_static, -> do
+    where.not(role: STATIC_FORM_ROLES)
+  end
+
   scope :active, -> do
     joins(:instance).merge(Hmis::Form::Instance.active)
   end


### PR DESCRIPTION
Don't show Static forms in the Form management UI because they cannot be changed.