### PR TITLE
Dg/va_history_dashboard-6646

### DIFF
--- a/app/models/consent/implied.rb
+++ b/app/models/consent/implied.rb
@@ -59,33 +59,27 @@ class Consent::Implied
     consent_text
   end
 
-  def scope_for_residential_enrollments(user)
+  def consent_view_permission
     revoked_consent = release_current_status == revoked_consent_string
 
-    permission = if revoked_consent
+    if revoked_consent
       :can_view_clients
     else
       :can_view_client_enrollments_with_roi
     end
+  end
 
+  def scope_for_residential_enrollments(user)
     scope = @client.service_history_enrollments.
       entry.
       hud_residential
-    scope.joins(:project).merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: permission))
+    scope.joins(:project).merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: consent_view_permission))
   end
 
   def scope_for_other_enrollments(user)
-    revoked_consent = release_current_status == revoked_consent_string
-
-    permission = if revoked_consent
-      :can_view_clients
-    else
-      :can_view_client_enrollments_with_roi
-    end
-
     scope = @client.service_history_enrollments.
       entry.
       hud_non_residential
-    scope.joins(:project).merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: permission))
+    scope.joins(:project).merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: consent_view_permission))
   end
 end

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1146,6 +1146,12 @@ module GrdaWarehouse::Hud
       release_valid? || partial_release?
     end
 
+    def consent_view_permission
+      return unless GrdaWarehouse::Config.implied_consent?
+
+      active_consent_model.consent_view_permission
+    end
+
     def consent_form_valid?
       if release_duration.in?(['One Year', 'Two Years'])
         release_valid? && consent_form_signed_on.present? && consent_form_signed_on >= self.class.consent_validity_period.ago

--- a/app/views/clients/files/_index.haml
+++ b/app/views/clients/files/_index.haml
@@ -17,13 +17,12 @@
       %li.nav-item
         %a.nav-link{href: '#consent', role: "presentation", data: {toggle: :tab}}
           Consent Forms
-    - unless @client.revoked_consent?
-      %li.nav-item
-        %a.nav-link{href: '#other', role: "presentation", data: {toggle: :tab}}
-          - if can_use_separated_consent?
-            Files
-          - else
-            Other Files
+    %li.nav-item
+      %a.nav-link{href: '#other', role: "presentation", data: {toggle: :tab}}
+        - if can_use_separated_consent?
+          Files
+        - else
+          Other Files
     - if can_manage_client_files?
       %li.nav-item
         %a.nav-link{href: '#deleted', role: "presentation", data: {toggle: :tab}}

--- a/drivers/client_access_control/app/models/client_access_control/client_history_month.rb
+++ b/drivers/client_access_control/app/models/client_access_control/client_history_month.rb
@@ -48,16 +48,21 @@ module ClientAccessControl
     end
 
     def available_projects(month:, year:, client:, user:)
-      @available_projects ||= ::GrdaWarehouse::Hud::Project.
-        joins(service_history_enrollments: :enrollment).
-        merge(::GrdaWarehouse::Hud::Enrollment.visible_to(user)).
-        merge(
-          ::GrdaWarehouse::ServiceHistoryEnrollment.open_between(
-            start_date: date_range_for(month: month, year: year).first,
-            end_date: date_range_for(month: month, year: year).last,
-          ).where(client_id: client.id),
-        ).distinct.to_a.
-        sort_by { |p| p.name(user) }
+      @available_projects ||= begin
+        projects = ::GrdaWarehouse::Hud::Project.
+          joins(service_history_enrollments: :enrollment).
+          merge(::GrdaWarehouse::Hud::Enrollment.visible_to(user)).
+          merge(
+            ::GrdaWarehouse::ServiceHistoryEnrollment.open_between(
+              start_date: date_range_for(month: month, year: year).first,
+              end_date: date_range_for(month: month, year: year).last,
+            ).where(client_id: client.id),
+          ).distinct.to_a.
+          sort_by { |p| p.name(user) }
+        # projects = projects.select { |p| client.project_ids_available_to(user).include?(p.ProjectID) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
+        projects = projects.select { |p| p.can?(user) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
+        projects
+      end
     end
 
     def available_project_types(month:, year:, client:, user:)
@@ -281,7 +286,9 @@ module ClientAccessControl
             days: week,
           }
           projects = {}
-          enrollments(month: month, year: year, client: client, week: week, user: user).each do |she|
+          enrollments = enrollments(month: month, year: year, client: client, week: week, user: user)
+          enrollments = enrollments.select { |e| e.project.can?(user) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
+          enrollments.each do |she|
             project = she.project
             projects = add_project_for_week(projects: projects, project: project, she: she, user: user)
             if she.move_in_date.present?

--- a/drivers/client_access_control/app/models/client_access_control/client_history_month.rb
+++ b/drivers/client_access_control/app/models/client_access_control/client_history_month.rb
@@ -59,7 +59,7 @@ module ClientAccessControl
             ).where(client_id: client.id),
           ).distinct.to_a.
           sort_by { |p| p.name(user) }
-        # projects = projects.select { |p| client.project_ids_available_to(user).include?(p.ProjectID) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
+        # Limit the visible projects to just those available to the user for when the VA dashboard is being used.
         projects = projects.select { |p| p.can?(user) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
         projects
       end
@@ -287,6 +287,7 @@ module ClientAccessControl
           }
           projects = {}
           enrollments = enrollments(month: month, year: year, client: client, week: week, user: user)
+          # Limit the visible projects to just those available to the user for when the VA dashboard is being used.
           enrollments = enrollments.select { |e| e.project.can?(user) } if ::GrdaWarehouse::Config.get(:client_dashboard).to_s == 'va'
           enrollments.each do |she|
             project = she.project


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update th history page for the VA dashboard to only show projects available to the current user. The revoked chack on the files page was also remove to allow access to the homeless history. The files here are being limited based on visibility to the user.

_Note: This is using a project visibility method new to release-135._

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
