### PR TITLE
Hmis recent items and clients perf

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -178,7 +178,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/grda_warehouse/hud/project.rb",
-      "line": 313,
+      "line": 311,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"#{access_to_project_through_viewable_entities(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_organization(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_data_source(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_coc_codes(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)} OR #{access_to_project_through_project_access_groups(user, lambda do\n connection.quote(s)\n end, lambda do\n connection.quote_column_name(s)\n end)}\")",
       "render_path": null,
@@ -1264,6 +1264,29 @@
       "confidence": "Weak",
       "cwe_id": [
         22
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "608768d8d06f61fc8f52cd432a83ee4f1b2ec096b8bab3913f38b4cc7c80ffdf",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "drivers/hmis/app/models/hmis/hud/client.rb",
+      "line": 126,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "where(\"#{c_t[:id].to_sql} IN (#{[unenrolled.joins(:data_source).merge(GrdaWarehouse::DataSource.hmis(user)), joins(:projects).where(p_t[:id].in(Hmis::Hud::Project.with_access(user, *permissions, **kwargs).pluck(:id))), joins(:wip).where(wip_t[:project_id].in(Hmis::Hud::Project.with_access(user, *permissions, **kwargs).pluck(:id)))].map do\n s.select(c_t[:id].to_sql).to_sql\n end.join(\" UNION ALL \")})\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Hmis::Hud::Client",
+        "method": null
+      },
+      "user_input": "Hmis::Hud::Project.with_access(user, *permissions, **kwargs).pluck(:id)",
+      "confidence": "High",
+      "cwe_id": [
+        89
       ],
       "note": ""
     },
@@ -2395,7 +2418,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "drivers/homeless_summary_report/app/models/homeless_summary_report/report.rb",
-      "line": 961,
+      "line": 963,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "clients.send(variant).send(\"spm_#{field}\").average(\"spm_#{field}\")",
       "render_path": null,
@@ -3450,6 +3473,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-02-03 18:30:11 +0000",
+  "updated": "2024-03-17 23:49:45 +0000",
   "brakeman_version": "5.4.1"
 }

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -123,7 +123,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     ]
     sql = scopes.map { |s| s.select(c_t[:id].to_sql).to_sql }.join(' UNION ALL ')
 
-    where("#{c_t[:id].to_sql} IN (#{sql})")
+    where(c_t[:id].in(Arel.sql(sql)))
   end
 
   scope :visible_to, ->(user) do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

API performance on my local db with pg13 and ~400,000 clients and enrollments is quite poor. This PR helps some of the worst performing queries I see.

The change here is to the recent items and client authorization methods which have been adjusted to avoid plucking all visible client ids. Also added a limit to recent items, it should return a max of 10 items now.

### testing
* Recent items query should return in less than 3s (previously 6)
* Client pages should return more quickly

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Performance fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
