### PR TITLE
Fix null pointer on default_shelter_agency_contacts

### DIFF
--- a/app/models/grda_warehouse/tasks/push_clients_to_cas.rb
+++ b/app/models/grda_warehouse/tasks/push_clients_to_cas.rb
@@ -344,7 +344,7 @@ module GrdaWarehouse::Tasks
           CasAccess::Tag.find(id).name
         end&.join('; ')
       elsif key == :default_shelter_agency_contacts
-        value.join('; ')
+        value&.join('; ')
       elsif key == :active_cohort_ids
         value.map do |id|
           GrdaWarehouse::Cohort.find(id).name


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix [this null pointer exception](https://green-river.sentry.io/issues/5504065398/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=7f4b1cc5-8a70-4702-ae99-7d733bd52650&project=4503977346662400&referrer=slack) for cases where there are no default_shelter_agency_contacts.

This bug was introduced by this pr https://github.com/greenriver/hmis-warehouse/pull/4252 which [returns nil](https://github.com/greenriver/hmis-warehouse/blame/21a4c52e00d1ce1f3a3443239832a871cf99f2a2/app/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat.rb#L328) if user is not found.

This can be re-targeted to 125 if its not considered urgent, but, the page is not viewable for a particular client currently.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
