### PR TITLE
187331827-fuzzy-match-enrollment-data-loaders

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/base_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/base_loader.rb
@@ -187,7 +187,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
         row.row[enrollment_id_field] = nil
         cleared += 1
       end
-      logger.info("Cleared #{cleared} invalid enrollment ids")
+      log_info("Cleared #{cleared} invalid enrollment ids")
     end
 
     def extrapolate_missing_enrollment_ids(rows, enrollment_id_field:)
@@ -222,7 +222,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
           matched += 1
         end
       end
-      logger.info("Extrapolation matched #{matched} of #{missing.size} missing enrollment ids")
+      log_info("Extrapolation matched #{matched} of #{missing.values.map(&:size).sum} missing enrollment ids")
     end
 
     # some record sets can't be bulk inserted. Disabling paper trial reduces runtime when

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
@@ -12,8 +12,11 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     def perform
       validate_cde_configs
-      rows = reader.rows(filename: filename)
+      rows = reader.rows(filename: filename).to_a
       clobber_records(rows) if clobber
+
+      clear_invalid_enrollment_ids(rows, enrollment_id_field: ENROLLMENT_ID_COL)
+      extrapolate_missing_enrollment_ids(rows, enrollment_id_field: ENROLLMENT_ID_COL)
 
       create_assessment_records(rows)
       create_form_processor_records(rows)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_assessment_loader.rb
@@ -34,6 +34,16 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
     protected
 
+    # for extrapolate_missing_enrollment_ids
+    def row_personal_id(row)
+      normalize_uuid(row.field_value('Participant Enterprise Identifier'))
+    end
+
+    # for extrapolate_missing_enrollment_ids
+    def row_date_provided(row)
+      parse_date(row_assessment_date(row))
+    end
+
     def ce_assessment_level
       nil
     end
@@ -107,7 +117,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
 
         assessment_date = row_assessment_date(row)
         # derived "last updated" timestamp for 9am on AssessmentDate
-        last_updated_timestamp = assessment_date.beginning_of_day.to_datetime + 9.hours
+        last_updated_timestamp = parse_date(assessment_date).beginning_of_day.to_datetime + 9.hours
         {
           data_source_id: data_source.id,
           CustomAssessmentID: row_assessment_id(row),

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/tc_hmis/importers/loaders/custom_services_loader.rb
@@ -43,6 +43,7 @@ module HmisExternalApis::TcHmis::Importers::Loaders
       create_service_types
       create_cdeds
       rows = @reader.rows(filename: filename, header_row_number: 2, field_id_row_number: nil).to_a
+      clear_invalid_enrollment_ids(rows, enrollment_id_field: ENROLLMENT_ID)
       extrapolate_missing_enrollment_ids(rows, enrollment_id_field: ENROLLMENT_ID)
 
       # services is an instance variable because it holds state that is updated by ar_import, and is needed in create_records


### PR DESCRIPTION

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[PT issue](https://www.pivotaltracker.com/story/show/187331827)

* custom assessment loader uses fuzzy enrollment match for missing or invalid enrollment ids
* custom services loader treats invalid enrollments as missing, falls back to fuzzy match


## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
