### PR TITLE
Care Team QAs should not use UK (collaterals) but should allow U3

### DIFF
--- a/app/models/health/qualifying_activity_base.rb
+++ b/app/models/health/qualifying_activity_base.rb
@@ -58,7 +58,13 @@ module Health
       elsif mode_of_contact.present? && mode_of_contact[:dynamic_code].present?
         modlist << mode_of_contact[:dynamic_code].call(@qa)
       end
-      modlist << client_reached[@qa.reached_client&.to_sym].try(:[], :code)
+
+      reached = client_reached[@qa.reached_client&.to_sym]
+      if reached.present? && reached[:code].present?
+        modlist << reached[:code]
+      elsif reached.present? && reached[:dynamic_code].present?
+        modlist << reached[:dynamic_code].call(@qa)
+      end
 
       return modlist.reject(&:blank?).compact
     end

--- a/app/models/health/qualifying_activity_v3.rb
+++ b/app/models/health/qualifying_activity_v3.rb
@@ -98,7 +98,14 @@ module Health
         },
         collateral: {
           title: 'Collateral contact - not with client directly',
-          code: 'UK',
+          dynamic_code: ->(qa) do
+            case qa.activity&.to_sym
+            when :care_team
+              '' # UK is implied for care team meetings
+            else
+              'UK'
+            end
+          end,
           weight: 30,
         },
       }.sort_by { |_, m| m[:weight] }.to_h
@@ -159,7 +166,7 @@ module Health
           title: 'Meeting with 3+ care team members',
           code: 'G9007',
           weight: 40,
-          allowed: ['U1', 'U2', '95', '93'],
+          allowed: ['U1', 'U2', 'U3', '95', '93'],
           required: [],
           per_day: 1,
         },

--- a/spec/factories/health/qualifying_activities.rb
+++ b/spec/factories/health/qualifying_activities.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
   factory :care_team_qa, class: 'Health::QualifyingActivity' do
     user_full_name { 'First Last' }
     follow_up { 'X' }
-    date_of_activity { '2023-04-01'.to_date }
+    date_of_activity { '2024-04-01'.to_date }
     mode_of_contact { :other }
     mode_of_contact_other { 'X' }
     reached_client { :yes }

--- a/spec/models/health/qualifying_activity_spec.rb
+++ b/spec/models/health/qualifying_activity_spec.rb
@@ -382,18 +382,48 @@ RSpec.describe Health::QualifyingActivity, type: :model do
     end
   end
 
-  describe '2024 care team indirect contact changes' do
-    let(:phone_qa) { create :care_team_qa, mode_of_contact: :email }
+  describe '2024 care team contact changes' do
+    let(:qa) { create :care_team_qa }
+    it 'codes an in person meeting that includes the client as face to face' do
+      qa.mode_of_contact = :in_person
+      qa.reached_client = :yes
 
-    it 'is a U3 before 2024-01-01' do
-      phone_qa.date_of_activity = '2023-12-31'.to_date
-      # binding.pry
-      expect(phone_qa.compute_procedure_valid?).to be true
+      expect(qa.modifiers).to contain_exactly('U1', 'U2')
     end
 
-    it 'is forbidden on 2024-01-01' do
-      phone_qa.date_of_activity = '2024-01-01'.to_date
-      expect(phone_qa.compute_procedure_valid?).to be false
+    it "codes an in person meeting that doesn't include the client as face to face" do
+      qa.mode_of_contact = :in_person
+      qa.reached_client = :no
+
+      expect(qa.modifiers).to contain_exactly('U2')
+    end
+
+    it 'codes an in person meeting that is marked as collateral as face to face' do
+      qa.mode_of_contact = :in_person
+      qa.reached_client = :collateral
+
+      expect(qa.modifiers).to contain_exactly('U2')
+    end
+
+    it 'codes a phone call that includes the client as telehealth' do
+      qa.mode_of_contact = :phone_call
+      qa.reached_client = :yes
+
+      expect(qa.modifiers).to contain_exactly('U1', '93')
+    end
+
+    it "codes a phone call that doesn't include the client as indirect" do
+      qa.mode_of_contact = :phone_call
+      qa.reached_client = :no
+
+      expect(qa.modifiers).to contain_exactly('U3')
+    end
+
+    it 'codes a phone call that is marked as a collateral as indirect and not as collateral' do
+      qa.mode_of_contact = :phone_call
+      qa.reached_client = :collateral
+
+      expect(qa.modifiers).to contain_exactly('U3')
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Work around that CCs file care team QAs as including collateral contacts, but MH says that collaterals are expected for care team QAs, and forbids the UK (contact with collaterals) modifier.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
