### PR TITLE
Revert to previous behavior of storing all nil->false

### DIFF
--- a/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
+++ b/drivers/hmis/app/jobs/hmis/assessment_questions_job.rb
@@ -36,7 +36,8 @@ module Hmis
               value = custom_assessment.custom_data_elements.select { |cde| cde.data_element_definition_id == cded.id }&.map(&:value)
               value = nil if value.blank? # [] => nil
               value = value.first if value&.size == 1 # [value] => value
-              value = yes_no_nil(value) if cded.field_type.to_sym == :boolean # false => 'No'
+              # Don't change this, TcHmisHat calculator relies on booleans being stored as 'Yes' or 'No'
+              value = yes_no(value) if cded.field_type.to_sym == :boolean # false => 'No'
 
               questions << ce_assessment.assessment_questions.build(
                 enrollment_id: ce_assessment.enrollment_id,
@@ -79,9 +80,9 @@ module Hmis
       @custom_data_element_definitions_by_key ||= Hmis::Hud::CustomDataElementDefinition.where(owner_type: 'Hmis::Hud::CustomAssessment').index_by(&:key)
     end
 
-    private def yes_no_nil(bool)
-      return nil if bool.nil?
-
+    private def yes_no(bool)
+      # Nil is intentionally saved as 'No' to match previous behavior.
+      # This will be the case even for questions that were hidden on the page at time of assessment.
       bool ? 'Yes' : 'No'
     end
   end

--- a/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
+++ b/drivers/hmis/spec/jobs/assessment_questions_job_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
 
         expect(ce_assessment.assessment_questions.map(&:attributes)).to contain_exactly(
           a_hash_including('AssessmentQuestion' => cded_str.key, 'AssessmentAnswer' => 'response'),
-          a_hash_including('AssessmentQuestion' => cded_bool.key, 'AssessmentAnswer' => nil),
+          a_hash_including('AssessmentQuestion' => cded_bool.key, 'AssessmentAnswer' => 'No'), # nil boolean response gets stored as No
           a_hash_including('AssessmentQuestion' => cded_int.key, 'AssessmentAnswer' => nil),
         )
       end
@@ -209,7 +209,7 @@ RSpec.describe Hmis::AssessmentQuestionsJob, type: :model do
           ),
           a_hash_including(
             'AssessmentQuestion' => cded_bool.key,
-            'AssessmentAnswer' => nil,
+            'AssessmentAnswer' => 'No', # nil boolean response gets stored as No
             'AssessmentQuestionGroup' => 'Section 2',
             'AssessmentQuestionOrder' => 2,
           ),


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

PR https://github.com/greenriver/hmis-warehouse/pull/4367  changed behavior such that `nil` boolean responses were being stored as `nil` as opposed to `No`. This PR reverts that change, so all `nil` boolean responses are stored as "No" again.

TBH this doesn't feel quite right, because many of the questions are often hidden on the page. Just because they are nil doesn't mean the answer is no. In any case I think it best to keep the behavior that we had previously (before https://github.com/greenriver/hmis-warehouse/pull/4367), and maybe have further discussion on whether it should be changed. (Imo if this is special logic thats needed because of the cas calculator, it should happen in the calculator. "AssessmentQuestions" should match what was _Actually answered_).

The change from 4367 also resulted in https://github.com/greenriver/hmis-warehouse/pull/4377 since we were now handling nil booleans. But I think we should keep that, because we shouldn't blow up when we encounter them.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
