### PR TITLE
Only check git when deploying first env in group

### DIFF
--- a/config/deploy/docker/deploy
+++ b/config/deploy/docker/deploy
@@ -5,8 +5,13 @@ require_relative 'lib/deployer'
 
 args = CommandArgs.new
 
-args.deployments.each do |deployment|
-  puts "Deploying #{deployment[:target_group_name]}..."
+args.deployments.each_with_index do |deployment, idx|
+  puts "Deploying #{deployment[:target_group_name]} #{idx}..."
+
+  # If this is not the first deployment in a group, skip the git check, so that it doesn't fail
+  # mid-group if a new commit is pushed.
+  deployment[:skip_remote_git_check] = true unless idx.zero?
+
   Deployer.new(**deployment).run!
 
   # poll between deployments to prevent scaling out too much while we have
@@ -16,5 +21,5 @@ args.deployments.each do |deployment|
 end
 EcsTools.new.poll_state_until_stable!(CommandArgs.cluster)
 
-puts "Updating one ECS instance agent if needed."
+puts 'Updating one ECS instance agent if needed.'
 EcsTools.new.update_ecs_agents!(CommandArgs.cluster)

--- a/config/deploy/docker/lib/deployer.rb
+++ b/config/deploy/docker/lib/deployer.rb
@@ -48,6 +48,8 @@ class Deployer
 
   attr_accessor :service_registry_arns
 
+  attr_accessor :skip_remote_git_check
+
   attr_accessor :args
 
   def initialize(args)
@@ -62,6 +64,7 @@ class Deployer
     self.web_options              = args.fetch(:web_options)
     self.registry_id              = args.fetch(:registry_id)
     self.repo_name                = args.fetch(:repo_name)
+    self.skip_remote_git_check    = args.fetch(:skip_remote_git_check)
     self.variant                  = 'web'
     self.version                  = `git rev-parse --short=7 HEAD`.chomp
     self.args                     = OpenStruct.new(args)
@@ -120,7 +123,7 @@ class Deployer
   def _initial_steps
     # _ensure_clean_repo!
     _set_revision!
-    _check_that_you_pushed_to_remote!
+    _check_that_you_pushed_to_remote! unless skip_remote_git_check
     _docker_login!
     _wait_for_image_ready
     _check_secrets!


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

When deploying a group, only confirm push/pull status on first deploy

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
