### PR TITLE
Hotfix for SPM dependent report regressions

### DIFF
--- a/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
+++ b/drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb
@@ -685,8 +685,8 @@ module HomelessSummaryReport
           calculations: [:count, :average, :median],
         },
         m2_reentry_days: {
-          cells: [['2', 'B7']],
-          value_accessor: ->(_spm_return) { spm_episode.days_to_return },
+          cells: [['2a and 2b', 'B7']],
+          value_accessor: ->(spm_return) { spm_return.days_to_return },
           title: 'Re-Entering Homelessness',
         },
         m7a1_destination: {

--- a/drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb
+++ b/drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Datalab Testkit SPM All-Projects', type: :model do
     xit 'Measure 2' do
       compare_results(
         file_path: result_file_prefix + 'spm',
-        question: '2',
+        question: '2a and 2b',
       )
     end
 

--- a/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
+++ b/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
@@ -88,7 +88,7 @@ module LongitudinalSpm
     def describe_filter_as_html
       filter.describe_filter_as_html(
         [
-          :end,
+          :start,
           :comparison_pattern,
           :coc_codes,
           :project_type_codes,

--- a/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
+++ b/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
@@ -172,7 +172,7 @@ module LongitudinalSpm
           ],
         },
         'Measure 2' => {
-          '2' => [
+          '2a and 2b' => [
             'J2',
             'J3',
             'J4',

--- a/drivers/longitudinal_spm/app/views/longitudinal_spm/warehouse_reports/reports/show.haml
+++ b/drivers/longitudinal_spm/app/views/longitudinal_spm/warehouse_reports/reports/show.haml
@@ -26,7 +26,7 @@
           = "Table #{table}:"
           = @report.spm_describe(table)
           = @report.spm_describe(table, cell)
-        .chart{id: "spm_#{table.gsub('.', '_')}_#{cell}"}
+        .chart{id: "spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"}
         = content_for :page_js do
           :javascript
             options = {
@@ -54,7 +54,7 @@
                   }
                 }
               },
-              bindto: "\#spm_#{table.gsub('.', '_')}_#{cell}"
+              bindto: "\#spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"
             };
 
             // Tables 2 and 7 should be 0-100 (and labeled as percentage)

--- a/drivers/performance_measurement/app/models/performance_measurement/report.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/report.rb
@@ -421,7 +421,7 @@ module PerformanceMeasurement
         # Episode
         # universe membership has spm_enrollments which have hud enrollments
         scope.preload(universe_membership: { enrollments: { enrollment: :project } })
-      when '2'
+      when '2a and 2b'
         # Return
         scope.preload(universe_membership: { exit_enrollment: { enrollment: :project } })
       else
@@ -1204,7 +1204,7 @@ module PerformanceMeasurement
           ],
         },
         {
-          cells: [['2', 'B7']],
+          cells: [['2a and 2b', 'B7']],
           title: 'Returned to Homelessness Within 6 months',
           measure: :m2,
           history_source: :m2_history,

--- a/drivers/performance_metrics/app/models/performance_metrics/report.rb
+++ b/drivers/performance_metrics/app/models/performance_metrics/report.rb
@@ -604,13 +604,13 @@ module PerformanceMetrics
         # NOTE: SPM has a 2 year look-back so they may not be in the enrolled clients
         spm_report = run_spm
         # M2 B7 is TOTAL Returns to Homeless - Number of Returns in 2 Years
-        spm_returners = answer_members(spm_report, '2', 'I7') # HudSpmReport::Fy2023::Return
+        spm_returners = answer_members(spm_report, '2a and 2b', 'I7') # HudSpmReport::Fy2023::Return
         # M2 I7 is Total Number of Persons who Exited to a Permanent Housing Destination (2 Years Prior)
-        spm_leavers = answer_members(spm_report, '2', 'B7') # HudSpmReport::Fy2023::Return
+        spm_leavers = answer_members(spm_report, '2a and 2b', 'B7') # HudSpmReport::Fy2023::Return
         # 1A D2 is Average LOT Experiencing Homelessness ES, SH, and TH
         spm_episodes = answer_members(spm_report, '1a', 'D2') # HudSpmReport::Fy2023::Episode
 
-        spm_leavers.each do |client_id, spm_client|
+        spm_leavers.each do |client_id, spm_return|
           days_in_es = nil
           days_to_return = nil
 
@@ -623,8 +623,8 @@ module PerformanceMetrics
           report_client = report_clients[client_id] || Client.new
           report_client.assign_attributes(
             client_id: client_id,
-            first_name: spm_client.first_name,
-            last_name: spm_client.last_name,
+            first_name: spm_return.client.first_name,
+            last_name: spm_return.client.last_name,
             report_id: id,
             "#{period}_period_days_in_es" => days_in_es,
             "#{period}_period_days_to_return" => days_to_return,

--- a/drivers/performance_metrics/app/models/performance_metrics/report.rb
+++ b/drivers/performance_metrics/app/models/performance_metrics/report.rb
@@ -617,8 +617,8 @@ module PerformanceMetrics
           spm_returner = spm_returners[client_id]
           spm_leaver = spm_leavers.keys.include?(client_id)
           if spm_returner
-            days_in_es = spm_episodes[client_id].days_homeless
-            days_to_return = spm_returner.days_to_return
+            days_in_es = spm_episodes[client_id]&.days_homeless
+            days_to_return = spm_returner&.days_to_return
           end
           report_client = report_clients[client_id] || Client.new
           report_client.assign_attributes(


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes some reports that depend on the SPM that were broken with a recent table rename.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
