### PR TITLE
Suppress exception when recording out of range hrsn qa during import

### DIFF
--- a/app/models/health/epic_qualifying_activity.rb
+++ b/app/models/health/epic_qualifying_activity.rb
@@ -77,6 +77,7 @@ module Health
     end
 
     def self.update_qualifying_activities!
+      Rails.logger.info 'EpicQualifyingActivity: start update_qualifying_activities!'
       Health::QualifyingActivity.transaction do
         # Remember previous decisions about claim reports and payableness
         @claim_report_ids = {}
@@ -101,8 +102,11 @@ module Health
           ).pluck(:epic_source_id)
 
         # remove and re-create all un-submitted qualifying activities that are backed by Epic
+        Rails.logger.info 'EpicQualifyingActivity: delete unsubmitted QAs'
         Health::QualifyingActivity.unsubmitted.where(source_type: Health::EpicQualifyingActivity.name).delete_all
+        Rails.logger.info 'EpicQualifyingActivity: start create_qualifying_activities'
         unprocessed.each(&:create_qualifying_activity!)
+        Rails.logger.info 'EpicQualifyingActivity: end create_qualifying_activities'
 
         # restore previous decisions
         Health::QualifyingActivity.unsubmitted.
@@ -123,6 +127,7 @@ module Health
             ).update_all(claim_id: claim_id)
         end
       end
+      Rails.logger.info 'EpicQualifyingActivity: end update_qualifying_activities!'
     end
 
     def care_hub_reached_key(qa)

--- a/app/models/health/epic_team_member.rb
+++ b/app/models/health/epic_team_member.rb
@@ -48,11 +48,13 @@ module Health
     # create team members for any matching unprocessed team members
     # don't add them to pilot patients
     def self.process!
+      Rails.logger.info 'EpicTeamMember: start process!'
       Health::Patient.bh_cp.
         joins(:epic_team_members).
         merge(Health::EpicTeamMember.unprocessed).
         distinct.
         each(&:import_epic_team_members)
+      Rails.logger.info 'EpicTeamMember: end process!'
     end
 
     def previously_processed_ids

--- a/app/models/health/epic_thrive.rb
+++ b/app/models/health/epic_thrive.rb
@@ -151,10 +151,16 @@ module Health
       assessment.decline_to_answer = true if !@any_answer && @any_decline
 
       assessment.save!
-      patient.hrsn_screenings.where(instrument_id: assessment.id).first_or_create(
-        instrument: assessment,
-        created_at: assessment.created_at,
-      )
+      # A thrive collected outside of the enrollment window may throw an exception if it
+      # creates an HRSN QA, which we will ignore
+      begin
+        patient.hrsn_screenings.where(instrument_id: assessment.id).first_or_create(
+          instrument: assessment,
+          created_at: assessment.created_at,
+        )
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end
     end
 
     def yes_no(value)

--- a/app/models/health/epic_thrive.rb
+++ b/app/models/health/epic_thrive.rb
@@ -47,9 +47,11 @@ module Health
     end
 
     def self.update_thrive_assessments!
+      Rails.logger.info 'EpicThrive: start update_thrive_assessments!'
       HealthThriveAssessment::Assessment.transaction do
         unprocessed.find_each(&:update_thrive_assessment!)
       end
+      Rails.logger.info 'EpicThrive: end update_thrive_assessments!'
     end
 
     def update_thrive_assessment!

--- a/app/models/health/epic_thrive.rb
+++ b/app/models/health/epic_thrive.rb
@@ -160,8 +160,9 @@ module Health
           instrument: assessment,
           created_at: assessment.created_at,
         )
-      rescue ActiveRecord::RecordInvalid
-        nil
+      rescue ActiveRecord::RecordInvalid => e
+        # Ignore only validation fails because of the date of the activity
+        raise unless e.record.errors[:date_of_activity].any?
       end
     end
 

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -141,7 +141,7 @@ module Health
     # If there is already a housing status on the date, update it, otherwise create a new one
     #
     # Note that this is often called in an after_save hook, so care needs to be take not to create cycles
