### PR TITLE
Patch client headshot issue by returning null instead of empty string

### DIFF
--- a/app/controllers/source_clients_controller.rb
+++ b/app/controllers/source_clients_controller.rb
@@ -62,7 +62,7 @@ class SourceClientsController < ApplicationController
     expires_in max_age, public: false
     image = @client.image_for_source_client(max_age)
     # NOTE: The test environment is really unhappy when there's no image
-    if image && ! Rails.env.test?
+    if image.present? && ! Rails.env.test?
       send_data image, type: ::MimeMagic.by_magic(image), disposition: 'inline'
     else
       head(:forbidden)

--- a/app/controllers/source_clients_controller.rb
+++ b/app/controllers/source_clients_controller.rb
@@ -62,7 +62,7 @@ class SourceClientsController < ApplicationController
     expires_in max_age, public: false
     image = @client.image_for_source_client(max_age)
     # NOTE: The test environment is really unhappy when there's no image
-    if !image.blank? && !Rails.env.test?
+    if !image.empty? && !Rails.env.test?
       send_data image, type: ::MimeMagic.by_magic(image), disposition: 'inline'
     else
       head(:forbidden)

--- a/app/controllers/source_clients_controller.rb
+++ b/app/controllers/source_clients_controller.rb
@@ -62,7 +62,7 @@ class SourceClientsController < ApplicationController
     expires_in max_age, public: false
     image = @client.image_for_source_client(max_age)
     # NOTE: The test environment is really unhappy when there's no image
-    if image.present? && ! Rails.env.test?
+    if !image.blank? && !Rails.env.test?
       send_data image, type: ::MimeMagic.by_magic(image), disposition: 'inline'
     else
       head(:forbidden)

--- a/app/models/concerns/client_file_base.rb
+++ b/app/models/concerns/client_file_base.rb
@@ -64,13 +64,23 @@ module ClientFileBase
     def as_preview
       return client_file.download unless client_file.variable?
 
-      client_file.variant(resize_to_limit: [1920, 1080]).processed.download
+      begin
+        client_file.variant(resize_to_limit: [1920, 1080]).processed.download
+      rescue ActiveStorage::FileNotFoundError
+        Rails.logger.warn('Could not find client file')
+        return nil
+      end
     end
 
     def as_thumb
       return nil unless client_file.variable?
 
-      client_file.variant(resize_to_limit: [400, 400]).processed.download
+      begin
+        client_file.variant(resize_to_limit: [400, 400]).processed.download
+      rescue ActiveStorage::FileNotFoundError
+        Rails.logger.warn('Could not find client file')
+        return nil
+      end
     end
   end
 end

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -18,7 +18,7 @@ module ClientImageConsumer
 
       # Check first for locally uploaded image or a cached ETO image
       # Otherwise, check for an image connected to any source client
-      local_client_image_data || source_clients.detect(&:image_for_source_client)&.image_for_source_client
+      local_client_image_data || source_clients.detect { |sc| sc.image_for_source_client.length > 100 }&.image_for_source_client
     end
 
     def image_for_source_client(_cache_for = 10.minutes)

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -18,7 +18,7 @@ module ClientImageConsumer
 
       # Check first for locally uploaded image or a cached ETO image
       # Otherwise, check for an image connected to any source client
-      local_client_image_data || source_clients.detect { |sc| sc.image_for_source_client.length > 100 }&.image_for_source_client
+      local_client_image_data || source_clients.detect { |sc| (sc.image_for_source_client || '').length > 100 }&.image_for_source_client
     end
 
     def image_for_source_client(_cache_for = 10.minutes)

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -10,10 +10,14 @@ module ClientImageConsumer
     has_many :client_files unless respond_to?(:client_files)
     has_many :source_eto_client_lookups, through: :source_clients, source: :eto_client_lookups
 
-    # Returns actual image bytes. Cache time limit not yet implemented.
+    # Cache time limit not yet implemented
+    # @return [String, nil] actual image bytes.
     def image(_cache_for = 10.minutes)
+      # If we call `image` on a source client, return the attached image
+      return image_for_source_client if source?
+
       # Check first for locally uploaded image or a cached ETO image
-      # Otherwise, check for an image connected to the source client
+      # Otherwise, check for an image connected to any source client
       local_client_image_data || source_clients.detect(&:image_for_source_client)&.image_for_source_client
     end
 

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -14,7 +14,7 @@ module ClientImageConsumer
     def image(_cache_for = 10.minutes)
       # Check first for locally uploaded image or a cached ETO image
       # Otherwise, check for an image connected to the source client
-      local_client_image_data.presence || source_clients.detect(&:image_for_source_client)&.image_for_source_client.presence
+      local_client_image_data || source_clients.detect(&:image_for_source_client)&.image_for_source_client
     end
 
     def image_for_source_client(_cache_for = 10.minutes)

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -14,7 +14,7 @@ module ClientImageConsumer
     def image(_cache_for = 10.minutes)
       # Check first for locally uploaded image or a cached ETO image
       # Otherwise, check for an image connected to the source client
-      local_client_image_data || source_clients.detect(&:image_for_source_client)&.image_for_source_client
+      local_client_image_data.presence || source_clients.detect(&:image_for_source_client)&.image_for_source_client.presence
     end
 
     def image_for_source_client(_cache_for = 10.minutes)

--- a/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
+++ b/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
@@ -116,7 +116,7 @@ class ClientAccessControl::ClientsController < ApplicationController
     response.headers['Last-Modified'] = Time.zone.now.httpdate
     expires_in max_age, public: false
     image = @client.image(max_age)
-    if image && ! Rails.env.test?
+    if !image.blank? && !Rails.env.test?
       send_data image, type: ::MimeMagic.by_magic(image), disposition: 'inline'
     else
       head(:forbidden)

--- a/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
+++ b/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb
@@ -116,7 +116,7 @@ class ClientAccessControl::ClientsController < ApplicationController
     response.headers['Last-Modified'] = Time.zone.now.httpdate
     expires_in max_age, public: false
     image = @client.image(max_age)
-    if !image.blank? && !Rails.env.test?
+    if !image.empty? && !Rails.env.test?
       send_data image, type: ::MimeMagic.by_magic(image), disposition: 'inline'
     else
       head(:forbidden)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

[This change](https://github.com/greenriver/hmis-warehouse/pull/4412/files) made it so that the function `def image(_cache_for = 10.minutes)` would return an empty string `''` in some cases (the empty string comes from the function `image_for_source_client`).

That resulted in the below line evaluating, which results in [Argument Error :type option required](https://green-river.sentry.io/issues/5195363249/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=5fad2771-6712-4eee-92ee-1c3bddab8db2&project=4503977346662400&referrer=slack) because `::MimeMagic.by_magic('')` returns nil.
https://github.com/greenriver/hmis-warehouse/blob/3b2b80c82b9eb47cb32e00a46c3f79412ca6a9f6/drivers/client_access_control/app/controllers/client_access_control/clients_controller.rb#L120


This changes makes it so the `image` function returns nil, which results in `image && ! Rails.env.test?` evaluating to falsy, and this the `send_data` method is not invoked. (Which is correct, because there is no image). Tested with the client id from the linked Sentry.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
