### PR TITLE
Add cleanup function for fixing incorrect PersonalID references, other clean fn improvements and tests

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -21,33 +21,45 @@ module Hmis::Hud::Concerns::Shared
       "GrdaWarehouse::Hud::#{self.class.name.demodulize}".constantize.find(id)
     end
 
-    def self.hud_class_names
+    def self.enrollment_related_hud_class_names
       [
-        'Export',
-        'Organization',
-        'Project',
-        'Client',
         'Disability',
         'EmploymentEducation',
-        'Enrollment',
-        'HmisParticipation',
-        'CeParticipation',
         'Exit',
-        'Funder',
         'HealthAndDv',
         'IncomeBenefit',
-        'Inventory',
-        'ProjectCoc',
-        'Affiliation',
         'Service',
         'CurrentLivingSituation',
         'Assessment',
         'AssessmentQuestion',
         'AssessmentResult',
         'Event',
-        'User',
         'YouthEducationStatus',
       ].freeze
+    end
+
+    def self.hud_class_names
+      [
+        *enrollment_related_hud_class_names,
+        'Export',
+        'Organization',
+        'Project',
+        'Client',
+        'Enrollment',
+        'HmisParticipation',
+        'CeParticipation',
+        'Funder',
+        'Inventory',
+        'ProjectCoc',
+        'Affiliation',
+        'User',
+      ].freeze
+    end
+
+    def self.hmis_enrollment_related_classes
+      enrollment_related_hud_class_names.map do |name|
+        "Hmis::Hud::#{name}".constantize
+      end
     end
 
     def self.hmis_classes

--- a/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
+++ b/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
@@ -22,7 +22,7 @@ class Hmis::Hud::CurrentLivingSituation < Hmis::Hud::Base
   after_commit :warehouse_trigger_processing
 
   private def warehouse_trigger_processing
-    return unless warehouse_columns_changed?
+    return unless enrollment && warehouse_columns_changed?
 
     # NOTE: we only really need to do this for SO at the moment, but this is future-proofing against
     # pre-processing CLS in other enrollments

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -32,7 +32,7 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
   end
 
   private def warehouse_trigger_processing
-    return unless warehouse_columns_changed?
+    return unless enrollment && warehouse_columns_changed?
 
     enrollment.invalidate_processing!
     queue_service_history_processing!

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -32,7 +32,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
   after_commit :warehouse_trigger_processing
 
   private def warehouse_trigger_processing
-    return unless warehouse_columns_changed?
+    return unless enrollment && warehouse_columns_changed?
 
     # NOTE: we only really need to do this for bed-nights at the moment, but this is future-proofing against
     # pre-processing all services

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -72,38 +72,39 @@ module HmisDataCleanup
       end
     end
 
-    # UNTESTED!!!
-    def self.fix_bad_personal_id_references_on_services!
+    # Fix any instances of enrollment-related records where the PersonalID does nots match the Enrollment's PersonalIDs
+    def self.fix_incorrect_personal_id_references!(classes: nil)
+      classes&.each do |klass|
+        raise "Invalid class: #{klass.name}" unless Hmis::Hud::Enrollment.hmis_enrollment_related_classes.include?(klass)
+      end
+
+      classes ||= Hmis::Hud::Enrollment.hmis_enrollment_related_classes
       data_source_id = GrdaWarehouse::DataSource.hmis.first.id
-      # Find and fix Services where the PersonalID does not match the PersonalID on the referenced Enrollment
-      # We may want to expand this to other Enrollment-related record types
-      GrdaWarehouse::Hud::Service.where(data_source_id: data_source_id).left_outer_joins(:enrollment).
-        where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
-        find_in_batches do |batch|
-        # map {EnrollmentID=>PersonalID} for each enrollment referenced by this batch of services
-        eid_to_pid = GrdaWarehouse::Hud::Enrollment.where(
-          data_source_id: data_source_id,
-          EnrollmentID: batch.pluck(:EnrollmentID),
-        ).pluck(:EnrollmentID, :PersonalID).to_h
 
