### PR TITLE
Set form defaults when creating new Service or Custom Assessment

### DIFF
--- a/drivers/hmis/app/graphql/mutations/create_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/create_form_definition.rb
@@ -14,8 +14,7 @@ module Mutations
       raise 'not allowed' unless current_user.can_manage_forms?
 
       attrs = input.to_attributes
-      # TODO(#6277) support starting off with an empty definition
-      attrs[:definition] = attrs[:definition] || { item: [{ link_id: 'name', type: 'STRING', text: 'Question Item' }] }
+      attrs[:definition] = attrs[:definition] || { item: initial_form_definition_items(attrs[:role]) }
 
       definition = Hmis::Form::Definition.new(
         version: 0,
@@ -24,10 +23,105 @@ module Mutations
       )
 
       validation_errors = definition.validate_json_form
+      # rubocop:disable Style/IfUnlessModifier
+      if Hmis::Form::Definition.with_role(definition.role).where(identifier: definition.identifier).exists?
+        validation_errors << HmisErrors::Error.new(:identifier, :invalid, message: 'is not unique. Please choose another identifier')
+      end
+      # rubocop:enable Style/IfUnlessModifier
+
       return { errors: validation_errors } if validation_errors.any?
 
       definition.save!
       { form_definition: definition }
+    end
+
+    # Basic defaults for some form roles. Future improvements may include:
+    # - "locking" fields or attributes that are required, like Assessment Date
+    # - allowing the user to choose a template (like "Regular Service" vs "Financial Assistance Service")
+    # - managing these "templates" in configuration
+    def initial_form_definition_items(role)
+      case role.to_sym
+      when :SERVICE
+        [service_date_provided_item]
+      when :CUSTOM_ASSESSMENT
+        [section_group(items: [assessment_date_item], num: 1)]
+      else
+        [{ link_id: 'name', type: 'STRING', text: 'Question Item' }]
+      end
+    end
+
+    def section_group(items: [], num: 1)
+      {
+        "text": "Section #{num}",
+        "type": 'GROUP',
+        "link_id": "section_#{num}",
+        "item": items,
+      }
+    end
+
+    def service_date_provided_item
+      {
+        "type": 'DATE',
+        "link_id": 'date_provided',
+        "text": 'Date Provided',
+        "required": true,
+        "mapping": {
+          "field_name": 'dateProvided',
+        },
+        "bounds": [
+          {
+            # cannot be before entry date
+            "id": 'min-service-date',
+            "type": 'MIN',
+            "value_local_constant": '$entryDate',
+          },
+          {
+            # cannot be in the future
+            "id": 'max-service-date',
+            "type": 'MAX',
+            "value_local_constant": '$today',
+          },
+          {
+            # cannot be after exit date
+            "id": 'max-service-date-exit-date',
+            "type": 'MAX',
+            "value_local_constant": '$exitDate',
+          },
+        ],
+      }
+    end
+
+    def assessment_date_item
+      {
+        "type": 'DATE',
+        "link_id": 'assessment_date',
+        "text": 'Assessment Date',
+        "required": true,
+        "mapping": {
+          "field_name": 'assessmentDate',
+        },
+        "assessment_date": true,
+        "bounds": [
+          {
+            # cannot be before entry date
+            "id": 'min-assmt-date',
+            "type": 'MIN',
+            "value_local_constant": '$entryDate',
+          },
+          {
+            # cannot be in the future
+            "id": 'max-assmt-date',
+            "type": 'MAX',
+            "value_local_constant": '$today',
+          },
+          {
+            # cannot be after exit date
+            "id": 'max-assmt-date-exit',
+            "type": 'MAX',
+            "value_local_constant": '$exitDate',
+          },
+        ],
+      }
     end
   end
 end

--- a/drivers/hmis/lib/form_data/allegheny/services/esg_funding_service.json
+++ b/drivers/hmis/lib/form_data/allegheny/services/esg_funding_service.json
@@ -81,8 +81,7 @@
       "text": "Amount",
       "mapping": {
         "field_name": "faAmount"
-      },
-      "service_detail_type": "CLIENT"
+      }
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/default/services/service.json
+++ b/drivers/hmis/lib/form_data/default/services/service.json
@@ -141,7 +141,6 @@
         "field_name": "faStartDate"
       },
       "enable_behavior": "ANY",
-      "service_detail_type": "CLIENT",
       "enable_when": [
         {
           "local_constant": "$hudRecordType",
@@ -159,7 +158,6 @@
         "field_name": "faEndDate"
       },
       "enable_behavior": "ANY",
-      "service_detail_type": "CLIENT",
       "enable_when": [
         {
           "local_constant": "$hudRecordType",
@@ -184,7 +182,6 @@
         "field_name": "faAmount"
       },
       "enable_behavior": "ANY",
-      "service_detail_type": "CLIENT",
       "enable_when": [
         {
           "local_constant": "$hudRecordType",


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This is the "quick and dirty" approach for https://github.com/open-path/Green-River/issues/6249

When a user creates a new Service or Custom Assessment form, pre-populate it with the date field, including sensible bounds. There is currently no restriction in place as far as the user editing these values.


## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
