### PR TITLE
BUGFIX: Don't create older housing status change QAs

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -154,7 +154,7 @@ module Health
         housing_statuses.create(collected_on: on_date, status: status)
       end
 
-      generate_daily_hrsn_qa(housing_status) if prior_housing_status.present?
+      generate_daily_hrsn_qa(housing_status) if prior_housing_status.present? && on_date > '2024-03-01'.to_date
       housing_status
     end
 
@@ -165,6 +165,7 @@ module Health
       return unless housing_status.positive_for_homelessness? && previous_status.present? && ! previous_status.positive_for_homelessness? # Only record no -> yes
 
       return if Health::QualifyingActivity.find_by(date_of_activity: housing_status.collected_on, activity: :sdoh_positive).present? # Don't duplicate QAs
+      return if housing_status.collected_on < Health::QualifyingActivityV2::EFFECTIVE_DATE_RANGE.first # SDoH QAs added in CP 2.0
 
       user = User.system_user # Mark created QAs as from the system
       ::Health::QualifyingActivity.create!(


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

We rebuild the patient history from EPIC daily, so we need to make sure we don't create older QAs based on historical data.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
