### PR TITLE
Fix conditional validation on external forms

### DIFF
--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -90,10 +90,14 @@ $(function () {
     event.preventDefault(); // Prevent the default form submission
     event.stopPropagation();
 
-    /* only validate fields that are not disabled, as a way to skip validation on hidden inputs
-       (only works because we happen to disable hidden inputs) */
-    $('.needs-validation').find('input,select,textarea').filter(':not(:disabled)').each(function () {
-      $(this).removeClass('is-valid is-invalid').addClass(this.checkValidity() ? 'is-valid' : 'is-invalid');
+    $('.needs-validation').find('input,select,textarea').each(function () {
+      var isHidden = $(this).closest('.dependent-form-group:not(.visible)').length > 0
+      if (isHidden) {
+        // This element is hidden because it has conditional visibility, so we don't need to validate it and we can clear the validity status
+        $(this).removeClass('is-valid is-invalid')
+      } else {
+        $(this).removeClass('is-valid is-invalid').addClass(this.checkValidity() ? 'is-valid' : 'is-invalid');
+      }
     });
 
     var invalid = $('.is-invalid');


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Don't validate any fields that are hidden due to conditional visibility. I previously tried to fix this by relying on disabled attribute, but it doesn't catch cases where an input is hidden because it belongs to a group that is hidden.

Bug reproduction:
* Open the PIT in external forms view locally
* Select "interview"
* Enter a couple fields and submit (Expect validation error)
* Switch to "observational"
* Enter all visibly required fields and submit
  * EXPECTATION: successful submit
  * REALITY: fails to submit without visible error, because some of the interview-only fields were required

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
