### PR TITLE
Don't delete everything if the file failed to load

### DIFF
--- a/drivers/custom_imports_boston_assessment_lookups/app/models/custom_imports_boston_assessment_lookups/import_file.rb
+++ b/drivers/custom_imports_boston_assessment_lookups/app/models/custom_imports_boston_assessment_lookups/import_file.rb
@@ -47,6 +47,9 @@ module CustomImportsBostonAssessmentLookups
     end
 
     def post_process
+      # Refuse to delete anything if the import has no rows, we probably didn't get a file
+      return unless rows.exits?
+
       update(status: 'adding')
       GrdaWarehouse::AssessmentAnswerLookup.transaction do
         GrdaWarehouse::AssessmentAnswerLookup.where(data_source_id: data_source_id).delete_all


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a bug where assessment lookups are deleted if a file isn't found during the import process.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
