### PR TITLE
Add can_manage_forms permission

### DIFF
--- a/db/migrate/20240506135053_add_can_manage_forms_permission.rb
+++ b/db/migrate/20240506135053_add_can_manage_forms_permission.rb
@@ -1,0 +1,12 @@
+class AddCanManageFormsPermission < ActiveRecord::Migration[7.0]
+  def up
+    ::Hmis::Role.ensure_permissions_exist
+    ::Hmis::Role.reset_column_information
+
+    ::Hmis::Role.where(can_configure_data_collection: true).update_all(can_manage_forms: true)
+  end
+
+  def down
+    remove_column :hmis_roles, :can_manage_forms
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -375,19 +375,38 @@ CREATE SEQUENCE public.agencies_id_seq
 
 ALTER SEQUENCE public.agencies_id_seq OWNED BY public.agencies.id;
 
+
+--
+-- Name: app_config_properties; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.app_config_properties (
     id bigint NOT NULL,
     key character varying NOT NULL,
     value jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
- );
+);
 
-CREATE SEQUENCE public.app_config_properties_id_seq AS integer START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+--
+-- Name: app_config_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.app_config_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: app_config_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.app_config_properties_id_seq OWNED BY public.app_config_properties.id;
-ALTER TABLE ONLY public.app_config_properties ALTER COLUMN id SET DEFAULT nextval('public.app_config_properties_id_seq'::regclass);
-ALTER TABLE ONLY public.app_config_properties ADD CONSTRAINT app_config_properties_pkey PRIMARY KEY (id);
-CREATE UNIQUE INDEX index_app_config_properties_on_key ON public.app_config_properties USING btree (key);
+
 
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
@@ -888,8 +907,9 @@ CREATE TABLE public.hmis_roles (
     can_manage_scan_cards boolean DEFAULT false,
     can_manage_external_form_submissions boolean DEFAULT false,
     can_view_client_contact_info boolean DEFAULT false,
+    can_view_client_name boolean DEFAULT false,
     can_view_client_photo boolean DEFAULT false,
-    can_view_client_name boolean DEFAULT false
+    can_manage_forms boolean DEFAULT false
 );
 
 
