### PR TITLE
Support multiple visibility conditions in HTML External Forms

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -225,7 +225,7 @@
       "check_name": "RegexDoS",
       "message": "Model attribute used in regular expression",
       "file": "app/models/health/qualifying_activity.rb",
-      "line": 68,
+      "line": 70,
       "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
       "code": "/#{[Health::QualifyingActivityV1, Health::QualifyingActivityV2, Health::QualifyingActivityV3].map do\n (version::ATTRIBUTE_SUFFIX + \"$\")\n end.join(\"|\")}/",
       "render_path": null,
@@ -239,29 +239,6 @@
       "cwe_id": [
         20,
         185
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "13a7f90845cffdc12900858d9d2d0e853dcd03c123ae71ebfe37e725f6d6453a",
-      "check_name": "FileAccess",
-      "message": "Parameter value used in file name",
-      "file": "drivers/client_access_control/app/controllers/client_access_control/history_controller.rb",
-      "line": 119,
-      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open(Rails.root.join(\"tmp\", \"service_history_pdf_#{::GrdaWarehouse::Hud::Client.destination.find(params[:client_id].to_i).id}.pdf\"), \"wb\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ClientAccessControl::HistoryController",
-        "method": "pdf"
-      },
-      "user_input": "params[:client_id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
       ],
       "note": ""
     },
@@ -663,7 +640,7 @@
       "check_name": "Execute",
       "message": "Possible command injection",
       "file": "drivers/hmis/app/models/hmis/form/definition.rb",
-      "line": 350,
+      "line": 359,
       "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
       "code": "`No Definition found for System form #{role}`",
       "render_path": null,
@@ -977,6 +954,28 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
+      "fingerprint": "4f50bd02cffae24567d5d511f692ceeae1ac8183f4092cb176a63afabf3b18df",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml",
+      "line": 4,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "HmisExternalApis::ExternalForms::FormGenerator.new(self, @form_definition).render_node(node)",
+      "render_path": null,
+      "location": {
+        "type": "template",
+        "template": "hmis_external_apis/external_forms/form"
+      },
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
       "fingerprint": "51ec304bfb996e9d40ff69207ead86771b77a085b4a1bee4454fa4821f70fa70",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -1049,7 +1048,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on model attribute",
       "file": "drivers/hmis/app/models/hmis/form/definition.rb",
-      "line": 393,
+      "line": 414,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "{ :SERVICE => ({ :owner_class => \"Hmis::Hud::HmisService\", :permission => :can_edit_enrollments }), :PROJECT => ({ :owner_class => \"Hmis::Hud::Project\", :permission => :can_edit_project_details }), :ORGANIZATION => ({ :owner_class => \"Hmis::Hud::Organization\", :permission => :can_edit_organization }), :CLIENT => ({ :owner_class => \"Hmis::Hud::Client\", :permission => :can_edit_clients }), :FUNDER => ({ :owner_class => \"Hmis::Hud::Funder\", :permission => :can_edit_project_details }), :INVENTORY => ({ :owner_class => \"Hmis::Hud::Inventory\", :permission => :can_edit_project_details }), :PROJECT_COC => ({ :owner_class => \"Hmis::Hud::ProjectCoc\", :permission => :can_edit_project_details }), :HMIS_PARTICIPATION => ({ :owner_class => \"Hmis::Hud::HmisParticipation\", :permission => :can_edit_project_details }), :CE_PARTICIPATION => ({ :owner_class => \"Hmis::Hud::CeParticipation\", :permission => :can_edit_project_details }), :CE_ASSESSMENT => ({ :owner_class => \"Hmis::Hud::Assessment\", :permission => :can_edit_enrollments }), :CE_EVENT => ({ :owner_class => \"Hmis::Hud::Event\", :permission => :can_edit_enrollments }), :CASE_NOTE => ({ :owner_class => \"Hmis::Hud::CustomCaseNote\", :permission => :can_edit_enrollments }), :FILE => ({ :owner_class => \"Hmis::File\", :permission => ([:can_manage_any_client_files, :can_manage_own_client_files]), :authorize => (lambda do\n Hmis::File.authorize_proc.call(entity_base, user)\n end) }), :REFERRAL_REQUEST => ({ :owner_class => \"HmisExternalApis::AcHmis::ReferralRequest\", :permission => :can_manage_incoming_referrals }), :REFERRAL => ({ :owner_class => \"HmisExternalApis::AcHmis::ReferralPosting\", :permission => :can_manage_outgoing_referrals }), :CURRENT_LIVING_SITUATION => ({ :owner_class => \"Hmis::Hud::CurrentLivingSituation\", :permission => :can_edit_enrollments }), :OCCURRENCE_POINT => ({ :owner_class => \"Hmis::Hud::Enrollment\", :permission => :can_edit_enrollments }), :ENROLLMENT => ({ :owner_class => \"Hmis::Hud::Enrollment\", :permission => :can_edit_enrollments }), :NEW_CLIENT_ENROLLMENT => ({ :permission => :can_edit_enrollments, :owner_class => \"Hmis::Hud::Enrollment\" }), :CLIENT_DETAIL => ({ :owner_class => \"Hmis::Hud::Client\", :permission => :can_edit_clients }), :EXTERNAL_FORM => ({ :owner_class => \"HmisExternalApis::ExternalForms::FormSubmission\", :permission => :can_manage_external_form_submissions }) }[role.to_sym][:owner_class].constantize",
       "render_path": null,
