### PR TITLE
Don't assume DisabilityResponse for HOPWA programs at annual

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/disability.json
@@ -297,7 +297,24 @@
       ]
     },
     {
-      "fragment": "#hopwa_disability"
+      "type": "GROUP",
+      "link_id": "hopwa_section",
+      "text": "HOPWA Questions",
+      "enable_behavior": "ALL",
+      "enable_when": [
+        {
+          "_comment": "q_4_08_2 question may come from disability fragment OR hopwa_disability_for_annual fragment",
+          "question": "q_4_08_2",
+          "operator": "EQUAL",
+          "answer_code": "YES"
+        }
+      ],
+      "item": [
+        {
+          "fragment": "#hopwa_disability",
+          "_comment": "the hopwa_disability fragment also has a rule ensuring that it is only included for HOPWA-funded projects. For non-HOPWA programs, this whole hopwa_section group is excluded (because groups are excluded if all children are excluded)."
+        }
+      ]
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/default/fragments/disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/disability.json
@@ -303,7 +303,6 @@
       "enable_behavior": "ALL",
       "enable_when": [
         {
-          "_comment": "q_4_08_2 question may come from disability fragment OR hopwa_disability_for_annual fragment",
           "question": "q_4_08_2",
           "operator": "EQUAL",
           "answer_code": "YES"

--- a/drivers/hmis/lib/form_data/default/fragments/disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/disability.json
@@ -311,7 +311,7 @@
       "item": [
         {
           "fragment": "#hopwa_disability",
-          "_comment": "the hopwa_disability fragment also has a rule ensuring that it is only included for HOPWA-funded projects. For non-HOPWA programs, this whole hopwa_section group is excluded (because groups are excluded if all children are excluded)."
+          "_comment": "The hopwa_disability fragment has a rule in HudAssessmentFormRules2024 ensuring that it is only included for HOPWA-funded projects. For non-HOPWA programs, this whole hopwa_section group is excluded (because groups are excluded if all children are excluded)."
         }
       ]
     }

--- a/drivers/hmis/lib/form_data/default/fragments/hopwa_disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/hopwa_disability.json
@@ -1,7 +1,6 @@
 {
   "type": "GROUP",
   "link_id": "hopwa_disability",
-  "text": "HOPWA Questions",
   "item": [
     {
       "type": "CHOICE",

--- a/drivers/hmis/lib/form_data/default/fragments/hopwa_disability_for_annual.json
+++ b/drivers/hmis/lib/form_data/default/fragments/hopwa_disability_for_annual.json
@@ -1,24 +1,40 @@
 {
-  "fragment": "#hopwa_disability",
+  "type": "GROUP",
+  "link_id": "hopwa_annual_section",
+  "prefill": true,
+  "text": "HOPWA Questions",
+  "rule": {
+    "operator": "ALL",
+    "parts": [
+      {
+        "variable": "projectFunderComponents",
+        "operator": "INCLUDE",
+        "value": "HUD: HOPWA"
+      }
+    ]
+  },
   "item": [
     {
       "type": "CHOICE",
-      "link_id": "q_4_08_2_hiv_aids_hopwa",
+      "link_id": "hiv_aids_disability",
       "text": "HIV/AIDS",
-      "hidden": true,
       "mapping": {
         "record_type": "DISABILITY_GROUP",
         "field_name": "hivAids"
       },
-      "initial": [
-        {
-          "_comment": "Set to YES so that DisabilityResponse is stored as YES for HIV/AIDS Disability record, even though Annual does not collect the full disability table. This fragment is only included for HOPWA projects.",
-          "value_code": "YES",
-          "initial_behavior": "OVERWRITE"
-        }
-      ],
-      "disabled_display": "HIDDEN",
       "pick_list_reference": "NoYesReasonsForMissingData"
+    },
+    {
+      "fragment": "#hopwa_disability",
+      "enable_behavior": "ALL",
+      "enable_when": [
+        {
+          "_comment": "Only ask w4/w6 if disability response is Yes for HIV/AIDS. Even at HOPWA programs, there may be other household members who respond No.",
+          "question": "hiv_aids_disability",
+          "operator": "EQUAL",
+          "answer_code": "YES"
+        }
+      ]
     }
   ]
 }

--- a/drivers/hmis/lib/form_data/default/fragments/hopwa_disability_for_annual.json
+++ b/drivers/hmis/lib/form_data/default/fragments/hopwa_disability_for_annual.json
@@ -3,6 +3,7 @@
   "link_id": "hopwa_annual_section",
   "prefill": true,
   "text": "HOPWA Questions",
+  "_comment": "The hopwa_disability fragment already has a rule in HudAssessmentFormRules2024 ensuring that it is only included for HOPWA-funded projects. We need this additional rule here to toggle whether the extra HIV/AIDS Disability question is shown.",
   "rule": {
     "operator": "ALL",
     "parts": [


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix my incorrect spec for https://github.com/open-path/Green-River/issues/6463. I had incorrectly said that we can assume all clients at HOPWA programs have DisabilityResponse:1 for Disability 8. That turns out not to be true, because households can be enrolled in HOPWA programs with members that do not have HIV/AIDS.

This updates the forms so that Disability 8 is asked at Annual, and W4/W6 are only ever asked if client response "Yes" to Disability 8.


* For HOPWA-funded programs...
   - [x] On Intake/Update/Exit, ask W4/W6 only if client responds "Yes" to HIV/AIDS
   - [x] On Annual, ask  W4/W6 only if client responds "Yes" to HIV/AIDS
* For non-HOPWA-funded programs...
   - [x] Never ask W4/W6

HOPWA questions on Annual:
<img width="900" alt="Screenshot 2024-08-28 at 11 37 48 AM" src="https://github.com/user-attachments/assets/b7dc6a04-48fb-4a35-bc02-ddd8eba1e46d">

HOPWA questions on Intake:
<img width="1149" alt="Screenshot 2024-08-28 at 11 38 45 AM" src="https://github.com/user-attachments/assets/6f19e0ad-ea84-411b-9cb9-3260557113bb">

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
