### PR TITLE
Synthetic events should not be duplicated

### DIFF
--- a/app/models/grda_warehouse/synthetic/assessment.rb
+++ b/app/models/grda_warehouse/synthetic/assessment.rb
@@ -34,9 +34,10 @@ module GrdaWarehouse::Synthetic
       create_hud_assessments
 
       # Clean up orphans in HUD table
-      GrdaWarehouse::Hud::Assessment.
-        where(synthetic: true).
-        where.not(AssessmentID: select(:hud_assessment_assessment_id)).
+      assessment_source.
+        synthetic.
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        where(assessment_source.arel_table[:AssessmentID].not_in(arel_table.project(:hud_assessment_assessment_id))).
         delete_all
     end
 

--- a/app/models/grda_warehouse/synthetic/assessment.rb
+++ b/app/models/grda_warehouse/synthetic/assessment.rb
@@ -36,7 +36,7 @@ module GrdaWarehouse::Synthetic
       # Clean up orphans in HUD table
       assessment_source.
         synthetic.
-        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field
         where(assessment_source.arel_table[:AssessmentID].not_in(arel_table.project(:hud_assessment_assessment_id))).
         delete_all
     end

--- a/app/models/grda_warehouse/synthetic/event.rb
+++ b/app/models/grda_warehouse/synthetic/event.rb
@@ -57,7 +57,8 @@ module GrdaWarehouse::Synthetic
       # Clean up orphans in HUD table
       event_source.
         synthetic.
-        where.not(EventID: select(:hud_event_event_id)).
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        where(event_source.arel_table[:EventID].not_in(arel_table.project(:hud_event_event_id))).
         delete_all
     end
 

--- a/app/models/grda_warehouse/synthetic/event.rb
+++ b/app/models/grda_warehouse/synthetic/event.rb
@@ -57,7 +57,7 @@ module GrdaWarehouse::Synthetic
       # Clean up orphans in HUD table
       event_source.
         synthetic.
-        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field
         where(event_source.arel_table[:EventID].not_in(arel_table.project(:hud_event_event_id))).
         delete_all
     end

--- a/app/models/grda_warehouse/synthetic/youth_education_status.rb
+++ b/app/models/grda_warehouse/synthetic/youth_education_status.rb
@@ -47,9 +47,10 @@ module GrdaWarehouse::Synthetic
       create_hud_youth_education_statuses
 
       # Clean up orphans in HUD table
-      GrdaWarehouse::Hud::YouthEducationStatus.
+      youth_education_status_source.
         synthetic.
-        where.not(YouthEducationStatusID: select(:hud_youth_education_status_youth_education_status_id)).
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        where(youth_education_status_source.arel_table[:YouthEducationStatusID].not_in(arel_table.project(:hud_youth_education_status_youth_education_status_id))).
         delete_all
     end
 

--- a/app/models/grda_warehouse/synthetic/youth_education_status.rb
+++ b/app/models/grda_warehouse/synthetic/youth_education_status.rb
@@ -49,7 +49,7 @@ module GrdaWarehouse::Synthetic
       # Clean up orphans in HUD table
       youth_education_status_source.
         synthetic.
-        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field, must use Arel.sql
+        # ActiveRecord doesn't work with a simple select since it returns nil in the ID field
         where(youth_education_status_source.arel_table[:YouthEducationStatusID].not_in(arel_table.project(:hud_youth_education_status_youth_education_status_id))).
         delete_all
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes a bad active record scope that was failing to cleanup extra synthetic items.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
