### PR TITLE
Remove import overrides that would have done nothing in previous version

### DIFF
--- a/db/warehouse/migrate/20240304181225_remove_incorrect_import_overrides.rb
+++ b/db/warehouse/migrate/20240304181225_remove_incorrect_import_overrides.rb
@@ -1,0 +1,21 @@
+class RemoveIncorrectImportOverrides < ActiveRecord::Migration[6.1]
+  def up
+    return unless RailsDrivers.loaded.include?(:hmis_csv_importer)
+
+    HmisCsvImporter::ImportOverride.where(
+      file_name: 'Inventory.csv',
+      replaces_column: ['CoCCode', 'InventoryStartDate', 'InventoryEndDate'],
+      replacement_value: [nil, ''],
+    ).delete_all
+    HmisCsvImporter::ImportOverride.where(
+      file_name: 'ProjectCoC.csv',
+      replaces_column: ['CoCCode', 'Zip', 'Geocode', 'GeographyType'],
+      replacement_value: [nil, '']
+    ).delete_all
+    HmisCsvImporter::ImportOverride.where(
+      file_name: 'Project.csv',
+      replaces_column: ['OperatingStartDate', 'OperatingEndDate', 'ProjectType'],
+      replacement_value: [nil, '']
+    ).delete_all
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -265,7 +265,7 @@ CREATE FUNCTION public.service_history_service_insert_trigger() RETURNS trigger
             INSERT INTO service_history_services_2001 VALUES (NEW.*);
          ELSIF  ( NEW.date BETWEEN DATE '2000-01-01' AND DATE '2000-12-31' ) THEN
             INSERT INTO service_history_services_2000 VALUES (NEW.*);
-
+        
       ELSE
         INSERT INTO service_history_services_remainder VALUES (NEW.*);
         END IF;
@@ -6193,7 +6193,9 @@ CREATE TABLE public.cohort_clients (
     user_boolean_46 boolean,
     user_boolean_47 boolean,
     user_boolean_48 boolean,
-    user_boolean_49 boolean
+    user_boolean_49 boolean,
+    sheltered_days_homeless_last_three_years integer,
+    unsheltered_days_homeless_last_three_years integer
 );
 
 
@@ -13335,40 +13337,6 @@ CREATE SEQUENCE public.hmis_assessments_id_seq
 --
 
 ALTER SEQUENCE public.hmis_assessments_id_seq OWNED BY public.hmis_assessments.id;
-
-
---
--- Name: hmis_auto_exit_configs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.hmis_auto_exit_configs (
-    id bigint NOT NULL,
-    length_of_absence_days integer NOT NULL,
-    project_type integer,
-    organization_id bigint,
-    project_id bigint,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: hmis_auto_exit_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.hmis_auto_exit_configs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: hmis_auto_exit_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.hmis_auto_exit_configs_id_seq OWNED BY public.hmis_auto_exit_configs.id;
 
 
 --
@@ -27870,13 +27838,6 @@ ALTER TABLE ONLY public.hmis_assessments ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
--- Name: hmis_auto_exit_configs id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_auto_exit_configs ALTER COLUMN id SET DEFAULT nextval('public.hmis_auto_exit_configs_id_seq'::regclass);
-
-
---
 -- Name: hmis_case_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -31665,14 +31626,6 @@ ALTER TABLE ONLY public.hmis_assessment_details
 
 ALTER TABLE ONLY public.hmis_assessments
     ADD CONSTRAINT hmis_assessments_pkey PRIMARY KEY (id);
-
-
---
--- Name: hmis_auto_exit_configs hmis_auto_exit_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_auto_exit_configs
-    ADD CONSTRAINT hmis_auto_exit_configs_pkey PRIMARY KEY (id);
 
 
 --
@@ -52250,20 +52203,6 @@ CREATE INDEX index_hmis_assessments_on_site_id ON public.hmis_assessments USING 
 
 
 --
--- Name: index_hmis_auto_exit_configs_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_auto_exit_configs_on_organization_id ON public.hmis_auto_exit_configs USING btree (organization_id);
-
-
---
--- Name: index_hmis_auto_exit_configs_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_auto_exit_configs_on_project_id ON public.hmis_auto_exit_configs USING btree (project_id);
-
-
---
 -- Name: index_hmis_case_notes_on_client_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -60901,4 +60840,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240217192729'),
 ('20240218201801'),
 ('20240218222444'),
-('20240220171320');
+('20240220171320'),
+('20240221195839'),
+('20240222152739'),
+('20240229132014'),
+('20240304181225');
+
+

--- a/drivers/hmis_csv_importer/app/controllers/hmis_csv_importer/import_overrides_controller.rb
+++ b/drivers/hmis_csv_importer/app/controllers/hmis_csv_importer/import_overrides_controller.rb
@@ -18,6 +18,9 @@ class HmisCsvImporter::ImportOverridesController < ApplicationController
   end
 
   def destroy
+    @override = import_override_source.find(params[:id].to_i)
+    @override.destroy
+    respond_with(@override, location: hmis_csv_importer_data_source_import_overrides_path(@data_source))
   end
 
   private def set_data_source

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
@@ -96,4 +96,14 @@ class HmisCsvImporter::ImportOverride < GrdaWarehouseBase
   def hud_key
     associated_class.hud_key.to_s
   end
+
+  def project
+    return [] unless associated_class.column_names.include?('ProjectID')
+    return [] if matched_hud_key.blank? && replaces_value.blank?
+
+    project_ids = associated_class.where(data_source_id: data_source_id).to_a.select do |row|
+      applies?(row)
+    end.map(&:ProjectID)
+    GrdaWarehouse::Hud::Project.where(data_source_id: data_source_id, ProjectID: project_ids).to_a
+  end
 end

--- a/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
+++ b/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
@@ -10,7 +10,15 @@
   %tbody
     - overrides.each do |override|
       %tr
-        %td= override.file_name
+        %td
+          = override.file_name
+          - projects = override.project
+          - if projects.any?
+            .associated-projects
+              Associated Project
+              %ul
+                - projects.each do |project|
+                  %li= link_to_if can_view_projects?, project.name(current_user, ignore_confidential_status: can_edit_projects?), project_path(project)
         %td= override.replaces_column
         %td= override.describe_with
         %td= override.describe_when


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* The previous override code handled empty values differently (they were ignored.) This removes any overrides where the result would have been to remove the value from the column.  The new system supports this, but incorrectly added overrides if the previous value was a blank string.
* Adds missing destroy logic for import overrides
* Additionally, this adds a link to the associated projects if any exists.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
