### PR TITLE
Fix form version bugs in Client Details and Case Notes

### DIFF
--- a/drivers/hmis/app/graphql/mutations/submit_form.rb
+++ b/drivers/hmis/app/graphql/mutations/submit_form.rb
@@ -25,11 +25,11 @@ module Mutations
       # Look up form definition
       definition = Hmis::Form::Definition.find_by(id: input.form_definition_id)
       raise HmisErrors::ApiError, 'Form Definition not found' unless definition.present?
-      raise HmisErrors::ApiError, 'FormDefinition status is invalid' unless definition.valid_status_for_submit?
+      raise HmisErrors::ApiError, "FormDefinition #{definition.id} status #{definition.status} is invalid" unless definition.valid_status_for_submit?
 
       # Determine record class
       klass = definition.owner_class
-      raise HmisErrors::ApiError, 'Form Definition not configured' unless klass.present?
+      raise HmisErrors::ApiError, "Form Definition #{definition.id} not configured" unless klass.present?
 
       # Find or create record
       if input.record_id.present?
@@ -44,7 +44,6 @@ module Mutations
       raise HmisErrors::ApiError, 'Record not found' unless record.present?
 
       # Check permission
-      allowed = nil
       perms_to_check = definition.record_editing_permissions
       if definition.allowed_proc.present?
         allowed = definition.allowed_proc.call(entity_for_permissions, current_user)

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1962,6 +1962,7 @@ type CustomCaseNote {
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
   enrollment: Enrollment!
+  formDefinitionId: ID!
   id: ID!
   informationDate: ISO8601Date
   user: ApplicationUser
@@ -8988,6 +8989,11 @@ type Query {
   Get the most relevant Form Definition to use for record viewing/editing
   """
   recordFormDefinition(
+    """
+    Form Definition ID, if known
+    """
+    id: ID
+
     """
     Optional Project to select the relevant form, and to apply rule filtering
     (e.g. show/hide questions based on Project applicability)

--- a/drivers/hmis/app/graphql/types/hmis_schema/custom_case_note.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/custom_case_note.rb
@@ -17,6 +17,7 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :content, String, null: false
     field :information_date, GraphQL::Types::ISO8601Date, null: true
+    field :form_definition_id, ID, null: false
     custom_data_elements_field
 
     def enrollment
@@ -25,6 +26,10 @@ module Types
 
     def client
       load_ar_association(object, :client)
+    end
+
+    def form_definition_id
+      load_ar_association(object, :form_processor)&.definition_id
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
@@ -26,7 +26,7 @@ module Types
     end
 
     def definition(parent:)
-      definition = load_ar_association(object, :definition)
+      definition = load_ar_association(object, :published_definition)
       raise "Unable to load definition for instance: #{object.id}" unless definition.present?
 
       definition.filter_context = { project: parent } if parent.is_a?(Hmis::Hud::Project)

--- a/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb
@@ -26,7 +26,7 @@ module Types
     end
 
     def definition(parent:)
-      definition = load_ar_association(object, :published_definition)
+      definition = load_ar_association(object, :definitions).select(&:published?).first
       raise "Unable to load definition for instance: #{object.id}" unless definition.present?
 
       definition.filter_context = { project: parent } if parent.is_a?(Hmis::Hud::Project)

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -501,7 +501,7 @@ module Types
     field :client_detail_forms, [Types::HmisSchema::OccurrencePointForm], null: false, description: 'Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form)'
     def client_detail_forms
       # No authorization required, this just resolving application configuration
-      Hmis::Form::Instance.active.with_role(:CLIENT_DETAIL).sort_by_option(:form_title)
+      Hmis::Form::Instance.active.with_role(:CLIENT_DETAIL).published.sort_by_option(:form_title)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/service_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/service_type.rb
@@ -42,8 +42,8 @@ module Types
     def form_definitions
       raise 'unauthorized' unless current_user.can_configure_data_collection?
 
-      definitions_for_type = load_ar_association(object, :definitions)
-      definitions_for_category = load_ar_association(category_record, :definitions)
+      definitions_for_type = load_ar_association(object, :definitions).select(&:published?)
+      definitions_for_category = load_ar_association(category_record, :definitions).select(&:published?)
       (definitions_for_type + definitions_for_category).uniq.sort_by(&:id)
     end
 

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -41,7 +41,9 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
                      )
                    end
 
-  scope :with_role, ->(role) { joins(:definition).where(fd_t[:role].in(role).and(fd_t[:status].eq(:published))) }
+  scope :with_role, ->(role) { joins(:definition).where(fd_t[:role].in(role)) }
+
+  scope :published, -> { joins(:definition).merge(Hmis::Form::Definition.published) }
 
   # Find instances that are for a specific Project
   scope :for_project, ->(project_id) { for_projects.where(entity_id: project_id) }

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -11,16 +11,14 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
 
   belongs_to :entity, polymorphic: true, optional: true
 
-  # This relationship could be clearer as a has_many relationship, since the instance may have many definition records.
-  # However, there are many usages of this relation from before we implemented form versioning,
-  # so to reduce impact, for now we have just modified the scope to prioritize a published definition if it exists.
+  # This belongs_to relationship is a bit confusing since now form identifiers can have multiple versions.
+  # We should aim to gradually replace usages of :definition with the has_many :definitions relationship below,
+  # so that we're explicit about which statuses of definition (draft, published, retired) we accept in a given situation.
   belongs_to :definition,
              -> { order(Arel.sql("CASE WHEN status = 'published' THEN 0 WHEN status = 'draft' THEN 1 ELSE 2 END")) },
              foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
 
-  # Use published_definition when we want to filter out Instances on all non-published forms
-  belongs_to :published_definition, -> { published },
-             foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
+  has_many :definitions, primary_key: :definition_identifier, foreign_key: :identifier, class_name: 'Hmis::Form::Definition'
 
   belongs_to :custom_service_category, optional: true, class_name: 'Hmis::Hud::CustomServiceCategory'
   belongs_to :custom_service_type, optional: true, class_name: 'Hmis::Hud::CustomServiceType'

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -10,7 +10,7 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   self.table_name = :hmis_form_instances
 
   belongs_to :entity, polymorphic: true, optional: true
-  belongs_to :definition, foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
+  belongs_to :definition, -> { where(status: 'published') }, foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
 
   belongs_to :custom_service_category, optional: true, class_name: 'Hmis::Hud::CustomServiceCategory'
   belongs_to :custom_service_type, optional: true, class_name: 'Hmis::Hud::CustomServiceType'

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -18,6 +18,10 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
              -> { order(Arel.sql("CASE WHEN status = 'published' THEN 0 WHEN status = 'draft' THEN 1 ELSE 2 END")) },
              foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
 
+  # Use published_definition when we want to filter out Instances on all non-published forms
+  belongs_to :published_definition, -> { published },
+             foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'
+
   belongs_to :custom_service_category, optional: true, class_name: 'Hmis::Hud::CustomServiceCategory'
   belongs_to :custom_service_type, optional: true, class_name: 'Hmis::Hud::CustomServiceType'
 

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -10,6 +10,10 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   self.table_name = :hmis_form_instances
 
   belongs_to :entity, polymorphic: true, optional: true
+
+  # This relationship could be clearer as a has_many relationship, since the instance may have many definition records.
+  # However, there are many usages of this relation from before we implemented form versioning,
+  # so to reduce impact, for now we have just modified the scope to prioritize a published definition if it exists.
   belongs_to :definition,
              -> { order(Arel.sql("CASE WHEN status = 'published' THEN 0 WHEN status = 'draft' THEN 1 ELSE 2 END")) },
              foreign_key: :definition_identifier, primary_key: :identifier, class_name: 'Hmis::Form::Definition'

--- a/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::CustomServiceCategory < Hmis::Hud::Base
   belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   has_many :service_types, class_name: 'Hmis::Hud::CustomServiceType'
   has_many :form_instances, class_name: 'Hmis::Form::Instance'
-  has_many :definitions, through: :form_instances
+  has_many :definitions, through: :form_instances, source: :definition # todo @martha - `definitions` is probably clearer, but `definition` would be the one that doesn't change behavior
 
   validates_presence_of :name, allow_blank: false
 

--- a/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_category.rb
@@ -14,7 +14,7 @@ class Hmis::Hud::CustomServiceCategory < Hmis::Hud::Base
   belongs_to :user, **hmis_relation(:UserID, 'User'), optional: true
   has_many :service_types, class_name: 'Hmis::Hud::CustomServiceType'
   has_many :form_instances, class_name: 'Hmis::Form::Instance'
-  has_many :definitions, through: :form_instances, source: :definition # todo @martha - `definitions` is probably clearer, but `definition` would be the one that doesn't change behavior
+  has_many :definitions, through: :form_instances, source: :definitions
 
   validates_presence_of :name, allow_blank: false
 

--- a/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::CustomServiceType < Hmis::Hud::Base
   belongs_to :custom_service_category
   has_many :custom_services
   has_many :form_instances, class_name: 'Hmis::Form::Instance'
-  has_many :definitions, through: :form_instances, source: :definition
+  has_many :definitions, through: :form_instances, source: :definitions
 
   alias_attribute :category, :custom_service_category
 

--- a/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_service_type.rb
@@ -15,7 +15,7 @@ class Hmis::Hud::CustomServiceType < Hmis::Hud::Base
   belongs_to :custom_service_category
   has_many :custom_services
   has_many :form_instances, class_name: 'Hmis::Form::Instance'
-  has_many :definitions, through: :form_instances
+  has_many :definitions, through: :form_instances, source: :definition
 
   alias_attribute :category, :custom_service_category
 

--- a/drivers/hmis/spec/requests/hmis/client_detail_forms_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_detail_forms_spec.rb
@@ -1,0 +1,65 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+
+  let!(:definition) { create :hmis_form_definition, identifier: 'client_detail_form', role: :CLIENT_DETAIL, version: 1 }
+  let!(:form_rule) { create :hmis_form_instance, definition_identifier: 'client_detail_form', entity: nil, active: true }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  describe 'client detail forms query' do
+    let(:query) do
+      <<~GRAPHQL
+        query ClientDetailForms {
+          clientDetailForms {
+            id
+            dataCollectedAbout
+            definition {
+              id
+              identifier
+              status
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it 'resolves client detail forms' do
+      response, result = post_graphql { query }
+      expect(response.status).to eq(200), result.inspect
+      forms = result.dig('data', 'clientDetailForms')
+      expect(forms.size).to eq(1)
+      expect(forms.first.dig('definition', 'id')).to eq(definition.id.to_s)
+    end
+
+    context 'when there is a draft or retired form (regression #6779)' do
+      let!(:retired) { create :hmis_form_definition, identifier: 'client_detail_form', role: :CLIENT_DETAIL, status: 'retired', version: 0 }
+      let!(:draft) { create :hmis_form_definition, identifier: 'client_detail_form', role: :CLIENT_DETAIL, status: 'draft', version: 2 }
+
+      it 'only resolves published' do
+        response, result = post_graphql { query }
+        expect(response.status).to eq(200), result.inspect
+        forms = result.dig('data', 'clientDetailForms')
+        expect(forms.size).to eq(1)
+        expect(forms.first.dig('definition', 'id')).to eq(definition.id.to_s)
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
GH issue: https://github.com/open-path/Green-River/issues/6779

Regarding 2 in the linked ticket: I've proposed here to ~restrict the Instance's Definitions relationship to `{ where(status: 'published') }`. I don't yet feel confident that that will not have any other unintended knock-on effects and indeed it seems to be causing a test failure that I'm still investigating.~ Edit: there are for sure other places in the code where we need the definition regardless of its status. For example, when checking if the user has permission to delete a form instance, we check the role from the definition. I've proposed instead prioritizing the published definition in this relation.
Regarding 3: I've proposed to use the form definition ID attached to the case note's form processor. I'm eager for feedback on this idea.
Regarding 1: Interestingly, I never got to the bottom of why a draft form definitions was getting returned in the buggy [`client_detail_forms` query](https://github.com/greenriver/hmis-warehouse/blob/10de915680000021ecdd89df692f4cf3f22a6dd8/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L486-L490). Even when I ssh'ed in to training and ran the code from that query in a rails console, I could only get it to return published versions. However, I think this probably will be fixed by the fix to 2 above, so I haven't spent too much time investigating.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
