### PR TITLE
Fix bug in assessment eligibility logic

### DIFF
--- a/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
+++ b/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
@@ -42,7 +42,7 @@ class Hmis::EnrollmentAssessmentEligibilityList
     # Exit/Update/Annual can only be added to open enrollment
     roles << EXIT_ROLE unless assessment_started?(EXIT_ROLE)
     roles += [UPDATE_ROLE, ANNUAL_ROLE] unless assessment_submitted?(EXIT_ROLE)
-    roles << POST_EXIT_ROLE if assessment_submitted?(EXIT_ROLE) && !assessment_started?(POST_EXIT_ROLE) && enrollment.head_of_household?
+    roles << POST_EXIT_ROLE if assessment_submitted?(EXIT_ROLE) && !assessment_started?(POST_EXIT_ROLE)
     roles << CUSTOM_ASSESSMENT
 
     filtered_definitions(roles).each do |definition|

--- a/drivers/hmis/app/models/hmis/form/instance_enrollment_match.rb
+++ b/drivers/hmis/app/models/hmis/form/instance_enrollment_match.rb
@@ -29,6 +29,7 @@ class Hmis::Form::InstanceEnrollmentMatch
     when ALL_MATCH
       true
     when HOH_AND_ADULTS_MATCH
+      # HoH and Adults means that the form should be collected for the HoH AND and any adults in the household
       enrollment.head_of_household? || enrollment.adult?
     when HOH_MATCH
       enrollment.head_of_household?

--- a/drivers/hmis/app/models/hmis/form/instance_enrollment_match.rb
+++ b/drivers/hmis/app/models/hmis/form/instance_enrollment_match.rb
@@ -29,7 +29,7 @@ class Hmis::Form::InstanceEnrollmentMatch
     when ALL_MATCH
       true
     when HOH_AND_ADULTS_MATCH
-      enrollment.head_of_household? && enrollment.adult?
+      enrollment.head_of_household? || enrollment.adult?
     when HOH_MATCH
       enrollment.head_of_household?
     when ALL_VETERANS_MATCH

--- a/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
+++ b/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
@@ -1,0 +1,935 @@
+[
+  {
+    "link_id": "income-and-sources",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG – Collection required for all components except ES-NbN",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: Rural Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HUD-VASH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: PFS"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "HHS: PATH – Collection required for all components",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HHS: PATH"
+        },
+        {
+          "_comment": "HHS: RHY – Collection only required for MGH, TLP, and Demo",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 23},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 24},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 26}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "VA: SSVF – Collection required for RRH and Homelessness Prevention",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "VA: SSVF"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value": 12},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 30
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  },
+  {
+    "link_id": "non-cash-benefits",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG – Collection required for all components except ES-NbN",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: Rural Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HUD-VASH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: PFS"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "HHS: PATH – Collection required for all components",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HHS: PATH"
+        },
+        {
+          "_comment": "HHS: RHY – Collection only required for BCP (HP and ES), MGH, TLP, and Demo",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 22},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 23},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 24},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 26}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "VA: SSVF – Collection required for RRH and Homelessness Prevention",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "VA: SSVF"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value": 12},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 30
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  },
+  {
+    "link_id": "health-insurance",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG – Collection required for all components except ES-NbN",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: Rural Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HUD-VASH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: PFS"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "HHS: PATH – Collection required for all components",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HHS: PATH"
+        },
+        {
+          "_comment": "HHS: RHY – Collection required for all components",
+          "variable": "projectFunderComponents"                          ,
+          "operator": "INCLUDE"                                          ,
+          "value"   : "HHS: RHY"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "VA: SSVF – Collection required for RRH and Homelessness Prevention",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "VA: SSVF"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value": 12},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 30
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  },
+  {
+    "link_id": "disability-table",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG – Collection required for all components except ES-NbN",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 55},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6}  ,
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HUD-VASH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 35},
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "HHS: PATH – Collection required for all components",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HHS: PATH"
+        },
+        {
+          "_comment": "HHS: RHY – Collection required for all components",
+          "variable": "projectFunderComponents"                          ,
+          "operator": "INCLUDE"                                          ,
+          "value"   : "HHS: RHY"
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunderComponents"          ,
+          "operator": "INCLUDE"                          ,
+          "value"   : "VA: Community Contract Safe Haven"
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  },
+  {
+    "link_id": "disability-table-r4",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG – Collection required for all components except ES-NbN",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 55},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6}  ,
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 20
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 35},
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 30
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  },
+  {
+    "link_id": "4.11",
+    "_comment": "Default HUD Rules + Local/NA funders",
+    "rule": {
+      "operator": "ANY",
+      "parts": [
+        {
+          "_comment": "Local or N/A funder",
+          "operator": "ANY",
+          "parts": [
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 46},
+            {"variable": "projectFunders", "operator": "INCLUDE", "value": 34}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: CoC"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: ESG – Collection required for all components ",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HUD: ESG"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: ESG RUSH – Collection required for all components except Emergency Shelter or Street Outreach",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: ESG RUSH"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 0},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 1},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 4}
+          ]
+        },
+        {
+          "_comment": "HUD: HOPWA – Collection required for all components",
+          "variable": "projectFunderComponents"                            ,
+          "operator": "INCLUDE"                                            ,
+          "value"   : "HUD: HOPWA"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Unsheltered Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents"      ,
+              "operator": "INCLUDE"                      ,
+              "value"   : "HUD: Unsheltered Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: Rural Special NOFO – Collection required for all components except SSO Coordinated Entry",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: Rural Special NOFO"
+            },
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 6},
+            {"variable": "projectType", "operator": "NOT_EQUAL", "value": 14}
+          ]
+        },
+        {
+          "_comment": "HUD: HUD-VASH – Collection required for HUD VASH Collaborative Case Management",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HUD-VASH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "HUD: PFS – Collection required for all permanent housing projects",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "HUD: PFS"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value":  3},
+                {"variable": "projectType", "operator": "EQUAL", "value":  9},
+                {"variable": "projectType", "operator": "EQUAL", "value": 10},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "HHS: PATH – Collection required for all components",
+          "variable": "projectFunderComponents"                           ,
+          "operator": "INCLUDE"                                           ,
+          "value"   : "HHS: PATH"
+        },
+        {
+          "operator": "ALL",
+          "_comment": "VA: SSVF – Collection required for RRH and Homelessness Prevention",
+          "parts": [
+            {
+              "variable": "projectFunderComponents",
+              "operator": "INCLUDE"                ,
+              "value"   : "VA: SSVF"
+            },
+            {
+              "operator": "ANY",
+              "parts": [
+                {"variable": "projectType", "operator": "EQUAL", "value": 12},
+                {"variable": "projectType", "operator": "EQUAL", "value": 13}
+              ]
+            }
+          ]
+        },
+        {
+          "_comment": "VA: GPD – Collection required for all components",
+          "variable": "projectFunderComponents"                         ,
+          "operator": "INCLUDE"                                         ,
+          "value"   : "VA: GPD"
+        },
+        {
+          "_comment": "VA: Community Contract Safe Haven",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 30
+        },
+        {
+          "variable": "projectFunderComponents"              ,
+          "operator": "INCLUDE"                              ,
+          "value"   : "VA: CRS Contract Residential Services"
+        },
+        {
+          "_comment": "YHDP",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 43
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

1. Fix: `HoH and Adults` means that the form should be collected for the HoH AND and adults in the household
2. Fix: don't only show Post-Exit for HoH. Rely on the Form Instance which specifies the correct eligibility (HoH and Adults)

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
