### PR TITLE
CAS Sync Method fix for client search results

### DIFF
--- a/app/models/concerns/cas_client_data.rb
+++ b/app/models/concerns/cas_client_data.rb
@@ -192,11 +192,13 @@ module CasClientData
           ).exists?
         end
       when :project_group
-        project_ids = GrdaWarehouse::Config.cas_sync_project_group.projects.ids
+        project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids
+        return false unless project_ids.present?
+
         service_history_enrollments.ongoing.in_project(project_ids).exists?
       when :boston
         # Enrolled in project in the project group
-        project_ids = GrdaWarehouse::Config.cas_sync_project_group.projects.ids
+        project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids
         project_group_scope = service_history_enrollments.ongoing
         project_group_scope = project_group_scope.in_project(project_ids) if project_ids.any?
 

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -187,7 +187,8 @@ module GrdaWarehouse
 
     def self.cas_sync_project_group
       project_group_id = get(:cas_sync_project_group_id)
-      GrdaWarehouse::ProjectGroup.find(project_group_id)
+      # Use find_by to prevent throwing a 404 on the client search page
+      GrdaWarehouse::ProjectGroup.find_by(id: project_group_id)
     end
 
     def invalidate_cache

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -351,15 +351,17 @@ module GrdaWarehouse::Hud
           with_service_between(start_date: range.first, end_date: range.last)
         where(id: enrollment_scope.select(:client_id))
       when :project_group
-        project_ids = GrdaWarehouse::Config.cas_sync_project_group.projects.ids
+        project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids
+        return none if project_ids.blank?
+
         enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.ongoing.in_project(project_ids)
         where(id: enrollment_scope.select(:client_id))
       when :boston
         # Release on file
         scope = where(housing_release_status: [full_release_string, partial_release_string])
         # enrolled in the chosen project group
-        project_ids = GrdaWarehouse::Config.cas_sync_project_group.projects.ids
-        if project_ids.any?
+        project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids
+        if project_ids.present?
           enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.ongoing.in_project(project_ids)
           scope = scope.where(id: enrollment_scope.select(:client_id))
         end


### PR DESCRIPTION


[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes a bug where a CAS sync method is chosen that requires a project group but none is chosen.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