@@ -2501,6 +2521,13 @@ ALTER TABLE ONLY public.agencies ALTER COLUMN id SET DEFAULT nextval('public.age
 
 
 --
+-- Name: app_config_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.app_config_properties ALTER COLUMN id SET DEFAULT nextval('public.app_config_properties_id_seq'::regclass);
+
+
+--
 -- Name: clients_unduplicated id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2892,6 +2919,14 @@ ALTER TABLE ONLY public.activity_logs
 
 ALTER TABLE ONLY public.agencies
     ADD CONSTRAINT agencies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: app_config_properties app_config_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.app_config_properties
+    ADD CONSTRAINT app_config_properties_pkey PRIMARY KEY (id);
 
 
 --
@@ -3423,6 +3458,13 @@ CREATE INDEX index_agencies_consent_limits_on_agency_id ON public.agencies_conse
 --
 
 CREATE INDEX index_agencies_consent_limits_on_consent_limit_id ON public.agencies_consent_limits USING btree (consent_limit_id);
+
+
+--
+-- Name: index_app_config_properties_on_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_app_config_properties_on_key ON public.app_config_properties USING btree (key);
 
 
 --
@@ -4343,5 +4385,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240401041826'),
 ('20240401132430'),
 ('20240402161400'),
+('20240402204100'),
 ('20240404162012'),
-('20240402204100');
+('20240506135053');
+
+

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -13410,40 +13410,6 @@ ALTER SEQUENCE public.hmis_assessments_id_seq OWNED BY public.hmis_assessments.i
 
 
 --
--- Name: hmis_auto_exit_configs; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.hmis_auto_exit_configs (
-    id bigint NOT NULL,
-    length_of_absence_days integer NOT NULL,
-    project_type integer,
-    organization_id bigint,
-    project_id bigint,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: hmis_auto_exit_configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.hmis_auto_exit_configs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: hmis_auto_exit_configs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.hmis_auto_exit_configs_id_seq OWNED BY public.hmis_auto_exit_configs.id;
-
-
---
 -- Name: hmis_case_notes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -18259,8 +18225,8 @@ CREATE TABLE public.hmis_form_definitions (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     title character varying NOT NULL,
-    deleted_at timestamp without time zone,
-    external_form_object_key character varying
+    external_form_object_key character varying,
+    deleted_at timestamp without time zone
 );
 
 
@@ -28714,13 +28680,6 @@ ALTER TABLE ONLY public.hmis_assessments ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
--- Name: hmis_auto_exit_configs id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_auto_exit_configs ALTER COLUMN id SET DEFAULT nextval('public.hmis_auto_exit_configs_id_seq'::regclass);
-
-
---
 -- Name: hmis_case_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -32166,14 +32125,6 @@ ALTER TABLE ONLY public.hmis_assessment_details
 
 ALTER TABLE ONLY public.hmis_assessments
     ADD CONSTRAINT hmis_assessments_pkey PRIMARY KEY (id);
-
-
---
--- Name: hmis_auto_exit_configs hmis_auto_exit_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.hmis_auto_exit_configs
-    ADD CONSTRAINT hmis_auto_exit_configs_pkey PRIMARY KEY (id);
 
 
 --
@@ -53212,20 +53163,6 @@ CREATE INDEX index_hmis_assessments_on_site_id ON public.hmis_assessments USING 
 
 
 --
--- Name: index_hmis_auto_exit_configs_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_auto_exit_configs_on_organization_id ON public.hmis_auto_exit_configs USING btree (organization_id);
-
-
---
--- Name: index_hmis_auto_exit_configs_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_hmis_auto_exit_configs_on_project_id ON public.hmis_auto_exit_configs USING btree (project_id);
-
-
---
 -- Name: index_hmis_case_notes_on_client_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -59698,13 +59635,6 @@ CREATE UNIQUE INDEX test_shs ON public.service_history_services_2000 USING btree
 --
 
 CREATE INDEX tt ON public.hmis_2022_exits USING btree ("EnrollmentID", "PersonalID", importer_log_id, data_source_id);
-
-
---
--- Name: tt_hh_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX tt_hh_id ON public.service_history_enrollments USING btree (household_id);
 
 
 --

--- a/drivers/hmis/app/graphql/mutations/create_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/create_form_definition.rb
@@ -11,7 +11,7 @@ module Mutations
     field :form_definition, Types::Forms::FormDefinition, null: true
 
     def resolve(input:)
-      raise 'not allowed' unless current_user.can_configure_data_collection?
+      raise 'not allowed' unless current_user.can_manage_forms?
 
       attrs = input.to_attributes
       attrs[:definition] = attrs[:definition] || { item: [{ link_id: 'name', type: 'STRING' }] }

--- a/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
@@ -11,7 +11,7 @@ module Mutations
     field :form_definition, Types::Forms::FormDefinition, null: true
 
     def resolve(id:)
-      raise 'not allowed' unless current_user.can_configure_data_collection?
+      raise 'not allowed' unless current_user.can_manage_forms?
 
       definition = Hmis::Form::Definition.find_by(id: id)
       raise 'not found' unless definition

--- a/drivers/hmis/app/graphql/mutations/update_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/update_form_definition.rb
@@ -12,7 +12,7 @@ module Mutations
     field :form_definition, Types::Forms::FormDefinition, null: true
 
     def resolve(id:, input:)
-      raise 'not allowed' unless current_user.can_configure_data_collection?
+      raise 'not allowed' unless current_user.can_manage_forms?
 
       definition = Hmis::Form::Definition.find_by(id: id)
       raise 'not found' unless definition

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8783,6 +8783,7 @@ type QueryAccess {
   canManageClientAlerts: Boolean!
   canManageDeniedReferrals: Boolean!
   canManageExternalFormSubmissions: Boolean!
+  canManageForms: Boolean!
   canManageIncomingReferrals: Boolean!
   canManageInventory: Boolean!
   canManageOutgoingReferrals: Boolean!

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -380,8 +380,15 @@ class Hmis::Role < ::ApplicationRecord
         category: 'Administration',
         sub_category: 'Enrollment Management',
       },
+      can_manage_forms: {
+        description: 'Ability to edit forms',
+        administrative: true,
+        access: [:editable],
+        category: 'Administration',
+        sub_category: 'Admin Tools',
+      },
       can_configure_data_collection: {
-        description: 'Ability to configure custom assessments, services, auto-exit, and other application rules',
+        description: 'Ability to configure rules for custom assessments, services, auto-exit, etc, but not to edit forms',
         administrative: true,
         access: [:editable],
         category: 'Administration',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -388,7 +388,7 @@ class Hmis::Role < ::ApplicationRecord
         sub_category: 'Admin Tools',
       },
       can_configure_data_collection: {
-        description: 'Ability to configure rules for custom assessments, services, auto-exit, etc, but not to edit forms',
+        description: 'Ability to configure data collection rules for assessments, services, auto-exit, and more.',
         administrative: true,
         access: [:editable],
         category: 'Administration',


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/5981

This PR adds a new permission, can_manage_forms, which takes over some but not all duties from can_configure_data_collection.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
