### PR TITLE
Set unique ExportID when merging CSVs

### DIFF
--- a/drivers/datalab_testkit/app/models/datalab_testkit/testkit_csv_merge.rb
+++ b/drivers/datalab_testkit/app/models/datalab_testkit/testkit_csv_merge.rb
@@ -44,7 +44,7 @@ module DatalabTestkit
       source_table.each do |row|
         next if dups.include?(row[0])
 
-        row['ExportID'] = 'MERGED-ID'
+        row['ExportID'] = export_id(row)
         destination_table << row.values_at
       end
 
@@ -53,6 +53,10 @@ module DatalabTestkit
           csv << row
         end
       end
+    end
+
+    def export_id(row)
+      @export_id ||= "MERGED-ID-#{row['ExportID']}"
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Instead of setting ExportID to a constant, set it to `MERGED-ID-<export id from first file processed>`. When using the merger to import real data, this should prevent any problems around non-unique export ids.
* Instructions for running the merger are in the README of its driver

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
