### PR TITLE
Rescue missing source data on account downloads page

### DIFF
--- a/app/views/account_downloads/_list.haml
+++ b/app/views/account_downloads/_list.haml
@@ -7,7 +7,12 @@
         %th Generated From
     %tbody
       - @items.each.map do |item|
-        - next unless item.generator_url
+        - url = nil
+        -# Attempt to fetch the url, sometimes the original item has been deleted, just remove showing those.
+        - begin
+          - url = item.generator_url
+        - rescue
+        - next unless url
         %tr
           %td
             = link_to item.download_title, item.download_url, download: 'download'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Sometimes the source (HUD report; cohort; etc.) are deleted after generating a file for downloading.  Rescue this situation and don't show the download if this is the case.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
