### PR TITLE
Add dedicated query for assessment form definition lookup

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9217,9 +9217,18 @@ enum RelationshipToHoH {
 }
 
 type Reminder {
+  """
+  Relevant existing assessment, if any
+  """
+  assessmentId: ID
   client: Client!
   dueDate: ISO8601Date
   enrollment: Enrollment!
+
+  """
+  Form definition to use, if a new assessment is needed
+  """
+  formDefinitionId: ID
   id: ID!
   overdue: Boolean!
   topic: ReminderTopic!

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8238,6 +8238,31 @@ type Query {
   Assessment lookup
   """
   assessment(id: ID!): Assessment
+
+  """
+  Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID
+  """
+  assessmentFormDefinition(
+    """
+    Date to use for Rule filtering on the definition
+    """
+    assessmentDate: ISO8601Date
+
+    """
+    Form Definition ID, if known
+    """
+    id: ID
+
+    """
+    Project to use for Rule filtering on the definition
+    """
+    projectId: ID!
+
+    """
+    Assessment role, if looking up by role
+    """
+    role: AssessmentRole
+  ): FormDefinition
   autoExitConfigs(limit: Int, offset: Int): AutoExitConfigsPaginated!
 
   """
@@ -8289,9 +8314,9 @@ type Query {
   funder(id: ID!): Funder
 
   """
-  Get most relevant/recent form definition for the specified Role and project (optionally)
+  Get the most relevant Form Definition to use for record viewing/editing
   """
-  getFormDefinition(enrollmentId: ID, projectId: ID, role: FormRole!): FormDefinition
+  getFormDefinition(projectId: ID, role: FormRole!): FormDefinition
 
   """
   Get most relevant form definition for the specified service type

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -325,6 +325,9 @@ enum AssessmentLevel {
   INVALID
 }
 
+"""
+Form Roles that are used for assessments. These types of forms are submitted using SubmitAssessment.
+"""
 enum AssessmentRole {
   """
   Annual
@@ -8314,16 +8317,6 @@ type Query {
   funder(id: ID!): Funder
 
   """
-  Get the most relevant Form Definition to use for record viewing/editing
-  """
-  getFormDefinition(projectId: ID, role: FormRole!): FormDefinition
-
-  """
-  Get most relevant form definition for the specified service type
-  """
-  getServiceFormDefinition(projectId: ID!, serviceTypeId: ID!): FormDefinition
-
-  """
   Household lookup
   """
   household(id: ID!): Household
@@ -8362,6 +8355,17 @@ type Query {
   """
   projectCoc(id: ID!): ProjectCoc
   projects(filters: ProjectFilterOptions, limit: Int, offset: Int, sortOrder: ProjectSortOption): ProjectsPaginated!
+
+  """
+  Get the most relevant Form Definition to use for record viewing/editing
+  """
+  recordFormDefinition(
+    """
+    Optional Project to apply rule filtering (e.g. show/hide questions based on Project applicability)
+    """
+    projectId: ID
+    role: RecordFormRole!
+  ): FormDefinition
   referralPosting(id: ID!): ReferralPosting
 
   """
@@ -8370,6 +8374,11 @@ type Query {
   service(id: ID!): Service
   serviceCategories(limit: Int, offset: Int): ServiceCategoriesPaginated!
   serviceCategory(id: ID!): ServiceCategory
+
+  """
+  Get most relevant form definition for the specified service type
+  """
+  serviceFormDefinition(projectId: ID!, serviceTypeId: ID!): FormDefinition
 
   """
   Service type lookup
@@ -8635,6 +8644,106 @@ Types allowed for recent items
 enum RecentItemType {
   Client
   Project
+}
+
+"""
+Form Roles that are used for record-editing. These types of forms are submitted using SubmitForm.
+"""
+enum RecordFormRole {
+  """
+  Case note
+  """
+  CASE_NOTE
+
+  """
+  CE assessment
+  """
+  CE_ASSESSMENT
+
+  """
+  CE event
+  """
+  CE_EVENT
+
+  """
+  CE participation
+  """
+  CE_PARTICIPATION
+
+  """
+  Client
+  """
+  CLIENT
+
+  """
+  Client detail
+  """
+  CLIENT_DETAIL
+
+  """
+  Current living situation
+  """
+  CURRENT_LIVING_SITUATION
+
+  """
+  Enrollment
+  """
+  ENROLLMENT
+
+  """
+  File
+  """
+  FILE
+
+  """
+  Funder
+  """
+  FUNDER
+
+  """
+  HMIS participation
+  """
+  HMIS_PARTICIPATION
+
+  """
+  Inventory
+  """
+  INVENTORY
+
+  """
+  New client enrollment
+  """
+  NEW_CLIENT_ENROLLMENT
+
+  """
+  Occurrence point
+  """
+  OCCURRENCE_POINT
+
+  """
+  Organization
+  """
+  ORGANIZATION
+
+  """
+  Project
+  """
+  PROJECT
+
+  """
+  Project CoC
+  """
+  PROJECT_COC
+
+  """
+  Referral request
+  """
+  REFERRAL_REQUEST
+
+  """
+  Service
+  """
+  SERVICE
 }
 
 """
@@ -10235,6 +10344,9 @@ enum SexualOrientation {
   QUESTIONING_UNSURE
 }
 
+"""
+Form Roles that are used for non-configurable forms. These types of forms are submitted using custom mutations.
+"""
 enum StaticFormRole {
   """
   Auto exit config

--- a/drivers/hmis/app/graphql/types/forms/enums/assessment_role.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/assessment_role.rb
@@ -9,6 +9,7 @@
 module Types
   class Forms::Enums::AssessmentRole < Types::BaseEnum
     graphql_name 'AssessmentRole'
+    description 'Form Roles that are used for assessments. These types of forms are submitted using SubmitAssessment.'
 
     with_enum_map Hmis::Form::Definition.assessment_type_enum_map, prefix_description_with_key: false
   end

--- a/drivers/hmis/app/graphql/types/forms/enums/record_form_role.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/record_form_role.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2023 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class Forms::Enums::RecordFormRole < Types::BaseEnum
+    graphql_name 'RecordFormRole'
+    description 'Form Roles that are used for record-editing. These types of forms are submitted using SubmitForm.'
+
+    with_enum_map Hmis::Form::Definition.record_form_role_enum_map, prefix_description_with_key: false
+  end
+end

--- a/drivers/hmis/app/graphql/types/forms/enums/static_form_role.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/static_form_role.rb
@@ -9,6 +9,7 @@
 module Types
   class Forms::Enums::StaticFormRole < Types::BaseEnum
     graphql_name 'StaticFormRole'
+    description 'Form Roles that are used for non-configurable forms. These types of forms are submitted using custom mutations.'
 
     with_enum_map Hmis::Form::Definition.static_form_role_enum_map, prefix_description_with_key: false
   end

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -38,7 +38,7 @@ module Types
     end
 
     def cache_key
-      [object.id, project&.id, active_date].join('|')
+      [object.id, project&.id, active_date&.strftime('%Y-%m-%d')].join('|')
     end
 
     def system

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -64,7 +64,7 @@ module Types
       raise "Assessment without form processor: #{object.id}" unless form_processor.present?
 
       # If definition is stored on form processor, return that.
-      # TODO: check if form is retired? For non-WIP assessments, we should
+      # TODO: check if form is retired? For non-WIP non-custom assessments, we should
       # really be choosing the "latest" form, which may not be the one on the FormProcessor.
       definition = load_ar_association(form_processor, :definition)
       # If there was no definition specified, which would occur if this is a migrated assessment, choose an appropriate one.

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -171,15 +171,12 @@ module Types
       Hmis::File.viewable_by(current_user).find_by(id: id)
     end
 
-    field :get_form_definition, Types::Forms::FormDefinition, 'Get the most relevant Form Definition to use for record viewing/editing', null: true do
-      argument :role, Types::Forms::Enums::FormRole, required: true
-      argument :project_id, ID, required: false
+    field :record_form_definition, Types::Forms::FormDefinition, 'Get the most relevant Form Definition to use for record viewing/editing', null: true do
+      argument :role, Types::Forms::Enums::RecordFormRole, required: true
+      argument :project_id, ID, required: false, description: 'Optional Project to apply rule filtering (e.g. show/hide questions based on Project applicability)'
     end
-    def get_form_definition(role:, project_id: nil)
-      # Guards to ensure correct usage. It would probably be better to make yet another enum just for this query arg
-      raise 'Not supported, use assessmentFormDefinition to look up assessment forms' if Hmis::Form::Definition::HUD_ASSESSMENT_FORM_ROLES.include?(role.to_sym)
-      raise 'Not supported, use staticFormDefinition to look up static forms' if Hmis::Form::Definition::STATIC_FORM_ROLES.include?(role.to_sym)
-      raise 'Not supported, use getServiceFormDefinition to look up service forms' if role == 'SERVICE'
+    def record_form_definition(role:, project_id: nil)
+      raise 'Not supported, use serviceFormDefinition to look up service forms' if role == 'SERVICE'
 
       project = Hmis::Hud::Project.find_by(id: project_id) if project_id.present?
       record = Hmis::Form::Definition.find_definition_for_role(role, project: project)
@@ -213,11 +210,11 @@ module Types
       record
     end
 
-    field :get_service_form_definition, Types::Forms::FormDefinition, 'Get most relevant form definition for the specified service type', null: true do
+    field :service_form_definition, Types::Forms::FormDefinition, 'Get most relevant form definition for the specified service type', null: true do
       argument :service_type_id, ID, required: true
       argument :project_id, ID, required: true
     end
-    def get_service_form_definition(service_type_id:, project_id:)
+    def service_form_definition(service_type_id:, project_id:)
       project = Hmis::Hud::Project.find_by(id: project_id)
       raise HmisErrors::ApiError, 'Project not found' unless project.present?
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -183,7 +183,7 @@ module Types
 
       project = Hmis::Hud::Project.find_by(id: project_id) if project_id.present?
       record = Hmis::Form::Definition.find_definition_for_role(role, project: project)
-      record.filter_context = { project: project } # Apply project-specific filtering rules. Only relevant for some form types.
+      record&.filter_context = { project: project } # Apply project-specific filtering rules. Only relevant for some form types.
       record
     end
 
@@ -208,7 +208,7 @@ module Types
       end
 
       # Set filter context, so that form rules are applied
-      record.filter_context = { project: project, active_date: assessment_date }
+      record&.filter_context = { project: project, active_date: assessment_date }
       record
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -171,18 +171,44 @@ module Types
       Hmis::File.viewable_by(current_user).find_by(id: id)
     end
 
-    field :get_form_definition, Types::Forms::FormDefinition, 'Get most relevant/recent form definition for the specified Role and project (optionally)', null: true do
+    field :get_form_definition, Types::Forms::FormDefinition, 'Get the most relevant Form Definition to use for record viewing/editing', null: true do
       argument :role, Types::Forms::Enums::FormRole, required: true
-      argument :enrollment_id, ID, required: false
       argument :project_id, ID, required: false
     end
+    def get_form_definition(role:, project_id: nil)
+      # Guards to ensure correct usage. It would probably be better to make yet another enum just for this query arg
+      raise 'Not supported, use assessmentFormDefinition to look up assessment forms' if Hmis::Form::Definition::HUD_ASSESSMENT_FORM_ROLES.include?(role.to_sym)
+      raise 'Not supported, use staticFormDefinition to look up static forms' if Hmis::Form::Definition::STATIC_FORM_ROLES.include?(role.to_sym)
+      raise 'Not supported, use getServiceFormDefinition to look up service forms' if role == 'SERVICE'
 
-    def get_form_definition(role:, enrollment_id: nil, project_id: nil)
       project = Hmis::Hud::Project.find_by(id: project_id) if project_id.present?
-      project = Hmis::Hud::Enrollment.find_by(id: enrollment_id)&.project if enrollment_id.present?
-
       record = Hmis::Form::Definition.find_definition_for_role(role, project: project)
-      record.filter_context = { project: project }
+      record.filter_context = { project: project } # Apply project-specific filtering rules. Only relevant for some form types.
+      record
+    end
+
+    field :assessment_form_definition, Types::Forms::FormDefinition, 'Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID', null: true do
+      argument :project_id, ID, required: true, description: 'Project to use for Rule filtering on the definition'
+      argument :id, ID, required: false, description: 'Form Definition ID, if known'
+      argument :role, Types::Forms::Enums::AssessmentRole, required: false, description: 'Assessment role, if looking up by role'
+      argument :assessment_date, GraphQL::Types::ISO8601Date, required: false, description: 'Date to use for Rule filtering on the definition'
+    end
+    def assessment_form_definition(project_id:, id: nil, role: nil, assessment_date: nil)
+      raise 'id or role required' if id.nil? && role.nil?
+
+      project = Hmis::Hud::Project.find(project_id)
+      # Ensure that user can view enrollments for this project. There is no need to expose assessment forms otherwise.
+      not_authorized! unless current_user.can_view_enrollment_details_for?(project)
+
+      if id
+        # If ID is specified, we assume that it's correct for this project.
+        record = Hmis::Form::Definition.find(id)
+      else
+        record = Hmis::Form::Definition.find_definition_for_role(role, project: project)
+      end
+
+      # Set filter context, so that form rules are applied
+      record.filter_context = { project: project, active_date: assessment_date }
       record
     end
 
@@ -353,6 +379,9 @@ module Types
       argument :id, ID, required: true
     end
     def form_definition(id:)
+      # NOTE: this query is only used for form management. It probably should
+      # not be used for the application, because there is no project context passed
+      # to the definition.
       raise 'Access denied' unless current_user.can_configure_data_collection?
 
       Hmis::Form::Definition.find(id)

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -198,7 +198,7 @@ module Types
 
       project = Hmis::Hud::Project.find(project_id)
       # Ensure that user can view enrollments for this project. There is no need to expose assessment forms otherwise.
-      not_authorized! unless current_user.can_view_enrollment_details_for?(project)
+      raise 'Access denied' unless current_user.can_view_enrollment_details_for?(project)
 
       if id
         # If ID is specified, we assume that it's correct for this project.

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -192,6 +192,7 @@ module Types
       argument :id, ID, required: false, description: 'Form Definition ID, if known'
       argument :role, Types::Forms::Enums::AssessmentRole, required: false, description: 'Assessment role, if looking up by role'
       argument :assessment_date, GraphQL::Types::ISO8601Date, required: false, description: 'Date to use for Rule filtering on the definition'
+      validates required: { one_of: [:id, :role] }
     end
     def assessment_form_definition(project_id:, id: nil, role: nil, assessment_date: nil)
       raise 'id or role required' if id.nil? && role.nil?

--- a/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
@@ -14,6 +14,8 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :enrollment, HmisSchema::Enrollment, null: false
     field :overdue, Boolean, null: false
+    field :form_definition_id, ID, null: true, description: 'Form definition to use, if a new assessment is needed'
+    field :assessment_id, ID, null: true, description: 'Relevant existing assessment, if any'
 
     def client
       object.enrollment.client

--- a/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
+++ b/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
@@ -20,7 +20,7 @@ class Hmis::EnrollmentAssessmentEligibilityList
   end
 
   INTAKE_ROLE = 'INTAKE'.freeze
-  UPDATE_ROLE = 'UPDATE '.freeze
+  UPDATE_ROLE = 'UPDATE'.freeze
   ANNUAL_ROLE = 'ANNUAL'.freeze
   EXIT_ROLE = 'EXIT'.freeze
   POST_EXIT_ROLE = 'POST_EXIT'.freeze

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -34,10 +34,12 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   has_many :form_processors
   has_many :custom_service_types, through: :instances, foreign_key: :identifier, primary_key: :form_definition_identifier
 
-  # Forms that are assessments
-  HUD_ASSESSMENT_FORM_ROLES = [:INTAKE, :UPDATE, :ANNUAL, :EXIT, :POST_EXIT, :CUSTOM_ASSESSMENT].freeze
+  # Forms that are used for Assessments. These are submitted using SubmitAssessment mutation.
+  ASSESSMENT_FORM_ROLES = [:INTAKE, :UPDATE, :ANNUAL, :EXIT, :POST_EXIT, :CUSTOM_ASSESSMENT].freeze
 
-  # System forms (forms that are required for basic HMIS functionality, and are configurable)
+  # "System" Record-editing Forms
+  # These are forms that are *required* for basic HMIS functionality, and are configurable.
+  # These are submitted using SubmitForm mutation.
   SYSTEM_FORM_ROLES = [
     :PROJECT,
     :ORGANIZATION,
@@ -51,7 +53,13 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     :CE_PARTICIPATION,
   ].freeze
 
-  # Forms used for data collection on Enrollments (features that can be "toggled" on and off by specifying Instances)
+  # "Data Collection Feature" Record-editing Forms
+  # These are forms that are *optional* for HMIS functionality, and are configurable. They
+  # are primarily for Enrollment-level data collection.
+  #
+  # Each one is considered a feature that can be "toggled on" for a given project by enabling
+  # a Form Instance for it.
+  # These are submitted using SubmitForm mutation.
   DATA_COLLECTION_FEATURE_ROLES = [
     :CURRENT_LIVING_SITUATION,
     :SERVICE,
@@ -64,22 +72,24 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     :REFERRAL_REQUEST,
   ].freeze
 
-  # Static forms are not configurable
+  # Static Forms
+  # Non-configurable forms. These are submitted using custom mutations.
   STATIC_FORM_ROLES = [
     :FORM_RULE,
     :AUTO_EXIT_CONFIG,
     :FORM_DEFINITION,
   ].freeze
 
+  # All form roles
   FORM_ROLES = [
-    *HUD_ASSESSMENT_FORM_ROLES,
+    *ASSESSMENT_FORM_ROLES,
     *SYSTEM_FORM_ROLES,
     *DATA_COLLECTION_FEATURE_ROLES,
     *STATIC_FORM_ROLES,
     :OCCURRENCE_POINT,
     :CLIENT_DETAIL,
     # Other/misc forms
-    :FILE, # should maybe be considered a data collection feature, but different becase its at Client-level (not Project)
+    :FILE, # should maybe be considered a data collection feature, but different because its at Client-level (not Project)
   ].freeze
 
   validates :role, inclusion: { in: FORM_ROLES.map(&:to_s) }
@@ -166,6 +176,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     },
   }.freeze
 
+  # HUD-defined numeric representation of Data Collection Stage for each HUD Assessment
   FORM_DATA_COLLECTION_STAGES = {
     INTAKE: 1,
     UPDATE: 2,
@@ -174,10 +185,15 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     POST_EXIT: 6,
   }.freeze
 
+  # All form roles
   use_enum_with_same_key :form_role_enum_map, FORM_ROLES.excluding(:CE)
-  # may add back CE as HUD Assessment Role when we implement CE assessments. Same for implementing customs. Unsure at this point, so leaving them out.
-  use_enum_with_same_key :assessment_type_enum_map, HUD_ASSESSMENT_FORM_ROLES.excluding(:CE)
+  # Form roles that can be used with SubmitForm for editing records
+  use_enum_with_same_key :record_form_role_enum_map, FORM_ROLES.excluding(*ASSESSMENT_FORM_ROLES, *STATIC_FORM_ROLES)
+  # Form roles for Assessments
+  use_enum_with_same_key :assessment_type_enum_map, ASSESSMENT_FORM_ROLES
+  # Form roles that represent optional "features"
   use_enum_with_same_key :data_collection_feature_role_enum_map, DATA_COLLECTION_FEATURE_ROLES
+  # Form roles that are static
   use_enum_with_same_key :static_form_role_enum_map, STATIC_FORM_ROLES
 
   scope :exclude_definition_from_select, -> {
@@ -277,7 +293,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   end
 
   def hud_assessment?
-    HUD_ASSESSMENT_FORM_ROLES.include?(role.to_sym)
+    ASSESSMENT_FORM_ROLES.excluding(:CUSTOM_ASSESSMENT).include?(role.to_sym)
   end
 
   def intake?

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -35,7 +35,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   has_many :custom_service_types, through: :instances, foreign_key: :identifier, primary_key: :form_definition_identifier
 
   # Forms that are assessments
-  HUD_ASSESSMENT_FORM_ROLES = [:INTAKE, :UPDATE, :ANNUAL, :EXIT, :CE, :POST_EXIT, :CUSTOM_ASSESSMENT].freeze
+  HUD_ASSESSMENT_FORM_ROLES = [:INTAKE, :UPDATE, :ANNUAL, :EXIT, :POST_EXIT, :CUSTOM_ASSESSMENT].freeze
 
   # System forms (forms that are required for basic HMIS functionality, and are configurable)
   SYSTEM_FORM_ROLES = [

--- a/drivers/hmis/app/models/hmis/reminders/reminder.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder.rb
@@ -1,6 +1,6 @@
 module Hmis
   module Reminders
-    Reminder = Struct.new(:topic, :due_date, :overdue, :enrollment, keyword_init: true) do
+    Reminder = Struct.new(:topic, :due_date, :overdue, :enrollment, :form_definition_id, :assessment_id, keyword_init: true) do
       # id is used for sorting on the front end
       def id
         "#{sortable_date}.#{enrollment.id}.#{topic}"

--- a/drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb
@@ -42,18 +42,18 @@ RSpec.describe 'Graphql HMIS Assessment Eligibility', type: :request do
     result.dig('data', 'enrollment', 'assessmentEligibilities').map { |n| n['role'] }
   end
 
-  it 'resolves intake, exit, annual' do
+  it 'resolves intake, exit, annual, and update' do
     records = run_query(enrollment: e1)
-    expect(records).to contain_exactly('INTAKE', 'EXIT', 'ANNUAL')
+    expect(records).to contain_exactly('INTAKE', 'EXIT', 'ANNUAL', 'UPDATE')
   end
 
   context 'with project entry' do
     before(:each) do
       create(:hmis_custom_assessment, data_source: ds1, enrollment: e1, data_collection_stage: 1)
     end
-    it 'resolves exit and annual' do
+    it 'resolves exit and annual and update' do
       records = run_query(enrollment: e1)
-      expect(records).to contain_exactly('EXIT', 'ANNUAL')
+      expect(records).to contain_exactly('EXIT', 'ANNUAL', 'UPDATE')
     end
 
     context 'with project exit' do

--- a/drivers/hmis/spec/requests/hmis/form_definition_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_definition_lookup_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   describe 'Form definition lookup for record-editing' do
     let(:query) do
       <<~GRAPHQL
-        query GetFormDefinition($projectId: ID, $role: FormRole!) {
-          getFormDefinition(projectId: $projectId, role: $role) {
+        query recordFormDefinition($projectId: ID, $role: RecordFormRole!) {
+          recordFormDefinition(projectId: $projectId, role: $role) {
             #{form_definition_fragment}
           }
         }
@@ -43,7 +43,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       aggregate_failures 'checking response' do
         expect(response.status).to eq(200), result.inspect
-        form_definition = result.dig('data', 'getFormDefinition')
+        form_definition = result.dig('data', 'recordFormDefinition')
         expect(form_definition).to be_present
         expect(form_definition['role']).to eq(role.to_s)
       end
@@ -79,7 +79,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let(:service_query) do
       <<~GRAPHQL
         query GetServiceFormDefinition($serviceTypeId: ID!, $projectId: ID!) {
-          getServiceFormDefinition(serviceTypeId: $serviceTypeId, projectId: $projectId) {
+          serviceFormDefinition(serviceTypeId: $serviceTypeId, projectId: $projectId) {
             #{form_definition_fragment}
           }
         }
@@ -93,7 +93,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       response, result = post_graphql({ project_id: p1.id.to_s, service_type_id: cst1.id.to_s }) { service_query }
       aggregate_failures 'checking response' do
         expect(response.status).to eq 200
-        form_definition = result.dig('data', 'getServiceFormDefinition')
+        form_definition = result.dig('data', 'serviceFormDefinition')
         expect(form_definition).to be_nil
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       aggregate_failures 'checking response' do
         expect(response.status).to eq 200
-        form_definition = result.dig('data', 'getServiceFormDefinition')
+        form_definition = result.dig('data', 'serviceFormDefinition')
         expect(form_definition).to be_present
         expect(form_definition['id']).to eq(service_form_definition.id.to_s)
       end
@@ -129,7 +129,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       aggregate_failures 'checking response' do
         expect(response.status).to eq 200
-        form_definition = result.dig('data', 'getServiceFormDefinition')
+        form_definition = result.dig('data', 'serviceFormDefinition')
         expect(form_definition).to be_present
         expect(form_definition['id']).to eq(service_form_definition.id.to_s)
       end

--- a/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
@@ -193,8 +193,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     let(:query) do
       <<~GRAPHQL
-        query GetFormDefinition($projectId: ID, $role: FormRole!) {
-          getFormDefinition(projectId: $projectId, role: $role) {
+        query recordFormDefinition($projectId: ID, $role: RecordFormRole!) {
+          recordFormDefinition(projectId: $projectId, role: $role) {
             #{form_definition_fragment}
           }
         }
@@ -204,7 +204,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     def query_form_definition_items
       response, result = post_graphql({ project_id: p1.id.to_s, role: form_role }) { query }
       expect(response.status).to eq(200), result.inspect
-      result.dig('data', 'getFormDefinition', 'definition', 'item', 0, 'item')
+      result.dig('data', 'recordFormDefinition', 'definition', 'item', 0, 'item')
     end
 
     describe 'applies projectType rule' do

--- a/drivers/hmis/spec/requests/hmis/get_form_definition_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/get_form_definition_rules_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   describe 'Conditional fields' do
-    let(:form_role) { 'UPDATE' }
+    # FIXME GIG: analogous test for assessment definition lookup
+    let(:form_role) { 'PROJECT' }
     let(:base_items) do
       [
         {
@@ -47,9 +48,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     def assign_rule(rule)
       base_items[0]['rule'] = rule
-      Hmis::Form::Definition
-        .where(role: form_role)
-        .update_all(definition: { 'item' => [{ 'type': 'GROUP', 'link_id': 'group-1', 'item': base_items }] })
+      Hmis::Form::Definition.
+        where(role: form_role).
+        update_all(definition: { 'item' => [{ 'type': 'GROUP', 'link_id': 'group-1', 'item': base_items }] })
     end
 
     describe 'form definition with projectType rule' do

--- a/drivers/hmis/spec/requests/hmis/get_form_definition_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/get_form_definition_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
+  # FIXME
   Hmis::Form::Definition::HUD_ASSESSMENT_FORM_ROLES.excluding(:CE, :POST_EXIT, :CUSTOM_ASSESSMENT).each do |role|
     it 'should find default definition by role' do
       response, result = post_graphql({ enrollment_id: e1.id.to_s, role: role }) { query }


### PR DESCRIPTION


## Description

Add a dedicated query for looking up the form definition to use for an assessment.

This is needed to support multiple custom assessments https://github.com/greenriver/hmis-frontend/pull/619

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
