### PR TITLE
Dont update client record when uploading image

### DIFF
--- a/drivers/hmis/app/graphql/mutations/update_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client_image.rb
@@ -8,16 +8,18 @@ module Mutations
   class UpdateClientImage < BaseMutation
     argument :client_id, ID, required: true
     argument :image_blob_id, ID, required: true
+    argument :lock_version, Integer, required: false
 
     field :client, Types::HmisSchema::Client, null: true
 
-    def resolve(client_id:, image_blob_id:)
+    def resolve(client_id:, image_blob_id:, lock_version: nil)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
 
       raise HmisErrors::ApiError, 'Record not found' unless client.present?
       raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
 
       client.image_blob_id = image_blob_id
+      client.lock_version = lock_version if lock_version
       client.save!
       client = client.reload
 

--- a/drivers/hmis/app/graphql/mutations/update_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client_image.rb
@@ -8,20 +8,17 @@ module Mutations
   class UpdateClientImage < BaseMutation
     argument :client_id, ID, required: true
     argument :image_blob_id, ID, required: true
-    argument :lock_version, Integer, required: false
 
     field :client, Types::HmisSchema::Client, null: true
 
-    def resolve(client_id:, image_blob_id:, lock_version: nil)
+    def resolve(client_id:, image_blob_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
 
       raise HmisErrors::ApiError, 'Record not found' unless client.present?
       raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
 
       client.image_blob_id = image_blob_id
-      client.lock_version = lock_version if lock_version
-      client.save!
-      client = client.reload
+      client.save_image_blob_as_client_headshot!
 
       {
         client: client,

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -11227,7 +11227,6 @@ input UpdateClientImageInput {
   """
   clientMutationId: String
   imageBlobId: ID!
-  lockVersion: Int
 }
 
 """

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -11227,6 +11227,7 @@ input UpdateClientImageInput {
   """
   clientMutationId: String
   imageBlobId: ID!
+  lockVersion: Int
 }
 
 """

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -90,20 +90,24 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   after_create :warehouse_identify_duplicate_clients
   after_update :warehouse_match_existing_clients
   before_save :set_source_hash
-  after_save do
+  after_save :save_image_blob_as_client_headshot!
+
+  # The client creation form sets image_blob_id
+  # This is also called directly by UpdateClientImage operation
+  def save_image_blob_as_client_headshot!
     current_image_blob = ActiveStorage::Blob.find_by(id: image_blob_id)
     self.image_blob_id = nil
-    if current_image_blob
-      file = GrdaWarehouse::ClientFile.new(
-        client_id: id,
-        user_id: user.id,
-        name: 'Client Headshot',
-        visible_in_window: false,
-      )
-      file.tag_list.add('Client Headshot')
-      file.client_file.attach(current_image_blob)
-      file.save!
-    end
+    return unless current_image_blob
+
+    file = GrdaWarehouse::ClientFile.new(
+      client_id: id,
+      user_id: user.id,
+      name: 'Client Headshot',
+      visible_in_window: false,
+    )
+    file.tag_list.add('Client Headshot')
+    file.client_file.attach(current_image_blob)
+    file.save!
   end
 
   # Includes clients where..


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

We were unnecessarily calling `client.save!` when uploading an image. 

https://www.pivotaltracker.com/n/projects/2591838/stories/187371856

Tested on QA:
* Uploading an image does not affect the lock version
* Uploading an image from client from when creating a new client still works

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
