### PR TITLE
Don't try to import current living situations that don't have a client

### DIFF
--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/current_living_situation.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/current_living_situation.rb
@@ -50,6 +50,8 @@ module HmisDataQualityTool
             current_living_situation: current_living_situation,
             report: report,
           )
+          next unless item.present?
+
           sections(report).each do |_, calc|
             section_title = calc[:title]
             intermediate[section_title] ||= { denominator: {}, invalid: {} }
@@ -82,6 +84,8 @@ module HmisDataQualityTool
 
       project = current_living_situation.enrollment.project
       client = current_living_situation.enrollment.client
+      return unless client.present?
+
       report_item = new(
         report_id: report.id,
         current_living_situation_id: current_living_situation.id,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This should fix a situation where for whatever reason the [HMIS DQ Tool can't determine the client associated with a particular current living situation](https://green-river.sentry.io/issues/5284427357/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=ad8ce549-446a-486f-b25b-4585f1b30535&project=4503977346662400&referrer=slack).

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
