### PR TITLE
Patch validator issue for Service CDEDs

### DIFF
--- a/drivers/hmis/app/graphql/mutations/publish_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/publish_form_definition.rb
@@ -61,8 +61,12 @@ module Mutations
 
       # Common attributes for any CDEDs we will initialize
       data_source = GrdaWarehouse::DataSource.hmis.first
+      # FIXME: some definitions support multiple owner_types (SERVICE, NEW_CLIENT_ENROLLMENT).
+      # This needs to be updated to account for that. The mapping.record_type field should specify the record type.
+      owner_type = definition.owner_class.sti_name
+
       cded_attributes = {
-        owner_type: definition.owner_class.sti_name,
+        owner_type: owner_type,
         form_definition_identifier: definition.identifier,
         data_source: data_source,
         user_id: Hmis::Hud::User.from_user(current_user).user_id,
@@ -80,7 +84,7 @@ module Mutations
         next if item.mapping&.custom_field_key
 
         cded_key = "#{cded_key_prefix}_#{item.link_id}"
-        cded_key = ensure_unique_key(definition.owner_class.sti_name, cded_key)
+        cded_key = ensure_unique_key(owner_type, cded_key)
 
         cdeds << Hmis::Hud::CustomDataElementDefinition.new(
           key: cded_key,

--- a/drivers/hmis/app/models/hmis/form/definition_validator.rb
+++ b/drivers/hmis/app/models/hmis/form/definition_validator.rb
@@ -214,7 +214,9 @@ class Hmis::Form::DefinitionValidator
   def check_cdeds(document, role)
     owner_type = Hmis::Form::Definition.owner_class_for_role(role)&.sti_name
     # For Service forms, the CDED owner is allowed to be Service OR CustomService
-    owner_type = ['Hmis::Hud::Service', 'Hmis::Hud::CustomService'] if owner_type == 'Hmis::Hud::HmisService'
+    owner_type = ['Hmis::Hud::Service', 'Hmis::Hud::CustomService'] if role == 'SERVICE'
+    # For New Client Enrollment forms, the CDED owner is allowed to be Client OR Enrollment
+    owner_type = ['Hmis::Hud::Client', 'Hmis::Hud::Enrollment'] if role == 'NEW_CLIENT_ENROLLMENT'
     return unless owner_type
 
     cdeds_by_owner_key = Hmis::Hud::CustomDataElementDefinition.where(owner_type: owner_type).index_by { |cded| [cded.owner_type, cded.key] }

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -261,7 +261,12 @@ module HmisUtil
       record.set_hud_requirements
 
       # Validate definition
-      errors = record.validate_json_form
+      errors = Hmis::Form::DefinitionValidator.perform(
+        form_definition,
+        role,
+        # Don't validate CDEDs in dev env, to make it easier to test seeding installation-specific forms
+        skip_cded_validation: Rails.env.development?,
+      )
       raise(JsonFormException, errors.first.full_message) if errors.any?
 
       record.save!


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fixes bug where validator would fail on a Service form that collects a CDED where `owner_type: "Hmis::Hud::CustomService"`. That is valid, Service forms can collect CDEDs for Hmis::Hud::CustomService and or Hmis::Hud::Service

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
