### PR TITLE
Disable new reporting menu in production

### DIFF
--- a/app/models/menu/menu.rb
+++ b/app/models/menu/menu.rb
@@ -80,6 +80,9 @@ class Menu::Menu
       title: Translation.translate('Warehouse Reports'),
       id: 'warehouse-reports',
     )
+    # Disabling new menu changes temporarily in production until we have more design feedback
+    return menu if Rails.env.production?
+
     item = Menu::Item.new(
       user: user,
       visible: ->(user) { user.can_view_any_reports? },


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Temporarily limiting menu changes to staging and development.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
