### PR TITLE
Replace match->contains_exactly in HMIS tests

### DIFF
--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -856,10 +856,10 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         expect(client.name_data_quality).to eq(1)
         # Ensure all names persisted
         expect(client.names.count).to eq(2)
-        expect(client.names.map(&:attributes)).to match([
-                                                          a_hash_including(primary_name.excluding(:nameDataQuality).stringify_keys),
-                                                          a_hash_including(secondary_name.excluding(:nameDataQuality).stringify_keys),
-                                                        ])
+        expect(client.names.map(&:attributes)).to contain_exactly(
+          a_hash_including(primary_name.excluding(:nameDataQuality).stringify_keys),
+          a_hash_including(secondary_name.excluding(:nameDataQuality).stringify_keys),
+        )
         expect(client.dob.strftime('%Y-%m-%d')).to eq('2000-03-29')
         expect(client.dob_data_quality).to eq(1)
         expect(client.ssn).to eq('XXXXX1234')
@@ -1022,10 +1022,10 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       # Ensure all names persisted
       expect(client.names.size).to eq(2)
       expect(client.names.pluck(:id)).not_to include(old_secondary_name.id)
-      expect(client.names.map(&:attributes)).to match([
-                                                        a_hash_including({ first: 'Atticus Changed', primary: false, id: old_primary_name.id }.stringify_keys),
-                                                        a_hash_including({ first: 'Charlotte', primary: true }.stringify_keys),
-                                                      ])
+      expect(client.names.map(&:attributes)).to contain_exactly(
+        a_hash_including({ first: 'Atticus Changed', primary: false, id: old_primary_name.id }.stringify_keys),
+        a_hash_including({ first: 'Charlotte', primary: true }.stringify_keys),
+      )
     end
 
     it 'handles "deleting" primary name' do

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
       it "should error if assessment date is missing (#{role})" do
         apply_assessment_date(nil)
         validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        expect(validations).to match([a_hash_including(severity: :error, type: :required)])
+        expect(validations).to contain_exactly(a_hash_including(severity: :error, type: :required))
       end
 
       it "should succeed if assessment date is the same as entry date (#{role})" do
@@ -120,7 +120,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         if assessment.intake?
           expect(validations).to be_empty
         else
-          expect(validations).to match([a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.before_entry_message(e1.entry_date))])
+          expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.before_entry_message(e1.entry_date)))
         end
       end
 
@@ -130,7 +130,7 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
         if assessment.exit?
           expect(validations).to be_empty
         else
-          expect(validations).to match([a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.after_exit_message(e1_exit.exit_date))])
+          expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.after_exit_message(e1_exit.exit_date)))
         end
       end
     end
@@ -155,11 +155,11 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
 
         # Validate HoH
         validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        expect(validations).to match([a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.hoh_exits_before_others)])
+        expect(validations).to contain_exactly(a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.hoh_exits_before_others))
 
         # Validate other member
         validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment2).map(&:to_h)
-        expect(validations).to match([a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.member_exits_after_hoh(e1.exit_date))])
+        expect(validations).to contain_exactly(a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.member_exits_after_hoh(e1.exit_date)))
       end
 
       it 'should warn if HoH exit date is before other members (unpersisted)' do
@@ -175,11 +175,11 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
 
         # Validate HoH
         validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment, household_members: [e1, e2]).map(&:to_h)
-        expect(validations).to match([a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.hoh_exits_before_others)])
+        expect(validations).to contain_exactly(a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.hoh_exits_before_others))
 
         # Validate other member
         validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment2, household_members: [e1, e2]).map(&:to_h)
-        expect(validations).to match([a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.member_exits_after_hoh(e1.exit_date))])
+        expect(validations).to contain_exactly(a_hash_including(severity: :warning, message: Hmis::Hud::Validators::ExitValidator.member_exits_after_hoh(e1.exit_date)))
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       aggregate_failures 'checking response' do
         expect(response.status).to eq(200), result&.inspect
