### PR TITLE
Add HUD:HOME funder component

### DIFF
--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/disability_rule.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/disability_rule.json
@@ -17,9 +17,9 @@
         },
         {
           "_comment": "client request (#6428)",
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "547"
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HOME"
         },
         {
           "_comment": "Local or N/A funder, less some projects. TODO: use a project group",
@@ -76,9 +76,9 @@
         },
         {
           "_comment": "client request (#6428)",
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "547"
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HOME"
         },
         {
           "_comment": "Local or N/A funder, less some projects. TODO: use a project group",

--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/health_insurance_rule.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/health_insurance_rule.json
@@ -17,9 +17,9 @@
         },
         {
           "_comment": "client request (#6428)",
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "547"
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HOME"
         },
         {
           "_comment": "Local or N/A funder, less some projects. TODO: use a project group",

--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/income_and_sources_rule.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/income_and_sources_rule.json
@@ -17,9 +17,9 @@
         },
         {
           "_comment": "client request (#6428)",
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "547"
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HOME"
         },
         {
           "_comment": "Local or N/A funder, less some projects. TODO: use a project group",

--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/non_cash_benefits_rule.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/non_cash_benefits_rule.json
@@ -17,9 +17,9 @@
         },
         {
           "_comment": "client request (#6428)",
-          "variable": "projectId",
-          "operator": "EQUAL",
-          "value": "547"
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "HUD: HOME"
         },
         {
           "_comment": "Local or N/A funder, less some projects. TODO: use a project group",

--- a/drivers/hmis_external_apis/public/schemas/form_definition.json
+++ b/drivers/hmis_external_apis/public/schemas/form_definition.json
@@ -256,6 +256,7 @@
                 "HUD: CoC",
                 "HUD: ESG",
                 "HUD: ESG RUSH",
+                "HUD: HOME",
                 "HUD: HOPWA",
                 "HUD: HUD-VASH",
                 "HUD: PFS",

--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -633,6 +633,7 @@ module HudUtility2024
       'HUD: Rural Special NOFO' => [55],
       'HUD: HUD-VASH' => [20],
       'HUD: PFS' => [HudUtility2024.funding_source('HUD: Pay for Success', true, raise_on_missing: true)], # Pay for Success
+      'HUD: HOME' => [50, 51],
     }
   end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add a funder component for `HUD: HOME` and `HUD: HOME (ARP)`, and update an override rule (originally from https://github.com/open-path/Green-River/issues/6428) to apply to the funder component instead of the specific project.

## How to test
* seed definitions with CLIENT=<client>
* make a project that only has a HUD HOME funder
* intake should have psdes

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
