### PR TITLE
Initial value for Enumeration#sum when the first element is nil

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -351,7 +351,6 @@ Layout/SpaceBeforeBlockBraces:
     - 'app/models/grda_warehouse/export/hmis_twenty_twenty/exit.rb'
     - 'app/models/grda_warehouse/tasks/enrollment_extras_import.rb'
     - 'app/models/grda_warehouse/warehouse_reports/touch_point.rb'
-    - 'app/models/health/claims/view_model.rb'
     - 'app/models/health/cp_members/file_base.rb'
     - 'app/models/health/epic_patient.rb'
     - 'app/models/health/premium_payment.rb'
@@ -418,7 +417,6 @@ Layout/SpaceInsideBlockBraces:
     - 'app/models/grda_warehouse/export/hmis_twenty_twenty/exit.rb'
     - 'app/models/grda_warehouse/warehouse_reports/touch_point.rb'
     - 'app/models/health/agency_patient_referral.rb'
-    - 'app/models/health/claims/view_model.rb'
     - 'app/models/health/cp_members/file_base.rb'
     - 'app/models/health/epic_patient.rb'
     - 'app/models/health/goal/base.rb'
@@ -442,7 +440,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'app/models/grda_warehouse/grades/utilization.rb'
     - 'app/models/grda_warehouse/hud_chronic.rb'
     - 'app/models/grda_warehouse/us_census_api/census_variable.rb'
-    - 'app/models/health/claims/view_model.rb'
     - 'app/models/health/goal/base.rb'
     - 'app/models/health/premium_payment.rb'
     - 'app/models/health_base.rb'
@@ -1113,7 +1110,6 @@ Style/TrailingCommaInArrayLiteral:
   Exclude:
     - 'app/models/grda_warehouse/vispdat/family.rb'
     - 'app/models/grda_warehouse/vispdat/youth.rb'
-    - 'app/models/health/claims/view_model.rb'
     - 'app/models/report_generators/data_quality/fy2017/q6.rb'
 
 # Offense count: 296
@@ -1130,7 +1126,6 @@ Style/TrailingCommaInHashLiteral:
     - 'app/models/grda_warehouse/shape.rb'
     - 'app/models/grda_warehouse/tasks/enrollment_extras_import.rb'
     - 'app/models/grda_warehouse/vispdat/family.rb'
-    - 'app/models/health/claims/view_model.rb'
     - 'app/models/health/soap/file_list.rb'
     - 'app/models/health_base.rb'
     - 'app/models/reporting/d3_charts.rb'

--- a/app/models/health/claims/view_model.rb
+++ b/app/models/health/claims/view_model.rb
@@ -119,13 +119,17 @@ module Health::Claims
     end
 
     def load_cost_values
-      implementation_sum = @patient.amount_paids.implementation.map(&:total).sum&.round rescue 0 # rubocop:disable Style/RescueModifier
+      # FIXME: Rails 7.1 is expected to change the behavior of Enumeration#sum
+      #   This adds an initial value of 0 for cases where the first value is nil. This is behavior preserving as it
+      #   will still fail when it adds the nil (will be caught, and 0 returned). Should this really be replacing the
+      #   nils with 0s so the average is available?
+      implementation_sum = @patient.amount_paids.implementation.map(&:total).sum(0)&.round rescue 0 # rubocop:disable Style/RescueModifier
       implementation_count = @patient.amount_paids.implementation.map(&:total).count&.round
       patient = [
         implementation_sum,
         implementation_count,
       ]
-      baseline_sum = @patient.amount_paids.baseline.map(&:total).sum&.round rescue 0 # rubocop:disable Style/RescueModifier
+      baseline_sum = @patient.amount_paids.baseline.map(&:total).sum(0)&.round rescue 0 # rubocop:disable Style/RescueModifier
       baseline_count = @patient.amount_paids.baseline.map(&:total).count&.round rescue 0 # rubocop:disable Style/RescueModifier
       sdh = [
         baseline_sum,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Rails 7 deprecates (and Rails 7.1 is expected to remove) support for `Enumeration#sum` when the first element is
non-numeric, and instead expects the initial value be passed in.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Code clean-up / housekeeping

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
