### PR TITLE
Fix bug with blank geolocation

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/geolocation_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/geolocation_processor.rb
@@ -14,6 +14,8 @@ module Hmis::Hud::Processors
     end
 
     def process(field, value)
+      return @processor.send(factory_name).destroy if value.nil? || value.empty?
+
       attribute_name = ar_attribute_name(field)
 
       raise ArgumentError, "Unexpected attribute for Geolocation: #{attribute_name}" unless attribute_name == 'coordinates'

--- a/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
@@ -173,6 +173,7 @@ RSpec.describe 'Update External Form Submission', type: :request do
             'captcha_score': '1.', # also test that extraneous fields get filtered out
             'form_definition_id': definition.id,
             'form_content_digest': 'something random',
+            'Geolocation.coordinates': '',
           }.stringify_keys
           create(:hmis_external_form_submission, raw_data: data, definition: definition)
         end
@@ -183,7 +184,8 @@ RSpec.describe 'Update External Form Submission', type: :request do
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'updateExternalFormSubmission', 'externalFormSubmission', 'status')).to eq('reviewed')
           end.to change(Hmis::Hud::Client, :count).by(1).
-            and change(Hmis::Hud::Enrollment, :count).by(1)
+            and change(Hmis::Hud::Enrollment, :count).by(1).
+            and not_change(ClientLocationHistory::Location, :count)
 
           submission.reload
           expect(submission.enrollment.relationship_to_hoh).to eq(1)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6541
Fixes https://github.com/open-path/Green-River/issues/6541#issuecomment-2359006523

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
