### PR TITLE
Use perform_later to queue ConsumeExternalFormSubmissionsJob

### DIFF
--- a/drivers/hmis/app/graphql/mutations/refresh_external_submissions.rb
+++ b/drivers/hmis/app/graphql/mutations/refresh_external_submissions.rb
@@ -12,7 +12,7 @@ module Mutations
       return { success: true } if Delayed::Job.queued?(handlers) || Delayed::Job.running?(handlers)
 
       queue = ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
-      HmisExternalApis::ConsumeExternalFormSubmissionsJob.delay(priority: -5, queue: queue)
+      HmisExternalApis::ConsumeExternalFormSubmissionsJob.set(priority: -5, queue: queue).perform_later
 
       { success: true }
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

The existing queueing method wasn't queuing anything when testing on staging. I think because there was no method invoked after `delay`.

`set` and `perform_later` come from [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html#queues), which is the base class for our BaseJob

Tested on staging

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
