### PR TITLE
Avoid missing template error if create fails

### DIFF
--- a/app/controllers/admin/health/coordination_teams_controller.rb
+++ b/app/controllers/admin/health/coordination_teams_controller.rb
@@ -16,7 +16,7 @@ module Admin::Health
     def create
       @team = team_class.create(team_params)
       flash[:error] = @team.errors.full_messages.join('; ') if @team.errors.any?
-      respond_with(@team, location: admin_health_coordination_teams_path)
+      redirect_to(admin_health_coordination_teams_path)
     end
 
     def update


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Pressing 'Add' to create a Health Care Team without entering the required values was going to 'new', which does not exist.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
