### PR TITLE
Remove requirement that PCTP be sent in last year for  CP2 engagement.

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -356,8 +356,9 @@ module Health
     # CP 2 relaxed the requirements for the PCTP so that it required in-house clinical approval instead of needing
     # to be approved by the patients PCP.
     # Oct 31, 2023: simplified engagement to be based on PCTP being sent to PCP in the last year
+    # May 7, 2024: Removed requirement that the PCTP had to be sent in the last year, leaving just that it had to be sent
     def self.cp_2_engagement(on) # rubocop:disable Naming/MethodParameterName
-      where(id: Health::PctpCareplan.recent.sent_within(on - 365.days .. on).select(:patient_id))
+      where(id: Health::PctpCareplan.recent.sent_within(.. on).select(:patient_id))
     end
 
     scope :engagement_required_by, ->(date) do

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -358,7 +358,7 @@ module Health
     # Oct 31, 2023: simplified engagement to be based on PCTP being sent to PCP in the last year
     # May 7, 2024: Removed requirement that the PCTP had to be sent in the last year, leaving just that it had to be sent
     def self.cp_2_engagement(on) # rubocop:disable Naming/MethodParameterName
-      where(id: Health::PctpCareplan.recent.sent_within(.. on).select(:patient_id))
+      where(id: Health::PctpCareplan.sent_within(.. on).select(:patient_id))
     end
 
     scope :engagement_required_by, ->(date) do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Change the definition of CP2 engagement so the filter doesn't require a PCTP in the last year.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
