### PR TITLE
Enable project cleanup for projects with no enrollments

### DIFF
--- a/app/models/grda_warehouse/tasks/project_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/project_cleanup.rb
@@ -57,10 +57,12 @@ module GrdaWarehouse::Tasks
 
       sh_project_types_for_check = sh_project_types(project)
       project_types_match_sh_types = true
+      # If SHE only has one set of project types, that's generally good, just confirm they match the project's types
       if sh_project_types_for_check.count == 1
         (project_type, computed_project_type) = sh_project_types_for_check.first
         project_types_match_sh_types = project.ProjectType == project_type && project.computed_project_type == computed_project_type
       end
+      # If SHE has more than one set of project types, we'll need to rebuild
       project_type_changed_in_source = sh_project_types_for_check.count > 1
       project_type_changed_in_source || project_override_changed || ! project_types_match_sh_types
     end

--- a/app/models/grda_warehouse/tasks/project_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/project_cleanup.rb
@@ -28,16 +28,16 @@ module GrdaWarehouse::Tasks
       @projects = load_projects
 
       @projects.each do |project|
-        next unless project.enrollments.exists?
+        any_enrollments = project.enrollments.exists?
 
         if should_update_type?(project)
           fix_project_type(project)
-        elsif homeless_mismatch?(project) # if should_update_type? returned true, these have been fixed
+        elsif homeless_mismatch?(project) && any_enrollments # if should_update_type? returned true, these have been fixed
           invalidate_enrollments(project)
         end
 
         fix_name(project)
-        fix_client_locations(project)
+        fix_client_locations(project) if any_enrollments
         remove_unneeded_hmis_participations(project)
       end
       GrdaWarehouse::Tasks::ServiceHistory::Enrollment.batch_process_unprocessed!(max_wait_seconds: 1_800)
@@ -68,16 +68,16 @@ module GrdaWarehouse::Tasks
     def fix_project_type(project)
       blank_initial_computed_project_type = project.computed_project_type.blank?
       debug_log("Updating type for #{project.ProjectName} << #{project.organization&.OrganizationName || 'unknown'} in #{project.data_source.short_name}... current ProjectType: #{project.ProjectType} acts_as: #{project.act_as_project_type} project types in Service History:  #{sh_project_types(project).inspect}") unless blank_initial_computed_project_type
-      project_type = project.compute_project_type
+      computed_project_type = project.compute_project_type
       # Force a rebuild of all related enrollments
       project_source.transaction do
         project.enrollments.invalidate_processing!
-        project.update(computed_project_type: project_type)
+        project.update(computed_project_type: computed_project_type)
         # Fix the SHE with record_type "first"
         service_history_enrollment_source.where(
           project_id: project.ProjectID,
           data_source_id: project.data_source_id,
-        ).update_all(computed_project_type: project_type, project_type: project_type)
+        ).update_all(computed_project_type: computed_project_type, project_type: project.ProjectType)
       end
       debug_log("done invalidating enrollments for #{project.ProjectName}") unless blank_initial_computed_project_type
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Include projects with no enrollments in the project cleanup so they get the right project types and names.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
