### PR TITLE
BUGFIX: To record a housing status, we need both a status and a date.

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -142,7 +142,7 @@ module Health
     #
     # Note that this is often called in an after_save hook, so care needs to be take not to create cycles
     def record_housing_status(status, on_date: Date.current)
-      return unless status.present?
+      return unless status.present? && on_date.present?
 
       prior_housing_status = recent_housing_status
       housing_status = if prior_housing_status&.collected_on == on_date


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix for case where if a case management note was added without a date, record_housing_status would fail.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
