### PR TITLE
Add test cases for processing "upgraded" assessment submissions

### DIFF
--- a/drivers/hmis/README.md
+++ b/drivers/hmis/README.md
@@ -70,6 +70,9 @@ The `debug` helper, defined in [e2e_tests.rb](e2e_tests.rb), enables pausing the
 - Click the icon for Current Sessions (left sidebar between `<>` and the Settings gear icon).
 - Under "Current Sessions" there should be a link to "Open Path HMIS." Clicking this link will take you to the current session, in which you can interact and inspect the DOM.
 
+Other debugging tips:
+- Use `byebug`
+- Use `print page.body` to print the page contents at a given point
 
 ## Run Full E2E test suite locally
 

--- a/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_household_assessments.rb
@@ -11,8 +11,6 @@ module Mutations
     argument :submissions, [Types::HmisSchema::VersionedRecordInput], required: true
     argument :confirmed, Boolean, 'Whether warnings have been confirmed', required: false
     argument :validate_only, Boolean, 'Validate assessments but don\'t submit them', required: false
-    # TODO: this should accept a Form Definition ID, to ensure that forms are validated against the
-    # form that is currently being used
 
     field :assessments, [Types::HmisSchema::Assessment], null: true
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -70,6 +70,7 @@ module Types
 
     # EXPENSIVE! Do not use in batch
     def upgraded_definition_for_editing
+      return if object.in_progress? # WIP assessments should use the original form for editing
       return unless form_processor.definition_id # tiny optimization: avoid calling 'definition' if it will invoke find_definition_for_role twice
 
       previous_definition = definition

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -52,8 +52,14 @@ FactoryBot.define do
     end
     transient do
       data_source { nil } # Data source needed to create CDEDs
+      append_items { nil } # Items to append to FormDefinition content
     end
     after(:create) do |instance, evaluator|
+      if evaluator.append_items
+        instance.definition['item'][0]['item'].push(*Array.wrap(evaluator.append_items))
+        instance.save!
+      end
+
       next unless instance.published? && evaluator.data_source
 
       # Create CDEDs for items that have { mapping: { custom_field_key: '...' } }

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -200,7 +200,7 @@ FactoryBot.define do
   end
 
   # Custom Assessment that creates/updates a Custom Data Element
-  factory :custom_assessment_with_custom_fields_and_rules, parent: :hmis_form_definition do
+  factory :custom_assessment_with_custom_fields, parent: :hmis_form_definition do
     role { :CUSTOM_ASSESSMENT }
     title { 'Test Custom Assessment' }
     sequence(:identifier) { |n| "custom_assessment_#{n}" }

--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature 'Assessment definition selection', type: :system do
     end
 
     def unlock_household_assessment
-      click_button 'Unlock Assessment'
+      find('button', text: 'Unlock Assessment').trigger('click')
       assert_text 'Save & Submit' # Unlock succeeded
     end
 

--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -182,7 +182,7 @@ RSpec.feature 'Assessment definition selection', type: :system do
 
     def unlock_household_assessment
       click_button 'Unlock Assessment'
-      assert_no_text 'This assessment has been submitted.' # Unlock succeeded
+      assert_text 'Save & Submit' # Unlock succeeded
     end
 
     def submit_household_assessment
@@ -240,6 +240,8 @@ RSpec.feature 'Assessment definition selection', type: :system do
       end
 
       it 'submits with published form' do
+        assert_text definition.title
+        assert_text 'New question'
         unlock_household_assessment
         fill_in 'new_question', with: 'e2 answer'
 

--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -15,12 +15,23 @@ RSpec.feature 'Assessment definition selection', type: :system do
 
   # Test context for viewing/editing an "individual assessment" (non-household) using a Custom Assessment form
   context 'Performing individual Custom Assessment' do
-    let!(:definition) { create :custom_assessment_with_custom_fields_and_rules, title: 'Very Custom Assessment', data_source: ds1 }
     let!(:old_definition) do
