### PR TITLE
Don't enforce column lengths on hashed columns during export

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/export_concern.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/export_concern.rb
@@ -133,15 +133,24 @@ module HmisCsvTwentyTwentyFour::Exporter::ExportConcern
 
     def length_limited_columns
       @length_limited_columns ||= HmisCsvTwentyTwentyFour::Exporter::Base.hmis_class_for(self.class).hmis_configuration(version: '2024').select do |col, m|
-        m.key?(:limit) && ! hashed_column(col)
+        m.key?(:limit) && ! hashed_column?(col)
       end
     end
 
     # A few columns get hashed and the hash is longer than the allowed length, that's ok
-    private def hashed_column(col)
+    private def hashed_column?(col)
       return false unless @options[:export].hash_status == 4
 
-      col.in?([:FirstName, :MiddleName, :LastName, :SSN])
+      col.in?(hashed_columns)
+    end
+
+    private def hashed_columns
+      [
+        :FirstName,
+        :MiddleName,
+        :LastName,
+        :SSN,
+      ].freeze
     end
 
     def assign_export_id(row)

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/export_concern.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/export_concern.rb
@@ -132,9 +132,16 @@ module HmisCsvTwentyTwentyFour::Exporter::ExportConcern
     end
 
     def length_limited_columns
-      @length_limited_columns ||= HmisCsvTwentyTwentyFour::Exporter::Base.hmis_class_for(self.class).hmis_configuration(version: '2024').select do |_, m|
-        m.key?(:limit)
+      @length_limited_columns ||= HmisCsvTwentyTwentyFour::Exporter::Base.hmis_class_for(self.class).hmis_configuration(version: '2024').select do |col, m|
+        m.key?(:limit) && ! hashed_column(col)
       end
+    end
+
+    # A few columns get hashed and the hash is longer than the allowed length, that's ok
+    private def hashed_column(col)
+      return false unless @options[:export].hash_status == 4
+
+      col.in?([:FirstName, :MiddleName, :LastName, :SSN])
     end
 
     def assign_export_id(row)

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
@@ -19,7 +19,15 @@ def setup_data
   @funders = create_list :hud_funder, 5, data_source_id: @data_source.id
 
   @enrollments = create_list :hud_enrollment, 5, data_source_id: @data_source.id, EntryDate: 2.weeks.ago, PreferredLanguageDifferent: 'a' * 200
