### PR TITLE
Make client alert expiry minimum tomorrow

### DIFF
--- a/drivers/hmis/lib/form_data/static/client_alert.json
+++ b/drivers/hmis/lib/form_data/static/client_alert.json
@@ -34,7 +34,8 @@
           "id": "min-expiration",
           "type": "MIN",
           "_comment": "entry date cannot be in the past",
-          "value_local_constant": "$tomorrow"
+          "value_local_constant": "$today",
+          "offset": 1
         }
       ]
     }

--- a/drivers/hmis/lib/form_data/static/client_alert.json
+++ b/drivers/hmis/lib/form_data/static/client_alert.json
@@ -34,7 +34,7 @@
           "id": "min-expiration",
           "type": "MIN",
           "_comment": "entry date cannot be in the past",
-          "value_local_constant": "$today"
+          "value_local_constant": "$tomorrow"
         }
       ]
     }


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a bug where creating an alert whose expiry date is equal to today causes the alert to immediately disappear since it's already expired. The desired behavior instead is that users shouldn't be able to create alerts that expire today. Alerts should expire tomorrow or later.
PT issue: [#187135490](https://www.pivotaltracker.com/story/show/187135490)
For once, I think, this warehouse PR depends on the frontend PR and not the other way around? 😮 so I'm not sure what that means with regards to the timing of releases, but let me know if there is anything I can do to help with keeping track of the timing relative to the release schedules of the two different repos.
https://github.com/greenriver/hmis-frontend/pull/670

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
