### PR TITLE
Limit project-level charts and details when using static SPMs for CoC Performance Measurement

### DIFF
--- a/drivers/performance_measurement/app/models/performance_measurement/result.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/result.rb
@@ -88,6 +88,64 @@ module PerformanceMeasurement
       [gauge_width, goal, goal_progress].max
     end
 
+    # Duplicate of data_for_system_level_bar, but hide comparison if no project-level details are available
+    def data_for_individual_project_bar
+      average_metric = field.to_s.ends_with?('_average')
+      unit = if average_metric
+        'average days'
+      else
+        primary_unit
+      end
+      columns = if report.using_static_spm_for_comparison?
+        [
+          [
+            'x',
+            comparison_year,
+          ],
+          [
+            unit,
+            comparison_primary_value,
+          ],
+        ]
+      else
+        [
+          [
+            'x',
+            comparison_year,
+            report_year,
+          ],
+          [
+            unit,
+            comparison_primary_value,
+            primary_value,
+          ],
+        ]
+      end
+      if average_metric
+        columns << if report.using_static_spm_for_comparison?
+          [
+            'median days',
+            related_median.primary_value,
+          ]
+        else
+          [
+            'median days',
+            related_median.comparison_primary_value,
+            related_median.primary_value,
+          ]
+        end
+      end
+      {
+        x: 'x',
+        columns: columns,
+        type: 'bar',
+        labels: {
+          colors: 'white',
+          centered: true,
+        },
+      }
+    end
+
     def data_for_system_level_bar
       average_metric = field.to_s.ends_with?('_average')
       unit = if average_metric

--- a/drivers/performance_measurement/app/models/performance_measurement/result.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/result.rb
@@ -100,11 +100,11 @@ module PerformanceMeasurement
         [
           [
             'x',
-            comparison_year,
+            report_year,
           ],
           [
             unit,
-            comparison_primary_value,
+            primary_value,
           ],
         ]
       else

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/goal_configs/_static_spms.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/goal_configs/_static_spms.haml
@@ -4,7 +4,7 @@
       %i.icon-plus
       Add Static SPM for Comparison
 %p
-  You can optionally provide information from historic SPMs.  If available These will be shown as the comparison values for values calculated by the SPM for the #{Translation.translate('CoC Performance Measurement Dashboard')} report where the comparison date range matches the entered data.
+  You can optionally provide information from historic SPMs.  If available, these will be shown as the comparison values for values calculated by the SPM for the #{Translation.translate('CoC Performance Measurement Dashboard')} report where the comparison date range matches the entered data.
 %ul
   %li Static SPM start and end dates must match the expected comparison dates to be included
   %li If two static SPMs have the same start and end dates, the newest version will be used

--- a/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_details_row.haml
+++ b/drivers/performance_measurement/app/views/performance_measurement/warehouse_reports/reports/_details_row.haml
@@ -2,6 +2,7 @@
 - numerator_label = @report.detail_numerator_label_for(key)
 - pit_count_types = @report.detail_pit_types(key)
 - project_id = if defined?(project_id) then project_id else nil end
+- data = if project_id.present? then result.data_for_individual_project_bar else result.data_for_system_level_bar end
 %h3.mb-6= @report.detail_title_for(key)
 .row
   .col-6
@@ -46,17 +47,19 @@
 
   .col-6
     %div
-      .ml-auto.c-chart--vertical-bar{ class: class_name, data: { chart: result.data_for_system_level_bar.to_json }}
+      .ml-auto.c-chart--vertical-bar{ class: class_name, data: { chart: data.to_json }}
     - if denominator_label.present? && show_label_detail
       .card.p-3.mt-4
-        .mb-0.d-flex
-          .mr-2 #{result.comparison_year}:
-          .mb-0
-            %strong= result.comparison_numerator
-            = numerator_label
-            of
-            %strong= result.comparison_denominator
-            = denominator_label
+        -# Hide comparisons at the project level if using static SPM
+        - unless @report.using_static_spm_for_comparison?
+          .mb-0.d-flex
+            .mr-2 #{result.comparison_year}:
+            .mb-0
+              %strong= result.comparison_numerator
+              = numerator_label
+              of
+              %strong= result.comparison_denominator
+              = denominator_label
         .mb-0.d-flex
           .mr-2 #{result.report_year}:
           .mb-0


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Addresses findings in https://github.com/open-path/Green-River/issues/6295#issuecomment-2310943880

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
