### PR TITLE
Limit household calculations to CoCs as appropriate

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/household_type_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/household_type_calculations.rb
@@ -141,7 +141,9 @@ module
     end
 
     private def set_household_counts(household_scope, coc_code = base_count_sym)
-      household_scope.joins(enrollment: :client).preload(:client, enrollment: :client).distinct.find_each(batch_size: 1_000) do |enrollment|
+      scope = household_scope.joins(enrollment: :client).preload(:client, enrollment: :client).distinct
+      scope = scope.in_coc(coc_code: coc_code) unless coc_code.to_sym == base_count_sym
+      scope.find_each(batch_size: 1_000) do |enrollment|
         date = [enrollment.entry_date, filter.start_date].max
         age = GrdaWarehouse::Hud::Client.age(date: date, dob: enrollment.client&.DOB&.to_date)
         en = {


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Household calculations in the Demographic Summary report download weren't getting limited by CoC even though it appeared they should have been.  This fixes that.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
