### PR TITLE
Disallow deleting non-draft forms

### DIFF
--- a/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
@@ -11,17 +11,16 @@ module Mutations
     field :form_definition, Types::Forms::FormDefinition, null: true
 
     def resolve(id:)
-      raise 'not allowed' unless current_user.can_manage_forms?
+      access_denied! unless current_user.can_manage_forms?
 
       definition = Hmis::Form::Definition.find_by(id: id)
       raise 'not found' unless definition
-      raise "can't delete definition with active rules" if definition.instances.active.exists?
+      raise 'can only delete draft forms' unless definition.draft?
 
       definition.destroy!
 
       {
         form_definition: definition,
-        errors: [],
       }
     end
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

only drafts can be deleted

https://github.com/greenriver/hmis-frontend/pull/818

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
