### PR TITLE
Hotfix for neighborhoods on CAS readiness

### DIFF
--- a/app/controllers/clients/cas_readiness_controller.rb
+++ b/app/controllers/clients/cas_readiness_controller.rb
@@ -15,7 +15,6 @@ module Clients
     after_action :log_client
 
     def edit
-      @neighborhoods = CasAccess::Neighborhood.order(:name).pluck(:id, :name) if CasBase.db_exists? && RailsDrivers.loaded.include?(:cas_access)
     end
 
     background_render_action(:render_content, ::BackgroundRender::CasReadinessJob) do
@@ -25,12 +24,6 @@ module Clients
         token: form_authenticity_token,
       }
     end
-
-    # used to background load the content for edit so we don't get 504s
-    # def render_content
-    #   @neighborhoods = CasAccess::Neighborhood.order(:name).pluck(:id, :name) if CasBase.db_exists? && RailsDrivers.loaded.include?(:cas_access)
-    #   render(layout: false) if request.post?
-    # end
 
     def update
       update_params = cas_readiness_params

--- a/app/views/clients/cas_readiness/_set_asides.haml
+++ b/app/views/clients/cas_readiness/_set_asides.haml
@@ -11,4 +11,6 @@
   .c-card.c-card--flush.c-card--padded.c-card--block
     .row
       .col-sm-4
-        = f.input :neighborhood_interests, collection: @neighborhoods, label_method: :second, value_method: :first, label: nil, include_blank: 'Select neighborhoods', required: false, input_html: {multiple: :multiple, style: 'width: 100%;'}, as: :select_two
+        - neighborhoods = []
+        - neighborhoods = CasAccess::Neighborhood.order(:name).pluck(:id, :name) if CasBase.db_exists? && RailsDrivers.loaded.include?(:cas_access)
+        = f.input :neighborhood_interests, collection: neighborhoods, label_method: :second, value_method: :first, label: nil, include_blank: 'Select neighborhoods', required: false, input_html: {multiple: :multiple, style: 'width: 100%;'}, as: :select_two


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Neighborhoods were accidentally dropped from the CAS Readiness page due to the backgrounding of the page load.  This restores them.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
