### PR TITLE
Add protection for time analysis on login attempts to ennumerate valid login usernames

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,7 +19,7 @@ class Users::SessionsController < Devise::SessionsController
   def begin_time_log
     # Timestamp for tracking login time to help ensure that the application response time is consistent for valid/invalid usernames.
     # This helps prevent using login method time to enumerate valid vs invalid usernames
-    @session_create_timestamp = Time.now
+    @session_create_timestamp = Time.current
   end
 
   def end_time_log

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -27,7 +27,7 @@ class Users::SessionsController < Devise::SessionsController
     # We want to make sure valid and invalid username attempts all take the same minimum amount of time to process and then add a random salt.
     elapsed = Time.now - @session_create_timestamp
     wait_time = MIN_REQ_LOGIN_TIME - elapsed + rand(0.5..1)
-    sleep(wait_time) if elapsed < MIN_REQ_LOGIN_TIME
+    sleep(wait_time) if wait_time.positive? && elapsed < MIN_REQ_LOGIN_TIME
   end
 
   def create


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Enforce a minimum 2 second login time to protect against identifying valid usernames using login time analysis. 

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
