### PR TITLE
Send errors to Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -234,6 +234,8 @@ gem 'business_time', '~> 0.10.0'
 gem 'cable_ready', '>= 5.0.0.rc2'
 gem 'graphql', '~> 2.0'
 gem 'sentry-rails', '~> 5.5'
+gem 'sentry-ruby'
+gem 'sentry-delayed_job'
 gem 'warning'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -841,6 +841,9 @@ GEM
       railties (>= 4.0.0)
     sdoc (2.2.0)
       rdoc (>= 5.0)
+    sentry-delayed_job (5.7.0)
+      delayed_job (>= 4.0)
+      sentry-ruby (~> 5.7.0)
     sentry-rails (5.7.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.7.0)
@@ -1167,7 +1170,9 @@ DEPENDENCIES
   sassc-rails
   scenic
   sdoc
+  sentry-delayed_job
   sentry-rails (~> 5.5)
+  sentry-ruby
   shoulda
   simple_form
   simplecov

--- a/app/models/grda_warehouse/custom_imports/config.rb
+++ b/app/models/grda_warehouse/custom_imports/config.rb
@@ -68,9 +68,6 @@ module GrdaWarehouse::CustomImports
     def import!(force = false)
       import_type.constantize.new(config_id: id, data_source_id: data_source_id, status: 'queued').import!(force)
       update(last_import_attempted_at: Time.current)
-    rescue StandardError => e
-      Sentry.capture_exception(e)
-      Rails.logger.error(e.message)
     end
   end
 

--- a/app/models/grda_warehouse/custom_imports/config.rb
+++ b/app/models/grda_warehouse/custom_imports/config.rb
@@ -68,6 +68,9 @@ module GrdaWarehouse::CustomImports
     def import!(force = false)
       import_type.constantize.new(config_id: id, data_source_id: data_source_id, status: 'queued').import!(force)
       update(last_import_attempted_at: Time.current)
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+      Rails.logger.error(e.message)
     end
   end
 

--- a/drivers/custom_imports_boston_service/app/models/custom_imports_boston_service/import_file.rb
+++ b/drivers/custom_imports_boston_service/app/models/custom_imports_boston_service/import_file.rb
@@ -38,6 +38,10 @@ module CustomImportsBostonService
       file.drop(1).each_slice(batch_size) do |lines|
         loaded_rows += lines.count
         cleaned_headers = headers.reject { |h| h == 'do_not_import' }
+
+        # Check for any headers we don't know how to handle
+        raise "Unable to import, headers in #{filename} do not match expectation" unless (cleaned_headers - rows.klass.column_names).empty?
+
         rows.klass.import!(
           cleaned_headers,
           clean_rows(headers, lines),

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -305,7 +305,7 @@ namespace :grda_warehouse do
 
     TextMessage::Message.send_pending! if GrdaWarehouse::Config.get(:send_sms_for_covid_reminders) && RailsDrivers.loaded.include?(:text_message)
     GrdaWarehouse::CustomImports::Config.active.each do |config|
-      config.delay.import!
+      config.delay(queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running), attempts: 1).import!
     end
     TaskQueue.queue_unprocessed!
     GrdaWarehouse::ProjectGroup.maintain_project_lists!


### PR DESCRIPTION
…the delayed job worker

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

There are errors that for whatever reason Delayed Job is just eating.   Until we figure out where that's occurring, send the errors directly to sentry.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
