### PR TITLE
Deprecate RADIO_BUTTONS_VERTICAL component

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1475,7 +1475,7 @@ enum Component {
   """
   Render a choice input item as vertical radio buttons
   """
-  RADIO_BUTTONS_VERTICAL
+  RADIO_BUTTONS_VERTICAL @deprecated(reason: "All radio buttons are now vertical")
 
   """
   Signature input component

--- a/drivers/hmis/app/graphql/types/forms/enums/component.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/component.rb
@@ -21,7 +21,7 @@ module Types
     value 'CHECKBOX', 'Render a boolean input item as a checkbox'
     value 'RADIO_BUTTONS', 'Render a choice input item as radio buttons'
     value 'DROPDOWN', 'Render a choice input item as a dropdown'
-    value 'RADIO_BUTTONS_VERTICAL', 'Render a choice input item as vertical radio buttons'
+    value 'RADIO_BUTTONS_VERTICAL', 'Render a choice input item as vertical radio buttons', deprecation_reason: 'All radio buttons are now vertical'
     value 'SSN', 'SSN input component'
     value 'MINUTES_DURATION', 'Duration component with hours and minutes, value stored as minutes'
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6378
This PR deprecates the RADIO_BUTTONS_VERTICAL component option. All radio buttons will be vertical going forward.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
