### PR TITLE
Fix identify duplicates performance issue

### DIFF
--- a/spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb
+++ b/spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb
@@ -104,6 +104,8 @@ RSpec.describe GrdaWarehouse::Tasks::IdentifyDuplicates, type: :model do
 
   # Check for obvious match is private...
   def check_for_obvious_match(client_id)
-    GrdaWarehouse::Tasks::IdentifyDuplicates.new.send(:check_for_obvious_match, client_id)
+    inst = GrdaWarehouse::Tasks::IdentifyDuplicates.new
+    inst.send(:build_destination_lookups)
+    inst.send(:check_for_obvious_match, client_id)
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Quick fix for https://github.com/open-path/Green-River/issues/6740 by removing expensive code from the initialize fn.

Introduced in https://github.com/greenriver/hmis-warehouse/pull/4553/files#r1773347288

A better solution would probably be to changes this class to a Job, and queue it normally. Right now maybe only HMIS code queues it on the long running queue.

Add `private` in front of methods that are not used outside the class

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
