### PR TITLE
6719-performance-monitoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,6 +485,7 @@ GEM
       rake
     ffi-geos (2.4.0)
       ffi (>= 1.0.0)
+    fiber-storage (1.0.0)
     flamegraph (0.9.5)
     geocoder (1.8.2)
     get_process_mem (0.2.7)
@@ -500,8 +501,9 @@ GEM
       mini_portile2 (~> 2.7)
     graphiql-rails (1.10.0)
       railties
-    graphql (2.3.1)
+    graphql (2.3.16)
       base64
+      fiber-storage
     grover (1.1.7)
       combine_pdf (~> 1.0)
       nokogiri (~> 1.0)
@@ -916,13 +918,13 @@ GEM
       railties (>= 4.0.0)
     sdoc (2.6.1)
       rdoc (>= 5.0)
-    sentry-delayed_job (5.17.1)
+    sentry-delayed_job (5.19.0)
       delayed_job (>= 4.0)
-      sentry-ruby (~> 5.17.1)
-    sentry-rails (5.17.1)
+      sentry-ruby (~> 5.19.0)
+    sentry-rails (5.19.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.17.1)
-    sentry-ruby (5.17.1)
+      sentry-ruby (~> 5.19.0)
+    sentry-ruby (5.19.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     set (1.1.0)

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -9,7 +9,7 @@ class HmisSchema < GraphQL::Schema
   query(Types::HmisSchema::QueryType)
 
   trace_with(GraphqlTraceBehavior)
-  trace_with(GraphQL::Tracing::SentryTrace) if Sentry.configuration&.traces_sample_rate.positive?
+  trace_with(GraphQL::Tracing::SentryTrace) if Sentry.configuration&.traces_sample_rate&.positive?
 
   # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
   # - after upgrade to Rails 7.1 we could replace Dataloader with AsyncDataloader for performance

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -9,6 +9,7 @@ class HmisSchema < GraphQL::Schema
   query(Types::HmisSchema::QueryType)
 
   trace_with(GraphqlTraceBehavior)
+  trace_with(GraphQL::Tracing::SentryTrace) if Sentry.configuration&.traces_sample_rate.positive?
 
   # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
   # - after upgrade to Rails 7.1 we could replace Dataloader with AsyncDataloader for performance

--- a/drivers/hmis/spec/support/graphql_helpers.rb
+++ b/drivers/hmis/spec/support/graphql_helpers.rb
@@ -109,8 +109,11 @@ module GraphqlHelpers
     ERRORS
   end
 
+  # FIXME: this is not supported by graphql. We should find another way to test types, such as
+  # https://graphql-ruby.org/testing/helpers.html
   def to_gql_input_object(values, klass, current_user: nil)
-    klass.new(nil, context: { current_user: current_user }, defaults_used: Set.new, ruby_kwargs: values)
+    context = GraphQL::Query.new(HmisSchema, '{ __typename }', context: { current_user: current_user }).context
+    klass.new(nil, context: context, defaults_used: Set.new, ruby_kwargs: values)
   end
 
   def expect_gql_error(arr, message: nil)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
_Blocked awaiting confirmation around additional quota_

* update graphql gem (for sentry tracing)
* update sentry gems
* Support sentry performance tracing on QA
[Issue](https://github.com/open-path/Green-River/issues/6719)

## Test instructions
* set env var to enable tracing locally `SENTRY_PERFORMANCE_TRACE_RATE=1.0`
* at this time, you cannot use GR's shared sentry account. I'm testing with a free trial account. You may need to change `WAREHOUSE_SENTRY_DSN`
* requests to the warehouse should be logged under the "project/traces" tab in sentry

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)
- [x] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
