### PR TITLE
Revert project service scope changes to improve performance

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -239,10 +239,6 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     end
   end
 
-  scope :with_invalid_references, -> {
-    left_outer_joins(:client).where(c_t[:id].eq(nil))
-  }
-
   after_create :warehouse_trigger_processing
   after_update :warehouse_trigger_processing
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -69,11 +69,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   # minutes. It needs optimization; for now we use a class method instead of a AR association
   # has_many :hmis_services, through: :enrollments_including_wip
   def hmis_services
-    invalid_enrollment_ids = enrollments.with_invalid_references.pluck(e_t[:enrollment_id])
-    Hmis::Hud::HmisService.joins(:project).
-      where(Hmis::Hud::Project.arel_table[:id].eq(id)).
-      where(Hmis::Hud::HmisService.arel_table[:EnrollmentID].not_in(invalid_enrollment_ids)).
-      joins(:client)
+    Hmis::Hud::HmisService.joins(:project).where(Hmis::Hud::Project.arel_table[:id].eq(id))
   end
 
   has_and_belongs_to_many :project_groups,

--- a/drivers/hmis/spec/models/hmis/hud/hmis_service_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/hmis_service_spec.rb
@@ -11,17 +11,24 @@ RSpec.describe Hmis::Hud::HmisService, type: :model do
   let!(:service) { create :hmis_hud_service, data_source: ds1, record_type: service_type.hud_record_type, type_provided: service_type.hud_type_provided }
   let!(:project) { service.enrollment.project }
 
-  it 'does not include services for an enrollment with an invalid client id' do
-    expect do
-      # update_column skips validation
-      service.enrollment.update_column(:personal_id, 'this_is_an_invalid_client_id')
-    end.to change(project.hmis_services, :count).by(-1)
+  it 'works' do
+    # contains view model of the service
+    expect(project.hmis_services).to contain_exactly(Hmis::Hud::HmisService.find_by(owner: service))
   end
 
-  it 'does not include services with an invalid client id' do
-    expect do
-      # update_column skips validation
-      service.update_column(:personal_id, 'this_is_an_invalid_client_id')
-    end.to change(project.hmis_services, :count).by(-1)
-  end
+  # Reverted behavior for performance reasons. If this happens, a data cleanup should occur instead.
+  # it 'does not include services for an enrollment with an invalid client id' do
+  #   expect do
+  #     # update_column skips validation
+  #     service.enrollment.update_column(:personal_id, 'this_is_an_invalid_client_id')
+  #   end.to change(project.hmis_services, :count).by(-1)
+  # end
+
+  # Reverted behavior for performance reasons. If this happens, a data cleanup should occur instead.
+  # it 'does not include services with an invalid client id' do
+  #   expect do
+  #     # update_column skips validation
+  #     service.update_column(:personal_id, 'this_is_an_invalid_client_id')
+  #   end.to change(project.hmis_services, :count).by(-1)
+  # end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Revert https://github.com/greenriver/hmis-warehouse/pull/4188 and  https://github.com/greenriver/hmis-warehouse/pull/4180 after reaching alternate conclusion about how to handle invalid references. We will go with data fix (https://github.com/greenriver/hmis-warehouse/pull/4191) instead. [PT](https://www.pivotaltracker.com/n/projects/2591838/stories/187269047)

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
