### PR TITLE
Time-based Annual Assessment Calculation

### DIFF
--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -274,7 +274,7 @@ module HmisDataQualityTool
 
       # Annuals are expected for stayers where the HoH has been present more than a year
       # and the client in question was present on the most-recent anniversary date
-      annual_expected = if annual_assessment_expected?(hoh) && stayer
+      annual_expected = if annual_assessment_expected?(enrollment: hoh, report_end_date: report.end_date) && stayer
         anniversary_date = anniversary_date(entry_date: hoh.first_date_in_program, report_end_date: report.end_date)
         enrollment_range = (enrollment.EntryDate .. [enrollment&.exit&.ExitDate, report.end_date].compact.min)
         enrollment_range.cover?(anniversary_date)

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2020/base.rb
@@ -132,7 +132,7 @@ module HudApr::Generators::Shared::Fy2020
             alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
-            annual_assessment_expected: annual_assessment_expected?(last_service_history_enrollment),
+            annual_assessment_expected: annual_assessment_expected?(enrollment: last_service_history_enrollment, report_end_date: @report.end_date),
             annual_assessment_in_window: annual_assessment_in_window?(last_service_history_enrollment, income_at_annual_assessment&.InformationDate),
             approximate_time_to_move_in: approximate_move_in_dates[last_service_history_enrollment.client_id],
             came_from_street_last_night: enrollment.PreviousStreetESSH,

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2021/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2021/base.rb
@@ -57,7 +57,7 @@ module HudApr::Generators::Shared::Fy2021
 
           hh_id = get_hh_id(last_service_history_enrollment)
           hoh_enrollment = hoh_enrollments[get_hoh_id(hh_id)]
-          household_assessment_required[hh_id] = annual_assessment_expected?(hoh_enrollment)
+          household_assessment_required[hh_id] = annual_assessment_expected?(enrollment: hoh_enrollment, report_end_date: @report.end_date)
           end_date = if needs_ce_assessments?
             # Only HoHs get CE assessments, so we prefer their entry date
             hoh_enrollment&.first_date_in_program || last_service_history_enrollment.first_date_in_program

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2023/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2023/base.rb
@@ -57,7 +57,7 @@ module HudApr::Generators::Shared::Fy2023
 
           hh_id = get_hh_id(last_service_history_enrollment)
           hoh_enrollment = hoh_enrollments[get_hoh_id(hh_id)]
-          household_assessment_required[hh_id] = annual_assessment_expected?(hoh_enrollment)
+          household_assessment_required[hh_id] = annual_assessment_expected?(enrollment: hoh_enrollment, report_end_date: @report.end_date)
           end_date = if needs_ce_assessments?
             # Only HoHs get CE assessments, so we prefer their entry date
             hoh_enrollment&.first_date_in_program || last_service_history_enrollment.first_date_in_program

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
@@ -189,6 +189,10 @@ module HudApr::Generators::Shared::Fy2024
           #   household_types[hh_id]
           # end
           hoh_anniversary_date = anniversary_date(entry_date: hoh_enrollment.first_date_in_program, report_end_date: @report.end_date)
+          # Households with required assessments are calculated earlier for performance reasons.
+          # An APR is being submitted to verify assessment requirements for non-HoH adults entering the HH at a different date than the HoH.
+          # e.g. If an adult enters 1 day prior HoH assessment date, is their assessment required on the HoH date (1 day later) or on the following year (1 year + 1 day later)
+          #      If an adult enters 1 day after the HoH assessment date is their assessment due on the HoH date (1 year - 1 day later) or on the following year (2 years - 1 day)
           annual_assessment_expected = if age.present? && age >= 18
             household_assessment_required[hh_id] && last_service_history_enrollment.first_date_in_program < hoh_anniversary_date
           else

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
@@ -84,7 +84,7 @@ module HudApr::Generators::Shared::Fy2024
 
           hh_id = get_hh_id(last_service_history_enrollment)
           hoh_enrollment = hoh_enrollments[get_hoh_id(hh_id)]
-          household_assessment_required[hh_id] = annual_assessment_expected?(hoh_enrollment)
+          household_assessment_required[hh_id] = annual_assessment_expected?(enrollment: hoh_enrollment, report_end_date: @report.end_date)
           end_date = if needs_ce_assessments?
             # Only HoHs get CE assessments, so we prefer their entry date
             hoh_enrollment&.first_date_in_program || last_service_history_enrollment.first_date_in_program

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/base.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/base.rb
@@ -111,7 +111,7 @@ module HudDataQualityReport::Generators::Fy2020
             alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
-            annual_assessment_expected: annual_assessment_expected?(last_service_history_enrollment),
+            annual_assessment_expected: annual_assessment_expected?(enrollment: last_service_history_enrollment, report_end_date: @report.end_date),
             annual_assessment_in_window: annual_assessment_in_window?(last_service_history_enrollment, income_at_annual_assessment&.InformationDate),
             approximate_time_to_move_in: approximate_move_in_dates[last_service_history_enrollment.client_id],
             came_from_street_last_night: enrollment.PreviousStreetESSH,

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2022/base.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2022/base.rb
@@ -43,7 +43,7 @@ module HudDataQualityReport::Generators::Fy2022
 
           hh_id = get_hh_id(last_service_history_enrollment)
           hoh_enrollment = hoh_enrollments[get_hoh_id(hh_id)]
-          household_assessment_required[hh_id] = annual_assessment_expected?(hoh_enrollment)
+          household_assessment_required[hh_id] = annual_assessment_expected?(enrollment: hoh_enrollment, report_end_date: @report.end_date)
           date = [
             @report.start_date,
             last_service_history_enrollment.first_date_in_program,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update the calculation for if an annnual assessment is expected to use a time-based calculation regardless of if the service is a NBN. This will no longer count bed nights and instead go strictly by a year-based active enrollment anniversary.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
