### PR TITLE
CoC and date range enforcement

### DIFF
--- a/app/models/filters/hud_filter_base.rb
+++ b/app/models/filters/hud_filter_base.rb
@@ -70,7 +70,7 @@ module Filters
         ids_with_enrollments = GrdaWarehouse::Hud::Project.
           where(id: effective_project_ids).
           joins(:enrollments).
-          merge(GrdaWarehouse::Hud::Enrollemnt.open_during_range(effective_range)).
+          merge(GrdaWarehouse::Hud::Enrollment.open_during_range(effective_range)).
           distinct.
           pluck(:id)
         ids_for_open_projects = GrdaWarehouse::Hud::Project.

--- a/app/models/filters/hud_filter_base.rb
+++ b/app/models/filters/hud_filter_base.rb
@@ -59,6 +59,16 @@ module Filters
       @effective_project_ids.uniq.reject(&:blank?)
     end
 
+    # Limit the effective project ids to only those with enrollments that overlap the report range
+    def effective_project_ids_with_ongoing_enrollments
+      @effective_project_ids_with_ongoing_enrollments ||= GrdaWarehouse::Hud::Project.
+        where(id: effective_project_ids).
+        joins(:enrollments).
+        merge(GrdaWarehouse::Hud::Enrollemnt.open_during_range(range)).
+        distinct.
+        pluck(:id)
+    end
+
     def apply(scope, except: [])
       # @filter is required for these to work
       @filter = self

--- a/app/models/filters/hud_filter_base.rb
+++ b/app/models/filters/hud_filter_base.rb
@@ -66,7 +66,8 @@ module Filters
     # the report range, and will allow the data quality checks for enrollments that are open
     # outside of the operating end dates
     def effective_project_ids_during_range(effective_range)
-      @effective_project_ids_during_range ||= begin
+      @effective_project_ids_during_range ||= {}
+      @effective_project_ids_during_range[effective_range] ||= begin
         ids_with_enrollments = GrdaWarehouse::Hud::Project.
           where(id: effective_project_ids).
           joins(:enrollments).
@@ -79,6 +80,8 @@ module Filters
           pluck(:id)
         (ids_with_enrollments + ids_for_open_projects).uniq
       end
+
+      @effective_project_ids_during_range[effective_range]
     end
 
     def apply(scope, except: [])

--- a/app/models/filters/hud_filter_base.rb
+++ b/app/models/filters/hud_filter_base.rb
@@ -65,17 +65,17 @@ module Filters
     # Looking for both of these will enable reporting on non-HMIS participating projects open during
     # the report range, and will allow the data quality checks for enrollments that are open
     # outside of the operating end dates
-    def effective_project_ids_during_range
+    def effective_project_ids_during_range(effective_range)
       @effective_project_ids_during_range ||= begin
         ids_with_enrollments = GrdaWarehouse::Hud::Project.
           where(id: effective_project_ids).
           joins(:enrollments).
-          merge(GrdaWarehouse::Hud::Enrollemnt.open_during_range(range)).
+          merge(GrdaWarehouse::Hud::Enrollemnt.open_during_range(effective_range)).
           distinct.
           pluck(:id)
         ids_for_open_projects = GrdaWarehouse::Hud::Project.
           where(id: effective_project_ids).
-          active_during(range).
+          active_during(effective_range).
           pluck(:id)
         (ids_with_enrollments + ids_for_open_projects).uniq
       end

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
@@ -41,6 +41,11 @@ module HmisCsvTwentyTwentyFour::Exporter
         enrollment_scope.
           modified_within_range(range: (export.start_date..export.end_date))
       end
