### PR TITLE
Fix test failure in referral job

### DIFF
--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -45,8 +45,14 @@ FactoryBot.define do
       with_custom_client_name { false }
     end
     after(:build) do |client, evaluator|
-      HudUtility2024.races.except('RaceNone').keys.each { |f| client.send("#{f}=", [0, 1].sample) }
-      HudUtility2024.gender_fields.excluding(:GenderNone).each { |f| client.send("#{f}=", [0, 1].sample) }
+      race_attributes = HudUtility2024.races.except('RaceNone').keys.map { |r| [r, [0, 1].sample] }.to_h
+      race_attributes['RaceNone'] = 99 if race_attributes.values.sum.zero?
+      client.assign_attributes(race_attributes)
+
+      gender_attributes = HudUtility2024.gender_fields.excluding(:GenderNone).map { |r| [r, [0, 1].sample] }.to_h
+      gender_attributes['GenderNone'] = 99 if gender_attributes.values.sum.zero?
+      client.assign_attributes(gender_attributes)
+
       client.build_primary_custom_client_name if evaluator.with_custom_client_name
     end
   end

--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -45,12 +45,12 @@ FactoryBot.define do
       with_custom_client_name { false }
     end
     after(:build) do |client, evaluator|
-      race_attributes = HudUtility2024.races.except('RaceNone').keys.map { |r| [r, [0, 1].sample] }.to_h
-      race_attributes['RaceNone'] = 99 if race_attributes.values.sum.zero?
+      race_attributes = HudUtility2024.races.except('RaceNone').keys.map { |r| [r, [1, 0].sample] }.to_h
+      race_attributes['RaceNone'] = [8, 9, 99].sample if race_attributes.values.sum.zero?
       client.assign_attributes(race_attributes)
 
-      gender_attributes = HudUtility2024.gender_fields.excluding(:GenderNone).map { |r| [r, [0, 1].sample] }.to_h
-      gender_attributes['GenderNone'] = 99 if gender_attributes.values.sum.zero?
+      gender_attributes = HudUtility2024.gender_fields.excluding(:GenderNone).map { |r| [r, [1, 0].sample] }.to_h
+      gender_attributes['GenderNone'] = [8, 9, 99].sample if gender_attributes.values.sum.zero?
       client.assign_attributes(gender_attributes)
 
       client.build_primary_custom_client_name if evaluator.with_custom_client_name

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
@@ -284,7 +284,7 @@ module HmisExternalApis::AcHmis
 
     # Accepts a list of 2024 integer values for gender from Data Dictionary
     def gender_attributes_from_codes(codes)
-      attributes = HudUtility2024.gender_id_to_field_name.invert.map do |k, v|
+      attributes = HudUtility2024.gender_id_to_field_name.invert.excluding(:GenderNone).map do |k, v|
         [k, codes.include?(v) ? 1 : 0]
       end.to_h
       attributes[:GenderNone] = attributes.values.sum.zero? ? 99 : nil
@@ -293,7 +293,7 @@ module HmisExternalApis::AcHmis
 
     # Accepts a list of 2024 integer values for race from Data Dictionary
     def race_attributes_from_codes(codes)
-      attributes = HudUtility2024.race_id_to_field_name.invert.map do |k, v|
+      attributes = HudUtility2024.race_id_to_field_name.invert.excluding(:RaceNone).map do |k, v|
         [k, codes.include?(v) ? 1 : 0]
       end.to_h
       attributes[:RaceNone] = attributes.values.sum.zero? ? 99 : nil

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
@@ -282,21 +282,21 @@ module HmisExternalApis::AcHmis
       return false
     end
 
-    # Accepts a list of 2024 integer values for gender from Data Dictionary
+    # Accepts a list of 2024 integer values for gender from Data Dictionary [0,1,2,3,4,5,6,8,9,99]
     def gender_attributes_from_codes(codes)
       attributes = HudUtility2024.gender_id_to_field_name.invert.excluding(:GenderNone).map do |k, v|
         [k, codes.include?(v) ? 1 : 0]
       end.to_h
-      attributes[:GenderNone] = attributes.values.sum.zero? ? 99 : nil
+      attributes[:GenderNone] = (codes & [8, 9, 99]).first || 99 if attributes.values.sum.zero?
       attributes
     end
 
-    # Accepts a list of 2024 integer values for race from Data Dictionary
+    # Accepts a list of 2024 integer values for race from Data Dictionary # [1,2,3,4,5,6,7,8,9,99]
     def race_attributes_from_codes(codes)
       attributes = HudUtility2024.race_id_to_field_name.invert.excluding(:RaceNone).map do |k, v|
         [k, codes.include?(v) ? 1 : 0]
       end.to_h
-      attributes[:RaceNone] = attributes.values.sum.zero? ? 99 : nil
+      attributes[:RaceNone] = (codes & [8, 9, 99]).first || 99 if attributes.values.sum.zero?
       attributes
     end
   end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This test would fail when hmis_hud_client_complete happened to set all races and genders to `0`. 

* This fixes the underlying issue, which is that the Referral API  would not set RaceNone/GenderNone correctly when generating new clients from API requests
* It also updates the client factory to set valid RaceNone/GenderNone values

Example of a failure here https://github.com/greenriver/hmis-warehouse/actions/runs/10838051274/job/30075420742


```
  1) HmisExternalApis::AcHmis::ReferralsController send referral receives referral for new clients
     Failure/Error: expect(client.race_multi).to eq(source_client.race_multi)

       expected: []
            got: [99]
```

Sorry it took so long to get around to this one!

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
