### PR TITLE
Allow referring to a project that you don't have access to

### DIFF
--- a/drivers/hmis/app/graphql/mutations/submit_form.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_form.rb
@@ -55,7 +55,7 @@ module Mutations
         # allow if no permission check defined
         allowed = true
       end
-      raise HmisErrors::ApiError, 'Access Denied' unless allowed
+      access_denied! unless allowed
 
       # Build FormProcessor
       # It wont be persisted, but it handles validation and updating the relevant record(s)
@@ -177,9 +177,13 @@ module Mutations
       when 'HmisExternalApis::AcHmis::ReferralRequest'
         [project, klass.new({ project_id: project&.id })]
       when 'HmisExternalApis::AcHmis::ReferralPosting'
+        # Look up the receiving project without `viewable_by` scope, since referrer may not have access to receiving project
+        receiving_project = Hmis::Hud::Project.find_by(id: input.project_id)
+        access_denied! unless enrollment.present? && receiving_project.present?
+
         referral_posting = HmisExternalApis::AcHmis::ReferralPosting.new_with_referral(
           enrollment: enrollment, # enrollment at the source project
-          receiving_project: project,
+          receiving_project: receiving_project,
           user: current_user,
         )
         # Evaluate permission (can manage outgoing referrals) against the source project, not the receiving project

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -775,6 +775,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       it 'succeeds when referer lacks access to receiving project' do
         # User has access to refer from p1, but no access to p2
         create_access_control(hmis_user, p1, with_permission: [:can_manage_outgoing_referrals, :can_view_project, :can_view_enrollment_details])
+        expect(Hmis::Hud::Project.viewable_by(hmis_user).where(id: p2.id).exists?).to be false # confirm setup
+
         _, errors = submit_form(test_input)
         expect(errors).to be_empty
       end

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
         it 'should fail if user lacks permission' do
           remove_permissions(access_control, *definition.record_editing_permissions)
-          expect_gql_error post_graphql(input: { input: test_input }) { mutation }
+          expect_gql_error post_graphql(input: { input: test_input }) { mutation }, message: 'access denied'
         end
 
         it 'should update user correctly' do
@@ -760,6 +760,24 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(posting.referral.enrollment).to eq(hoh)
       expect(posting.project).to eq(p2)
       expect(posting.status).to eq('assigned_status')
+    end
+
+    context 'referral permissions' do
+      before(:each) { access_control.destroy! } # remove blanket access
+
+      [:can_manage_outgoing_referrals, :can_view_enrollment_details, :can_view_project].each do |permission|
+        it "fails when referer lacks #{permission} in source project" do
+          create_access_control(hmis_user, p1, without_permission: permission)
+          expect_gql_error post_graphql(input: { input: test_input }) { mutation }, message: 'access denied'
+        end
+      end
+
+      it 'succeeds when referer lacks access to receiving project' do
+        # User has access to refer from p1, but no access to p2
+        create_access_control(hmis_user, p1, with_permission: [:can_manage_outgoing_referrals, :can_view_project, :can_view_enrollment_details])
+        _, errors = submit_form(test_input)
+        expect(errors).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update outgoing referral behavior to support referring to a project that you don't have access to view.

Addresses QA issue on https://github.com/open-path/Green-River/issues/6037#issuecomment-2130176153.

This was not needed previously since outgoing referrals was only used by admins that could access all projects.

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
