### PR TITLE
Expose HMIS custom assessments on the client dashboard

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -397,6 +397,10 @@ module ApplicationHelper
     HmisEnforcement.hmis_admin_visible?(current_user)
   end
 
+  def url_for_hmis(data_source, path)
+    "//#{data_source.hmis}/#{path}"
+  end
+
   def omni_auth_providers
     if ENV['OKTA_DOMAIN'].present?
       [['Okta', '/users/auth/okta']]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -397,10 +397,6 @@ module ApplicationHelper
     HmisEnforcement.hmis_admin_visible?(current_user)
   end
 
-  def url_for_hmis(data_source, path)
-    "//#{data_source.hmis}/#{path}"
-  end
-
   def omni_auth_providers
     if ENV['OKTA_DOMAIN'].present?
       [['Okta', '/users/auth/okta']]

--- a/app/models/concerns/hmis_structure/user.rb
+++ b/app/models/concerns/hmis_structure/user.rb
@@ -11,6 +11,10 @@ module HmisStructure::User
   included do
     self.hud_key = :UserID
     acts_as_paranoid(column: :DateDeleted) unless included_modules.include?(Paranoia)
+
+    def name
+      "#{user_first_name} #{user_last_name}"
+    end
   end
 
   module ClassMethods

--- a/app/models/concerns/user_permissions.rb
+++ b/app/models/concerns/user_permissions.rb
@@ -20,7 +20,6 @@ module UserPermissions
         :can_assign_or_view_users_to_clients,
         :can_view_or_search_clients,
         :can_view_or_search_clients_or_window, # TODO: START_ACL remove after ACL migration is complete
-        :can_view_enrollment_details_tab, # TODO: START_ACL remove after ACL migration is complete
         :can_access_some_client_search,
         :can_view_enrollment_details_tab,
         :window_file_access,
@@ -87,7 +86,7 @@ module UserPermissions
     # END_ACL
 
     def can_view_enrollment_details_tab
-      can_view_clients? && can_view_enrollment_details?
+      can_view_clients? || can_view_enrollment_details?
     end
 
     # TODO: START_ACL remove after ACL migration is complete

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -567,6 +567,8 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
       "#{base}/client/#{entity.id}"
     when GrdaWarehouse::Hud::Enrollment
       "#{base}/client/#{entity.client&.id}/enrollments/#{entity.id}"
+    when Hmis::Hud::CustomAssessment
+      "#{base}/client/#{entity.enrollment&.client&.id}/enrollments/#{entity.enrollment&.id}/assessments/#{entity.id}"
     end
 
     # For any other Enrollment-related record, link to the enrollment page

--- a/app/models/grda_warehouse/hud/user.rb
+++ b/app/models/grda_warehouse/hud/user.rb
@@ -42,9 +42,5 @@ module GrdaWarehouse::Hud
 
     belongs_to :export, **hud_assoc(:ExportID, 'Export'), inverse_of: :users, optional: true
     belongs_to :data_source
-
-    def name
-      "#{user_first_name} #{user_last_name}"
-    end
   end
 end

--- a/app/views/clients/hud_assessments/show.haml
+++ b/app/views/clients/hud_assessments/show.haml
@@ -1,4 +1,4 @@
-- title = 'HUD Assessment'
+- title = 'HUD Coordinated Entry Assessment'
 - content_for :modal_title, title
 = content_for :crumbs do
   = link_to enrollment_details_client_path(@client) do

--- a/app/views/clients/hud_assessments/show.haml
+++ b/app/views/clients/hud_assessments/show.haml
@@ -20,9 +20,9 @@
         %dt Prioritization Status
         %dd= HudUtility2024.prioritization_status @assessment.PrioritizationStatus
         %dt Created
-        %dd= HudUtility2024.prioritization_status @assessment.DateCreated
+        %dd= @assessment.DateCreated
         %dt Updated
-        %dd= HudUtility2024.prioritization_status @assessment.DateUpdated
+        %dd= @assessment.DateUpdated
     - if @assessment.assessment_results.any?
       .assessment-results.ml-8
         %h3 Assessment Results

--- a/app/views/clients/rollup/_assessments.html.haml
+++ b/app/views/clients/rollup/_assessments.html.haml
@@ -5,8 +5,18 @@
 - if RailsDrivers.loaded.include?(:eccovia_data)
   - eccovia_assessments = @client.source_eccovia_assessments
 - if @client.source_assessments.exists?
