### PR TITLE
Multi racial filter adjustment

### DIFF
--- a/app/models/concerns/filter/filter_scopes.rb
+++ b/app/models/concerns/filter/filter_scopes.rb
@@ -131,7 +131,7 @@ module Filter::FilterScopes
       scope.merge(race_scope)
     end
 
-    private def multi_racial_clients(include_hispanic_latinaeo: true)
+    private def multi_racial_clients(include_hispanic_latinaeo: false)
       # Looking at all races with responses of 1, where we have a sum > 1
       columns = [
         c_t[:AmIndAKNative],


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This changes the default when filtering by race to not include hispanic/latin@ in the calculation of multi-racial.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
