### PR TITLE
Audit UI updates

### DIFF
--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -76,6 +76,10 @@ module Types
         # Try to label Custom Data Elements based on their definition label
         definition_id = item_attributes['data_element_definition_id']
         custom_data_element_labels_by_id[definition_id] || 'Custom Data Element'
+      when 'Hmis::Hud::CustomAssessment'
+        # Try to label Assessment by name (eg "Exit Assessment")
+        # This would need adjustment to support naming fully custom assessments (eg "SPDAT Assessment")
+        HudUtility2024.assessment_name_by_data_collection_stage[item_attributes['DataCollectionStage']] || 'Assessment'
       else
         object.item_type.demodulize.gsub(/^Custom(Client)?/, '').
           underscore.humanize.titleize

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -144,7 +144,7 @@ module Types
         [Hmis::Hud::Exit],
         [Hmis::Hud::Event, 'CE Event'],
         [Hmis::Hud::Assessment, 'CE Assessment'],
-        [Hmis::Hud::CustomDataElement],
+        [Hmis::Hud::CustomDataElement, 'Custom Field'],
         [Hmis::Hud::CustomCaseNote],
       ].map do |model, name|
         model_picklist_item(model: model, name: name)
@@ -152,11 +152,15 @@ module Types
     end
 
     def self.client_audit_event_record_type_picklist
-      [
+      client_audited_models = [
         [Hmis::Hud::Client],
         [Hmis::Hud::CustomClientAddress],
         [Hmis::Hud::CustomClientContactPoint, 'Contact Information'],
-      ].map do |model, name|
+      ]
+      # If installation has any custom client fields, include a general filter option for them
+      has_client_cdes = Hmis::Hud::CustomDataElementDefinition.for_type(Hmis::Hud::Client.sti_name).exists?
+      client_audited_models << [Hmis::Hud::CustomDataElement, 'Custom Field'] if has_client_cdes
+      client_audited_models.map do |model, name|
         model_picklist_item(model: model, name: name)
       end.sort_by { |h| h[:label] }
     end

--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -686,4 +686,14 @@ module HudUtility2024
 
     send(label_method, sub_type_provided)
   end
+
+  def assessment_name_by_data_collection_stage
+    {
+      1 => 'Intake Assessment',
+      2 => 'Update Assessment',
+      3 => 'Exit Assessment',
+      5 => 'Annual Assessment',
+      6 => 'Post-Exit Assessment',
+    }.freeze
+  end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

1. Label assessments by type ("Exit Assessments")
2. Show audit history for Client Custom Data Elements on the client audit history page
3. Make use of the new `client_id` field on version when figuring out which records to include in client audit history
4. Add a new filter option "Custom Field" for showing custom data elements (needed for Pathways). It would be nice if you could select the specific cded but that didn't seem worth it now.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
