### PR TITLE
Use GR version of composite primary keys gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ gem 'rubyzip', '>= 1.2.1' # >= 1.2.1 due to CVE-2017-5946
 gem 'rails-html-sanitizer', '>= 1.4.4' # >= 1.4.4 due to CVE-2022-23519
 gem 'sshkit'
 gem 'paranoia', '~> 2.0'
-gem 'composite_primary_keys', '~> 14.0.9'
+# gem 'composite_primary_keys', '~> 14.0.9'
+gem 'composite_primary_keys', git: 'https://github.com/greenriver/composite_primary_keys', branch: 'ea/preload-has-many-through-fix'
 gem 'pg'
 gem 'activerecord-sqlserver-adapter'
 gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,14 @@ GIT
       http
 
 GIT
+  remote: https://github.com/greenriver/composite_primary_keys
+  revision: c6fd56bcfe74156ec61119e293f76b11f6858a66
+  branch: ea/preload-has-many-through-fix
+  specs:
+    composite_primary_keys (14.0.9)
+      activerecord (~> 7.0.2)
+
+GIT
   remote: https://github.com/greenriver/hellosign-ruby-sdk.git
   revision: 5718c3f96c37153fb18c02c9ade0e4112a8c7926
   specs:
@@ -354,8 +362,6 @@ GEM
     combine_pdf (1.0.26)
       matrix
       ruby-rc4 (>= 0.1.5)
-    composite_primary_keys (14.0.9)
-      activerecord (~> 7.0.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (1.0.0)
@@ -622,6 +628,8 @@ GEM
     nio4r (2.7.1)
     nokogiri (1.16.4)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
@@ -1084,7 +1092,7 @@ DEPENDENCIES
   charlock_holmes
   coffee-rails
   combine_pdf
-  composite_primary_keys (~> 14.0.9)
+  composite_primary_keys!
   cuprite
   curb
   daemons


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This seems to fix the data load issue where preload was loading entire tables that it shouldn't have.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
