### PR TITLE
Enforce only one background report per type

### DIFF
--- a/app/jobs/reporting/hud/run_report_job.rb
+++ b/app/jobs/reporting/hud/run_report_job.rb
@@ -40,8 +40,7 @@ module Reporting::Hud
 
     private def requeue_job(class_name)
       # Re-queue this repot before processing if another report is running for the same class
-      # This should help prevent tying up delayed job workers that are really just waiting
-      # for the previous import to complete
+      # This should help prevent tying up delayed job workers when someone kicks off a dozen of the same report.
       a_t = Delayed::Job.arel_table
       job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
       return unless job_object

--- a/app/jobs/reporting/hud/run_report_job.rb
+++ b/app/jobs/reporting/hud/run_report_job.rb
@@ -7,24 +7,53 @@
 module Reporting::Hud
   class RunReportJob < BaseJob
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+    WAIT_MINUTES = 10
 
     def perform(class_name, report_id, email: true)
-      raise "Unknown HUD Report class: #{class_name}" unless Rails.application.config.hud_reports[class_name].present?
+      lock_obtained = HudReports::ReportInstance.with_advisory_lock(advisory_lock_name(class_name), timeout_seconds: 0) do
+        raise "Unknown HUD Report class: #{class_name}" unless Rails.application.config.hud_reports[class_name].present?
 
-      report = HudReports::ReportInstance.find_by(id: report_id)
-      # Occassionally people delete the report before it actually runs
-      return unless report.present?
+        report = HudReports::ReportInstance.find_by(id: report_id)
+        # Occassionally people delete the report before it actually runs
+        return unless report.present?
 
-      report.start_report
-      @generator = class_name.constantize.new(report)
-      @generator.class.questions.each do |q, klass|
-        next unless report.build_for_questions.include?(q)
+        report.start_report
+        @generator = class_name.constantize.new(report)
+        @generator.class.questions.each do |q, klass|
+          next unless report.build_for_questions.include?(q)
 
-        klass.new(@generator, report).run!
+          klass.new(@generator, report).run!
+        end
+
+        report_completed = report.complete_report
+        NotifyUser.driver_hud_report_finished(@generator).deliver_now if report.user_id && email
+        report_completed
       end
+      return if lock_obtained
 
-      report.complete_report
-      NotifyUser.driver_hud_report_finished(@generator).deliver_now if report.user_id && email
+      requeue_job(class_name)
+    end
+
+    private def advisory_lock_name(class_name)
+      "hud_report_#{class_name}"
+    end
+
+    private def requeue_job(class_name)
+      # Re-queue this repot before processing if another report is running for the same class
+      # This should help prevent tying up delayed job workers that are really just waiting
+      # for the previous import to complete
+      a_t = Delayed::Job.arel_table
+      job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
+      return unless job_object
+
+      Rails.logger.info("Report: #{class_name} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      new_job = job_object.dup
+      new_job.update(
+        locked_at: nil,
+        locked_by: nil,
+        run_at: Time.current + WAIT_MINUTES.minutes,
+        attempts: 0,
+      )
     end
   end
 end

--- a/app/jobs/warehouse_reports/generic_report_job.rb
+++ b/app/jobs/warehouse_reports/generic_report_job.rb
@@ -45,8 +45,7 @@ module WarehouseReports
 
     private def requeue_job(class_name)
       # Re-queue this repot before processing if another report is running for the same class
-      # This should help prevent tying up delayed job workers that are really just waiting
-      # for the previous import to complete
+      # This should help prevent tying up delayed job workers when someone kicks off a dozen of the same report.
       a_t = Delayed::Job.arel_table
       job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
       return unless job_object

--- a/app/jobs/warehouse_reports/generic_report_job.rb
+++ b/app/jobs/warehouse_reports/generic_report_job.rb
@@ -9,26 +9,56 @@ module WarehouseReports
     include ArelHelper
 
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+    WAIT_MINUTES = 10
 
     # NOTE: instances of report_class must provide `title`, `url`, and `run_and_save!` methods
     # `title` should return a string suitable for an email subject
     # `run_and_save!` should run whatever calculations are necessary and save the results
     # `url` must provide a link to the individual report
     def perform(user_id:, report_class:, report_id:)
-      klass = allowed_reports[report_class]
-      if klass
-        report = klass.find_by(id: report_id)
-        # Occassionally people delete the report before it actually runs
-        return unless report.present?
+      lock_obtained = HudReports::ReportInstance.with_advisory_lock(advisory_lock_name(report_class), timeout_seconds: 0) do
+        report_completed = false
+        klass = allowed_reports[report_class]
+        if klass
+          report = klass.find_by(id: report_id)
+          # Occassionally people delete the report before it actually runs
+          return unless report.present?
 
-        report.run_and_save!
+          report_completed = report.run_and_save!
 
-        NotifyUser.report_completed(user_id, report).deliver_later
-      else
-        setup_notifier('Generic Report Runner')
-        msg = "Unable to run report, #{report_class} is not included in the allowed list of reports."
-        @notifier.ping(msg) if @send_notifications
+          NotifyUser.report_completed(user_id, report).deliver_later
+        else
+          setup_notifier('Generic Report Runner')
+          msg = "Unable to run report, #{report_class} is not included in the allowed list of reports."
+          @notifier.ping(msg) if @send_notifications
+        end
+        report_completed
       end
+      return if lock_obtained
+
+      requeue_job(report_class)
+    end
+
+    private def advisory_lock_name(report_class)
+      "generic_report_#{report_class}"
+    end
+
+    private def requeue_job(class_name)
+      # Re-queue this repot before processing if another report is running for the same class
+      # This should help prevent tying up delayed job workers that are really just waiting
+      # for the previous import to complete
+      a_t = Delayed::Job.arel_table
+      job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
+      return unless job_object
+
+      Rails.logger.info("Report: #{class_name} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      new_job = job_object.dup
+      new_job.update(
+        locked_at: nil,
+        locked_by: nil,
+        run_at: Time.current + WAIT_MINUTES.minutes,
+        attempts: 0,
+      )
     end
 
     def allowed_reports


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add check to ensure only one report is run per reprot type at a time.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
