### PR TITLE
Deprecate static form for external submission review

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -11083,7 +11083,7 @@ enum StaticFormRole {
   """
   External form submission review
   """
-  EXTERNAL_FORM_SUBMISSION_REVIEW
+  EXTERNAL_FORM_SUBMISSION_REVIEW @deprecated(reason: "External forms are moving to a directly configured react form, rather than a static form.")
 
   """
   Form definition

--- a/drivers/hmis/app/graphql/types/base_enum.rb
+++ b/drivers/hmis/app/graphql/types/base_enum.rb
@@ -39,7 +39,7 @@ module Types
         # Ensure we are using DATA_NOT_COLLECTED key for 99s
         member_values[:key] = 'DATA_NOT_COLLECTED' if member_values[:value]&.to_s == '99'
 
-        value to_enum_key(member_values[:key]), member_values[:desc], value: member_values[:value]
+        value to_enum_key(member_values[:key]), member_values[:desc], value: member_values[:value], deprecation_reason: member_values[:deprecation_reason]
       end
     end
 

--- a/drivers/hmis/app/graphql/types/forms/enums/static_form_role.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/static_form_role.rb
@@ -11,6 +11,9 @@ module Types
     graphql_name 'StaticFormRole'
     description 'Form Roles that are used for non-configurable forms. These types of forms are submitted using custom mutations.'
 
-    with_enum_map Hmis::Form::Definition.static_form_role_enum_map, prefix_description_with_key: false
+    with_enum_map Hmis::Form::Definition.static_form_role_enum_map, prefix_description_with_key: false do |member|
+      member[:deprecation_reason] = 'External forms are moving to a directly configured react form, rather than a static form.' if member[:key] == 'EXTERNAL_FORM_SUBMISSION_REVIEW'
+      member
+    end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/greenriver/hmis-warehouse/pull/4713#discussion_r1765474000
This comes out of the decision to move the External Forms review UI from a static form to a directly configured React form, since the static form doesn't seem to be making development any easier.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
