### PR TITLE
AssessmentQuestionsJob v2 that processes CustomDataElements

### DIFF
--- a/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
+++ b/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
@@ -4,100 +4,89 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# Job for processing CustomAssessments that represent CE Assessments (e.g. HAT) into HUD CE AssessmentQuestions table.
+# This is necessary because CAS calculators rely and answers to be present in the AssessmentQuestions table.
 module Hmis
   class AssessmentQuestionsJob < BaseJob
-    attr_accessor :form_processor
+    include ::Hmis::Concerns::HmisArelHelper
+    attr_accessor :custom_assessment_ids
 
-    # DO NOT CHANGE: Frontend code sends this value
-    HIDDEN_FIELD_VALUE = '_HIDDEN'.freeze
+    def initialize(custom_assessment_ids)
+      @custom_assessment_ids = Array.wrap(custom_assessment_ids)
+    end
 
-    def perform(form_processor_id)
-      @form_processor = Hmis::Form::FormProcessor.find(form_processor_id)
-      assessment = form_processor.ce_assessment
-      return unless assessment.present?
+    def perform
+      custom_assessment_scope.each do |custom_assessment|
+        form_processor = custom_assessment.form_processor
+        ce_assessment = form_processor.ce_assessment # AssessmentQuestions will be tied to this HUD CE Assessment
+        next unless ce_assessment.present?
 
-      ::GrdaWarehouse::Hud::AssessmentQuestion.transaction do
-        assessment.assessment_questions.delete_all
-        questions_to_import = [].tap do |questions|
-          form_processor.hud_values.each do |key, value|
-            next if key.include?('.') # Field is stored in another HUD object
-            next if value == HIDDEN_FIELD_VALUE
+        definition = form_definitions_by_id[form_processor.definition_id]
+        raise "Form Definition not found: #{form_processor.definition_id}" unless definition
 
-            value = case question_type(key)
-            when 'BOOLEAN'
-              if value
-                'Yes'
-              else
-                'No'
-              end
-            else
-              value
+        ::GrdaWarehouse::Hud::AssessmentQuestion.transaction do
+          ce_assessment.assessment_questions.delete_all
+
+          questions_to_import = [].tap do |questions|
+            question_items = definition.link_id_item_hash.values.select { |item| item.mapping&.custom_field_key.present? }
+            question_items.each_with_index do |item, index|
+              next unless item.mapping&.custom_field_key
+
+              key = item.mapping.custom_field_key
+              cded = custom_data_element_definitions_by_key[key]
+              raise "No custom data element definition found for key: #{key}" unless cded
+
+              # find responses to this question
+              value = custom_assessment.custom_data_elements.select { |cde| cde.data_element_definition_id == cded.id }&.map(&:value)
+              value = nil if value.blank? # [] => nil
+              value = value.first if value&.size == 1 # [value] => value
+              value = yes_no_nil(value) if cded.field_type.to_sym == :boolean # false => 'No'
+
+              questions << ce_assessment.assessment_questions.build(
+                enrollment_id: ce_assessment.enrollment_id,
+                personal_id: ce_assessment.personal_id,
+                user_id: ce_assessment.user_id,
+                date_created: ce_assessment.date_created,
+                date_updated: ce_assessment.date_updated,
+
+                # Note: this key is referenced by the tc_hat calculator
+                assessment_question: key,
+                # Truncate to ensure value is not too long for db
+                assessment_answer: value&.to_s&.truncate(500),
+                # Name of the section that this question belongs to
+                assessment_question_group: definition.link_id_section_hash[item.link_id],
+                # Order of this question in the form
+                assessment_question_order: index + 1,
+              )
             end
-
-            questions << assessment.assessment_questions.build(
-              enrollment_id: assessment.enrollment_id,
-              personal_id: assessment.personal_id,
-              user_id: assessment.user_id,
-              date_created: assessment.assessment_date,
-              date_updated: Time.current,
-
-              assessment_question: key,
-              # Truncate to ensure value is not too long for db
-              assessment_answer: value&.to_s&.truncate(500),
-              assessment_question_group: question_group(key),
-              assessment_question_order: question_order(key),
-            )
           end
