### PR TITLE
include waiting for the load event to fire when converting the dq tool chart to pdf.

### DIFF
--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -18542,9 +18542,9 @@ CREATE TABLE public.hmis_form_processors (
     current_living_situation_id integer,
     ce_assessment_id bigint,
     ce_event_id bigint,
-    backup_values jsonb,
     owner_type character varying NOT NULL,
-    owner_id bigint NOT NULL
+    owner_id bigint NOT NULL,
+    backup_values jsonb
 );
 
 
@@ -63002,8 +63002,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240529195902'),
 ('20240529202928'),
 ('20240529205526'),
-('20240531020035'),
 ('20240531020034'),
+('20240531020035'),
 ('20240531152432'),
 ('20240603185124'),
 ('20240603190227'),

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
@@ -52,8 +52,7 @@ module HmisDataQualityTool::DocumentExports
             display_header_footer: true,
             header_template: '',
             footer_template: ApplicationController.render(template: 'hmis_data_quality_tool/warehouse_reports/reports/pdf_footer', layout: false),
-            # wait_until: 'networkidle0',
-            wait_for_selector: '.content_has_loaded',
+            wait_until: 'networkidle0',
             margin: {
               bottom: '.75in',
             },

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
@@ -52,7 +52,10 @@ module HmisDataQualityTool::DocumentExports
             display_header_footer: true,
             header_template: '',
             footer_template: ApplicationController.render(template: 'hmis_data_quality_tool/warehouse_reports/reports/pdf_footer', layout: false),
-            wait_until: 'networkidle0',
+            # Wait for both of the following to be true before rendering the PDF:
+            # - The 'load' event has fired: all dependent resources (i.e. images & charts) have loaded
+            # - There are no more than 0 network connections for at least `500` ms.
+            wait_until: ['load', 'networkidle0'],
             # wait_for_selector: 'done',
             margin: {
               bottom: '.75in',

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb
@@ -52,11 +52,8 @@ module HmisDataQualityTool::DocumentExports
             display_header_footer: true,
             header_template: '',
             footer_template: ApplicationController.render(template: 'hmis_data_quality_tool/warehouse_reports/reports/pdf_footer', layout: false),
-            # Wait for both of the following to be true before rendering the PDF:
-            # - The 'load' event has fired: all dependent resources (i.e. images & charts) have loaded
-            # - There are no more than 0 network connections for at least `500` ms.
-            wait_until: ['load', 'networkidle0'],
-            # wait_for_selector: 'done',
+            # wait_until: 'networkidle0',
+            wait_for_selector: '.content_has_loaded',
             margin: {
               bottom: '.75in',
             },

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
@@ -4,9 +4,12 @@
 = render 'timeliness'
 = render 'time_in_enrollment'
 - if @pdf
-  %div.content_is_loading
+  .content_is_loading
   = content_for :page_js do
     :javascript
       $(function() {
-        $('.content_is_loading').attr('class', 'content_has_loaded')
+        // force JS to wait long enought the charts have loaded for the PDF
+        setTimeout(() => {
+          $('.content_is_loading').addClass('content_has_loaded')
+        }, '10000');
       });

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
@@ -3,3 +3,10 @@
 = render 'enrollment_completeness'
 = render 'timeliness'
 = render 'time_in_enrollment'
+- if @pdf
+  %div.content_is_loading
+  = content_for :page_js do
+    :javascript
+      $(function() {
+        $('.content_is_loading').attr('class', 'content_has_loaded')
+      });

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_by_chart.haml
@@ -3,13 +3,3 @@
 = render 'enrollment_completeness'
 = render 'timeliness'
 = render 'time_in_enrollment'
-- if @pdf
-  .content_is_loading
-  = content_for :page_js do
-    :javascript
-      $(function() {
-        // force JS to wait long enought the charts have loaded for the PDF
-        setTimeout(() => {
-          $('.content_is_loading').addClass('content_has_loaded')
-        }, '10000');
-      });

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_client_completeness.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_client_completeness.haml
@@ -7,6 +7,7 @@
 = content_for :page_js do
   :javascript
     $(function() {
+      'use strict';
       var completeness_clients = new HmisDqToolCompleteness(
         #{@report.completeness('Clients').to_json.html_safe},
         '.completeness-chart-clients',

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_enrollment_completeness.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_enrollment_completeness.haml
@@ -7,6 +7,7 @@
 = content_for :page_js do
   :javascript
     $(function() {
+      'use strict';
       var completeness_enrollments = new HmisDqToolCompleteness(
         #{@report.completeness('Enrollments').to_json.html_safe},
         '.completeness-chart-enrollments',

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_time_in_enrollment.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_time_in_enrollment.haml
@@ -27,6 +27,7 @@
 = content_for :page_js do
   :javascript
     $(function() {
+      'use strict';
       var time_in_program = new HmisDqToolTimeInEnrollment(#{@report.time_in_enrollment_chart.to_json.html_safe}, '.time-in-program-chart');
       time_in_program.build_chart();
     });

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_timeliness.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/_timeliness.haml
@@ -16,6 +16,7 @@
 = content_for :page_js do
   :javascript
     $(function() {
+      'use strict';
       var time_to_enter = new HmisDqToolTimeToEnter(
         #{@report.average_time_to_enter_date(:entry).to_json.html_safe},
         '.time-to-enter-chart',
@@ -27,5 +28,4 @@
         '.time-to-exit-chart',
         );
       time_to_exit.build_chart();
-
     });

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/by_chart.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/by_chart.haml
@@ -11,5 +11,6 @@
 
 .tab-content.mt-4
   .tab-pane.show.active.fade#by_category{role: 'tabpanel', aria: {labelledby: 'by-category'}}
-    .pull-right= render 'report_downloads/report_download', export: @pdf_export, excel_export: @excel_export, excel_download_path: nil
+    - unless Rails.env.production? # hide in production until we fix the charting
+      .pull-right= render 'report_downloads/report_download', export: @pdf_export, excel_export: @excel_export, excel_download_path: nil
     = render 'by_chart'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

In the DQ Tool report, wait for the `load` event to fire on the page before rendering for PDF conversion. This should force the PDF render to wait until the charts have completed before starting.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
