### PR TITLE
Client detail permissions

### DIFF
--- a/app/controllers/clients/enrollments_controller.rb
+++ b/app/controllers/clients/enrollments_controller.rb
@@ -10,7 +10,7 @@ module Clients
     include ClientPathGenerator
     include ClientDependentControllers
 
-    before_action :require_can_view_enrollment_details_tab!
+    before_action :require_can_view_enrollment_details!
     before_action :set_enrollment
 
     def show

--- a/app/controllers/clients/hud_assessments_controller.rb
+++ b/app/controllers/clients/hud_assessments_controller.rb
@@ -10,7 +10,7 @@ module Clients
     include AjaxModalRails::Controller
     include ClientDependentControllers
 
-    before_action :require_can_view_enrollment_details_tab!
+    before_action :require_can_view_enrollment_details!
     before_action :client
     before_action :assessment
 

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -16,7 +16,7 @@ class ClientsController < ApplicationController
 
   before_action :require_can_access_some_client_search!, only: [:simple]
   before_action :require_can_access_some_version_of_clients!, only: [:show, :service_range, :rollup, :image, :assessment]
-  before_action :require_can_view_enrollment_details_tab!, only: [:enrollment_details]
+  before_action :require_can_view_enrollment_details!, only: [:enrollment_details]
   before_action :require_can_see_this_client_demographics!, except: [:new, :create, :simple, :appropriate, :assessment, :health_assessment]
   before_action :require_can_edit_clients!, only: [:edit, :merge, :unmerge]
   before_action :require_can_create_clients!, only: [:new, :create]

--- a/app/models/concerns/user_permissions.rb
+++ b/app/models/concerns/user_permissions.rb
@@ -21,7 +21,6 @@ module UserPermissions
         :can_view_or_search_clients,
         :can_view_or_search_clients_or_window, # TODO: START_ACL remove after ACL migration is complete
         :can_access_some_client_search,
-        :can_view_enrollment_details_tab,
         :window_file_access,
         :can_access_vspdat_list,
         :can_create_or_modify_vspdat,
@@ -84,10 +83,6 @@ module UserPermissions
       can_view_clients? || can_search_window?
     end
     # END_ACL