-        end
-        ::GrdaWarehouse::Hud::AssessmentQuestion.import!(questions_to_import)
-      end
-    end
-
-    private def question_type(key)
-      form_definition[key].try(:[], :type)
-    end
-
-    private def question_group(key)
-      form_definition[key].try(:[], :group)
-    end
-
-    private def question_order(key)
-      form_definition[key].try(:[], :order)
-    end
-
-    def form_definition
-      @form_definition ||= {}.tap do |h|
-        @order = 1
-        definition = form_processor.definition.definition['item']
-        h.merge!(parse(definition))
-      end
-    end
-
-    # Parse form definition hash to determine the order that custom field keys are declared,
-    # and when they are nested within a group, the label on the group (otherwise nil)
-    #
-    # @return Hash of custom_field_keys to a hash containing {group: group_label, order: the order that the fields appear, type: the type declaration}
-    private def parse(definition, group: nil)
-      {}.tap do |h|
-        definition.each do |item|
-          type = item['type']
-          if type == 'GROUP'
-            group = item['text']
-            nested_definition = item['item']
-            h.merge!(parse(nested_definition, group: group))
-          else
-            key = item.dig('mapping', 'custom_field_key')
-            next unless key.present?
-
-            h[key] = {
-              group: group,
-              order: @order,
-              type: type,
-            }
-            @order += 1
-          end
+          ::GrdaWarehouse::Hud::AssessmentQuestion.import!(questions_to_import)
         end
       end
+    end
+
+    private def custom_assessment_scope
+      @custom_assessment_scope ||= Hmis::Hud::CustomAssessment.where(id: @custom_assessment_ids).
+        joins(:form_processor).
+        where(fp_t[:ce_assessment_id].not_eq(nil)).
+        preload(form_processor: [:ce_assessment], custom_data_elements: [:data_element_definition])
+    end
+
+    def form_definitions_by_id
+      @form_definitions_by_id ||= begin
+        definition_ids = Hmis::Form::FormProcessor.where(custom_assessment_id: @custom_assessment_ids).pluck(:definition_id).uniq
+        Hmis::Form::Definition.where(id: definition_ids).index_by(&:id)
+      end
+    end
+
+    def custom_data_element_definitions_by_key
+      @custom_data_element_definitions_by_key ||= Hmis::Hud::CustomDataElementDefinition.where(owner_type: 'Hmis::Hud::CustomAssessment').index_by(&:key)
+    end
+
+    private def yes_no_nil(bool)
+      return nil if bool.nil?
+
+      bool ? 'Yes' : 'No'
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/concerns/hmis_arel_helper.rb
+++ b/drivers/hmis/app/models/hmis/concerns/hmis_arel_helper.rb
@@ -25,6 +25,10 @@ module Hmis::Concerns::HmisArelHelper
       Hmis::Form::Instance.arel_table
     end
 
+    def fp_t
+      Hmis::Form::FormProcessor.arel_table
+    end
+
     def hs_t
       Hmis::Hud::HmisService.arel_table
     end
@@ -67,6 +71,6 @@ module Hmis::Concerns::HmisArelHelper
   end
 
   included do
-    delegate :cas_t, :wip_t, :ar_t, :hs_t, :cst_t, :csc_t, :cde_t, :cded_t, :hh_t, :u_t, :ut_t, :fd_t, to: 'self.class'
+    delegate :cas_t, :wip_t, :ar_t, :hs_t, :cst_t, :csc_t, :cde_t, :cded_t, :hh_t, :u_t, :ut_t, :fd_t, :fp_t, to: 'self.class'
   end
 end

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -135,11 +135,12 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   end
 
   def store_assessment_questions!
+    # Queue up job to store CE Assessment responses in the HUD CE AssessmentQuestions table
     # Rspec test isolation interferes with delayed job transaction
     if Rails.env.test?
-      ::Hmis::AssessmentQuestionsJob.perform_now(id)
+      ::Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_id)
     else
-      ::Hmis::AssessmentQuestionsJob.perform_later(id)
+      ::Hmis::AssessmentQuestionsJob.perform_later(custom_assessment_id)
     end
   end
 

