### PR TITLE
Fix invalid form

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/exit_reason.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/exit_reason.json
@@ -114,7 +114,8 @@
             "enable_when": [
               {
                 "question": "exit_reason",
-                "operator": "EXISTS"
+                "operator": "EXISTS",
+                "answer_boolean": true
               }
             ],
             "item": [


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix issue: 
```
HmisUtil::JsonForms::JsonFormException
EnableWhen 1 on Link ID exit_reason_other_group must have exactly one of: [answer_code, answer_codes, answer_group_code, answer_number, answer_boolean, compare_question]. Found keys: []
```
The frontend evaluates this the same way, so it doesn't affect the form, but it's no longer considered valid

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
