### PR TITLE
Render data source page for hmis without exports

### DIFF
--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -560,7 +560,7 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
   end
 
   def has_data? # rubocop:disable Naming/PredicateName
-    exports.any?
+    exports.any? || (hmis? && organizations.any?)
   end
 
   def organization_names


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This allows the organizations to render on the Data Source show page for an HMIS that doesn't have any Exports. Now that we have the fake data generator, that may be a more common workflow for local setup. And, there may be some installations that start from empty.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
