### PR TITLE
Remove confirmation modal from external forms

### DIFF
--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -84,8 +84,6 @@ $(function () {
     });
   };
 
-  $('#confirmSubmitModalButton').on('click', submitWithCaptcha);
-
   form.addEventListener('submit', function (event) {
     event.preventDefault(); // Prevent the default form submission
     event.stopPropagation();
@@ -101,7 +99,7 @@ $(function () {
       const y = invalid.get(0).getBoundingClientRect().top + window.scrollY;
       window.scrollTo(0, y - 120);
     } else {
-      $('#confirmSubmitModal').modal('show');
+      submitWithCaptcha();
     }
   });
 

--- a/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
+++ b/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
@@ -87,13 +87,6 @@
           %p.m-0 We're sorry, but our website requires JavaScript to function properly. Please enable JavaScript in your browser settings and refresh this page.
       .card.p-3= yield
 
-    = render_modal(html_id: 'confirmSubmitModal', title: 'Are You Ready to Submit?') do
-      .modal-body
-        %p Please take a moment to double-check your entries. Submit the form when you're ready.
-      .modal-footer
-        %button.mr-3.btn.btn-outline-primary{ type: "button", "data-dismiss" => "modal" } Go Back
-        %button#confirmSubmitModalButton.btn.btn-primary{ type: "button", "data-dismiss" => "modal" } Yes, Submit Now
-
     = render_modal(html_id: 'spinnerModal', title: 'Loading', blocker: true) do
       .modal-body
         .d-flex


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

per design discussion 9/5 was deemed unnecessary  for prevention screening and cumbersome for PIT

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
