### PR TITLE
rubocop

### DIFF
--- a/db/warehouse/migrate/20240320190835_add_service_referral_columns_to_report_path_client.rb
+++ b/db/warehouse/migrate/20240320190835_add_service_referral_columns_to_report_path_client.rb
@@ -1,6 +1,6 @@
 class AddServiceReferralColumnsToReportPathClient < ActiveRecord::Migration[6.1]
   def change
-    add_column :hud_report_path_clients, :cmh_service_provided, :boolean, default: false, null: false  
-    add_column :hud_report_path_clients, :cmh_referral_provided_and_attained, :boolean, default: false, null: false  
+    add_column :hud_report_path_clients, :cmh_service_provided, :boolean, default: false, null: false
+    add_column :hud_report_path_clients, :cmh_referral_provided_and_attained, :boolean, default: false, null: false
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/diversion_assessment_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/diversion_assessment_loader.rb
@@ -56,9 +56,5 @@ module HmisExternalApis::TcHmis::Importers::Loaders
     def ce_assessment_level
       1 # AssessmentLevel: 1 (crisis needs assessment)
     end
-
-    def ce_assessment_level
-      1 # AssessmentLevel: 1 (crisis needs assessment)
-    end
   end
 end


### PR DESCRIPTION
fix rubocop failures that slipped into the release somehow


## Type of change
[//]: # 'remove options that are not relevant'

- [x] Code clean-up / housekeeping


