### PR TITLE
include assessor as default contact in sync to cas

### DIFF
--- a/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
@@ -397,7 +397,7 @@ module GrdaWarehouse::CasProjectClientCalculator
     private def default_shelter_agency_contacts(client)
       contact_emails = client.client_contacts.shelter_agency_contacts.where.not(email: nil).pluck(:email)
       contact_emails << client.source_assessments.max_by(&:assessment_date)&.user&.user_email
-      contact_emails.compact
+      contact_emails.compact.uniq
     end
 
     private def contact_info_for_rrh_assessment(client)

--- a/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
@@ -395,7 +395,9 @@ module GrdaWarehouse::CasProjectClientCalculator
     end
 
     private def default_shelter_agency_contacts(client)
-      client.client_contacts.shelter_agency_contacts.where.not(email: nil).pluck(:email)
+      contact_emails = client.client_contacts.shelter_agency_contacts.where.not(email: nil).pluck(:email)
+      contact_emails << client.source_assessments.max_by(&:assessment_date)&.user&.user_email
+      contact_emails.compact
     end
 
     private def contact_info_for_rrh_assessment(client)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Include the assessment's assessor in the default client contacts when pushing to CAS

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