-      fd = create(:custom_assessment_with_custom_fields_and_rules, identifier: definition.identifier, title: 'Previous Very Custom Assessment', data_source: ds1, version: 0, status: :retired)
-      fd.definition['item'][0]['item'] << { 'type': 'DISPLAY', 'link_id': 'old_message', 'text': 'Text on old form' }
-      fd.save!
-      fd
+      old_item = {
+        'type': 'DISPLAY',
+        'link_id': 'old_message',
+        'text': 'Text on old form',
+      }
+      create(:custom_assessment_with_custom_fields_and_rules, title: 'Previous Very Custom Assessment', append_items: old_item, data_source: ds1, version: 0, status: :retired)
+    end
+
+    let!(:definition) do
+      new_item = {
+        'type': 'STRING',
+        'link_id': 'new_question',
+        'text': 'New question',
+        'mapping': { 'custom_field_key': 'new_question_key' },
+      }
+      create(:custom_assessment_with_custom_fields_and_rules, identifier: old_definition.identifier, title: 'Very Custom Assessment', append_items: new_item, data_source: ds1)
     end
 
     before(:each) do
@@ -42,6 +53,8 @@ RSpec.feature 'Assessment definition selection', type: :system do
           assert_text "#{c1.brief_name} Assessments" # wait until we're back on the assessment table
         end.to change(e1.custom_assessments, :count).by(1).
           and change(definition.form_processors, :count).by(1)
+
+        expect(e1.custom_assessments.first.form_processor.definition_id).to eq(definition.id)
       end
     end
 
@@ -63,12 +76,31 @@ RSpec.feature 'Assessment definition selection', type: :system do
         assert_text old_definition.title
 
         # unlock the assessment should upgrade to the newer form
-        click_button('Unlock Assessment', match: :first)
+        click_button 'Unlock Assessment'
         assert_text 'Submit' # Unlock succeeded
         assert_no_text old_definition.title
         assert_text definition.title
         expect(page).to have_field('Assessment Date', with: assessment.assessment_date.strftime('%m/%d/%Y'))
         assert_no_text 'Text on old form'
+
+        # fill in the new question and submit, to ensure it is saved
+        fill_in 'new_question', with: 'Answer to new question'
+        expect do
+          click_button 'Submit'
+          assert_text "#{c1.brief_name} Assessments"
+        end.to change(e1.custom_assessments, :count).by(0).
+          and change(assessment.custom_data_elements, :count).by(1)
+
+        expect(assessment.reload.form_processor.definition_id).to eq(definition.id)
+        expect(assessment.custom_data_elements.where(value_string: 'Answer to new question')).to exist
+
+        # Re-open the assessment to ensure it is using the new form now
+        assert_no_text old_definition.title
+        click_link definition.title
+        assert_text 'New question'
+        assert_text 'Answer to new question'
+        assert_no_text 'Text on old form'
+        assert_text 'Unlock Assessment'
       end
     end
 
@@ -80,6 +112,13 @@ RSpec.feature 'Assessment definition selection', type: :system do
         assert_text old_definition.title
         expect(page).to have_field('Assessment Date', with: wip_assessment.assessment_date.strftime('%m/%d/%Y'))
         assert_text 'Text on old form'
+
+        # Submit should use old form definition
+        expect do
+          click_button 'Submit'
+          assert_text "#{c1.brief_name} Assessments"
+        end.to change(wip_assessment, :wip).from(true).to(false)
+        expect(assessment.reload.form_processor.definition_id).to eq(old_definition.id)
       end
     end
   end
@@ -88,28 +127,40 @@ RSpec.feature 'Assessment definition selection', type: :system do
   # Household contains 4 members each with differently configured assessments, to ensure
   # that the correct form version is used for each member, even in the Household Assessments view.
   context 'Performing Household Intake assessments with various definition versions' do
-    let!(:definition) { create :hmis_intake_assessment_definition, title: 'New Special Intake' }
     let!(:old_definition) do
-      fd = create(:hmis_intake_assessment_definition, identifier: definition.identifier, title: 'Old Special Intake', version: 0, status: :retired)
-      fd.definition['item'][0]['item'] << { 'type': 'DISPLAY', 'link_id': 'old_message', 'text': 'Text on old form' }
-      fd.save!
-      fd
+      old_item = {
+        'type': 'STRING',
+        'link_id': 'old_question',
+        'text': 'Old question',
+        'mapping': { 'custom_field_key': 'old_question_key' },
+      }
+      create(:hmis_intake_assessment_definition, title: 'Old Special Intake', append_items: old_item, data_source: ds1, version: 0, status: :retired)
+    end
+
+    let!(:definition) do
+      new_item = {
+        'type': 'STRING',
+        'link_id': 'new_question',
+        'text': 'New question',
+        'mapping': { 'custom_field_key': 'new_question_key' },
+      }
+      create(:hmis_intake_assessment_definition, identifier: old_definition.identifier, title: 'New Special Intake', append_items: new_item, data_source: ds1)
     end
 
     # e1 (HoH): Intake was Submitted with old form
     let!(:c1) { create :hmis_hud_client, data_source: ds1, first_name: 'Parent', last_name: 'Jones' }
