### PR TITLE
Revert theme bug

### DIFF
--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -17,14 +17,18 @@ class Hmis::AppSettingsController < Hmis::BaseController
     end
 
     hostname = ENV['FQDN']
-    theme = GrdaWarehouse::Theme.hmis_theme_for_origin(current_hmis_host)
+
+    # Note: the commented-out theme call doesn't work yet because request.origin is nil for this request.
+    # So for now, multi-HMIS theming is not yet supported. Issue #6774
+    # theme = GrdaWarehouse::Theme.hmis_theme_for_origin(current_hmis_host)
+    theme = GrdaWarehouse::Theme.where(client: ENV['CLIENT']&.to_sym).filter(&:hmis_theme?).first
 
     render json: {
       oktaPath: okta_enabled ? '/hmis/users/auth/okta' : nil,
       logoPath: logo_path.present? ? ActionController::Base.helpers.asset_path(logo_path) : nil,
       warehouseUrl: "https://#{hostname}",
       warehouseName: Translation.translate('Boston DND Warehouse'),
-      appName: Translation.translate('Open Path HMIS'),
+      appName: Translation.translate('Open Path HMIS'), # TODO: app name should be configurable per data source
       resetPasswordUrl: "https://#{hostname}/users/password/new",
       unlockAccountUrl: "https://#{hostname}/users/unlock/new",
       manageAccountUrl: "https://#{hostname}/account/edit",

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -29,6 +29,8 @@ class Hmis::BaseController < ActionController::Base
   end
 
   def current_hmis_host
+    raise 'cannot determine HMIS host because origin is missing' unless request.origin.present?
+
     URI.parse(request.origin).host
   end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Reverts a bug that  was introduced on release-136 https://github.com/greenriver/hmis-warehouse/pull/4760. I haven't been able to repro the bug locally, but it looks like the origin header is missing on unauthenticated requests. 

I am just disabling it for now because the multi-installation themes is not a priority, and the fix was not immediately obvious.
Linked issue https://github.com/open-path/Green-River/issues/6774 in comment.

Sentry: https://green-river.sentry.io/issues/5912596754/?environment=staging&project=4503977346662400&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
