### PR TITLE
Patch frozen string bug in cas sync

### DIFF
--- a/app/models/grda_warehouse/hud/assessment.rb
+++ b/app/models/grda_warehouse/hud/assessment.rb
@@ -79,7 +79,7 @@ module GrdaWarehouse::Hud
       assessment_answer&.downcase! unless case_sensitive
       answer&.downcase! unless case_sensitive
 
-      assessment_answer == answer
+      (assessment_answer || '') == answer
     end
 
     def results_matching_requirement(question, answer = nil)

--- a/app/models/grda_warehouse/hud/assessment.rb
+++ b/app/models/grda_warehouse/hud/assessment.rb
@@ -75,8 +75,8 @@ module GrdaWarehouse::Hud
       return nil if matching_question.blank?
       return matching_question unless answer.present?
 
-      assessment_answer = matching_question.AssessmentAnswer.to_s
-      assessment_answer.downcase! unless case_sensitive
+      assessment_answer = matching_question.AssessmentAnswer&.to_s
+      assessment_answer&.downcase! unless case_sensitive
       answer&.downcase! unless case_sensitive
 
       assessment_answer == answer

--- a/spec/fixtures/files/service_history/child_in_household/source/AssessmentQuestions.csv
+++ b/spec/fixtures/files/service_history/child_in_household/source/AssessmentQuestions.csv
@@ -1,3 +1,4 @@
 "AssessmentQuestionID","AssessmentID","EnrollmentID","PersonalID","AssessmentQuestionGroup","AssessmentQuestionOrder","AssessmentQuestion","AssessmentAnswer","DateCreated","DateUpdated","UserID","DateDeleted","ExportID"
 Q-1,1-1,1-4,1-1,,,hat_e11_cps,Yes,2017-01-01 00:00:00,2017-01-01 00:00:00,catalina,,1-1
 Q-2,1-1,1-4,1-1,,,hat_e14_ipv_date,2015-01-02,2017-01-01 00:00:00,2017-01-01 00:00:00,catalina,,1-1
+Q-1,1-1,1-4,1-1,,,hat_c7_can_pass_drug_test,,2017-01-01 00:00:00,2017-01-01 00:00:00,catalina,,1-1

--- a/spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
+++ b/spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
@@ -49,5 +49,10 @@ RSpec.describe GrdaWarehouse::CasProjectClientCalculator::TcHat, type: :model do
       client = GrdaWarehouse::Hud::Client.destination.find_by(personal_id: '1-1')
       expect(@calculator.value_for_cas_project_client(client: client, column: :dv_date)).to eq('2015-01-02'.to_date)
     end
+
+    it 'doesn\'t fail on null AssessmentAnswer for boolean' do
+      client = GrdaWarehouse::Hud::Client.destination.find_by(personal_id: '1-1')
+      expect(@calculator.value_for_cas_project_client(client: client, column: :drug_test)).to be_nil
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

`nil.to_s` produces a frozen string, which was causing an error when `AssessmentAnswer` is nil (Which is valid)

https://greenriver.slack.com/archives/C1GSH9M6D/p1715867494073379?thread_ts=1715866046.812799&cid=C1GSH9M6D

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
