### PR TITLE
Zparks/8 30 2024 fixup csg services

### DIFF
--- a/drivers/ma_reports/app/models/ma_reports/csg_engage/report_components/household_member.rb
+++ b/drivers/ma_reports/app/models/ma_reports/csg_engage/report_components/household_member.rb
@@ -114,8 +114,22 @@ module MaReports::CsgEngage::ReportComponents
     # field('Expense')
 
     field('Services') do
-      enrollment.services.map do |service|
-        MaReports::CsgEngage::ReportComponents::Service.new(service)
+      services = enrollment.services.order(DateProvided: :desc).limit(1)
+
+      if services.present?
+        services.map do |service|
+          MaReports::CsgEngage::ReportComponents::Service.new(service)
+        end
+      else
+        [
+          {
+            'Service' => {
+              'ServiceDateTimeBegin' => enrollment.EntryDate&.strftime('%m/%d/%Y'),
+              'ServiceDateTimeEnd' => enrollment.exit&.ExitDate&.strftime('%m/%d/%Y'),
+              'ServiceProvided' => 'Project Enrollment',
+            },
+          },
+        ]
       end
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Updates CSG Engage models to only send the latest service per household member. If no services exist, it will now send a "Project Enrollment" service with a start date equal to the enrollment start date and an end date equal to the exit date (if present).

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
