### PR TITLE
BUGFIX: Set#merge instead of <<

### DIFF
--- a/app/models/health/team_performance.rb
+++ b/app/models/health/team_performance.rb
@@ -169,12 +169,14 @@ module Health
         begin
           set = Set.new
           patient_ids.each_slice(100).each do |patient_id_slice|
-            set << ClaimsReporting::MedicalClaim.
-              annual_well_care_visits.
-              service_in(anchor - WELLCARE_WINDOW... anchor).
-              joins(:patient).
-              where(hp_t[:id].in(patient_id_slice)).
-              pluck(hp_t[:id])
+            set.merge(
+              ClaimsReporting::MedicalClaim.
+                annual_well_care_visits.
+                service_in(anchor - WELLCARE_WINDOW... anchor).
+                joins(:patient).
+                where(hp_t[:id].in(patient_id_slice)).
+                pluck(hp_t[:id]),
+            )
           end
 
           set.to_a


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Use `Set#merge` instead of `<<` to flatten adding an array of items to a set

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
