### PR TITLE
Error on unauthorized object; adjust ClientAccessLoader logic for bad data

### DIFF
--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -54,7 +54,7 @@ class HmisSchema < GraphQL::Schema
     raise GraphQL::UnauthorizedError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
   end
 
-  # Return nil for anauthorized fields. This is expeced in some cases, for example non-summary fields on Enrollment.
+  # Return nil for unauthorized fields. This is expeced in some cases, for example non-summary fields on Enrollment.
   def self.unauthorized_field(_error)
     nil
   end

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -46,4 +46,9 @@ class HmisSchema < GraphQL::Schema
     # For example, use Rails' GlobalID library (https://github.com/rails/globalid):
     GlobalID.find(global_id)
   end
+
+  # Override hook to handle cases when `authorized?` returns false for an object (Default behavior is to return nil)
+  def self.unauthorized_object(error)
+    raise GraphQL::ExecutionError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
+  end
 end

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -49,6 +49,6 @@ class HmisSchema < GraphQL::Schema
 
   # Override hook to handle cases when `authorized?` returns false for an object (Default behavior is to return nil)
   def self.unauthorized_object(error)
-    raise GraphQL::ExecutionError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
+    raise GraphQL::UnauthorizedError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
   end
 end

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -47,8 +47,15 @@ class HmisSchema < GraphQL::Schema
     GlobalID.find(global_id)
   end
 
-  # Override hook to handle cases when `authorized?` returns false for an object (Default behavior is to return nil)
+  # Raise exception when `authorized?` returns false for an object (Default behavior is to return nil)
+  # This is an unexpected error because we should always be doing permission checks
+  # (e.g. applying viewable_by scope) before trying to resolve something.
   def self.unauthorized_object(error)
     raise GraphQL::UnauthorizedError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
+  end
+
+  # Return nil for anauthorized fields. This is expeced in some cases, for example non-summary fields on Enrollment.
+  def self.unauthorized_field(_error)
+    nil
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/client_access_loader.rb
+++ b/drivers/hmis/app/models/hmis/hud/client_access_loader.rb
@@ -14,10 +14,11 @@ class Hmis::Hud::ClientAccessLoader < Hmis::BaseAccessLoader
     client_ids = items.map { |i| i.first.id }.compact.uniq
 
     group_view_t = Hmis::GroupViewableEntity.arel_table
+    # Note: joins `projects` instead of `enrollments` to match the behavior of Client.with_access scope
     orphan_client_ids = Hmis::Hud::Client.
-      left_outer_joins(:enrollments).
+      left_outer_joins(:projects).
       where(id: client_ids).
-      where(arel.e_t[:id].eq(nil)).
+      where(arel.p_t[:id].eq(nil)).
       pluck(arel.c_t[:id])
 
     access_group_ids_by_client_id = Hmis::Hud::Project.

--- a/drivers/hmis/spec/requests/hmis/client_search_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         # client has 1 non-deleted Enrollment that is at a deleted Project (specific regression scenario)
         enrollment = create(:hmis_hud_enrollment, client: client, data_source: ds1)
         enrollment.project.delete
-        expect(enrollment.reload.project).to be_nil # confirm setup
+        raise unless enrollment.reload.project.nil? # confirm setup
       end
 
       it 'should return the client' do

--- a/drivers/hmis/spec/requests/hmis/client_search_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_spec.rb
@@ -250,6 +250,40 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
   end
+
+  describe 'Searching against bad data' do
+    let!(:client) { create :hmis_hud_client, first_name: 'Genevieve', data_source: ds1 }
+    def perform_search
+      post_graphql(input: { first_name: client.first_name }) { query }
+    end
+
+    it 'should raise when authorization check failed (regression #6641)' do
+      # remove client access
+      remove_permissions(access_control, :can_view_clients)
+
+      # mock a scenario where client search incorrectly returns a Client that will fail the `authorized?` check (ClientAccessLoader query)
+      expect(Hmis::Hud::Client).to receive(:client_search).and_return(Hmis::Hud::Client.where(id: client.id))
+
+      expect_gql_error perform_search, message: /failed authorization check/
+    end
+
+    context 'when client has an Enrollment at a deleted project (regression #6641)' do
+      before(:each) do
+        # client has 1 non-deleted Enrollment that is at a deleted Project (specific regression scenario)
+        enrollment = create(:hmis_hud_enrollment, client: client, data_source: ds1)
+        enrollment.project.delete
+        expect(enrollment.reload.project).to be_nil # confirm setup
+      end
+
+      it 'should return the client' do
+        # search should successfully return the client, despite their "bad" Enrollment
+        response, result = perform_search
+        expect(response.status).to eq(200), result.inspect
+        clients = result.dig('data', 'clientSearch', 'nodes')
+        expect(clients).to contain_exactly(a_hash_including({ 'id' => client.id.to_s }))
+      end
+    end
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Fix a bug that would arise when there were undeleted enrollments at deleted projects. The Client.viewable_by scope joins the client with _projects_, so the ClientAccessLoader is updated to do the same. (This mismatch was causing the authorized check to fail)
* Raise an error when authorized check fails on an object. 


https://github.com/open-path/Green-River/issues/6641


Bug reproduction:

```rails
client = Hmis::Hud::Client.hmis.find { |c| c.enrollments.count == 1 }
deleted_project = Hmis::Hud::Project.only_deleted.last
en = client.enrollments.first
en.update!(project: deleted_project)
# search for the client in HMIS by name
# OLD BEHAVIOR: an exception will be raised because they are unauthorized
# NEW BEHAVIOR: no error, client is returned. they appear to have no enrollments in hmis
```

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
