### PR TITLE
Support collecting CE Event on an Assessment

### DIFF
--- a/db/warehouse/migrate/20240208184013_add_ce_event_to_form_processor.rb
+++ b/db/warehouse/migrate/20240208184013_add_ce_event_to_form_processor.rb
@@ -1,0 +1,7 @@
+class AddCeEventToFormProcessor < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :hmis_form_processors, :ce_event
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -17106,7 +17106,8 @@ CREATE TABLE public.hmis_form_processors (
     youth_education_status_id integer,
     employment_education_id integer,
     current_living_situation_id integer,
-    ce_assessment_id bigint
+    ce_assessment_id bigint,
+    ce_event_id bigint
 );
 
 
@@ -51702,6 +51703,13 @@ CREATE INDEX index_hmis_form_processors_on_ce_assessment_id ON public.hmis_form_
 
 
 --
+-- Name: index_hmis_form_processors_on_ce_event_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hmis_form_processors_on_ce_event_id ON public.hmis_form_processors USING btree (ce_event_id);
+
+
+--
 -- Name: index_hmis_form_processors_on_chronic_health_condition_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -60586,6 +60594,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240126164153'),
 ('20240205174218'),
 ('20240205175100'),
-('20240205230723');
+('20240205230723'),
+('20240208184013');
 
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -236,6 +236,7 @@ type Assessment {
   disabilityGroup: DisabilityGroup
   employmentEducation: EmploymentEducation
   enrollment: Enrollment!
+  event: Event
   exit: Exit
   healthAndDv: HealthAndDv
   id: ID!
@@ -9246,6 +9247,11 @@ enum RelatedRecordType {
   EnrollmentCoc
   """
   ENROLLMENT_COC
+
+  """
+  Event
+  """
+  EVENT
 
   """
   Exit

--- a/drivers/hmis/app/graphql/types/forms/enums/related_record_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/related_record_type.rb
@@ -22,5 +22,6 @@ module Types
     value 'CURRENT_LIVING_SITUATION', 'CurrentLivingSituation'
     value 'YOUTH_EDUCATION_STATUS', 'YouthEducationStatus'
     value 'EMPLOYMENT_EDUCATION', 'EmploymentEducation'
+    value 'EVENT', 'Event'
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -33,6 +33,7 @@ module Types
     end
     # Related records that were created by this Assessment, if applicable
     field :ce_assessment, Types::HmisSchema::CeAssessment, null: true
+    field :event, Types::HmisSchema::Event, null: true
     field :income_benefit, Types::HmisSchema::IncomeBenefit, null: true
     field :health_and_dv, Types::HmisSchema::HealthAndDv, null: true
     field :exit, Types::HmisSchema::Exit, null: true
@@ -79,6 +80,10 @@ module Types
 
     def ce_assessment
       form_processor ? load_ar_association(form_processor, :ce_assessment) : nil
+    end
+
+    def event
+      form_processor ? load_ar_association(form_processor, :ce_event) : nil
     end
 
     def income_benefit

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -33,6 +33,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   # Note: this is NOT the assessment that created this processor, that's CustomAssessment. Rather this is a
   # Coordinated Entry (CE) Assessment that was created by the processor. The HUD model for CE Assessment is 'Assessment'
   belongs_to :ce_assessment, class_name: 'Hmis::Hud::Assessment', optional: true, autosave: true
+  belongs_to :ce_event, class_name: 'Hmis::Hud::Event', optional: true, autosave: true
 
   validate :hmis_records_are_valid, on: :form_submission
 
@@ -154,7 +155,6 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
       self.exit = enrollment_factory.exit
     else
       self.exit = enrollment_factory.build_exit(
-        personal_id: enrollment_factory.client.personal_id,
         user_id: custom_assessment&.user_id,
       )
     end
@@ -165,11 +165,21 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
 
     if create
       self.ce_assessment ||= enrollment_factory.assessments.build(
-        personal_id: enrollment_factory.personal_id,
         user_id: custom_assessment&.user_id,
       )
     end
     ce_assessment
+  end
+
+  def ce_event_factory(create: true)
+    return owner if owner.is_a? Hmis::Hud::Event
+
+    if create
+      self.ce_event ||= enrollment_factory.events.build(
+        user_id: custom_assessment&.user_id,
+      )
+    end
+    ce_event
   end
 
   def health_and_dv_factory(create: true)
@@ -315,6 +325,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
       :developmental_disability_factory,
       :chronic_health_condition_factory,
       :ce_assessment_factory,
+      :ce_event_factory,
       :hiv_aids_factory,
       :mental_health_disorder_factory,
       :substance_use_disorder_factory,

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -91,7 +91,12 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   end
 
   def owner_container_name
-    @owner_container_name ||= owner.class.name.demodulize
+    @owner_container_name ||= case owner
+    when Hmis::Hud::Assessment
+      'CeAssessment' # special case since the container name and class name don't match
+    else
+      owner.class.name.demodulize
+    end
   end
 
   def owner_factory(create: true) # rubocop:disable Lint/UnusedMethodArgument
@@ -309,8 +314,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
       YouthEducationStatus: Hmis::Hud::Processors::YouthEducationStatusProcessor,
       EmploymentEducation: Hmis::Hud::Processors::EmploymentEducationProcessor,
       CurrentLivingSituation: Hmis::Hud::Processors::CurrentLivingSituationProcessor,
-      Assessment: Hmis::Hud::Processors::CeAssessmentProcessor, # CE Assessment owner
-      CeAssessment: Hmis::Hud::Processors::CeAssessmentProcessor, # Custom Assessment includes CE Assessment
+      CeAssessment: Hmis::Hud::Processors::CeAssessmentProcessor,
       Event: Hmis::Hud::Processors::CeEventProcessor,
       CustomCaseNote: Hmis::Hud::Processors::CustomCaseNoteProcessor,
     }.freeze

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -46,6 +46,8 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   has_one :youth_education_status, through: :form_processor
   has_one :employment_education, through: :form_processor
   has_one :current_living_situation, through: :form_processor
+  has_one :ce_assessment, through: :form_processor
+  has_one :ce_event, through: :form_processor
 
   accepts_nested_attributes_for :custom_data_elements, allow_destroy: true
 

--- a/drivers/hmis/app/models/hmis/hud/processors/ce_event_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/ce_event_processor.rb
@@ -7,7 +7,7 @@
 module Hmis::Hud::Processors
   class CeEventProcessor < Base
     def factory_name
-      :owner_factory
+      :ce_event_factory
     end
 
     def schema

--- a/drivers/hmis/lib/form_data/default/records/ce_event.json
+++ b/drivers/hmis/lib/form_data/default/records/ce_event.json
@@ -10,6 +10,7 @@
           "link_id": "4.20.1",
           "text": "Event Date",
           "mapping": {
+            "record_type": "EVENT",
             "field_name": "eventDate"
           },
           "bounds": [
@@ -39,7 +40,10 @@
           "text": "Event Type",
           "pick_list_reference": "CE_EVENTS",
           "link_id": "4.20.2",
-          "mapping": { "field_name": "event" }
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "event"
+          }
         },
         {
           "type": "CHOICE",
@@ -47,7 +51,10 @@
           "text": "Client housed/re-housed in a safe alternative",
           "pick_list_reference": "NoYesMissing",
           "link_id": "4.20.A",
-          "mapping": { "field_name": "probSolDivRrResult" },
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "probSolDivRrResult"
+          },
           "enable_when": [
             {
               "question": "4.20.2",
@@ -62,7 +69,10 @@
           "text": "Enrolled in Aftercare project",
           "pick_list_reference": "NoYesMissing",
           "link_id": "4.20.B",
-          "mapping": { "field_name": "referralCaseManageAfter" },
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "referralCaseManageAfter"
+          },
           "enable_when": [
             {
               "question": "4.20.2",
@@ -76,7 +86,10 @@
           "required": false,
           "link_id": "4.20.C",
           "text": "Location of Crisis Housing or Permanent Housing Referral",
-          "mapping": { "field_name": "locationCrisisOrPhHousing" },
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "locationCrisisOrPhHousing"
+          },
           "enable_behavior": "ANY",
           "enable_when": [
             {
@@ -118,7 +131,10 @@
           "pick_list_reference": "ReferralResult",
           "component": "RADIO_BUTTONS_VERTICAL",
           "link_id": "4.20.D",
-          "mapping": { "field_name": "referralResult" },
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "referralResult"
+          },
           "enable_behavior": "ANY",
           "enable_when": [
             {
@@ -169,6 +185,7 @@
           "link_id": "4.20.E",
           "text": "Result Date",
           "mapping": {
+            "record_type": "EVENT",
             "field_name": "resultDate"
           },
           "enable_when": [

--- a/drivers/hmis/lib/form_data/qa_hmis/custom_assessments/qa_ce_event_assessment.json
+++ b/drivers/hmis/lib/form_data/qa_hmis/custom_assessments/qa_ce_event_assessment.json
@@ -1,0 +1,87 @@
+{
+  "item": [
+    {
+      "link_id": "event",
+      "type": "GROUP",
+      "text": "Event",
+      "item": [
+        {
+          "text": "Event Date",
+          "type": "DATE",
+          "link_id": "event-date",
+          "required": true,
+          "assessment_date": true,
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "eventDate"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "required": true,
+          "text": "Event Type",
+          "pick_list_reference": "CE_EVENTS",
+          "link_id": "4.20.2",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "event"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "required": false,
+          "text": "Client housed/re-housed in a safe alternative",
+          "pick_list_reference": "NoYesMissing",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "probSolDivRrResult"
+          },
+          "link_id": "4.20.A"
+        },
+        {
+          "type": "CHOICE",
+          "required": false,
+          "text": "Enrolled in Aftercare project",
+          "pick_list_reference": "NoYesMissing",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "referralCaseManageAfter"
+          },
+          "link_id": "4.20.B"
+        },
+        {
+          "type": "TEXT",
+          "required": false,
+          "link_id": "4.20.C",
+          "text": "Location of Crisis Housing or Permanent Housing Referral",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "locationCrisisOrPhHousing"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "required": false,
+          "text": "Referral Result",
+          "pick_list_reference": "ReferralResult",
+          "component": "RADIO_BUTTONS_VERTICAL",
+          "link_id": "4.20.D",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "referralResult"
+          }
+        },
+        {
+          "type": "DATE",
+          "required": false,
+          "link_id": "4.20.E",
+          "text": "Result Date",
+          "mapping": {
+            "record_type": "EVENT",
+            "field_name": "resultDate"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/test/custom_assessments/housing_needs_assessment.json
+++ b/drivers/hmis/lib/form_data/test/custom_assessments/housing_needs_assessment.json
@@ -2,37 +2,19 @@
   "item": [
     {
       "type": "GROUP",
-      "link_id": "event-group",
+      "text": "TEST Housing Needs Assessment",
+      "link_id": "housing-needs-assessment-example-group",
       "item": [
         {
           "type": "DATE",
           "required": true,
           "link_id": "4.19.1",
           "text": "Assessment Date",
+          "assessment_date": true,
           "mapping": {
             "record_type": "ASSESSMENT",
             "field_name": "assessmentDate"
-          },
-          "bounds": [
-            {
-              "id": "max",
-              "_comment": "cannot be in the future",
-              "type": "MAX",
-              "value_local_constant": "$today"
-            },
-            {
-              "id": "max-exit",
-              "_comment": "cannot be after exit date",
-              "type": "MAX",
-              "value_local_constant": "$exitDate"
-            },
-            {
-              "id": "min",
-              "_comment": "cannot be before entry date",
-              "type": "MIN",
-              "value_local_constant": "$entryDate"
-            }
-          ]
+          }
         },
         {
           "type": "TEXT",
@@ -42,13 +24,7 @@
           "mapping": {
             "record_type": "ASSESSMENT",
             "field_name": "assessmentLocation"
-          },
-          "initial": [
-            {
-              "initial_behavior": "IF_EMPTY",
-              "value_local_constant": "$projectName"
-            }
-          ]
+          }
         },
         {
           "type": "CHOICE",


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Support collecting ce Event records on HMIS assessments.

To test: check out https://github.com/greenriver/hmis-warehouse/pull/3995, seed definitions to load the qa form, add an instance for it in the ui, try submitting assessment

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
