### PR TITLE
Add guard to ConsumeExternalSubmissionsJob for too many submissions

### DIFF
--- a/app/models/aws_s3.rb
+++ b/app/models/aws_s3.rb
@@ -82,6 +82,12 @@ class AwsS3
     end
   end
 
+  def count(prefix: '')
+    # Note that this DOES still call list_objects_v2 internally, but ignores the 1000 key limit.
+    # See https://stackoverflow.com/questions/2862617/how-can-i-tell-how-many-objects-ive-stored-in-an-s3-bucket
+    @bucket.objects(prefix: prefix).count
+  end
+
   # Return oldest first
   def fetch_key_list(prefix: '')
     @bucket.objects(prefix: prefix).sort_by(&:last_modified).map(&:key)

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/external_forms/consume_external_form_submissions_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/external_forms/consume_external_form_submissions_job_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe 'HmisExternalApis::ConsumeExternalFormSubmissionsJob', type: :mod
   before do
     allow(s3_client_double).to receive(:list_objects).and_return([s3_object_double])
     allow(s3_client_double).to receive(:delete).with(key: anything).and_return(true)
+    allow(s3_client_double).to receive(:count).and_return(1)
     allow(s3_client_double).to receive(:get_as_io).with(key: anything).and_return(StringIO.new(submission_document))
   end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

GH issue: https://github.com/open-path/Green-River/issues/6727
This PR
- Adds a new method on our internal AWS S3 client `count` to return the number of objects in the bucket, matching an optional prefix. I noticed watching the logs that this *does* actually call `list_objects_v2` internally, and auto paginates, like this:

```
s3.count 
[Aws::S3::Client 200 0.291649 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke")  

[Aws::S3::Client 200 0.293278 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzE4OTgudHh0W21pbmlvX2NhY2hlOnYyLHJldHVybjpd")  

[Aws::S3::Client 200 1.098882 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzI3OTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.043598 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzM2OTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.048936 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzQ1OTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.791828 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzU0OTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.03343 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzYzOTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.039963 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzcyOTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.035371 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzgxOTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.036496 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzkwOTgudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

[Aws::S3::Client 200 0.003619 0 retries] list_objects_v2(prefix:"",bucket:"openpath-development-warehouse-external-form-submissions-mke",continuation_token:"bWtlLzk5OTkudHh0W21pbmlvX2NhY2hlOnYyLGlkOjQ1N2ZkNmNmLTM1YzUtNDA1Mi04MGEwLTc5NmY0Y2IzODBkYSxwOjAsczowXQ==")  

=> 10001

```
- Raises in the `ConsumeExternalFormSubmissionsJob` if the count is > 10,000
- Raises the max in that job to 10_000

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
