### PR TITLE
Update R15 rule for hud compliance

### DIFF
--- a/drivers/hmis/lib/hmis_util/hud_assessment_form_rules_2024.rb
+++ b/drivers/hmis/lib/hmis_util/hud_assessment_form_rules_2024.rb
@@ -9,13 +9,11 @@ module HmisUtil
     # Keys match Link IDs in our default HUD Assessments.
     #
     # KNOWN HUD COMPLIANCE ISSUES:
-    # - q_4_11 (DV) should enforce collection for `HOH_AND_ADULTS`
-    # - P4.1 should enforce collection for `HOH_AND_ADULTS`
-    # - W4 (part of hopwa_disability) should enforce compliance at Annual data collection stage
+    # - W4 (part of hopwa_disability) should enforce compliance at Annual data collection stage (GH#6463)
 
     HUD_LINK_ID_RULES = {
       q_4_11: { stages: ['INTAKE', 'UPDATE'],
-                data_collected_about: nil, # should be 'HOH_AND_ADULTS',
+                data_collected_about: 'HOH_AND_ADULTS',
                 rule: { 'operator' => 'ANY',
                         'parts' =>
         [
@@ -600,7 +598,7 @@ module HmisUtil
           { '_comment' => 'YHDP', 'variable' => 'projectFunders', 'operator' => 'INCLUDE', 'value' => 43 },
         ] } },
       P4_1: { stages: ['INTAKE', 'UPDATE', 'ANNUAL', 'EXIT'],
-              data_collected_about: nil, # should be 'HOH_AND_ADULTS',
+              data_collected_about: 'HOH_AND_ADULTS',
               rule: { 'operator' => 'ANY',
                       'parts' =>
         [
@@ -700,13 +698,10 @@ module HmisUtil
         ] } },
       R15: { stages: ['EXIT'],
              data_collected_about: 'HOH_AND_ADULTS',
-             rule: { 'operator' => 'ALL',
-                     '_comment' => 'HHS: RHY – Collection required for all components except for Street Outreach',
-                     'parts' =>
-        [
-          { 'variable' => 'projectFunderComponents', 'operator' => 'INCLUDE', 'value' => 'HHS: RHY' },
-          { 'variable' => 'projectType', 'operator' => 'NOT_EQUAL', 'value' => 4 },
-        ] } },
+             rule: { '_comment' => 'HHS: RHY – Collection required for all components',
+                     'variable' => 'projectFunderComponents',
+                     'operator' => 'INCLUDE',
+                     'value' => 'HHS: RHY' } },
       R16: { stages: ['EXIT'],
              data_collected_about: 'HOH_AND_ADULTS',
              rule: { '_comment' => 'HHS: RHY – Collection required for all components',


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Closes https://github.com/open-path/Green-River/issues/6451

Fix longstanding HUD compliance issue for R15. It should be collected for all RHY including SO.

Reference: [R15 on page 80 of data dictionary](https://files.hudexchange.info/resources/documents/HMIS-Data-Dictionary-2024.pdf)

Add 2 additional enforcements for `data_collected_about`. These have no effect, but they make it so you won't be allowed to adjust the data collected about to "below" the required level (eg can't set it to "HoH" when the minimum is "hoh and adults"). 


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
