### PR TITLE
Ignore null DateProvided in AutoExitJob

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -28,10 +28,10 @@ module Hmis
           most_recent_contact = if project.es_nbn? # Night-by-night Emergency Shelter
             # For NBN shelters, the most recent contact is the last bed night.
             # If the client had no bed nights, use the enrollment (entry date) as the last contact.
-            enrollment.services.bed_nights.order(:date_provided).last || enrollment
+            enrollment.services.bed_nights.where.not(date_provided: nil).order(:date_provided).last || enrollment
           else
             [
-              enrollment.services.order(:date_provided).last,
+              enrollment.services.where.not(date_provided: nil).order(:date_provided).last,
               enrollment.custom_services.order(:date_provided).last,
               enrollment.current_living_situations.order(:information_date).last,
               enrollment.custom_assessments.order(:assessment_date).last,
@@ -40,6 +40,7 @@ module Hmis
           end
 
           most_recent_contact_date = contact_date_for_entity(most_recent_contact)
+          next unless most_recent_contact_date.present?
           next unless (Date.current - most_recent_contact_date).to_i >= config.length_of_absence_days
 
           auto_exit_count += 1


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Bug: AutoExitJob would throw an error if Service.DateProvided was nil
Fix: ignore services where date provided is nil

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
