### PR TITLE
Quarterly full refresh upload to AC DW

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
@@ -12,39 +12,27 @@ module HmisExternalApis::AcHmis
 
     attr_accessor :state
 
-    def perform(mode)
-      setup_notifier("AC Data Warehouse upload (mode: #{mode})")
+    def perform(methods)
+      setup_notifier("AC Data Warehouse upload (methods: #{methods})")
       if Exporters::DataWarehouseUploader.can_run?
-        Rails.logger.info "Running #{mode} upload clients job"
+        Rails.logger.info "Running #{methods} DW upload job"
 
-        # The 'mode' indicates which upload(s) to run. Daily and quarterly uploads are run on a schedule.
-        # It's possible to run individual jobs for testing purposes or if we ever need to run manually.
-        case mode
-        when 'clients_with_mci_ids_and_address' then clients_with_mci_ids_and_address
-        when 'hmis_csv_export' then hmis_csv_export
-        when 'hmis_csv_export_full_refresh' then hmis_csv_export_full_refresh
-        when 'project_crosswalk' then project_crosswalk
-        when 'move_in_addresses' then move_in_address_export
-        when 'postings' then posting_export
-        when 'custom_fields' then custom_fields_export
-        when 'pathways' then pathways_export
-        when 'daily_uploads'
-          clients_with_mci_ids_and_address
-          hmis_csv_export
-          project_crosswalk
-          move_in_address_export
-          posting_export
-          custom_fields_export
-          pathways_export # we should remove this eventually, same data is included in custom_fields_export
-        when 'quarterly_uploads'
-          hmis_csv_export_full_refresh
-        else
-          raise "invalid item to upload: #{mode}"
+        Array.wrap(methods).each do |method|
+          if method == 'daily_uploads'
+            daily_uploads.each { |m| send(m) } # run all exports in the daily_uploads group
+          elsif method == 'quarterly_uploads'
+            hmis_csv_export_full_refresh
+          elsif known?(method)
+            # run one export individually. only used for testing purposes or manual runs.
+            send(method)
+          else
+            raise "unknown method: #{method}" unless known?(method)
+          end
         end
         self.state = :success
       else
         self.state = :not_run
-        Rails.logger.info "Not running #{mode} due to lack of credentials"
+        Rails.logger.info "Not running #{methods} due to lack of credentials"
       end
     rescue StandardError => e
       puts e.message
@@ -54,6 +42,27 @@ module HmisExternalApis::AcHmis
     end
 
     private
+
+    def known?(method)
+      known_methods.include?(method)
+    end
+
+    def known_methods
+      [
+        'clients_with_mci_ids_and_address',
+        'hmis_csv_export',
+        'hmis_csv_export_full_refresh', # runs quarterly
+        'project_crosswalk',
+        'move_in_address_export',
+        'posting_export',
+        'custom_fields_export',
+        'pathways_export',
+      ].freeze
+    end
+
+    def daily_uploads
+      known_methods - ['hmis_csv_export_full_refresh']
+    end
 
     def clients_with_mci_ids_and_address
       export = Exporters::ClientExport.new
@@ -88,7 +97,7 @@ module HmisExternalApis::AcHmis
 
     def hmis_csv_export_full_refresh
       export = HmisExternalApis::AcHmis::Exporters::HmisExportFetcher.new
-      export.run!(lookback_years: 10)
+      export.run!(start_date: 10.years.ago.to_date)
 
       hash = Digest::MD5.hexdigest(export.content)
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/hmis_export_fetcher.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/hmis_export_fetcher.rb
@@ -15,7 +15,7 @@ module HmisExternalApis::AcHmis::Exporters
 
     delegate :content, to: :export
 
-    def run!
+    def run!(lookback_years: 3)
       data_source = HmisExternalApis::AcHmis.data_source
       user = User.system_user
       version = '2024'
@@ -24,7 +24,7 @@ module HmisExternalApis::AcHmis::Exporters
         data_source_ids: [data_source.id],
         version: version,
         user_id: user.id,
-        start_date: 3.years.ago.to_date,
+        start_date: lookback_years.years.ago.to_date,
       )
 
       Rails.logger.info 'Generating HMIS CSV Export'

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/hmis_export_fetcher.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/hmis_export_fetcher.rb
@@ -15,7 +15,7 @@ module HmisExternalApis::AcHmis::Exporters
 
     delegate :content, to: :export
 
-    def run!(lookback_years: 3)
+    def run!(start_date: 3.years.ago.to_date)
       data_source = HmisExternalApis::AcHmis.data_source
       user = User.system_user
       version = '2024'
@@ -24,7 +24,7 @@ module HmisExternalApis::AcHmis::Exporters
         data_source_ids: [data_source.id],
         version: version,
         user_id: user.id,
-        start_date: lookback_years.years.ago.to_date,
+        start_date: start_date,
       )
 
       Rails.logger.info 'Generating HMIS CSV Export'

--- a/drivers/hmis_external_apis/lib/tasks/export.rake
+++ b/drivers/hmis_external_apis/lib/tasks/export.rake
@@ -6,16 +6,11 @@ namespace :export do
     next unless HmisEnforcement.hmis_enabled?
     next unless GrdaWarehouse::DataSource.hmis.exists?
 
-    [
-      'clients_with_mci_ids_and_address',
-      'hmis_csv_export',
-      'project_crosswalk',
-      'move_in_addresses',
-      'postings',
-      'custom_fields',
-      'pathways',
-    ].each do |export_mode|
-      HmisExternalApis::AcHmis::DataWarehouseUploadJob.perform_later(export_mode)
-    end
+    # Daily uploads to AC Data Warehouse
+    HmisExternalApis::AcHmis::DataWarehouseUploadJob.perform_later('daily_uploads')
+
+    # Quarterly upload to AC Data Warehouse (10-year lookback HMIS CSV)
+    today = Date.current
+    HmisExternalApis::AcHmis::DataWarehouseUploadJob.perform_later('quarterly_uploads') if today == today.beginning_of_quarter
   end
 end

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job_spec.rb
@@ -38,8 +38,11 @@ RSpec.describe HmisExternalApis::AcHmis::DataWarehouseUploadJob, type: :job do
   end
 
   it 'uploads 10-year full refresh hmis csv' do
-    expect(hmis_csv_exporter).to receive(:run!).with(lookback_years: 10)
-    subject.perform('hmis_csv_export_full_refresh')
+    travel_to Time.local(2024, 1, 1) do
+      today = Date.current
+      expect(hmis_csv_exporter).to receive(:run!).with(start_date: today - 10.years)
+      subject.perform('hmis_csv_export_full_refresh')
+    end
   end
 
   it 'uploads project crosswalk' do
@@ -57,7 +60,7 @@ RSpec.describe HmisExternalApis::AcHmis::DataWarehouseUploadJob, type: :job do
   end
 
   it 'uploads move in addresses' do
-    subject.perform('move_in_addresses')
+    subject.perform('move_in_address_export')
     expect(subject.state).to eq(:success)
   end
 end


### PR DESCRIPTION
## Description

https://github.com/open-path/Green-River/issues/6196

* Add a quarterly upload with a 10 year lookback of HMIS CSV
* Add `daily_uploads` mode so we don't need to maintain the list of uploads in the rake task, which was a little confusing

## Type of change
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