-        # update PersonalID on each Service
-        batch.each do |service|
-          real_personal_id = eid_to_pid[service.EnrollmentID]
-          unless real_personal_id
-            puts "Enrollment not found: Service##{service.id}, EnrollmentID##{service.EnrollmentID}"
-            next
+      Hmis::Hud::Base.transaction do
+        classes.each do |klass|
+          Rails.logger.info "[#{klass.name}] Processing"
+
+          klass.where(data_source_id: data_source_id).left_outer_joins(:enrollment).
+            where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
+            find_in_batches do |batch|
+            Rails.logger.info "[#{klass.name}] Processing batch"
+
+            # map {EnrollmentID=>PersonalID} for each enrollment referenced by this batch of records
+            eid_to_pid = GrdaWarehouse::Hud::Enrollment.where(
+              data_source_id: data_source_id,
+              EnrollmentID: batch.map(&:EnrollmentID),
+            ).pluck(:EnrollmentID, :PersonalID).to_h
+
+            # values = []
+            batch.each do |record|
+              real_personal_id = eid_to_pid[record.EnrollmentID]
+              next unless real_personal_id
+
+              record.update_columns(PersonalID: real_personal_id)
+            end
           end
-
-          service.PersonalID = real_personal_id
         end
-        result = GrdaWarehouse::Hud::Service.import(
-          batch,
-          validate: false,
-          timestamps: false,
-          on_duplicate_key_update: { conflict_target: [:id], columns: [:PersonalID] },
-        )
-
-        raise "Failed: #{result.failed_instances}" if result.failed_instances.present?
       end
     end
 

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -45,16 +45,12 @@ module HmisDataCleanup
     # Assign Household ID where missing
     def self.assign_missing_household_ids!
       Hmis::Hud::Enrollment.hmis.where(household_id: [nil, '']).find_in_batches do |batch|
-        values = []
         batch.each do |enrollment|
-          values << {
-            id: enrollment.id,
-            HouseholdID: Digest::MD5.hexdigest([enrollment.EnrollmentID, enrollment.PersonalID, enrollment.ProjectID].join('__')),
-          }
+          enrollment.HouseholdID = Digest::MD5.hexdigest([enrollment.EnrollmentID, enrollment.PersonalID, enrollment.ProjectID].join('__'))
         end
 
         result = Hmis::Hud::Enrollment.import(
-          values,
+          batch,
           validate: false,
           timestamps: false,
           on_duplicate_key_update: { conflict_target: [:id], columns: [:HouseholdID] },

--- a/drivers/hmis/spec/factories/hmis/hud/assessment_questions.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessment_questions.rb
@@ -5,11 +5,9 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_assessment_question, class: 'Hmis::Hud::AssessmentQuestion' do
+  factory :hmis_assessment_question, class: 'Hmis::Hud::AssessmentQuestion', parent: :hmis_base_factory do
     sequence(:AssessmentQuestionID, 500)
-    data_source { association :hmis_data_source }
     assessment { association :hmis_hud_assessment, data_source: data_source }
-    user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     assessment_question { 'Question?' }

--- a/drivers/hmis/spec/factories/hmis/hud/assessment_results.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessment_results.rb
@@ -5,11 +5,9 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_assessment_result, class: 'Hmis::Hud::AssessmentResult' do
+  factory :hmis_assessment_result, class: 'Hmis::Hud::AssessmentResult', parent: :hmis_base_factory do
     sequence(:AssessmentResultID, 500)
-    data_source { association :hmis_data_source }
     assessment { association :hmis_hud_assessment, data_source: data_source }
-    user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     assessment_result_type { 'Result Type' }

--- a/drivers/hmis/spec/factories/hmis/hud/assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/assessments.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_hud_assessment, class: 'Hmis::Hud::Assessment' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_hud_assessment, class: 'Hmis::Hud::Assessment', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:AssessmentID, 500)

--- a/drivers/hmis/spec/factories/hmis/hud/current_living_situations.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/current_living_situations.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_current_living_situation, class: 'Hmis::Hud::CurrentLivingSituation' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_current_living_situation, class: 'Hmis::Hud::CurrentLivingSituation', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:CurrentLivingSitID, 500)

--- a/drivers/hmis/spec/factories/hmis/hud/disabilities.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/disabilities.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_disability, class: 'Hmis::Hud::Disability' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_disability, class: 'Hmis::Hud::Disability', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:DisabilitiesID, 500)
@@ -15,7 +13,5 @@ FactoryBot.define do
     disability_response { 1 }
     information_date { Date.yesterday }
     data_collection_stage { 1 }
-    DateCreated { Time.now }
-    DateUpdated { Time.now }
   end
 end

--- a/drivers/hmis/spec/factories/hmis/hud/employment_educations.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/employment_educations.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_employment_education, class: 'Hmis::Hud::EmploymentEducation' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_employment_education, class: 'Hmis::Hud::EmploymentEducation', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:EmploymentEducationID, 500)