-  - ce_assessments = @client.source_assessments.preload(:assessment_questions).to_a.group_by(&:name)
-- if hmis_forms.any? || eccovia_assessments.any? || ce_assessments.any?
+  - ce_assessments = @client.source_assessments.preload(:assessment_questions).to_a
+- custom_hmis_assessments = []
+- if HmisEnforcement.hmis_enabled?
+  - custom_hmis_assessments = @client.hmis_source_custom_assessments.order(assessment_date: :desc).preload(:user, enrollment: [:data_source, { project: :warehouse_project }], form_processor: :definition).to_a
+  -# remove any CE assessments for which we have a matching HMIS custom assessment.  The custom assessment will give better fidelity
+  -# we'll add back the ce assessment details on the show page
+  - custom_hmis_assessments.each do |assessment|
+    - ce_assessments.delete_if { |ce| ce.id == assessment.form_processor.ce_assessment_id }
+  - custom_hmis_assessments = custom_hmis_assessments.group_by { |a| a.form_processor.definition.title }
+
+- ce_assessments = ce_assessments.group_by(&:name)
+- if hmis_forms.any? || eccovia_assessments.any? || ce_assessments.any? || custom_hmis_assessments.any?
   - if hmis_forms.any?
     %table.table
       %thead
@@ -83,6 +93,40 @@
               %td= assessment.AssessmentDate
               %td= HudUtility2024.prioritization_status assessment.PrioritizationStatus
               %td= assessment.user&.name
+              %td.zero-width
+  - if custom_hmis_assessments.any?
+    %table.table
+      %thead
+        %tr
+          %th Assessment Name
+          %th Project
+          %th Collection Date
+          %th Staff
+          %th View in HMIS
+          %th
+      %tbody
+        - custom_hmis_assessments.each_with_index do |(name, (assessment, *assessments)), i|
+          - any_buttons = assessments.any?
+          - cz = "assessment_type_#{i}"
+          %tr{ class: ( 'assessment__new-type' if any_buttons )}
+            %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+            %td= assessment.enrollment.project.warehouse_project.name(current_user)
+            %td= assessment.AssessmentDate
+            %td= assessment.user&.name
+            - path = "client/#{assessment.enrollment.client.id}/enrollments/#{assessment.enrollment.id}/assessments/#{assessment.id}"
+            %td= link_to 'HMIS', url_for_hmis(assessment.enrollment.data_source, path), target: :_blank
+            %td.zero-width
+              - if any_buttons
+                %a.btn.btn-secondary.btn-xs.btn-icon-only.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
+                  %span.icon-plus
+          - assessments.each do |assessment|
+            %tr{ class: cz, style: 'display:none;' }
+              %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+              %td= assessment.enrollment.project.warehouse_project.name(current_user)
+              %td= assessment.AssessmentDate
+              %td= assessment.user&.name
+              - path = "client/#{assessment.enrollment.client.id}/enrollments/#{assessment.enrollment.id}/assessments/#{assessment.id}"
+              %td= link_to 'HMIS', url_for_hmis(assessment.enrollment.data_source, path), target: :_blank
               %td.zero-width
 
 - else

--- a/app/views/clients/rollup/_assessments.html.haml
+++ b/app/views/clients/rollup/_assessments.html.haml
@@ -13,7 +13,7 @@
   -# we'll add back the ce assessment details on the show page
   - custom_hmis_assessments.each do |assessment|
     - ce_assessments.delete_if { |ce| ce.id == assessment.form_processor.ce_assessment_id }
-  - custom_hmis_assessments = custom_hmis_assessments.group_by { |a| a.form_processor.definition.title }
+  - custom_hmis_assessments = custom_hmis_assessments.group_by(&:title)
 
 - ce_assessments = ce_assessments.group_by(&:name)
 - if hmis_forms.any? || eccovia_assessments.any? || ce_assessments.any? || custom_hmis_assessments.any?
@@ -77,7 +77,7 @@
           - any_buttons = assessments.any?
           - cz = "assessment_type_#{i}"
           %tr{ class: ( 'assessment__new-type' if any_buttons )}
-            %td= link_to name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+            %td= link_to_if can_view_enrollment_details_tab?, name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
             %td= HudUtility2024.assessment_type assessment.AssessmentType
             %td= assessment.AssessmentDate
             %td= HudUtility2024.prioritization_status assessment.PrioritizationStatus
