### PR TITLE
Update all HMIS source clients in MCI Unique ID change job

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -79,30 +79,36 @@ module HmisExternalApis::AcHmis
       no_change_count = 0
       unrecognized_destination_id_count = 0
 
-      clients_by_destination_id = clients.index_by(&:warehouse_id).stringify_keys
+      # is this dropping multiples source clients?
+      clients_by_destination_id = clients.group_by(&:warehouse_id).stringify_keys
 
       records_needing_processing.each do |record|
-        client = clients_by_destination_id[record['clientId']]
-        if client.nil?
+        # Find source clients for this destination id
+        clients = clients_by_destination_id[record['clientId']]
+        if clients.nil? || clients.size.zero?
           unrecognized_destination_id_count += 1
           next
         end
 
-        external_id = external_ids[client.id]
+        # Iterate through each source client. If there are multiple source clients, they will
+        # get the same MCI Unique ID and be merged in the merge step.
+        clients.each do |client|
+          external_id = external_ids[client.id] # mci unique id
 
-        if external_id.blank?
-          insert_count += 1
-          HmisExternalApis::ExternalId.create!(
-            value: record['mciUniqId'],
-            source: client,
-            namespace: NAMESPACE,
-            remote_credential: data_warehouse_api.send(:creds),
-          )
-        elsif external_id.value != record['mciUniqId']
-          update_count += 1
-          external_id.update_attribute(:value, record['mciUniqId'])
-        else
-          no_change_count += 1
+          if external_id.blank?
+            insert_count += 1
+            HmisExternalApis::ExternalId.create!(
+              value: record['mciUniqId'],
+              source: client,
+              namespace: NAMESPACE,
+              remote_credential: data_warehouse_api.send(:creds),
+            )
+          elsif external_id.value != record['mciUniqId']
+            update_count += 1
+            external_id.update_attribute(:value, record['mciUniqId'])
+          else
+            no_change_count += 1
+          end
         end
       end
 

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -79,13 +79,13 @@ module HmisExternalApis::AcHmis
       no_change_count = 0
       unrecognized_destination_id_count = 0
 
-      # is this dropping multiples source clients?
+      # HMIS Source Clients, keyed by Destination ID
       clients_by_destination_id = clients.group_by(&:warehouse_id).stringify_keys
 
       records_needing_processing.each do |record|
         # Find source clients for this destination id
         clients = clients_by_destination_id[record['clientId']]
-        if clients.nil? || clients.size.zero?
+        if clients.nil?
           unrecognized_destination_id_count += 1
           next
         end

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -82,4 +82,22 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
 
     expect(job.merge_sets.length).to eq(1)
   end
+
+  it 'triggers merge of duplicate mci unique IDs for source clients with the same destination id' do
+    stub_api
+
+    # Second Source Client that does not have an MCI Unique ID, but shares the same destination clients
+    other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
+    other_client.warehouse_client_source.update(destination_id: client.warehouse_id)
+
+    # confirm setup
+    expect(client.destination_client.source_clients.size).to eq(2)
+    expect(client.destination_client.source_clients.pluck(:id)).to contain_exactly(client.id, other_client.id)
+
+    allow(Hmis::MergeClientsJob).to receive(:perform_later).with(client_ids: [client.id, other_client.id].sort, actor_id: user.id)
+
+    perform
+
+    expect(job.merge_sets.length).to eq(1)
+  end
 end


### PR DESCRIPTION
## Description

The data warehouse changes job fetches mci unique id changes from the DW API.

It should update the HMIS Source Clients MCI Unique ID values based on the response. Because we were using `index_by` we were actually dropping all but 1 source clients. This leads to lots of clients not having mci unique ids. This fixes it so we update all the source clients.

https://www.pivotaltracker.com/story/show/186957217

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
