### PR TITLE
Always make HUD User optional

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment.rb
@@ -21,7 +21,7 @@ class Hmis::Hud::Assessment < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :assessment_questions, **hmis_relation(:AssessmentID, 'AssessmentQuestion'), dependent: :destroy
   has_many :assessment_results, **hmis_relation(:AssessmentID, 'AssessmentResult'), dependent: :destroy

--- a/drivers/hmis/app/models/hmis/hud/assessment_question.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_question.rb
@@ -17,5 +17,5 @@ class Hmis::Hud::AssessmentQuestion < Hmis::Hud::Base
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
 end

--- a/drivers/hmis/app/models/hmis/hud/assessment_result.rb
+++ b/drivers/hmis/app/models/hmis/hud/assessment_result.rb
@@ -17,5 +17,5 @@ class Hmis::Hud::AssessmentResult < Hmis::Hud::Base
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
 end

--- a/drivers/hmis/app/models/hmis/hud/ce_participation.rb
+++ b/drivers/hmis/app/models/hmis/hud/ce_participation.rb
@@ -13,5 +13,5 @@ class Hmis::Hud::CeParticipation < Hmis::Hud::Base
 
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects, optional: true
 end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -43,7 +43,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
 
   has_many :custom_assessments, through: :enrollments
 
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :clients
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :clients, optional: true
   has_many :income_benefits, through: :enrollments
   has_many :disabilities, through: :enrollments
   has_many :health_and_dvs, through: :enrollments

--- a/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
+++ b/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::CurrentLivingSituation < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -27,7 +27,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
   has_many :custom_data_elements, as: :owner, dependent: :destroy

--- a/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_case_note.rb
@@ -21,7 +21,7 @@ class Hmis::Hud::CustomCaseNote < Hmis::Hud::Base
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :custom_data_elements, as: :owner, dependent: :destroy
   accepts_nested_attributes_for :custom_data_elements, allow_destroy: true

--- a/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_address.rb
@@ -40,7 +40,7 @@ class Hmis::Hud::CustomClientAddress < Hmis::Hud::Base
   validates :enrollment_address_type, presence: { in: ENROLLMENT_TYPES }, allow_nil: true
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :enrollment, **hmis_relation(:EnrollmentID, 'Enrollment'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy

--- a/drivers/hmis/app/models/hmis/hud/custom_client_contact_point.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_contact_point.rb
@@ -31,7 +31,7 @@ class Hmis::Hud::CustomClientContactPoint < Hmis::Hud::Base
   ].freeze
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :ContactPointID]

--- a/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_client_name.rb
@@ -27,7 +27,7 @@ class Hmis::Hud::CustomClientName < Hmis::Hud::Base
   end
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_one :active_range, class_name: 'Hmis::ActiveRange', as: :entity, dependent: :destroy
   alias_to_underscore [:NameDataQuality, :CustomClientNameID, :PersonalID]

--- a/drivers/hmis/app/models/hmis/hud/custom_data_element.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_data_element.rb
@@ -29,7 +29,7 @@ class Hmis::Hud::CustomDataElement < Hmis::Hud::Base
 
   belongs_to :owner, polymorphic: true, optional: false
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :custom_data_elements
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :custom_data_elements
   belongs_to :data_element_definition, class_name: 'Hmis::Hud::CustomDataElementDefinition', optional: false
   delegate :key, :label, :repeats, to: :data_element_definition
 

--- a/drivers/hmis/app/models/hmis/hud/custom_data_element_definition.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_data_element_definition.rb
@@ -24,7 +24,7 @@ class Hmis::Hud::CustomDataElementDefinition < Hmis::Hud::Base
   SERVICE_OWNER_TYPES = ['Hmis::Hud::Service', 'Hmis::Hud::CustomService'].freeze
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :assessments
   belongs_to :custom_service_type, class_name: 'Hmis::Hud::CustomServiceType', optional: true
   has_many :values, class_name: 'Hmis::Hud::CustomDataElement', inverse_of: :data_element_definition, foreign_key: :data_element_definition_id
 

--- a/drivers/hmis/app/models/hmis/hud/custom_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service.rb
@@ -16,7 +16,7 @@ class Hmis::Hud::CustomService < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
+  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services, optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :custom_service_type
   alias_attribute :service_type, :custom_service_type

--- a/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::CustomServiceCategory < Hmis::Hud::Base
   has_paper_trail
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   has_many :service_types, class_name: 'Hmis::Hud::CustomServiceType'
 
   def to_pick_list_option

--- a/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
@@ -11,7 +11,7 @@ class Hmis::Hud::CustomServiceType < Hmis::Hud::Base
   has_paper_trail
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :custom_service_category
   has_many :custom_services
 

