### PR TITLE
External forms style updates and bug fixes

### DIFF
--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -90,7 +90,9 @@ $(function () {
     event.preventDefault(); // Prevent the default form submission
     event.stopPropagation();
 
-    $('.needs-validation').find('input,select,textarea').each(function () {
+    /* only validate fields that are not disabled, as a way to skip validation on hidden inputs
+       (only works because we happen to disable hidden inputs) */
+    $('.needs-validation').find('input,select,textarea').filter(':not(:disabled)').each(function () {
       $(this).removeClass('is-valid is-invalid').addClass(this.checkValidity() ? 'is-valid' : 'is-invalid');
     });
 
@@ -107,7 +109,12 @@ $(function () {
 
   $('.needs-validation').find('input,select,textarea').on('focusout', function () {
     // check element validity and change class
-    $(this).removeClass('is-valid is-invalid').addClass(this.checkValidity() ? 'is-valid' : 'is-invalid');
+    var isValid = this.checkValidity();
+    $(this).removeClass('is-valid is-invalid').addClass(isValid ? 'is-valid' : 'is-invalid');
+    // If this is a valid radio button, mark other radio options as valid too
+    if (isValid && $(this).is(':radio')) {
+      $('input[name="' + this.name + '"]').removeClass('is-valid is-invalid').addClass(isValid ? 'is-valid' : 'is-invalid');
+    }
   });
 });
 

--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -38,7 +38,7 @@ $(function () {
 
     // Request a presigned URL
     $.ajax({
-      url: presignUrl,
+      url: presignUrl, // NOTE: for local testing, this should be "/hmis_external_api/external_forms/presign"
       type: 'GET',
       contentType: 'application/json',
       data: { captchaToken: captchaToken },

--- a/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
+++ b/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
@@ -19,7 +19,7 @@ module HmisExternalApis::ExternalFormsHelper
     render partial_path('form/textarea'), label: label, name: name, required: required, rows: rows, html_id: next_html_id, input_invalid_feedback: input_invalid_feedback
   end
 
-  def render_numeric_input(label:, name:, required: false, input_placeholder: nil, input_pattern: '\d*', input_html_id: nil, input_helper: nil, input_invalid_feedback: 'Must be a number')
+  def render_numeric_input(label:, name:, required: false, input_placeholder: nil, input_pattern: '\d*', input_html_id: next_html_id, input_helper: nil, input_invalid_feedback: 'Must be a number')
     render_form_input(label: label, name: name, required: required, input_pattern: input_pattern, input_mode: 'numeric', input_placeholder: input_placeholder, input_html_id: input_html_id, input_helper: input_helper, input_invalid_feedback: input_invalid_feedback)
   end
 

--- a/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
+++ b/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
@@ -14,9 +14,9 @@ module HmisExternalApis::ExternalFormsHelper
     render partial_path('form/input'), label: label, input_type: input_type, name: name, required: required, input_pattern: input_pattern, html_id: input_html_id, input_mode: input_mode, input_placeholder: input_placeholder, input_class: input_class, input_helper: input_helper, input_invalid_feedback: input_invalid_feedback
   end
 
-  def render_form_textarea(label:, name:, required: false, rows: 2, input_invalid_feedback: nil)
+  def render_form_textarea(label:, name:, required: false, rows: 2, input_invalid_feedback: nil, input_helper: nil)
     input_invalid_feedback ||= required ? 'This is required' : nil
-    render partial_path('form/textarea'), label: label, name: name, required: required, rows: rows, html_id: next_html_id, input_invalid_feedback: input_invalid_feedback
+    render partial_path('form/textarea'), label: label, name: name, required: required, rows: rows, html_id: next_html_id, input_invalid_feedback: input_invalid_feedback, input_helper: input_helper
   end
 
   def render_numeric_input(label:, name:, required: false, input_placeholder: nil, input_pattern: '\d*', input_html_id: next_html_id, input_helper: nil, input_invalid_feedback: 'Must be a number')

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -119,7 +119,6 @@ module HmisExternalApis::ExternalForms
       end
 
       render_form_group(node: node) do
-        context.tag.div(node['text'].html_safe)
         context.tag.div(node['text'].html_safe, class: classes)
       end
     end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -107,8 +107,20 @@ module HmisExternalApis::ExternalForms
     end
 
     def render_display_node(node)
+      classes = case node['component']
+      when 'ALERT_INFO'
+        'alert alert-info'
+      when 'ALERT_WARNING'
+        'alert alert-warning'
+      when 'ALERT_ERROR'
+        'alert alert-danger'
+      when 'ALERT_SUCCESS'
+        'alert alert-success'
+      end
+
       render_form_group(node: node) do
         context.tag.div(node['text'].html_safe)
+        context.tag.div(node['text'].html_safe, class: classes)
       end
     end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -77,7 +77,7 @@ module HmisExternalApis::ExternalForms
         when 'EMAIL'
           render_form_input(label: node['text'], name: node_name(node), required: node['required'], input_type: 'email', input_invalid_feedback: 'Enter a valid email address')
         else
-          render_form_input(label: node['text'], name: node_name(node), required: node['required'], input_type: 'text')
+          render_form_input(label: node['text'], name: node_name(node), required: node['required'], input_type: 'text', input_helper: node['helper_text'])
         end
       end
     end
@@ -96,7 +96,7 @@ module HmisExternalApis::ExternalForms
 
     def render_text_node(node)
       render_form_group(node: node) do
-        render_form_textarea(label: node['text'], name: node_name(node), required: node['required'])
+        render_form_textarea(label: node['text'], name: node_name(node), required: node['required'], input_helper: node['helper_text'])
       end
     end
 

--- a/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
+++ b/drivers/hmis_external_apis/app/views/layouts/hmis_external_apis/external_forms.haml
@@ -35,10 +35,6 @@
         max-width: 540px;
         margin-bottom: 4rem;
       }
-      .dependent-form-group > .form-group {
-        padding-left : 1.25rem;
-        border-left: 5px solid #eee;
-      }
       @media (max-width: 540px) {
         main.container {
           padding-left: 0;
@@ -69,6 +65,10 @@
       }
       .form-check {
         margin: 0.25rem;
+      }
+      /* reduce padding for groups of checkboxes */
+      fieldset > .form-group:has(> .form-check) {
+          margin-bottom: 0px;
       }
 
   %body.bg-light


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

These changes were pulled out from https://github.com/greenriver/hmis-warehouse/pull/4667 and can go in the release branch.

* BUG: validator would validate hidden fields, which is inconsistent with other form implementation
* BUG: if a radio element was required, it would still have error treatment on other options after you selected one of them
* FEATURE: support helper text on text inputs
* BUG: html input ID wasn't being set on numeric inputs
* FEATURE: support alert styling for display items
* STYLE CHANGE: remove indentation for conditional items
* STYLE CHANGE: reduce padding for groups of checkboxes

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
