### PR TITLE
More correctly count disabilities

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/high_acuity_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/high_acuity_calculations.rb
@@ -68,7 +68,7 @@ module
     end
 
     private def high_acuity_client_ids(key, coc_code = base_count_sym)
-      # These two are stored as client_ids, the remaining are enrollment, client_id pairs
+      # These three are stored as client_ids, the remaining are enrollment, client_id pairs
       if key.in?([:client, :household, :one_disability])
         high_acuity_clients[key][coc_code]
       else
@@ -121,75 +121,56 @@ module
             clients[key] = {}
           end
 
-          initialize_high_acuity_client_counts(clients)
-
-          report_scope.distinct.
-            joins(client: :source_enrollment_disabilities).
-            merge(GrdaWarehouse::Hud::Disability.chronically_disabled).
-            pluck(:client_id, :id, e_t[:TimesHomelessPastThreeYears], e_t[:DisablingCondition], d_t[:DisabilityType], d_t[:DisabilityResponse], d_t[:IndefiniteAndImpairs]).
-            group_by { |e| [e.shift, e.shift, e.shift, e.shift] }.
-            each do |(client_id, enrollment_id, times_homeless, disabling_condition), disabilities|
-              # Exclude 8, 9, & 99 responses. Assume this enrollment consitutes 1 episode
-              next if times_homeless.nil? || times_homeless > 4
-              # Don't count anyone we've already counted in the chronic counts
-              next if chronic_clients[:client].include?(client_id)
-
-              counted_disabilities = Set.new
-              disabilities.each do |d_type, response, indefinite|
-                next unless response.in?(GrdaWarehouse::Hud::Disability.positive_responses)
-
-                # developmental and hiv are always indefinite and impairing
-                if d_type.in?([6, 8])
-                  counted_disabilities << d_type
-                elsif indefinite == 1
-                  counted_disabilities << d_type
-                end
-              end
-              # Only count disabling condition if there are no supporting disability details
-              counted_disabilities << :disabling_condition if disabling_condition == 1 && counted_disabilities.count.zero?
-
-              clients[:one_disability][base_count_sym] << client_id if counted_disabilities.count == 1
-
-              # Don't count anyone with only one disabling condition
-              next unless counted_disabilities.count > 1
-
-              set_high_acuity_client_counts(clients, client_id, enrollment_id)
-            end
-
-          available_coc_codes.each do |coc_code|
+          ([base_count_sym] + available_coc_codes).each do |coc_code|
             initialize_high_acuity_client_counts(clients, coc_code.to_sym)
 
-            report_scope.distinct.in_coc(coc_code: coc_code).
+            scope = report_scope.distinct
+            scope = scope.in_coc(coc_code: coc_code) unless coc_code == base_count_sym
+            scope.
               joins(client: :source_enrollment_disabilities).
               merge(GrdaWarehouse::Hud::Disability.chronically_disabled).
               pluck(:client_id, :id, e_t[:TimesHomelessPastThreeYears], e_t[:DisablingCondition], d_t[:DisabilityType], d_t[:DisabilityResponse], d_t[:IndefiniteAndImpairs]).
-              group_by { |e| [e.shift, e.shift, e.shift, e.shift] }.
-              each do |(client_id, enrollment_id, times_homeless, disabling_condition), disabilities|
-                # Exclude 8, 9, & 99 responses. Assume this enrollment consitutes 1 episode
-                next if times_homeless.nil? || times_homeless > 4
+              group_by(&:shift).
+              each do |client_id, row|
+                counts_by_enrollment = {}
+
                 # Don't count anyone we've already counted in the chronic counts
-                next if chronic_clients[:client][base_count_sym].include?(client_id)
+                next if chronic_clients[:client].include?(client_id)
 