-        expect(errors).to match([a_hash_including('severity' => 'warning', 'type' => 'data_not_collected')])
+        expect(errors).to contain_exactly(a_hash_including('severity' => 'warning', 'type' => 'data_not_collected'))
         expect(assessment).to be_nil
 
         # It is still WIP, and fields should NOT have been updated

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq(200), result&.inspect
         expect(assessments).to be_nil
         expect(errors.size).to eq(1)
-        expect(errors).to match([a_hash_including('severity' => 'warning', 'type' => 'data_not_collected')])
+        expect(errors).to contain_exactly(a_hash_including('severity' => 'warning', 'type' => 'data_not_collected'))
         expect(Hmis::Hud::CustomAssessment.in_progress.count).to eq(3)
       end
     end
@@ -224,10 +224,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq(200), result&.inspect
         expect(assessments).to be_nil
         expect(errors.size).to eq(2)
-        expect(errors).to match([
-                                  a_hash_including('severity' => 'warning', 'message' => expected_message, 'recordId' => a2.id.to_s),
-                                  a_hash_including('severity' => 'warning', 'message' => expected_message, 'recordId' => a3.id.to_s),
-                                ])
+        expect(errors).to contain_exactly(
+          a_hash_including('severity' => 'warning', 'message' => expected_message, 'recordId' => a2.id.to_s),
+          a_hash_including('severity' => 'warning', 'message' => expected_message, 'recordId' => a3.id.to_s),
+        )
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       input = { enrollment_id: hoh_enrollment.id, form_definition_id: definition.id, **build_minimum_values(definition) }
       _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
       errors = result.dig('data', 'submitAssessment', 'errors')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot exit head of household because there are existing open enrollments. Please assign a new HoH.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot exit head of household because there are existing open enrollments. Please assign a new HoH.'))
     end
 
     it 'succeeds if exiting non-HoH member' do
@@ -313,7 +313,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
       errors = result.dig('data', 'submitAssessment', 'errors')
       assessment_id = result.dig('data', 'submitAssessment', 'assessment', 'id')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'An exit assessment for this enrollment already exists.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'An exit assessment for this enrollment already exists.'))
       expect(assessment_id).to eq(nil)
     end
   end
@@ -328,7 +328,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       input = { enrollment_id: other_enrollment.id, form_definition_id: definition.id, **build_minimum_values(definition) }
       _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
       errors = result.dig('data', 'submitAssessment', 'errors')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot submit intake assessment because the Head of Household\'s intake has not yet been completed.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot submit intake assessment because the Head of Household\'s intake has not yet been completed.'))
     end
 
     it 'succeeds if entering HoH' do
@@ -399,7 +399,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
       errors = result.dig('data', 'submitAssessment', 'errors')
       assessment_id = result.dig('data', 'submitAssessment', 'assessment', 'id')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'An intake assessment for this enrollment already exists.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'An intake assessment for this enrollment already exists.'))
       expect(assessment_id).to eq(nil)
     end
   end
@@ -423,12 +423,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       'attribute' => 'insuranceFromAnySource',
       'fullMessage' => Hmis::Hud::Validators::IncomeBenefitValidator::INSURANCE_SOURCES_UNSPECIFIED,
     }
-    expect(errors).to match([a_hash_including(expected_error)])
+    expect(errors).to contain_exactly(a_hash_including(expected_error))
 
     # Ensure using validate_only gives the same error
     _resp, result = post_graphql(input: { input: input.merge(validate_only: true) }) { submit_assessment_mutation }
     errors = result.dig('data', 'submitAssessment', 'errors')
