### PR TITLE
Update Family Member Calculation

### DIFF
--- a/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
@@ -199,9 +199,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         question_matching_requirement('c_additional_household_members')&.AssessmentAnswer&.to_i&.positive?
       pregnant_or_parenting_pathway_response = most_recent_pathways_or_transfer(client).
         question_matching_requirement('c_pathway_pregnant_parentingchild')&.AssessmentAnswer&.to_i&.positive?
-      household_size_pathway_response = most_recent_pathways_or_transfer(client).
-        question_matching_requirement('c_pathways_Household_size')&.AssessmentAnswer.to_i || 0
-      household_members_response || pregnant_or_parenting_pathway_response || household_size_pathway_response > 1
+      household_members_response || pregnant_or_parenting_pathway_response
     end
 
     private def child_in_household(client)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

For Pathways 2024, use Are you pregnant or parenting a child under 18? as a proxy for family_member, note this leaves the 2021 calculation in-place as well.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
