### PR TITLE
Bugfix in MigrateAssessmentsJob for generating empty intakes; performance improvement

### DIFF
--- a/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
@@ -67,7 +67,6 @@ module Hmis
       total = full_enrollment_scope.count
       Rails.logger.info "#{total} Enrollments to process"
 
-      # Note: joining with project drops WIP enrollments. That should be fine since they won't have assessment records yet.
       full_enrollment_scope.in_batches(of: 5_000) do |batch|
         # Build entry/exit assessments
         build_assessments(
@@ -108,6 +107,7 @@ module Hmis
     end
 
     def full_enrollment_scope
+      # Note: joining with project drops WIP enrollments. That should be fine since they won't have assessment records yet.
       @full_enrollment_scope ||= Hmis::Hud::Enrollment.joins(:project).merge(project_scope)
     end
 

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -384,11 +384,12 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
 
   def build_synthetic_intake_assessment
     assessment = Hmis::Hud::CustomAssessment.new(
-      enrollment: self,
-      client: client,
-      data_source: data_source,
+      CustomAssessmentID: Hmis::Hud::Base.generate_uuid,
+      enrollment_id: enrollment_id,
+      personal_id: personal_id,
       assessment_date: entry_date,
-      user: user, # same user that's on the enrollment
+      user_id: user_id || Hmis::Hud::User.system_user(data_source_id: data_source_id)&.user_id,
+      data_source_id: data_source_id,
       data_collection_stage: 1, # Intake
       wip: false,
     )

--- a/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
+++ b/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
       end
 
       it 'ignores records tied to wip enrollments' do
-        e1.save_in_progress!
+        e1.save_in_progress
         expect do
           Hmis::MigrateAssessmentsJob.perform_now(data_source_id: ds1.id)
         end.to change(e1.custom_assessments, :count).by(0)
@@ -160,6 +160,10 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
         expect(e2.intake_assessment.in_progress?).to eq(false)
         expect(e2.intake_assessment.assessment_date).to eq(e2.entry_date)
         expect(e2.intake_assessment.form_processor).not_to be_nil
+
+        # e1 should still only have 1 intake assessment, with the records present
+        expect(e1.custom_assessments.where(data_collection_stage: 1).count).to eq(1)
+        expect(e1.intake_assessment.form_processor.health_and_dv).to be_present
       end
 
       it 'works even if enrollment has a bad UserID' do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Fix a bug in `build_synthetic_intake_assessment` that would cause it to fail when `UserID` was unresolvable (aka ` enrollment.user` is nil) or when `UserID` was nil.
* Use AR Import to import CustomAssessment records, instead of calling `save!` on each individually.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
