### PR TITLE
do not show 'Other' files when client has revoked consent

### DIFF
--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1114,6 +1114,10 @@ module GrdaWarehouse::Hud
       end
     end
 
+    def revoked_consent?
+      release_current_status == self.class.revoked_consent_string
+    end
+
     def release_current_status
       active_consent_model.release_current_status
     end

--- a/app/views/clients/files/_index.haml
+++ b/app/views/clients/files/_index.haml
@@ -17,12 +17,13 @@
       %li.nav-item
         %a.nav-link{href: '#consent', role: "presentation", data: {toggle: :tab}}
           Consent Forms
-    %li.nav-item
-      %a.nav-link{href: '#other', role: "presentation", data: {toggle: :tab}}
-        - if can_use_separated_consent?
-          Files
-        - else
-          Other Files
+    - unless @client.revoked_consent?
+      %li.nav-item
+        %a.nav-link{href: '#other', role: "presentation", data: {toggle: :tab}}
+          - if can_use_separated_consent?
+            Files
+          - else
+            Other Files
     - if can_manage_client_files?
       %li.nav-item
         %a.nav-link{href: '#deleted', role: "presentation", data: {toggle: :tab}}


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Hide the 'Other' tab in the Clinet Files page when clients have revoked consent.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
