### PR TITLE
PIT DV calculation adjustment

### DIFF
--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/base.rb
@@ -397,9 +397,17 @@ module HudPit::Generators::Pit::Fy2023
           title: 'Adults with indefinite and impairing HIV/AIDS',
           query: a_t[:hiv_aids_indefinite_impairing].eq(true),
         },
+        # Adjusted in 2024 to match 2023 version of adult_dv_survivors_currently_fleeing
+        # Interpretation of the following is that it should only include people who
+        # were homeless because they were fleeing
+        # https://www.hud.gov/sites/dfiles/OCHCO/documents/2023-11cpdn.pdf
+        # they must only report the number of
+        # survivors of domestic violence who are currently experiencing homelessness because of domestic
+        # violence, dating violence, sexual assault, or stalking, as opposed to reporting on survivors who have
+        # ever experienced these circumstances.
         adult_dv_survivors: {
           title: 'Adult Survivors of Domestic Violence (optional)',
-          query: a_t[:domestic_violence].eq(true),
+          query: a_t[:domestic_violence_currently_fleeing].eq(true),
         },
         adult_dv_survivors_currently_fleeing: {
           title: 'Adult Survivors of Domestic Violence (optional) Currently Fleeing',

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/base.rb
@@ -397,17 +397,9 @@ module HudPit::Generators::Pit::Fy2023
           title: 'Adults with indefinite and impairing HIV/AIDS',
           query: a_t[:hiv_aids_indefinite_impairing].eq(true),
         },
-        # Adjusted in 2024 to match 2023 version of adult_dv_survivors_currently_fleeing
-        # Interpretation of the following is that it should only include people who
-        # were homeless because they were fleeing
-        # https://www.hud.gov/sites/dfiles/OCHCO/documents/2023-11cpdn.pdf
-        # they must only report the number of
-        # survivors of domestic violence who are currently experiencing homelessness because of domestic
-        # violence, dating violence, sexual assault, or stalking, as opposed to reporting on survivors who have
-        # ever experienced these circumstances.
         adult_dv_survivors: {
           title: 'Adult Survivors of Domestic Violence (optional)',
-          query: a_t[:domestic_violence_currently_fleeing].eq(true),
+          query: a_t[:domestic_violence].eq(true),
         },
         adult_dv_survivors_currently_fleeing: {
           title: 'Adult Survivors of Domestic Violence (optional) Currently Fleeing',

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
@@ -424,9 +424,17 @@ module HudPit::Generators::Pit::Fy2024
           title: 'Adults with HIV/AIDS',
           query: a_t[:hiv_aids].eq(true),
         },
+        # Adjusted in 2024 to match 2023 version of adult_dv_survivors_currently_fleeing
+        # Interpretation of the following is that it should only include people who
+        # were homeless because they were fleeing
+        # https://www.hud.gov/sites/dfiles/OCHCO/documents/2023-11cpdn.pdf
+        # they must only report the number of
+        # survivors of domestic violence who are currently experiencing homelessness because of domestic
+        # violence, dating violence, sexual assault, or stalking, as opposed to reporting on survivors who have
+        # ever experienced these circumstances.
         adult_dv_survivors: {
           title: 'Adult Survivors of Domestic Violence (optional)',
-          query: a_t[:domestic_violence].eq(true),
+          query: a_t[:domestic_violence_currently_fleeing].eq(true),
         },
       }
     end

--- a/drivers/hud_pit/app/views/hud_pit/pits/_all_questions.haml
+++ b/drivers/hud_pit/app/views/hud_pit/pits/_all_questions.haml
@@ -8,7 +8,7 @@
     = link_to hud_reports_historic_pits_path do
       Pre-2022 PIT reports
   %p
-    = link_to new_hud_reports_pit_path do
+    = link_to new_hud_reports_pit_path, class: 'btn btn-primary' do
       Generate New PIT
 
 = render 'hud_reports/all_questions_table'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

        Adjusted in 2024 to match 2023 version of adult_dv_survivors_currently_fleeing
        Interpretation of the following is that it should only include people who
        were homeless because they were fleeing
        https://www.hud.gov/sites/dfiles/OCHCO/documents/2023-11cpdn.pdf
        they must only report the number of
        survivors of domestic violence who are currently experiencing homelessness because of domestic
        violence, dating violence, sexual assault, or stalking, as opposed to reporting on survivors who have
        ever experienced these circumstances.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
