### PR TITLE
Allow providers to view outgoing referrals even if they cannot see the destination project

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9312,7 +9312,7 @@ type ReferralPosting {
   postingIdentifier: ID
 
   """
-  Project that household is being referred to
+  Project that household is being referred to, if user can access it
   """
   project: Project
   referralDate: ISO8601Date!
@@ -9330,6 +9330,11 @@ type ReferralPosting {
   Name of project or external source that the referral originated from
   """
   referredFrom: String!
+
+  """
+  Name of the Project that household is being referred to
+  """
+  referredTo: String
 
   """
   Note associated with the Referral Posting that either came from the External

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -24,7 +24,7 @@ module Types
 
     def self.options_for_type(pick_list_type, user:, project_id: nil, client_id: nil, household_id: nil)
       result = static_options_for_type(pick_list_type, user: user)
-      return result if result.present?
+      return result unless result.nil? # check nil so we return an empty array if it was static but there were no options
 
       project = Hmis::Hud::Project.viewable_by(user).find_by(id: project_id) if project_id.present?
       client = Hmis::Hud::Client.viewable_by(user).find_by(id: client_id) if client_id.present?
@@ -78,6 +78,8 @@ module Types
         external_form_types_for_project(project)
       when 'ASSESSMENT_NAMES'
         assessment_names_for_project(project)
+      else
+        raise "Unknown pick list type: #{pick_list_type}"
       end
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_referral_postings.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_referral_postings.rb
@@ -22,9 +22,11 @@ module Types
       end
 
       # TODO(#186102846) support filtering
-      def scoped_referral_postings(scope, sort_order: nil)
-        scope = scope.viewable_by(current_user).
-          preload(referral: { household_members: :client }).
+      def scoped_referral_postings(scope, sort_order: nil, dangerous_skip_permission_check: false)
+        # note: viewability is based on the project that is receiving the referral
+        scope = scope.viewable_by(current_user) unless dangerous_skip_permission_check
+
+        scope = scope.preload(referral: { household_members: :client }).
           preload(:unit_type).
           preload(:status_note_updated_by).
           preload(:status_updated_by).

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -44,8 +44,9 @@ module Types
     field :referral_result, HmisSchema::Enums::Hud::ReferralResult
     field :denial_note, String, description: 'Admin Note associated with the denial (entered from the Denial Screen)'
     field :referred_from, String, null: false, description: 'Name of project or external source that the referral originated from'
+    field :referred_to, String, null: true, description: 'Name of the Project that household is being referred to'
     field :unit_type, HmisSchema::UnitTypeObject, null: true
-    field :project, HmisSchema::Project, null: true, description: 'Project that household is being referred to'
+    field :project, HmisSchema::Project, null: true, description: 'Project that household is being referred to, if user can access it'
     field :organization, HmisSchema::Organization, null: true
     custom_data_elements_field
 
@@ -108,6 +109,10 @@ module Types
       enrollment_project&.project_name || 'Coordinated Entry'
     end
 
+    def referred_to
+      project&.project_name
+    end
+
     def organization
       project&.organization
     end
@@ -143,7 +148,10 @@ module Types
     end
 
     def project
-      load_ar_association(object, :project)
+      receiving_project = load_ar_association(object, :project)
+      return unless current_permission?(permission: :can_view_project, entity: receiving_project)
+
+      receiving_project
     end
 
     def referral

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -110,7 +110,7 @@ module Types
     end
 
     def referred_to
-      project&.project_name
+      load_ar_association(object, :project)&.project_name
     end
 
     def organization

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
@@ -11,7 +11,7 @@ module HmisExternalApis::AcHmis
     include ::Hmis::Hud::Concerns::HasCustomDataElements
     belongs_to :referral, class_name: 'HmisExternalApis::AcHmis::Referral'
     belongs_to :referral_request, class_name: 'HmisExternalApis::AcHmis::ReferralRequest', optional: true
-    belongs_to :project, class_name: 'Hmis::Hud::Project'
+    belongs_to :project, class_name: 'Hmis::Hud::Project' # project that is receiving the referral
     belongs_to :unit_type, class_name: 'Hmis::UnitType', optional: true
     belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
@@ -26,6 +26,7 @@ module HmisExternalApis::AcHmis
 
     scope :from_link, -> { where.not(identifier: nil) }
 
+    # viewability is based on whether the user can see the project that is RECEIVING the referral. It does not check referral perms.
     scope :viewable_by, ->(_user) { raise } # this scope is replaced by ::Hmis::Hud::Concerns::ProjectRelated
     include ::Hmis::Hud::Concerns::ProjectRelated
 

--- a/drivers/hmis_external_apis/extensions/hmis/hud/project_extension.rb
+++ b/drivers/hmis_external_apis/extensions/hmis/hud/project_extension.rb
@@ -12,6 +12,7 @@ module HmisExternalApis
 
         included do
           has_many :external_referral_requests, class_name: 'HmisExternalApis::AcHmis::ReferralRequest', dependent: :destroy
+          # "incoming" referral postings for this project
           has_many :external_referral_postings, class_name: 'HmisExternalApis::AcHmis::ReferralPosting', dependent: :destroy
           has_many :external_unit_availability_syncs, class_name: 'HmisExternalApis::AcHmis::UnitAvailabilitySync', dependent: :destroy
         end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

**Before**: If a provider didn't have access to the receiving project of a referral that they send, the referral would not appear in the "Outgoing Referrals" table.
**After**: All outgoing referrals appear in the table, as long as the user has "can manage outgoing referrals" for the project, regardless of destination.

Also fixes a bug whereby the pick list query would error if the pick list had no options in it.

This is a follow-up to https://github.com/greenriver/hmis-warehouse/pull/4389, issue https://github.com/open-path/Green-River/issues/6037

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
