### PR TITLE
Make geocode nullable

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8362,7 +8362,7 @@ type ProjectCoc {
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
-  geocode: String!
+  geocode: String
   geographyType: GeographyType
   id: ID!
   state: String

--- a/drivers/hmis/app/graphql/types/hmis_schema/project_coc.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project_coc.rb
@@ -16,7 +16,7 @@ module Types
 
     hud_field :id, ID, null: false
     hud_field :coc_code, null: true
-    hud_field :geocode
+    hud_field :geocode, null: true
     hud_field :address1
     hud_field :address2
     hud_field :city


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Support resolving null geocode. It is allowed to be null in the database, so we should support resolving that. It was previously non-null because HUD spec requires it.

https://green-river.sentry.io/issues/5249984838/?project=4504006381273088&query=is%3Aunresolved+geocode&referrer=issue-stream&statsPeriod=90d&stream_index=0

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
