### PR TITLE
Fix substance use config

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
@@ -169,12 +169,15 @@ module HmisExternalApis::TcHmis::Importers::Loaders
       expected = 0
       actual = 0
 
+      seen = Set.new
       records = [].tap do |cdes|
         rows.each do |row|
           expected += 1
           row_field_value = row.field_value(TOUCHPOINT_NAME)
           config = configs[row_field_value]
           next if config.blank?
+
+          seen.add(row_field_value)
 
           row_field_value = row_question_value(row)
           if config[:service_fields].keys.include?(row_field_value)
@@ -204,6 +207,8 @@ module HmisExternalApis::TcHmis::Importers::Loaders
         end
       end
       log_processed_result(name: 'create cdes', expected: expected, actual: actual)
+      missed = configs.keys - seen.to_a
+      log_info("did not find any values for #{missed.size} of #{configs.size} touchpoints: #{missed.sort.join(', ')}") if missed.any?
       records
     end
 
@@ -346,24 +351,6 @@ module HmisExternalApis::TcHmis::Importers::Loaders
               cleaner: ->(note) { note },
             },
           },
-        },
-        '1A-SA Breakfast' => {
-          service_type: 'Breakfast',
-          service_fields: {},
-          id_prefix: 'breakfast',
-          elements: {},
-        },
-        '1A-SA Lunch' => {
-          service_type: 'Lunch',
-          service_fields: {},
-          id_prefix: 'lunch',
-          elements: {},
-        },
-        '1-SA Dinner' => {
-          service_type: 'Dinner',
-          service_fields: {},
-          id_prefix: 'dinner',
-          elements: {},
         },
         'Budgeting/Financial Planning' => {
           service_type: 'Budgeting/Financial Planning',

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
@@ -489,31 +489,6 @@ module HmisExternalApis::TcHmis::Importers::Loaders
             },
           },
         },
-        'Substance Abuse Individual' => substance_abuse_config,
-        'Substance Abuse Group' => substance_abuse_config,
-      }.freeze
-    end
-
-    # several services user this same config, they are imported to the same service
-    def substance_abuse_config
-      {
-        service_type: 'Substance Abuse',
-        service_fields: {},
-        id_prefix: 'substance-abuse',
-        elements: {
-          'Contact Location/Method' => {
-            key: :service_contact_location,
-            cleaner: ->(location) { normalize_location(location) },
-          },
-          'Time Spent on Contact' => {
-            key: :service_time_spent,
-            cleaner: ->(time) { parse_duration(time) },
-          },
-          'Case Notes' => {
-            key: :service_notes,
-            cleaner: ->(note) { note },
-          },
-        },
         'Support Groups (Tenant Support Services)' => {
           service_type: 'Tenant Support Group',
           service_fields: {},
@@ -555,6 +530,31 @@ module HmisExternalApis::TcHmis::Importers::Loaders
               key: :services_provided_when_we_love,
               cleaner: ->(services) { services.split('|') },
             },
+          },
+        },
+        'Substance Abuse Individual' => substance_abuse_config,
+        'Substance Abuse Group' => substance_abuse_config,
+      }.freeze
+    end
+
+    # several services user this same config, they are imported to the same service
+    def substance_abuse_config
+      {
+        service_type: 'Substance Abuse',
+        service_fields: {},
+        id_prefix: 'substance-abuse',
+        elements: {
+          'Contact Location/Method' => {
+            key: :service_contact_location,
+            cleaner: ->(location) { normalize_location(location) },
+          },
+          'Time Spent on Contact' => {
+            key: :service_time_spent,
+            cleaner: ->(time) { parse_duration(time) },
+          },
+          'Case Notes' => {
+            key: :service_notes,
+            cleaner: ->(note) { note },
           },
         },
       }.dup.freeze


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

`Support Groups (Tenant Support Services)` and  `Case Management/Case Management notes` were inside substance_use_config. I think that must have been an accident. I haven't run this code change.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
