### PR TITLE
Add custom rule patch for a project to collect PSDEs

### DIFF
--- a/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
+++ b/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
@@ -28,6 +28,12 @@
           "value": 1
         },
         {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
+        },
+        {
           "operator": "ALL",
           "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
           "parts": [
@@ -280,6 +286,12 @@
               "value": 34
             }
           ]
+        },
+        {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
         },
         {
           "operator": "ALL",
@@ -541,6 +553,12 @@
           ]
         },
         {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
+        },
+        {
           "operator": "ALL",
           "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
           "parts": [
@@ -780,6 +798,12 @@
           ]
         },
         {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
+        },
+        {
           "operator": "ALL",
           "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
           "parts": [
@@ -993,6 +1017,12 @@
           ]
         },
         {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
+        },
+        {
           "operator": "ALL",
           "_comment": "HUD: CoC – Collection required for all components except SSO Coordinated Entry",
           "parts": [
@@ -1192,6 +1222,12 @@
               "value": 34
             }
           ]
+        },
+        {
+          "_comment": "Exception for a HUD CoC-funded SSO project that wants to collect",
+          "variable": "projectId",
+          "operator": "EQUAL",
+          "value": "1174"
         },
         {
           "operator": "ALL",


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

add a custom additional rule for collecting PSDE for a project that falls out of the current requirements, but wants to collect. will cause a conflict with https://github.com/greenriver/hmis-warehouse/pull/4475 so I'll make sure to update that when I resolve the conflict.


Closes https://github.com/orgs/open-path/projects/8/views/3?pane=issue&itemId=68602404

## Type of change
- [x] config change

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