+      # Limit to the chosen CoC codes if any are specified
+      # Also include any blank records since enrollment.EnrollmentCoC isn't always set correctly
+      filter = export.filter
+      export_scope = export_scope.where(EnrollmentCoC: filter.coc_codes + [nil]) if filter.coc_codes.any?
+
       note_involved_user_ids(scope: export_scope, export: export)
 
       export_scope.distinct.preload(:user, :project, client: :warehouse_client_source)

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/project_coc.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/project_coc.rb
@@ -28,6 +28,10 @@ module HmisCsvTwentyTwentyFour::Exporter
         hmis_class.where(project_exists_for_model(project_scope, hmis_class)).
           modified_within_range(range: (export.start_date..export.end_date))
       end
+      # Limit to the chosen CoC codes if any are specified
+      filter = export.filter
+      export_scope = export_scope.where(CoCCode: filter.coc_codes) if filter.coc_codes.any?
+
       note_involved_user_ids(scope: export_scope, export: export)
 
       export_scope.distinct.preload(:user, :project)

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb
@@ -1,0 +1,99 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'export_helper'
+require_relative './multi_enrollment_tests'
+
+def project_test_type
+  'enrollment date-based'
+end
+
+RSpec.describe HmisCsvTwentyTwentyFour::Exporter::Base, type: :model do
+  # Setup such that there are more than 3 of each item, but three fall within the date range
+  before(:all) do
+    cleanup_test_environment
+    setup_data
+
+    @coc_code = 'XX-500'
+
+    # Move 2 enrollments out of the range
+    en_1 = @enrollments.min_by(&:id)
+    en_1.update(EnrollmentCoC: nil)
+    en_2 = @enrollments.max_by(&:id)
+    en_2.update(EnrollmentCoC: 'XX-501')
+
+    # Move two unrelated project CoCs out of the range
+    p_cocs = @project_cocs.reject { |pc| pc.ProjectID.in?([en_1.ProjectID, en_1.ProjectID]) }.first(2)
+    p_cocs.first.update(CoCCode: nil)
+    p_cocs.last.update(CoCCode: 'XX-501')
+
+    @involved_project_ids = @projects.map(&:id)
+    @exporter = HmisCsvTwentyTwentyFour::Exporter::Base.new(
+      start_date: 3.week.ago.to_date,
+      end_date: 1.weeks.ago.to_date,
+      projects: @involved_project_ids,
+      coc_codes: [@coc_code], # Limit to one coc
+      period_type: 3,
+      directive: 3,
+      user_id: @user.id,
+    )
+    @exporter.export!(cleanup: false, zip: false, upload: false)
+  end
+
+  after(:all) do
+    @exporter.remove_export_files
+    cleanup_test_environment
+  end
+
+  def involved_projects
+    GrdaWarehouse::Hud::Project.where(id: @involved_project_ids)
+  end
+
+  def involved_enrollments
+    GrdaWarehouse::Hud::Enrollment.order(id: :asc).where(ProjectID: involved_projects.select(:ProjectID))
+  end
+
+  def involved_project_cocs
+    GrdaWarehouse::Hud::ProjectCoc.order(id: :asc).where(ProjectID: involved_projects.select(:ProjectID), CoCCode: @coc_code)
+  end
+
+  describe 'Exporting for one CoC' do
+    it 'enrollment scope should find two enrollments' do
+      expect(@exporter.enrollment_scope.count).to eq 2
+    end
+    it 'creates one CSV file' do
+      expect(File.exist?(csv_file_path(@enrollment_class))).to be true
+    end
+    it 'adds two rows to the enrollment CSV file' do
+      csv = CSV.read(csv_file_path(@enrollment_class), headers: true)
+      expect(csv.count).to eq 2
+    end
+    it 'EnrollmentIDs from CSV file match the ids of the two enrollments in the CoC or are blank' do
+      csv = CSV.read(csv_file_path(@enrollment_class), headers: true)
+      csv_ids = csv.map { |m| m['EnrollmentID'] }.sort
+      source_ids = involved_enrollments.select { |en| (en.EnrollmentCoC == @coc_code || en.EnrollmentCoC.blank?) && en.project.project_cocs.pluck(:CoCCode).include?(@coc_code) }.map(&:id).sort.map(&:to_s)
+      expect(csv_ids).to eq source_ids
+    end
+
+    it 'project_coc scope should find three enrollments' do
+      expect(@exporter.project_scope.joins(:project_cocs).count).to eq 3
+    end
+    it 'creates one CSV file' do
+      expect(File.exist?(csv_file_path(@project_coc_class))).to be true
+    end
+    it 'adds three rows to the project_coc CSV file' do
+      csv = CSV.read(csv_file_path(@project_coc_class), headers: true)
+      expect(csv.count).to eq 3
+    end
+    it 'ProjectCoC from CSV file match the ids of the three project CoCs in the CoC' do
+      csv = CSV.read(csv_file_path(@project_coc_class), headers: true)
+      csv_ids = csv.map { |m| m['ProjectCoCID'] }.sort
+      source_ids = involved_project_cocs.select { |en| en.CoCCode == @coc_code }.map(&:id).sort.map(&:to_s)
+      expect(csv_ids).to eq source_ids
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/export_helper.rb
@@ -16,10 +16,11 @@ def setup_data
   @organizations = create_list :hud_organization, 5, data_source_id: @data_source.id
   @inventories = create_list :hud_inventory, 5, data_source_id: @data_source.id
   @affiliations = create_list :hud_affiliation, 5, data_source_id: @data_source.id
