### PR TITLE
Clean up custom assessment display in warehouse

### DIFF
--- a/drivers/hmis/app/views/hmis_client/assessments/show.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/show.haml
@@ -28,14 +28,14 @@
 - if @assessment.custom_data_elements.any?
   %h2 Questions
   .well
-    - @assessment.custom_data_elements.each do |cde|
-      - cded = cde.data_element_definition
-      - label = cded.label
-      - key = cded.key # <== this is what is referenced as custom_Field_key in the form def
-      - value = cde.value # this is a function, it will read value_string,value_date etc.
+    - @assessment.custom_data_elements.group_by(&:data_element_definition).each do |cded, cdes|
+      -# values of the CustomDataElement(s)
+      - values_arr = cdes.map(&:value)
+      - display_value = values_arr.join(', ')
+      - display_value = yes_no(values_arr.first) if [true, false].include?(values_arr.first) && values_arr.size == 1
       %dl
-        %dt= label
-        %dd= value
+        %dt= cded.label # label of the CustomDataElementDefinition
+        %dd= display_value
 - elsif !@assessment.hud_assessment?
   .none-found No questions provided.
 -# Always link to HMIS for HUD Assessments, since the majority of data is non-Custom so wont be shown here.


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## comma-separate multiple choice answers
<img width="605" alt="Screenshot 2024-05-15 at 2 46 11 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/f8dd1ebd-64f8-409e-9686-0a0ca5d08116">

==>

<img width="689" alt="Screenshot 2024-05-15 at 2 53 25 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/1b743bab-fe35-44fe-b037-fdf619d03a3d">

## nicer boolean display
was "true" "false" before
<img width="268" alt="Screenshot 2024-05-15 at 2 59 13 PM" src="https://github.com/greenriver/hmis-warehouse/assets/5333982/daadc486-7657-4d22-ae11-d4d28ff67492">



## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
