### PR TITLE
Demographic summary fix

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/first_time_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/first_time_calculations.rb
@@ -97,7 +97,8 @@ module
     # inactivity period (default is 24 months).
     private def client_ids_with_prior_homelessness
       @client_ids_with_prior_homelessness ||= begin
-        project_types = HudUtility2024.homeless_project_type_numbers & filter.project_type_numbers
+        # This report uses `filter.project_type_codes` `filter.project_type_ids` will convert those to the number equivalents
+        project_types = HudUtility2024.homeless_project_type_numbers & filter.project_type_ids
         # Use month duration to handle leap years
         inactivity_duration = filter.inactivity_days > 90 ? filter.inactivity_days.days.in_months.round.months : filter.inactivity_days.days
         # NOTE: this is limited to the report universe, except for the date range


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes the chronic (and probably high acuity) section of the Demographic Summary report by using the correct method on filter base to obtain the project types.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
