### PR TITLE
Patch eligible assessments list

### DIFF
--- a/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
+++ b/drivers/hmis/app/models/hmis/enrollment_assessment_eligibility_list.rb
@@ -54,7 +54,7 @@ class Hmis::EnrollmentAssessmentEligibilityList
 
   def filtered_definitions(roles)
     fi_t = Hmis::Form::Instance.arel_table
-    definitions_by_role = Hmis::Form::Definition.
+    definitions_by_role = Hmis::Form::Definition.published.
       # skip definition for performance
       exclude_definition_from_select.
       # preload active instances

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -234,7 +234,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
       active.
       for_project_through_entities(self).
       joins(:definition).
-      where(fd_t[:role].eq(:SERVICE)).
+      where(fd_t[:role].eq(:SERVICE).and(fd_t[:status].eq(Hmis::Form::Definition::PUBLISHED))).
       pluck(:custom_service_type_id, :custom_service_category_id)
 
     type_matches = cst_t[:id].in(ids.map(&:first))

--- a/drivers/hmis/spec/factories/hmis/form/instances.rb
+++ b/drivers/hmis/spec/factories/hmis/form/instances.rb
@@ -12,10 +12,11 @@ FactoryBot.define do
     system { false }
     transient do
       role { nil }
+      definition_status { nil }
     end
     after(:create) do |instance, evaluator|
       instance.definition.update(role: evaluator.role) if evaluator.role.present?
-      instance.definition.update(identifier: evaluator.definition_identifier) if evaluator.definition_identifier.present?
+      instance.definition.update(status: evaluator.definition_status) if evaluator.definition_status.present?
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -168,6 +168,15 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
       expect(pick_list_options).to be_empty
     end
+
+    it 'does not return service types that only have unpublished forms' do
+      # Form is "active,"" but it is not published. The service type should not be considered available
+      instance = create(:hmis_form_instance, role: role, entity: nil, custom_service_type: cst)
+      instance.definition.update!(status: :retired)
+
+      pick_list_options = Types::Forms::PickListOption.available_service_types_picklist(project)
+      expect(pick_list_options).to be_empty
+    end
   end
 
   describe 'occurrence_point_form_instances' do

--- a/drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb
@@ -47,6 +47,38 @@ RSpec.describe 'Graphql HMIS Assessment Eligibility', type: :request do
     expect(records).to contain_exactly('INTAKE', 'EXIT', 'ANNUAL', 'UPDATE')
   end
 
+  context 'with custom assessment definitions' do
+    # Active published form that also has retired and draft versions. Only the published one should be considered eligible.
+    let!(:published_active_form) do
+      fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published, version: 2)
+      create(:hmis_form_instance, definition: fd, active: true, entity: e1.project)
+      fd
+    end
+    let!(:retired_form) { create :hmis_form_definition, role: :CUSTOM_ASSESSMENT, identifier: published_active_form.identifier, status: :retired, version: 1 }
+    let!(:draft_form) { create :hmis_form_definition, role: :CUSTOM_ASSESSMENT, identifier: published_active_form.identifier, status: :draft, version: 3 }
+
+    # Ineligible because form instance is 'inactive'
+    let!(:published_inactive_form) do
+      fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published)
+      create(:hmis_form_instance, definition: fd, active: false, entity: e1.project)
+      fd
+    end
+
+    # Ineligible because form is only active in a different project
+    let!(:published_inactive_form) do
+      fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published)
+      create(:hmis_form_instance, definition: fd, active: true, entity: create(:hmis_hud_project, data_source: ds1))
+      fd
+    end
+
+    it 'only resolves published eligible custom assessment definition' do
+      response, result = post_graphql(enrollmentId: e1.id) { query }
+      expect(response.status).to eq(200)
+      custom_assmt_eligibilities = result.dig('data', 'enrollment', 'assessmentEligibilities').filter { |n| n['role'] == 'CUSTOM_ASSESSMENT' }
+      expect(custom_assmt_eligibilities).to contain_exactly(a_hash_including('formDefinitionId' => published_active_form.id.to_s))
+    end
+  end
+
   context 'with project entry' do
     before(:each) do
       create(:hmis_custom_assessment, data_source: ds1, enrollment: e1, data_collection_stage: 1)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Patches 2 bugs:

1. If a Custom Assessment has multiple versions (eg draft, published, retired) they would all show up in the New Assessment dropdown because the AssessmentEligibilityList did not filter them out.
2. If a Service is marked as "active" (per Form Rules) but doesn't have any published Forms, it would still be included in the AVAILABLE_SERVICE_TYPES list. This state could occur if you start a new draft form and set up some rules for it, but haven't published it yet. In that case, it should not appear as an available service until its published.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
