### PR TITLE
Order thrives by completion date -- still putting in-progress first

### DIFF
--- a/app/views/health/careplans/_ssms_table.haml
+++ b/app/views/health/careplans/_ssms_table.haml
@@ -6,7 +6,7 @@
         %th Date Completed
         %th Case Manager
     %tbody
-      - @patient&.thrive_assessments&.each do |assessment|
+      - @patient&.thrive_assessments&.newest_first&.each do |assessment|
         %tr
           %td
             = link_to client_health_thrive_assessment_assessment_path(@client, assessment), data: { loads_in_pjax_modal: true } do

--- a/drivers/health_thrive_assessment/app/models/health_thrive_assessment/assessment.rb
+++ b/drivers/health_thrive_assessment/app/models/health_thrive_assessment/assessment.rb
@@ -19,6 +19,9 @@ module HealthThriveAssessment
 
     scope :in_progress, -> { where(completed_on: nil) }
     scope :completed_within, ->(range) { where(completed_on: range) }
+    scope :newest_first, -> do
+      order(arel_table[:completed_on].desc.nulls_first)
+    end
 
     scope :allowed_for_engagement, -> do
       joins(patient: :patient_referrals).


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The ordering (or lack thereof) of THRIVES was confusing CCs. So, add ordering to the display to put the most recent first, leaving an in progress at the top (if any)

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
