### PR TITLE
Hotfix for HMIS override performance

### DIFF
--- a/drivers/hmis_csv_importer/app/controllers/hmis_csv_importer/import_overrides_controller.rb
+++ b/drivers/hmis_csv_importer/app/controllers/hmis_csv_importer/import_overrides_controller.rb
@@ -9,7 +9,10 @@ class HmisCsvImporter::ImportOverridesController < ApplicationController
   before_action :set_data_source
 
   def index
-    @overrides = import_override_scope.sorted
+    available_files = HmisCsvImporter::ImportOverride.available_files_for(@data_source.id)
+    @selected_filename = available_files.detect { |f| f == params[:filename] } || available_files.first
+    @overrides = import_override_scope.sorted.where(file_name: @selected_filename)
+    @pagy, @overrides = pagy(@overrides, items: 25)
   end
 
   def create

--- a/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_filter.haml
+++ b/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/_filter.haml
@@ -1,0 +1,11 @@
+- overridden_files = HmisCsvImporter::ImportOverride.available_files_for(@data_source.id)
+- if overridden_files.count > 1
+  %nav.nav.nav-pills
+  - overridden_files.each.with_index do |f, i|
+    - classes = ['btn', 'd-block', 'mb-4']
+    - if f == @selected_filename
+      - classes << 'btn-primary'
+    - else
+      - classes << 'btn-secondary'
+
+    = link_to f, url_for(params.permit(:page).merge(filename: f)), class: classes

--- a/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/index.haml
+++ b/drivers/hmis_csv_importer/app/views/hmis_csv_importer/import_overrides/index.haml
@@ -7,10 +7,16 @@
   = link_to new_hmis_csv_importer_data_source_import_override_path(data_source: @data_source.id), class: 'btn btn-primary ml-auto' do
     %i.icon-plus
     Add Override
-- if @overrides.any?
-  .card.mb-4
-    = render 'table', overrides: @overrides, data_source: @data_source, editable: true, show_associated_project: true, can_apply_override: true
-
+- if @pagy.count.positive?
+  .row
+    .col-sm-2
+      = render 'filter'
+    .col-sm-10
+      - entry_name = 'import override'
+      = render 'common/pagination_top', item_name: entry_name
+      .card.mb-4
+        = render 'table', overrides: @overrides, data_source: @data_source, editable: true, show_associated_project: true, can_apply_override: true
+      = render 'common/pagination_bottom', item_name: entry_name
 - else
   .none-found
     No Overrides for #{@data_source.name}


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This makes it so that the import overrides page will load when there are more than a handful of overrides in a data source.  It:
1. Adds pagination to the override list page
2. Limits to one type of override on the list page at a time
3. Adds navigation to go between file types and pages

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