-    expect(errors).to match([a_hash_including(expected_error)])
+    expect(errors).to contain_exactly(a_hash_including(expected_error))
   end
 end
 

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       }
       _resp, result = post_graphql(input: input) { submit_assessment_mutation }
       errors = result.dig('data', 'submitHouseholdAssessments', 'errors')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'Please include the head of household. Other household members cannot be entered without the HoH.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'Please include the head of household. Other household members cannot be entered without the HoH.'))
     end
 
     it 'succeeds if (WIP) HoH is included' do
@@ -117,7 +117,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       }
       _resp, result = post_graphql(input: input) { submit_assessment_mutation }
       errors = result.dig('data', 'submitHouseholdAssessments', 'errors')
-      expect(errors).to match([a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot exit head of household because there are existing open enrollments. Please assign a new HoH, or exit all open enrollments.')])
+      expect(errors).to contain_exactly(a_hash_including('severity' => 'error', 'fullMessage' => 'Cannot exit head of household because there are existing open enrollments. Please assign a new HoH, or exit all open enrollments.'))
     end
 
     it 'succeeds if all members are present' do

--- a/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     mutate(input: { input: input }) do |matches, errors|
       expect(errors).to be_empty
       expect(matches.length).to eq(1)
-      expect(matches).to match([a_hash_including('score' => 98)])
+      expect(matches).to contain_exactly(a_hash_including('score' => 98))
     end
   end
 
@@ -158,7 +158,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     mutate(input: { input: input }) do |matches, errors|
       expect(errors).to be_empty
       expect(matches.length).to eq(1)
-      expect(matches).to match([a_hash_including('existingClientId' => '123')])
+      expect(matches).to contain_exactly(a_hash_including('existingClientId' => '123'))
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb
@@ -104,20 +104,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       aggregate_failures 'checking response' do
         expect(response.status).to eq 200
         elements = result.dig('data', 'client', 'customDataElements')
-        expect(elements).to match([
-                                    a_hash_including(
-                                      'key' => cded2.key,
-                                      'label' => cded2.label,
-                                      'values' => [
-                                        a_hash_including('valueBoolean' => cde2.value_boolean),
-                                      ],
-                                    ),
-                                    a_hash_including(
-                                      'key' => cded3.key,
-                                      'label' => cded3.label,
-                                      'value' => a_hash_including('valueJson' => cde3.value_json),
-                                    ),
-                                  ])
+        expect(elements).to contain_exactly(
+          a_hash_including(
+            'key' => cded2.key,
+            'label' => cded2.label,
+            'values' => [
+              a_hash_including('valueBoolean' => cde2.value_boolean),
+            ],
+          ),
+          a_hash_including(
+            'key' => cded3.key,
+            'label' => cded3.label,
+            'value' => a_hash_including('valueJson' => cde3.value_json),
+          ),
+        )
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -405,10 +405,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq(200), result&.inspect
         expect(record_id).to be_nil
         expect(p1.operating_end_date).to be_nil
-        expect(errors).to match([
-                                  a_hash_including('severity' => 'warning', 'type' => 'information', 'fullMessage' => Hmis::Hud::Validators::ProjectValidator.open_funders_message(1)),
-                                  a_hash_including('severity' => 'warning', 'type' => 'information', 'fullMessage' => Hmis::Hud::Validators::ProjectValidator.open_inventory_message(1)),
-                                ])
+        expect(errors).to contain_exactly(
+          a_hash_including('severity' => 'warning', 'type' => 'information', 'fullMessage' => Hmis::Hud::Validators::ProjectValidator.open_funders_message(1)),
+          a_hash_including('severity' => 'warning', 'type' => 'information', 'fullMessage' => Hmis::Hud::Validators::ProjectValidator.open_inventory_message(1)),
+        )
         expect(i1.reload.inventory_end_date).to be nil
         expect(f1.reload.end_date).to be nil
       end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Fix intermittent test failure for `match` where the array is not sorted deterministically: https://github.com/greenriver/hmis-warehouse/actions/runs/8989290248/job/24692077276 by switching to `contains_exactly`
* Change all usages to `contains_exactly` since that is usually what we want

## Type of change
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
