### PR TITLE
Add date to schema for form builder bounds

### DIFF
--- a/drivers/hmis_external_apis/public/schemas/form_definition.json
+++ b/drivers/hmis_external_apis/public/schemas/form_definition.json
@@ -127,6 +127,9 @@
         "value_number": {
           "type": "integer"
         },
+        "value_date": {
+          "type": "string"
+        },
         "offset": {
           "type": "integer"
         },


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6484
Prompted by thread: https://github.com/greenriver/hmis-frontend/pull/886#discussion_r1718594163

This PR adds `value_date` as a valid schema type for bounds.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
