### PR TITLE
6260 truncate old loader tables

### DIFF
--- a/lib/tasks/truncate_csv_and_loader_tables.rake
+++ b/lib/tasks/truncate_csv_and_loader_tables.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+desc 'truncate HUD loader csv and importer tables'
+# rails truncate_csv_and_loader_tables[2022]
+# rails truncate_csv_and_loader_tables[2022,confirmed]
+task :truncate_csv_and_loader_tables , %i[year confirm] => :environment do |_task, args|
+  year = args.year
+  raise "valid year required" unless year =~ /\A202\d\z/
+
+  connection = HmisCsvImporter::Importer::ImporterLog.connection
+  tables = connection.tables
+    # matches hmis_csv_2024_project_cocs and hmis_2024_project_cocs
+    .grep(/\Ahmis_(csv_)?#{year}_[a-z_]+\z/)
+    # keep projects and export tables
+    .grep_v(/#{year}_(projects|exports)\z/)
+    .sort
+
+  raise "no tables found for year:#{year}" if tables.empty?
+
+  summary_message = "Truncating #{tables.size} tables from \"#{connection.current_database}\": #{tables.join(', ')}"
+  if args.confirm != 'confirmed'
+    puts summary_message
+    puts "Are you sure you want to proceed? (yes/no)"
+    if STDIN.gets.chomp.downcase == 'yes'
+      puts 'truncating...'
+    else
+      puts 'aborting...'
+      exit(1)
+    end
+  end
+  Rails.logger.info summary_message
+
+  tables.each do |table|
+    connection.execute("TRUNCATE #{table} RESTART IDENTITY RESTRICT")
+    # note: according to postgres docs, disk space is reclaimed immediately after truncate without requiring a vacuum
+  end
+end

--- a/lib/tasks/truncate_csv_and_loader_tables.rake
+++ b/lib/tasks/truncate_csv_and_loader_tables.rake
@@ -3,25 +3,25 @@
 desc 'truncate HUD loader csv and importer tables'
 # rails truncate_csv_and_loader_tables[2022]
 # rails truncate_csv_and_loader_tables[2022,confirmed]
-task :truncate_csv_and_loader_tables , %i[year confirm] => :environment do |_task, args|
+task :truncate_csv_and_loader_tables, [:year, :confirm] => :environment do |_task, args|
   year = args.year
-  raise "valid year required" unless year =~ /\A202\d\z/
+  raise 'valid year required' unless year =~ /\A202\d\z/
 
   connection = HmisCsvImporter::Importer::ImporterLog.connection
-  tables = connection.tables
+  tables = connection.tables.
     # matches hmis_csv_2024_project_cocs and hmis_2024_project_cocs
-    .grep(/\Ahmis_(csv_)?#{year}_[a-z_]+\z/)
+    grep(/\Ahmis_(csv_)?#{year}_[a-z_]+\z/).
     # keep projects and export tables
-    .grep_v(/#{year}_(projects|exports)\z/)
-    .sort
+    grep_v(/#{year}_(projects|exports)\z/).
+    sort
 
   raise "no tables found for year:#{year}" if tables.empty?
 
   summary_message = "Truncating #{tables.size} tables from \"#{connection.current_database}\": #{tables.join(', ')}"
   if args.confirm != 'confirmed'
     puts summary_message
-    puts "Are you sure you want to proceed? (yes/no)"
-    if STDIN.gets.chomp.downcase == 'yes'
+    puts 'Are you sure you want to proceed? (yes/no)'
+    if $stdin.gets.chomp.downcase == 'yes'
       puts 'truncating...'
     else
       puts 'aborting...'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

[GH issue](https://github.com/open-path/Green-River/issues/6260)

Adds rake task to truncate tables by pattern. Task could be run per-installation or added to a migration

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Data clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
