### PR TITLE
Move days homeless calculations up so they always run

### DIFF
--- a/app/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb
@@ -35,6 +35,8 @@ module GrdaWarehouse::CasProjectClientCalculator
         :ssvf_eligible,
         :child_in_household,
         :default_shelter_agency_contacts,
+        :days_homeless_in_last_three_years_cached,
+        :literally_homeless_last_three_years_cached,
       ].freeze
     end
 
@@ -138,8 +140,6 @@ module GrdaWarehouse::CasProjectClientCalculator
         :housing_for_formerly_homeless,
         :neighborhood_ids_for_cas,
         :cas_assessment_collected_at, # note this is really just assessment_collected_at
-        :days_homeless_in_last_three_years_cached,
-        :literally_homeless_last_three_years_cached,
         :drug_test,
         :heavy_drug_use,
         :sober,
@@ -271,14 +271,14 @@ module GrdaWarehouse::CasProjectClientCalculator
 
     private def days_homeless_in_last_three_years_cached(client)
       days = 0
-      days += (client.tc_hat_additional_days_homeless || 0)
+      days += client.tc_hat_additional_days_homeless || 0
 
       days + (client.processed_service_history&.days_homeless_last_three_years || 0)
     end
 
     private def literally_homeless_last_three_years_cached(client)
       days = 0
-      days += (client.tc_hat_additional_days_homeless || 0)
+      days += client.tc_hat_additional_days_homeless || 0
 
       days + (client.processed_service_history&.literally_homeless_last_three_years || 0)
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This makes it so that the days homeless calculations don't require someone has a TC HAT on file.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
