### PR TITLE
Fix for system pathways chart details and calculations

### DIFF
--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -89,7 +89,7 @@ module HudUtility2024
   def project_type_number(type)
     # attempt to lookup full name
     number = project_type(type, true) # reversed
-    return number if number.present?
+    return number if number.present? && number.is_a?(Integer)
 
     # perform an acronym lookup
     project_type_brief(type, true) # reversed


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This updates `HudUtility2024.project_type_number` to correctly attempt the brief version of the lookup if the full project type name isn't matched.  It was previously returning the unmatched string since the return value for `project_type` if nothing is matched is the original input.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
