### PR TITLE
Update the Override summary report to use importer overrides

### DIFF
--- a/app/views/projects/show.haml
+++ b/app/views/projects/show.haml
@@ -117,7 +117,7 @@
 - if overrides.any?
   %p The following import overrides are in effect for this project.
   .mb-4.card
-    = render 'hmis_csv_importer/import_overrides/table', overrides: overrides, data_source: @project.data_source, editable: false
+    = render 'hmis_csv_importer/import_overrides/table', overrides: overrides, data_source: @project.data_source, editable: false, show_associated_project: true
 - if @show_census
   = render 'census'
 = render 'funders', funders: @project.funders

--- a/app/views/source_data/show.haml
+++ b/app/views/source_data/show.haml
@@ -45,7 +45,7 @@
       - if overrides.any?
         %p The following import overrides are in effect for this record.
         .mb-4
-          = render 'hmis_csv_importer/import_overrides/table', overrides: overrides, data_source: @data_source, editable: false
+          = render 'hmis_csv_importer/import_overrides/table', overrides: overrides, data_source: @data_source, editable: false, show_associated_project: true
 
 .card
   %table.table.table-striped

--- a/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
+++ b/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
@@ -13,7 +13,7 @@
         %td
           = override.file_name
           - projects = override.project
-          - if projects.any?
+          - if projects.any? && show_associated_project
             .associated-projects
               Associated Project
               %ul

--- a/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/affiliation_extension.rb
+++ b/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/affiliation_extension.rb
@@ -11,6 +11,7 @@ module HmisCsvImporter::GrdaWarehouse::Hud
     included do
       has_many :imported_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Importer::Affiliation', primary_key: [:AffiliationID, :data_source_id], foreign_key: [:AffiliationID, :data_source_id]
       has_many :loaded_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Loader::Affiliation', primary_key: [:AffiliationID, :data_source_id], foreign_key: [:AffiliationID, :data_source_id]
+      has_many :import_overrides, class_name: 'HmisCsvImporter::ImportOverride', primary_key: [hud_key, :data_source_id], foreign_key: [:matched_hud_key, :data_source_id]
     end
   end
 end

--- a/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/funder_extension.rb
+++ b/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/funder_extension.rb
@@ -11,6 +11,7 @@ module HmisCsvImporter::GrdaWarehouse::Hud
     included do
       has_many :imported_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Importer::Funder', primary_key: [:FunderID, :data_source_id], foreign_key: [:FunderID, :data_source_id]
       has_many :loaded_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Loader::Funder', primary_key: [:FunderID, :data_source_id], foreign_key: [:FunderID, :data_source_id]
+      has_many :import_overrides, class_name: 'HmisCsvImporter::ImportOverride', primary_key: [hud_key, :data_source_id], foreign_key: [:matched_hud_key, :data_source_id]
     end
   end
 end

--- a/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/inventory_extension.rb
+++ b/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/inventory_extension.rb
@@ -11,6 +11,7 @@ module HmisCsvImporter::GrdaWarehouse::Hud
     included do
       has_many :imported_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Importer::Inventory', primary_key: [:InventoryID, :data_source_id], foreign_key: [:InventoryID, :data_source_id]
       has_many :loaded_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Loader::Inventory', primary_key: [:InventoryID, :data_source_id], foreign_key: [:InventoryID, :data_source_id]
+      has_many :import_overrides, class_name: 'HmisCsvImporter::ImportOverride', primary_key: [hud_key, :data_source_id], foreign_key: [:matched_hud_key, :data_source_id]
     end
   end
 end

--- a/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/project_coc_extension.rb
+++ b/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/project_coc_extension.rb
@@ -11,6 +11,8 @@ module HmisCsvImporter::GrdaWarehouse::Hud
     included do
       has_many :imported_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Importer::ProjectCoc', primary_key: [:ProjectCoCID, :data_source_id], foreign_key: [:ProjectCoCID, :data_source_id]
       has_many :loaded_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Loader::ProjectCoc', primary_key: [:ProjectCoCID, :data_source_id], foreign_key: [:ProjectCoCID, :data_source_id]
+
+      has_many :import_overrides, class_name: 'HmisCsvImporter::ImportOverride', primary_key: [hud_key, :data_source_id], foreign_key: [:matched_hud_key, :data_source_id]
     end
   end
 end

--- a/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/project_extension.rb
+++ b/drivers/hmis_csv_importer/extensions/grda_warehouse/hud/project_extension.rb
@@ -11,6 +11,7 @@ module HmisCsvImporter::GrdaWarehouse::Hud
     included do
       has_many :imported_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Importer::Project', primary_key: [:ProjectID, :data_source_id], foreign_key: [:ProjectID, :data_source_id]
       has_many :loaded_items_2022, class_name: '::HmisCsvTwentyTwentyTwo::Loader::Project', primary_key: [:ProjectID, :data_source_id], foreign_key: [:ProjectID, :data_source_id]
+      has_many :import_overrides, class_name: 'HmisCsvImporter::ImportOverride', primary_key: [hud_key, :data_source_id], foreign_key: [:matched_hud_key, :data_source_id]
 
       def convert_to_aggregated!
         existing = HmisCsvImporter::Aggregated::Enrollment.where(data_source_id: data_source_id, ProjectID: self.ProjectID).exists?

