### PR TITLE
Bugfix for daily HRSN generation

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -161,7 +161,7 @@ module Health
     private def generate_daily_hrsn_qa(housing_status)
       return unless engaged? # Daily HRSNs are not produced until the patient is engaged
 
-      previous_status = Health::HousingStatus.as_of(date: housing_status.collected_on - 1.day).first
+      previous_status = housing_statuses.as_of(date: housing_status.collected_on - 1.day).first
       return unless housing_status.positive_for_homelessness? && previous_status.present? && ! previous_status.positive_for_homelessness? # Only record no -> yes
 
       return if Health::QualifyingActivity.find_by(date_of_activity: housing_status.collected_on, activity: :sdoh_positive).present? # Don't duplicate QAs


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix for a bug in the daily HRSN generator that retrieves the wrong prior housing status.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
