### PR TITLE
Client cleanup - include all client columns

### DIFF
--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -551,12 +551,8 @@ module GrdaWarehouse::Tasks
       end
 
       # Set DifferentIdentityText
-      additional = sorted_source_clients.map { |m| m[:DifferentIdentityText] }.compact
-      dest_attr[:DifferentIdentityText] = if additional.empty?
-        nil
-      else
-        additional.first
-      end
+      additional = sorted_source_clients.map { |m| m[:DifferentIdentityText] }.compact_blank
+      dest_attr[:DifferentIdentityText] = additional.presence&.first
 
       # if we have any yes responses, set this to nil, otherwise use the most-recent GenderNone response
       if dest_attr.values_at(*gender_columns).any?(1)
@@ -603,12 +599,8 @@ module GrdaWarehouse::Tasks
       end
 
       # Set AdditionalRaceEthnicity
-      additional = sorted_source_clients.map { |m| m[:AdditionalRaceEthnicity] }.compact
-      dest_attr[:AdditionalRaceEthnicity] = if additional.empty?
-        nil
-      else
-        additional.first
-      end
+      additional = sorted_source_clients.map { |m| m[:AdditionalRaceEthnicity] }.compact_blank
+      dest_attr[:AdditionalRaceEthnicity] = additional.presence&.first
 
       # if we have any yes responses, set this to nil, otherwise use the most-recent RaceNone response
       if dest_attr.values_at(*race_columns).any?(1)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
This updates `ClientCleanup` to include all (or almost all) client columns when setting values on the destination client.  Specifically, we were never setting some veteran related values which are needed for SSVF reporting and weren't being exported in the HMIS CSV exporter.  Additionally, `AdditionalRaceEthnicity` and `DifferentIdentityText` are included to make the exporter more complete.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
