### PR TITLE
Only send telehealth POS codes when the member is reached

### DIFF
--- a/app/models/health/qualifying_activity_v2.rb
+++ b/app/models/health/qualifying_activity_v2.rb
@@ -235,8 +235,11 @@ module Health
     end
 
     private def telehealth?
-      # Treat contact as telehealth unless a collateral is reached (so, no a failed contact is still telehealth)
-      @qa.mode_of_contact&.to_sym.in?([:video_call]) && @qa.reached_client.to_sym != :collateral
+      # Video calls are only considered telehealth is the client is reached
+      # Calls w/ collaterals are still coded as U3
+      # For missed calls, if they are marked with a telehealth POS, MH flags them for
+      # for the POS instead of their not being a contact, and this is confusing
+      @qa.mode_of_contact&.to_sym.in?([:video_call]) && @qa.reached_client.to_sym == :yes
     end
   end
 end

--- a/app/models/health/qualifying_activity_v3.rb
+++ b/app/models/health/qualifying_activity_v3.rb
@@ -245,8 +245,11 @@ module Health
     end
 
     private def telehealth?
-      # Treat contact as telehealth unless a collateral is reached (so, no a failed contact is still telehealth)
-      @qa.mode_of_contact&.to_sym.in?([:phone_call, :video_call]) && @qa.reached_client.to_sym != :collateral
+      # Calls are only considered telehealth is the client is reached
+      # Calls w/ collaterals are still coded as U3
+      # For missed calls, if they are marked with a telehealth POS, MH flags them for
+      # for the POS instead of their not being a contact, and this is confusing
+      @qa.mode_of_contact&.to_sym.in?([:phone_call, :video_call]) && @qa.reached_client.to_sym == :yes
     end
   end
 end

--- a/spec/models/health/claim_spec.rb
+++ b/spec/models/health/claim_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Health::Claim, type: :model do
     create(:qualifying_activity, patient_id: patient.id, date_of_activity: Date.yesterday, mode_of_contact: :phone_call,
                                  reached_client: :collateral, reached_client_collateral_contact: 'who', force_payable: true)
   end
+  let!(:qa7) do
+    create(:qualifying_activity, patient_id: patient.id, date_of_activity: Date.today, mode_of_contact: :phone_call,
+                                 reached_client: :no, force_payable: true)
+  end
   let!(:claim) { create :health_claim }
 
   before(:each) do
@@ -24,5 +28,8 @@ RSpec.describe Health::Claim, type: :model do
   it 'smoke test' do
     claim.build_claims_file
     claim.convert_claims_to_text
+    # binding.pry # 'puts claim.convert_claims_to_text' to bench check
   end
+
+  # TODO: automate the claims file introspection rather than bench checks
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Based on the RA from the MassHealth EDI testing environment, only send telehealth POS codes w/ telehealth modifiers if there is no client contact, as the POS code error gets flagged instead of that there was no contact.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
