### PR TITLE
Hotfix for Static SPMs

### DIFF
--- a/drivers/performance_measurement/app/models/performance_measurement/details.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/details.rb
@@ -721,6 +721,9 @@ module PerformanceMeasurement::Details
           calculation_description: 'Data is from all successful exits in SPM Measure 7.',
           calculation_column: [:retention_or_positive_destination],
           measure: 'Measure 7',
+          # NOTE: these are hard-coded in ResultCalculation.rb since it's somewhat complex
+          # tables: ['7a1', '7b.1', '7b.2'],
+          # cells: ['C2', 'C3', 'C4'],
           detail_columns: [
             'retention_or_positive_destination',
           ],
@@ -740,6 +743,9 @@ module PerformanceMeasurement::Details
           calculation_description: 'The number of persons who exited SO to a positive destination divided by the total number of persons who exited SO.',
           calculation_column: :so_destination_positive,
           measure: 'Measure 7',
+          # NOTE: these are hard-coded in ResultCalculation.rb since it's somewhat complex
+          # tables: ['7a1'],
+          # cells: ['C2', 'C3', 'C4'],
           detail_columns: [
             'so_destination',
           ],
@@ -759,6 +765,9 @@ module PerformanceMeasurement::Details
           calculation_description: 'The number of persons who exited to permanent housing destination divided by the number of persons who exited ES, SH, TH, RRH, plus persons in other PH projects who exited without moving into housing.',
           calculation_column: :es_sh_th_rrh_destination_positive,
           measure: 'Measure 7',
+          # NOTE: these are hard-coded in ResultCalculation.rb since it's somewhat complex
+          # tables: ['7b.1'],
+          # cells: ['C2', 'C3'],
           detail_columns: [
             'es_sh_th_rrh_destination',
           ],
@@ -778,6 +787,9 @@ module PerformanceMeasurement::Details
           calculation_description: 'The number of persons with a Housing Move-In Date that either exited to a permanent destination after moving into housing or remained in the PH project divided by the number of persons housed by PH projects.',
           calculation_column: :moved_in_destination_positive,
           measure: 'Measure 7',
+          # NOTE: these are hard-coded in ResultCalculation.rb since it's somewhat complex
+          # tables: [ '7b.2'],
+          # cells: ['C2', 'C3'],
           detail_columns: [
             'moved_in_destination',
           ],

--- a/drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb
@@ -184,11 +184,7 @@ module PerformanceMeasurement::ResultCalculation
     def count_of_homeless_clients_in_range(detail, project: nil)
       field = detail[:calculation_column]
       reporting_count = client_count(field, :reporting, project_id: project&.project_id)
-      comparison_count = if existing_static_comparison_spm.present?
-        existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
-      else
-        client_count(field, :comparison, project_id: project&.project_id)
-      end
+      comparison_count = client_count(field, :comparison, project_id: project&.project_id)
 
       progress = calculate_processed(detail[:goal_calculation], reporting_count, comparison_count)
       PerformanceMeasurement::Result.new(
@@ -213,11 +209,7 @@ module PerformanceMeasurement::ResultCalculation
     def count_of_sheltered_homeless_clients(detail, project: nil)
       field = detail[:calculation_column]
       reporting_count = client_count(field, :reporting, project_id: project&.project_id)
-      comparison_count = if existing_static_comparison_spm.present?
-        existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
-      else
-        client_count(field, :comparison, project_id: project&.project_id)
-      end
+      comparison_count = client_count(field, :comparison, project_id: project&.project_id)
 
       progress = calculate_processed(detail[:goal_calculation], reporting_count, comparison_count)
       PerformanceMeasurement::Result.new(
@@ -347,19 +339,16 @@ module PerformanceMeasurement::ResultCalculation
       field = detail[:calculation_column]
 
       reporting_count = client_count_present(field, :reporting, project_id: project&.project_id)
-      comparison_count = if existing_static_comparison_spm.present?
-        existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
-      else
-        client_count_present(field, :comparison, project_id: project&.project_id)
-      end
       reporting_days = client_sum(field, :reporting, project_id: project&.project_id)
-      comparison_days = if existing_static_comparison_spm.present?
+      reporting_average = average(reporting_days, reporting_count)
+
+      comparison_average = if existing_static_comparison_spm.present?
         existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
       else
-        client_sum(field, :comparison, project_id: project&.project_id)
+        comparison_count = client_count_present(field, :comparison, project_id: project&.project_id)
+        comparison_days = client_sum(field, :comparison, project_id: project&.project_id)
+        average(comparison_days, comparison_count)
       end
-      reporting_average = average(reporting_days, reporting_count)
-      comparison_average = average(comparison_days, comparison_count)
 
       progress = calculate_processed(detail[:goal_calculation], reporting_average)
       PerformanceMeasurement::Result.new(
@@ -485,19 +474,16 @@ module PerformanceMeasurement::ResultCalculation
       field = detail[:calculation_column]
 
       reporting_count = client_count_present(field, :reporting, project_id: project&.project_id)
-      comparison_count = if existing_static_comparison_spm.present?
-        existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
-      else
-        client_count_present(field, :comparison, project_id: project&.project_id)
-      end
       reporting_days = client_sum(field, :reporting, project_id: project&.project_id)
-      comparison_days = if existing_static_comparison_spm.present?
+      reporting_average = average(reporting_days, reporting_count)
+
+      comparison_average = if existing_static_comparison_spm.present?
         existing_static_comparison_spm.data_for(detail[:table], detail[:cell]) || 0
       else
-        client_sum(field, :comparison, project_id: project&.project_id)
+        comparison_count = client_count_present(field, :comparison, project_id: project&.project_id)
+        comparison_days = client_sum(field, :comparison, project_id: project&.project_id)
+        average(comparison_days, comparison_count)
       end
-      reporting_average = average(reporting_days, reporting_count)
-      comparison_average = average(comparison_days, comparison_count)
 
       progress = calculate_processed(detail[:goal_calculation], reporting_average)
       PerformanceMeasurement::Result.new(

--- a/drivers/performance_measurement/app/models/performance_measurement/static_spm.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/static_spm.rb
@@ -11,10 +11,10 @@ module PerformanceMeasurement
 
     belongs_to :goal
     KNOWN_SPM_CELLS = {
-      '1a' => ['B2', 'D2', 'G2'],
-      '1b' => ['B2', 'D2', 'G2'],
-      '2a and 2b' => ['B7'],
-      '3.2' => ['C2'],
+      '1a' => ['D2', 'G2'],
+      '1b' => ['D2', 'G2'],
+      '2a and 2b' => ['B7', 'C7', 'E7'],
+      # '3.2' => ['C2'], # actually using the PIT counts
       '4.1' => ['C2', 'C3'],
       '4.2' => ['C2', 'C3'],
       '4.3' => ['C2', 'C3'],
@@ -23,8 +23,8 @@ module PerformanceMeasurement
       '4.6' => ['C2', 'C3'],
       '5.1' => ['C4'],
       '7a.1' => ['C2', 'C3', 'C4'],
-      '7b.1' => ['C2', 'C3', 'C4'],
-      '7b.2' => ['C2', 'C3', 'C4'],
+      '7b.1' => ['C2', 'C3'],
+      '7b.2' => ['C2', 'C3'],
     }.freeze
     KNOWN_SPM_METHODS = KNOWN_SPM_CELLS.map do |table, cells|
       cells.map do |cell|


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This fixes a couple of calculations, tightens up our documentation of static SPM use, and limits the fields collected to those used.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
