### PR TITLE
5723-improve-rack-middleware-config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,9 +78,6 @@ module BostonHmis
     # rather than using static error pages in public/.
     config.exceptions_app = routes
 
-    config.middleware.use Rack::Attack # needed pre rails 5.1
-    config.middleware.use IdProtector
-
     # FIXME: required to make forms in pjax modals work
     config.action_controller.per_form_csrf_tokens = false
 

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -5,3 +5,6 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!
+
+# fixes issue where stack trace is swallowed by middleware
+Rails.backtrace_cleaner.add_silencer { |line| line =~ /lib\/util\/id_protector/ }

--- a/lib/util/id_protector.rb
+++ b/lib/util/id_protector.rb
@@ -3,6 +3,7 @@
 #
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
+
 class IdProtector
   def initialize(app)
     @app = app
@@ -27,5 +28,13 @@ class IdProtector
       end
     end
     @app.call(env)
+  end
+end
+
+require 'rack/attack'
+class IdProtectorRailtie < ::Rails::Railtie
+  initializer 'id-protector.middleware' do |app|
+    # put id protector behind rack attack
+    app.middleware.insert_after(Rack::Attack, IdProtector)
   end
 end


### PR DESCRIPTION

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_
fix missing backtrace in id-protector
fix duplicate inclusion of rack attack
order middleware so id-protector is after rack-attack

## Description

diff of `rails middleware`
```diff
 use Rack::ETag
 use Rack::TempfileReaper
 use Warden::Manager
-use Rack::Attack
-use IdProtector
 use OmniAuth::Builder
 use OmniAuth::Builder
 use Rack::Attack
+use IdProtector
 run BostonHmis::Application.routes
```
## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