@@ -1635,29 +1634,6 @@
         89
       ],
       "note": "Injection from internal sources"
-    },
-    {
-      "warning_type": "File Access",
-      "warning_code": 16,
-      "fingerprint": "8209c231f3717f00dfbf5f1ae66d9b27926d43b14bc03133faed58d17aa086e6",
-      "check_name": "FileAccess",
-      "message": "Parameter value used in file name",
-      "file": "drivers/client_access_control/app/controllers/client_access_control/history_controller.rb",
-      "line": 122,
-      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open(Rails.root.join(\"tmp\", \"service_history_pdf_#{::GrdaWarehouse::Hud::Client.destination.find(params[:client_id].to_i).id}.pdf\"))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ClientAccessControl::HistoryController",
-        "method": "pdf"
-      },
-      "user_input": "params[:client_id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -3023,28 +2999,6 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "f32a91544ec2960cf67499214f9dd41072818f5c4c0d756d32c389c908bb7426",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml",
-      "line": 4,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "HmisExternalApis::ExternalForms::FormGenerator.new(self).render_node(node)",
-      "render_path": null,
-      "location": {
-        "type": "template",
-        "template": "hmis_external_apis/external_forms/form"
-      },
-      "user_input": null,
-      "confidence": "High",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "f47f3a7065a132bc6a80a941cd002157fd72f089cf801dcd4be2d52746d410fa",
@@ -3229,6 +3183,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-08-07 04:08:29 +0000",
+  "updated": "2024-08-30 15:34:57 +0000",
   "brakeman_version": "6.1.2"
 }

--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -111,6 +111,7 @@ $(function () {
   });
 });
 
