### PR TITLE
Removed Clients Cohort Tab - restore clients

### DIFF
--- a/app/controllers/cohorts/clients_controller.rb
+++ b/app/controllers/cohorts/clients_controller.rb
@@ -54,7 +54,7 @@ module Cohorts
 
       @visible_columns = [CohortColumns::Meta.new]
       @visible_columns += @cohort.visible_columns(user: current_user)
-      delete_column = if params[:population] == 'deleted'
+      delete_column = if @cohort.deleted_clients_tab?(params[:population])
         CohortColumns::Delete.new(title: 'Restore')
       else
         CohortColumns::Delete.new

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -144,6 +144,14 @@ module GrdaWarehouse
       end
     end
 
+    def deleted_clients_tab?(population)
+      return true if population.to_s == 'deleted' # backwards compatibility
+
+      tab = cohort_tabs.find_by(name: population)
+      # If the source of the clients on this tab looks for deleted clients
+      tab.base_scope == 'only_deleted'
+    end
+
     private def active_tab(user, population)
       tab = cohort_tabs.find_by(name: population)
       return tab if tab&.show_for?(user)

--- a/app/views/cohorts/_client_table.haml
+++ b/app/views/cohorts/_client_table.haml
@@ -16,7 +16,7 @@
 
   .text-right.mt-4
     - if current_user.can_add_cohort_clients? && !(@cohort.system_cohort || @cohort.auto_maintained?)
-      - if @population.to_sym == :deleted
+      - if @cohort.deleted_clients_tab?(@population)
         - url = bulk_restore_cohort_cohort_clients_path(cohort_id: @cohort.id)
         = simple_form_for :cc, url: url, method: :post, html: {class: :jBulkDelete} do |f|
           = f.input :cohort_client_ids, as: :hidden, input_html: {class: :cohort_client_ids}


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes an issue where the restore clients button wasn't showing on the deleted clients tab on cohorts if the tab wasn't named "deleted".

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
