### PR TITLE
Fix the APR PIT calculation

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_seven.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_seven.rb
@@ -286,7 +286,10 @@ module HudApr::Generators::Shared::Fy2024
 
     private def pit_universe(month:)
       pit_date = pit_date(month: month, before: @report.end_date)
-      universe.members.where("pit_enrollments ? '#{pit_date}'").where(a_t[:first_date_in_program].lteq(pit_date))
+      # Logic for step 4 is enforced when addding PIT dates to the client record
+      # If a client doesn't have any overlapping enrollments that qualify, they won't
+      # have a record for the PIT date
+      universe.members.where("pit_enrollments ? '#{pit_date}'")
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* The APR was unnecessarily re-checking the entry date when determining if someone was served on the PIT date.
* Additionally, the date it was checking was the "latest enrollment" when it should have been "any" enrollment.
* Logic is correctly captured in `pit_enrollment_info` and PIT dates are only added to the APR client if they have a valid enrollment.
 
## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
