### PR TITLE
TC HAT pregnancy status - always family

### DIFF
--- a/app/models/grda_warehouse/cas_project_client_calculator/tc_hat.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/tc_hat.rb
@@ -182,6 +182,12 @@ module GrdaWarehouse::CasProjectClientCalculator
       question_title = 'If you do not have legal custody'
       custody_later = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
 
+      question_title = 'Are you currently pregnant?'
+      pregnant = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+
+      # Pregnant clients are always considered a family
+      return true if pregnant
+
       # There is a child, but the parent doesn't, and won't have custody
       return false if single_parent && (!custody_now && !custody_later)
       # Client indicated the household is adult only

--- a/app/models/grda_warehouse/cas_project_client_calculator/tc_hat.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/tc_hat.rb
@@ -82,6 +82,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         site_case_management_required: 'client need site-based case management',
         ongoing_case_management_required: 'client need ongoing housing case management',
         currently_fleeing: 'are you currently fleeing',
+        cas_pregnancy_status: 'Are you currently pregnant?',
       }.freeze
     end
     memoize :boolean_lookups
@@ -106,6 +107,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         site_case_management_required: 'Section D',
         ongoing_case_management_required: 'Section D',
         currently_fleeing: 'Section E',
+        cas_pregnancy_status: 'Section E',
       }
     end
 
@@ -146,6 +148,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         :rrh_desired,
         :required_minimum_occupancy,
         :required_number_of_bedrooms,
+        :cas_pregnancy_status,
       ]
     end
 
@@ -174,20 +177,18 @@ module GrdaWarehouse::CasProjectClientCalculator
       youth = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('youth')
 
       question_title = 'Are you a single parent with a child over the age of 10?'
-      single_parent = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+      single_parent = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('yes')
 
       question_title = 'Do you have legal custody'
-      custody_now = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+      custody_now = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('yes')
 
       question_title = 'If you do not have legal custody'
-      custody_later = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+      custody_later = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('yes')
 
-      question_title = 'Are you currently pregnant?'
-      pregnant = client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+      pregnant = for_boolean(client, :cas_pregnancy_status)
 
       # Pregnant clients are always considered a family
       return true if pregnant
-
       # There is a child, but the parent doesn't, and won't have custody
       return false if single_parent && (!custody_now && !custody_later)
       # Client indicated the household is adult only
@@ -233,7 +234,7 @@ module GrdaWarehouse::CasProjectClientCalculator
       question_title = 'Are you a single parent with'
       relevant_section = client.most_recent_tc_hat_for_destination.
         section_starts_with(section_title)
-      client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('Yes')
+      client.most_recent_tc_hat_for_destination.answer_from_section(relevant_section, question_title)&.downcase&.include?('yes')
     end
 
     private def neighborhood_ids_for_cas(client)

--- a/app/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
@@ -59,6 +59,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         required_number_of_bedrooms: 'Bedrooms required to house household',
         required_minimum_occupancy: 'Number of household members',
         child_in_household: 'Is the client a member of a household with at least one minor child',
+        cas_pregnancy_status: 'Are you currently pregnant?',
       }.freeze
     end
 
@@ -94,6 +95,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         legal_custody: :hat_a9_custody,
         future_custody: :hat_a10_future_custody,
         household_size: :hat_a8_household_size,
+        cas_pregnancy_status: :hat_e9_pregnant,
       }.freeze
     end
     memoize :assessment_keys
@@ -118,6 +120,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         :site_case_management_required,
         :ongoing_case_management_required,
         :currently_fleeing,
+        :cas_pregnancy_status,
       ].freeze
     end
     memoize :boolean_lookups
@@ -193,7 +196,10 @@ module GrdaWarehouse::CasProjectClientCalculator
       single_parent = for_boolean(client, :single_parent_child_over_ten)
       custody_now = for_boolean(client, :legal_custody)
       custody_later = for_boolean(client, :future_custody)
+      pregnant = for_boolean(client, :cas_pregnancy_status)
 
+      # Pregnant clients are always considered a family
+      return true if pregnant
       # There is a child, but the parent doesn't, and won't have custody
       return false if single_parent && (!custody_now && !custody_later)
       # Client indicated the household is adult only


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adjusts the calculation of `family_member` such that if a client has a `true` `pregnancy_status`, they are always marked as `family_member` `true`.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
