### PR TITLE
Patch bug in assessment filter

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
@@ -21,8 +21,8 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
     hud_data_collection_stages = []
     custom_identifiers = []
 
+    hud_role_to_dcs = Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES.excluding(:CUSTOM_ASSESSMENT)
     input.assessment_name.each do |t|
-      hud_role_to_dcs = Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES.excluding(:CUSTOM_ASSESSMENT)
       if hud_role_to_dcs.include?(t.to_sym)
         hud_data_collection_stages << hud_role_to_dcs[t.to_sym]
       else

--- a/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
@@ -17,6 +17,7 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_assessment_name(scope)
+    # "assessment_name" is either a HUD Role ('INTAKE') or a custom assessment form identifier ('my_assessment_form')
     hud_data_collection_stages = []
     custom_identifiers = []
 
@@ -30,8 +31,6 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
     end
 
     with_filter(scope, :assessment_name) do
-      # "assessment_name" is either a HUD Role ('INTAKE') or a custom assessment form identifier ('my_assessment_form')
-
       # we check data collection stage because migrated-in HUD Assessments may not be linked to a definition
       matches_hud_assessment = cas_t[:data_collection_stage].in(hud_data_collection_stages)
       matches_custom_assessment = fd_t[:identifier].in(custom_identifiers)

--- a/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
@@ -74,4 +74,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect(assessments.first['id']).to eq(intake_assessment.id.to_s)
     expect(assessments.second['id']).to eq(fully_custom_assessment.id.to_s)
   end
+
+  it 'should return intake even if it is not tied to a definition' do
+    intake_assessment.form_processor.update!(definition: nil)
+    response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE'] }) { query }
+    expect(response.status).to eq 200
+    assessments = result.dig('data', 'project', 'assessments', 'nodes')
+    expect(assessments.count).to eq 1
+    expect(assessments.first['id']).to eq(intake_assessment.id.to_s)
+  end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix bug where HUD assessments that were not tied to a definition were not returned in the assessment_name filter. This is a quirk that we should address with https://github.com/open-path/Green-River/issues/5709. Currently migrated-in assessments to not have definition_id on the form processor, since they were never submitted in the HMIS system.

https://github.com/open-path/Green-River/issues/6081

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