@@ -88,7 +88,7 @@
                   %span.icon-plus
           - assessments.each do |assessment|
             %tr{ class: cz, style: 'display:none;' }
-              %td= link_to name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+              %td= link_to_if can_view_enrollment_details_tab? name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
               %td= HudUtility2024.assessment_type assessment.AssessmentType
               %td= assessment.AssessmentDate
               %td= HudUtility2024.prioritization_status assessment.PrioritizationStatus

--- a/app/views/clients/rollup/_assessments.html.haml
+++ b/app/views/clients/rollup/_assessments.html.haml
@@ -95,39 +95,7 @@
               %td= assessment.user&.name
               %td.zero-width
   - if custom_hmis_assessments.any?
-    %table.table
-      %thead
-        %tr
-          %th Assessment Name
-          %th Project
-          %th Collection Date
-          %th Staff
-          %th View in HMIS
-          %th
-      %tbody
-        - custom_hmis_assessments.each_with_index do |(name, (assessment, *assessments)), i|
-          - any_buttons = assessments.any?
-          - cz = "assessment_type_#{i}"
-          %tr{ class: ( 'assessment__new-type' if any_buttons )}
-            %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
-            %td= assessment.enrollment.project.warehouse_project.name(current_user)
-            %td= assessment.AssessmentDate
-            %td= assessment.user&.name
-            - path = "client/#{assessment.enrollment.client.id}/enrollments/#{assessment.enrollment.id}/assessments/#{assessment.id}"
-            %td= link_to 'HMIS', url_for_hmis(assessment.enrollment.data_source, path), target: :_blank
-            %td.zero-width
-              - if any_buttons
-                %a.btn.btn-secondary.btn-xs.btn-icon-only.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
-                  %span.icon-plus
-          - assessments.each do |assessment|
-            %tr{ class: cz, style: 'display:none;' }
-              %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
-              %td= assessment.enrollment.project.warehouse_project.name(current_user)
-              %td= assessment.AssessmentDate
-              %td= assessment.user&.name
-              - path = "client/#{assessment.enrollment.client.id}/enrollments/#{assessment.enrollment.id}/assessments/#{assessment.id}"
-              %td= link_to 'HMIS', url_for_hmis(assessment.enrollment.data_source, path), target: :_blank
-              %td.zero-width
+    = render 'hmis_client/assessments/table', custom_hmis_assessments: custom_hmis_assessments
 
 - else
   .no-data

--- a/drivers/hmis/app/controllers/hmis_client/assessments_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_client/assessments_controller.rb
@@ -1,0 +1,29 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class HmisClient::AssessmentsController < ApplicationController
+  include AjaxModalRails::Controller
+  include ClientDependentControllers
+
+  before_action :require_can_view_enrollment_details_tab!
+  before_action :client
+  before_action :assessment
+
+  # before_action :require_can_manage_client_files!, only: [:update]
+  after_action :log_client
+
+  def show
+  end
+
+  def client
+    @client ||= destination_searchable_client_scope.find(params[:client_id].to_i)
+  end
+
+  def assessment
+    @assessment ||= @client.hmis_source_custom_assessments.preload(:user, :custom_data_elements, enrollment: :project, form_processor: :definition).
+      find(params[:id].to_i)
+  end
+end

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -106,6 +106,10 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
     wip
   end
 
+  def hud_assessment?
+    HudUtility2024.data_collection_stages.keys.include?(data_collection_stage)
+  end
+
   def intake?
     data_collection_stage == 1
   end
@@ -124,6 +128,14 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   def update?
     data_collection_stage == 2
+  end
+
+  def title
+    title = HudUtility2024.assessment_name_by_data_collection_stage[data_collection_stage]
+    # TODO(#187248703): replace with `definition.title` via definition_identifier column once that relationship exists
+    title ||= form_processor&.definition&.title
+    title ||= 'Custom Assessment'
+    title
   end
 
   def save_submitted_assessment!(current_user:, as_wip: false)

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -59,6 +59,8 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :services, through: :enrollments_including_wip
   has_many :custom_services, through: :enrollments_including_wip
 
+  has_one :warehouse_project, class_name: 'GrdaWarehouse::Hud::Project', foreign_key: :id, primary_key: :id
+
   accepts_nested_attributes_for :affiliations, allow_destroy: true
 
   # FIXME: joining services through enrollments confounds postgres. On larger projects, the query might take many

