### PR TITLE
Fix uniqueness constraint violation in Help

### DIFF
--- a/app/models/grda_warehouse/help.rb
+++ b/app/models/grda_warehouse/help.rb
@@ -173,7 +173,7 @@ class GrdaWarehouse::Help < GrdaWarehouseBase
 
   # Allow drivers to inject their help files
   def self.active_defaults
-    known_defaults + Rails.application.config.help_links
+    (known_defaults + Rails.application.config.help_links).uniq
   end
 
   def self.setup_default_links


### PR DESCRIPTION
## Description

Fix bug where seeding the database causes a uniqueness violation constraint from `GrdaWarehouse::Help.setup_default_links`. @martha saw this originally and I was able to replicate it

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