+// here
 window.addDependentGroup = function (inputName, condValue, targetSelector) {
   var target = $(targetSelector);
   var show = function () {

--- a/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
+++ b/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
@@ -73,10 +73,10 @@ module HmisExternalApis::ExternalFormsHelper
     render partial_path('form/checkbox'), label: label, name: name, html_id: next_html_id, required: required
   end
 
-  def render_dependent_block(input_name:, input_value:, &block)
+  def render_dependent_block(conditions:, &block)
     content = capture(&block)
     content_tag(:div, content, class: 'dependent-form-group fade-effect')
-    render partial_path('form/dependent_group'), content: content, html_id: next_html_id, input_name: input_name, input_value: input_value
+    render partial_path('form/dependent_group'), content: content, html_id: next_html_id, conditions: conditions
   end
 
   def next_html_id

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
@@ -22,7 +22,7 @@ class HmisExternalApis::PublishExternalFormsJob
     publication = definition.external_form_publications.new
 
     renderer = HmisExternalApis::ExternalFormsController.renderer.new
-    raw_content = renderer.render('hmis_external_apis/external_forms/form', assigns: { form_definition: definition.definition, page_title: definition.title })
+    raw_content = renderer.render('hmis_external_apis/external_forms/form', assigns: { form_definition: definition, page_title: definition.title })
 
     publication.object_key = definition.external_form_object_key
     publication.content_digest = digest = Digest::MD5.hexdigest(raw_content)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -12,11 +12,8 @@ module HmisExternalApis::ExternalForms
     def initialize(context, form_definition)
       @stack = []
       @context = context
-      @form_definition = form_definition # Hmis::Form::Definition
+      @form_definition = form_definition # Hmis::Form::Definition record
     end
-    # NEEDS:
-    # - multi-select (race/gender)
-    # - more than one conditional rule
 
     delegate :register_field,
              :render_form_input,
@@ -117,7 +114,7 @@ module HmisExternalApis::ExternalForms
 
     def render_choice_node(node)
       options = resolve_pick_list(node)
-      raise "missing options in #{node.inspect} " unless options.present?
+      raise "missing options in #{node.inspect}" unless options.present?
 
       render_form_group(node: node) do
         case node['component']
@@ -183,7 +180,7 @@ module HmisExternalApis::ExternalForms
       field_name = node.dig('mapping', 'field_name')
 
       # Join with period since that's the expected submission shape (Client.firstName)
-      # If problematic we can replace this with a hyphen, and process is accordingly in ConsumeExternalFormSubmissionsJob
+      # If problematic we can use another separator and process accordingly in ConsumeExternalFormSubmissionsJob
       [processor_name, custom_field_key || field_name].compact.join('.')
     end
 
@@ -192,8 +189,7 @@ module HmisExternalApis::ExternalForms
     # Example: { 'link_id_1' => 'custom_field_key_x' }
     def link_id_to_node_name
       @link_id_to_node_name ||= form_definition.link_id_item_hash.map do |link_id, node|
-        # Skip items without mapping
-        # Note: the hash already group items (see link_id_item_hash)
+        # Skip items without mapping. Note: the hash already excludes group items (see link_id_item_hash)
         next unless node['mapping']
 
         [link_id, node_name(node)]

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml
@@ -1,5 +1,5 @@
-%h1.h3.mb-4= @form_definition['name']
+-# %h1.h3.mb-4= @form_definition.definition['name']
 %form{method: 'post', autocomplete: "off",  novalidate: true }
-  - @form_definition['item']&.each do |node|
-    = HmisExternalApis::ExternalForms::FormGenerator.new(self).render_node(node).html_safe
+  - @form_definition.definition['item']&.each do |node|
+    = HmisExternalApis::ExternalForms::FormGenerator.new(self, @form_definition).render_node(node).html_safe
   = render_form_actions

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form.haml
@@ -1,4 +1,4 @@
--# %h1.h3.mb-4= @form_definition.definition['name']
+%h1.h3.mb-4= @form_definition.title
 %form{method: 'post', autocomplete: "off",  novalidate: true }
   - @form_definition.definition['item']&.each do |node|
     = HmisExternalApis::ExternalForms::FormGenerator.new(self, @form_definition).render_node(node).html_safe

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_dependent_group.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_dependent_group.haml
@@ -4,8 +4,7 @@
   :javascript
     'use strict';
     $(function() {
-      var inputName= #{input_name.to_json.html_safe};
-      var inputValue = #{input_value.to_json.html_safe};
+      var conditions= #{conditions.to_json.html_safe};
       var target = '#' + #{html_id.to_json.html_safe};
-      window.addDependentGroup(inputName, inputValue, target);
+      window.addMultiDependentGroup(conditions, target);
     });

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_dependent_group.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_dependent_group.haml
@@ -6,5 +6,5 @@
     $(function() {
       var conditions= #{conditions.to_json.html_safe};
       var target = '#' + #{html_id.to_json.html_safe};
-      window.addMultiDependentGroup(conditions, target);
+      window.addDependentGroup(conditions, target);
     });

--- a/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
+++ b/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
@@ -57,7 +57,7 @@
         position: relative;
         opacity: 1;
         visibility: visible;
-        max-height: 2000px; /* Adjust as necessary to fit content */
+        max-height: 8000px; /* Adjust as necessary to fit content */
       }
       /* override primary color for contrast */
       .btn-primary.btn-primary {


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

https://github.com/open-path/Green-River/issues/6614

Add additional functionality that is needed for PIT:
- [x] Bug: Stop assuming that `link_id` and `custom_field_key` always match
- [x] Support multiple `enable_when` conditions
- [x] Support resolving a `pick_list_reference` when it refers to a HUD enum (eg `NoYesMissing`)
- [x] Support items where `mapping` has `record_type` and/or `field_name` (will be needed because switching to using FormProcessor to process submissions that include related records https://github.com/greenriver/hmis-warehouse/pull/4657)

QA:
- [x] test prevention screening as local HTML form (note: a couple changes need to be made for prevention screening to work, because it has 2 conditionals where it references a dependent `question` by custom_field_key instead of by link_id)
- [x] test PIT as local HTML form

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
