### PR TITLE
Raise errors from AutoExitJob

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -44,15 +44,13 @@ module Hmis
 
           auto_exit_count += 1
           auto_exit_projects.add(project.id)
-          auto_exit(enrollment, most_recent_contact)
+          Hmis::Hud::Base.transaction do
+            auto_exit(enrollment, most_recent_contact)
+          end
         end
       end
 
       @notifier&.ping("Auto-exited #{auto_exit_count} Enrollments in #{auto_exit_projects.size} Projects")
-    rescue StandardError => e
-      puts e.message
-      @notifier.ping('Failure in auto-exit job', { exception: e })
-      Rails.logger.fatal e.message
     end
 
     private

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -138,11 +138,8 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
     e1 = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: Date.current - 2.months
     create :hmis_custom_service, data_source: ds1, client: c1, enrollment: e1, user: u1, date_provided: Date.current - 31.days
 
-    allow(Rails.logger).to receive(:fatal).and_return nil
-
-    Hmis::AutoExitJob.perform_now
+    expect { Hmis::AutoExitJob.perform_now }.to raise_error('Auto-exit config unusually low: 29')
 
     expect(e1.exit).to be_nil
-    expect(Rails.logger).to have_received(:fatal).with('Auto-exit config unusually low: 29')
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Now that https://github.com/greenriver/hmis-warehouse/pull/4294 is in, we should be able to raise errors directly from delayed jobs so they get to sentry.  Errors were being swallowed (https://github.com/open-path/Green-River/issues/6056)
* Also, wrap exit changes in a transaction

I'm not sure how to test the sentry part locally, but I can test it in QA.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