--- a/drivers/hmis/spec/factories/hmis/hud/events.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/events.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_hud_event, class: 'Hmis::Hud::Event' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_hud_event, class: 'Hmis::Hud::Event', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:EventID, 500)

--- a/drivers/hmis/spec/factories/hmis/hud/exits.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/exits.rb
@@ -6,9 +6,9 @@
 
 FactoryBot.define do
   factory :hmis_hud_exit, class: 'Hmis::Hud::Exit', parent: :hmis_base_factory do
+    client { association :hmis_hud_client, data_source: data_source }
+    enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:ExitID, 50)
-    sequence(:EnrollmentID, 20)
-    sequence(:PersonalID, 30)
     sequence(:ExitDate) do |n|
       dates = [
         Date.yesterday,

--- a/drivers/hmis/spec/factories/hmis/hud/exits.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/exits.rb
@@ -5,7 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_hud_exit, class: 'Hmis::Hud::Exit' do
+  factory :hmis_hud_exit, class: 'Hmis::Hud::Exit', parent: :hmis_base_factory do
     sequence(:ExitID, 50)
     sequence(:EnrollmentID, 20)
     sequence(:PersonalID, 30)
@@ -20,7 +20,6 @@ FactoryBot.define do
       dates[n % 5].to_date
     end
     destination { 1 }
-    user { association :hmis_hud_user, data_source: data_source }
 
     after(:build) do |exit|
       next unless exit.enrollment.present?

--- a/drivers/hmis/spec/factories/hmis/hud/health_and_dvs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/health_and_dvs.rb
@@ -5,15 +5,11 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_health_and_dv, class: 'Hmis::Hud::HealthAndDv' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_health_and_dv, class: 'Hmis::Hud::HealthAndDv', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:HealthAndDVID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }
-    DateCreated { Time.now }
-    DateUpdated { Time.now }
   end
 end

--- a/drivers/hmis/spec/factories/hmis/hud/hmis_base_factory.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/hmis_base_factory.rb
@@ -1,0 +1,18 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+FactoryBot.define do
+  factory :hmis_base_factory, class: 'Hmis::Hud::Base' do
+    data_source { association :hmis_data_source }
+    user { association :hmis_hud_user, data_source: data_source }
+    DateCreated { Time.current }
+    DateUpdated { Time.current }
+  end
+
+  trait :skip_validate do
+    to_create { |instance| instance.save(validate: false) }
+  end
+end

--- a/drivers/hmis/spec/factories/hmis/hud/income_benefits.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/income_benefits.rb
@@ -5,15 +5,11 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_income_benefit, class: 'Hmis::Hud::IncomeBenefit' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_income_benefit, class: 'Hmis::Hud::IncomeBenefit', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:IncomeBenefitsID, 500)
     information_date { Date.yesterday }
     data_collection_stage { 1 }
-    DateCreated { Time.now }
-    DateUpdated { Time.now }
   end
 end

--- a/drivers/hmis/spec/factories/hmis/hud/services.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/services.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_hud_service, class: 'Hmis::Hud::Service' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_hud_service, class: 'Hmis::Hud::Service', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:ServicesID, 500)

--- a/drivers/hmis/spec/factories/hmis/hud/youth_education_statuses.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/youth_education_statuses.rb
@@ -5,9 +5,7 @@
 ###
 
 FactoryBot.define do
