### PR TITLE
Expose Access Control users on the role edit page

### DIFF
--- a/app/views/admin/roles/edit.haml
+++ b/app/views/admin/roles/edit.haml
@@ -5,6 +5,11 @@
   = render 'new_form', f: f, submit_text: 'Update Role'
 
 .mt-4
-  -# TODO: START_ACL replace when ACL transition is complete
-  -# = render 'users/user_members_table', item: @role, path_to_add_users: nil, path_to_delete_item: admin_role_path(@role), delete_user_lambda: nil
-  = render 'users/user_members_table', item: @role, path_to_add_users: admin_role_users_path(@role), path_to_delete_item: admin_role_path(@role), delete_user_lambda: ->(user) { admin_role_user_path(@role, user) }, users_lambda: ->(role) { role.legacy_users }
+  -# TODO: START_ACL remove when ACL transition is complete
+  .mb-6
+    = render 'users/user_members_table', item: @role, path_to_add_users: admin_role_users_path(@role), path_to_delete_item: admin_role_path(@role), delete_user_lambda: ->(user) { admin_role_user_path(@role, user) }, users_lambda: ->(role) { role.legacy_users }
+  -# END_ACL
+  - if User.anyone_using_acls?
+    %h2 Users Through Access Controls
+    %p The following users inherit this role through an Access Control.
+    = render 'users/user_members_table', item: @role, path_to_add_users: nil, path_to_delete_item: admin_role_path(@role), delete_user_lambda: nil


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This includes users who inherit roles through access controls on the role edit page if there is at least one user using Access Controls.

<img width="1374" alt="325749034-29d2773d-44ad-48b3-b7ef-945d98d384d5" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/e7543d79-a5b3-4345-91aa-1c25c0306bc4">

## Type of change
[//]: # 'remove options that are not relevant'

- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
