### PR TITLE
Additional fields for form version table

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3949,6 +3949,8 @@ FormDefinition
 """
 type FormDefinition {
   cacheKey: ID!
+  dateCreated: ISO8601DateTime!
+  dateUpdated: ISO8601DateTime!
   definition: FormDefinitionJson!
   formRules(filters: FormRuleFilterOptions, limit: Int, offset: Int, sortOrder: FormRuleSortOption): FormRulesPaginated!
   id: ID!
@@ -3958,6 +3960,7 @@ type FormDefinition {
   status: FormStatus!
   system: Boolean!
   title: String!
+  updatedBy: ApplicationUser
 }
 
 type FormDefinitionForJsonResult {

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -30,6 +30,9 @@ module Types
     field :raw_definition, JsonObject, null: false
     field :system, Boolean, null: false
     field :status, HmisSchema::Enums::FormStatus, null: false
+    field :date_updated, GraphQL::Types::ISO8601DateTime, null: false, method: :updated_at
+    field :date_created, GraphQL::Types::ISO8601DateTime, null: false, method: :created_at
+    field :updated_by, Types::Application::User, null: true
     form_rules_field :form_rules, method: :instances
 
     # Filtering is implemented within this resolver rather than a separate concern. This
@@ -55,6 +58,10 @@ module Types
 
     def system
       load_ar_association(object, :instances).any?(&:system)
+    end
+
+    def updated_by
+      load_last_user_from_versions(object)
     end
 
     protected

--- a/drivers/hmis/app/graphql/types/forms/form_identifier.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_identifier.rb
@@ -42,7 +42,7 @@ module Types
     end
 
     def all_versions
-      load_ar_association(object, :all_versions)
+      object.all_versions.order(version: :desc)
     end
 
     def display_version


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Resolve timestamps and user on form definition
* Sort versions by most recently updated
* Use PaperTrail `save_with_version` to persist a version when the draft is updated, despite the fact that we `ignore` the `definition` field. At some point we made the decision to ignore this field because it is large and we don't really need to persist the version history of changes to `draft`s.

Frontend PR: https://github.com/greenriver/hmis-frontend/pull/809

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
