### PR TITLE
Prevent submitting draft form

### DIFF
--- a/drivers/hmis/app/graphql/mutations/submit_form.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_form.rb
@@ -25,6 +25,7 @@ module Mutations
       # Look up form definition
       definition = Hmis::Form::Definition.find_by(id: input.form_definition_id)
       raise HmisErrors::ApiError, 'Form Definition not found' unless definition.present?
+      raise HmisErrors::ApiError, 'FormDefinition status is invalid' unless definition.valid_status_for_submit?
 
       # Determine record class
       klass = definition.owner_class

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment_input.rb
@@ -29,6 +29,7 @@ module Types
     def _find_or_create_assessment
       form_definition = Hmis::Form::Definition.find_by(id: form_definition_id)
       raise HmisErrors::ApiError, 'FormDefinition not found' unless form_definition.present?
+      raise HmisErrors::ApiError, 'FormDefinition status is invalid' unless form_definition.valid_status_for_submit?
 
       # If updating existing assessment, find it
       if assessment_id.present?

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -393,6 +393,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     status == PUBLISHED
   end
 
+  def valid_status_for_submit?
+    published? || retired?
+  end
+
   def self.owner_class_for_role(role)
     return Hmis::Hud::CustomAssessment if ASSESSMENT_FORM_ROLES.include?(role.to_sym)
 

--- a/drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb
@@ -175,6 +175,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end.to raise_error(RuntimeError)
     end
 
+    it 'should error if form definition is draft' do
+      draft = create(:hmis_form_definition, version: 2, status: Hmis::Form::Definition::DRAFT, identifier: fd1.identifier)
+      expect_gql_error post_graphql(input: { input: test_input.merge(form_definition_id: draft.id) }) { mutation }
+    end
+
     [
       [
         'should error if assessment date is missing',

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
@@ -237,6 +237,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_gql_error post_graphql(input: { input: test_input.merge(assessment_id: '999') }) { mutation }
     end
 
+    it 'should error if form definition is draft' do
+      draft = create(:hmis_form_definition, version: 2, status: Hmis::Form::Definition::DRAFT, identifier: fd1.identifier)
+      expect_gql_error post_graphql(input: { input: test_input.merge(form_definition_id: draft.id) }) { mutation }
+    end
+
     [
       [
         'should return an error if a required field is missing',

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -281,6 +281,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect_gql_error post_graphql(input: { input: test_input }) { mutation }, message: 'access denied'
         end
 
+        it 'should fail if form definition is draft' do
+          draft = create(:hmis_form_definition, version: definition.version + 1, status: Hmis::Form::Definition::DRAFT, identifier: definition.identifier)
+          expect_gql_error post_graphql(input: { input: test_input.merge(form_definition_id: draft.id) }) { mutation }
+        end
+
         it 'should update user correctly' do
           next if role == :REFERRAL # skip for referral, tested separately
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6520

This PR prevents submitting a draft form in the SaveAssessment, SubmitAssessment, and SubmitForm mutations, and adds spec tests.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
