### PR TITLE
Make Form Definitions paranoid, restrict deleting them

### DIFF
--- a/db/warehouse/migrate/20240312153543_add_paranoid_definition.rb
+++ b/db/warehouse/migrate/20240312153543_add_paranoid_definition.rb
@@ -1,0 +1,6 @@
+class AddParanoidDefinition < ActiveRecord::Migration[6.1]
+  def change
+    # Add deleted_at for acts_as_paranoid
+    add_column :hmis_form_definitions, :deleted_at, :datetime
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -17048,7 +17048,8 @@ CREATE TABLE public.hmis_form_definitions (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     title character varying NOT NULL,
-    external_form_object_key character varying
+    external_form_object_key character varying,
+    deleted_at timestamp without time zone
 );
 
 
@@ -60823,6 +60824,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240223002628'),
 ('20240228192937'),
 ('20240229132014'),
-('20240304181225');
+('20240304181225'),
+('20240312153543');
 
 

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -25,13 +25,19 @@
 #     User-facing title of the form definition
 class Hmis::Form::Definition < ::GrdaWarehouseBase
   self.table_name = :hmis_form_definitions
+  acts_as_paranoid
+
+  # There is no need to track the JSON blob, because form should be immutable once they are managed through the Form Editor config tool.
+  # When changes are needed, they will be applied to a duplicated Hmis::Form::Definition with a bumped `version`.
+  has_paper_trail skip: [:definition] # skip controls whether paper_trail will save that field with the version record
+
   include Hmis::Hud::Concerns::HasEnums
 
   # convenience attr for passing graphql args
   attr_accessor :filter_context
 
-  has_many :instances, foreign_key: :definition_identifier, primary_key: :identifier
-  has_many :form_processors
+  has_many :instances, foreign_key: :definition_identifier, primary_key: :identifier, dependent: :restrict_with_exception
+  has_many :form_processors, dependent: :restrict_with_exception
   has_many :custom_service_types, through: :instances, foreign_key: :identifier, primary_key: :form_definition_identifier
 
   # Forms that are used for Assessments. These are submitted using SubmitAssessment mutation.

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -29,7 +29,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
 
   # There is no need to track the JSON blob, because form should be immutable once they are managed through the Form Editor config tool.
   # When changes are needed, they will be applied to a duplicated Hmis::Form::Definition with a bumped `version`.
-  has_paper_trail skip: [:definition] # skip controls whether paper_trail will save that field with the version record
+  has_paper_trail(
+    version: :paper_version, # dont conflict with `version` column. will this break something? https://github.com/paper-trail-gem/paper_trail#6-extensibility
+    skip: [:definition], # skip controls whether paper_trail will save that field with the version record
+  )
 
   include Hmis::Hud::Concerns::HasEnums
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

https://www.pivotaltracker.com/n/projects/2591838/stories/187150766
* Add restrictions around deleting FormDefinitions. Form Definitions are meant to be immutable once they are "published" (not yet in place). You should only be able to delete a form if it is not referenced by any form instances (aka rules) or form processors.
* Add acts as paranoid and paper trail to form definition

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
