### PR TITLE
Re-implement enrollment coc export filter

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/base.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/base.rb
@@ -25,7 +25,7 @@ module HmisCsvTwentyTwentyFour::Exporter
       start_date:,
       end_date:,
       projects:,
-      coc_codes: nil,
+      coc_codes: [],
       period_type: nil,
       directive: nil,
       hash_status: nil,
@@ -57,6 +57,9 @@ module HmisCsvTwentyTwentyFour::Exporter
       @faked_environment = faked_environment
       @confidential = confidential
       @selected_options = options
+      # We also provide CoC Codes via options, make sure those are added to any CoC codes provided for backwards
+      # compatibility with old code
+      @coc_codes += options['coc_codes'] if options['coc_codes'].present?
     end
 
     # Exports HMIS data in the specified CSV format, wrapped in a zip file.

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
@@ -41,10 +41,6 @@ module HmisCsvTwentyTwentyFour::Exporter
         enrollment_scope.
           modified_within_range(range: (export.start_date..export.end_date))
       end
-      # Limit to the chosen CoC codes if any are specified
-      # Also include any blank records since enrollment.EnrollmentCoC isn't always set correctly
-      filter = export.filter
-      export_scope = export_scope.where(EnrollmentCoC: filter.coc_codes + [nil]) if filter.coc_codes.any?
 
       note_involved_user_ids(scope: export_scope, export: export)
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Re-work the enrollment CoC filter when exporting to use the existing mechanism and prevent getting enrollment related records when the enrollment isn't included.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
