### PR TITLE
Fix for missing EntryDate in SHE rebuilds

### DIFF
--- a/app/models/grda_warehouse/tasks/service_history/enrollment.rb
+++ b/app/models/grda_warehouse/tasks/service_history/enrollment.rb
@@ -199,7 +199,7 @@ module GrdaWarehouse::Tasks::ServiceHistory
           end
           # Rails.logger.debug '===RebuildEnrollmentsJob=== Days built'
           # Rails.logger.debug ::NewRelic::Agent::Samplers::MemorySampler.new.sampler.get_sample
-          if exit.present?
+          if exit.present? && exit.ExitDate.present?
             date = exit.ExitDate
             insert = build_service_history_enrollment_insert(exit_record(date))
             service_history_enrollment_source.connection.insert(insert.to_sql)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This attempts to handle the situation where `Enrollment.EntryDate` or `Exit.ExitDate`, which are required, are missing.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
