### PR TITLE
Fix Project Location map link permissions

### DIFF
--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -292,7 +292,8 @@ module GrdaWarehouse::Hud
     #   within the context of reporting confidential_scope_limiter is almost always non_confidential
     #   within the client dashboard context, confidential_scope_limiter is :all, which includes confidential projects
     #   names of confidential projects are obfuscated unless the user can_view_confidential_project_names
-    # @param permission [Symbol] a permission to determine the scope for which the projects are viewable
+    # @param permission [Symbol] a permission to determine the scope for which the projects are viewable.
+    #   Caution, this permission is NOT checked if the user is using legacy permissions (not on ACLs).
     scope :viewable_by, ->(user, confidential_scope_limiter: :non_confidential, permission: :can_view_projects) do
       query = viewable_by_entity(user, permission: permission)
       # If a user can't report on confidential projects, exclude them entirely
@@ -327,10 +328,6 @@ module GrdaWarehouse::Hud
         )
       end
       # END_ACL
-    end
-
-    def can?(user, permission: :can_view_projects)
-      self.class.viewable_by(user, permission: permission).where(id: id).exists?
     end
 
     scope :editable_by, ->(user) do

--- a/app/views/projects/show.haml
+++ b/app/views/projects/show.haml
@@ -49,7 +49,7 @@
           %tr
             %th Project Contacts
             %td= link_to 'View/Edit', project_contacts_path(@project)
-        - if @project.can?(current_user, permission: :can_view_project_locations) && RailsDrivers.loaded.include?(:client_location_history)
+        - if can_view_project_locations? && RailsDrivers.loaded.include?(:client_location_history)
           %tr
             %th Client Locations
             %td= link_to 'View', map_client_location_history_project_path(@project)


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

PIT QA fix for: https://github.com/open-path/Green-River/issues/6481#issuecomment-2389756617

**Bug**: For a user using legacy permissions (not ACLs), you can still see the "Client Locations" link in the Warehouse Project page, even if you don't have the permission to view project locations.

The issue is that the `Project`'s `viewable_by_entity` [scope](https://github.com/greenriver/hmis-warehouse/blob/10de915680000021ecdd89df692f4cf3f22a6dd8/app/models/grda_warehouse/hud/project.rb#L298-L323) accepts a permission arg, but only uses the permission if the user is using ACLs. If they are using legacy access controls then it just checks viewability.

**Fix:** Per @gigxz 's suggestion I've simplified the permission check so it's not ACL-compatible, since this view on the whole is not ACL-ready (it is also using `can_edit_projects?` and `can_delete_projects?` without checking against the specific entity).

(I thought I [checked this case](https://github.com/greenriver/hmis-warehouse/pull/4696#discussion_r1763441566) before but was likely fooled by local caching.)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
