### PR TITLE
Hotfix for rebuild of service history services materialized view

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -96,5 +96,11 @@ module BostonHmis
     config.help_links = []
     config.location_processors = []
     config.queued_tasks = {}
+
+    # FIX for service history services change
+    config.queued_tasks[:service_history_services_materialized_rebuild_and_process] = -> do
+      GrdaWarehouse::ServiceHistoryServiceMaterialized.rebuild!
+      GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The recent rebuild of the service history services tables didn't play well with the materialized view, this forces a rebuild as a background task.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
