### PR TITLE
Add active filter to Service pick lists

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -246,6 +246,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   def available_service_types
     # Find form rules for services that are applicable to this project
     ids = Hmis::Form::Instance.for_services.
+      active.
       for_project_through_entities(self).
       joins(:definition).
       where(fd_t[:role].eq(:SERVICE)).

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       expect(selected_instance).to eq(expected)
     end
 
-    it 'does not return inactive serviec types' do
+    it 'does not return inactive service types' do
       instance = create(:hmis_form_instance, role: role, entity: nil, custom_service_type: cst)
       pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
       expect(pick_list_options.size).to eq(1)

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       expect(pick_list_options.size).to eq(1)
       expect(pick_list_options[0][:label]).to eq('Custom Type')
       instance.active = false
-      instance.save
+      instance.save!
       pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
       expect(pick_list_options).to be_empty
     end

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -157,6 +157,17 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       expected = create(:hmis_form_instance, role: role, entity: nil, custom_service_type: cst)
       expect(selected_instance).to eq(expected)
     end
+
+    it 'does not return inactive serviec types' do
+      instance = create(:hmis_form_instance, role: role, entity: nil, custom_service_type: cst)
+      pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
+      expect(pick_list_options.size).to eq(1)
+      expect(pick_list_options[0][:label]).to eq('Custom Type')
+      instance.active = false
+      instance.save
+      pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
+      expect(pick_list_options).to be_empty
+    end
   end
 
   describe 'occurrence_point_form_instances' do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

PT issue: https://www.pivotaltracker.com/story/show/187002403
Fixes behavior of pick list for Services so that inactive ones don't appear in the list, and adds a regression test.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