--- a/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
+++ b/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
     # Repeat-string field
     let!(:cded_str) { create :hmis_custom_data_element_definition, label: 'Multiple strings', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', repeats: true }
-    # let!(:cde1a) { create :hmis_custom_data_element, data_element_definition: cded1, owner: p1, data_source: ds1, value_string: 'First value' }
-    # let!(:cde1b) { create :hmis_custom_data_element, data_element_definition: cded1, owner: p1, data_source: ds1, value_string: 'Second value' }
 
     # Boolean field
     let!(:cded_bool) { create :hmis_custom_data_element_definition, label: 'A bool', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', field_type: :boolean, repeats: false }

--- a/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
+++ b/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
@@ -1,0 +1,237 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
+  context 'generates AssessmentQuestions' do
+    let!(:ds1) { create(:hmis_data_source) }
+
+    # Repeat-string field
+    let!(:cded_str) { create :hmis_custom_data_element_definition, label: 'Multiple strings', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', repeats: true }
+    # let!(:cde1a) { create :hmis_custom_data_element, data_element_definition: cded1, owner: p1, data_source: ds1, value_string: 'First value' }
+    # let!(:cde1b) { create :hmis_custom_data_element, data_element_definition: cded1, owner: p1, data_source: ds1, value_string: 'Second value' }
+
+    # Boolean field
+    let!(:cded_bool) { create :hmis_custom_data_element_definition, label: 'A bool', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', field_type: :boolean, repeats: false }
+    # let!(:cde2) { create :hmis_custom_data_element, data_element_definition: cded2, owner: c1, data_source: ds1, value_boolean: true }
+
+    # Integer field
+    let!(:cded_int) { create :hmis_custom_data_element_definition, label: 'A number', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', field_type: :integer }
+
+    # cruft: unrelated cded on custom assessment
+    let!(:cded_cruft) { create :hmis_custom_data_element_definition, label: 'CDED not in assessment', data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment', field_type: :string }
+
+    let!(:ce_definition) do
+      form_content = {
+        'item': [
+          {
+            'type': 'GROUP',
+            'link_id': 'group_1',
+            'text': 'Section 1',
+            'item': [
+              {
+                'type': 'STRING',
+                'link_id': 'question_one',
+                'repeats': true,
+                'mapping': { 'custom_field_key': cded_str.key },
+              },
+              {
+                # cruft
+                'type': 'DISPLAY',
+                'link_id': 'display',
+                'text': 'This is a display item',
+              },
+            ],
+          },
+          {
+            'type': 'GROUP',
+            'link_id': 'group_2',
+            'text': 'Section 2',
+            'item': [
+              {
+                'type': 'BOOLEAN',
+                'link_id': 'question_two',
+                'mapping': { 'custom_field_key': cded_bool.key },
+              },
+              {
+                # cruft
+                'type': 'STRING',
+                'link_id': 'field',
+                'mapping': { 'field_name': 'ignored' },
+              },
+              {
+                'type': 'GROUP',
+                'link_id': 'group_inner',
+                'item': [
+                  {
+                    'type': 'INTEGER',
+                    'link_id': 'question_three',
+                    'mapping': { 'custom_field_key': cded_int.key },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+      create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, definition: form_content)
+    end
+
+    let!(:u1) { create :hmis_hud_user, data_source: ds1 }
+    let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
+    let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+    let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+    let!(:ce_assessment) { create(:hmis_hud_assessment, data_source: ds1, enrollment: e1, client: c1) }
+    let!(:custom_assessment) do
+      ca = create(:hmis_custom_assessment, definition: ce_definition, data_source: ds1, enrollment: e1, client: c1)
+      ca.form_processor.update!(ce_assessment: ce_assessment)
+      ca
+    end
+
+    describe 'when responses do not exist' do
+      let!(:cde_str1) { create :hmis_custom_data_element, data_element_definition: cded_str, owner: custom_assessment, data_source: ds1, value_string: 'response' }
+
+      it 'creates AssessmentQuestions with some empty values' do
+        expect do
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+        end.to change(ce_assessment.assessment_questions, :count).by(3)
+
+        expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
+          a_hash_including('AssessmentQuestion' => cded_str.key, 'AssessmentAnswer' => 'response'),
+          a_hash_including('AssessmentQuestion' => cded_bool.key, 'AssessmentAnswer' => nil),
+          a_hash_including('AssessmentQuestion' => cded_int.key, 'AssessmentAnswer' => nil),
+        )
+      end
+    end
+
+    describe 'when all responses exist' do
+      # responses for cded_str
+      let!(:cde_str1) { create :hmis_custom_data_element, data_element_definition: cded_str, owner: custom_assessment, data_source: ds1, value_string: 'First value' }
+      let!(:cde_str2) { create :hmis_custom_data_element, data_element_definition: cded_str, owner: custom_assessment, data_source: ds1, value_string: 'Second value' }
+      # response for cded_bool
+      let!(:cde_bool) { create :hmis_custom_data_element, data_element_definition: cded_bool, owner: custom_assessment, data_source: ds1, value_boolean: true }
+      # response for cded_int
+      let!(:cde_int) { create :hmis_custom_data_element, data_element_definition: cded_int, owner: custom_assessment, data_source: ds1, value_integer: 6 }
+
+      it 'creates AssessmentQuestions with correct group and order' do
+        expect do
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+        end.to change(ce_assessment.assessment_questions, :count).by(3)
+
+        expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
+          a_hash_including(
+            'AssessmentQuestion' => cded_str.key,
+            'AssessmentAnswer' => '["First value", "Second value"]',
+            'AssessmentQuestionGroup' => 'Section 1',
+            'AssessmentQuestionOrder' => 1,
+          ),
+          a_hash_including(
+            'AssessmentQuestion' => cded_bool.key,
+            'AssessmentAnswer' => 'Yes',
+            'AssessmentQuestionGroup' => 'Section 2',
+            'AssessmentQuestionOrder' => 2,
+          ),
+          a_hash_including(
+            'AssessmentQuestion' => cded_int.key,
+            'AssessmentAnswer' => '6',
+            'AssessmentQuestionGroup' => 'Section 2',
+            'AssessmentQuestionOrder' => 3,
+          ),
+        )
+      end
+
+      it 'can re-process changed values' do
+        # create AssessmentQuestions
+        expect do
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+        end.to change(ce_assessment.assessment_questions, :count).by(3)
+        bool_question = ce_assessment.assessment_questions.find_by(assessment_question: cded_bool.key)
+        expect(bool_question.AssessmentAnswer).to eq('Yes')
+
+        # change a response value
+        cde_bool.update!(value_boolean: false)
+
+        # re-run the job
+        expect do
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+        end.to change(ce_assessment.assessment_questions, :count).by(0)
+
+        bool_question = ce_assessment.assessment_questions.find_by(assessment_question: cded_bool.key)
+        expect(bool_question.AssessmentAnswer).to eq('No')
+      end
+    end
+
+    describe 'for multiple custom assessments with different definitions' do
+      let!(:cded_str_2) { create :hmis_custom_data_element_definition, data_source: ds1, owner_type: 'Hmis::Hud::CustomAssessment' }
+      let!(:ce_definition_2) do
+        form_content = {
+          'item': [
+            {
+              'type': 'GROUP',
+              'link_id': 'fd2_group1',
+              'text': 'Foo',
+              'item': [
+                {
+                  'type': 'STRING',
+                  'link_id': 'fd2_question1',
+                  'repeats': true,
+                  'mapping': { 'custom_field_key': cded_str_2.key },
+                },
+              ],
+            },
+          ],
+        }
+        create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, definition: form_content)
+      end
+      let!(:ce_assessment_2) { create(:hmis_hud_assessment, data_source: ds1, enrollment: e1, client: c1) }
+      let!(:custom_assessment_2) do
+        ca = create(:hmis_custom_assessment, definition: ce_definition_2, data_source: ds1, enrollment: e1, client: c1)
+        ca.form_processor.update!(ce_assessment: ce_assessment_2)
+        ca
+      end
+      let!(:cde_str1) { create :hmis_custom_data_element, data_element_definition: cded_str_2, owner: custom_assessment_2, data_source: ds1, value_string: 'other form response' }
+
+      it 'can run on a batch of Custom Assessments that use different definitions' do
+        expect do
+          Hmis::AssessmentQuestionsJob.perform_now([custom_assessment.id, custom_assessment_2.id])
+        end.to change(ce_assessment.assessment_questions, :count).by(3).
+          and change(ce_assessment_2.assessment_questions, :count).by(1)
+
+        expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
+          a_hash_including(
+            'AssessmentQuestion' => cded_str.key,
+            'AssessmentAnswer' => nil,
+            'AssessmentQuestionGroup' => 'Section 1',
+            'AssessmentQuestionOrder' => 1,
+          ),
+          a_hash_including(
+            'AssessmentQuestion' => cded_bool.key,
+            'AssessmentAnswer' => nil,
+            'AssessmentQuestionGroup' => 'Section 2',
+            'AssessmentQuestionOrder' => 2,
+          ),
+          a_hash_including(
+            'AssessmentQuestion' => cded_int.key,
+            'AssessmentAnswer' => nil,
+            'AssessmentQuestionGroup' => 'Section 2',
+            'AssessmentQuestionOrder' => 3,
+          ),
+        )
+
+        expect(ce_assessment_2.assessment_questions.map(&:attributes)).to contain_exactly(
+          a_hash_including(
+            'AssessmentQuestion' => cded_str_2.key,
+            'AssessmentAnswer' => 'other form response',
+            'AssessmentQuestionGroup' => 'Foo',
+            'AssessmentQuestionOrder' => 1,
+          ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description


Make the following changes to AssessmentQuestionsJob:
* Process responses from `custom_data_elements` instead of processing the `hud_values` blob. This allows us to process migrated-in CE Assessments into AssessmentQuestions.
* Support processing multiple assessments (since we will need to run this in batches for migrated data)
* Use existing form definition utils for `AssessmentQuestionGroup` and `AssessmentQuestionOrder`
* Make `DateCreated`/`DateUpdated` on `AssessmentQuestions` reflect the values on HUD `Assessment`
* Add tests


https://github.com/open-path/Green-River/issues/6069

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
