### PR TITLE
Add report_class to health pdfs so "Recent Downloads" doesn't crash.

### DIFF
--- a/drivers/health_comprehensive_assessment/app/models/health_comprehensive_assessment/document_exports/health_ca_pdf_export.rb
+++ b/drivers/health_comprehensive_assessment/app/models/health_comprehensive_assessment/document_exports/health_ca_pdf_export.rb
@@ -116,5 +116,9 @@ module HealthComprehensiveAssessment::DocumentExports
     private def controller_class
       HealthComprehensiveAssessment::AssessmentsController
     end
+
+    protected def report_class
+      HealthComprehensiveAssessment::Assessment
+    end
   end
 end

--- a/drivers/health_pctp/app/models/health_pctp/document_exports/health_pctp_pdf_export.rb
+++ b/drivers/health_pctp/app/models/health_pctp/document_exports/health_pctp_pdf_export.rb
@@ -99,5 +99,9 @@ module HealthPctp::DocumentExports
     private def controller_class
       HealthPctp::CareplansController
     end
+
+    protected def report_class
+      HealthPctp::Careplan
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The "Recent Downloads" tab for users fails if the pdf exporter doesn't include `report_class`.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
