### PR TITLE
remove clean scope on service filters

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/service_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/service_filter.rb
@@ -12,8 +12,7 @@ class Hmis::Filter::ServiceFilter < Hmis::Filter::BaseFilter
       yield_self(&method(:with_service_category)).
       yield_self(&method(:with_service_type)).
       yield_self(&method(:with_project_type)).
-      yield_self(&method(:with_project)).
-      yield_self(&method(:clean_scope))
+      yield_self(&method(:with_project))
   end
 
   protected


### PR DESCRIPTION

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
Low hanging fruit from [PT Issue](https://www.pivotaltracker.com/story/show/187373409)
Filtered services were timing out on prod. Removing clean_scope on service filters is expensive. It is likely it was originally introduced to remove risk of duplicates but that shouldn't be an issue now

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
