### PR TITLE
Show search permissions when a new role is shown

### DIFF
--- a/app/javascript/role_manager.js
+++ b/app/javascript/role_manager.js
@@ -59,6 +59,8 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
         if (target_role == $(column).data('roleManagerRoleValue')) {
           $(column).removeClass('hide')
         }
+        const search_string = $('.j-table__search').val().toLowerCase()
+        this.showSearchPermissions(search_string, false)
       });
     } else {
       this.roleColumnTargets.forEach((column) => {
@@ -81,15 +83,21 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
   }
 
   searchPermissions(e) {
+    const target = $(e.currentTarget)
+    const search_string = target.val().toLowerCase()
+    this.showSearchPermissions(search_string)
+  }
+
+  showSearchPermissions(search_string, reset=true) {
     // if we have more than three characters
     // 1. Expand all sections
     // 2. hide any permission where the search string doesn't exit in the text
-    const target = $(e.currentTarget)
-    const search_string = target.val().toLowerCase()
     if (search_string.length > 2) {
       this.permissionCategoryTargets.forEach((section) => {
         $(section).siblings('.panel-collapse').collapse('show')
       });
+      $(this.subCategoryWrapperTargets).removeClass('hide')
+
       this.individualPermissionTargets.forEach((permission) => {
         const wrapper = $(permission).closest('.form-check')
         const sub_category = $(permission).closest('.sub-category-wrapper').find('.sub-category-title')
@@ -107,8 +115,7 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
           $(section).addClass('hide')
         }
       });
-    } else {
-      // reset
+    } else if(reset) {
       this.permissionCategoryTargets.forEach((section) => {
         $(section).siblings('.panel-collapse').collapse('hide')
       });


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Bugfix for showing a role column when there is an active search.

Was not showing the permissions for the existing search if a a hidden role was shown.

To reproduce:
- Hide a role
- Enter a search term (e.g., '2fa')
- Show the hidden role

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