-  factory :hmis_youth_education_status, class: 'Hmis::Hud::YouthEducationStatus' do
-    data_source { association :hmis_data_source }
-    user { association :hmis_hud_user, data_source: data_source }
+  factory :hmis_youth_education_status, class: 'Hmis::Hud::YouthEducationStatus', parent: :hmis_base_factory do
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
     sequence(:YouthEducationStatusID, 500)

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -1,0 +1,69 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe HmisDataCleanup::Util, type: :model do
+  let!(:hmis_ds) { create :hmis_data_source }
+  let!(:o1) { create :hmis_hud_organization, data_source: hmis_ds }
+  let!(:p1) { create :hmis_hud_project, data_source: hmis_ds, organization: o1 }
+  let!(:e1) { create :hmis_hud_enrollment, DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds, project: p1 }
+  let!(:e2) { create :hmis_hud_enrollment, DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds, project: p1 }
+  let!(:e3) { create :hmis_hud_enrollment, DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds }
+  let!(:e4) { create :hmis_hud_enrollment, DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds }
+
+  before(:all) do
+    # create cruft in other data sources
+    [:destination_data_source, :source_data_source].each do |ds_factory|
+      ds = create(ds_factory)
+      proj = create(:hud_project, data_source_id: ds.id)
+      client = create(:grda_warehouse_hud_client, data_source_id: ds.id)
+      5.times do
+        create(:grda_warehouse_hud_enrollment, data_source_id: ds.id, client: client, project: proj, DateCreated: 5.years.ago, DateUpdated: 5.years.ago)
+      end
+    end
+  end
+
+  def expect_leaves_non_hmis_data_alone(&block)
+    expect do
+      yield block
+    end.to change(GrdaWarehouse::Hud::Enrollment, :count).by(0).
+      and change(GrdaWarehouse::Version, :count).by(0).
+      and change(GrdaWarehouse::Hud::Enrollment.where(DateUpdated: 5.minutes.ago..), :count).by(0)
+  end
+
+  context 'clear_enrollment_export_ids' do
+    it 'works' do
+      GrdaWarehouse::Hud::Enrollment.update_all(ExportID: 'XYZ')
+
+      old_timestamp = e1.date_updated
+      HmisDataCleanup::Util.clear_enrollment_export_ids!
+
+      expect(e1.date_updated).to eq(old_timestamp)
+      expect(GrdaWarehouse::Hud::Enrollment.where(data_source: hmis_ds).where.not(ExportID: nil).exists?).to be false
+      expect(GrdaWarehouse::Hud::Enrollment.where.not(data_source: hmis_ds).where(ExportID: nil).exists?).to be false
+    end
+
+    it 'leaves no trace' do
+      GrdaWarehouse::Hud::Enrollment.update_all(ExportID: 'XYZ')
+      expect_leaves_non_hmis_data_alone do
+        HmisDataCleanup::Util.clear_enrollment_export_ids!
+      end
+    end
+  end
+
+  context 'all utilities' do
+    it 'leave non-HMIS data untouched' do
+      expect_leaves_non_hmis_data_alone do
+        HmisDataCleanup::Util.update_all_enrollment_cocs!('KY-100')
+      end
+    end
+  end
+  # TODO test assign_missing_household_ids!
+  # TODO test make_sole_member_hoh!!
+  # TODO test all others
+end

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
       yield block
     end.to change(GrdaWarehouse::Hud::Enrollment, :count).by(0).
       and change(GrdaWarehouse::Version, :count).by(0).
-      and change(GrdaWarehouse::Hud::Enrollment.where(DateUpdated: 5.minutes.ago..), :count).by(0)
+      # none of the utils should set timestamps on any records
+      and change(GrdaWarehouse::Hud::Enrollment.where(DateUpdated: 5.minutes.ago..), :count).by(0).
+      and change(GrdaWarehouse::Hud::Service.where(DateUpdated: 5.minutes.ago..), :count).by(0).
+      and change(GrdaWarehouse::Hud::CurrentLivingSituation.where(DateUpdated: 5.minutes.ago..), :count).by(0).
+      and change(GrdaWarehouse::Hud::Client.where(DateUpdated: 5.minutes.ago..), :count).by(0)
   end
 
   context 'clear_enrollment_export_ids' do
@@ -53,6 +57,77 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
       expect_leaves_non_hmis_data_alone do
         HmisDataCleanup::Util.clear_enrollment_export_ids!
       end
