### PR TITLE
Add additional lookback years for the homeless history PDF generation. Still default selection to 3 years.

### DIFF
--- a/drivers/client_access_control/app/views/client_access_control/history/_pdf_generation_form.haml
+++ b/drivers/client_access_control/app/views/client_access_control/history/_pdf_generation_form.haml
@@ -1,6 +1,16 @@
 - if window_file_access?
+  :ruby
+    pdf_history_options = {
+      'Last 1 year' => 1,
+      'Last 2 years' => 2, 
+      'Last 3 years' => 3, 
+      'Last 4 years' => 4, 
+      'Last 5 years' => 5, 
+      'Last 6 years' => 6, 
+      'Last 7 years' => 7,
+    }
   - url = polymorphic_path([:queue] + history_path_generator, client_id: @client.id)
   = simple_form_for :pdf, url: url, method: :post do |f|
-    = f.input :years, as: :select_two, collection: {'Last 3 years' => 3, 'Last 5 years' => 5}, include_blank: false, label: false, style: 'width: 100%;'
+    = f.input :years, as: :select_two, collection: pdf_history_options, selected: 3, include_blank: false, label: false, style: 'width: 100%;'
     .d-flex
       = f.submit 'Generate PDF', class: "btn btn-secondary ml-auto"


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add additional lookback years as selectable options in the homeless history PDF generation. Options changed from only 3 or 5 years to instead include 1 through 7 years as the HUD retention policy is 7 years ([ref](https://www.hudexchange.info/faqs/3304/what-are-the-minimum-and-maximum-data-retention-requirements-for-hmis-data/))

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