-
-    def can_view_enrollment_details_tab
-      can_view_clients? || can_view_enrollment_details?
-    end
 
     # TODO: START_ACL remove after ACL migration is complete
     def can_access_window_search

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -527,7 +527,7 @@ class Role < ApplicationRecord
         sub_category: 'Privacy',
       },
       can_view_enrollment_details: {
-        description: 'Access to the enrollment details tab.  Users with Can View Clients get this automatically.',
+        description: 'Grants access to the enrollment details tab. Includes all related records such as Assessments, Services, Current Living Situations, and more.',
         administrative: false,
         category: 'Client Extras',
         sub_category: 'General Client Access',

--- a/app/views/clients/_enrollment_table.haml
+++ b/app/views/clients/_enrollment_table.haml
@@ -77,7 +77,7 @@
           - elsif e[:project_type_id].in?(HudUtility2024.project_types_with_move_in_dates)
             - title += ";<br /><b>Move-in Date:</b> No move-in date"
           %span{data: { toggle: :tooltip, title: title.html_safe, html: 'true' }}
-            - include_link = current_user.can_view_enrollment_details_tab?
+            - include_link = current_user.can_view_enrollment_details?
             = link_to_if include_link, e[:entry_date], client_enrollment_path(@client.id, e[:hmis_id])
           - if e[:chronically_homeless_at_start]
             %i.icon-passport{data: {toggle: :tooltip, title: 'Chronic at entry'}}

--- a/app/views/clients/_tab_navigation.haml
+++ b/app/views/clients/_tab_navigation.haml
@@ -29,7 +29,7 @@
     hmis.merge!({
       enrollment_details_client_path(@client) => {
         title: 'Enrollment Details',
-        permission: can_view_enrollment_details_tab? && show_demographic,
+        permission: can_view_enrollment_details? && show_demographic,
       },
       client_history_path(@client) => {
         title: 'History',

--- a/app/views/clients/rollup/_assessments.html.haml
+++ b/app/views/clients/rollup/_assessments.html.haml
@@ -77,7 +77,7 @@
           - any_buttons = assessments.any?
           - cz = "assessment_type_#{i}"
           %tr{ class: ( 'assessment__new-type' if any_buttons )}
-            %td= link_to_if can_view_enrollment_details_tab?, name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+            %td= link_to_if can_view_enrollment_details?, name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
             %td= HudUtility2024.assessment_type assessment.AssessmentType
             %td= assessment.AssessmentDate
             %td= HudUtility2024.prioritization_status assessment.PrioritizationStatus
@@ -88,7 +88,7 @@
                   %span.icon-plus
           - assessments.each do |assessment|
             %tr{ class: cz, style: 'display:none;' }
-              %td= link_to_if can_view_enrollment_details_tab?, name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+              %td= link_to_if can_view_enrollment_details?, name, client_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
               %td= HudUtility2024.assessment_type assessment.AssessmentType
               %td= assessment.AssessmentDate
               %td= HudUtility2024.prioritization_status assessment.PrioritizationStatus

--- a/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
+++ b/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
@@ -16,7 +16,7 @@ class ClientAccessControl::ClientsController < ApplicationController
 
   before_action :require_can_access_some_client_search!, only: [:index, :simple]
   before_action :require_can_access_some_version_of_clients!, only: [:show, :service_range, :rollup, :image]
-  before_action :require_can_view_enrollment_details_tab!, only: [:enrollment_details]
+  before_action :require_can_view_enrollment_details!, only: [:enrollment_details]
   before_action :require_can_see_this_client_demographics!, except: [:index, :simple, :appropriate, :new, :from_source]
   before_action :set_client, only: [:show, :service_range, :rollup, :image, :enrollment_details]
   before_action :require_can_create_clients!, only: [:new]

--- a/drivers/hmis/app/controllers/hmis_client/assessments_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_client/assessments_controller.rb
@@ -8,7 +8,7 @@ class HmisClient::AssessmentsController < ApplicationController
   include AjaxModalRails::Controller
   include ClientDependentControllers
 
-  before_action :require_can_view_enrollment_details_tab!
+  before_action :require_can_view_enrollment_details!
   before_action :client
   before_action :assessment
 

--- a/drivers/hmis/app/views/hmis_client/assessments/_table.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/_table.haml
@@ -12,7 +12,7 @@
       - any_buttons = assessments.any?
       - cz = "assessment_type_#{i}"
       %tr{ class: ( 'assessment__new-type' if any_buttons )}
-        %td= link_to_if can_view_enrollment_details_tab?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+        %td= link_to_if can_view_enrollment_details?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
         %td= assessment.enrollment.project.warehouse_project.name(current_user)
         %td= assessment.AssessmentDate
         %td= assessment.user&.name
@@ -26,7 +26,7 @@
               %span.icon-plus
       - assessments.each do |assessment|
         %tr{ class: cz, style: 'display:none;' }
-          %td= link_to_if can_view_enrollment_details_tab?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+          %td= link_to_if can_view_enrollment_details?, name, hmis_client_client_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
           %td= assessment.enrollment.project.warehouse_project.name(current_user)
           %td= assessment.AssessmentDate
           %td= assessment.user&.name


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This replaces `can_view_enrollment_details_tab` permission with `can_view_enrollment_details`.  Previously this had required `can_view_clients` as well, then it was changed to be an `or` so you could have either and see the details tab.  Decided this would be better as a stand-alone permission.

It should not affect existing installations since you had to have both `can_view_clients` and `can_view_enrollment_details` to see the pages.  

## Type of change
[//]: # 'remove options that are not relevant'

- [ ] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
