### PR TITLE
Hide user groups when a user is using ACLs

### DIFF
--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -63,20 +63,21 @@
                 - names.each do |name|
                   .mb-1= name
             %td
-              -# TODO: START_ACL cleanup after ACL transition
-              - names = user.access_groups.general.order(name: :asc).distinct.map(&:name)
-              - names.uniq.sort.each do |name|
-                .mb-1= name
-            %td
-              - providers = user.oauth_identities.map(&:provider_name).sort.uniq
-              - if providers.any?
-                %div= "Sign-in provided by #{providers.to_sentence}"
-              = render 'user_invitation_status', user: user
               -# TODO: START_ACL remove after ACL transition
               - if user.using_acls?
                 .mt-2
                   = checkmark(true)
                   ACLs Enabled
+              - else
+                -# TODO: START_ACL cleanup after ACL transition
+                - names = user.access_groups.general.order(name: :asc).distinct.map(&:name)
+                - names.uniq.sort.each do |name|
+                  .mb-1= name
+            %td
+              - providers = user.oauth_identities.map(&:provider_name).sort.uniq
+              - if providers.any?
+                %div= "Sign-in provided by #{providers.to_sentence}"
+              = render 'user_invitation_status', user: user
             %td
               - if user.invitation_status != :active || user.access_locked?
                 .mb-6


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This hides the "groups" from a user list if the user is using ACLs and instead displays "ACLs Enabled"

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
