### PR TITLE
patch rexml CVE-2024-39908

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails', '~> 7.0.8.1'
 gem 'rails_drivers', github: 'greenriver/rails_drivers', branch: 'rails-7'
 # gem 'rails_drivers', path: '/usr/local/bundle/tmp/rails_drivers'
 gem 'rack', '>= 2.2.8.1'
-gem 'rexml', '>= 3.2.7'
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -782,8 +782,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rgeo (2.4.0)
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
@@ -1245,4 +1245,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   2.5.7
+   2.5.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1186,7 +1186,6 @@ DEPENDENCIES
   reline
   responders
   rest-client (~> 2.0)
-  rexml (>= 3.2.7)
   rgeo (~> 2.4.0)
   rgeo-geojson
   rgeo-proj4


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Patches security vulnerability in rexml. Addresses CI failure
* Remove rexml dependency from Gemfile; it does not seem to be a direct dependency in our codebase

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
