### PR TITLE
Fix bug(?) in Current Living Situation resolution

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -128,7 +128,7 @@ module Types
     def current_living_situations(**args)
       check_enrollment_details_access
 
-      resolve_assessments(object.current_living_situations, dangerous_skip_permission_check: true, **args)
+      resolve_current_living_situations(object.current_living_situations, dangerous_skip_permission_check: true, **args)
     end
 
     def organization


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6075

I *think* this is a bug in the Project schema object's Current Living Situation resolver. I noticed that sorting CLS by information date (which, I think, should happen [here](https://github.com/greenriver/hmis-warehouse/blob/47cfee51730ef5fa07ba5c0557440d4f1d1579bc/drivers/hmis/app/graphql/types/hmis_schema/has_current_living_situations.rb#L35)) wasn't working on the Project's list of CLS, and when stepping thru in the debugger to discover why, I saw that that code wasn't actually getting called.

Let me know if I've got it wrong and this `resolve_assessments` here was intentional?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
