### PR TITLE
Override performance

### DIFF
--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
@@ -137,7 +137,7 @@ class HmisCsvImporter::ImportOverride < GrdaWarehouseBase
       applies?(row)
     end.map(&:ProjectID)
     # Limit to 10 for performance
-    GrdaWarehouse::Hud::Project.where(data_source_id: data_source_id, ProjectID: project_ids.first(10)).to_a
+    GrdaWarehouse::Hud::Project.where(data_source_id: data_source_id, ProjectID: project_ids.uniq.first(10)).to_a
   end
 
   def apply_to_warehouse

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/import_override.rb
@@ -136,7 +136,8 @@ class HmisCsvImporter::ImportOverride < GrdaWarehouseBase
     project_ids = associated_class.where(data_source_id: data_source_id).to_a.select do |row|
       applies?(row)
     end.map(&:ProjectID)
-    GrdaWarehouse::Hud::Project.where(data_source_id: data_source_id, ProjectID: project_ids).to_a
+    # Limit to 10 for performance
+    GrdaWarehouse::Hud::Project.where(data_source_id: data_source_id, ProjectID: project_ids.first(10)).to_a
   end
 
   def apply_to_warehouse

--- a/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
+++ b/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_table.haml
@@ -18,9 +18,13 @@
           - if projects.any? && show_associated_project
             .associated-projects
               Associated Project
+              - if projects.count == 10
+                %br
+                %small (Limited to the first 10 matching projects)
               %ul
                 - projects.each do |project|
                   %li= link_to_if can_view_projects?, project.name(current_user, ignore_confidential_status: can_edit_projects?), project_path(project)
+
         %td= override.replaces_column
         %td= override.describe_with
         %td= override.describe_when


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This limits the number of projects shown on the override page to help with performance.
<img width="1093" alt="Screenshot 2024-09-17 at 9 03 58 AM" src="https://github.com/user-attachments/assets/0ccbae5c-a884-4094-b7d1-9047104b9c9c">

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
