### PR TITLE
187248703 custom assessments get definition identifiers

### DIFF
--- a/db/warehouse/migrate/20240317153543_add_definition_identifiers_to_custom_assessments.rb
+++ b/db/warehouse/migrate/20240317153543_add_definition_identifiers_to_custom_assessments.rb
@@ -1,0 +1,8 @@
+class AddDefinitionIdentifiersToCustomAssessments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :CustomAssessments, :form_definition_identifier, :string
+    safety_assured do
+      add_index :CustomAssessments, :form_definition_identifier
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -843,7 +843,8 @@ CREATE TABLE public."CustomAssessments" (
     "DateUpdated" timestamp without time zone NOT NULL,
     "DateDeleted" timestamp without time zone,
     wip boolean DEFAULT false NOT NULL,
-    lock_version integer DEFAULT 0 NOT NULL
+    lock_version integer DEFAULT 0 NOT NULL,
+    form_definition_identifier character varying
 );
 
 
@@ -50673,6 +50674,13 @@ CREATE INDEX "index_CurrentLivingSituation_on_pending_date_deleted" ON public."C
 
 
 --
+-- Name: index_CustomAssessments_on_definition_identifier; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX "index_CustomAssessments_on_definition_identifier" ON public."CustomAssessments" USING btree (form_definition_identifier);
+
+
+--
 -- Name: index_CustomCaseNote_on_EnrollmentID; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -62637,6 +62645,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240229132014'),
 ('20240304181225'),
 ('20240312153543'),
+('20240317153543'),
 ('20240319171241'),
 ('20240320134450'),
 ('20240320190835'),

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -37,6 +37,7 @@ module Types
       klass
     end
 
+    # object is a GrdaWarehouse::Version (papertrail)
     field :id, ID, null: false
     field :record_id, ID, null: false, method: :item_id
     field :record_name, String, null: false

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -39,6 +39,8 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   # convenience attr for passing graphql args
   attr_accessor :filter_context
 
+  has_many :custom_assessments, class_name: 'Hmis::Hud::CustomAssessment', dependent: :restrict_with_exception,
+                                primary_key: 'identifier', foreign_key: 'form_definition_identifier'
   has_many :instances, foreign_key: :definition_identifier, primary_key: :identifier, dependent: :restrict_with_exception
   has_many :form_processors, dependent: :restrict_with_exception
   has_many :custom_service_types, through: :instances, foreign_key: :identifier, primary_key: :form_definition_identifier

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -30,8 +30,10 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
-  # a better name would be "form_definition"
-  belongs_to :definition, primary_key: 'identifier', foreign_key: 'form_definition_identifier', class_name: 'Hmis::Form::Definition', optional: true
+  # WARNING: use form_processor.definition instead to get the specific version of the form definition
+  belongs_to :definition,
+             -> { from('(SELECT DISTINCT ON (identifier) * FROM hmis_form_definitions ORDER BY identifier, version DESC) as hmis_form_definitions') },
+             primary_key: 'identifier', foreign_key: 'form_definition_identifier', class_name: 'Hmis::Form::Definition', optional: true
 
   has_one :form_processor, class_name: 'Hmis::Form::FormProcessor', dependent: :destroy
   has_one :health_and_dv, through: :form_processor

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -30,9 +30,10 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   belongs_to :client, **hmis_relation(:PersonalID, 'Client')
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :assessments, optional: true
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+  # a better name would be "form_definition"
+  belongs_to :definition, primary_key: 'identifier', foreign_key: 'form_definition_identifier', class_name: 'Hmis::Form::Definition', optional: true
 
   has_one :form_processor, class_name: 'Hmis::Form::FormProcessor', dependent: :destroy
-  has_one :definition, through: :form_processor
   has_one :health_and_dv, through: :form_processor
   has_one :income_benefit, through: :form_processor
   has_one :physical_disability, through: :form_processor
@@ -132,10 +133,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
 
   def title
     title = HudUtility2024.assessment_name_by_data_collection_stage[data_collection_stage]
-    # TODO(#187248703): replace with `definition.title` via definition_identifier column once that relationship exists
-    title ||= form_processor&.definition&.title
-    title ||= 'Custom Assessment'
-    title
+    title || definition&.title.presence || 'Custom Assessment'
   end
 
   def save_submitted_assessment!(current_user:, as_wip: false)
@@ -176,6 +174,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
       user_id: user.user_id,
       assessment_date: assessment_date,
       data_collection_stage: Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[form_definition.role.to_sym] || 99,
+      form_definition_identifier: form_definition.identifier,
       **enrollment.slice(:data_source_id, :personal_id, :enrollment_id),
     )
     new_assessment.build_form_processor(definition: form_definition)

