### PR TITLE
Patch enqueuing custom assessment job

### DIFF
--- a/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
+++ b/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
@@ -9,13 +9,9 @@
 module Hmis
   class AssessmentQuestionsJob < BaseJob
     include ::Hmis::Concerns::HmisArelHelper
-    attr_accessor :custom_assessment_ids
 
-    def initialize(custom_assessment_ids)
+    def perform(custom_assessment_ids:)
       @custom_assessment_ids = Array.wrap(custom_assessment_ids)
-    end
-
-    def perform
       custom_assessment_scope.each do |custom_assessment|
         form_processor = custom_assessment.form_processor
         ce_assessment = form_processor.ce_assessment # AssessmentQuestions will be tied to this HUD CE Assessment
@@ -66,7 +62,7 @@ module Hmis
     end
 
     private def custom_assessment_scope
-      @custom_assessment_scope ||= Hmis::Hud::CustomAssessment.where(id: @custom_assessment_ids).
+      Hmis::Hud::CustomAssessment.where(id: @custom_assessment_ids).
         joins(:form_processor).
         where(fp_t[:ce_assessment_id].not_eq(nil)).
         preload(form_processor: [:ce_assessment], custom_data_elements: [:data_element_definition])

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -138,9 +138,9 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
     # Queue up job to store CE Assessment responses in the HUD CE AssessmentQuestions table
     # Rspec test isolation interferes with delayed job transaction
     if Rails.env.test?
-      ::Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_id)
+      ::Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: custom_assessment_id)
     else
-      ::Hmis::AssessmentQuestionsJob.perform_later(custom_assessment_id)
+      ::Hmis::AssessmentQuestionsJob.perform_later(custom_assessment_ids: custom_assessment_id)
     end
   end
 

--- a/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
+++ b/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
       it 'creates AssessmentQuestions with some empty values' do
         expect do
-          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: custom_assessment.id)
         end.to change(ce_assessment.assessment_questions, :count).by(3)
 
         expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
@@ -118,7 +118,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
       it 'creates AssessmentQuestions with correct group and order' do
         expect do
-          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: custom_assessment.id)
         end.to change(ce_assessment.assessment_questions, :count).by(3)
 
         expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
@@ -146,7 +146,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
       it 'can re-process changed values' do
         # create AssessmentQuestions
         expect do
-          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: custom_assessment.id)
         end.to change(ce_assessment.assessment_questions, :count).by(3)
         bool_question = ce_assessment.assessment_questions.find_by(assessment_question: cded_bool.key)
         expect(bool_question.AssessmentAnswer).to eq('Yes')
@@ -156,7 +156,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
         # re-run the job
         expect do
-          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment.id)
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: custom_assessment.id)
         end.to change(ce_assessment.assessment_questions, :count).by(0)
 
         bool_question = ce_assessment.assessment_questions.find_by(assessment_question: cded_bool.key)
@@ -196,7 +196,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
       it 'can run on a batch of Custom Assessments that use different definitions' do
         expect do
-          Hmis::AssessmentQuestionsJob.perform_now([custom_assessment.id, custom_assessment_2.id])
+          Hmis::AssessmentQuestionsJob.perform_now(custom_assessment_ids: [custom_assessment.id, custom_assessment_2.id])
         end.to change(ce_assessment.assessment_questions, :count).by(3).
           and change(ce_assessment_2.assessment_questions, :count).by(1)
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix bug introduced in https://github.com/greenriver/hmis-warehouse/pull/4367
`perform_later` didn't work like that. Use a named arg instead.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
