### PR TITLE
active_cohort column breaking on download when cohort names does not exist

### DIFF
--- a/app/models/cohort_columns/active_cohorts.rb
+++ b/app/models/cohort_columns/active_cohorts.rb
@@ -18,7 +18,7 @@ module CohortColumns
 
     def value(cohort_client) # OK
       cohort_ids = cohort_client.client.active_cohort_ids - [cohort.id]
-      cohort_names.values_at(*cohort_ids).join('; ')
+      cohort_names&.values_at(*cohort_ids)&.join('; ')
     end
   end
 end

--- a/app/models/grda_warehouse/cohorts/document_exports/cohort_excel_export.rb
+++ b/app/models/grda_warehouse/cohorts/document_exports/cohort_excel_export.rb
@@ -23,12 +23,20 @@ module GrdaWarehouse::Cohorts::DocumentExports
       params['population'] ||= 'Active Clients'
     end
 
+    protected def cohort_names
+      @cohort_names ||= cohort_class.pluck(:id, :name, :short_name).
+        map do |id, name, short_name|
+        [id, short_name.presence || name]
+      end.to_h
+    end
+
     protected def view_assigns
       {
         user: user,
         cohort: cohort,
         cohort_clients: cohort_clients,
         population: population,
+        cohort_names: cohort_names,
       }
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes issue when creating the cohorts export when the active cohorts column is selected and the cohort_names does not exist.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
