### PR TITLE
6309-dob-view-bugfix

### DIFF
--- a/app/models/grda_warehouse/pii_provider.rb
+++ b/app/models/grda_warehouse/pii_provider.rb
@@ -80,8 +80,13 @@ class GrdaWarehouse::PiiProvider
     dob&.strftime(Date::DATE_FORMATS[:default]) || age&.to_s
   end
 
-  def dob_and_age
-    record.dob ? "#{record.dob&.year} (#{age})" : nil
+  def dob_and_age(force_year_only: false)
+    return nil unless record.dob
+
+    display_dob = record.dob
+    display_dob = display_dob&.year if force_year_only || !policy.can_view_full_dob?
+
+    "#{display_dob} (#{age})"
   end
 
   # return nil rather than 'redacted' for consistent return type

--- a/drivers/client_access_control/app/views/client_access_control/clients/search/_demographics.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/search/_demographics.haml
@@ -5,7 +5,7 @@
     client.source_clients_searchable_to(current_user).each do |sc|
       pii = sc.pii_provider(user: current_user)
       ssns.push(pii.ssn(force_mask: true))
-      ages.push(pii.dob_and_age)
+      ages.push(pii.dob_and_age(force_year_only: true))
     end
     ssns = ssns.compact.uniq
     ages = ages.compact.uniq

--- a/spec/models/grda_warehouse/pii_provider_spec.rb
+++ b/spec/models/grda_warehouse/pii_provider_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'GrdaWarehouse::PiiProvider', type: :model do
     }
   end
   let(:masked_ssn) { 'XXX-XX-6789' }
+  let(:age_with_year_only) { "#{pii_attributes[:dob].year} (#{pii_age})" }
 
   def new_policy(**perms)
     # roles and policy have the same shape
@@ -53,6 +54,11 @@ RSpec.describe 'GrdaWarehouse::PiiProvider', type: :model do
       actual = GrdaWarehouse::PiiProvider.viewable_dob(pii_attributes[:dob], policy: policy)
       expect(actual).to eq(pii_attributes[:dob])
     end
+    it('displays dob year and age') do
+      expected = "#{pii_attributes[:dob]} (#{pii_age})"
+      expect(pii.dob_and_age).to eq(expected)
+    end
+    it('displays force-masked dob') { expect(pii.dob_and_age(force_year_only: true)).to eq(age_with_year_only) }
   end
 
   context('pii with view photo permission') do
@@ -86,8 +92,7 @@ RSpec.describe 'GrdaWarehouse::PiiProvider', type: :model do
     # age is always shown
     it('displays age') { expect(pii.age).to eq(pii_age) }
     it('displays dob year and age') do
-      expected = "#{pii_attributes[:dob].year} (#{pii_age})"
-      expect(pii.dob_and_age).to eq(expected)
+      expect(pii.dob_and_age).to eq(age_with_year_only)
     end
     it('redacts viewable dob') do
       actual = GrdaWarehouse::PiiProvider.viewable_dob(pii_attributes[:dob], policy: policy)


### PR DESCRIPTION

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[GH Issue 6309](https://github.com/open-path/Green-River/issues/6309)
* ensure users with permission to see dob see the full dob, not just year
* fixes bug in [PR 4311](https://github.com/greenriver/hmis-warehouse/pull/4311)
* Note: the client search intentionally doesn't show full dob, even if you have permission to see it. This was the pre-existing behavior

See steps to reproduce in the issue (6309)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
