### PR TITLE
Update project types for ES dashboard to pull from HUD Utility

### DIFF
--- a/app/controllers/warehouse_reports/outcomes_controller.rb
+++ b/app/controllers/warehouse_reports/outcomes_controller.rb
@@ -23,7 +23,7 @@ module WarehouseReports
           class: WarehouseReport::Outcomes::RrhReport,
           index_path: warehouse_reports_rrh_index_path,
           scope: ::Reporting::Housed.rrh,
-          project_types: [13],
+          project_types: HudUtility2024.performance_reporting[:rrh],
         },
         psh: {
           class: WarehouseReport::Outcomes::PshReport,
@@ -35,13 +35,13 @@ module WarehouseReports
           class: WarehouseReport::Outcomes::EsReport,
           index_path: warehouse_reports_shelter_index_path,
           scope: ::Reporting::Housed.es,
-          project_types: [1],
+          project_types: HudUtility2024.performance_reporting[:es],
         },
         th: {
           class: WarehouseReport::Outcomes::ThReport,
           index_path: warehouse_reports_th_index_path,
           scope: ::Reporting::Housed.th,
-          project_types: [2],
+          project_types: HudUtility2024.performance_reporting[:th],
         },
       }
     end

--- a/app/models/reporting/housed.rb
+++ b/app/models/reporting/housed.rb
@@ -20,7 +20,7 @@ module Reporting
     end
 
     scope :rrh, -> do
-      where(project_type: 13)
+      where(project_type: HudUtility2024.performance_reporting[:rrh])
     end
 
     scope :psh, -> do
@@ -28,15 +28,15 @@ module Reporting
     end
 
     scope :es, -> do
-      where(project_type: 1)
+      where(project_type: HudUtility2024.performance_reporting[:es])
     end
 
     scope :th, -> do
-      where(project_type: 2)
+      where(project_type: HudUtility2024.performance_reporting[:th])
     end
 
     scope :sh, -> do
-      where(project_type: 8)
+      where(project_type: HudUtility2024.performance_reporting[:sh])
     end
 
     scope :youth, -> do

--- a/app/models/warehouse_report/outcomes/es_report.rb
+++ b/app/models/warehouse_report/outcomes/es_report.rb
@@ -72,7 +72,7 @@ class WarehouseReport::Outcomes::EsReport < WarehouseReport::Outcomes::Base
   end
 
   def project_types
-    [1]
+    HudUtility2024.performance_reporting[:es]
   end
 
   def self.available_subpopulations


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

ES Dashboard Project types were not including Entry/Exit typein the Project or project type filters. This updates the filters to pull the types from the HUDUtilities file instead of hard coding.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
