### PR TITLE
Turn off validations for EPIC QAs

### DIFF
--- a/app/models/health/epic_qualifying_activity.rb
+++ b/app/models/health/epic_qualifying_activity.rb
@@ -73,7 +73,7 @@ module Health
         reached_client: care_hub_reached_key(qa),
         activity: care_hub_activity_key(qa),
       )
-      qa.save
+      qa.save(validate: false)
     end
 
     def self.update_qualifying_activities!


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

I can't figure out where this change got lost -- but, it is the source of the Sentry errors, and is affecting the client.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
