### PR TITLE
Default to 99 for vsp value

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/organization.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/organization.rb
@@ -16,21 +16,17 @@ module Types
       Hmis::Hud::Organization.hmis_configuration(version: '2024')
     end
 
-    hud_field :id, ID, null: false
-    field :hud_id, ID, null: false
-    hud_field :organization_name
+    field :id, ID, null: false
+    field :hud_id, ID, null: false, method: :organization_id
+    field :organization_name, String, null: false
     projects_field :projects, filter_args: { omit: [:organization], type_name: 'ProjectsForEnrollment' }
-    hud_field :victim_service_provider, HmisSchema::Enums::Hud::NoYesMissing
+    field :victim_service_provider, HmisSchema::Enums::Hud::NoYesMissing, null: false, default_value: 99
     field :description, String, null: true
     field :contact_information, String, null: true
     custom_data_elements_field
     access_field do
       can :delete_organization
       can :edit_organization
-    end
-
-    def hud_id
-      object.organization_id
     end
 
     def projects(**args)


### PR DESCRIPTION


## Description

Resolve 99 for vsp field when nil

https://green-river.sentry.io/issues/5090154064/?referrer=slack&notification_uuid=c84ad516-c939-49b5-8a1c-6087220b2191&environment=production&alert_rule_id=14757490&alert_type=issue


To reproduce: create an organization with nil in the victim_service_provider column. Try to view in the HMIS.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
