### PR TITLE
Adjust format of date for external forms

### DIFF
--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_date.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_date.haml
@@ -28,12 +28,12 @@
 
       $([month, day, year].join(', ')).on('change', function() {
         var parts = [
+          $(year).val(),
           $(month).val().padStart(2, '0'),
-          $(day).val().padStart(2, '0'),
-          $(year).val()
+          $(day).val().padStart(2, '0')
         ]
         // console.info(parts.join('/'));
-        $(date).val(parts.join('/'));
+        $(date).val(parts.join('-'));
       });
 
       var dateValidationMessage = function(month, day, year) {


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Note: Opening this PR against the release branch rather than `pit-external-forms` since it's a bug in the existing logic.

**Bug**: When submitting the TCHC prevention form locally, a CDE for date fields (such as dob) gets saved with blank value_date.

**Root cause**: The date is being submitted in an unexpected format, `mm/dd/yyyy`. [Expected format](https://github.com/greenriver/hmis-warehouse/blob/bdaf04c01458bb256af19ce3fbfd7b9e397a5f1e/drivers/hmis/app/models/hmis/hud/processors/base.rb#L297) is `yyyy-mm-dd`. However, I believe the error is getting swallowed due to the `validate: false` passed [here](https://github.com/greenriver/hmis-warehouse/blob/9e8161c41fea28d65a3da65ad1a05e5278b6edcf/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb#L82), so we silently create a blank cde.

**Question**: I can see in my local database that ingesting dates used to be working correctly, back in March when we first worked on the Prevention Screening. I'm not sure what change we made that led to the regression?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
