### PR TITLE
SSN formatter should handle any character

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,7 @@ module ApplicationHelper
     if can_view_full_ssn?
       # pad with leading 0s if we don't have enough characters
       number = number.to_s.rjust(9, '0') if number.present?
-      content_tag :span, number.to_s.gsub(/(\d{3})[^\d]?(\d{2})[^\d]?(\d{4})/, '\1-\2-\3')
+      content_tag :span, number.to_s.gsub(HudUtility2024::SSN_RGX, '\1-\2-\3')
     else
       masked_ssn(number)
     end
@@ -149,7 +149,7 @@ module ApplicationHelper
   def masked_ssn(number)
     # pad with leading 0s if we don't have enough characters
     number = number.to_s.rjust(9, '0') if number.present?
-    content_tag :span, number.to_s.gsub(/(\d{3})[^\d]?(\d{2})[^\d]?(\d{4})/, 'XXX-XX-\3')
+    content_tag :span, number.to_s.gsub(HudUtility2024::SSN_RGX, 'XXX-XX-\3')
   end
 
   def beautify_option(_key, value)

--- a/app/models/grda_warehouse/pii_provider.rb
+++ b/app/models/grda_warehouse/pii_provider.rb
@@ -140,7 +140,7 @@ class GrdaWarehouse::PiiProvider
     value.rjust(9, '0')
   end
 
-  SSN_RGX = /(\d{3})[^\d]?(\d{2})[^\d]?(\d{4})/
+  SSN_RGX = HudUtility2024::SSN_RGX
   private_constant :SSN_RGX
 
   def format_masked_ssn(value)

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
@@ -55,7 +55,7 @@ module HmisDataQualityTool
     def self.masked_ssn(number)
       # pad with leading 0s if we don't have enough characters
       number = number.to_s.rjust(9, '0') if number.present?
-      number.to_s.gsub(/(\d{3})[^\d]?(\d{2})[^\d]?(\d{4})/, 'XXX-XX-\3')
+      number.to_s.gsub(HudUtility2024::SSN_RGX, 'XXX-XX-\3')
     end
 
     def self.detail_headers_for_export

--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -10,6 +10,8 @@ module HudUtility2024
 
   module_function
 
+  SSN_RGX = /(\w{3})[^\w]?(\w{2})[^\w]?(\w{4})/
+
   def races(multi_racial: false)
     return race_field_name_to_description unless multi_racial
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update the SSN Display to allow alphanumeric characters instead of solely numeric. This will allow the regex to work with Clarity beginning to send `x`s as a placeholder in the SSNs

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
