### PR TITLE
Inter CoC report should use EnrollmentCoC

### DIFF
--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -1,4 +1,4 @@
-//= require action_cable
+//= require actioncable
 //= require_self
 (function() {
   this.App || (this.App = {});

--- a/app/models/warehouse_report/overlapping_coc.rb
+++ b/app/models/warehouse_report/overlapping_coc.rb
@@ -35,9 +35,8 @@ class WarehouseReport::OverlappingCoc < WarehouseReport
         end_date: end_date,
       )
 
-    my_enrollments = e_scope.in_coc(
-      coc_code: coc_code,
-    )
+    my_enrollments = e_scope.joins(:enrollment).
+      where(e_t[:enrollment_coc].eq(coc_code))
 
     my_client_ids = my_enrollments.distinct.pluck(:client_id)
 
@@ -45,9 +44,9 @@ class WarehouseReport::OverlappingCoc < WarehouseReport
       client_id: my_client_ids,
     ).where.not(
       id: my_enrollments.select(:id),
-    ).joins(project: :project_cocs).group(
-      GrdaWarehouse::Hud::ProjectCoc.coc_code_coalesce.to_sql,
-    ).distinct.count(:client_id)
+    ).joins(:enrollment).
+      group(e_t[:enrollment_coc]).
+      distinct.count(:client_id)
 
     other_client_counts
   end

--- a/app/models/warehouse_report/overlapping_coc_by_project_type.rb
+++ b/app/models/warehouse_report/overlapping_coc_by_project_type.rb
@@ -246,8 +246,6 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
   private def enrollment_details(services, user)
     services.group_by { |s| s.service_history_enrollment.project }.map do |project, project_services|
       {
-        # FIXME
-        # coc: project.project_cocs.first.effective_coc_code,
         coc: project_services.first.enrollment.enrollment_coc,
         project_name: project.name(user),
         project_type: ::HudUtility2024.project_type_brief(project.ProjectType),

--- a/app/models/warehouse_report/overlapping_coc_by_project_type.rb
+++ b/app/models/warehouse_report/overlapping_coc_by_project_type.rb
@@ -81,7 +81,8 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
       residential.
       open_between(start_date: @start_date, end_date: @end_date).
       service_within_date_range(start_date: @start_date, end_date: @end_date).
-      in_coc(coc_code: coc_code)
+      joins(:enrollment).
+      merge(GrdaWarehouse::Hud::Enrollment.where(EnrollmentCoC: coc_code))
 
     if @project_type
       scope = scope.merge(
@@ -110,9 +111,12 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
 
   def service_histories(project_type: nil)
     scope = GrdaWarehouse::ServiceHistoryService.joins(
-      service_history_enrollment: {
-        project: :project_cocs,
-      },
+      service_history_enrollment: [
+        :enrollment,
+        {
+          project: :project_cocs,
+        },
+      ],
     ).service_between(
       start_date: @start_date,
       end_date: @end_date,
@@ -136,7 +140,7 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
             where(client_id: clients).
             in_project_type(p_type).
             distinct.
-            merge(GrdaWarehouse::Hud::ProjectCoc.in_coc(coc_code: coc)).
+            merge(GrdaWarehouse::Hud::Enrollment.where(enrollment_coc: coc)).
             pluck(:client_id, :project_type, :date).each do |c_id, p_type2, date|
               dates[p_type2][coc] << [c_id, date]
             end
@@ -208,11 +212,7 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
     # force this to only return data for the first 50, beyond that is unnecessary
     relevant_client_ids = relevant_client_ids[0..50]
     service_histories.where(client_id: relevant_client_ids).
-      preload(
-        service_history_enrollment: {
-          project: :project_cocs,
-        },
-      ).
+      preload(service_history_enrollment: [:enrollment, { project: :project_cocs }]).
       group_by(&:client_id).map do |client_id, services|
         client = clients_by_id[client_id]
         {
@@ -246,7 +246,9 @@ class WarehouseReport::OverlappingCocByProjectType < WarehouseReport
   private def enrollment_details(services, user)
     services.group_by { |s| s.service_history_enrollment.project }.map do |project, project_services|
       {
-        coc: project.project_cocs.first.effective_coc_code,
+        # FIXME
+        # coc: project.project_cocs.first.effective_coc_code,
+        coc: project_services.first.enrollment.enrollment_coc,
         project_name: project.name(user),
         project_type: ::HudUtility2024.project_type_brief(project.ProjectType),
         history: history_details(project_services),

--- a/app/views/warehouse_reports/overlapping_coc_utilization/_overlap.haml
+++ b/app/views/warehouse_reports/overlapping_coc_utilization/_overlap.haml
@@ -6,7 +6,6 @@
   end
   project_types = report.chart_by_project_type
   total_non_overlapping_clients = report.total_non_overlapping_clients
-
 - if project_types.empty? && filters.coc2 && filters.coc1
   .alert.alert-warning
     No shared clients between #{filters.coc1.number_and_name} and #{filters.coc2.number_and_name} found.

--- a/app/views/warehouse_reports/overlapping_coc_utilization/_overlap.haml
+++ b/app/views/warehouse_reports/overlapping_coc_utilization/_overlap.haml
@@ -6,6 +6,7 @@
   end
   project_types = report.chart_by_project_type
   total_non_overlapping_clients = report.total_non_overlapping_clients
+
 - if project_types.empty? && filters.coc2 && filters.coc1
   .alert.alert-warning
     No shared clients between #{filters.coc1.number_and_name} and #{filters.coc2.number_and_name} found.


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This updates the Inter-CoC report to look at Enrollment.EnrollmentCoC instead of Project.ProjectCoC records when determining overlap.  Historically EnrollmentCoC has had worse data quality, but using ProjectCoC prevents using the report in situations where projects operate in multiple CoCs.

Additionally, this fixes a deprecation where `action_cable.js` is now referred to as `actioncable.js`.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
