### PR TITLE
Add picklist of projects receiving referrals

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -6535,6 +6535,11 @@ enum PickListType {
   All Projects that the User can see
   """
   PROJECT
+
+  """
+  Open Projects that can receive referrals
+  """
+  PROJECTS_RECEIVING_REFERRALS
   REFERRAL_OUTCOME
 
   """

--- a/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
@@ -15,6 +15,7 @@ module Types
     value 'ENROLLABLE_PROJECTS', 'Projects that the User can enroll Clients in'
     value 'RESIDENTIAL_PROJECTS', 'Residential Projects'
     value 'OPEN_PROJECTS', 'Open Projects that the user can see'
+    value 'PROJECTS_RECEIVING_REFERRALS', 'Open Projects that can receive referrals'
     value 'ORGANIZATION', 'All Organizations that the User can see'
     value 'ASSESSMENT_NAMES', 'Assessment names, including custom assessments and assessments that are inactive. If a project is specified, the list is limited to assessments that exist in the project (both active and inactive).'
     value 'GEOCODE'

--- a/drivers/hmis/app/models/hmis/form/instance_project_match.rb
+++ b/drivers/hmis/app/models/hmis/form/instance_project_match.rb
@@ -51,7 +51,6 @@ class Hmis::Form::InstanceProjectMatch
       end
     end
 
-    # rubocop:disable Style/GuardClause
     if could_match_project_type? && could_match_funder?
       return matches_project_type? && matches_project_funder? ? PROJECT_TYPE_AND_FUNDER_MATCH : nil
     elsif could_match_project_type?
@@ -59,7 +58,6 @@ class Hmis::Form::InstanceProjectMatch
     elsif could_match_funder?
       return matches_project_funder? ? PROJECT_FUNDER_MATCH : nil
     end
-    # rubocop:enable Style/GuardClause
 
     return matches_default? ? DEFAULT_MATCH : nil
   end
@@ -86,6 +84,8 @@ class Hmis::Form::InstanceProjectMatch
   end
 
   def matches_project_funder?
+    # TODO: Should this be based on _active_ funders? Currently this would apply rules to a project
+    # that used to be funded by a certain funder.
     instance.funder.presence&.in?(project.funders.map(&:funder)) ||
       instance.other_funder.presence&.in?(project.funders.map(&:other_funder))
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Targeting against 117 since this completes the functionality that was added with https://github.com/greenriver/hmis-warehouse/pull/4389.

When you go to make a referral, the project dropdown previously showed all open projects. With https://github.com/greenriver/hmis-frontend/pull/783 it shows only projects that have enabled Referral forms, which means they can receive referrals. This lets us configure which projects receive referrals using Form Rules.


## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
