### PR TITLE
Bug fix: dont delete instances when deleting a form draft

### DIFF
--- a/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_form_definition.rb
@@ -17,7 +17,16 @@ module Mutations
       raise 'not found' unless definition
       raise 'can only delete draft forms' unless definition.draft?
 
-      definition.destroy!
+      has_other_versions = definition.all_versions.count > 1
+
+      Hmis::Form::Definition.transaction do
+        # If this is the last remaining version of this form, remove all Form Instances.
+        definition.instances.each(&:destroy!) unless has_other_versions
+
+        # Soft-delete the Form Definition. This will error if there are any form_processors or external_form_submissions
+        # that reference this particular form, which there shouldn't be because it's a Draft.
+        definition.destroy!
+      end
 
       {
         form_definition: definition,

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -40,13 +40,15 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   # convenience attr for passing graphql args
   attr_accessor :filter_context
 
-  has_many :instances, foreign_key: :definition_identifier, primary_key: :identifier, dependent: :restrict_with_exception
+  # --- Relations by id ----
   has_many :form_processors, dependent: :restrict_with_exception
-  has_many :custom_service_types, through: :instances, foreign_key: :identifier, primary_key: :form_definition_identifier
   has_many :external_form_submissions, class_name: 'HmisExternalApis::ExternalForms::FormSubmission', dependent: :restrict_with_exception
   has_many :external_form_publications, class_name: 'HmisExternalApis::ExternalForms::FormPublication', dependent: :destroy
-  has_many :custom_data_element_definitions, class_name: 'Hmis::Hud::CustomDataElementDefinition', dependent: :nullify,
-                                             primary_key: 'identifier', foreign_key: 'form_definition_identifier'
+
+  # --- Relations by identifier ----
+  has_many :instances, foreign_key: 'definition_identifier', primary_key: 'identifier'
+  has_many :custom_service_types, through: :instances, foreign_key: 'identifier', primary_key: 'form_definition_identifier'
+  has_many :custom_data_element_definitions, class_name: 'Hmis::Hud::CustomDataElementDefinition', primary_key: 'identifier', foreign_key: 'form_definition_identifier'
   has_one :published_version, -> { order(version: :desc).published }, class_name: 'Hmis::Form::Definition', primary_key: 'identifier', foreign_key: 'identifier'
   has_one :draft_version, -> { order(version: :desc).draft }, class_name: 'Hmis::Form::Definition', primary_key: 'identifier', foreign_key: 'identifier'
   has_many :all_versions, class_name: 'Hmis::Form::Definition', primary_key: 'identifier', foreign_key: 'identifier'

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -236,6 +236,14 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
 
   scope :with_role, ->(role) { where(role: role) }
 
+  before_destroy :can_be_destroyed, prepend: true
+  private def can_be_destroyed
+    return if draft?
+
+    errors.add(:base, 'Non-draft form cannot be destroyed')
+    throw :abort
+  end
+
   # Finding the appropriate form definition for a project:
   #  * find the active published definitions for the required role (i.e. INTAKE)
   #  * choose the form instance with the most specific match that is also associated with any of those definitions

--- a/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE', 'fully-custom-assessment-identifier'] }) { query }
     expect(response.status).to eq 200
     assessments = result.dig('data', 'project', 'assessments', 'nodes')
-    expect(assessments.count).to eq 2
-    expect(assessments.first['id']).to eq(intake_assessment.id.to_s)
-    expect(assessments.second['id']).to eq(fully_custom_assessment.id.to_s)
+    expect(assessments).to contain_exactly(
+      a_hash_including('id' => intake_assessment.id.to_s),
+      a_hash_including('id' => fully_custom_assessment.id.to_s),
+    )
   end
 
   it 'should return intake even if it is not tied to a definition' do

--- a/drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb
@@ -1,0 +1,82 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'DeleteFormDefinition mutation', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation DeleteFormDefinition($id: ID!) {
+        deleteFormDefinition(id: $id) {
+          formDefinition {
+            id
+          }
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_manage_forms]) }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  it 'deletes draft that has no other versions (deletes form rules)' do
+    draft_fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :draft)
+    instance = create(:hmis_form_instance, definition: draft_fd, entity: nil)
+
+    response, result = post_graphql(id: draft_fd.id) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    # Deletes the draft
+    expect(draft_fd.reload).to be_deleted
+    # Deletes the instance
+    expect { instance.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it 'deletes draft that has other versions (retains form rules and CDEDs)' do
+    draft_fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :draft, version: 2)
+    published_fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published, identifier: draft_fd.identifier, version: 1)
+    cded = create(:hmis_custom_data_element_definition, form_definition_identifier: published_fd.identifier)
+    instance = create(:hmis_form_instance, definition: published_fd, entity: nil)
+    # an assessment that has been submitted using the published version
+    custom_assessment = create(:hmis_custom_assessment, definition: published_fd)
+
+    response, result = post_graphql(id: draft_fd.id) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    # Deletes the draft
+    expect(draft_fd.reload).to be_deleted
+    # Keeps the other version
+    expect(published_fd.reload).not_to be_deleted
+    # Keeps the instance
+    expect(instance.reload).to be_present
+    # Keeps the CDED
+    expect(cded.reload).not_to be_deleted
+    # Does not affect existing assessments
+    expect(custom_assessment.reload.form_processor.definition).to eq(published_fd)
+  end
+
+  it 'errors if form is published' do
+    published_fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published)
+
+    expect_gql_error post_graphql(id: published_fd.id) { mutation }, message: /can only delete draft forms/
+  end
+  it 'errors if form is retired' do
+    published_fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :retired)
+
+    expect_gql_error post_graphql(id: published_fd.id) { mutation }, message: /can only delete draft forms/
+  end
+  it 'errors if use lacks permission' do
+    fd = create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :draft)
+    remove_permissions(access_control, :can_manage_forms)
+    expect_access_denied post_graphql(id: fd.id) { mutation }
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

https://github.com/open-path/Green-River/issues/6331

Adjust `dependent` behavior on relations to Definition.

This fixes a bug where calling `destroy!` on a definition would delete all the Form Instances that apply to it, even if there are other forms with the same `identifier` that are still present and governed by those instances.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
