### PR TITLE
rdoc patch CVE-2024-27281

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -718,7 +718,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     rbtree (0.4.6)
-    rdoc (6.3.2)
+    rdoc (6.3.4.1)
     redcarpet (3.5.1)
     redis (4.5.1)
     redis-actionpack (5.2.0)


### PR DESCRIPTION
## Description

Patch security issue  in rdoc for CI

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Dependency update
