### PR TITLE
Minio config for HTTPS

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,3 @@
+silence_warnings do
+  OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -24,7 +24,7 @@ amazon:
 minio:
   service: S3
   force_path_style: true # don't force dns hoop jumping
-  endpoint: <%= ENV.fetch('MINIO_ENDPOINT', "http://s3.dev.test:9000") %>
+  endpoint: <%= ENV.fetch('MINIO_ENDPOINT', "https://s3.dev.test:9000") %>
   access_key_id:  local_access_key
   secret_access_key: local_secret_key
   region: us-east-1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -255,13 +255,20 @@ services:
       MINIO_SECRET_KEY: local_secret_key
       MINIO_ROOT_USER: local_access_key
       MINIO_ROOT_PASSWORD: local_secret_key
-    expose:
-      - '9000'
-      - '9001'
     ports:
       - 9000:9000
       - 9001:9001 # enable for UI access
-    command: server --certs-dir /certs /data
+    command: server --certs-dir /certs /data --console-address ":9001"
+    labels:
+      - traefik.enable=${TRAEFIK_ENABLED:-false}
+      - traefik.http.routers.minio.entrypoints=web
+      - traefik.http.routers.minio.rule=Host(`${MINIO_DOMAIN:-s3.dev.test}`)
+      - traefik.http.services.minio_https.loadbalancer.server.port=9000
+      - traefik.http.routers.minio_https.rule=Host(`${MINIO_DOMAIN:-s3.dev.test}`)
+      - traefik.http.routers.minio_https.tls=true
+      - traefik.http.routers.minio_https.entrypoints=web-secure
+      - traefik.http.middlewares.minio_https.redirectscheme.scheme=https
+      - traefik.http.routers.minio.middlewares=op_https
 
 volumes:
   bundle_alpine:


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This enables minio to provide fake S3 for both the HMIS and warehouse by moving it to https.

For this to work, you'll need to add your CA named `full-chain-ca.crt` and the `*.dev.test` certificate and keys in to the files named `private.key` and `public.key` as shown in this screenshot:
<img width="213" alt="Screenshot 2024-05-29 at 1 32 26 PM" src="https://github.com/greenriver/hmis-warehouse/assets/1346876/d6f5016e-bb38-4927-bb48-7314072a1e51">

## Type of change
[//]: # 'remove options that are not relevant'

- [ ] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
