### PR TITLE
Resolve more household enrollment details

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5028,10 +5028,13 @@ type HmisParticipationsPaginated {
 }
 
 type Household {
+  anyInProgress: Boolean!
   assessments(filters: AssessmentsForHouseholdFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
+  earliestEntryDate: ISO8601Date!
   householdClients: [HouseholdClient!]!
   householdSize: Int!
   id: ID!
+  latestExitDate: ISO8601Date!
   shortId: ID!
   staffAssignments(isCurrentlyAssigned: Boolean, limit: Int, offset: Int): StaffAssignmentsPaginated
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5034,7 +5034,7 @@ type Household {
   householdClients: [HouseholdClient!]!
   householdSize: Int!
   id: ID!
-  latestExitDate: ISO8601Date!
+  latestExitDate: ISO8601Date
   shortId: ID!
   staffAssignments(isCurrentlyAssigned: Boolean, limit: Int, offset: Int): StaffAssignmentsPaginated
 }

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -19,7 +19,7 @@ module Types
     end
     field :any_in_progress, Boolean, null: false
     field :earliest_entry_date, GraphQL::Types::ISO8601Date, null: false
-    field :latest_exit_date, GraphQL::Types::ISO8601Date, null: false
+    field :latest_exit_date, GraphQL::Types::ISO8601Date, null: true
 
     assessments_field filter_args: { omit: [:project, :project_type], type_name: 'AssessmentsForHousehold' }
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -17,6 +17,9 @@ module Types
     field :staff_assignments, HmisSchema::StaffAssignment.page_type, null: true do
       argument :is_currently_assigned, Boolean, required: false
     end
+    field :any_in_progress, Boolean, null: false
+    field :earliest_entry_date, GraphQL::Types::ISO8601Date, null: false
+    field :latest_exit_date, GraphQL::Types::ISO8601Date, null: false
 
     assessments_field filter_args: { omit: [:project, :project_type], type_name: 'AssessmentsForHousehold' }
 
@@ -60,6 +63,18 @@ module Types
       else
         scope.with_deleted.where.not(deleted_at: nil).order(created_at: :desc, deleted_at: :desc, id: :desc)
       end
+    end
+
+    def any_in_progress
+      object.any_wip?
+    end
+
+    def earliest_entry_date
+      object.earliest_entry
+    end
+
+    def latest_exit_date
+      object.latest_exit
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Comes from QA on https://github.com/open-path/Green-River/issues/6337
Specifically, https://github.com/greenriver/hmis-frontend/pull/871#discussion_r1705506453

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