--- a/drivers/hmis/lib/tasks/one_time_migration_20240317.rake
+++ b/drivers/hmis/lib/tasks/one_time_migration_20240317.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+desc 'One time data migration to populate custom assessment definition identifiers'
+# rails driver:hmis:populate_assessment_definition_identifiers_20231121
+task populate_assessment_definition_identifiers_20231121: [:environment] do
+  # not running in a transaction custom assessments is fairly large, we expect the new relation to be null initially
+  # so rollback would just be `Hmis::Hud::CustomAssessment.update_all(form_definition_identifier: nil)`
+
+  # update the non-hud assessments
+  # (also updates deleted records)
+  Hmis::Hud::CustomAssessment.connection.execute <<~SQL
+    UPDATE "CustomAssessments"
+    SET "form_definition_identifier" = "hmis_form_definitions"."identifier"
+    FROM "hmis_form_processors", "hmis_form_definitions"
+    WHERE "hmis_form_processors"."custom_assessment_id" = "CustomAssessments"."id"
+      AND "CustomAssessments"."form_definition_identifier" IS NULL
+      AND "hmis_form_definitions"."id" = "hmis_form_processors"."definition_id"
+  SQL
+
+  # update hud assessments
+  arel = Hmis::ArelHelper.instance
+  data_source = GrdaWarehouse::DataSource.hmis.first!
+  Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES.each do |role, stage|
+    # This is expensive but needed as each project might have a different form definition for a given data collection stage
+    # {intake => [project_id, ...]}
+    project_ids_by_fd_identifier = {}
+    Hmis::Hud::Project.where(data_source: data_source).group_by do |project|
+      fd = Hmis::Form::Definition.find_definition_for_role(role, project: project)
+      next unless fd
+
+      project_ids_by_fd_identifier[fd.identifier] ||= []
+      project_ids_by_fd_identifier[fd.identifier].push(project.project_id)
+    end
+
+    project_ids_by_fd_identifier.each do |fd_identifier, project_ids|
+      assessment_scope = Hmis::Hud::CustomAssessment.with_deleted.
+        joins(:enrollment).
+        where(arel.e_t[:project_id].in(project_ids)).
+        where(data_collection_stage: stage).
+        where(form_definition_identifier: nil)
+      assessment_scope.update_all(form_definition_identifier: fd_identifier)
+    end
+  end
+end

--- a/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     after(:create) do |assessment, evaluator|
       assessment.build_form_processor(values: evaluator.values, hud_values: evaluator.hud_values, definition: evaluator.definition)
       assessment.form_processor.definition ||= build(:hmis_form_definition)
+      assessment.form_definition_identifier = assessment.form_processor.definition.identifier
       assessment.save!
     end
   end
@@ -52,6 +53,7 @@ FactoryBot.define do
     end
     after(:create) do |assessment, evaluator|
       assessment.form_processor = create(:hmis_form_processor, custom_assessment: assessment, values: evaluator.values, hud_values: evaluator.hud_values)
+      assessment.form_definition_identifier = assessment.form_processor.definition.identifier
       assessment.save_in_progress
     end
   end

--- a/drivers/hmis/spec/requests/hmis/enrollment_audit_history_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/enrollment_audit_history_spec.rb
@@ -80,4 +80,24 @@ RSpec.describe 'Client Audit History Query', type: :request do
       expect(records.dig(0, 'recordName')).to eq('Exit')
     end
   end
+
+  context 'enrollment with custom assessment' do
+    let(:form_definition) { create(:hmis_form_definition) }
+    let!(:custom_assessment) do
+      create(:hmis_custom_assessment, definition: form_definition, enrollment: e1, client: e1.client, data_source: ds1, data_collection_stage: 99)
+    end
+    shared_examples 'assesses correct title' do
+      it 'shows the correct assessment title' do
+        records = run_query(id: e1.id, filters: { enrollment_record_type: ['Hmis::Hud::CustomAssessment'] })
+        expect(records.dig(0, 'recordName')).to eq(form_definition.title)
+      end
+    end
+
+    include_examples 'assesses correct title'
+
+    context 'deleted' do
+      before(:each) { custom_assessment.destroy! }
+      include_examples 'assesses correct title'
+    end
+  end
 end

--- a/drivers/hmis/spec/requests/hmis/project_services_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_services_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect do
           response, result = post_graphql(id: p1.id, limit: limit) { query }
           expect(response.status).to eq(200), result.inspect
-        end.to perform_under(200).ms
+        end.to perform_under(300).ms
       end
     end
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

__NOTE:__ this is on hold pending additional discovery

[PT issue
](https://www.pivotaltracker.com/story/show/187248703)

Questions:
* some concerns of this relationship, see PT issue for details

Changes:
* add direct association between CustomAssessment and FormDefinition
* migration script to populate the new assocation
* restrict deletion of form definitions if they reference custom assessmens
* tests to ensure audit events can now find correct definition titles for deleted assessments
* adjust timeout on test to address CI failure

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
