### PR TITLE
report duplicate custom assessments and custom services

### DIFF
--- a/drivers/hmis/lib/hmis_data_cleanup/duplicate_records_report.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/duplicate_records_report.rb
@@ -1,0 +1,50 @@
+class HmisDataCleanup::DuplicateRecordsReport
+  def duplicate_custom_assessments(data_source)
+    # to reduce the search space, find the enrollment ids that might be duplicates
+    candidate_enrollment_ids = Hmis::Hud::CustomAssessment.
+      where(data_source: data_source).
+      joins(:form_processor).group(:EnrollmentID, :definition_id, :AssessmentDate).
+      having('COUNT(*) > 1').
+      count.
+      keys.map { |k| k[0] }
+
+    find_true_duplicates(candidate_enrollment_ids, Hmis::Hud::CustomAssessment.where(data_source: data_source))
+  end
+
+  def duplicate_custom_services(data_source)
+    # to reduce the search space, find the enrollment ids that might be duplicates
+    candidate_enrollment_ids = Hmis::Hud::CustomService.
+      where(data_source: data_source).
+      group(:EnrollmentID, :custom_service_type_id, :DateProvided).
+      having('COUNT(*) > 1').
+      count.
+      keys.map { |k| k[0] }
+
+    find_true_duplicates(candidate_enrollment_ids, Hmis::Hud::CustomService.where(data_source: data_source))
+  end
+
+  protected
+
+  def find_true_duplicates(enrollment_ids, scope)
+    by_identity = {}
+    enrollment_ids.in_groups_of(500).each do |enrollment_id_batch|
+      batch = scope.where(EnrollmentID: enrollment_id_batch)
+      batch.preload(:custom_data_elements).find_each do |record|
+        identity = identify_for_deduplication(record)
+        by_identity[identity] ||= []
+        by_identity[identity].push(record.id)
+      end
+    end
+    by_identity.values.filter(&:many?)
+  end
+
+  def identify_for_deduplication(record)
+    identity_attributes = record.attributes.except('id', record.hud_key.to_s, 'UserID', 'DateCreated', 'DateUpdated', 'DateDeleted', 'lock_version').map do |item|
+      item.join(':')
+    end
+    cde_attributes = record.custom_data_elements.to_a.map do |cde|
+      [cde.data_element_definition_id.to_s, cde.value.to_s].join(':')
+    end.sort
+    [identity_attributes, cde_attributes].flat_map { |ary| ary.join(':') }
+  end
+end

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -496,6 +496,26 @@ module HmisDataCleanup
       # s3.put(file_name: filename, prefix: 'initial-migration')
     end
 
+    def self.write_duplicate_custom_assessments(file_name: "#{Date.current.strftime('%Y-%m-%d')}_duplicate_custom_assessments.txt")
+      data_source = GrdaWarehouse::DataSource.hmis.first.id
+      dupes = HmisDataCleanup::DuplicateRecordsReport.new.duplicate_custom_assessments(data_source)
+      File.open(file_name, 'w') do |file|
+        dupes.each do |row|
+          file.puts row.join(',')
+        end
+      end
+    end
+
+    def self.write_duplicate_custom_services(file_name: "#{Date.current.strftime('%Y-%m-%d')}_duplicate_custom_services.txt")
+      data_source = GrdaWarehouse::DataSource.hmis.first.id
+      dupes = HmisDataCleanup::DuplicateRecordsReport.new.duplicate_custom_services(data_source)
+      File.open(file_name, 'w') do |file|
+        dupes.each do |row|
+          file.puts row.join(',')
+        end
+      end
+    end
+
     # Method for restoring enrollments that were deleted in an import.
     # Probably needs to be called in batches, depending on the size of the enrollment scope.
     def restore_deleted_enrollments!(enrollments_to_restore, conflict_set: nil, dry_run: false)

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -196,6 +196,54 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
+  context 'with duplicate custom assessments' do
+    let(:form_definition) { create(:hmis_form_definition) }
+    let(:cded) { create(:hmis_custom_data_element_definition, owner_type: 'Hmis::Hud::CustomAssessment') }
+    let!(:today) { Date.current }
+
+    let!(:not_dupe) do
+      create(:hmis_custom_assessment, client: e1.client, enrollment: e1, AssessmentDate: today, definition: form_definition).tap do |ca|
+        create(:hmis_custom_data_element, data_element_definition: cded, owner: ca, value_string: 'test1')
+      end
+    end
+    let!(:dupes) do
+      2.times.map do
+        create(:hmis_custom_assessment, client: e1.client, enrollment: e1, AssessmentDate: today, definition: form_definition) do |ca|
+          create(:hmis_custom_data_element, data_element_definition: cded, owner: ca, value_string: 'test2')
+        end
+      end
+    end
+
+    it 'identifies duplicates' do
+      results = HmisDataCleanup::DuplicateRecordsReport.new.duplicate_custom_assessments(hmis_ds)
+      expect(results).to contain_exactly(dupes.map(&:id))
+    end
+  end
+
+  context 'with duplicate custom services' do
+    let(:custom_service_type) { create(:hmis_custom_service_type) }
+    let(:cded) { create(:hmis_custom_data_element_definition, owner_type: 'Hmis::Hud::CustomService') }
+    let!(:today) { Date.current }
+
+    let!(:not_dupe) do
+      create(:hmis_custom_service, client: e1.client, enrollment: e1, DateProvided: today, custom_service_type: custom_service_type).tap do |cs|
+        create(:hmis_custom_data_element, data_element_definition: cded, owner: cs, value_string: 'test1')
+      end
+    end
+    let!(:dupes) do
+      2.times.map do
+        create(:hmis_custom_service, client: e1.client, enrollment: e1, DateProvided: today, custom_service_type: custom_service_type) do |cs|
+          create(:hmis_custom_data_element, data_element_definition: cded, owner: cs, value_string: 'test2')
+        end
+      end
+    end
+
+    it 'identifies duplicates' do
+      results = HmisDataCleanup::DuplicateRecordsReport.new.duplicate_custom_services(hmis_ds)
+      expect(results).to contain_exactly(dupes.map(&:id))
+    end
+  end
+
   context 'enrollments with incorrect EnrollmentCoCs' do
     before(:each) do
       e1.update(enrollment_coc: 'MA-500')


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

methods to detect and report "true" duplicate assessments and services. To be duplicates, the records must share the same attributes and cdes

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Utility / Helper

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
