### PR TITLE
Add static form for reviewing external submissions

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3741,7 +3741,7 @@ type ExternalFormSubmission {
   definition: FormDefinition!
   id: ID!
   notes: String
-  spamScore: Float
+  spam: Boolean
   status: ExternalFormSubmissionStatus!
   submittedAt: ISO8601DateTime!
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3755,7 +3755,7 @@ input ExternalFormSubmissionFilterOptions {
 External Form Submission Input
 """
 input ExternalFormSubmissionInput {
-  note: String
+  notes: String
   spam: Boolean
   status: ExternalFormSubmissionStatus
 }
@@ -4134,6 +4134,11 @@ enum FormRole {
   External form
   """
   EXTERNAL_FORM
+
+  """
+  External form submission review
+  """
+  EXTERNAL_FORM_SUBMISSION_REVIEW
 
   """
   File
@@ -10682,6 +10687,11 @@ enum StaticFormRole {
   Client alert
   """
   CLIENT_ALERT
+
+  """
+  External form submission review
+  """
+  EXTERNAL_FORM_SUBMISSION_REVIEW
 
   """
   Form definition

--- a/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission.rb
@@ -15,7 +15,7 @@ module Types
 
     field :id, ID, null: false
     field :submitted_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :spam_score, Float, null: true
+    field :spam, Boolean, null: true
     field :status, HmisSchema::Enums::ExternalFormSubmissionStatus, null: false
     field :notes, String, null: true
     field :definition, Forms::FormDefinition, null: false

--- a/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission_input.rb
@@ -13,7 +13,11 @@ module Types
     argument :notes, String, required: false
 
     def to_params
-      to_h
+      {
+        status: status,
+        notes: notes,
+        spam_score: spam ? 0 : 1,
+      }
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission_input.rb
@@ -10,7 +10,7 @@ module Types
 
     argument :status, HmisSchema::Enums::ExternalFormSubmissionStatus, required: false
     argument :spam, Boolean, required: false
-    argument :note, String, required: false
+    argument :notes, String, required: false
 
     def to_params
       to_h

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -85,6 +85,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     :PROJECT_CONFIG,
     :CLIENT_ALERT,
     :FORM_DEFINITION,
+    :EXTERNAL_FORM_SUBMISSION_REVIEW,
   ].freeze
 
   # All form roles

--- a/drivers/hmis/lib/form_data/static/external_form_submission_review.json
+++ b/drivers/hmis/lib/form_data/static/external_form_submission_review.json
@@ -1,0 +1,22 @@
+{
+  "item": [
+    {
+      "type": "TEXT",
+      "link_id": "notes",
+      "text": "User Notes",
+      "mapping": {
+        "field_name": "notes"
+      },
+      "required": true
+    },
+    {
+      "link_id": "reviewed",
+      "type": "BOOLEAN",
+      "component": "CHECKBOX",
+      "text": "Mark reviewed",
+      "mapping": {
+        "field_name": "reviewed"
+      }
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/static/external_form_submission_review.json
+++ b/drivers/hmis/lib/form_data/static/external_form_submission_review.json
@@ -17,6 +17,15 @@
       "mapping": {
         "field_name": "reviewed"
       }
+    },
+    {
+      "link_id": "spam",
+      "type": "BOOLEAN",
+      "component": "CHECKBOX",
+      "text": "Spam",
+      "mapping": {
+        "field_name": "spam"
+      }
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/static/external_form_submission_review.json
+++ b/drivers/hmis/lib/form_data/static/external_form_submission_review.json
@@ -22,7 +22,7 @@
       "link_id": "spam",
       "type": "BOOLEAN",
       "component": "CHECKBOX",
-      "text": "Spam",
+      "text": "Mark spam",
       "mapping": {
         "field_name": "spam"
       }

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
@@ -11,6 +11,12 @@ module HmisExternalApis::ExternalForms
 
     has_many :custom_data_elements, as: :owner, dependent: :destroy, class_name: 'Hmis::Hud::CustomDataElement'
 
+    def spam
+      # The recaptcha spam score is a float between 0 (likely spam) and 1.0 (likely real)
+      # For now we will start with 0.5 as the threshold, maybe we will adjust in future
+      spam_score && spam_score < 0.5
+    end
+
     def self.apply_filters(input)
       Hmis::Filter::ExternalFormSubmissionFilter.new(input).filter_scope(self)
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This adds a static form role and json definition for the frontend form, so a user can review an external form submission, marking it as Reviewed or Spam and adding notes.

Following up on [this thread](https://github.com/greenriver/hmis-warehouse/pull/4037#discussion_r1517847147), this also makes some changes to the way spam score is passed around. It should be a boolean in the API, but a score (from recaptcha) in the backend. One thing I realized is that this means if the user manually marks something as spam, we will lose the recaptcha spam score from the database, since it gets overwritten with 1 or 0.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