--- a/drivers/override_summary/app/views/override_summary/warehouse_reports/reports/index.haml
+++ b/drivers/override_summary/app/views/override_summary/warehouse_reports/reports/index.haml
@@ -14,19 +14,27 @@
     - content_for :panel_collapse_content, flush: true do
       - projects.each do |project_name, data|
         .mb-6
-          %h3= project_name
+          %h3= link_to project_name, project_path(data[:project]), target: :_blank
           - if data[:projects]
             - data[:projects].each do |project|
-              .mb-2= link_to project.name(ignore_confidential_status: true), project_path(project), target: :_blank
-              = render 'table', klass: GrdaWarehouse::Hud::Project, object: project
+              .mb-4.card
+                = render 'hmis_csv_importer/import_overrides/table', overrides: project.import_overrides, data_source: project.data_source, editable: false, show_associated_project: false
           - if data[:inventories]
             - data[:inventories].each do |inventory|
-              = link_to 'Inventory', edit_inventory_path(inventory), target: :_blank
-              = render 'table', klass: GrdaWarehouse::Hud::Inventory, object: inventory
+              .mb-4.card
+                = render 'hmis_csv_importer/import_overrides/table', overrides: inventory.import_overrides, data_source: inventory.data_source, editable: false, show_associated_project: false
           - if data[:project_cocs]
             - data[:project_cocs].each do |project_coc|
-              = link_to 'Project CoC', edit_project_coc_path(project_coc), target: :_blank
-              = render 'table', klass: GrdaWarehouse::Hud::ProjectCoc, object: project_coc
+              .mb-4.card
+                = render 'hmis_csv_importer/import_overrides/table', overrides: project_coc.import_overrides, data_source: project_coc.data_source, editable: false, show_associated_project: false
+          - if data[:funders]
+            - data[:funders].each do |funder|
+              .mb-4.card
+                = render 'hmis_csv_importer/import_overrides/table', overrides: funder.import_overrides, data_source: funder.data_source, editable: false, show_associated_project: false
+          - if data[:affiliations]
+            - data[:affiliations].each do |affiliation|
+              .mb-4.card
+                = render 'hmis_csv_importer/import_overrides/table', overrides: affiliation.import_overrides, data_source: affiliation.data_source, editable: false, show_associated_project: false
     = render 'common/panel_collapse', id: organization_name.parameterize, title: organization_name
 - else
   .none-found No overrides found

--- a/drivers/override_summary/app/views/override_summary/warehouse_reports/reports/index.xlsx.axlsx
+++ b/drivers/override_summary/app/views/override_summary/warehouse_reports/reports/index.xlsx.axlsx
@@ -14,33 +14,36 @@ wb_styles.add_style(
   },
 )
 wb.add_worksheet(name: @report.title) do |sheet|
-  sheet.add_row(['Organization', 'Project', 'Overriden Item', 'Column', 'HMIS Value', 'Override Value', 'URL'], style: th_style)
+  sheet.add_row(['Organization', 'Project', 'Item', 'Replaces', 'With', 'When', 'URL'], style: th_style)
   @report.data.each do |organization_name, projects|
     projects.each do |project_name, data|
       data[:projects].each do |object|
-        object.class.override_columns.each do |override, hmis|
-          overridden_value = object.send(override)
-          next if overridden_value.blank?
-
-          sheet.add_row([organization_name, project_name, 'Project', hmis, object.send(hmis), overridden_value, project_url(object)])
+        object.import_overrides.each do |override|
+          sheet.add_row([organization_name, project_name, override.file_name, override.replaces_column, override.describe_with, override.describe_when, project_url(data[:project])])
         end
       end
 
       data[:inventories].each do |object|
-        object.class.override_columns.each do |override, hmis|
-          overridden_value = object.send(override)
-          next if overridden_value.blank?
-
-          sheet.add_row([organization_name, project_name, 'Inventory', hmis, object.send(hmis), overridden_value, edit_inventory_url(object)])
+        object.import_overrides.each do |override|
+          sheet.add_row([organization_name, project_name, override.file_name, override.replaces_column, override.describe_with, override.describe_when, project_url(data[:project])])
         end
       end
 
       data[:project_cocs].each do |object|
-        object.class.override_columns.each do |override, hmis|
-          overridden_value = object.send(override)
-          next if overridden_value.blank?
+        object.import_overrides.each do |override|
+          sheet.add_row([organization_name, project_name, override.file_name, override.replaces_column, override.describe_with, override.describe_when, project_url(data[:project])])
+        end
+      end
 
-          sheet.add_row([organization_name, project_name, 'Project CoC', hmis, object.send(hmis), overridden_value, edit_project_coc_url(object)])
+      data[:funders].each do |object|
+        object.import_overrides.each do |override|
+          sheet.add_row([organization_name, project_name, override.file_name, override.replaces_column, override.describe_with, override.describe_when, project_url(data[:project])])
+        end
+      end
+
+      data[:affiliations].each do |object|
+        object.import_overrides.each do |override|
+          sheet.add_row([organization_name, project_name, override.file_name, override.replaces_column, override.describe_with, override.describe_when, project_url(data[:project])])
         end
       end
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
Updates to the Import Overrides report to expose the new importer overrides instead of the no longer used versions.

<img width="1132" alt="Screenshot 2024-04-01 at 9 33 13 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/03349a11-4a4a-4b99-a5a1-64394b57b2c5">


## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
