### PR TITLE
Make referral posting endpoint idempotent

### DIFF
--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/referrals_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/referrals_controller.rb
@@ -27,7 +27,6 @@ module HmisExternalApis::AcHmis
       (referral, errors, message) = HmisExternalApis::AcHmis::CreateReferralJob.perform_now(params: unsafe_params)
       return respond_with_errors(errors) if errors.any?
 
-      # todo @martha
       json = { message: message, id: referral.identifier }
       request_log.update!(response: json, http_status: 200)
       render json: json

--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/referrals_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/referrals_controller.rb
@@ -24,10 +24,11 @@ module HmisExternalApis::AcHmis
       errors = validate_request(unsafe_params)
       return respond_with_errors(errors) if errors.any?
 
-      (referral, errors) = HmisExternalApis::AcHmis::CreateReferralJob.perform_now(params: unsafe_params)
+      (referral, errors, message) = HmisExternalApis::AcHmis::CreateReferralJob.perform_now(params: unsafe_params)
       return respond_with_errors(errors) if errors.any?
 
-      json = { message: 'Referral Created', id: referral.identifier }
+      # todo @martha
+      json = { message: message, id: referral.identifier }
       request_log.update!(response: json, http_status: 200)
       render json: json
     rescue JSON::ParserError => e


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6499
This PR makes the referral posting endpoint idempotent, and adds a spec test.

Questions about API surface:
- 'Posting already exists with a different project' - is it OK to introduce this new language to the API? Any updates to the wording?
- 'Referral Created' is still returned even if the referral hasn't been created because the referral posting already existed. Should we change this, and if so, to what?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
