### PR TITLE
Standardize alignment for CE Performance Dashboard details columns

### DIFF
--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
@@ -10,9 +10,9 @@
     %table.table.table-striped
       %thead
         %tr
-          %th{ width: '80%' } Event Type
-          %th{ width: '20%' }= comparison_year
-          %th{ width: '20%' }= report_year
+          %th.w-75 Event Type
+          %th= comparison_year
+          %th= report_year
       %tbody
         - reporting.each do |k, v|
           %tr

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_event_breakdown_table.haml
@@ -10,9 +10,9 @@
     %table.table.table-striped
       %thead
         %tr
-          %th Event Type
-          %th= comparison_year
-          %th= report_year
+          %th{ width: '80%' } Event Type
+          %th{ width: '20%' }= comparison_year
+          %th{ width: '20%' }= report_year
       %tbody
         - reporting.each do |k, v|
           %tr

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_exit_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_exit_breakdown_table.haml
@@ -11,9 +11,9 @@
         %table.table.table-striped
           %thead
             %tr
-              %th= type.constantize.breakdown_title
-              %th= comparison_year
-              %th= report_year
+              %th{ width: '80%' }= type.constantize.breakdown_title
+              %th{ width: '20%' }= comparison_year
+              %th{ width: '20%' }= report_year
           %tbody
             - destinations.each do |k, v|
               %tr

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_exit_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_exit_breakdown_table.haml
@@ -11,9 +11,9 @@
         %table.table.table-striped
           %thead
             %tr
-              %th{ width: '80%' }= type.constantize.breakdown_title
-              %th{ width: '20%' }= comparison_year
-              %th{ width: '20%' }= report_year
+              %th.w-75= type.constantize.breakdown_title
+              %th= comparison_year
+              %th= report_year
           %tbody
             - destinations.each do |k, v|
               %tr

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
@@ -9,12 +9,12 @@
   %table.table.table-striped
     %thead
       %tr
-        %th
+        %th{ width: '80%' }
           Sub-Population
           - if @result.hoh_only?
             (For Heads of Household Only)
-        %th= comparison_year
-        %th= report_year
+        %th{ width: '20%' }= comparison_year
+        %th{ width: '20%' }= report_year
     %tbody
       - reporting.each do |k, v|
         - sub_pop = sub_pops[k]

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_sub_population_table.haml
@@ -9,12 +9,12 @@
   %table.table.table-striped
     %thead
       %tr
-        %th{ width: '80%' }
+        %th.w-75
           Sub-Population
           - if @result.hoh_only?
             (For Heads of Household Only)
-        %th{ width: '20%' }= comparison_year
-        %th{ width: '20%' }= report_year
+        %th= comparison_year
+        %th= report_year
     %tbody
       - reporting.each do |k, v|
         - sub_pop = sub_pops[k]

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
@@ -11,9 +11,9 @@
       %table.table.table-striped
         %thead
           %tr
-            %th Housing Needs Assessment Range
-            %th= comparison_year
-            %th= report_year
+            %th{ width: '80%' } Housing Needs Assessment Range
+            %th{ width: '20%' }= comparison_year
+            %th{ width: '20%' }= report_year
         %tbody
           - reporting.each do |vispdat_range, v|
             %tr
@@ -30,9 +30,9 @@
       %table.table.table-striped
         %thead
           %tr
-            %th Housing Needs Assessment Type
-            %th= comparison_year
-            %th= report_year
+            %th{ width: '80%' } Housing Needs Assessment Type
+            %th{ width: '20%' }= comparison_year
+            %th{ width: '20%' }= report_year
         %tbody
           - reporting.each do |vispdat_type, v|
             %tr

--- a/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
+++ b/drivers/ce_performance/app/views/ce_performance/warehouse_reports/reports/_vispdat_breakdown_table.haml
@@ -11,9 +11,9 @@
       %table.table.table-striped
         %thead
           %tr
-            %th{ width: '80%' } Housing Needs Assessment Range
-            %th{ width: '20%' }= comparison_year
-            %th{ width: '20%' }= report_year
+            %th.w-75 Housing Needs Assessment Range
+            %th= comparison_year
+            %th= report_year
         %tbody
           - reporting.each do |vispdat_range, v|
             %tr
@@ -30,9 +30,9 @@
       %table.table.table-striped
         %thead
           %tr
-            %th{ width: '80%' } Housing Needs Assessment Type
-            %th{ width: '20%' }= comparison_year
-            %th{ width: '20%' }= report_year
+            %th.w-75 Housing Needs Assessment Type
+            %th= comparison_year
+            %th= report_year
         %tbody
           - reporting.each do |vispdat_type, v|
             %tr


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update the CE Performance Dashboard details page so the columns for each breakdown align.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
