### PR TITLE
6198 - HMIS API: add 'createdBy' to hud meta data

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -259,6 +259,7 @@ type Assessment {
   assessmentDate: ISO8601Date!
   ceAssessment: CeAssessment
   client: Client!
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dataCollectionStage: DataCollectionStage
   dateCreated: ISO8601DateTime
@@ -630,6 +631,7 @@ type CeAssessment {
   assessmentLocation: String!
   assessmentType: AssessmentType
   client: Client!
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -653,6 +655,7 @@ type CeParticipation {
   accessPoint: NoYes
   ceParticipationStatusEndDate: ISO8601Date
   ceParticipationStatusStartDate: ISO8601Date
+  createdBy: ApplicationUser
   crisisAssessment: NoYes
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -722,6 +725,7 @@ type Client {
   assessments(filters: AssessmentFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
   auditHistory(filters: ClientAuditEventFilterOptions, limit: Int, offset: Int): ClientAuditEventsPaginated!
   contactPoints: [ClientContactPoint!]!
+  createdBy: ApplicationUser
   currentLivingSituations(limit: Int, offset: Int): CurrentLivingSituationsPaginated!
   customCaseNotes(limit: Int, offset: Int, sortOrder: CustomCaseNoteSortOption): CustomCaseNotesPaginated!
   customDataElements: [CustomDataElement!]!
@@ -829,6 +833,7 @@ type ClientAddress {
   city: String
   client: Client!
   country: String
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -975,6 +980,7 @@ type ClientAuditEventsPaginated {
 
 type ClientContactPoint {
   client: Client!
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -1087,6 +1093,7 @@ input ClientMergeInput {
 
 type ClientName {
   client: Client!
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -1694,6 +1701,7 @@ HUD Current Living Situation
 type CurrentLivingSituation {
   client: Client!
   clsSubsidyType: RentalSubsidyType
+  createdBy: ApplicationUser
   currentLivingSituation: CurrentLivingSituationOptions!
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
@@ -1899,6 +1907,7 @@ Case Note
 type CustomCaseNote {
   client: Client!
   content: String!
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -1967,6 +1976,7 @@ enum CustomDataElementType {
 }
 
 type CustomDataElementValue {
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -2848,6 +2858,7 @@ type DisabilitiesPaginated {
 type Disability {
   antiRetroviral: NoYesReasonsForMissingData
   client: Client!
+  createdBy: ApplicationUser
   dataCollectionStage: DataCollectionStage!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -3065,6 +3076,7 @@ HUD Employment Education
 """
 type EmploymentEducation {
   client: Client!
+  createdBy: ApplicationUser
   dataCollectionStage: DataCollectionStage!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -3219,6 +3231,7 @@ type Enrollment {
   clientLeaseholder: NoYesMissing
   cocPrioritized: NoYesMissing
   countOutreachReferralApproaches: Int
+  createdBy: ApplicationUser
   criminalRecord: NoYesMissing
   currentLivingSituations(limit: Int, offset: Int): CurrentLivingSituationsPaginated!
   currentPregnant: NoYesMissing
@@ -3556,6 +3569,7 @@ HUD Event
 """
 type Event {
   client: Client!
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -3730,6 +3744,7 @@ type Exit {
   counselingMethods: [CounselingMethod!]
   counselingReceived: NoYesMissing
   countOfExchangeForSex: CountExchangeForSex
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -4443,6 +4458,7 @@ enum FormStatus {
 
 type Funder {
   active: Boolean!
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -4880,6 +4896,7 @@ enum HOPWAMedAssistedLivingFac {
 
 type HealthAndDv {
   client: Client!
+  createdBy: ApplicationUser
   currentlyFleeing: NoYesReasonsForMissingData
   dataCollectionStage: DataCollectionStage!
   dateCreated: ISO8601DateTime
@@ -4959,6 +4976,7 @@ enum HealthStatus {
 }
 
 type HmisParticipation {
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -5219,6 +5237,7 @@ type IncomeBenefit {
   client: Client!
   cobra: NoYesMissing
   connectionWithSoar: NoYesReasonsForMissingData
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dataCollectionStage: DataCollectionStage!
   dateCreated: ISO8601DateTime
@@ -5363,6 +5382,7 @@ type Inventory {
   chVetBedInventory: Int
   chYouthBedInventory: Int
   cocCode: String
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -6322,6 +6342,7 @@ union OmnisearchResult = Client | Project
 type Organization {
   access: OrganizationAccess!
   contactInformation: String
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -8381,6 +8402,7 @@ type Project {
   ceParticipations(limit: Int, offset: Int): CeParticipationsPaginated!
   contactInformation: String
   continuumProject: NoYes
+  createdBy: ApplicationUser
   currentLivingSituations(limit: Int, offset: Int): CurrentLivingSituationsPaginated!
   customDataElements: [CustomDataElement!]!
 
@@ -8456,6 +8478,7 @@ type ProjectCoc {
   address2: String
   city: String
   cocCode: String
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -10018,6 +10041,7 @@ HUD or Custom Service rendered
 """
 type Service {
   client: Client!
+  createdBy: ApplicationUser
   customDataElements: [CustomDataElement!]!
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
@@ -10049,6 +10073,7 @@ type ServiceCategoriesPaginated {
 }
 
 type ServiceCategory {
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -10283,6 +10308,7 @@ enum ServiceSubTypeProvided {
 
 type ServiceType {
   category: String!
+  createdBy: ApplicationUser
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
@@ -12414,6 +12440,7 @@ HUD Youth Education Status
 """
 type YouthEducationStatus {
   client: Client!
+  createdBy: ApplicationUser
   currentEdStatus: CurrentEdStatus
   currentSchoolAttend: CurrentSchoolAttended
   dataCollectionStage: DataCollectionStage!

--- a/drivers/hmis/app/graphql/sources/paper_trail_versions.rb
+++ b/drivers/hmis/app/graphql/sources/paper_trail_versions.rb
@@ -1,0 +1,40 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class Sources::PaperTrailVersions < ::GraphQL::Dataloader::Source
+  def initialize(item_type)
+    @item_type = item_type
+  end
+
+  def fetch(item_ids)
+    versions_by_item_id = GrdaWarehouse.paper_trail_versions.
+      where.not(whodunnit: nil).
+      where(item_type: @item_type, item_id: item_ids).
+      order(:created_at, :id).
+      select(:id, :event, :whodunnit, :item_id, :item_type, :user_id, :true_user_id). # select only fields we need for performance
+      to_a.group_by(&:item_id)
+
+    item_ids.map do |item_id|
+      versions = versions_by_item_id[item_id] || []
+
+      latest_version = versions.last # db-ordered so we choose the last record
+      created_by_version = versions.detect { |e| e.event == 'create' }
+
+      {
+        last_user_id: version_user_id(latest_version),
+        created_by_user_id: version_user_id(created_by_version),
+      }
+    end
+  end
+
+  protected
+
+  def version_user_id(version)
+    return nil unless version
+
+    version.clean_true_user_id || version.clean_user_id
+  end
+end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_hud_metadata.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_hud_metadata.rb
@@ -14,6 +14,7 @@ module Types
       included do
         # User that most recently touched the record
         field(:user, Application::User, null: true) {}
+        field(:created_by, Application::User, null: true) {}
 
         # Note: while these are required in the HUD spec, they are not (yet) required
         # by the database schema. If/when they become required in the db for all hud tables,
@@ -24,14 +25,11 @@ module Types
         field(:date_deleted, GraphQL::Types::ISO8601DateTime, null: true) {}
 
         define_method(:user) do
-          version_holder = case object
-          when Hmis::Hud::HmisService
-            # service is a database view; it doesn't have its own versions
-            load_ar_association(object, :owner)
-          else
-            object
-          end
-          load_last_user_from_versions(version_holder) if version_holder
+          load_last_user_from_versions(object)
+        end
+
+        define_method(:created_by) do
+          load_created_by_user_from_versions(object)
         end
       end
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

[GH Issue](https://github.com/open-path/Green-River/issues/6198)

[HMIS FE PR](https://github.com/greenriver/hmis-frontend/pull/846)

Also also moves version query into data source, this should reduce queries needed to resolve users on a collection

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
