### PR TITLE
Patch bug where you can refer a WIP household

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
@@ -23,6 +23,7 @@ module Mutations
         find_by(id: input.enrollment_id)
       handle_error('enrollment not found') unless enrollment
       handle_error('access denied') unless current_user.can_manage_outgoing_referrals_for?(enrollment.project)
+      handle_error('cannot refer incomplete enrollment') if enrollment.in_progress?
 
       project = Hmis::Hud::Project.
         viewable_by(current_user).

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -66,7 +66,7 @@ module Types
       when 'AVAILABLE_UNITS_FOR_ENROLLMENT'
         available_units_for_enrollment(project, household_id: household_id)
       when 'OPEN_HOH_ENROLLMENTS_FOR_PROJECT'
-        open_hoh_enrollments_for_project(project)
+        open_hoh_enrollments_for_project(project, user: user)
       when 'ENROLLMENTS_FOR_CLIENT'
         enrollments_for_client(client, user: user)
       when 'EXTERNAL_FORM_TYPES_FOR_PROJECT'
@@ -376,12 +376,12 @@ module Types
       picklist.compact
     end
 
-    def self.open_hoh_enrollments_for_project(project)
+    # This is used for selecting a household for an "outgoing referral"
+    def self.open_hoh_enrollments_for_project(project, user:)
       raise 'Project required' unless project.present?
 
-      # No need for viewable_by here because we know the project is already veiwable by the user
-      enrollments = project.enrollments.
-        open_on_date(Date.current + 1.day). # exclude clients that exited today
+      enrollments = project.enrollments.viewable_by(user).
+        open_excluding_wip.
         heads_of_households.
         preload(:client).
         preload(household: :enrollments)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix bug found by @martha . The recent `project_pk` change introduced a bug whereby you could refer households that have a WIP HoH enrollment. 

* Update the pick list to use `open_excluding_wip` scope.
* Throw an explicit error if application attempts to refer a WIP HoH


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
