### PR TITLE
Do not verify authenticity token on External HMIS APIs

### DIFF
--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
@@ -7,8 +7,11 @@
 module HmisExternalApis
   class BaseController < ApplicationController
     before_action :authorize_request
+    # Not needed for API-key authenticated endpoints
     skip_before_action :verify_authenticity_token
+    # Not needed for API-key authenticated endpoints
     skip_before_action :authenticate_user!
+
     prepend_before_action :skip_timeout
 
     NotAuthorized = Class.new(StandardError)

--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
@@ -7,6 +7,7 @@
 module HmisExternalApis
   class BaseController < ApplicationController
     before_action :authorize_request
+    skip_before_action :verify_authenticity_token
     skip_before_action :authenticate_user!
     prepend_before_action :skip_timeout
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Patch issue that was seemingly introduced by https://github.com/greenriver/hmis-warehouse/commit/03f3faf0495265b555ef5119cf97ec24a1136760#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07


Tested locally and confirmed it fixes the regression

## Type of change

- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
