### PR TITLE
Allow exports to work if a project's organization is missing

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/hmis_participation/overrides.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/hmis_participation/overrides.rb
@@ -24,7 +24,7 @@ module HmisCsvTwentyTwentyFour::Exporter
     end
 
     def self.apply_overrides(row)
-      missing_type = if row.project.organization.VictimServiceProvider == 1
+      missing_type = if row.project&.organization&.VictimServiceProvider == 1
         2 # Assume VSPs are using a CD if we don't know
       else
         0


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This works around a situation where the organization of a project can't be found during an export to prevent throwing an error that prevents the export from working at all.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
