### PR TITLE
Fix bug on client assessment filtering

### DIFF
--- a/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/assessment_filter.rb
@@ -17,6 +17,8 @@ class Hmis::Filter::AssessmentFilter < Hmis::Filter::BaseFilter
   protected
 
   def with_assessment_name(scope)
+    return scope unless input.assessment_name
+
     # "assessment_name" is either a HUD Role ('INTAKE') or a custom assessment form identifier ('my_assessment_form')
     hud_data_collection_stages = []
     custom_identifiers = []

--- a/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     hmis_login(user)
   end
 
-  let(:query) do
+  let(:project_assessments_query) do
     <<~GRAPHQL
       query GetProjectAssessments(
         $id: ID!
@@ -51,15 +51,38 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
+  let(:client_assessments_query) do
+    <<~GRAPHQL
+      query GetClientAssessments(
+        $id: ID!
+        $filters: AssessmentFilterOptions = null
+      ) {
+        client(id: $id) {
+          assessments(
+            filters: $filters
+          ) {
+            nodes {
+              id
+              role
+              definition {
+                title
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+  end
+
   it 'should return all assessments when no filter is passed' do
-    response, result = post_graphql(id: p1.id, filters: {}) { query }
+    response, result = post_graphql(id: p1.id, filters: {}) { project_assessments_query }
     expect(response.status).to eq 200
     assessments = result.dig('data', 'project', 'assessments', 'nodes')
     expect(assessments.count).to eq 3
   end
 
   it 'should return only intake when intake filter is passed' do
-    response, result = post_graphql(id: p1.id, filters: { assessment_name: 'INTAKE' }) { query }
+    response, result = post_graphql(id: p1.id, filters: { assessment_name: 'INTAKE' }) { project_assessments_query }
     expect(response.status).to eq 200
     assessments = result.dig('data', 'project', 'assessments', 'nodes')
     expect(assessments.count).to eq 1
@@ -67,7 +90,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   it 'should return both intake and fully custom assessment when both filters are passed' do
-    response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE', 'fully-custom-assessment-identifier'] }) { query }
+    response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE', 'fully-custom-assessment-identifier'] }) { project_assessments_query }
     expect(response.status).to eq 200
     assessments = result.dig('data', 'project', 'assessments', 'nodes')
     expect(assessments.count).to eq 2
@@ -77,10 +100,17 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'should return intake even if it is not tied to a definition' do
     intake_assessment.form_processor.update!(definition: nil)
-    response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE'] }) { query }
+    response, result = post_graphql(id: p1.id, filters: { assessment_name: ['INTAKE'] }) { project_assessments_query }
     expect(response.status).to eq 200
     assessments = result.dig('data', 'project', 'assessments', 'nodes')
     expect(assessments.count).to eq 1
     expect(assessments.first['id']).to eq(intake_assessment.id.to_s)
+  end
+
+  it 'should return all assessments for project when project filter is passed' do
+    response, result = post_graphql(id: c1.id, filters: { project: [p1.id] }) { client_assessments_query }
+    expect(response.status).to eq 200
+    assessments = result.dig('data', 'client', 'assessments', 'nodes')
+    expect(assessments.count).to eq 3
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6327

This PR fixes the bug in the ticket above, by accepting a nil `assessmentName` as input to the assessment filter options. It also adds a regression test. To test manually, follow the instructions in the linked ticket - it should succeed and correctly filter the assessments by project and project type.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
