### PR TITLE
CoC performance details fix

### DIFF
--- a/drivers/performance_measurement/app/controllers/performance_measurement/warehouse_reports/reports_controller.rb
+++ b/drivers/performance_measurement/app/controllers/performance_measurement/warehouse_reports/reports_controller.rb
@@ -15,7 +15,7 @@ module PerformanceMeasurement::WarehouseReports
     before_action :require_can_access_some_version_of_clients!, only: [:clients]
     before_action :require_my_project!, only: [:clients]
     before_action :require_can_publish_reports!, only: [:raw, :update]
-    before_action :set_report, except: [:index, :create, :details]
+    before_action :set_report, except: [:index, :create, :details, :clients]
     before_action :set_pdf_export, only: [:show]
 
     @include_in_published_version = false


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix for https://github.com/open-path/Green-River/issues/6568, don't call set_report when `params[:id]` isn't expected to be present.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
