### PR TITLE
Add viewable_by scope to ProjectConfig

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -465,7 +465,7 @@ module Types
     def project_configs
       raise 'not allowed' unless current_user.can_configure_data_collection?
 
-      Hmis::ProjectConfig.all
+      Hmis::ProjectConfig.viewable_by(current_user)
     end
 
     field :project_can_accept_referral, Boolean, 'Whether the destination project is able to accept a referral for the client(s) belonging to the source enrollment', null: false do

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -28,7 +28,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   scope :viewable_by, ->(user) do
     # Special case this, rather than using ProjectRelated concern, because project isn't a direct relationship.
     # Project config can apply to a project, an organization, or a project type.
-    # Right now we have no way to gate viewability for ProjectConfigs defined by project type - TODO(#6691)
+    # Right now we have no way to gate viewability by data source for ProjectConfigs defined by project type - TODO(#6691)
     project_ids = Hmis::Hud::Project.viewable_by(user).pluck(:id)
     organization_ids = Hmis::Hud::Organization.viewable_by(user).pluck(:id)
     where(project_id: project_ids).

--- a/drivers/hmis/spec/requests/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_config_spec.rb
@@ -47,28 +47,51 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
-  let!(:c1) { create :hmis_hud_client, data_source: ds1 }
-  describe 'when the user has access' do
-    let!(:access_control) { create_access_control(hmis_user, p1) }
-
-    it 'should successfully create a new auto enter config' do
-      mutation_input = { config_type: 'AUTO_ENTER', project_type: 'ES_ENTRY_EXIT' }
-      response, result = post_graphql(input: mutation_input) { create_project_config }
-      expect(response.status).to eq(200), result.inspect
-      project_config_id = result.dig('data', 'createProjectConfig', 'projectConfig', 'id')
-      expect(project_config_id).not_to be_nil
-      project_config = Hmis::ProjectConfig.find(project_config_id)
-      expect(project_config.class.name).to eq('Hmis::ProjectAutoEnterConfig')
-      expect(project_config.project_type).to eq(0)
-    end
+  let(:get_project_configs) do
+    <<~GRAPHQL
+      query GetProjectConfigs {
+        projectConfigs {
+          nodesCount
+          nodes {
+            id
+          }
+        }
+      }
+    GRAPHQL
   end
 
-  describe 'when the user does not have access' do
-    let!(:access_control) { create_access_control(hmis_user, p1, without_permission: [:can_configure_data_collection]) }
+  let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+  let!(:access_control) { create_access_control(hmis_user, p1) }
 
-    it 'should throw an error when trying to create a project config' do
-      mutation_input = { config_type: 'AUTO_ENTER', project_type: 'ES_ENTRY_EXIT' }
-      expect_access_denied(post_graphql(input: mutation_input) { create_project_config })
+  it 'should successfully create a new auto enter config' do
+    mutation_input = { config_type: 'AUTO_ENTER', project_type: 'ES_ENTRY_EXIT' }
+    response, result = post_graphql(input: mutation_input) { create_project_config }
+    expect(response.status).to eq(200), result.inspect
+    project_config_id = result.dig('data', 'createProjectConfig', 'projectConfig', 'id')
+    expect(project_config_id).not_to be_nil
+    project_config = Hmis::ProjectConfig.find(project_config_id)
+    expect(project_config.class.name).to eq('Hmis::ProjectAutoEnterConfig')
+    expect(project_config.project_type).to eq(0)
+  end
+
+  it 'should throw an error when the user does not have access' do
+    remove_permissions(access_control, :can_configure_data_collection)
+    mutation_input = { config_type: 'AUTO_ENTER', project_type: 'ES_ENTRY_EXIT' }
+    expect_access_denied(post_graphql(input: mutation_input) { create_project_config })
+  end
+
+  describe 'when there are multiple hmis data sources' do
+    let!(:ds2) { create :hmis_data_source }
+    let!(:p2) { create :hmis_hud_project, data_source: ds2 }
+    let!(:ds2_access_control) { create_access_control(hmis_user, ds2) }
+    let!(:ds1_project_config) { create :hmis_project_auto_enter_config, project: p1 }
+    let!(:ds2_project_config) { create :hmis_project_auto_enter_config, project: p2 }
+
+    it 'should do return only the configs in the current data source' do
+      response, result = post_graphql { get_project_configs }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'projectConfigs', 'nodesCount')).to eq(1)
+      expect(result.dig('data', 'projectConfigs', 'nodes', 0, 'id')).to eq(ds1_project_config.id.to_s)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
I encountered [this error](https://greenriver.slack.com/archives/C0610D9HSSH/p1728058451516149) while QAing the recent change to the [GraphQL object-level authorization](https://github.com/open-path/Green-River/issues/6758). The problem is that `ProjectConfigs` don't have a `viewable_by` scope. Previously they would have just all been returned, but since we added the data source ID check to the GraphQL permission checker, now it is surfacing as an uncaught error.

I know this isn't a complete fix because project configs are not associated to data source IDs directly and they should be (https://github.com/open-path/Green-River/issues/6691).

To reproduce, visit https://qa-hmis-2.openpath.host/admin/project-configs

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
- Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
