### PR TITLE
Validate dates in MPER importer

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
@@ -394,7 +394,7 @@ module HmisExternalApis::AcHmis::Importers
 
             # Abort import if we find a malformatted date. Dates like '30-JUN-24' would be incorrectly
             # parsed and lead to unexpected behavior in the HMIS.
-            raise(AbortImportException, "Incorrectly formatted date in #{file}.#{col}: #{r[col]}")
+            raise(AbortImportException, "Incorrectly formatted date in #{file} #{col}: #{r[col]}")
           end
         end
       end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/projects_importer.rb
@@ -383,6 +383,22 @@ module HmisExternalApis::AcHmis::Importers
         r['data_source_id'] = data_source.id
       end
 
+      # Validate format of all dates before attempting import, so we don't import them incorrectly
+      date_columns = csv.headers.filter { |h| h.end_with?('Date') }
+      if date_columns.any?
+        date_columns.each do |col|
+          records.each do |r|
+            next unless r[col]
+            # break as soon as we find 1 correctly formatted record for this column
+            break if valid_date?(r[col])
+
+            # Abort import if we find a malformatted date. Dates like '30-JUN-24' would be incorrectly
+            # parsed and lead to unexpected behavior in the HMIS.
+            raise(AbortImportException, "Incorrectly formatted date in #{file}.#{col}: #{r[col]}")
+          end
+        end
+      end
+
       if ignore_columns.present?
         records.each do |r|
           ignore_columns.each do |col|
@@ -453,6 +469,20 @@ module HmisExternalApis::AcHmis::Importers
       elsif headers.include?('ResidentialAffiliation') || headers.include?('TrackingMethod')
         '2022'
       end
+    end
+
+    # Validate date format 'YYYY-MM-DD'
+    def valid_date?(str)
+      format_ok = str.match(/\d{4}-\d{2}-\d{2}/)
+      return false unless format_ok
+
+      begin
+        Date.strptime(str, '%Y-%m-%d')
+      rescue StandardError
+        return false
+      end
+
+      true
     end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/s3_zip_files_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/s3_zip_files_importer.rb
@@ -22,14 +22,14 @@ module HmisExternalApis::AcHmis::Importers
       self.skip_lambda = ->(_s3_object) { false }
       self.found_csvs = []
 
-      creds = GrdaWarehouse::RemoteCredentials::S3.find_by(slug: MPER_SLUG)
+      creds = GrdaWarehouse::RemoteCredentials::S3.active.find_by(slug: MPER_SLUG)
       self.remote_credential = creds
       self.bucket_name = creds&.bucket || bucket_name
       self.prefix = creds&.s3_prefix || ''
     end
 
     def self.run_mper?
-      GrdaWarehouse::RemoteCredentials::S3.where(slug: MPER_SLUG).exists?
+      GrdaWarehouse::RemoteCredentials::S3.active.where(slug: MPER_SLUG).exists?
     end
 
     def self.mper

--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Funder.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Funder.csv
@@ -1,0 +1,2 @@
+FunderID,ProjectID,Funder,OtherFunder,GrantID,StartDate,EndDate,DateCreated,DateUpdated,UserID,DateDeleted,ExportID
+F10001234,1000,46,CYF Funded,G1000,01-JUL-20,30-JUN-24,2018-07-02 09:07:00,2022-05-26 11:05:22,MPER,,ABCDEFGHIJKLMNO20230404

--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Inventory.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Inventory.csv
@@ -1,0 +1,1 @@
+../../../../../../../../drivers/hud_lsa/spec/fixtures/files/lsa/fy2022/sample_results/Inventory.csv

--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Organization.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Organization.csv
@@ -1,0 +1,2 @@
+OrganizationID,OrganizationName,VictimServiceProvider,OrganizationCommonName,DateCreated,DateUpdated,UserID,DateDeleted,ExportID
+127,ORG NUMBER 127,0,ORGANIZATION NUMBER ONE HUNDRED TWENTY SEVEN,2000-11-01 12:11:15,2015-07-01 10:07:35,T011111,,ABCDEFGHIJKLMNO20230404

--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Project.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/Project.csv
@@ -1,0 +1,2 @@
+﻿ProjectID,OrganizationID,ProjectName,ProjectCommonName,OperatingStartDate,OperatingEndDate,ContinuumProject,ProjectType,HousingType,ResidentialAffiliation,TrackingMethod,HMISParticipatingProject,TargetPopulation,HOPWAMedAssistedLivingFac,PITCount,Walkin,DateCreated,DateUpdated,UserID,DateDeleted,ExportID
+1000,127,Project 1000,Project 1000,2018-07-01,9999-12-31,1,6,,1,,1,,2,,0,2018-07-02 09:07:00,2023-04-29 08:04:50,SYS,,ABCDEFGHIJKLMNO20230404

--- a/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/ProjectUnitTypes.csv
+++ b/drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid/ProjectUnitTypes.csv
@@ -1,0 +1,3 @@
+ProgramID,UnitTypeID,UnitCapacity,IsActive
+1000,42,10,Y
+1000,43,5,N

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
@@ -9,6 +9,7 @@ require 'rails_helper'
 RSpec.describe HmisExternalApis::AcHmis::Importers::ProjectsImporter, type: :model do
   let!(:ds) { create(:hmis_data_source) }
   let(:dir) { 'drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects' }
+  let(:invalid_data_dir) { 'drivers/hmis_external_apis/spec/fixtures/hmis_external_apis/ac_hmis/importers/projects_invalid' }
   let(:mper_creds) { create(:ac_hmis_mper_credential) }
   let!(:active_unit_type) do
     # Match ProjectUnitType.csv
@@ -57,5 +58,19 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::ProjectsImporter, type: :mod
     expect(p1.project_type).to eq(1)
     expect(p1.operating_start_date).to eq(start_date_override)
     expect(p1.operating_end_date).to eq(end_date_override)
+  end
+
+  it 'fails when funder dates are formatted incorrectly' do
+    allow(Rails.logger).to receive(:fatal).and_return nil
+
+    Dir.chdir(invalid_data_dir) do
+      importer = HmisExternalApis::AcHmis::Importers::ProjectsImporter.new(dir: '.', key: 'data.zip', etag: '12345')
+      importer.run!
+    end
+
+    expect(Rails.logger).to have_received(:fatal).with('Incorrectly formatted date in Funder.csv StartDate: 01-JUL-20')
+    expect(Rails.logger).to have_received(:fatal).with('ProjectsImporter aborted before it finished.')
+    expect(GrdaWarehouse::Hud::Project.count).to eq(0)
+    expect(GrdaWarehouse::Hud::Funder.count).to eq(0)
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Cancel import if we get a bad date. Sometimes when they do an upgrade they start sending `30-JUN-24` it has happened twice before. Our HUD HMIS importer imports that as something like `0024-06-30`. Maybe it should be fixed downstream.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