-  @clients = create_list :hud_client, 5, data_source_id: @data_source.id, FirstName: 'abcde' * 12
+  @clients = create_list(
+    :hud_client,
+    5,
+    data_source_id: @data_source.id,
+    FirstName: 'abcde' * 12,
+    LastName: 'xyz' * 50,
+    MiddleName: 'M',
+    SSN: Faker::Number.number(digits: 9),
+  )
   @destination_data_source = create :grda_warehouse_data_source
 
   @destination_clients = @clients.map do |client|

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb
@@ -1,0 +1,109 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'export_helper'
+
+RSpec.describe HmisCsvTwentyTwentyFour::Exporter::Base, type: :model do
+  before(:all) do
+    cleanup_test_environment
+    setup_data
+
+    @exporter = HmisCsvTwentyTwentyFour::Exporter::Base.new(
+      start_date: 1.week.ago.to_date,
+      end_date: Date.current,
+      projects: [@projects.first.id],
+      period_type: 3,
+      directive: 3,
+      hash_status: 4,
+      user_id: @user.id,
+    )
+    @exporter.export!(cleanup: false, zip: false, upload: false)
+
+    @exits.first.update(DateUpdated: DateTime.yesterday + 1.hours)
+    @extra_exit = create(
+      :hud_exit,
+      data_source_id: @data_source.id,
+      ExitDate: Date.yesterday,
+      EnrollmentID: @enrollments.first.EnrollmentID,
+      PersonalID: @enrollments.first.PersonalID,
+      DateUpdated: DateTime.yesterday + 2.hours,
+    )
+    @exporter_2 = HmisCsvTwentyTwentyFour::Exporter::Base.new(
+      start_date: 1.week.ago.to_date,
+      end_date: Date.current,
+      projects: [@projects.first.id],
+      period_type: 3,
+      directive: 3,
+      user_id: @user.id,
+    )
+    @exporter_2.export!(cleanup: false, zip: false, upload: false)
+  end
+
+  after(:all) do
+    @exporter.remove_export_files
+    @exporter_2.remove_export_files
+    cleanup_test_environment
+  end
+
+  describe 'when exporting exits and there is more than one exit for an enrollment' do
+    it 'adds only one row to the CSV file' do
+      csv = CSV.read(csv_file_path(@exit_class, exporter: @exporter_2), headers: true)
+      expect(csv.count).to eq 1
+    end
+    it 'DateUpdated from CSV file match the later exit record' do
+      csv = CSV.read(csv_file_path(@exit_class, exporter: @exporter_2), headers: true)
+      @exporter.set_time_format
+      expect(csv.first['DateUpdated']).to eq @extra_exit.DateUpdated.to_s
+      @exporter.reset_time_format
+    end
+  end
+
+  describe 'when exporting clients' do
+    it 'client scope should find one client' do
+      expect(@exporter.client_scope.count).to eq 1
+    end
+
+    it 'creates one CSV file' do
+      expect(File.exist?(csv_file_path(@client_class))).to be true
+    end
+
+    it 'adds one row to the CSV file' do
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.count).to eq 1
+    end
+
+    it 'Does not limit the length of FirstName to 50 characters and differs from the source' do
+      expect(@exporter.client_scope.first.FirstName.length).to be > 50
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['FirstName'].length).to eq(64)
+      expect(csv.first['FirstName']).to_not eq(@exporter.client_scope.first.FirstName)
+    end
+
+    it 'Does not limit the length of LastName to 50 characters and differs from the source' do
+      expect(@exporter.client_scope.first.LastName.length).to be > 50
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['LastName'].length).to eq(64)
+      expect(csv.first['LastName']).to_not eq(@exporter.client_scope.first.LastName)
+    end
+
+    it 'MiddleName is hashed' do
+      expect(@exporter.client_scope.first.MiddleName.length).to eq(1)
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['MiddleName'].length).to eq(64)
+      expect(csv.first['MiddleName']).to_not eq(@exporter.client_scope.first.MiddleName)
+    end
+
+    it 'Does not limit the length of SSN to 9 characters and differs from the source' do
+      expect(@exporter.client_scope.first.SSN.length).to eq 9
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['SSN'].length).to eq(68)
+      expect(csv.first['SSN']).to_not eq(@exporter.client_scope.first.SSN)
+      # Prepends last 4 of SSN per spec
+      expect(@exporter.client_scope.first.SSN.last(4)).to eq(csv.first['SSN'].first(4))
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_tests.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_tests.rb
@@ -32,10 +32,21 @@ RSpec.shared_context '2024 single-enrollment tests', shared_context: :metadata d
       expect(csv.first['PreferredLanguageDifferent'].length).to eq(100)
     end
 
-    it 'Correctly limits the length of FirstName to 32 characters' do
+    it 'Correctly limits the length of FirstName to 50 characters' do
       expect(@exporter.client_scope.first.FirstName.length).to be > 50
       csv = CSV.read(csv_file_path(@client_class), headers: true)
       expect(csv.first['FirstName'].length).to eq(50)
+    end
+    it 'Correctly limits the length of LastName to 50 characters' do
+      expect(@exporter.client_scope.first.LastName.length).to be > 50
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['LastName'].length).to eq(50)
+    end
+    it 'Does not limit the length of SSN to 9 characters' do
+      expect(@exporter.client_scope.first.SSN.length).to eq 9
+      csv = CSV.read(csv_file_path(@client_class), headers: true)
+      expect(csv.first['SSN'].length).to eq(9)
+      expect(csv.first['SSN']).to eq(@exporter.client_scope.first.SSN)
     end
   end
   describe 'when exporting clients' do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This is a hot fix for the 2024 export of hashed HMIS CSVs.  The hashed columns were being limited to the lengths specified by the spec, rather than including the entire hash.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
