### PR TITLE
ensure migrations are runnable

### DIFF
--- a/drivers/hmis/lib/tasks/one_time_migration_20240303.rake
+++ b/drivers/hmis/lib/tasks/one_time_migration_20240303.rake
@@ -46,7 +46,8 @@ class OneTimeMigration20230303
   # on_error allows customization of error handling incase we want to collect them instead of raising
   def validate_definition(...)
     # NOTE: validate_definition no longer exists, use DefinitionValidator for validation. Not fixing since this is one-time code
-    HmisUtil::JsonForms.new.validate_definition(...)
+    # HmisUtil::JsonForms.new.validate_definition(...)
+    true
   end
 
   def definition_valid?(definition)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
 
Per slack Convo on 6/1 with Sandy, migrations should be runnable 
> Migrations are not running for me because MigrateHmisFormData references OneTimeMigration20230303 via migrate_hmis_link_ids which uses validate_definition which it notes ‘no longer exists’ — I’m going to just comment the line out for my dev, but, is that the correct solution in general so that our codebase is installable?
## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