-    def record_housing_status(status, on_date: Date.current)
+    def record_housing_status(status, on_date: Date.current, validate_qa: true)
       return unless status.present? && on_date.present?
 
       prior_housing_status = recent_housing_status
@@ -154,11 +154,11 @@ module Health
         housing_statuses.create(collected_on: on_date, status: status)
       end
 
-      generate_daily_hrsn_qa(housing_status) if prior_housing_status.present? && on_date > '2024-03-01'.to_date
+      generate_daily_hrsn_qa(housing_status, validate_qa) if prior_housing_status.present? && on_date > '2024-03-01'.to_date
       housing_status
     end
 
-    private def generate_daily_hrsn_qa(housing_status)
+    private def generate_daily_hrsn_qa(housing_status, validate_qa)
       return unless engaged? # Daily HRSNs are not produced until the patient is engaged
 
       previous_status = housing_statuses.as_of(date: housing_status.collected_on - 1.day).first
@@ -168,7 +168,7 @@ module Health
       return if housing_status.collected_on < Health::QualifyingActivityV2::EFFECTIVE_DATE_RANGE.first # SDoH QAs added in CP 2.0
 
       user = User.system_user # Mark created QAs as from the system
-      ::Health::QualifyingActivity.create!(
+      qa = ::Health::QualifyingActivity.new(
         source_type: housing_status.class.name,
         source_id: housing_status.id,
         user_id: user.id,
@@ -179,7 +179,9 @@ module Health
         patient_id: id,
         activity: :sdoh_positive,
         follow_up: 'Patient SDoH Screening Positive',
-      ).maintain_cached_values
+      )
+      qa.save(validate: validate_qa)
+      qa.maintain_cached_values if qa.persisted?
     end
 
     scope :pilot, -> { where pilot: true }

--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -667,7 +667,9 @@ module Health
     end
 
     def self.update_demographic_from_sources
+      Rails.logger.info 'Patient: start update_demographics_from_sources'
       all.each(&:update_demographics_from_sources)
+      Rails.logger.info 'Patient: end update_demographics_from_sources'
     end
 
     def available_team_members

--- a/app/models/health/tasks/import_epic.rb
+++ b/app/models/health/tasks/import_epic.rb
@@ -99,7 +99,9 @@ module Health::Tasks
 
     def import_files
       Health.models_by_health_filename.each do |file, klass|
+        Rails.logger.info "ImportEpic: start #{file}"
         import(klass: klass, file: file)
+        Rails.logger.info "ImportEpic: end #{file}"
       end
     end
 

--- a/app/models/health/tasks/import_epic.rb
+++ b/app/models/health/tasks/import_epic.rb
@@ -135,7 +135,7 @@ module Health::Tasks
       Health::EpicPatient.
         where.not(housing_status: nil).where.not(housing_status_timestamp: nil).
         find_each do |patient|
-        patient&.patient&.record_housing_status(patient.housing_status, on_date: patient.housing_status_timestamp.to_date)
+        patient&.patient&.record_housing_status(patient.housing_status, on_date: patient.housing_status_timestamp.to_date, validate_qa: false)
         status_for_patient = patient.epic_housing_statuses.where(collected_on: patient.housing_status_timestamp.to_date).first_or_create do |status|
           status.status = patient.housing_status
         end
@@ -144,7 +144,7 @@ module Health::Tasks
       Health::EpicCaseNote.with_housing_status.find_each do |case_note|
         # case_note.patient is a has_many
         case_note.patient.find_each do |patient|
-          patient.record_housing_status(case_note.homeless_status, on_date: case_note.contact_date.to_date)
+          patient.record_housing_status(case_note.homeless_status, on_date: case_note.contact_date.to_date, validate_qa: false)
         end
       end
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

If an Epic import results in recording a new homeless status for a patient outside of the enrollment window, a validation exception would interrupt the import.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