-                counted_disabilities = Set.new
-                disabilities.each do |d_type, response, indefinite|
-                  next unless response.in?(GrdaWarehouse::Hud::Disability.positive_responses)
+                row.group_by { |e| [e.shift, e.shift, e.shift] }.
+                  each do |(enrollment_id, times_homeless, disabling_condition), disabilities|
+                    # Exclude 8, 9, & 99 responses. Assume this enrollment consitutes 1 episode
+                    next if times_homeless.nil? || times_homeless > 4
 
-                  # developmental and hiv are always indefinite and impairing
-                  if d_type.in?([6, 8])
-                    counted_disabilities << d_type
-                  elsif indefinite == 1
-                    counted_disabilities << d_type
+                    counted_disabilities = Set.new
+                    disabilities.each do |d_type, response, indefinite|
+                      next unless response.in?(GrdaWarehouse::Hud::Disability.positive_responses)
+
+                      # developmental and hiv are always indefinite and impairing
+                      if d_type.in?([6, 8])
+                        counted_disabilities << d_type
+                      elsif indefinite == 1
+                        counted_disabilities << d_type
+                      end
+                    end
+                    # Only count disabling condition if there are no supporting disability details
+                    counted_disabilities << :disabling_condition if disabling_condition == 1 && counted_disabilities.count.zero?
+
+                    counts_by_enrollment[enrollment_id] = counted_disabilities.count
                   end
+                counts = counts_by_enrollment.values
+                # Count any client who has one disability (and never reported more than one)
+                if counts.max == 1
+                  clients[:one_disability][coc_code.to_sym] << client_id
+                  # Don't count anyone with only one or no disabling condition
+                  next
                 end
-                # Only count disabling condition if there are no supporting disability details
-                counted_disabilities << :disabling_condition if disabling_condition == 1 && counted_disabilities.count.zero?
 
-                clients[:one_disability][coc_code.to_sym] << client_id if counted_disabilities.count == 1
+                counts_by_enrollment.each do |enrollment_id, count|
+                  next if count < 2
 
-                # Don't count anyone with only one disabling condition
-                next unless counted_disabilities.count > 1
-
-                set_high_acuity_client_counts(clients, client_id, enrollment_id, coc_code.to_sym)
+                  set_high_acuity_client_counts(clients, client_id, enrollment_id, coc_code.to_sym)
+                end
               end
           end
         end

--- a/drivers/core_demographics_report/app/models/core_demographics_report/high_acuity_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/high_acuity_calculations.rb
@@ -136,8 +136,6 @@ module
 
               counted_disabilities = Set.new
               disabilities.each do |d_type, response, indefinite|
-                counted_disabilities << :disabling_condition if disabling_condition == 1
-
                 next unless response.in?(GrdaWarehouse::Hud::Disability.positive_responses)
 
                 # developmental and hiv are always indefinite and impairing
@@ -147,6 +145,8 @@ module
                   counted_disabilities << d_type
                 end
               end
+              # Only count disabling condition if there are no supporting disability details
+              counted_disabilities << :disabling_condition if disabling_condition == 1 && counted_disabilities.count.zero?
 
               clients[:one_disability][base_count_sym] << client_id if counted_disabilities.count == 1
 
@@ -172,8 +172,6 @@ module
 
                 counted_disabilities = Set.new
                 disabilities.each do |d_type, response, indefinite|
-                  counted_disabilities << :disabling_condition if disabling_condition == 1
-
                   next unless response.in?(GrdaWarehouse::Hud::Disability.positive_responses)
 
                   # developmental and hiv are always indefinite and impairing
@@ -183,6 +181,8 @@ module
                     counted_disabilities << d_type
                   end
                 end
+                # Only count disabling condition if there are no supporting disability details
+                counted_disabilities << :disabling_condition if disabling_condition == 1 && counted_disabilities.count.zero?
 
                 clients[:one_disability][coc_code.to_sym] << client_id if counted_disabilities.count == 1
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This adjusts the mechanism used to count disabilities for high acuity clients, limiting to those that are actually indefinite and impairing, counting each disability only once per enrollment, counting Disabling Condition as one disability and only counting it if there are no other disabilities.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
