### PR TITLE
Patch fix in CreateFakeEnrollmentsJob

### DIFF
--- a/drivers/hmis/app/jobs/hmis/create_fake_enrollments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/create_fake_enrollments_job.rb
@@ -139,7 +139,6 @@ module Hmis
       Hmis::MigrateAssessmentsJob.perform_now(
         data_source_id: @data_source.id,
         enrollments: enrollments,
-        project_ids: projects.pluck(:id),
         generate_empty_intakes: true,
       )
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix bug where `MigrateAssessmentsJob` won't run because both project_ids and enrollment scope were passed. Only enrollment scope is needed.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
