### PR TITLE
Refactor team/agency performance counts

### DIFF
--- a/app/models/health/agency_performance.rb
+++ b/app/models/health/agency_performance.rb
@@ -37,22 +37,7 @@ module Health
 
         next unless patient_ids.any?
 
-        OpenStruct.new(
-          {
-            id: id,
-            name: name,
-            patient_referrals: patient_ids,
-            without_required_qa: patient_ids - with_completed_intake - with_required_qa,
-            without_required_f2f_visit: patient_ids - with_required_f2f_visit,
-            with_discharge_followup_completed: with_discharge_followup_completed.select { |p_id| p_id.in?(patient_ids) },
-            with_completed_intake: with_completed_intake.select { |p_id| p_id.in?(patient_ids) },
-            initial_intake_due: initial_intake_due.select { |p_id| p_id.in?(patient_ids) },
-            initial_intake_overdue: initial_intake_overdue.select { |p_id| p_id.in?(patient_ids) },
-            intake_renewal_due: intake_renewal_due.select { |p_id| p_id.in?(patient_ids) },
-            intake_renewal_overdue: intake_renewal_overdue.select { |p_id| p_id.in?(patient_ids) },
-            without_required_wellcare_visit: patient_ids - with_required_wellcare_visit,
-          },
-        )
+        create_count(name, patient_ids, self)
       end.compact
     end
 

--- a/app/models/health/performance_base.rb
+++ b/app/models/health/performance_base.rb
@@ -17,6 +17,25 @@ module Health
 
     attr_accessor :range
 
+    def create_count(name, patient_ids, calculator)
+      OpenStruct.new(
+        {
+          id: nil,
+          name: name,
+          patient_referrals: patient_ids,
+          without_required_qa: patient_ids - calculator.with_required_qa,
+          without_required_f2f_visit: patient_ids - calculator.with_required_f2f_visit,
+          with_discharge_followup_completed: calculator.with_discharge_followup_completed.select { |id| id.in?(patient_ids) },
+          with_completed_intake: calculator.with_completed_intake.select { |id| id.in?(patient_ids) },
+          initial_intake_due: calculator.initial_intake_due.select { |id| id.in?(patient_ids) },
+          initial_intake_overdue: calculator.initial_intake_overdue.select { |id| id.in?(patient_ids) },
+          intake_renewal_due: calculator.intake_renewal_due.select { |id| id.in?(patient_ids) },
+          intake_renewal_overdue: calculator.intake_renewal_overdue.select { |id| id.in?(patient_ids) },
+          without_required_wellcare_visit: patient_ids - calculator.with_required_wellcare_visit,
+        },
+      )
+    end
+
     def client_ids
       @client_ids ||= Health::Patient.where(id: patient_referrals.keys).
         pluck(:client_id, :id).to_h

--- a/app/models/health/team_performance.rb
+++ b/app/models/health/team_performance.rb
@@ -33,22 +33,7 @@ module Health
 
         next unless patient_ids.any?
 
-        OpenStruct.new(
-          {
-            id: nil,
-            name: name,
-            patient_referrals: patient_ids,
-            without_required_qa: patient_ids - with_required_qa,
-            without_required_f2f_visit: patient_ids - with_required_f2f_visit,
-            with_discharge_followup_completed: with_discharge_followup_completed.select { |id| id.in?(patient_ids) },
-            with_completed_intake: with_completed_intake.select { |id| id.in?(patient_ids) },
-            initial_intake_due: initial_intake_due.select { |id| id.in?(patient_ids) },
-            initial_intake_overdue: initial_intake_overdue.select { |id| id.in?(patient_ids) },
-            intake_renewal_due: intake_renewal_due.select { |id| id.in?(patient_ids) },
-            intake_renewal_overdue: intake_renewal_overdue.select { |id| id.in?(patient_ids) },
-            without_required_wellcare_visit: patient_ids - with_required_wellcare_visit,
-          },
-        )
+        create_count(name, patient_ids, self)
       end.compact
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The team and agency performance dashboards were out of sync: they had different logic for who to include in `without_required_qa`. DRY-up the creation of team/agency counts to fix this and keep them consistent in the future.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [X] Code clean-up / housekeeping

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
