### PR TITLE
Resolve key/value summary fields on form submission type

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3874,14 +3874,14 @@ enum ExpelledReason {
 
 type ExternalFormSubmission {
   """
-  ID of Client that was generated from this submission, if any
+  Client that was generated from this submission, if any
   """
   clientId: ID
   customDataElements: [CustomDataElement!]!
   definition: FormDefinition!
 
   """
-  ID of Enrollment that was generated from this submission, if any
+  Enrollment that was generated from this submission, if any
   """
   enrollmentId: ID
   id: ID!
@@ -3891,7 +3891,7 @@ type ExternalFormSubmission {
   submittedAt: ISO8601DateTime!
 
   """
-  summary fields for identifying the submission
+  Key/value responses for certain summary-level form questions
   """
   summaryFields: [KeyValue!]!
   values: JSON

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3873,13 +3873,27 @@ enum ExpelledReason {
 }
 
 type ExternalFormSubmission {
+  """
+  ID of Client that was generated from this submission, if any
+  """
+  clientId: ID
   customDataElements: [CustomDataElement!]!
   definition: FormDefinition!
+
+  """
+  ID of Enrollment that was generated from this submission, if any
+  """
+  enrollmentId: ID
   id: ID!
   notes: String
   spam: Boolean
   status: ExternalFormSubmissionStatus!
   submittedAt: ISO8601DateTime!
+
+  """
+  summary fields for identifying the submission
+  """
+  summaryFields: [KeyValue!]!
   values: JSON
 }
 
@@ -5543,6 +5557,11 @@ scalar JSON
 Arbitrary JSON Type
 """
 scalar JsonObject
+
+type KeyValue {
+  key: String!
+  value: String
+}
 
 """
 HUD LastGradeCompleted (R4.1)

--- a/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/external_form_submission.rb
@@ -22,6 +22,9 @@ module Types
     field :definition, Forms::FormDefinition, null: false
     field :values, GraphQL::Types::JSON, null: true
     custom_data_elements_field # Resolve for backwards compatibility. Can remove in a future release
+    field :enrollment_id, ID, null: true, description: 'Enrollment that was generated from this submission, if any'
+    field :client_id, ID, null: true, description: 'Client that was generated from this submission, if any'
+    field :summary_fields, [HmisSchema::KeyValue], null: false, description: 'Key/value responses for certain summary-level form questions'
 
     def definition
       load_ar_association(object, :definition)
@@ -33,6 +36,35 @@ module Types
       # a client, and then a user manually updates the client's name in HMIS, the form review UI should still display
       # the client name that was originally submitted with the form.
       object.form_values
+    end
+
+    # "Summary" fields are a subset of the form's fields that are displayed on the external forms review table.
+    # Includes Client first/last name plus any CDEDs where show_in_summary is true.
+    def summary_fields
+      cdeds_by_key = load_ar_association(definition, :custom_data_element_definitions).
+        select(&:show_in_summary).
+        index_by(&:key).stringify_keys
+
+      cded_keys = cdeds_by_key.keys
+
+      object.form_values.map do |key, value|
+        case key.to_s
+        when 'Client.firstName'
+          OpenStruct.new(id: 'first', key: 'First Name', value: value)
+        when 'Client.lastName'
+          OpenStruct.new(id: 'last', key: 'Last Name', value: value)
+        when *cded_keys
+          cded = cdeds_by_key[key]
+          OpenStruct.new(id: cded.id, key: cded.label, value: value)
+        end
+      end.compact.sort_by(&:key)
+    end
+
+    def client_id
+      enrollment = load_ar_association(object, :enrollment)
+      return unless enrollment
+
+      load_ar_association(enrollment, :client)&.id
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/key_value.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/key_value.rb
@@ -1,0 +1,14 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::KeyValue < Types::BaseObject
+    field :key, String, null: false
+    field :value, String, null: true
+  end
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
@@ -10,6 +10,7 @@ module HmisExternalApis::ExternalForms
     belongs_to :definition, class_name: 'Hmis::Form::Definition'
     # Enrollment that was generated as a result of processing this form submission. Only applicable for certain external forms, like the PIT.
     belongs_to :enrollment, class_name: 'Hmis::Hud::Enrollment', optional: true
+    has_one :client, through: :enrollment
     has_one :form_processor, class_name: 'Hmis::Form::FormProcessor', as: :owner, dependent: :destroy
 
     validate :validate_status_change


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

issue: https://github.com/open-path/Green-River/issues/6622
frontend pr: https://github.com/greenriver/hmis-frontend/pull/936

This supports showing summary fields on the table view (see screenshots on frontend pr). This is not the nicest approach, but it works for our current need which is to show some identifying details during PIT review. There is no option for specifying the sort order, they are always resolved alphabetically.

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
