### PR TITLE
Fix bug when processing boolean Custom Data Elements

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -128,7 +128,7 @@ class Hmis::Hud::Processors::Base
     # If this custom field only allows 1 value and there already is one, update it.
     if !cded.repeats && existing_values.exists?
       cde_attributes = { id: existing_values.first.id }
-      if value.present?
+      if value.present? || value.instance_of?(FalseClass)
         cde_attributes[value_field_name] = value
         cde_attributes.merge!(attrs)
       else

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -120,19 +120,21 @@ class Hmis::Hud::Processors::Base
       data_source_id: @processor.hud_user.data_source_id,
       data_element_definition: cded,
     }
+    # Normalize the input value
+    value = normalize_custom_field_value(cded, value)
+    # Infer the field name on the CustomDataElement
     value_field_name = "value_#{cded.field_type}"
-    value = attribute_value_for_enum(nil, value) # converts HIDDEN => nil
 
     existing_values = record.custom_data_elements.where(data_element_definition: cded, owner: record)
 
     # If this custom field only allows 1 value and there already is one, update it.
     if !cded.repeats && existing_values.exists?
       cde_attributes = { id: existing_values.first.id }
-      if value.present? || value.instance_of?(FalseClass)
+      if value.nil?
+        cde_attributes[:_destroy] = 1
+      else
         cde_attributes[value_field_name] = value
         cde_attributes.merge!(attrs)
-      else
-        cde_attributes[:_destroy] = 1
       end
     # If value(s) haven't changed, just update the User and timestamps
     elsif existing_values.map(&:value) == Array.wrap(value)
@@ -192,5 +194,70 @@ class Hmis::Hud::Processors::Base
     end
 
     { "#{attribute_name}_attributes" => attributes }
+  end
+
+  def normalize_custom_field_value(cded, value)
+    value = attribute_value_for_enum(nil, value) # converts HIDDEN => nil
+
+    # If this is a repeated element, normalize each value
+    if cded.repeats
+      Array.wrap(value).map do |val|
+        normalize_single_custom_field_value(cded, val)
+      end.compact.presence
+    # Else normalize the single element, and ensure its not an array
+    else
+      raise "Custom field '#{cded.key}' can't be an array" if value.is_a?(Array)
+
+      normalize_single_custom_field_value(cded, value)
+    end
+  end
+
+  def normalize_single_custom_field_value(cded, value)
+    return value if value.nil?
+
+    # Match on Hmis::Hud::CustomDataElementDefinition::FIELD_TYPES and normalize value
+    case cded.field_type
+    when 'string', 'text'
+      case value
+      when String
+        value&.presence&.strip
+      when Integer
+        value.to_s
+      else
+        raise "unexpected value \"#{value}\""
+      end
+    when 'integer'
+      case value
+      when Integer
+        value
+      else
+        raise "unexpected value \"#{value}\""
+      end
+    when 'float'
+      case value
+      when Float
+        value
+      else
+        raise "unexpected value \"#{value}\""
+      end
+    when 'date'
+      case value
+      when Date, DateTime
+        value.to_date
+      else
+        raise "unexpected value \"#{value}\""
+      end
+    when 'boolean'
+      case value
+      when nil, ''
+        nil
+      when true, false
+        value
+      else
+        raise "unexpected value \"#{value}\""
+      end
+    else
+      raise 'unsupported field type for custom data element'
+    end
   end
 end

--- a/drivers/hmis/spec/support/form_helpers.rb
+++ b/drivers/hmis/spec/support/form_helpers.rb
@@ -29,6 +29,12 @@ module FormHelpers
     definition.link_id_item_hash.find { |_link_id, item| item.required && item.mapping&.field_name&.present? }&.last
   end
 
+  def add_item_to_definition(definition, item)
+    definition.definition['item'] << item
+    definition.save!
+    definition
+  end
+
   def completed_form_values_for_role(role)
     yield(COMPLETE_VALUES[role]) if block_given?
 


### PR DESCRIPTION
## Description

Fix bug where changing a boolean custom data element value would sometimes remove the custom data element value.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
