### PR TITLE
Cohorts Selectable Project Groups

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -164,8 +164,8 @@ class CohortsController < ApplicationController
     cohort_options = cohort_options.except(:name) if @cohort.system_cohort
 
     # checks to see if user can see the project group OR if the project group is on the cohort pre-save.
-    user_can_view_new_project_group = cohort_options['project_group_id'].blank? || GrdaWarehouse::ProjectGroup.viewable_by(current_user).exists?(cohort_options['project_group_id'])
-    project_group_on_cohort_pre_save = @cohort.project_group_id == cohort_options['project_group_id'].to_i
+    user_can_view_new_project_group = cohort_options[:project_group_id].blank? || GrdaWarehouse::ProjectGroup.viewable_by(current_user).exists?(cohort_options[:project_group_id])
+    project_group_on_cohort_pre_save = @cohort.project_group_id == cohort_options[:project_group_id].to_i
     cohort_options = cohort_options.except(:project_group_id) unless user_can_view_new_project_group || project_group_on_cohort_pre_save
 
     @cohort.update(cohort_options)

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -166,7 +166,7 @@ class CohortsController < ApplicationController
     # checks to see if user can see the project group OR if the project group is on the cohort pre-save.
     user_can_view_new_project_group = cohort_options['project_group_id'].blank? || GrdaWarehouse::ProjectGroup.viewable_by(current_user).exists?(cohort_options['project_group_id'])
     project_group_on_cohort_pre_save = @cohort.project_group_id == cohort_options['project_group_id'].to_i
-    cohort_options = cohort_options.except(:project_group) unless user_can_view_new_project_group || project_group_on_cohort_pre_save
+    cohort_options = cohort_options.except(:project_group_id) unless user_can_view_new_project_group || project_group_on_cohort_pre_save
 
     @cohort.update(cohort_options)
 

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -163,6 +163,11 @@ class CohortsController < ApplicationController
     # END_ACL
     cohort_options = cohort_options.except(:name) if @cohort.system_cohort
 
+    # checks to see if user can see the project group OR if the project group is on the cohort pre-save.
+    user_can_view_new_project_group = cohort_options['project_group_id'].blank? || GrdaWarehouse::ProjectGroup.viewable_by(current_user).exists?(cohort_options['project_group_id'])
+    project_group_on_cohort_pre_save = @cohort.project_group_id == cohort_options['project_group_id'].to_i
+    cohort_options = cohort_options.except(:project_group) unless user_can_view_new_project_group || project_group_on_cohort_pre_save
+
     @cohort.update(cohort_options)
 
     # TODO: START_ACL remove when ACL transition complete

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -729,6 +729,23 @@ module GrdaWarehouse
       project_group.present?
     end
 
+    def selected_project_group_viewable_by(user)
+      return true if project_group.blank?
+
+      GrdaWarehouse::ProjectGroup.viewable_by(user).exists?(project_group.id)
+    end
+
+    def project_group_options_for_select(user)
+      options = GrdaWarehouse::ProjectGroup.options_for_select(user: user)
+      # Add the current selected option to the selectable list so it doesn't get overwritten
+      # if the user has the ability to edit the cohort but can't view the selected project group
+      if project_group.present? && !selected_project_group_viewable_by(user)
+        current_selected_data = [[project_group.name, project_group.id]]
+        options |= current_selected_data
+      end
+      options.sort
+    end
+
     def maintain
       return unless auto_maintained?
 

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -15,6 +15,8 @@ module GrdaWarehouse
     include Rails.application.routes.url_helpers
 
     acts_as_paranoid
+    has_paper_trail
+
     validates_presence_of :name
     validates :days_of_inactivity, numericality: { only_integer: true, allow_nil: true }
     validates :static_column_count, numericality: { only_integer: true }

--- a/app/views/cohorts/edit.haml
+++ b/app/views/cohorts/edit.haml
@@ -37,7 +37,7 @@
       = f.input :viewer_ids, collection: @users, as: :select_two, selected: @viewer_ids, input_html: {multiple: :multiple, style: 'width: 100%;'}, label: 'Grant read-only-level access to users', hint: 'Specified user will have access to view, but not change clients on this cohort.'
       %h3 Automation
       .well
-        = f.input :project_group_id, collection: GrdaWarehouse::ProjectGroup.options_for_select(user: current_user), as: :select_two, include_blank: 'Manually controlled (no project group)', hint: 'If you select a project group, this cohort will always contain clients with an open enrollment at a project contained in the group.  You will not be able to add and remove clients manually.'
+        = f.input :project_group_id, disabled: !@cohort.selected_project_group_viewable_by(current_user), collection: @cohort.project_group_options_for_select(current_user), as: :select_two, include_blank: 'Manually controlled (no project group)', hint: 'If you select a project group, this cohort will always contain clients with an open enrollment at a project contained in the group.  You will not be able to add and remove clients manually.'
       %h3 Integrations
       .well
         = f.input :show_on_client_dashboard, as: :pretty_boolean, label: 'Show cohort in client dashboard?'

--- a/app/views/cohorts/edit.haml
+++ b/app/views/cohorts/edit.haml
@@ -37,7 +37,7 @@
       = f.input :viewer_ids, collection: @users, as: :select_two, selected: @viewer_ids, input_html: {multiple: :multiple, style: 'width: 100%;'}, label: 'Grant read-only-level access to users', hint: 'Specified user will have access to view, but not change clients on this cohort.'
       %h3 Automation
       .well
-        = f.input :project_group_id, disabled: !@cohort.selected_project_group_viewable_by(current_user), collection: @cohort.project_group_options_for_select(current_user), as: :select_two, include_blank: 'Manually controlled (no project group)', hint: 'If you select a project group, this cohort will always contain clients with an open enrollment at a project contained in the group.  You will not be able to add and remove clients manually.'
+        = f.input :project_group_id, collection: @cohort.project_group_options_for_select(current_user), as: :select_two, include_blank: 'Manually controlled (no project group)', hint: 'If you select a project group, this cohort will always contain clients with an open enrollment at a project contained in the group.  You will not be able to add and remove clients manually.'
       %h3 Integrations
       .well
         = f.input :show_on_client_dashboard, as: :pretty_boolean, label: 'Show cohort in client dashboard?'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

1. Add paper trail to Cohorts.
2. Fix bug where a user has access to edit a cohort but does not have access to view the selected project group tied to the cohor automation. The cohort edit page now shows the selected project group but disables the selection in this scenario. Previously it would clear out the selected project group on save if the editing user did not have access to view the selected project group.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
