### PR TITLE
Fix flaking system test

### DIFF
--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -186,8 +186,12 @@ RSpec.feature 'Assessment definition selection', type: :system do
     end
 
     def submit_household_assessment
-      click_button 'Save & Submit'
-      assert_text 'This assessment has been submitted' # Submit succeeded
+      assert_text 'Save & Submit'
+      find("button[type='submit']").trigger('click')
+      print page.body
+      assert_text 'Submitting'
+      print page.body
+      assert_text 'This assessment has been submitted' # Submit succeeded -- failing on CI but not locally
     end
 
     def save_household_assessment
@@ -246,7 +250,7 @@ RSpec.feature 'Assessment definition selection', type: :system do
         fill_in 'new_question', with: 'e2 answer'
 
         expect do
-          submit_household_assessment
+          submit_household_assessment # xx
         end.to change(e2.custom_assessments, :count).by(0).
           and change(e2_assessment.custom_data_elements, :count).by(1)
 

--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -186,16 +186,12 @@ RSpec.feature 'Assessment definition selection', type: :system do
     end
 
     def submit_household_assessment
-      assert_text 'Save & Submit'
-      find("button[type='submit']").trigger('click')
-      print page.body
-      assert_text 'Submitting'
-      print page.body
-      assert_text 'This assessment has been submitted' # Submit succeeded -- failing on CI but not locally
+      find('button', text: 'Save & Submit').trigger('click')
+      assert_text 'This assessment has been submitted' # Submit succeeded
     end
 
     def save_household_assessment
-      click_button 'Save Assessment'
+      find('button', text: 'Save Assessment').trigger('click')
       assert_text(/Last saved [0-9] seconds? ago/) # Save succeeded
     end
 

--- a/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
+++ b/drivers/hmis/spec/system/hmis/assessment_definitions_spec.rb
@@ -186,7 +186,7 @@ RSpec.feature 'Assessment definition selection', type: :system do
     end
 
     def submit_household_assessment
-      find('button', text: 'Save & Submit').trigger('click')
+      find('button', text: 'Save & Submit').trigger('click') # note: using click_button fails on CI (#6619)
       assert_text 'This assessment has been submitted' # Submit succeeded
     end
 
@@ -246,7 +246,7 @@ RSpec.feature 'Assessment definition selection', type: :system do
         fill_in 'new_question', with: 'e2 answer'
 
         expect do
-          submit_household_assessment # xx
+          submit_household_assessment
         end.to change(e2.custom_assessments, :count).by(0).
           and change(e2_assessment.custom_data_elements, :count).by(1)
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Avoid using `click_button` as a short-term fix for failing tests.

This may have an underlying issue has to do with how the FormActions component and buttons are rendered. Ticket for that: https://github.com/open-path/Green-River/issues/6619

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