-  @project_cocs = create_list :hud_project_coc, 5, data_source_id: @data_source.id
+  @project_cocs = create_list :hud_project_coc, 5, data_source_id: @data_source.id, CoCCode: 'XX-500'
   @funders = create_list :hud_funder, 5, data_source_id: @data_source.id
 
-  @enrollments = create_list :hud_enrollment, 5, data_source_id: @data_source.id, EntryDate: 2.weeks.ago, PreferredLanguageDifferent: 'a' * 200
+  @enrollments = create_list :hud_enrollment, 5, data_source_id: @data_source.id, EntryDate: 2.weeks.ago, PreferredLanguageDifferent: 'a' * 200, EnrollmentCoC: 'XX-500'
+
   @clients = create_list(
     :hud_client,
     5,

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
@@ -207,7 +207,7 @@ module HudLsa::Generators::Fy2023
         version: '2024',
         start_date: lookback_stop_date,
         end_date: filter.end,
-        projects: filter.effective_project_ids,
+        projects: filter.effective_project_ids_with_ongoing_enrollments,
         coc_codes: filter.coc_code,
         period_type: 3,
         directive: 2,

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
@@ -119,7 +119,7 @@ module HudLsa::Generators::Fy2023
     # Any structural failures that will cause the run to fail should be caught here
     private def preflight_passes?
       issues = missing_data(user).except(:show_missing_data)
-      issue_project_ids = issues.values.flatten.map { |r| r[:id] }.uniq & filter.effective_project_ids_during_range(lookback_stop_date .. filter.end)
+      issue_project_ids = issues.values.flatten.map { |r| r[:id] }.uniq & filter.effective_project_ids_during_range(export_date_range)
       return true if issue_project_ids.empty?
 
       # Prevent report.complete_report from hiding the error
@@ -140,7 +140,7 @@ module HudLsa::Generators::Fy2023
       load 'lib/rds_sql_server/lsa/fy2023/lsa_queries.rb'
       rep = LsaSqlServer::LSAQueries.new
       rep.test_run = test?
-      rep.project_ids = filter.effective_project_ids_during_range(lookback_stop_date .. filter.end)
+      rep.project_ids = filter.effective_project_ids_during_range(export_date_range)
 
       # some setup
       if test?
@@ -169,6 +169,16 @@ module HudLsa::Generators::Fy2023
       create_summary_result(summary: summary.fetch_summary)
     end
 
+    private def export_date_range
+      # Special case for HIC.  This will generally be a 1 day run,
+      # but check for a slightly larger range since the LSA will almost always be a year.
+      # When running the HIC, we don't want the full look-back because it will include
+      # projects that were not operating during the report range, and thus shouldn't be included in the HIC
+      return filter.range if filter.range.count < 5
+
+      lookback_stop_date .. filter.end
+    end
+
     def create_hmis_csv_export
       return if test?
 
@@ -184,7 +194,7 @@ module HudLsa::Generators::Fy2023
         existing_export = GrdaWarehouse::HmisExport.order(created_at: :desc).limit(1).
           where(
             created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day,
-            start_date: lookback_stop_date,
+            start_date: export_date_range.first,
             version: 2024,
             period_type: 3,
             directive: 2,
@@ -193,8 +203,8 @@ module HudLsa::Generators::Fy2023
           ).
           # where project_ids contains the effective project ids, and effective contains the project ids
           # (equivalency without sort)
-          where('project_ids @> ?', filter.effective_project_ids_during_range(lookback_stop_date .. filter.end).to_json).
-          where('project_ids <@ ?', filter.effective_project_ids_during_range(lookback_stop_date .. filter.end).to_json).
+          where('project_ids @> ?', filter.effective_project_ids_during_range(export_date_range).to_json).
+          where('project_ids <@ ?', filter.effective_project_ids_during_range(export_date_range).to_json).
           where.not(file: nil)&.first
         if existing_export.present?
           @hmis_export = existing_export
@@ -205,9 +215,9 @@ module HudLsa::Generators::Fy2023
 
       @hmis_export = HmisCsvTwentyTwentyFour::Exporter::Base.new(
         version: '2024',
-        start_date: lookback_stop_date,
-        end_date: filter.end,
-        projects: filter.effective_project_ids_during_range(lookback_stop_date .. filter.end),
+        start_date: export_date_range.first,
+        end_date: export_date_range.last,
+        projects: filter.effective_project_ids_during_range(export_date_range),
         coc_codes: filter.coc_code,
         period_type: 3,
         directive: 2,

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
@@ -207,7 +207,7 @@ module HudLsa::Generators::Fy2023
         version: '2024',
         start_date: lookback_stop_date,
         end_date: filter.end,
-        projects: filter.effective_project_ids_with_ongoing_enrollments,
+        projects: filter.effective_project_ids_during_range,
         coc_codes: filter.coc_code,
         period_type: 3,
         directive: 2,

--- a/spec/models/filters/filter_base_spec.rb
+++ b/spec/models/filters/filter_base_spec.rb
@@ -89,5 +89,16 @@ RSpec.describe Filters::FilterBase, type: :model do
       expect(filter.effective_project_ids).not_to include es_project.id
       expect(filter.effective_project_ids).not_to include psh_project.id
     end
+
+    it 'includes and excludes projects based on operating start and end dates' do
+      psh_project.update(OperatingStartDate: '2020-01-01', OperatingEndDate: '2020-02-01')
+      es_project.update(OperatingStartDate: '2020-01-01', OperatingEndDate: '2021-01-05')
+      filter_params = {
+        project_type_codes: [:ph, :es],
+      }
+      filter = Filters::HudFilterBase.new(user_id: user.id).update(filter_params)
+      expect(filter.effective_project_ids_during_range('2021-01-01'.to_date .. '2021-02-01'.to_date)).not_to include psh_project.id
+      expect(filter.effective_project_ids_during_range('2021-01-01'.to_date .. '2021-02-01'.to_date)).to include es_project.id
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This does two things:
1. Enforces CoC code the HMIS CSV exporter
 a. if you choose a CoC Code and projects that don't operate in that CoC, the exporter will ignore the projects
 b. if you choose a CoC Code and project operates in more than one CoC, then only the data (Project CoC and Enrollment) for the chosen CoC Code will be exported.
2. For the LSA (and probably in the future all HUD reports) we now limit the project IDs to those that operate during the reporting range OR have ongoing enrollments that overlap the reporting range.  That way if you pick a project with no enrollments that is closed, it will be ignored. 
 
## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
