### PR TITLE
In AssessmentQuestionsJob, only truncate strings

### DIFF
--- a/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
+++ b/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
@@ -42,7 +42,8 @@ module Hmis
               date_updated: Time.current,
 
               assessment_question: key,
-              assessment_answer: value&.truncate(500), # Truncate to ensure value is not too long for db
+              # Truncate strings to ensure value is not too long for db
+              assessment_answer: value.instance_of?(String) ? value&.truncate(500) : value,
 
               assessment_question_group: question_group(key),
               assessment_question_order: question_order(key),


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

follow-up to GH issue: https://github.com/open-path/Green-River/issues/5703
The previous fix caused a bug when the value was not a string.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
