### PR TITLE
Age Discrepancy in Q5A - Correction Needed

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_twenty_seven.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_twenty_seven.rb
@@ -35,8 +35,7 @@ module HudApr::Generators::Shared::Fy2024
     end
 
     private def youth_filter
-      a_t[:age].between(12..24).and(a_t[:other_clients_over_25].eq(false)).
-        and(a_t[:dob_quality].in([1, 2]))
+      a_t[:age].between(12..24).and(a_t[:other_clients_over_25].eq(false))
     end
 
     private def q27a_youth_age


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Remove DOB quality from youth filter for APR Q27. This should align the question with the Q5a calculation.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
