### PR TITLE
Pass the assume role info through the full import stack

### DIFF
--- a/app/models/importers/hmis_auto_migrate/s3.rb
+++ b/app/models/importers/hmis_auto_migrate/s3.rb
@@ -14,10 +14,12 @@ module Importers::HmisAutoMigrate
       allowed_projects: false,
       file_path: 'tmp/hmis_import',
       region:,
-      access_key_id:,
-      secret_access_key:,
       bucket_name:,
       path:,
+      access_key_id: nil,
+      secret_access_key: nil,
+      s3_role_arn: nil,
+      s3_external_id: nil,
       file_password: nil,
       file_name: nil
     )
@@ -32,6 +34,13 @@ module Importers::HmisAutoMigrate
           bucket_name: bucket_name,
           access_key_id: access_key_id,
           secret_access_key: secret_access_key,
+        )
+      elsif s3_role_arn.present? && s3_external_id.present?
+        AwsS3.new(
+          region: region,
+          bucket_name: bucket_name,
+          role_arn: s3_role_arn,
+          external_id: s3_external_id,
         )
       else
         AwsS3.new(

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -132,6 +132,8 @@ namespace :grda_warehouse do
         region: conf.s3_region,
         access_key_id: conf.s3_access_key_id,
         secret_access_key: conf.s3_secret_access_key,
+        s3_external_id: conf.s3_external_id,
+        s3_role_arn: conf.s3_role_arn,
         bucket_name: conf.s3_bucket_name,
         path: conf.s3_path,
         file_password: conf.zip_file_password,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This is a hot fix for assuming roles with S3.  The current code works on the configuration page but failed to fully pass the configuration through to the delayed job.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
