### PR TITLE
Add missing record_type for custom field collected in enrollment form

### DIFF
--- a/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/sexual_orientation.json
+++ b/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/sexual_orientation.json
@@ -7,6 +7,7 @@
         "link_id": "sexual_orientation",
         "text": "Sexual Orientation",
         "mapping": {
+          "record_type": "CLIENT",
           "custom_field_key": "sexual_orientation"
         },
         "component": "DROPDOWN",


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This patch is used in a `CLIENT` form AND a `NEW_CLIENT_ENROLLMENT` form. The record_type must be specified because the default "owner" for the NEW_CLIENT_ENROLLMENT is `Hmis::Hud::Enrollment`.

Resolves https://github.com/open-path/Green-River/issues/6362


** how to test**:
* Hard-code the `env_key` in JsonForms.
* Seed definitions.
* Go to a project in HMIS => Add enrollment => Search => Add client
* Enter client details including sexual orientation
* Submit
* Go to the client dashboard and edit their demographics. You should see the sexual orientation value persisted.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
