### PR TITLE
Fix crash on validation fail in data quality tool report

### DIFF
--- a/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
+++ b/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
@@ -85,6 +85,7 @@ module HmisDataQualityTool::WarehouseReports
         respond_with(@report, location: @report.index_path)
       else
         @pagy, @reports = pagy(report_scope.ordered)
+        set_view_filter
         filters
         render :index
       end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[See sentry issue](https://green-river.sentry.io/issues/5349958796/events/e27036a362df413ca0bc6a91316c7866/)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## testing
visit [the report](https://hmis-warehouse.dev.test/hmis_data_quality_tool/warehouse_reports/reports). Create an invalid report (not sure how, I just changed the validation to always fail). On save it should render the index page instead of crashing


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
