### PR TITLE
Exporter incorrectly detecting override to PH

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment/overrides.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment/overrides.rb
@@ -68,7 +68,7 @@ module HmisCsvTwentyTwentyFour::Exporter
       # Not PH, no need to change
       return false unless existing_project_type.in?(psh_types)
 
-      last_loaded_project_type = row.project.loaded_items_2024.last&.ProjectType
+      last_loaded_project_type = row.project.loaded_items_2024.last&.ProjectType&.to_i
       # If we don't have a previous CSV version, we can't determine if it's been overridden
       return false if last_loaded_project_type.blank?
 

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
@@ -69,7 +69,7 @@ def setup_data
   columns = project.class.hmis_structure(version: '2024').keys.map(&:to_s)
   attributes = project.attributes.slice(*columns)
   attributes.merge!(
-    'ProjectType' => 1,
+    'ProjectType' => '1',
     'data_source_id' => project.data_source_id,
     'loaded_at' => DateTime.current - 1.days,
     'loader_id' => 1,

--- a/drivers/hmis_csv_twenty_twenty_two/app/models/hmis_csv_twenty_twenty_two/exporter/enrollment/overrides.rb
+++ b/drivers/hmis_csv_twenty_twenty_two/app/models/hmis_csv_twenty_twenty_two/exporter/enrollment/overrides.rb
@@ -82,7 +82,7 @@ module HmisCsvTwentyTwentyTwo::Exporter
       # Not PH, no need to change
       return false unless existing_project_type.in?(psh_types)
 
-      last_loaded_project_type = row.project.loaded_items_2022.last&.ProjectType
+      last_loaded_project_type = row.project.loaded_items_2022.last&.ProjectType&.to_i
       # If we don't have a previous CSV version, we can't determine if it's been overridden
       return false if last_loaded_project_type.blank?
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a situation where the exporter incorrectly identified a project as being overridden as PH and filled in the MoveInDate

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
