### PR TITLE
Support resolving unknown service type

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -10032,7 +10032,7 @@ type Service {
   otherTypeProvided: String
   recordType: RecordType
   referralOutcome: PATHReferralOutcome
-  serviceType: ServiceType!
+  serviceType: ServiceType
   subTypeProvided: ServiceSubTypeProvided
   typeProvided: ServiceTypeProvided
   user: ApplicationUser

--- a/drivers/hmis/app/graphql/types/hmis_schema/service.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/service.rb
@@ -29,7 +29,7 @@ module Types
     field :id, ID, null: false
     field :enrollment, Types::HmisSchema::Enrollment, null: false
     field :client, HmisSchema::Client, null: false
-    field :service_type, HmisSchema::ServiceType, null: false
+    field :service_type, HmisSchema::ServiceType, null: true
     field :date_provided, GraphQL::Types::ISO8601Date, null: true
     field :fa_amount, Float, null: true
     field :fa_start_date, GraphQL::Types::ISO8601Date, null: true


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Support resolving Service without Service Type. We don't have a guarantee that the HUD `Services.RecordType` and `Services.TypeProvided` will be present or valid. If they are not valid, we won't be able to link them to a CustomServiceType, so the type will be "unknown".

Frontend PR:  https://github.com/greenriver/hmis-frontend/pull/789

https://green-river.sentry.io/issues/5433122901/?referrer=slack&notification_uuid=bd5c7aa2-bd0e-4fc1-ad08-f452a326c45d&environment=production&alert_rule_id=14757490&alert_type=issue

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
