### PR TITLE
6206 restrict entry and exits on project operation dates

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/validators/base_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/base_validator.rb
@@ -48,6 +48,14 @@ class Hmis::Hud::Validators::BaseValidator < ActiveModel::Validator
     "cannot be after exit date (#{exit_date.strftime('%m/%d/%Y')})"
   end
 
+  def self.before_project_start_message(start_date)
+    "cannot be before project operation start date (#{start_date.strftime('%m/%d/%Y')})"
+  end
+
+  def self.after_project_end_message(end_date)
+    "cannot be after project operation end date (#{end_date.strftime('%m/%d/%Y')})"
+  end
+
   def self.future_message
     'cannot be in the future'
   end

--- a/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/enrollment_validator.rb
@@ -62,6 +62,11 @@ class Hmis::Hud::Validators::EnrollmentValidator < Hmis::Hud::Validators::BaseVa
     errors = HmisErrors::Errors.new
     dob = enrollment.client&.dob
     exit_date = enrollment.exit_date
+    project_start_date = enrollment.project.operating_start_date
+    project_end_date = enrollment.project.operating_end_date
+
+    errors.add(:entry_date, :out_of_range, message: before_project_start_message(project_start_date), **options) if project_start_date&.> entry_date
+    errors.add(:entry_date, :out_of_range, message: after_project_end_message(project_end_date), **options) if project_end_date&.< entry_date
 
     errors.add :entry_date, :out_of_range, message: future_message, **options if entry_date.future?
     errors.add :entry_date, :out_of_range, message: over_twenty_years_ago_message, **options if entry_date < (Date.current - 20.years)

--- a/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
@@ -40,7 +40,11 @@ class Hmis::Hud::Validators::ExitValidator < Hmis::Hud::Validators::BaseValidato
     entry_date = enrollment.entry_date
     dob = enrollment.client&.dob
     household_members ||= enrollment.household_members
+    project_start_date = enrollment.project.operating_start_date
+    project_end_date = enrollment.project.operating_end_date
 
+    errors.add(:exit_date, :out_of_range, message: before_project_start_message(project_start_date), **options) if project_start_date&.> exit_date
+    errors.add(:exit_date, :out_of_range, message: after_project_end_message(project_end_date), **options) if project_end_date&.< exit_date
     errors.add :exit_date, :out_of_range, message: before_entry_message(entry_date), **options if entry_date.present? && entry_date > exit_date
     errors.add :exit_date, :information, severity: :warning, message: over_thirty_days_ago_message, **options if exit_date < (Date.current - 30.days)
     errors.add :exit_date, :out_of_range, message: before_dob_message, **options if dob.present? && dob > exit_date

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -74,14 +74,17 @@ FactoryBot.define do
     role { :EXIT }
     definition do
       {
-        'item': [
+        item: [
           {
-            'type': 'DATE',
-            'link_id': 'date',
-            'required': true,
-            'warn_if_empty': false,
-            'assessment_date': true,
-            'mapping': { 'field_name': 'exitDate' },
+            type: 'DATE',
+            link_id: 'exit_date',
+            required: true,
+            warn_if_empty: false,
+            assessment_date: true,
+            mapping: {
+              record_type: 'EXIT',
+              field_name: 'exitDate',
+            },
           },
         ],
       }

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   TIME_FMT = '%Y-%m-%d %T.%3N'.freeze
 
+  let(:today) { Date.current }
   let!(:access_control) { create_access_control(hmis_user, p1) }
   let(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1 }
@@ -319,9 +320,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   describe 'Submitting an Intake assessment in a WIP household' do
-    let!(:hoh_enrollment) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, user: u1, entry_date: '2000-01-01' }
+    let!(:hoh_enrollment) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, user: u1, entry_date: today - 1.day }
     let!(:other_enrollment) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, user: u1, entry_date: '2000-01-01', household_id: hoh_enrollment.household_id, relationship_to_ho_h: 99 }
-    let(:assessment_date) { '2005-03-02' }
+    let(:assessment_date) { today.to_fs(:db) }
     let(:definition) { Hmis::Form::Definition.find_by(role: :INTAKE) }
 
     it 'fails if entering non-HoH member' do


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
[GH Issue](https://github.com/open-path/Green-River/issues/6206)

To test for project p1
* assign p1 operation end date to yesterday. Submitting an exit or creating an enrollment on p1 with today's date should fail with a validation message
* assign p1 operation start date to tomorrow. Submitting an exit or creating an enrollment on p1 with today's date should fail with a validation message

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
