### PR TITLE
Throw error if bulk assign causes overlapping enrollments

### DIFF
--- a/drivers/hmis/app/graphql/mutations/bulk_assign_service.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_assign_service.rb
@@ -54,7 +54,7 @@ module Mutations
             raise 'bulk service assignment generated invalid enrollment' unless enrollment.valid?
 
             entry_date_errors = Hmis::Hud::Validators::EnrollmentValidator.validate_entry_date(enrollment)
-            raise HmisErrors::ApiError, entry_date_errors.first.full_message unless entry_date_errors.empty?
+            error_out(entry_date_errors.first.full_message) unless entry_date_errors.empty?
 
             # Attempt to assign this enrollment to a unit if this project has units. This is AC-specific for now, and does
             # not support specifying the unit type. Needs improvement if/when we expand unit capabilities.

--- a/drivers/hmis/app/graphql/mutations/bulk_assign_service.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_assign_service.rb
@@ -53,7 +53,8 @@ module Mutations
             access_denied! unless can_enroll_clients
             raise 'bulk service assignment generated invalid enrollment' unless enrollment.valid?
 
-            # TODO(#187288068) warn about overlapping enrollments using Hmis::Hud::Validators::EnrollmentValidator.validate_entry_date
+            entry_date_errors = Hmis::Hud::Validators::EnrollmentValidator.validate_entry_date(enrollment)
+            raise HmisErrors::ApiError, entry_date_errors.first.full_message unless entry_date_errors.empty?
 
             # Attempt to assign this enrollment to a unit if this project has units. This is AC-specific for now, and does
             # not support specifying the unit type. Needs improvement if/when we expand unit capabilities.

--- a/drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb
@@ -156,5 +156,11 @@ RSpec.describe 'BulkAssignService', type: :request do
 
       expect_gql_error(perform_mutation(coc_code: 'MA-100'), message: 'Invalid CoC Code')
     end
+
+    it 'fails if client has an overlapping enrollment' do
+      create(:hmis_hud_enrollment, data_source: ds1, client: c1, project: p1, entry_date: Date.current)
+
+      expect_gql_error(perform_mutation(date_provided: 6.days.ago, client_ids: [c1.id]))
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

PT issue: https://www.pivotaltracker.com/story/show/187288068

This PR fixes the bug where a user could end up with overlapping enrollments through the new bulk services interface. It also adds a regression test.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
