### PR TITLE
Download Access Information

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -43,6 +43,15 @@ module Admin
       redirect_to({ action: :index }, notice: "Group #{@group.name} removed.")
     end
 
+    def download
+      respond_to do |format|
+        format.xlsx do
+          filename = "Access Details - #{Time.current.to_s(:db)}.xlsx"
+          headers['Content-Disposition'] = "attachment; filename=#{filename}"
+        end
+      end
+    end
+
     private def access_group_scope
       AccessGroup.general
     end

--- a/app/views/admin/groups/download.xlsx.axlsx
+++ b/app/views/admin/groups/download.xlsx.axlsx
@@ -1,0 +1,121 @@
+wb = xlsx_package.workbook
+wb.add_worksheet(name: 'Users') do |sheet|
+  sheet.add_row(['First Name', 'Last Name', 'Email', 'Agency', 'Role', 'Account Created', 'Last Login', 'Active'])
+  User.joins(:legacy_roles, :agency).find_each do |user|
+    user.legacy_roles.each do |role|
+      sheet.add_row(
+        [
+          user.first_name,
+          user.last_name,
+          user.email,
+          user.agency.name,
+          role.name,
+          user.created_at,
+          user.last_sign_in_at,
+          user.active_for_authentication? ? 'Y' : 'N',
+        ],
+      )
+    end
+  end
+end
+
+wb.add_worksheet(name: 'Roles') do |sheet|
+  permissions = Role.permissions_with_descriptions
+  labels = permissions.map { |key, permission| permission.try(:[], :title) || key.to_s.humanize }
+  sheet.add_row(['Role ID', 'Role Name'] + labels)
+  Role.find_each do |role|
+    active_permissions = permissions.keys.map { |perm| role.send(perm) ? 'X' : '' }
+    sheet.add_row([role.id, role.name] + active_permissions)
+  end
+end
+
+wb.add_worksheet(name: 'Agencies') do |sheet|
+  sheet.add_row(['ID', 'Agency Name'])
+  Agency.find_each do |agency|
+    sheet.add_row([agency.id, agency.name])
+  end
+end
+
+wb.add_worksheet(name: 'Projects') do |sheet|
+  sheet.add_row(['ID', 'HMIS Project ID', 'Project Name', 'Organization Name', 'Data Source Name'])
+  GrdaWarehouse::Hud::Project.preload(:organization, :data_source).find_each do |project|
+    sheet.add_row(
+      [
+        project.id,
+        project.ProjectID,
+        project.ProjectName,
+        project.organization&.OrganizationName,
+        project.data_source.name,
+      ],
+    )
+  end
+end
+
+wb.add_worksheet(name: 'Organizations') do |sheet|
+  sheet.add_row(['ID', 'HMIS Organization ID', 'Organization Name', 'Data Source Name'])
+  GrdaWarehouse::Hud::Organization.preload(:data_source).find_each do |organization|
+    sheet.add_row(
+      [
+        organization.id,
+        organization.OrganizationID,
+        organization.OrganizationName,
+        organization.data_source.name,
+      ],
+    )
+  end
+end
+
+wb.add_worksheet(name: 'Data Sources') do |sheet|
+  sheet.add_row(['ID', 'Data Source Name'])
+  GrdaWarehouse::DataSource.find_each do |ds|
+    sheet.add_row(
+      [
+        ds.id,
+        ds.name,
+      ],
+    )
+  end
+end
+
+wb.add_worksheet(name: 'Project Groups') do |sheet|
+  sheet.add_row(['ID', 'Project Group Name', 'Project Name'])
+  GrdaWarehouse::ProjectGroup.preload(:projects).find_each do |pg|
+    pg.projects.each do |project|
+      sheet.add_row(
+        [
+          pg.id,
+          pg.name,
+          project.ProjectName,
+        ],
+      )
+    end
+  end
+end
+
+wb.add_worksheet(name: 'CoC Codes') do |sheet|
+  sheet.add_row(['CoC Code'])
+  GrdaWarehouse::Hud::ProjectCoc.distinct.pluck(:CoCCode).each do |code|
+    sheet.add_row([code])
+  end
+end
+
+wb.add_worksheet(name: 'Cohorts') do |sheet|
+  sheet.add_row(['ID', 'Cohort Name', 'Active', 'System Cohort'])
+  GrdaWarehouse::Cohort.find_each do |cohort|
+    sheet.add_row(
+      [
+        cohort.id,
+        cohort.name,
+        cohort.active_cohort ? 'Y' : 'N',
+        cohort.system_cohort ? 'Y' : 'N',
+      ],
+    )
+  end
+end
+
+wb.add_worksheet(name: 'Reports') do |sheet|
+  sheet.add_row(['Report Name'])
+  GrdaWarehouse::WarehouseReports::ReportDefinition.enabled.pluck(:name).each do |report_name|
+    sheet.add_row([report_name])
+  end
+end

--- a/app/views/admin/groups/index.haml
+++ b/app/views/admin/groups/index.haml
@@ -36,5 +36,11 @@
                     %span.icon-cross
                     Delete
     = render 'common/pagination_bottom', item_name: 'group'
+    -# START_ACL remove this after permission migration is complete
+    -# Placing this here since Groups will be removed after a full transition to Access Controls
+    -# this download is only useful prior to the transtion
+    .mt-4
+      = link_to 'Download Access Summary', download_admin_groups_path(format: :xlsx), class: 'btn btn-secondary'
+    -# END_ACL
   - else
     .none-found No groups found.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -773,6 +773,7 @@ Rails.application.routes.draw do
     end
     resources :groups do
        resources :users, only: [:create, :destroy], controller: 'groups/users'
+       get :download, on: :collection
     end
     # END_ACL
     resources :access_controls do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This provides a button on the Access Groups page (at the bottom) to download data associated with users, roles, access groups, and associated entities.  This download can be used as a starting point for setting up Access Controls.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
