### PR TITLE
Fix AssessmentQuestionsJob truncation again

### DIFF
--- a/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
+++ b/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
@@ -42,9 +42,8 @@ module Hmis
               date_updated: Time.current,
 
               assessment_question: key,
-              # Truncate strings to ensure value is not too long for db
-              assessment_answer: value.instance_of?(String) ? value&.truncate(500) : value,
-
+              # Truncate to ensure value is not too long for db
+              assessment_answer: value&.to_s&.truncate(500),
               assessment_question_group: question_group(key),
               assessment_question_order: question_order(key),
             )


### PR DESCRIPTION

## Description

Resolves https://green-river.sentry.io/issues/5134491489/?referrer=slack&environment=production&alert_rule_id=12523843&alert_type=issue

Third times the charm 🙃 .. there are responses that are arrays `["this", "that", "another thing"]` that are reaching the >500 limit.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