--- a/drivers/hmis/app/views/hmis_client/assessments/_table.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/_table.haml
@@ -1,0 +1,31 @@
+%table.table
+  %thead
+    %tr
+      %th Assessment Name
+      %th Project
+      %th Collection Date
+      %th Staff
+      %th View in HMIS
+      %th
+  %tbody
+    - custom_hmis_assessments.each_with_index do |(name, (assessment, *assessments)), i|
+      - any_buttons = assessments.any?
+      - cz = "assessment_type_#{i}"
+      %tr{ class: ( 'assessment__new-type' if any_buttons )}
+        %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+        %td= assessment.enrollment.project.warehouse_project.name(current_user)
+        %td= assessment.AssessmentDate
+        %td= assessment.user&.name
+        %td= link_to 'HMIS', assessment.data_source.hmis_url_for(assessment), target: :_blank
+        %td.zero-width
+          - if any_buttons
+            %a.btn.btn-secondary.btn-xs.btn-icon-only.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
+              %span.icon-plus
+      - assessments.each do |assessment|
+        %tr{ class: cz, style: 'display:none;' }
+          %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+          %td= assessment.enrollment.project.warehouse_project.name(current_user)
+          %td= assessment.AssessmentDate
+          %td= assessment.user&.name
+          %td= link_to 'HMIS', assessment.data_source.hmis_url_for(assessment), target: :_blank
+          %td.zero-width

--- a/drivers/hmis/app/views/hmis_client/assessments/_table.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/_table.haml
@@ -5,7 +5,7 @@
       %th Project
       %th Collection Date
       %th Staff
-      %th View in HMIS
+      %th Source
       %th
   %tbody
     - custom_hmis_assessments.each_with_index do |(name, (assessment, *assessments)), i|
@@ -16,7 +16,10 @@
         %td= assessment.enrollment.project.warehouse_project.name(current_user)
         %td= assessment.AssessmentDate
         %td= assessment.user&.name
-        %td= link_to 'HMIS', assessment.data_source.hmis_url_for(assessment), target: :_blank
+        %td
+          = link_to assessment.data_source.hmis_url_for(assessment), target: :_blank do
+            Open in HMIS
+            %i.icon-link-ext
         %td.zero-width
           - if any_buttons
             %a.btn.btn-secondary.btn-xs.btn-icon-only.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
@@ -27,5 +30,8 @@
           %td= assessment.enrollment.project.warehouse_project.name(current_user)
           %td= assessment.AssessmentDate
           %td= assessment.user&.name
-          %td= link_to 'HMIS', assessment.data_source.hmis_url_for(assessment), target: :_blank
+          %td
+            = link_to assessment.data_source.hmis_url_for(assessment), target: :_blank do
+              Open in HMIS
+              %i.icon-link-ext
           %td.zero-width

--- a/drivers/hmis/app/views/hmis_client/assessments/_table.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/_table.haml
@@ -12,7 +12,7 @@
       - any_buttons = assessments.any?
       - cz = "assessment_type_#{i}"
       %tr{ class: ( 'assessment__new-type' if any_buttons )}
-        %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+        %td= link_to_if can_view_enrollment_details_tab?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
         %td= assessment.enrollment.project.warehouse_project.name(current_user)
         %td= assessment.AssessmentDate
         %td= assessment.user&.name
@@ -26,7 +26,7 @@
               %span.icon-plus
       - assessments.each do |assessment|
         %tr{ class: cz, style: 'display:none;' }
-          %td= link_to name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+          %td= link_to_if can_view_enrollment_details_tab?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
           %td= assessment.enrollment.project.warehouse_project.name(current_user)
           %td= assessment.AssessmentDate
           %td= assessment.user&.name

--- a/drivers/hmis/app/views/hmis_client/assessments/show.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/show.haml
@@ -1,0 +1,40 @@
+- title = @assessment.form_processor.definition.title
+- content_for :modal_title, title
+= content_for :crumbs do
+  = link_to appropriate_client_path(@client) do
+    &laquo; Client
+
+- related_ce_assessment = GrdaWarehouse::Hud::Assessment.find_by(id: @assessment.form_processor&.ce_assessment_id)
+.well
+  .d-flex
+    .assessment
+      %h3 Assessment Details
+      %dl
+        %dt Project
+        %dd= @assessment.enrollment.project.warehouse_project.name(current_user)
+        %dt Assessment Date
+        %dd= @assessment.AssessmentDate
+        - if related_ce_assessment.present?
+          %dt Assessment Level
+          %dd= HudUtility2024.assessment_level related_ce_assessment.AssessmentLevel
+          %dt Assessment Type
+          %dd= HudUtility2024.assessment_type related_ce_assessment.AssessmentType
+          %dt Prioritization Status
+          %dd= HudUtility2024.prioritization_status related_ce_assessment.PrioritizationStatus
+        %dt Created
+        %dd= @assessment.DateCreated
+        %dt Updated
+        %dd= @assessment.DateUpdated
+- if @assessment.custom_data_elements.any?
+  %h2 Questions
+  .well
+    - @assessment.custom_data_elements.each do |cde|
+      - cded = cde.data_element_definition
+      - label = cded.label
+      - key = cded.key # <== this is what is referenced as custom_Field_key in the form def
+      - value = cde.value # this is a function, it will read value_string,value_date etc.
+      %dl
+        %dt= label
+        %dd= value
+- else
+  .none-found No questions provided.

