### PR TITLE
bug fix for calculating client history dates - use provided years value instead of defaulting to 3

### DIFF
--- a/app/models/client_history.rb
+++ b/app/models/client_history.rb
@@ -19,7 +19,7 @@ class ClientHistory
     @years = years
 
     @client = ::GrdaWarehouse::Hud::Client.destination.find(client_id.to_i)
-    @dates = set_pdf_dates(client: @client, requesting_user: @requesting_user)
+    @dates = set_pdf_dates(client: @client, requesting_user: @requesting_user, years: years)
   end
 
   # Limit to Residential Homeless programs


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Fix issue where client history pdf was not taking the selected years into account when generating the service dates.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [X] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)