-    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, entry_date: 2.months.ago, relationship_to_hoh: 1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, entry_date: 25.days.ago, relationship_to_hoh: 1 }
     let!(:e1_assessment) { create(:hmis_intake_assessment, definition: old_definition, enrollment: e1) }
 
     # e2 (spouse): Intake was Submitted with published form
     let!(:c2) { create :hmis_hud_client, data_source: ds1, first_name: 'Spouse', last_name: 'Jones' }
-    let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, entry_date: 1.month.ago, relationship_to_hoh: 3, household_id: e1.household_id }
+    let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, entry_date: 20.days.ago, relationship_to_hoh: 3, household_id: e1.household_id }
     let!(:e2_assessment) { create(:hmis_intake_assessment, definition: definition, enrollment: e2) }
 
     # e3 (child): Intake was started with old form, not yet submitted
     let!(:c3) { create :hmis_hud_client, data_source: ds1, first_name: 'Kid 1', last_name: 'Jones' }
     let!(:e3) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c3, entry_date: 1.week.ago, relationship_to_hoh: 2, household_id: e1.household_id }
-    let!(:e3_assessment) { create(:hmis_intake_assessment, definition: old_definition, enrollment: e3, wip: true, values: { "entryDate": e3.entry_date.strftime('%Y-%m-%d') }) }
+    let!(:e3_assessment) { create(:hmis_intake_assessment, definition: old_definition, enrollment: e3, wip: true, values: { "entryDate": e3.entry_date.strftime('%Y-%m-%d'), "old_question": 'Previous answer' }) }
 
     # e4 (child): Intake not yet started
     let!(:c4) { create :hmis_hud_client, data_source: ds1, first_name: 'Kid 2', last_name: 'Jones' }
@@ -124,55 +175,115 @@ RSpec.feature 'Assessment definition selection', type: :system do
       click_link 'Intake'
     end
 
+    def unlock_household_assessment
+      click_button 'Unlock Assessment'
+      assert_text 'Save & Submit' # Unlock succeeded
+    end
+
+    def submit_household_assessment
+      click_button 'Save & Submit'
+      assert_text 'This assessment has been submitted' # Submit succeeded
+    end
+
+    def save_household_assessment
+      click_button 'Save Assessment'
+      assert_text(/Last saved [0-9] seconds? ago/) # Save succeeded
+    end
+
     context '[e1] for member with Intake that was submitted using an old form' do
+      before(:each) { find('button[role="tab"]', text: c1.brief_name).click }
+
       it 'opens the assessment with the old form version, and upgrades to new version on unlock' do
         # expect old form
         assert_text old_definition.title
-        assert_text 'Text on old form'
         assert_text 'Entry Date'
         assert_text e1.entry_date.strftime('%m/%d/%Y')
 
-        assert_text 'Last submitted'
-        click_button('Unlock Assessment', match: :first)
-        assert_text 'Save & Submit' # Unlock succeeded
+        unlock_household_assessment
 
         # expect new form
         assert_text definition.title
+        assert_text 'New question'
         assert_no_text old_definition.title
-        assert_no_text 'Text on old form'
         expect(page).to have_field('Entry Date', with: e1.entry_date.strftime('%m/%d/%Y'))
+      end
+
+      it 'submits new form fields' do
+        assert_text old_definition.title
+        unlock_household_assessment
+
+        # fill in the new question and submit, to ensure it is saved
+        fill_in 'new_question', with: 'Answer to new question'
+        expect do
+          submit_household_assessment
+        end.to change(e1.custom_assessments, :count).by(0).
+          and change(e1_assessment.custom_data_elements, :count).by(1)
+
+        expect(e1_assessment.reload.form_processor.definition_id).to eq(definition.id)
+        expect(e1_assessment.custom_data_elements.where(value_string: 'Answer to new question')).to exist
       end
     end
 
     context '[e2] for member with Intake that was submitted using the new form' do
-      it 'opens with published form' do
-        find('button[role="tab"]', text: c2.brief_name).click
+      before(:each) { find('button[role="tab"]', text: c2.brief_name).click }
 
+      it 'opens with published form' do
         assert_text definition.title
-        assert_no_text 'Text on old form'
         assert_text 'Entry Date'
         assert_text e2.entry_date.strftime('%m/%d/%Y')
