### PR TITLE
187269047-exclude-hmis-services-for-invalid-enrollments

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -239,6 +239,10 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     end
   end
 
+  scope :with_invalid_references, -> {
+    left_outer_joins(:client).where(c_t[:id].eq(nil))
+  }
+
   after_create :warehouse_trigger_processing
   after_update :warehouse_trigger_processing
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -69,7 +69,10 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   # minutes. It needs optimization; for now we use a class method instead of a AR association
   # has_many :hmis_services, through: :enrollments_including_wip
   def hmis_services
-    Hmis::Hud::HmisService.joins(:project).where(Hmis::Hud::Project.arel_table[:id].eq(id))
+    invalid_enrollment_ids = enrollments.with_invalid_references.pluck(e_t[:enrollment_id])
+    Hmis::Hud::HmisService.joins(:project).
+      where(Hmis::Hud::Project.arel_table[:id].eq(id)).
+      where(Hmis::Hud::HmisService.arel_table[:EnrollmentID].not_in(invalid_enrollment_ids))
   end
 
   has_and_belongs_to_many :project_groups,

--- a/drivers/hmis/spec/models/hmis/hud/hmis_service_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/hmis_service_spec.rb
@@ -1,0 +1,20 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+RSpec.describe Hmis::Hud::HmisService, type: :model do
+  let(:ds1) { create :hmis_data_source }
+  let!(:service_type) { create :hmis_custom_service_type_for_hud_service, data_source: ds1, name: 'some service' }
+  let!(:service) { create :hmis_hud_service, data_source: ds1, record_type: service_type.hud_record_type, type_provided: service_type.hud_type_provided }
+
+  it 'when an enrollment has an mismatched client, it is not included in services' do
+    project = service.enrollment.project
+    expect do
+      # update_column skips validation
+      service.enrollment.update_column(:personal_id, 'this_is_an_invalid_client_id')
+    end.to change(project.hmis_services, :count).by(-1)
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[PT issue](https://www.pivotaltracker.com/story/show/187269047)
Speculative solution to for services linked to invalid enrollments. Assumes relatively few invalid enrollments so breaking up into two queries might be faster than an additional join

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
