### PR TITLE
Don't warn about exits on the same day that project is closed

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/validators/project_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/project_validator.rb
@@ -32,9 +32,9 @@ class Hmis::Hud::Validators::ProjectValidator < Hmis::Hud::Validators::BaseValid
 
     # If project end date is changing
     if project.operating_end_date.present? && project.operating_end_date_changed?
-      # Check for open enrollments on the day after end date. (Don't want about people that exited today).
-      open_enrollments = project.enrollments.open_on_date(project.operating_end_date + 1)
-      errors.add :base, :information, severity: :warning, full_message: open_enrollments_message(open_enrollments.count) if open_enrollments.any?
+      # Warn about open enrollments. Manual says: "all clients must be exited on or before the Operating End Date".
+      num_open_enrollments = project.enrollments.open_on_date(project.operating_end_date + 1).count
+      errors.add :base, :information, severity: :warning, full_message: open_enrollments_message(num_open_enrollments) if num_open_enrollments > 0
     end
 
     # If project is being "closed" for the first time

--- a/drivers/hmis/app/models/hmis/hud/validators/project_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/project_validator.rb
@@ -32,7 +32,8 @@ class Hmis::Hud::Validators::ProjectValidator < Hmis::Hud::Validators::BaseValid
 
     # If project end date is changing
     if project.operating_end_date.present? && project.operating_end_date_changed?
-      open_enrollments = project.enrollments.open_on_date(project.operating_end_date)
+      # Check for open enrollments on the day after end date. (Don't want about people that exited today).
+      open_enrollments = project.enrollments.open_on_date(project.operating_end_date + 1)
       errors.add :base, :information, severity: :warning, full_message: open_enrollments_message(open_enrollments.count) if open_enrollments.any?
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

https://github.com/open-path/Green-River/issues/5978

Don't warn about enrollments that were closed on the same day as project exit. This is allowed per the [manual](https://files.hudexchange.info/resources/documents/HMIS-Data-Standards-Manual-2024.pdf):

> all clients must be exited on or before the ‘Operating End Date’. This may be achieved through a bulk update or auto exit (if such functionality exists), or manually. It is strongly encouraged that at a minimum, an alert or notification is provided to indicate active clients remain in the project. 

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
