### PR TITLE
Enable filtering on definition form rules

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -36,7 +36,11 @@ module Types
     field :date_created, GraphQL::Types::ISO8601DateTime, null: false, method: :created_at
     field :updated_by, Types::Application::User, null: true
     field :project_matches, Types::Forms::ProjectMatch.array_page_type, null: false
-    form_rules_field :form_rules, method: :instances
+    form_rules_field
+
+    def form_rules(**args)
+      resolve_form_rules(object.instances, **args)
+    end
 
     # Filtering is implemented within this resolver rather than a separate concern. This
     # gives us convenient to access the lazy batch loader for records (funder, orgs) that


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes the FormDefinition schema object so that its `formRules` attribute can now accept a filter argument.

GH issue: https://github.com/open-path/Green-River/issues/6109

This change comes out of: https://github.com/greenriver/hmis-frontend/pull/835#issuecomment-2214932520

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