--- a/drivers/hmis/app/models/hmis/hud/disability.rb
+++ b/drivers/hmis/app/models/hmis/hud/disability.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::Disability < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
   def substance_use_type?

--- a/drivers/hmis/app/models/hmis/hud/employment_education.rb
+++ b/drivers/hmis/app/models/hmis/hud/employment_education.rb
@@ -15,6 +15,6 @@ class Hmis::Hud::EmploymentEducation < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -69,7 +69,7 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_many :files, class_name: '::Hmis::File', dependent: :destroy, inverse_of: :enrollment
 
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :enrollments
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :enrollments
   belongs_to :household, **hmis_relation(:HouseholdID, 'Household'), inverse_of: :enrollments, optional: true
   has_one :wip, class_name: 'Hmis::Wip', as: :source, dependent: :destroy
   has_many :custom_data_elements, as: :owner, dependent: :destroy

--- a/drivers/hmis/app/models/hmis/hud/event.rb
+++ b/drivers/hmis/app/models/hmis/hud/event.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::Event < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :events
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :events
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
   SORT_OPTIONS = [:event_date].freeze

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 

--- a/drivers/hmis/app/models/hmis/hud/funder.rb
+++ b/drivers/hmis/app/models/hmis/hud/funder.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::Funder < Hmis::Hud::Base
 
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :projects
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 
   accepts_nested_attributes_for :custom_data_elements, allow_destroy: true

--- a/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
+++ b/drivers/hmis/app/models/hmis/hud/health_and_dv.rb
@@ -14,6 +14,6 @@ class Hmis::Hud::HealthAndDv < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 end

--- a/drivers/hmis/app/models/hmis/hud/hmis_participation.rb
+++ b/drivers/hmis/app/models/hmis/hud/hmis_participation.rb
@@ -13,5 +13,5 @@ class Hmis::Hud::HmisParticipation < Hmis::Hud::Base
 
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :projects
 end

--- a/drivers/hmis/app/models/hmis/hud/hmis_service.rb
+++ b/drivers/hmis/app/models/hmis/hud/hmis_service.rb
@@ -16,7 +16,7 @@ class Hmis::Hud::HmisService < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :owner, polymorphic: true # Service or CustomService
   belongs_to :custom_service_type

--- a/drivers/hmis/app/models/hmis/hud/income_benefit.rb
+++ b/drivers/hmis/app/models/hmis/hud/income_benefit.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::IncomeBenefit < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 

--- a/drivers/hmis/app/models/hmis/hud/inventory.rb
+++ b/drivers/hmis/app/models/hmis/hud/inventory.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::Inventory < Hmis::Hud::Base
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 
   accepts_nested_attributes_for :custom_data_elements, allow_destroy: true

--- a/drivers/hmis/app/models/hmis/hud/organization.rb
+++ b/drivers/hmis/app/models/hmis/hud/organization.rb
@@ -13,7 +13,7 @@ class Hmis::Hud::Organization < Hmis::Hud::Base
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :projects, **hmis_relation(:OrganizationID, 'Project'), dependent: :destroy
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :organizations
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :organizations
   has_many :custom_data_elements, as: :owner, dependent: :destroy
   has_many :group_viewable_entity_projects
   has_many :group_viewable_entities, through: :group_viewable_entity_projects, source: :group_viewable_entity

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -17,7 +17,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :organization, **hmis_relation(:OrganizationID, 'Organization')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :projects
 
   # Affiliations to residential projects. This should only be present if this project is SSO or RRH Services Only.
   has_many :affiliations, **hmis_relation(:ProjectID, 'Affiliation'), inverse_of: :project

--- a/drivers/hmis/app/models/hmis/hud/project_coc.rb
+++ b/drivers/hmis/app/models/hmis/hud/project_coc.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::ProjectCoc < Hmis::Hud::Base
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
 
   def required_fields
     @required_fields ||= [

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :services
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true, inverse_of: :services
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :custom_data_elements, as: :owner, dependent: :destroy
 

--- a/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
+++ b/drivers/hmis/app/models/hmis/hud/youth_education_status.rb
@@ -14,6 +14,6 @@ class Hmis::Hud::YouthEducationStatus < Hmis::Hud::Base
 
   belongs_to :enrollment, **hmis_enrollment_relation, optional: true
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
-  belongs_to :user, **hmis_relation(:UserID, 'User')
+  belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

HUD User should always be optional. We get imported data with `UserID`s that don't map to users in the HUD table, and that's ok.

We should have done this a while ago. Whenever data is entered into HMIS we set the UserID to the current user, so this wasn't coming up much as an error –– but I have seen it occasionally. We shouldn't be failing on this when checking `valid?` on the records.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