--- a/drivers/hmis/app/views/hmis_client/assessments/show.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/show.haml
@@ -1,4 +1,4 @@
-- title = @assessment.form_processor.definition.title
+- title = @assessment.title
 - content_for :modal_title, title
 = content_for :crumbs do
   = link_to appropriate_client_path(@client) do
@@ -36,5 +36,11 @@
       %dl
         %dt= label
         %dd= value
-- else
+- elsif !@assessment.hud_assessment?
   .none-found No questions provided.
+-# Always link to HMIS for HUD Assessments, since the majority of data is non-Custom so wont be shown here.
+- if @assessment.hud_assessment?
+  .none-found
+    %a{href: @assessment.data_source.hmis_url_for(@assessment), target: :blank}
+      Open in HMIS
+      %i.icon-link-ext.ml-2{style: 'color: inherit; font-size: inherit;'}

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -63,5 +63,11 @@ BostonHmis::Application.routes.draw do
       resources :access_controls
       resources :users, only: [:index, :edit, :update]
     end
+
+    namespace :hmis_client do
+      resources :clients, only: [:none] do
+        resources :assessments, only: [:show]
+      end
+    end
   end
 end

--- a/drivers/hmis/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/hmis/extensions/grda_warehouse/hud/client_extension.rb
@@ -10,6 +10,8 @@ module Hmis::GrdaWarehouse::Hud
 
     included do
       has_many :custom_client_addresses, **Hmis::Hud::Base.hmis_relation(:PersonalID, 'CustomClientAddress'), inverse_of: :client
+      has_many :hmis_custom_assessments, through: :enrollments
+      has_many :hmis_source_custom_assessments, through: :source_enrollments, source: :hmis_custom_assessments
 
       def as_hmis
         Hmis::Hud::Client.find(id)

--- a/drivers/hmis/extensions/grda_warehouse/hud/enrollment_extension.rb
+++ b/drivers/hmis/extensions/grda_warehouse/hud/enrollment_extension.rb
@@ -10,6 +10,7 @@ module Hmis::GrdaWarehouse::Hud
 
     included do
       has_many :custom_services, **Hmis::Hud::Base.hmis_enrollment_relation('CustomService'), inverse_of: :enrollment
+      has_many :hmis_custom_assessments, **Hmis::Hud::Base.hmis_enrollment_relation('CustomAssessment'), inverse_of: :enrollment
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This exposes HMIS custom assessments on the client dashboard in the warehouse.  These are added as rows to the Assessments card and have a link to the assessment in the HMIS as well as a modal that shows a very basic read-only view of the assessment in the same manner as ETO assessments or other similar items have been shown in the past.

Assessments are grouped by name with the most-recent by AssessmentDate visible, previous assessments are hidden behind the +.

### Custom Assessment in HMIS
<img width="1031" alt="Screenshot 2024-03-21 at 6 24 02 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/6e6a2f13-a9b2-4bff-ba2a-11a7807ef3d8">

### Client Dashboard in the Warehouse
<img width="958" alt="Screenshot 2024-03-21 at 6 21 31 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/809fd41a-7564-4f50-9f8a-78564ac181bb">

### Client Dashboard expanded
<img width="967" alt="Screenshot 2024-03-21 at 6 21 23 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/8254158c-7aa3-4ea4-8022-7318aea77522">

### Assessment modal in the warehouse (note it integrates some CE Assessment information at the top if a CE assessment is attached.)
<img width="737" alt="Screenshot 2024-03-21 at 6 20 19 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/01d049ab-601b-4f9b-b75d-94f9a35a9795">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
