### PR TITLE
Micro-optimize can_view_my_dashboard? query

### DIFF
--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -103,8 +103,11 @@ class Hmis::User < ApplicationRecord
   def can_view_my_dashboard?
     key = [self.class.name, __method__, id]
     Rails.cache.fetch(key, expires_in: 1.minutes) do
-      # This is a one-off custom logic permission. If we have more of these,
-      # we could make a helper in BaseAccess that accepts custom evaluation logic
+      # This is a one-off custom logic permission for determining when to show "My Dashbord" in HMIS. It is resolved on the root access object.
+      # This logic may evolve as we add more capabilities to the dashboard.
+      # If we have more use-cases for this, we could make a helper in BaseAccess that accepts custom evaluation logic.
+      return false unless Hmis::ProjectStaffAssignmentConfig.exists? # micro optimization for installations without staff assignment
+
       project_scope = Hmis::Hud::Project.with_access(self, :can_edit_enrollments).preload(:organization)
       Hmis::ProjectStaffAssignmentConfig.for_projects(project_scope).exists?
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Micro-optimization to improve performance for this query for installations that don't have any staff assignment configs. This query is significant because it is fetched on pageload for the HMIS (fetching the root access object) and blocks the rest of the app from loading.

Testing: load home page with and without `Hmis::ProjectStaffAssignmentConfig` records

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
