### PR TITLE
Add PercentAMI to HOPWA assessments

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/v4_percent_of_ami.json
+++ b/drivers/hmis/lib/form_data/default/fragments/v4_percent_of_ami.json
@@ -2,7 +2,7 @@
   "type": "GROUP",
   "link_id": "V4",
   "data_collected_about": "HOH",
-  "text": "Percent of AMI (SSVF Eligibility)",
+  "text": "Percent of AMI",
   "item": [
     {
       "type": "CHOICE",

--- a/drivers/hmis/lib/hmis_util/hud_assessment_form_rules_2024.rb
+++ b/drivers/hmis/lib/hmis_util/hud_assessment_form_rules_2024.rb
@@ -958,6 +958,12 @@ module HmisUtil
                            { 'variable' => 'projectType', 'operator' => 'EQUAL', 'value' => 13 },
                          ] },
                      ] },
+          {
+            '_comment' => 'Percent AMI is part of the HOPWA CAPER report, so it is asked for HOPWA-funded programs',
+            'variable' => 'projectFunderComponents',
+            'operator' => 'INCLUDE',
+            'value' => 'HUD: HOPWA',
+          },
         ] } },
       V6: { stages: ['INTAKE'],
             data_collected_about: 'HOH',


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Issue: https://github.com/open-path/Green-River/issues/6766

Tested locally with HOPWA program. Removed the "SSVF" part of the group label.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
