### PR TITLE
Fix broken project affiliation processing

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -59,6 +59,8 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :services, through: :enrollments_including_wip
   has_many :custom_services, through: :enrollments_including_wip
 
+  accepts_nested_attributes_for :affiliations, allow_destroy: true
+
   # FIXME: joining services through enrollments confounds postgres. On larger projects, the query might take many
   # minutes. It needs optimization; for now we use a class method instead of a AR association
   # has_many :hmis_services, through: :enrollments_including_wip


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix [bug](https://green-river.sentry.io/issues/5080132890/?alert_rule_id=14733065&alert_type=issue&environment=staging&notification_uuid=7e6a21a7-b6ca-4e12-bcae-1c6e0d5266c6&project=4503977346662400&referrer=slack) I introduced in PR https://github.com/greenriver/hmis-warehouse/pull/4086, add regression test

To test: project edit page, select Services Only, add affiliations

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
