### PR TITLE
Raise on empty client search in HMIS

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -39,6 +39,8 @@ module Types
     end
 
     def client_search(input:, **args)
+      raise 'Invalid search. At least 1 search param is required.' unless input.to_h.excluding(:projects, :organizations).values.compact_blank.any?
+
       # if the search should also sort by rank
       sorted = args[:sort_order] == :best_match
       search_scope = Hmis::Hud::Client.client_search(

--- a/drivers/hmis/spec/requests/hmis/client_search_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_spec.rb
@@ -42,62 +42,74 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
-  context 'User access tests' do
-    let!(:client1) { create :hmis_hud_client, data_source: ds1 }
-    let!(:client2) { create :hmis_hud_client, data_source: ds2 }
-    let!(:client3) { create :hmis_hud_client, data_source: ds1 }
+  context 'User access tests where user has full access to 1 project' do
+    let!(:client1) { create :hmis_hud_client, first_name: 'Darlene', last_name: 'Ranger', data_source: ds1 }
+    let!(:client2) { create :hmis_hud_client, first_name: 'Darlene', last_name: 'Ranger', data_source: ds2 }
+    let!(:client3) { create :hmis_hud_client, first_name: 'Darlene', last_name: 'Ranger', data_source: ds1 }
 
-    it 'should only show clients from HMIS data source' do
-      response, result = post_graphql(input: {}) { query }
-
-      expect(response.status).to eq 200
-      clients = result.dig('data', 'clientSearch', 'nodes')
-      expect(clients).to include({ 'id' => client1.id.to_s })
-      expect(clients).not_to include({ 'id' => client2.id.to_s })
-      expect(clients).to include({ 'id' => client3.id.to_s })
+    def perform_search(input = { text_search: 'Darlene Ranger' })
+      response, result = post_graphql(input: input) { query }
+      expect(response.status).to eq(200), result.inspect
+      result.dig('data', 'clientSearch', 'nodes')
     end
 
-    it 'should only show clients with enrollments at projects the user has view access for' do
-      create(:hmis_hud_enrollment, data_source: ds1, project: p1, client: client1, user: u1)
-      create(:hmis_hud_enrollment, data_source: ds1, project: p2, client: client3, user: u1)
+    it 'should return all unenrolled clients from HMIS data source' do
+      # Even though the current user only has access to view clients at p1,
+      # they can still see all "unenrolled" aka "orphaned" client records in their data source
+      clients = perform_search
+      expect(clients).to contain_exactly(
+        include({ 'id' => client1.id.to_s }),
+        include({ 'id' => client3.id.to_s }),
+      )
+    end
+
+    it 'should return clients enrolled at user\'s project' do
+      create(:hmis_hud_enrollment, data_source: ds1, project: p1, client: client1)
+      create(:hmis_hud_enrollment, data_source: ds1, project: p2, client: client3)
 
       expect(client1.enrollments).to contain_exactly(satisfy { |e| !e.in_progress? })
       expect(client3.enrollments).to contain_exactly(satisfy { |e| !e.in_progress? })
 
       # Shouldn't see client3 since it has enrollments elsewhere
-      _response, result = post_graphql(input: {}) { query }
-      expect(result.dig('data', 'clientSearch', 'nodes')).to contain_exactly(include('id' => client1.id.to_s))
+      clients = perform_search
+      expect(clients).to contain_exactly(include('id' => client1.id.to_s))
 
-      create(:hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: client3, user: u1)
+      create(:hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: client3)
       client3.reload
 
       expect(client3.enrollments).to contain_exactly(satisfy { |e| !e.in_progress? }, satisfy(&:in_progress?))
 
       # Now we should see client3 since it has a WIP enrollment at our project
-      _response, result = post_graphql(input: {}) { query }
-      expect(result.dig('data', 'clientSearch', 'nodes')).to contain_exactly(include('id' => client1.id.to_s), include('id' => client3.id.to_s))
+      clients = perform_search
+      expect(clients).to contain_exactly(
+        include('id' => client1.id.to_s),
+        include('id' => client3.id.to_s),
+      )
     end
 
-    it 'should exclude clients enrolled at a project without user view permission' do
+    it 'should exclude clients enrolled at other projects where user lacks can_view_clients' do
       # Grant user access to p2, but without the ability to view clients
       create_access_control(hmis_user, p2, without_permission: :can_view_clients)
       # Enroll client3 in p2
       create(:hmis_hud_enrollment, data_source: ds1, project: p2, client: client3, user: u1)
 
-      response, result = post_graphql(input: {}) { query }
-      expect(response.status).to eq 200
-      clients = result.dig('data', 'clientSearch', 'nodes')
-      expect(clients).to include({ 'id' => client1.id.to_s })
-      expect(clients).not_to include({ 'id' => client2.id.to_s })
-      expect(clients).not_to include({ 'id' => client3.id.to_s })
+      clients = perform_search
+      expect(clients).to contain_exactly(include('id' => client1.id.to_s))
     end
 
     it 'should return no clients if user does not have permission to view clients' do
       remove_permissions(access_control, :can_view_clients)
-      response, result = post_graphql(input: {}) { query }
-      expect(response.status).to eq 200
-      clients = result.dig('data', 'clientSearch', 'nodes')
+
+      clients = perform_search
       expect(clients).to be_empty
+    end
+
+    it 'should not allow search without tokens' do
+      expect_gql_error post_graphql(input: {}) { query }, message: /Invalid search/
+
+      # projects and organizations don't count as a query, they are meant to be used as a filter
+      expect_gql_error post_graphql(input: { projects: [p1.id] }) { query }, message: /Invalid search/
+      expect_gql_error post_graphql(input: { organizations: [o1.id] }) { query }, message: /Invalid search/
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe Hmis::SessionsController, type: :request do
         }
       }
     GRAPHQL
-    response, = post_graphql(input: {}) { query }
+    response, = post_graphql(input: { first_name: 'Tester' }) { query }
     response
   end
 end

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Hmis::SessionsController, type: :request do
       post hmis_user_session_path(hmis_user: { email: user.email, password: 'incorrect' })
     end
 
-    it 'denys API access' do
+    it 'denies API access' do
       expect(api_query_response.status).to eq 401
     end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

I noticed this while working on tests for https://github.com/greenriver/hmis-warehouse/pull/4682: the clientSearch query allows receiving an empty input object, which will resolve all viewable clients. The frontend doesn't expose a way to do it, but the api allowed it.

This PR removes the ability to search without any search parameters. 

Note: `ClientSearchUtil::NameSearch` already forbids _text search_ where the search term is < 3 chars. In that case, it will just return empty.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
