### PR TITLE
Stop resolving defaults on FormItem

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4157,7 +4157,7 @@ type FormItem {
   Primary text for the item
   """
   text: String
-  type: ItemType
+  type: ItemType!
 
   """
   Whether to show a warning if this question is unanswered

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4073,8 +4073,8 @@ type FormItem {
   """
   How to display item if it is disabled
   """
-  disabledDisplay: DisabledDisplay!
-  enableBehavior: EnableBehavior!
+  disabledDisplay: DisabledDisplay
+  enableBehavior: EnableBehavior
   enableWhen: [EnableWhen!]
 
   """
@@ -4085,7 +4085,7 @@ type FormItem {
   """
   Whether the item should always be hidden
   """
-  hidden: Boolean!
+  hidden: Boolean
 
   """
   Initial value(s) when item is first rendered
@@ -4116,7 +4116,7 @@ type FormItem {
   """
   Whether to allow pre-filling this section from a previous assessment
   """
-  prefill: Boolean!
+  prefill: Boolean
 
   """
   Prefix for the item label
@@ -4126,7 +4126,7 @@ type FormItem {
   """
   Whether human editing is allowed
   """
-  readOnly: Boolean!
+  readOnly: Boolean
 
   """
   Text to use for the item when displayed in read-only view
@@ -4136,17 +4136,17 @@ type FormItem {
   """
   Whether the item may repeat (for choice types, this means multiple choice)
   """
-  repeats: Boolean!
+  repeats: Boolean
 
   """
   Whether the item must be included in data results
   """
-  required: Boolean!
+  required: Boolean
 
   """
   Whether to apply this field to all clients or a single client when bulk creating
   """
-  serviceDetailType: ServiceDetailType
+  serviceDetailType: ServiceDetailType @deprecated(reason: "from old bulk services implementation, no longer supported")
 
   """
   Size of the input element
@@ -4157,12 +4157,12 @@ type FormItem {
   Primary text for the item
   """
   text: String
-  type: ItemType!
+  type: ItemType
 
   """
   Whether to show a warning if this question is unanswered
   """
-  warnIfEmpty: Boolean!
+  warnIfEmpty: Boolean
 }
 
 enum FormRole {

--- a/drivers/hmis/app/graphql/types/forms/form_item.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_item.rb
@@ -20,7 +20,7 @@ module Types
     field :bounds, [Forms::ValueBound], 'Bounds applied to the input value', null: true
 
     # field display
-    field :type, Types::Forms::Enums::ItemType, null: true
+    field :type, Types::Forms::Enums::ItemType, null: false
     field :prefill, Boolean, 'Whether to allow pre-filling this section from a previous assessment', null: true
     field :component, Types::Forms::Enums::Component, 'Component to use for display/input of this item', null: true
     field :text, String, 'Primary text for the item', null: true

--- a/drivers/hmis/app/graphql/types/forms/form_item.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_item.rb
@@ -15,31 +15,31 @@ module Types
     field :data_collected_about, Types::Forms::Enums::DataCollectedAbout, 'Include this item only if the Client meets this HUD DataCollectedAbout condition', null: true
 
     # Validation and input bounds
-    field :required, Boolean, 'Whether the item must be included in data results', null: false
-    field :warn_if_empty, Boolean, 'Whether to show a warning if this question is unanswered', null: false
+    field :required, Boolean, 'Whether the item must be included in data results', null: true
+    field :warn_if_empty, Boolean, 'Whether to show a warning if this question is unanswered', null: true
     field :bounds, [Forms::ValueBound], 'Bounds applied to the input value', null: true
 
     # field display
-    field :type, Types::Forms::Enums::ItemType, null: false
-    field :prefill, Boolean, 'Whether to allow pre-filling this section from a previous assessment', null: false
+    field :type, Types::Forms::Enums::ItemType, null: true
+    field :prefill, Boolean, 'Whether to allow pre-filling this section from a previous assessment', null: true
     field :component, Types::Forms::Enums::Component, 'Component to use for display/input of this item', null: true
     field :text, String, 'Primary text for the item', null: true
     field :brief_text, String, 'Label to use for placeholder and population table', null: true
     field :readonly_text, String, 'Text to use for the item when displayed in read-only view', null: true
     field :prefix, String, 'Prefix for the item label', null: true
     field :helper_text, String, 'Helper text for the item', null: true
-    field :hidden, Boolean, 'Whether the item should always be hidden', null: false
-    field :read_only, Boolean, 'Whether human editing is allowed', null: false
-    field :repeats, Boolean, 'Whether the item may repeat (for choice types, this means multiple choice)', null: false
+    field :hidden, Boolean, 'Whether the item should always be hidden', null: true
+    field :read_only, Boolean, 'Whether human editing is allowed', null: true
+    field :repeats, Boolean, 'Whether the item may repeat (for choice types, this means multiple choice)', null: true
     field :pick_list_reference, String, 'Reference to value set of possible answer options', null: true
     field :pick_list_options, [Forms::PickListOption], 'Permitted answers, for choice items', null: true
-    field :disabled_display, Forms::Enums::DisabledDisplay, 'How to display item if it is disabled', null: false
+    field :disabled_display, Forms::Enums::DisabledDisplay, 'How to display item if it is disabled', null: true
     field :size, Forms::Enums::InputSize, 'Size of the input element', null: true
-    field :enable_behavior, Forms::Enums::EnableBehavior, null: false
+    field :enable_behavior, Forms::Enums::EnableBehavior, null: true
     field :enable_when, [Forms::EnableWhen], null: true
     field :initial, [Forms::InitialValue], 'Initial value(s) when item is first rendered', null: true
     field :autofill_values, [Forms::AutofillValue], 'Value(s) to autofill based on conditional logic', null: true
-    field :service_detail_type, Forms::Enums::ServiceDetailType, 'Whether to apply this field to all clients or a single client when bulk creating', null: true
+    field :service_detail_type, Forms::Enums::ServiceDetailType, 'Whether to apply this field to all clients or a single client when bulk creating', null: true, deprecation_reason: 'from old bulk services implementation, no longer supported'
 
     # field mapping
     field :mapping, Types::Forms::FieldMapping, null: true
@@ -48,21 +48,9 @@ module Types
     # nested children
     field :item, ['Types::Forms::FormItem'], 'Nested items', null: true
 
-    # Most boolean attributes default to false.
-    [:required, :prefill, :hidden, :read_only, :repeats, :warn_if_empty].each do |bool_attr|
-      define_method(bool_attr) do
-        object[bool_attr.to_s] || false
-      end
-    end
-
-    # By default, disabled items are hidden
+    # By default, disabled items are hidden. Leaving here to match legacy behavior.
     def disabled_display
       object['disabled_display'] || 'HIDDEN'
-    end
-
-    # By default, item is enabled if any rules match
-    def enable_behavior
-      object['enable_behavior'] || 'ANY'
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

stop resolving a default for enable_behavior and booleans. this is no longer compatible with validation approach (https://github.com/greenriver/hmis-warehouse/pull/4493)

frontend pr with codegen update: https://github.com/greenriver/hmis-frontend/pull/825

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
