### PR TITLE
Add new github action to regenerate the datalab testkits on specific commit message

### DIFF
--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -160,13 +160,6 @@ jobs:
           aws_region: us-east-1
           flags: --recursive
       - name: Remove existing fixpoint files
-        env:
-          AWS_ACCESS_KEY_ID: local_access_key
-          AWS_SECRET_ACCESS_KEY: local_secret_key
-          GROVER_NO_SANDBOX: true
-          CHROMIUM_PATH: /usr/bin/chromium-browser
-          MAX_FAILURES: 60
-          LOG_LEVEL: INFO
         run: |
           rm ./drivers/datalab_testkit/spec/fixpoints/*
       - name: Generate new fixpoint files
@@ -179,7 +172,6 @@ jobs:
           LOG_LEVEL: INFO
         run: |
           bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
-          OKTA_DOMAIN=localhost OKTA_CLIENT_ID=x OKTA_CLIENT_SECRET=x bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/requests/omniauth_spec.rb spec/requests/sessions_controller_spec.rb # these tests need okta enabled
       - name: 'Copy old fixpoints to previous folder'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -169,12 +169,15 @@ jobs:
       #     LOG_LEVEL: INFO
       #   run: |
       #     bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
+      - name: Get current date
+        id: date
+        run: echo "today=$(date +'%Y-%m-%d')"
       - name: 'Copy old fixpoints to previous folder'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
           source: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/current/
-          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/previous/
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/previous/${{ env.today }}/
           aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -176,8 +176,8 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
-          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/current/
-          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/previous/${{ env.today }}/
+          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_PREVIOUS_FIXPOINT_PATH_FY_2024 }}${{ env.today }}/
           aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
@@ -187,7 +187,7 @@ jobs:
         with:
           command: cp
           source: ./drivers/datalab_testkit/spec/fixpoints/
-          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/current/
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
           aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -171,7 +171,7 @@ jobs:
       #     bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
       - name: Get current date
         id: date
-        run: echo "today=$(date +'%Y-%m-%d')"
+        run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       - name: 'Copy old fixpoints to previous folder'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -179,7 +179,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           flags: --recursive
-      - name: 'Copy new fixpoint files to current folder' # adding comment for test
+      - name: 'Copy new fixpoint files to current folder'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -159,16 +159,16 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           flags: --recursive
-      - name: Generate new fixpoint files
-        env:
-          AWS_ACCESS_KEY_ID: local_access_key
-          AWS_SECRET_ACCESS_KEY: local_secret_key
-          GROVER_NO_SANDBOX: true
-          CHROMIUM_PATH: /usr/bin/chromium-browser
-          MAX_FAILURES: 60
-          LOG_LEVEL: INFO
-        run: |
-          bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
+      # - name: Generate new fixpoint files
+      #   env:
+      #     AWS_ACCESS_KEY_ID: local_access_key
+      #     AWS_SECRET_ACCESS_KEY: local_secret_key
+      #     GROVER_NO_SANDBOX: true
+      #     CHROMIUM_PATH: /usr/bin/chromium-browser
+      #     MAX_FAILURES: 60
+      #     LOG_LEVEL: INFO
+      #   run: |
+      #     bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
       - name: 'Copy old fixpoints to previous folder'
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -1,0 +1,204 @@
+name: Rebuild Test Kit Fixpoints
+on:
+  push:
+    branches:
+      - "*"
+      - "**/*"
+concurrency:
+  group: ${{ github.ref }}-test_kit_fixpoints
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-20.04
+    if: contains(github.event.head_commit.message, '[gh:rebuild_fixpoints]')
+
+    # Docker Hub image that the job executes in
+    # $RUBY_VERSION
+    container: ruby:3.1.4-alpine3.18
+
+    # Service containers to run with job
+    services:
+      postgres:
+        image: postgis/postgis:12-3.1-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASS: postgres
+          POSTGRES_MULTIPLE_EXTENSIONS: postgis,hstore
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+
+      hmis-warehouse-sftp:
+        image: ghcr.io/greenriver/openpath-sftp:1.0
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        ports:
+          - '2222:22'
+
+      minio:
+        image: ghcr.io/greenriver/openpath-minio:1.0
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MINIO_ACCESS_KEY: local_access_key
+          MINIO_SECRET_KEY: local_secret_key
+        ports:
+          - '9000:9000'
+
+    env:
+      CLIENT: test
+      DATABASE_ADAPTER: postgresql
+      DATABASE_APP_DB_TEST: warehouse_app_test
+      DATABASE_DB_TEST: warehouse_test
+      DATABASE_APP_DB: warehouse_app_test
+      DATABASE_HOST: postgres
+      DATABASE_PASS: postgres
+      DATABASE_USER: postgres
+      DATABASE_WAREHOUSE_DB_TEST: warehouse_test
+      DEFAULT_FROM: greenriver.testing@mailinator.com
+      ENCRYPTION_KEY: strongEncryptionstrongEncryptionstrongEncryption
+      FQDN: openpath.host
+      HEALTH_DATABASE_ADAPTER: postgresql
+      HEALTH_DATABASE_DB_TEST: health_test
+      HEALTH_DATABASE_HOST: postgres
+      HEALTH_DATABASE_PASS: postgres
+      HEALTH_DATABASE_USER: postgres
+      HEALTH_FROM: greenriver.testing@mailinator.com
+      HOSTNAME: openpath.host
+      MINIO_ENDPOINT: http://minio:9000
+      USE_MINIO_ENDPOINT: true
+      PORT: 80
+      RAILS_ENV: test
+      REPORTING_DATABASE_ADAPTER: postgresql
+      REPORTING_DATABASE_DB_TEST: reporting_test
+      REPORTING_DATABASE_HOST: postgres
+      REPORTING_DATABASE_PASS: postgres
+      REPORTING_DATABASE_USER: postgres
+      WAREHOUSE_DATABASE_ADAPTER: postgis
+      WAREHOUSE_DATABASE_DB_TEST: warehouse_test
+      WAREHOUSE_DATABASE_HOST: postgres
+      WAREHOUSE_DATABASE_PASS: postgres
+      WAREHOUSE_DATABASE_USER: postgres
+      WAREHOUSE_DATABASE_DB: warehouse_test
+      HEALTH_DATABASE_DB: health_test
+      REPORTING_DATABASE_DB: reporting_test
+      # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+      PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium-browser
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up dependencies
+        run: |
+          apk add --no-cache \
+            nodejs yarn npm \
+            tzdata \
+            git \
+            bash \
+            freetds-dev \
+            icu icu-dev \
+            curl libcurl curl-dev \
+            imagemagick \
+            libmagic file-dev file \
+            build-base libxml2-dev libxslt-dev postgresql-dev \
+            libgcc libstdc++ libx11 glib libxrender libxext libintl ttf-dejavu ttf-droid ttf-freefont ttf-liberation ttf-freefont \
+            chromium nss freetype freetype-dev harfbuzz ca-certificates ttf-freefont \
+            lftp postgresql tmux postgis geos geos-dev \
+            shared-mime-info gpg gpg-agent
+
+          echo "postgres:5432:*:postgres:postgres" > ~/.pgpass
+          chmod 600 ~/.pgpass
+
+          yarn install --frozen-lockfile
+          gem install bundler --version=2.5.7
+
+      - name: Install gems
+        run: |
+          bundle config set --local without 'production staging development'
+          bundle install --jobs 4 --retry 3
+
+      - name: 'App setup'
+        run: |
+          cp config/secrets.yml.sample config/secrets.yml
+          mkdir app/assets/stylesheets/theme/styles
+          touch app/assets/stylesheets/theme/styles/_variables.scss
+          cp .rspec.sample .rspec
+          cp config/database.yml.ci config/database.yml
+
+      - name: Prepare test db
+        run: |
+          pg_isready -h postgres -U postgres
+          bin/db_prep
+
+          echo "Setting up .pgpass"
+          echo "postgres:*:*:postgres:postgres" > ~/.pgpass
+          chmod 600 ~/.pgpass
+      # fetch some closed source files
+      - name: 'Fetch testkit source files'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_SOURCE_PATH_FY_2024 }}
+          destination: ./drivers/datalab_testkit/spec/fixtures/inputs/
+          aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          flags: --recursive
+      - name: Remove existing fixpoint files
+        env:
+          AWS_ACCESS_KEY_ID: local_access_key
+          AWS_SECRET_ACCESS_KEY: local_secret_key
+          GROVER_NO_SANDBOX: true
+          CHROMIUM_PATH: /usr/bin/chromium-browser
+          MAX_FAILURES: 60
+          LOG_LEVEL: INFO
+        run: |
+          rm ./drivers/datalab_testkit/spec/fixpoints/*
+      - name: Generate new fixpoint files
+        env:
+          AWS_ACCESS_KEY_ID: local_access_key
+          AWS_SECRET_ACCESS_KEY: local_secret_key
+          GROVER_NO_SANDBOX: true
+          CHROMIUM_PATH: /usr/bin/chromium-browser
+          MAX_FAILURES: 60
+          LOG_LEVEL: INFO
+        run: |
+          bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
+          OKTA_DOMAIN=localhost OKTA_CLIENT_ID=x OKTA_CLIENT_SECRET=x bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/requests/omniauth_spec.rb spec/requests/sessions_controller_spec.rb # these tests need okta enabled
+      - name: 'Copy old fixpoints to previous folder'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_PREVIOUS_FIXPOINT_PATH_FY_2024 }}
+          aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          flags: --recursive
+      - name: 'Copy new fixpoint files to current folder'
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./drivers/datalab_testkit/spec/fixpoints/
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
+          aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          flags: --recursive
+          
+          

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -159,16 +159,16 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           flags: --recursive
-      # - name: Generate new fixpoint files
-      #   env:
-      #     AWS_ACCESS_KEY_ID: local_access_key
-      #     AWS_SECRET_ACCESS_KEY: local_secret_key
-      #     GROVER_NO_SANDBOX: true
-      #     CHROMIUM_PATH: /usr/bin/chromium-browser
-      #     MAX_FAILURES: 60
-      #     LOG_LEVEL: INFO
-      #   run: |
-      #     bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
+      - name: Generate new fixpoint files
+        env:
+          AWS_ACCESS_KEY_ID: local_access_key
+          AWS_SECRET_ACCESS_KEY: local_secret_key
+          GROVER_NO_SANDBOX: true
+          CHROMIUM_PATH: /usr/bin/chromium-browser
+          MAX_FAILURES: 60
+          LOG_LEVEL: INFO
+        run: |
+          bundle exec rspec --fail-fast=$MAX_FAILURES --color -P "drivers/datalab_testkit/spec/empty_spec.rb"
       - name: Get current date
         id: date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -176,8 +176,8 @@ jobs:
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp
-          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
-          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_PREVIOUS_FIXPOINT_PATH_FY_2024 }}
+          source: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/current/
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/previous/
           aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
@@ -187,7 +187,7 @@ jobs:
         with:
           command: cp
           source: ./drivers/datalab_testkit/spec/fixpoints/
-          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}${{ vars.AWS_S3_ACTIONS_FIXPOINT_PATH_FY_2024 }}
+          destination: ${{ secrets.AWS_S3_ACTION_BUCKET }}test-kit-fixpoint-automation-test/current/
           aws_access_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -182,7 +182,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           flags: --recursive
-      - name: 'Copy new fixpoint files to current folder'
+      - name: 'Copy new fixpoint files to current folder' # adding comment for test
         uses: keithweaver/aws-s3-github-action@v1.0.0
         with:
           command: cp

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -159,9 +159,6 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: us-east-1
           flags: --recursive
-      - name: Remove existing fixpoint files
-        run: |
-          rm ./drivers/datalab_testkit/spec/fixpoints/*
       - name: Generate new fixpoint files
         env:
           AWS_ACCESS_KEY_ID: local_access_key

--- a/drivers/datalab_testkit/spec/empty_spec.rb
+++ b/drivers/datalab_testkit/spec/empty_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require_relative 'models/datalab_testkit_context'
+
+RSpec.describe 'Empty test to load fixpoints' do
+  include_context 'datalab testkit context'
+  before(:all) do
+    setup
+  end
+
+  after(:all) do
+    cleanup
+  end
+
+  it 'Always Passes' do
+    expect(true).to be true
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add a new github action that will regenerate the testkit fixpoints when a commit with "[gh:rebuild_fixpoints]" in the commit message.

https://github.com/open-path/Green-River/issues/5945

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
