### PR TITLE
Monkey patch invalid content type

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -2,7 +2,7 @@ silence_warnings do
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
 end
 Rails.application.reloader.to_prepare do
-  # ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 - ['image/bmp']
+  # Remove image/bmp from the list of invalid content types, it is valid
   class ActiveStorage::Blob
     types = remove_const(:INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7) - ['image/bmp']
     INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = types

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,3 +1,10 @@
 silence_warnings do
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
 end
+Rails.application.reloader.to_prepare do
+  # ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 - ['image/bmp']
+  class ActiveStorage::Blob
+    types = remove_const(:INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7) - ['image/bmp']
+    INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = types
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

image/bmp was erroneously removed from valid content types in 7.0.  Monkey patch so that it stops whining.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
