### PR TITLE
Resolve referral_date as date

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/create_outgoing_referral_posting.rb
@@ -36,7 +36,7 @@ module Mutations
 
       referral = HmisExternalApis::AcHmis::Referral.new(
         enrollment: enrollment,
-        referral_date: Time.current,
+        referral_date: Date.current,
         service_coordinator: current_user.name,
       )
       referral.household_members = enrollment.household_members.preload(:client).map do |member|

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9314,7 +9314,7 @@ type ReferralPosting {
   Project that household is being referred to
   """
   project: Project
-  referralDate: ISO8601DateTime!
+  referralDate: ISO8601Date!
   referralIdentifier: ID
 
   """

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -14,7 +14,7 @@ module Types
 
     # Fields that come from Referral
     field :referral_identifier, ID
-    field :referral_date, GraphQL::Types::ISO8601DateTime, null: false
+    field :referral_date, GraphQL::Types::ISO8601Date, null: false
     field :referred_by, String, null: false
     field :referral_notes, String, description: 'Note associated with the Referral that came from an External API'
     field :chronic, Boolean


### PR DESCRIPTION
## Description

`referral_date` column is a `date` in the db. We were resolving it as a datetime which resolves as `2024-05-24T00:00:00+00:00` which makes it show up as `5/23/24` in the UI (which I believe is a bug https://github.com/greenriver/hmis-frontend/pull/784). But, we should be resolving it as a date in the first place.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