+    end
+  end
+
+  context 'fix_incorrect_personal_id_references' do
+    let!(:records_with_bad_references) do
+      records = []
+      shared_attributes = {
+        data_source: hmis_ds,
+        enrollment: e1,
+        PersonalID: 'not-real',
+        DateCreated: 5.years.ago,
+        DateUpdated: 5.years.ago,
+      }
+      records << create(:hmis_hud_service, :skip_validate, **shared_attributes)
+      records << create(:hmis_income_benefit, :skip_validate, **shared_attributes)
+      records << create(:hmis_health_and_dv, :skip_validate, **shared_attributes)
+      records << create(:hmis_youth_education_status, :skip_validate, **shared_attributes)
+      records << create(:hmis_employment_education, :skip_validate, **shared_attributes)
+      records << create(:hmis_disability, :skip_validate, **shared_attributes)
+      records << create(:hmis_hud_exit, :skip_validate, **shared_attributes)
+      records << create(:hmis_current_living_situation, :skip_validate, **shared_attributes)
+      records << create(:hmis_hud_assessment, :skip_validate, **shared_attributes)
+      records << create(:hmis_assessment_question, :skip_validate, **shared_attributes)
+      records << create(:hmis_assessment_result, :skip_validate, **shared_attributes)
+      records << create(:hmis_hud_event, :skip_validate, **shared_attributes)
+      records
+    end
+
+    let!(:records_with_good_references) do
+      records = []
+      shared_attributes = {
+        data_source: hmis_ds,
+        enrollment: e1,
+        client: e1.client,
+        DateCreated: 5.years.ago,
+        DateUpdated: 5.years.ago,
+      }
+      records << create(:hmis_hud_service, **shared_attributes)
+      records << create(:hmis_income_benefit, **shared_attributes)
+      records << create(:hmis_health_and_dv, **shared_attributes)
+      records << create(:hmis_youth_education_status, **shared_attributes)
+      records << create(:hmis_employment_education, **shared_attributes)
+      records << create(:hmis_disability, **shared_attributes)
+      records << create(:hmis_hud_exit, **shared_attributes)
+      records << create(:hmis_current_living_situation, **shared_attributes)
+      records << create(:hmis_hud_assessment, **shared_attributes)
+      records << create(:hmis_assessment_question, **shared_attributes)
+      records << create(:hmis_assessment_result, **shared_attributes)
+      records << create(:hmis_hud_event, **shared_attributes)
+      records
+    end
+
+    it 'works for services' do
+      bad_service = create(:hmis_hud_service, :skip_validate, enrollment: e1, PersonalID: 'unmatched-id', DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds)
+      good_service = create(:hmis_hud_service, :skip_validate, enrollment: e1, DateCreated: 5.years.ago, DateUpdated: 5.years.ago, data_source: hmis_ds)
+
+      HmisDataCleanup::Util.fix_incorrect_personal_id_references!(classes: [Hmis::Hud::Service])
+      [bad_service, good_service].each(&:reload)
+      expect(bad_service.personal_id).to eq(e1.personal_id)
+      expect(bad_service.enrollment).to be_present
+      expect(good_service.enrollment).to be_present
+    end
+
+    it 'works for all record types' do
+      HmisDataCleanup::Util.fix_incorrect_personal_id_references!
+      records_with_bad_references.each(&:reload)
+      expect(records_with_bad_references.map(&:PersonalID).uniq).to contain_exactly(e1.personal_id)
+    end
+
+    it 'leaves no trace' do
+      expect_leaves_non_hmis_data_alone { HmisDataCleanup::Util.fix_incorrect_personal_id_references! }
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
 
     it 'works for all record types' do
+      expect(records_with_bad_references.map(&:PersonalID).uniq).to contain_exactly('not-real')
+
       HmisDataCleanup::Util.fix_incorrect_personal_id_references!
       records_with_bad_references.each(&:reload)
       expect(records_with_bad_references.map(&:PersonalID).uniq).to contain_exactly(e1.personal_id)
@@ -128,6 +130,12 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
 
     it 'leaves no trace' do
       expect_leaves_non_hmis_data_alone { HmisDataCleanup::Util.fix_incorrect_personal_id_references! }
+    end
+
+    it 'dry run does nothing' do
+      HmisDataCleanup::Util.fix_incorrect_personal_id_references!(dry_run: true)
+      records_with_bad_references.each(&:reload)
+      expect(records_with_bad_references.map(&:PersonalID).uniq).to contain_exactly('not-real')
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     expect do
       yield block
     end.to not_change(GrdaWarehouse::Version, :count).
+      # Data in non-HMIS data sources should not be changed
       and(
         not_change do
           hmis_hud_classes.flat_map do |scope|
@@ -42,6 +43,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
           end
         end,
       ).
+      # DateUpdated should not be changed on any records in any data source
       and(
         not_change do
           hmis_hud_classes.flat_map do |scope|
@@ -204,7 +206,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
         HmisDataCleanup::Util.update_all_enrollment_cocs!('KY-600')
       end
 
-      expect(e1.enrollment_coc).to eq('KY-600')
+      expect(e1.reload.enrollment_coc).to eq('KY-600')
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Add `fix_incorrect_personal_id_references!` cleanup util [PT STORY](https://www.pivotaltracker.com/n/projects/2591838/stories/187269047)
* Make some existing utils more performant (hopefully!)
* Add test coverage (incomplete)

## Type of change
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
