### PR TITLE
Add pick list for project's external forms

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -6350,6 +6350,11 @@ enum PickListType {
   """
   ENROLLMENTS_FOR_CLIENT
   ENROLLMENT_AUDIT_EVENT_RECORD_TYPES
+
+  """
+  External form types for the project.
+  """
+  EXTERNAL_FORM_TYPES_FOR_PROJECT
   GEOCODE
 
   """

--- a/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
@@ -34,6 +34,7 @@ module Types
     value 'AVAILABLE_FILE_TYPES'
     value 'ENROLLMENTS_FOR_CLIENT', 'Enrollments for the client, including WIP and Exited.'
     value 'OPEN_HOH_ENROLLMENTS_FOR_PROJECT', 'Open HoH enrollments at the project.'
+    value 'EXTERNAL_FORM_TYPES_FOR_PROJECT', 'External form types for the project.'
     value 'CE_EVENTS', 'Grouped HUD CE Event types'
     value 'ENROLLMENT_AUDIT_EVENT_RECORD_TYPES'
     value 'CLIENT_AUDIT_EVENT_RECORD_TYPES'

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -67,6 +67,8 @@ module Types
         open_hoh_enrollments_for_project(project)
       when 'ENROLLMENTS_FOR_CLIENT'
         enrollments_for_client(client, user: user)
+      when 'EXTERNAL_FORM_TYPES_FOR_PROJECT'
+        external_form_types_for_project(project)
       end
     end
 
@@ -396,6 +398,14 @@ module Types
           label: "#{client.brief_name} #{desc} (Entered #{en.entry_date.strftime('%m/%d/%Y')})",
         }
       end
+    end
+
+    def self.external_form_types_for_project(project)
+      return [] unless project.present?
+
+      Hmis::Form::Instance.for_project(project).
+        order(:id).
+        map(&:to_pick_list_option)
     end
 
     def self.enrollments_for_client(client, user:)

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -404,7 +404,7 @@ module Types
       return [] unless project.present?
 
       Hmis::Form::Instance.for_project(project).
-        joins(:definition).
+        preload(:definition).
         order(:id).
         map(&:to_pick_list_option)
     end

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -404,6 +404,7 @@ module Types
       return [] unless project.present?
 
       Hmis::Form::Instance.for_project(project).
+        joins(:definition).
         order(:id).
         map(&:to_pick_list_option)
     end

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -108,4 +108,8 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
     enrollment_match = Hmis::Form::InstanceEnrollmentMatch.new(instance: self, enrollment: enrollment)
     enrollment_match.valid? ? project_match(project) : nil
   end
+
+  def to_pick_list_option
+    { code: id, label: definition.title }
+  end
 end

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -110,6 +110,6 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   end
 
   def to_pick_list_option
-    { code: id, label: definition.title }
+    { code: definition.identifier, label: definition.title }
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This PR will enable the dropdown in the frontend for picking the type of external form before showing the table of form submissions. (The dropdown won't be shown if there is only one type of form for this project.)

@ttoomey I'm happy to wait and merge this onto the main branch after your PR is merged, or we can merge it to your current PR -- up to you!

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
