### PR TITLE
Better exposure of HIC vs LSA on history page

### DIFF
--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -1448,6 +1448,8 @@ module Filters
         'System-Wide'
       when 2
         'Project-Focused'
+      when 3
+        'HIC'
       else
         'Auto Select'
       end

--- a/app/views/hud_reports/_reports.haml
+++ b/app/views/hud_reports/_reports.haml
@@ -25,11 +25,15 @@
             %td= render 'hud_reports/parameters', report: report
             %td
               - report.build_for_questions&.each do |question|
+                - question_label = question
+                -# Special case HIC (which is technically an LSA)
+                - if report.options.dig('lsa_scope') == 3
+                  - question_label = 'HIC'
                 - if report.remaining_questions.include?(question)
                   .btn.btn-sm.btn-secondary.btn-disabled.mb-2.ml-2{ data: { toggle: :tooltip, title: @generator.describe_table(question), html: 'true' }}
-                    = question
+                    = question_label
                 - else
-                  = link_to question, path_for_question_result(question, report: report), class: 'btn btn-secondary btn-sm mb-2 ml-2', data: { toggle: :tooltip, title: @generator.describe_table(question), html: 'true' }
+                  = link_to question_label, path_for_question_result(question, report: report), class: 'btn btn-secondary btn-sm mb-2 ml-2', data: { toggle: :tooltip, title: @generator.describe_table(question), html: 'true' }
             %td
               - unless report.running?
                 = link_to path_for_report(report), method: :delete, class: 'btn btn-sm btn-danger btn-icon-only', data: { confirm: 'Are you sure you want to delete this report?' }  do

--- a/drivers/hud_lsa/app/views/hud_lsa/lsas/history.haml
+++ b/drivers/hud_lsa/app/views/hud_lsa/lsas/history.haml
@@ -1,1 +1,21 @@
-= render 'hud_reports/history'
+= render 'breadcrumbs'
+- content_for :title, generator.generic_title
+
+%header.mb-3.d-flex
+  %h1= content_for :title
+  .ml-auto
+    = link_to "Generate New #{generator.short_name}", path_for_new, class: 'btn btn-secondary'
+    = link_to 'Generate New LSA for HIC', new_hic_hud_reports_lsas_path, class: 'btn btn-secondary'
+- if @show_recent
+  .well
+    .d-flex
+      %h2= "#{generator.short_name} Report"
+      .ml-auto
+        = link_to({format: :zip},{class: 'btn btn-primary'}) do
+          %span.icon-download2
+          Download Zip File
+
+    = render 'questions'
+
+= render 'hud_reports/year_tabs'
+= render 'hud_reports/reports_wrapper'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adds:
1. A button to launch a new HIC on the history page
2. Fix to display HIC under LSA Scope in the parameters
3. Hack to show HIC instead of LSA when the LSA was a HIC as the button name

<img width="1274" alt="Screenshot 2024-09-18 at 8 58 44 AM" src="https://github.com/user-attachments/assets/f76d020a-88e0-4064-986e-6e881e4f2efd">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
