### PR TITLE
Umerge clients bug

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -173,7 +173,9 @@ class ClientsController < ApplicationController
   # Create new warehouse_clients to link source and destination
   # Queue update to service history
   def unmerge
-    to_unmerge = client_params['unmerge'].reject(&:empty?)
+    to_unmerge = client_params['unmerge']&.reject(&:empty?)
+    redirect_to({ action: :edit }, alert: 'No clients selected.') and return unless to_unmerge
+
     hmis_receiver = client_params['hmis_receiver']
     health_receiver = client_params['health_receiver']
 
@@ -249,6 +251,8 @@ class ClientsController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   private def client_params
+    return {} unless params[:grda_warehouse_hud_client].present?
+
     params.require(:grda_warehouse_hud_client).
       permit(
         :hmis_receiver,

--- a/app/views/clients/_unmerge_form.haml
+++ b/app/views/clients/_unmerge_form.haml
@@ -59,11 +59,12 @@
                       Match Details
 
         .form-actions
-          = f.button :submit, "Split selected records from #{@client.FirstName} #{@client.LastName}", data: {confirm: "Are you sure you want to split #{@client.FirstName} #{@client.LastName}? Dependent data will be moved to the selected clients."}
+          = f.button :submit, "Split selected records from #{@client.FirstName} #{@client.LastName}", id: :splitButton, data: {confirm: "Are you sure you want to split #{@client.FirstName} #{@client.LastName}? Dependent data will be moved to the selected clients."}
 
 = content_for :page_js do
   :javascript
-    $('.jSplit').on('change', function(e){
+    $('.jSplit').on('change', function(e) {
+      // Don't let unselected clients be receivers
       var hmis_receiver = $('#grda_warehouse_hud_client_hmis_receiver_' + e.target.value)
       var health_receiver = $('#grda_warehouse_hud_client_health_receiver_' + e.target.value)
       hmis_receiver.prop('disabled', !e.target.checked)
@@ -72,4 +73,12 @@
         hmis_receiver.prop('checked', false)
         health_receiver.prop('checked', false)
       }
+
+      // Require at least one selected client to be split off
+      anyChecked = $('input[name="grda_warehouse_hud_client[unmerge][]"]').toArray().some((e) => e.checked)
+      $('#splitButton').prop('disabled', !anyChecked)
+    });
+
+    $(document).ready(function() {
+      $('#splitButton').prop('disabled', true)
     });


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

There was a bug in the client splitter that resulted in errors when invoking "Split" with no client marked to split. Added a back end guard for this case, and some front end JS to disable the "Split" button without selecting at least one client.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
