### PR TITLE
Bug fix for custom_rule eval

### DIFF
--- a/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         update_all(definition: { 'item' => [{ 'type': 'GROUP', 'link_id': 'group-1', 'item': base_items }] })
     end
 
+    describe 'form definition with no rules' do
+      it 'includes all items' do
+        expect(query_form_definition_items.size).to eq(base_items.size)
+      end
+    end
+
     describe 'form definition with projectType rule' do
       let(:project_type) { 5 }
       before(:each) { assign_rule(rule: { variable: 'projectType', operator: 'EQUAL', value: project_type }) }

--- a/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
@@ -48,8 +48,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       result.dig('data', 'assessmentFormDefinition', 'definition', 'item', 0, 'item')
     end
 
-    def assign_rule(rule)
-      base_items[0]['rule'] = rule
+    def assign_rule(rule: nil, custom_rule: nil)
+      base_items[0]['rule'] = rule if rule
+      base_items[0]['custom_rule'] = custom_rule if custom_rule
       Hmis::Form::Definition.
         where(role: form_role).
         update_all(definition: { 'item' => [{ 'type': 'GROUP', 'link_id': 'group-1', 'item': base_items }] })
@@ -57,7 +58,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     describe 'form definition with projectType rule' do
       let(:project_type) { 5 }
-      before(:each) { assign_rule({ variable: 'projectType', operator: 'EQUAL', value: project_type }) }
+      before(:each) { assign_rule(rule: { variable: 'projectType', operator: 'EQUAL', value: project_type }) }
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
       end
@@ -69,9 +70,52 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    describe 'form definition with projectType custom_rule' do
+      let(:project_type) { 5 }
+      before(:each) do
+        assign_rule(custom_rule:
+          { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type }] })
+      end
+      it 'excludes filtered items' do
+        expect(query_form_definition_items.size).to eq(base_items.size - 1)
+      end
+      describe 'with match' do
+        before(:each) { p1.update!(project_type: project_type) }
+        it 'includes all items' do
+          expect(query_form_definition_items.size).to eq(base_items.size)
+        end
+      end
+    end
+
+    describe 'form definition with projectType rule AND projectType custom_rule' do
+      let(:project_type) { 5 }
+      let(:project_type_2) { 6 }
+      before(:each) do
+        assign_rule(
+          rule: { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type }] },
+          custom_rule: { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type_2 }] },
+        )
+      end
+      it 'excludes filtered items' do
+        expect(query_form_definition_items.size).to eq(base_items.size - 1)
+      end
+      describe 'with match on HUD Rule (and no match on Custom rule)' do
+        before(:each) { p1.update!(project_type: project_type) }
+        it 'includes all items' do
+          expect(query_form_definition_items.size).to eq(base_items.size)
+        end
+      end
+      describe 'with match on custom rule (and no match on HUD rule)' do
+        before(:each) { p1.update!(project_type: project_type_2) }
+        it 'includes all items' do
+          expect(query_form_definition_items.size).to eq(base_items.size)
+        end
+      end
+    end
+
     describe 'form definition with projectFunders rule' do
       let(:funder) { 1234 }
-      before(:each) { assign_rule({ variable: 'projectFunders', operator: 'INCLUDE', value: funder }) }
+      before(:each) { assign_rule(rule: { variable: 'projectFunders', operator: 'INCLUDE', value: funder }) }
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
       end
@@ -97,7 +141,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     describe 'form definition with projectOtherFunders rule' do
       let(:other_funder) { '123XYZ' }
-      before(:each) { assign_rule({ variable: 'projectOtherFunders', operator: 'INCLUDE', value: other_funder }) }
+      before(:each) { assign_rule(rule: { variable: 'projectOtherFunders', operator: 'INCLUDE', value: other_funder }) }
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
       end
@@ -113,15 +157,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let(:project_type) { 5 }
       let(:funder) { 1234 }
       before(:each) do
-        assign_rule(
+        assign_rule(rule:
           {
             operator: 'ALL',
             parts: [
               { variable: 'projectType', operator: 'EQUAL', value: project_type },
               { variable: 'projectFunders', operator: 'INCLUDE', value: funder },
             ],
-          },
-        )
+          })
       end
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
@@ -147,15 +190,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let(:project_type) { 5 }
       let(:funder) { 1234 }
       before(:each) do
-        assign_rule(
+        assign_rule(rule:
           {
             operator: 'ANY',
             parts: [
               { variable: 'projectType', operator: 'EQUAL', value: project_type },
               { variable: 'projectFunders', operator: 'INCLUDE', value: funder },
             ],
-          },
-        )
+          })
       end
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)

--- a/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     describe 'form definition with projectType custom_rule' do
       let(:project_type) { 5 }
       before(:each) do
-        assign_rule(custom_rule:
-          { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type }] })
+        assign_rule(
+          custom_rule: { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type }] },
+        )
       end
       it 'excludes filtered items' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
@@ -96,7 +97,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           custom_rule: { operator: 'ANY', parts: [{ variable: 'projectType', operator: 'EQUAL', value: project_type_2 }] },
         )
       end
-      it 'excludes filtered items' do
+      it 'excludes filtered items (neither rules match)' do
         expect(query_form_definition_items.size).to eq(base_items.size - 1)
       end
       describe 'with match on HUD Rule (and no match on Custom rule)' do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Logic introduced in https://github.com/greenriver/hmis-warehouse/pull/4475 caused a regression:  it would default to showing an item that had a `custom_rule` and no `rule` even if the `custom_rule` evaluated to false. 

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
