### PR TITLE
Support comma-separated HMIS_HOSTNAME values for cors config

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 # Read more: https://github.com/cyu/rack-cors
 
-hmis_hostname = ENV['HMIS_HOSTNAME']
-if ENV['ENABLE_HMIS_API'] == 'true' && hmis_hostname.present?
+hmis_hostnames = ENV['HMIS_HOSTNAME']&.split(',')
+if ENV['ENABLE_HMIS_API'] == 'true' && hmis_hostnames.present?
   Rails.application.config.middleware.insert_before 0, Rack::Cors do
     # Allow requests to /hmis from the HMIS frontend host
     allow do
-      origins hmis_hostname
+      origins *hmis_hostnames
 
       resource '/hmis/*',
         headers: :any,

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -65,6 +65,8 @@ if ENV['OKTA_DOMAIN'].present?
       new_path = '/?authError=generic'
       Rack::Response.new(['302 Moved'], 302, 'Location' => new_path).finish
     }
+    raise 'Okta is not supported for multi-HMIS installations' if ENV['HMIS_HOSTNAME'].split(',').size > 1
+
     Rails.application.middleware.use OmniAuth::Builder do
       provider(
         OmniAuth::Strategies::CustomOkta,

--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -349,7 +349,10 @@ class SeedMaker
     end
 
     # Create HMIS Data Source
-    hmis_ds = GrdaWarehouse::DataSource.source.where(hmis: ENV['HMIS_HOSTNAME']).first_or_create! do |ds|
+    hostnames = ENV['HMIS_HOSTNAME'].split(',')
+    raise 'hmis seed doesn\'t support multiple hostnames' if hostnames.size > 1
+
+    hmis_ds = GrdaWarehouse::DataSource.source.where(hmis: hostnames.first).first_or_create! do |ds|
       ds.name = 'HMIS'
       ds.short_name = 'HMIS'
       ds.authoritative = true

--- a/sample.env
+++ b/sample.env
@@ -195,3 +195,4 @@ S3_PUBLIC_URL=
 # Optional: Enable API endpoints for the HMIS frontend
 # ENABLE_HMIS_API=true
 # HMIS_HOSTNAME=hmis.dev.test
+# Note: in production, HMIS_HOSTNAME can support comma-separated values (eg HMIS_HOSTNAME=hmis-1.openpath.host,hmis-2.openpath.host)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Support comma-separated HMIS_HOSTNAME value. In production, this is only used to inform the cors config and for Okta.

For now, just raise if we have a multi-HMIS setup with okta. Omniauth code could probably be adapted if we need to support multi-HMIS okta installations in the future.

Multi-HMIS setup for local development is not supported.

Related to epic https://github.com/open-path/Green-River/issues/6612

🚨 I haven't meaningfully tested this locally, beyond ensuring that the cors init doesn't barf at the input. I can deploy to QA to test it, but will need to coordinate with devops to change the existing `HMIS_HOSTNAME=qa-hmis.openpath.host` to `HMIS_HOSTNAME=qa-hmis.openpath.host,qa-hmis-2.openpath.host`

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
