### PR TITLE
PATH active before last enrollment

### DIFF
--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
@@ -173,11 +173,8 @@ module HudPathReport::Generators::Fy2024
       client_scope.find_in_batches(batch_size: 100) do |batch|
         pending_associations = {}
         batch.each do |client|
-          enrollment = last_enrollment(client)
+          enrollment = last_active_enrollment(client)
           next unless enrollment.present?
-
-          enrollment_active = active_in_path(enrollment)
-          next unless enrollment_active
 
           source_client = enrollment.client
           next unless source_client
@@ -212,7 +209,7 @@ module HudPathReport::Generators::Fy2024
             length_of_stay: enrollment.LengthOfStay,
             chronically_homeless: enrollment.chronically_homeless_at_start,
             domestic_violence: health_and_dv_latest&.DomesticViolenceVictim,
-            active_client: enrollment_active,
+            active_client: true, # Note, last_active_enrollment only returns active enrollments, so all are active, also, every question in the PATH report requires Active & ... so we really only report on active clients
             new_client: new_client,
             enrolled_client: enrolled_in_path(enrollment),
             newly_enrolled_client: newly_enrolled_in_path(enrollment),
@@ -276,8 +273,11 @@ module HudPathReport::Generators::Fy2024
       scope
     end
 
-    private def last_enrollment(client)
-      enrollments(client).first
+    # Per HUD: Per discussions with SAMSHA and as discussed in the last vendor call, we're asking vendors to filter down to only the active enrollments first and then to keep only the most recent enrollment. This is intended to include clients in situations where, for instance, they were active for the first six months before being exited and then returned the day before the report end date and have no services yet.
+    private def last_active_enrollment(client)
+      enrollments(client).detect do |en|
+        active_in_path(en)
+      end
     end
 
     # Part of the definition of New & Active is:

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
@@ -274,6 +274,7 @@ module HudPathReport::Generators::Fy2024
     end
 
     # Per HUD: Per discussions with SAMSHA and as discussed in the last vendor call, we're asking vendors to filter down to only the active enrollments first and then to keep only the most recent enrollment. This is intended to include clients in situations where, for instance, they were active for the first six months before being exited and then returned the day before the report end date and have no services yet.
+    # So we will choose the most-recently started "active" enrollment
     private def last_active_enrollment(client)
       enrollments(client).detect do |en|
         active_in_path(en)

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/base.rb
@@ -176,6 +176,9 @@ module HudPathReport::Generators::Fy2024
           enrollment = last_enrollment(client)
           next unless enrollment.present?
 
+          enrollment_active = active_in_path(enrollment)
+          next unless enrollment_active
+
           source_client = enrollment.client
           next unless source_client
 
@@ -209,7 +212,7 @@ module HudPathReport::Generators::Fy2024
             length_of_stay: enrollment.LengthOfStay,
             chronically_homeless: enrollment.chronically_homeless_at_start,
             domestic_violence: health_and_dv_latest&.DomesticViolenceVictim,
-            active_client: active_in_path(enrollment),
+            active_client: enrollment_active,
             new_client: new_client,
             enrolled_client: enrolled_in_path(enrollment),
             newly_enrolled_client: newly_enrolled_in_path(enrollment),

--- a/drivers/hud_path_report/spec/models/fy2024/datalab_path/path_organization_r.rb
+++ b/drivers/hud_path_report/spec/models/fy2024/datalab_path/path_organization_r.rb
@@ -37,7 +37,7 @@ RSpec.shared_context 'path organization r', shared_context: :metadata do
 
     # Pending: https://airtable.com/appFAz3WpgFmIJMm6/shr8TvO6KfAZ3mOJd/tblYhwasMJptw5fjj/viw7VMUmDdyDL70a7/recibeszBDplTEBFJ
     # 596228 - missing? DataLab is using the earlier enrollment, why? - later is active, but not enrolled
-    xit 'Q19-Q24' do
+    it 'Q19-Q24' do
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q19-Q24',

--- a/drivers/hud_path_report/spec/models/fy2024/datalab_path/path_organization_r.rb
+++ b/drivers/hud_path_report/spec/models/fy2024/datalab_path/path_organization_r.rb
@@ -37,7 +37,8 @@ RSpec.shared_context 'path organization r', shared_context: :metadata do
 
     # Pending: https://airtable.com/appFAz3WpgFmIJMm6/shr8TvO6KfAZ3mOJd/tblYhwasMJptw5fjj/viw7VMUmDdyDL70a7/recibeszBDplTEBFJ
     # 596228 - missing? DataLab is using the earlier enrollment, why? - later is active, but not enrolled
-    it 'Q19-Q24' do
+    # 844241 - entry date 8/17/2022, is active because of DateOfEngagement
+    xit 'Q19-Q24' do
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q19-Q24',


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This limits all enrollments used in the PATH report to "active" enrollments.  It does not yet fix the test where this was identified, that seems to be a different bug.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
