### PR TITLE
Fix multi-hmis theme bug and improve theme selection

### DIFF
--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -17,9 +17,7 @@ class Hmis::AppSettingsController < Hmis::BaseController
     end
 
     hostname = ENV['FQDN']
-
-    themes = GrdaWarehouse::Theme.where(client: ENV['CLIENT']&.to_sym).where.not(hmis_value: nil)
-    themes = themes.where(origin: current_hmis_host) if themes.size > 1
+    theme = GrdaWarehouse::Theme.hmis_theme_for_origin(current_hmis_host)
 
     render json: {
       oktaPath: okta_enabled ? '/hmis/users/auth/okta' : nil,
@@ -33,7 +31,7 @@ class Hmis::AppSettingsController < Hmis::BaseController
       casUrl: GrdaWarehouse::Config.get(:cas_url),
       revision: Git.revision,
       branch: Git.branch,
-      theme: themes.first&.hmis_value,
+      theme: theme&.hmis_value,
       globalFeatureFlags: {
         # Whether to show MCI ID in client search results
         mciId: HmisExternalApis::AcHmis::Mci.enabled?,


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

* Fix a bug in theme selection for multi-hmis environments (`themes.where(origin: ` was wrong, the field is `hmis_origin`)
* Add uniqueness constraint (max 1 theme per hmis)
* Move selection logic to theme class

https://github.com/open-path/Green-River/issues/6612

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
