### PR TITLE
Ignore attempts to remove service that is not found

### DIFF
--- a/drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'BulkAssignService', type: :request do
   end
 
   let!(:pc1) { create :hmis_hud_project_coc, data_source: ds1, project: p1, coc_code: 'CO-500' }
-  let!(:access_control) { create_access_control(hmis_user, ds1) }
+  let!(:access_control) { create_access_control(hmis_user, p1) }
   let(:bednight_service_type) { Hmis::Hud::CustomServiceType.find_by(hud_record_type: 200) }
   let!(:c1) { create :hmis_hud_client, data_source: ds1 }
 
@@ -130,6 +130,10 @@ RSpec.describe 'BulkAssignService', type: :request do
   end
 
   describe 'failure scenarios' do
+    # give user access to everything at p2. We will test removing access from p1.
+    let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+    let!(:p2_access_control) { create_access_control(hmis_user, p2) }
+
     it 'fails if user lacks can_view_project' do
       remove_permissions(access_control, :can_view_project)
       expect_access_denied perform_mutation

--- a/drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb
@@ -1,0 +1,90 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'BulkRemoveService', type: :request do
+  include_context 'hmis base setup'
+  include_context 'hmis service setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation BulkRemoveService($projectId: ID!, $serviceIds: [ID!]!) {
+        bulkRemoveService(projectId: $projectId, serviceIds: $serviceIds) {
+          success
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 1.week.ago }
+  let!(:s1) { create :hmis_hud_service_bednight, data_source: ds1, enrollment: e1, date_provided: 5.days.ago }
+
+  let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 1.week.ago }
+  let!(:s2) { create :hmis_hud_service_bednight, data_source: ds1, enrollment: e2, date_provided: 3.days.ago }
+
+  def perform_mutation(service_ids:, project_id: p1.id.to_s)
+    input = {
+      project_id: project_id,
+      service_ids: service_ids,
+    }
+    post_graphql(input) { mutation }
+  end
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  it 'remove services' do
+    hmis_service_ids = Hmis::Hud::HmisService.where(owner: [s1, s2]).map(&:id)
+
+    expect do
+      response, result = perform_mutation(service_ids: hmis_service_ids)
+      expect(response.status).to eq(200), result.inspect
+    end.to change(Hmis::Hud::Service, :count).by(-2).and not_change(Hmis::Hud::Enrollment, :count)
+
+    expect(s1.reload).to be_deleted
+    expect(s2.reload).to be_deleted
+  end
+
+  it 'ignores service IDs that are not found' do
+    expect do
+      response, result = perform_mutation(service_ids: ['9999999'])
+      expect(response.status).to eq(200), result.inspect
+    end.not_to change(Hmis::Hud::Service, :count)
+  end
+
+  it 'ignores service IDs that are in another project' do
+    other_service = create(:hmis_hud_service_bednight, data_source: ds1)
+    other_service_id = Hmis::Hud::HmisService.find_by(owner: other_service).id
+
+    expect do
+      response, result = perform_mutation(service_ids: [other_service_id])
+      expect(response.status).to eq(200), result.inspect
+    end.not_to change(Hmis::Hud::Service, :count)
+  end
+
+  describe 'failure scenarios' do
+    # give user access to everything at p2. We will test removing access from p1.
+    let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o1 }
+    let!(:p2_access_control) { create_access_control(hmis_user, p2) }
+
+    let!(:service_ids) { Hmis::Hud::HmisService.where(owner: [s1, s2]).map(&:id) }
+
+    it 'fails if user lacks can_view_project at p1' do
+      remove_permissions(access_control, :can_view_project)
+      expect_access_denied perform_mutation(service_ids: service_ids)
+    end
+
+    it 'fails if user lacks can_edit_enrollments at p1' do
+      remove_permissions(access_control, :can_edit_enrollments)
+      expect_access_denied perform_mutation(service_ids: service_ids)
+    end
+  end
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This is a counterpart to https://github.com/greenriver/hmis-warehouse/pull/4697, for completeness. 

The repro is the same:
**Bug Repro Instructions**
* Open bed nights page in two windows for the same project
* In one window, click remove on an existing assigned client
* In the other window, click remove on the same client
  * Previously result: unexplained error
  * New result: appears successful and refreshes


This also adds tests for `BulkRemoveService`, and updates the `BulkAssignService` tests to ensure permissions are checked against the project entity.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
