### PR TITLE
Enforce exit date when calculating CH at entry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,5 +102,19 @@ module BostonHmis
       GrdaWarehouse::ServiceHistoryServiceMaterialized.rebuild!
       GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts
     end
+
+    # Fix for chronic calculator
+    # Previously, imported data where the enrollment was in a literally homeless project
+    # where the client would accumulate days between entry & exit that counted toward
+    # "Chronically Homeless at start", the current date was used to make the chronic
+    # determination instead of the exit date
+    config.queued_tasks[:ch_enrollment_exited_rebuild] = -> do
+      # Invalidate the calculation for any enrollment with an exit date
+      # that was previously marked chronic at entry
+      GrdaWarehouse::ChEnrollment.joins(enrollment: :exit).
+        where(chronically_homeless_at_entry: true).
+        update_all(processed_as: nil)
+      GrdaWarehouse::ChEnrollment.maintain!
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a bug where an enrollment that arrives to the warehouse fully closed (with an exit date fairly far in the past) that would otherwise not be considered Chronic on the exit date, is marked as chronic because the calculation was happening based on the current date.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
