### PR TITLE
Add permission caching that fixes bug with project deletion

### DIFF
--- a/drivers/hmis/app/graphql/mutations/delete_project.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project.rb
@@ -12,6 +12,11 @@ module Mutations
 
     def resolve(id:)
       record = Hmis::Hud::Project.viewable_by(current_user).find_by(id: id)
+
+      # While this is redundant with the viewable_by() scope above, this check caches the authorization result so that
+      # the project object-level authorization check will succeed even after the project has been deleted
+      access_denied! unless current_permission?(permission: :can_view_project, entity: record)
+
       default_delete_record(record: record, field_name: :project, permissions: :can_delete_project)
     end
   end

--- a/drivers/hmis/spec/requests/hmis/delete_project_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_project_spec.rb
@@ -1,0 +1,59 @@
+#  Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+#  License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+#
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  include_context 'hmis base setup'
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+  let!(:p2) { create :hud_project, data_source_id: ds1.id, OrganizationID: o1.OrganizationID }
+
+  let(:delete_mutation) do
+    <<~GRAPHQL
+      mutation DeleteProject($id: ID!) {
+        deleteProject(input: { id: $id }) {
+          project {
+            id
+            projectName
+            projectType
+          }
+          errors {
+            type
+            message
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  describe 'delete project query' do
+    before(:each) do
+      hmis_login(user)
+    end
+
+    it 'should successfully delete' do
+      response, result = post_graphql({ id: p1.id }) { delete_mutation }
+      expect(response.status).to eq(200)
+      deleted_project = result.dig('data', 'deleteProject', 'project')
+      expect(deleted_project).not_to be_nil
+      expect(deleted_project['id']).to eq(p1.id.to_s)
+      p1.reload
+      expect(p1.date_deleted).not_to be_nil
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

PT issue: https://www.pivotaltracker.com/story/show/187201007

**Description of bug**: When deleting a Project from the HMIS ui, the deletion modal wouldn't close on success. This was because the mutation wasn't returning the project's ID back with the successful response, which the `DeleteMutationButton` checks for, [here](https://github.com/greenriver/hmis-frontend/blob/5a89dcddcac5be5b9fabc9900994418acc66c3c2/src/modules/dataFetching/components/DeleteMutationButton.tsx#L61).

**What was the issue**: After the project was deleted, the project's `self.authorized?` [method](https://github.com/greenriver/hmis-warehouse/blob/a29e2f125380909658091f105babe4f80dcd6fd3/drivers/hmis/app/graphql/types/hmis_schema/project.rb#L29-L33) would return false.

Poking around, I thought maybe this issue would also affect the Enrollment and Client schema types, because both have similar `self.authorized?` checks on the schema object themselves. However, they aren't affected by the bug, it turns out for two different reasons:
- Enrollment: the `self.authorized` check also checks if the user has permission to view that enrollment's project ([here](https://github.com/greenriver/hmis-warehouse/blob/a29e2f125380909658091f105babe4f80dcd6fd3/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb#L42-L43)). Since the project still exists, even after the enrollment is deleted, this returns `true`
- Client: Someone already discovered this bug on the client deletion mutation, and added [this code](https://github.com/greenriver/hmis-warehouse/blob/a29e2f125380909658091f105babe4f80dcd6fd3/drivers/hmis/app/graphql/mutations/delete_client.rb#L23-L25) to mitigate.

**What I've changed here**: Added similar code to the delete project mutation. It caches the result of a permission call before the project is deleted, so the project can still be returned to the frontend in the response to the deletion call.

**Open questions**:
- This caching fix seems a bit rickety to me, should we investigate/discuss other solutions? Even if we keep this approach, should it be moved somewhere more central so it can be used in common?
- The ticket mentions, "We could modify the onSuccess so it doesn't care if the object is resolved. It doesn't really matter, we just need to ensure there are no errors, which it already checks." Having discovered this bug, should I still make that frontend change? Is there any concern that it could end up swallowing issues that we actually want to know about?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
