### PR TITLE
Add background excel export to TX attachment three client data report

### DIFF
--- a/app/controllers/document_exports_controller_base.rb
+++ b/app/controllers/document_exports_controller_base.rb
@@ -113,6 +113,7 @@ class DocumentExportsControllerBase < ApplicationController
       'GrdaWarehouse::Cohorts::DocumentExports::CohortExcelExport',
       'UserDirectoryReport::DocumentExports::CasUserDirectoryExcelExport',
       'UserDirectoryReport::DocumentExports::WarehouseUserDirectoryExcelExport',
+      'TxClientReports::AttachmentThreeReportExports::AttachmentThreeReportExcelExport',
     ]
   end
 end

--- a/drivers/tx_client_reports/app/controllers/tx_client_reports/warehouse_reports/attachment_three_client_data_reports_controller.rb
+++ b/drivers/tx_client_reports/app/controllers/tx_client_reports/warehouse_reports/attachment_three_client_data_reports_controller.rb
@@ -14,6 +14,7 @@ module TxClientReports::WarehouseReports
 
     def index
       @rows = report.rows
+      @excel_export = TxClientReports::AttachmentThreeReportExports::AttachmentThreeReportExcelExport.new
       respond_to do |format|
         format.html do
           show_validations

--- a/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report.rb
@@ -13,6 +13,15 @@ module TxClientReports
       @filter = filter
     end
 
+    def self.viewable_by(user)
+      GrdaWarehouse::WarehouseReports::ReportDefinition.where(url: url).
+        viewable_by(user).exists?
+    end
+
+    def self.url
+      'tx_client_reports/warehouse_reports/attachment_three_client_data_reports'
+    end
+
     def attachment_three_headers
       [
         'Row Number',
@@ -65,7 +74,7 @@ module TxClientReports
           ('1' if row[:genders].include?(1)), # Male
           ('1' if row[:genders].include?(0)), # Female
           ('1' if row[:ethnicity] == 1),
-          ('1' if row[:ethnicity] == 0), # rubocop:disable Style/NumericPredicate
+          ('1' if row[:ethnicity] == 0),
           ('1' if row[:races] == ['AmIndAKNative']),
           ('1' if row[:races] == ['Asian']),
           ('1' if row[:races] == ['BlackAfAmerican']),

--- a/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
@@ -1,0 +1,74 @@
+###
+# Copyright 2016 - 2022 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module TxClientReports::AttachmentThreeReportExports
+  class AttachmentThreeReportExcelExport < ::GrdaWarehouse::DocumentExport
+    include ApplicationHelper
+
+    def authorized?
+      user.can_view_any_reports? && report_class.viewable_by(user)
+    end
+
+    protected def report
+      @report ||= report_class.new(filter)
+    end
+
+    protected def view_assigns
+      {
+        report: report,
+        filter: filter,
+      }
+    end
+
+    def perform
+      with_status_progression do
+        ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
+        warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
+          i.set_user(user, scope: :user, store: false, run_callbacks: false)
+        end
+
+        renderer = controller_class.renderer.new(
+          'warden' => warden_proxy,
+        )
+
+        write_tmp_file(
+          renderer.render(
+            action: :index,
+            format: :xlsx,
+            assigns: view_assigns,
+          ),
+          "Attachment III - Client Data #{Time.current.to_s(:db)}",
+        ) do |io|
+          self.pdf_file = io
+        end
+      end
+    end
+
+    def pdf_file=(file_io)
+      self.filename = File.basename(file_io.path)
+      self.file_data = file_io.read
+      self.mime_type = EXCEL_MIME_TYPE
+    end
+
+    private def write_tmp_file(data, file_name)
+      Dir.mktmpdir do |dir|
+        safe_name = file_name.gsub(/[^- a-z0-9]+/i, ' ').slice(0, 50).strip
+        file_path = "#{dir}/#{safe_name}.xlsx"
+        File.open(file_path, 'wb') { |file| file.write(data) }
+        yield(Pathname.new(file_path).open)
+      end
+      true
+    end
+
+    protected def report_class
+      TxClientReports::AttachmentThreeReport
+    end
+
+    private def controller_class
+      TxClientReports::WarehouseReports::AttachmentThreeClientDataReportsController
+    end
+  end
+end

--- a/drivers/tx_client_reports/app/views/tx_client_reports/warehouse_reports/attachment_three_client_data_reports/_filter.haml
+++ b/drivers/tx_client_reports/app/views/tx_client_reports/warehouse_reports/attachment_three_client_data_reports/_filter.haml
@@ -25,8 +25,6 @@
   - content_for :filter_actions do
     = f.submit 'Update Filter', class: 'btn btn-primary'
     - if show_report?
-      = link_to tx_client_reports_warehouse_reports_attachment_three_client_data_reports_path(format: :xlsx, params: @filter.for_params), class: 'btn btn-secondary' do
-        %i.icon-file-excel
-        Download Excel
+      = render 'report_downloads/report_download', export: nil, excel_export: @excel_export, excel_download_path: nil
 
   = render 'warehouse_reports/filters', f:f


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update the TX Attachment III Client Data report so the excel export is run in the background.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
