### PR TITLE
Remove ruby lsp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -282,9 +282,6 @@ group :development do
   gem 'bumbler', require: false
 
   gem 'graphiql-rails'
-
-  # vscode ruby
-  gem 'ruby-lsp', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -526,7 +526,6 @@ GEM
     kiba (4.0.0)
     kiba-common (1.5.0)
       kiba (>= 3.0.0, < 5)
-    language_server-protocol (3.17.0.3)
     linefit (0.3.4)
     list_matcher (1.1.8)
     llhttp-ffi (0.4.0)
@@ -649,7 +648,6 @@ GEM
       htmlentities (>= 4.0.0)
     pretender (0.3.4)
       actionpack (>= 4.2)
-    prism (0.15.1)
     progress_bar (1.3.3)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
@@ -806,10 +804,6 @@ GEM
     ruby-filemagic (0.7.3)
     ruby-graphviz (1.2.5)
       rexml
-    ruby-lsp (0.12.2)
-      language_server-protocol (~> 3.17.0)
-      prism (>= 0.15.1, < 0.16)
-      sorbet-runtime (>= 0.5.5685)
     ruby-mailchecker (4.0.13)
     ruby-next-core (0.15.3)
     ruby-ole (1.2.12.2)
@@ -870,7 +864,6 @@ GEM
     sniffer (0.5.0)
       anyway_config (>= 1.0)
       dry-initializer (~> 3)
-    sorbet-runtime (0.5.11109)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -1160,7 +1153,6 @@ DEPENDENCIES
   rspec-rails
   rubocop
   ruby-filemagic
-  ruby-lsp
   ruby-mailchecker
   ruby-prof
   rubyXL


### PR DESCRIPTION

I added ruby-lsp as a hack to get a it working in vscode with our container config. I figured out a better solution and no longer need the gem. I think I'm the only one that used it so should be safe to remove

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping
- [x] Dependency update
