### PR TITLE
Add PaperTrail to GroupViewableEntity (HMIS and Warehouse)

### DIFF
--- a/app/models/grda_warehouse/group_viewable_entity.rb
+++ b/app/models/grda_warehouse/group_viewable_entity.rb
@@ -10,6 +10,7 @@
 module GrdaWarehouse
   class GroupViewableEntity < GrdaWarehouseBase
     acts_as_paranoid
+    has_paper_trail
 
     # records with a access_group_id are part of the "legacy" permission system
     belongs_to :access_group, optional: true

--- a/drivers/hmis/app/models/hmis/group_viewable_entity.rb
+++ b/drivers/hmis/app/models/hmis/group_viewable_entity.rb
@@ -10,6 +10,7 @@
 module Hmis
   class GroupViewableEntity < GrdaWarehouseBase
     acts_as_paranoid
+    has_paper_trail
 
     # TODO: rename AccessGroup class to `Collection`, update all references
     belongs_to :collection, class_name: 'Hmis::AccessGroup', inverse_of: :group_viewable_entities


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

https://github.com/open-path/Green-River/issues/5725

Unblocks https://github.com/open-path/Green-River/issues/5790 (Building a UI/Report for viewing ACL changes). PaperTrail history for GroupViewableEntities is necessary to track which projects were added/removed from a Collection.

All other ACL records have PaperTrail already, in both HMIS and Warehouse. (Role, Collection, UserGroup, UserGroupMember, and AccessControl).

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