+        assert_text 'New question'
+      end
+
+      it 'submits with published form' do
+        unlock_household_assessment
+        fill_in 'new_question', with: 'e2 answer'
+
+        expect do
+          submit_household_assessment
+        end.to change(e2.custom_assessments, :count).by(0).
+          and change(e2_assessment.custom_data_elements, :count).by(1)
+
+        expect(e2_assessment.form_processor.definition_id).to eq(definition.id)
+        expect(e2_assessment.custom_data_elements.where(value_string: 'e2 answer')).to exist
       end
     end
 
     context '[e3] for member with WIP Intake that was started using the old form' do
-      it 'opens with old form in editing mode' do
-        find('button[role="tab"]', text: c3.brief_name).click
+      before(:each) { find('button[role="tab"]', text: c3.brief_name).click }
 
+      it 'opens with old form in editing mode' do
         assert_text 'This assessment is in progress'
         assert_text old_definition.title
-        assert_text 'Text on old form'
         expect(page).to have_field('Entry Date', with: e3.entry_date.strftime('%m/%d/%Y'))
+        expect(page).to have_field('old_question', with: 'Previous answer')
+      end
+
+      it 'saves with old form' do
+        expect do
+          save_household_assessment
+        end.not_to change(e3.custom_assessments.in_progress, :count)
+
+        expect(e3_assessment.form_processor.definition_id).to eq(old_definition.id)
       end
     end
 
     context '[e4] for member with no intake' do
-      it 'opens with new form in editing mode' do
-        find('button[role="tab"]', text: c4.brief_name).click
+      before(:each) { find('button[role="tab"]', text: c4.brief_name).click }
 
+      it 'opens with new form in editing mode' do
         assert_text 'This assessment has not been started'
         assert_text definition.title
-        assert_no_text 'Text on old form'
+        assert_text 'New question'
+      end
+
+      it 'saves with new form' do
+        fill_in 'new_question', with: 'Answer to new question'
+        expect do
+          save_household_assessment
+        end.to change(e4.custom_assessments.in_progress, :count).by(1)
+
+        # Ensure the form processor is using the new definition
+        expect(e4.intake_assessment.form_processor.definition_id).to eq(definition.id)
       end
     end
   end

--- a/drivers/hmis/spec/system/hmis/form_builder_spec.rb
+++ b/drivers/hmis/spec/system/hmis/form_builder_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'HMIS Form Builder', type: :system do
   end
 
   context 'with an existing published form' do
-    let!(:published) { create :custom_assessment_with_custom_fields_and_rules, data_source: ds1 }
+    let!(:published) { create :custom_assessment_with_custom_fields, data_source: ds1 }
 
     before(:each) do
       visit "/admin/forms/#{published.identifier}"
@@ -59,8 +59,8 @@ RSpec.feature 'HMIS Form Builder', type: :system do
   end
 
   context 'with an existing draft form' do
-    let!(:published) { create :custom_assessment_with_custom_fields_and_rules, identifier: 'system_test', version: 0, data_source: ds1 }
-    let!(:draft) { create :custom_assessment_with_custom_fields_and_rules, status: 'draft', identifier: 'system_test', version: 1, data_source: ds1 }
+    let!(:published) { create :custom_assessment_with_custom_fields, identifier: 'system_test', version: 0, data_source: ds1 }
+    let!(:draft) { create :custom_assessment_with_custom_fields, status: 'draft', identifier: 'system_test', version: 1, data_source: ds1 }
 
     before(:each) do
       visit "/admin/forms/#{draft.identifier}"

--- a/spec/support/e2e_tests.rb
+++ b/spec/support/e2e_tests.rb
@@ -42,6 +42,8 @@ module E2eTests
 
       ::Capybara.automatic_label_click = automatic_label_click
 
+      ::Capybara.ignore_hidden_elements = true
+
       # Normalizes whitespaces when using `has_text?` and similar matchers
       ::Capybara.default_normalize_ws = default_normalize_ws
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Requires frontend PR: https://github.com/greenriver/hmis-frontend/pull/901

* Regression test for bug fixed by https://github.com/greenriver/hmis-frontend/pull/901. The tests were asserting that the correct form definition was used for _rendering_ the DynamicForm/DynamicView, but they were NOT testing the submission process. This PR remediates that.
* Also stop resolving "upgraded definition for editing" for WIP assessments, since they don't need it

## Type of change
- [x] Tests

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
