### PR TITLE
remove-marginalia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -275,7 +275,6 @@ group :development do
   gem 'flamegraph', require: false
   gem 'stackprof', require: false
   gem 'active_record_query_trace', require: false
-  gem 'marginalia'
   gem 'overcommit', require: false
   gem 'rubocop', require: false
   # not used

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,9 +577,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    marginalia (1.11.1)
-      actionpack (>= 5.2)
-      activerecord (>= 5.2)
     matrix (0.4.2)
     maxminddb (0.1.22)
     memery (1.5.0)
@@ -1143,7 +1140,6 @@ DEPENDENCIES
   lograge
   logstop
   loofah (>= 2.19.1)
-  marginalia
   maxminddb
   memery
   memory_profiler

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -134,4 +134,17 @@ Rails.application.configure do
   routes.default_url_options ||= {}
   routes.default_url_options[:script_name] = ''
   routes.default_url_options[:host] = ENV['FQDN']
+
+  if ENV['DISABLE_AR_QUERY_TRACE'] != 'true'
+    # this used to be the Marginalia gem, now built-in to rails
+    config.active_record.query_log_tags_enabled = true
+    config.active_record.query_log_tags = [
+      :application,
+      :controller,
+      :action,
+      :job,
+      :source_location,
+    ]
+    ActiveRecord::QueryLogs.prepend_comment = false
+  end
 end

--- a/config/initializers/marginalia.rb
+++ b/config/initializers/marginalia.rb
@@ -1,5 +1,0 @@
-if Rails.env.development?
-  Marginalia::Comment.components = [:application, :controller, :action, :line]
-  Marginalia::Comment.prepend_comment = ! Rails.env.development?
-  Marginalia::Comment.lines_to_ignore = /^(?!.*\/app\/.*)/
-end

--- a/config/initializers/query_trace.rb
+++ b/config/initializers/query_trace.rb
@@ -1,9 +1,4 @@
-
-if Rails.env.development?
-  disabled = ENV['DISABLE_AR_QUERY_TRACE']
-  # Rails.logger.debug "Running initializer in #{__FILE__} DISABLE_AR_QUERY_TRACE=#{disabled.inspect}"
-  unless disabled
-    require 'active_record_query_trace'
-    ActiveRecordQueryTrace.enabled = true
-  end
+if Rails.env.development? && ENV['DISABLE_AR_QUERY_TRACE'] != 'true'
+  require 'active_record_query_trace'
+  ActiveRecordQueryTrace.enabled = true
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
Trying to track down issues with missing stack traces, I found the marginalia gem is now built into rails, it does not need to be included as a dependency.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
