### PR TITLE
Prevent switching the published path once published

### DIFF
--- a/app/views/common/_publish.haml
+++ b/app/views/common/_publish.haml
@@ -5,10 +5,15 @@
       .report-parameters.parameter-label= @report.filter.describe_filter_as_html(@report.known_params)
       = simple_form_for(@report, url: path_to_report, as: :public_report) do |f|
         %p You can optionally specify a sub-folder to make this report unique from others.  This often takes the form of a CoC code, or version number.  If you only expect to have one published version of the report, you can leave it blank.
-        .d-flex
-          = f.input :path, label: 'Folder',  wrapper_html: { class: 'ml-auto' }
-          .ml-4.pt-no-label
-            = f.submit 'Update Folder', class: 'btn btn-secondary'
+        - if @report.published?
+          %p
+            Published to the folder:
+            %strong= @report.published_report&.path
+        - else
+          .d-flex
+            = f.input :path, label: 'Folder',  wrapper_html: { class: 'ml-auto' }
+            .ml-4.pt-no-label
+              = f.submit 'Update Folder', class: 'btn btn-secondary'
       %hr
       - if @report.published?
         = render 'common/re_publish'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This removes the option to update the path of a report if it's published.  To change the path, you first must un-publish.

<img width="1153" alt="Screenshot 2024-05-08 at 10 41 34 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/be6244ac-d51e-4818-aa35-97220ef31147">
<img width="1161" alt="Screenshot 2024-05-08 at 10 41 48 AM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/bca129ef-dd03-409c-b766-07a86e05651d">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
