### PR TITLE
Include assessment and form def IDs in reminders

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9108,9 +9108,18 @@ enum RelationshipToHoH {
 }
 
 type Reminder {
+  """
+  Relevant existing assessment, if any
+  """
+  assessmentId: ID
   client: Client!
   dueDate: ISO8601Date
   enrollment: Enrollment!
+
+  """
+  Form definition to use, if a new assessment is needed
+  """
+  formDefinitionId: ID
   id: ID!
   overdue: Boolean!
   topic: ReminderTopic!

--- a/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
@@ -14,6 +14,8 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :enrollment, HmisSchema::Enrollment, null: false
     field :overdue, Boolean, null: false
+    field :form_definition_id, ID, null: true, description: 'Form definition to use, if a new assessment is needed'
+    field :assessment_id, ID, null: true, description: 'Relevant existing assessment, if any'
 
     def client
       object.enrollment.client

--- a/drivers/hmis/app/models/hmis/reminders/reminder.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder.rb
@@ -1,6 +1,6 @@
 module Hmis
   module Reminders
-    Reminder = Struct.new(:topic, :due_date, :overdue, :enrollment, keyword_init: true) do
+    Reminder = Struct.new(:topic, :due_date, :overdue, :enrollment, :form_definition_id, :assessment_id, keyword_init: true) do
       # id is used for sorting on the front end
       def id
         "#{sortable_date}.#{enrollment.id}.#{topic}"

--- a/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
@@ -39,11 +39,11 @@ module Hmis
       end
 
       def update_assessment_form_definition_id
-        @update_assessment_form_definition_id ||= Hmis::Form::Definition.find_definition_for_role(:UPDATE, project: project)
+        @update_assessment_form_definition_id ||= Hmis::Form::Definition.find_definition_for_role(:UPDATE, project: project)&.id
       end
 
       def annual_assessment_form_definition_id
-        @annual_assessment_form_definition_id ||= Hmis::Form::Definition.find_definition_for_role(:ANNUAL, project: project)
+        @annual_assessment_form_definition_id ||= Hmis::Form::Definition.find_definition_for_role(:ANNUAL, project: project)&.id
       end
 
       def normalize_yoy_date(date)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Include assessment and form def IDs in reminders to support  routing change

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
