### PR TITLE
Adjust renewals to ignore incomplete careplans

### DIFF
--- a/app/models/health/patient.rb
+++ b/app/models/health/patient.rb
@@ -471,13 +471,13 @@ module Health
     end
 
     scope :needs_renewal, ->(on: Date.current.end_of_month) do
-      joins(:recent_pctp_careplan).
-        merge(Health::PctpCareplan.recent.sent_within(.. on - 335.days)) # 1 year - 30 days
+      joins(:pctp_careplans).
+        merge(Health::PctpCareplan.sent.recent.sent_within(.. on - 335.days)) # 1 year - 30 days
     end
 
     scope :overdue_for_renewal, ->(on: Date.current.end_of_month) do
-      joins(:recent_pctp_careplan).
-        merge(Health::PctpCareplan.recent.sent_within(.. on - 365.days)) # 1 year
+      joins(:pctp_careplans).
+        merge(Health::PctpCareplan.sent.recent.sent_within(.. on - 365.days)) # 1 year
     end
 
     # For now, all patients are visible to all health users


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Include in-progress careplans in the renewal buckets.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
