### PR TITLE
Fix bug in form update mutation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/update_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/update_form_definition.rb
@@ -26,7 +26,7 @@ module Mutations
       # to match the expected format.
       # 2. The JSON Form Editor (old), which sends keys as a JSON string in the expected format and doesn't need
       # to be transformed, but calling recursively_transform on it is not harmful either.
-      definition.definition = recursively_transform(JSON.parse(input.definition))
+      definition.definition = recursively_transform(JSON.parse(input.definition)) if input.definition
 
       errors = HmisErrors::Errors.new
       ::HmisUtil::JsonForms.new.tap do |builder|

--- a/drivers/hmis/app/graphql/mutations/update_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/update_form_definition.rb
@@ -18,7 +18,7 @@ module Mutations
       raise 'not found' unless definition
       raise 'not allowed to change identifier' if input.identifier.present? && input.identifier != definition.identifier
 
-      definition.assign_attributes(**input.to_attributes)
+      definition.assign_attributes(**input.to_attributes) unless input.to_attributes.empty?
 
       # This definition could be coming from one of two places:
       # 1. The Form Builder (new), which sends input as a json-stringified Typescript object. Its keys are camelCase,

--- a/drivers/hmis/app/graphql/mutations/update_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/update_form_definition.rb
@@ -18,7 +18,8 @@ module Mutations
       raise 'not found' unless definition
       raise 'not allowed to change identifier' if input.identifier.present? && input.identifier != definition.identifier
 
-      definition.assign_attributes(**input.to_attributes) unless input.to_attributes.empty?
+      # This mutation can be used to update the definition or the title/role, which is why definition is optional.
+      definition.assign_attributes(**input.to_attributes) unless input.to_attributes.blank?
 
       # This definition could be coming from one of two places:
       # 1. The Form Builder (new), which sends input as a json-stringified Typescript object. Its keys are camelCase,

--- a/drivers/hmis/app/graphql/types/admin/form_definition_input.rb
+++ b/drivers/hmis/app/graphql/types/admin/form_definition_input.rb
@@ -12,9 +12,7 @@ module Types
     argument :definition, String, required: false
 
     def to_attributes
-      attrs = to_h.except(:definition)
-      attrs[:definition] = JSON.parse(definition) if definition.present?
-      attrs
+      to_h.except(:definition)
     end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
                 'mapping': { 'field_name': 'informationDate', 'custom_field_key': 'informationDate' },
               },
               {
-                'type': 'NUMBER',
+                'type': 'INTEGER',
                 'link_id': 'linkid_required',
                 'required': true,
                 'warn_if_empty': false,

--- a/drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         updateFormDefinition(id: $id, input: $input) {
           formDefinition {
             id
+            title
           }
           #{error_fields}
         }
@@ -63,5 +64,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     _response, result = post_graphql(id: fd1.id, input: input) { mutation }
     expect(response.status).to eq(200), result.inspect
     expect(result.dig('data', 'updateFormDefinition', 'errors')).to be_empty
+  end
+
+  it 'should work when no definition is provided' do
+    input = { title: 'a new title!' }
+    _response, result = post_graphql(id: fd1.id, input: input) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'updateFormDefinition', 'errors')).to be_empty
+    expect(result.dig('data', 'updateFormDefinition', 'formDefinition', 'title')).to eq('a new title!')
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a recently introduced [bug](https://greenriver.slack.com/archives/C0610D9HSSH/p1717693483092589) in the form update mutation.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
