### PR TITLE
Demographic Summary Export Hotfix

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/race_ethnicity_calculations.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/race_ethnicity_calculations.rb
@@ -76,7 +76,7 @@ module
           nil,
         ]
         available_coc_codes.each do |coc_code|
-          rows["_Race_data_#{title}"] += [
+          rows["_Race by Ethnicity_data_#{title}"] += [
             race_combination_count(id, coc_code.to_sym),
             race_combination_percentage(id, coc_code.to_sym) / 100,
           ]


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix for incorrect key name when building the race-ethnicity hash in the demographic summary report document export. This was only manifesting when specific CoCs were selected for the report.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
