### PR TITLE
Move form schema fixes to 123

### DIFF
--- a/drivers/hmis/app/graphql/types/base_field.rb
+++ b/drivers/hmis/app/graphql/types/base_field.rb
@@ -13,7 +13,7 @@ module Types
 
       super(*args, **kwargs, &block)
 
-      extension(DefaultValueExtension, default_value: default_value) if default_value.present?
+      extension(DefaultValueExtension, default_value: default_value) if default_value
 
       return_type = kwargs[:type]
       return unless return_type.is_a?(Class) && return_type < BasePaginated

--- a/drivers/hmis/app/graphql/types/forms/autofill_value.rb
+++ b/drivers/hmis/app/graphql/types/forms/autofill_value.rb
@@ -19,9 +19,10 @@ module Types
     field :sum_questions, [String], 'Link IDs of numeric questions to sum up and set as the value if condition is met', null: true
     field :formula, String, 'Expression with mathematical or logical function defining the value', null: true
 
-    # Condition specifying when to perform this autofill
-    field :autofill_behavior, Types::Forms::Enums::EnableBehavior, null: false
-    field :autofill_when, [Types::Forms::EnableWhen], null: false
+    # Condition specifying when to perform this autofill. If not provided, the autofill will always run.
+    # TODO: in future release, make the below fields nullable. For now, setting default_values so that they don't break the frontend, which currently (release-122) expects them to be present.
+    field :autofill_behavior, Types::Forms::Enums::EnableBehavior, null: false, default_value: 'ANY'
+    field :autofill_when, [Types::Forms::EnableWhen], null: false, default_value: []
     field :autofill_readonly, Boolean, 'Whether to perform autofill when displaying a read-only view (defaults to false)', null: true
   end
 end

--- a/drivers/hmis_external_apis/public/schemas/form_definition.json
+++ b/drivers/hmis_external_apis/public/schemas/form_definition.json
@@ -451,10 +451,6 @@
     "autofillValues": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "autofill_behavior",
-        "autofill_when"
-      ],
       "properties": {
         "_comment": {
           "type": "string"
@@ -852,7 +848,10 @@
                 "DISABILITY_TABLE",
                 "HORIZONTAL_GROUP",
                 "INFO_GROUP",
-                "INPUT_GROUP"
+                "INPUT_GROUP",
+                "TABLE",
+                "SIGNATURE_GROUP",
+                "SIGNATURE"
               ]
             },
             "item": {
@@ -866,6 +865,9 @@
               "type": "string"
             },
             "readonly_text": {
+              "type": "string"
+            },
+            "helper_text": {
               "type": "string"
             },
             "prefill": {
@@ -929,6 +931,10 @@
       "allOf": [
         {
           "$ref": "#/$defs/genericInputFormNode"
+        },
+        {
+          "$comment": "String inputs can have min/max bounds for character count",
+          "$ref": "#/$defs/boundedInputNode"
         },
         {
           "type": "object",


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Pull https://github.com/greenriver/hmis-warehouse/pull/4534 into release-123, plus allowing helper text on groups and bounds on string/text inputs.

Without this on 123, we will run into a situation where we are unable to update existing (and valid) forms using the form builder, because the schema is too strict.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
