### PR TITLE
Exclude exited households from case management dashboard

### DIFF
--- a/drivers/hmis/app/graphql/types/application/user.rb
+++ b/drivers/hmis/app/graphql/types/application/user.rb
@@ -104,7 +104,10 @@ module Types
 
     def staff_assignments
       # n+1, not performant for queries on collections
-      object.staff_assignments.viewable_by(current_user).active.order(created_at: :desc, id: :desc)
+      object.staff_assignments.
+        viewable_by(current_user).
+        open_on_date. # This will include households that exited today
+        order(created_at: :desc, id: :desc)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/application/user.rb
+++ b/drivers/hmis/app/graphql/types/application/user.rb
@@ -104,7 +104,7 @@ module Types
 
     def staff_assignments
       # n+1, not performant for queries on collections
-      object.staff_assignments.viewable_by(current_user).order(created_at: :desc, id: :desc)
+      object.staff_assignments.viewable_by(current_user).active.order(created_at: :desc, id: :desc)
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/staff_assignment.rb
+++ b/drivers/hmis/app/models/hmis/staff_assignment.rb
@@ -16,4 +16,8 @@ class Hmis::StaffAssignment < Hmis::HmisBase
     # Special case this, rather than using EnrollmentRelated concern, because we have to join through Household
     joins(:household).merge(Hmis::Hud::Household.viewable_by(user))
   end
+
+  scope :active, -> do
+    joins(:household).merge(Hmis::Hud::Household.active)
+  end
 end

--- a/drivers/hmis/app/models/hmis/staff_assignment.rb
+++ b/drivers/hmis/app/models/hmis/staff_assignment.rb
@@ -17,7 +17,7 @@ class Hmis::StaffAssignment < Hmis::HmisBase
     joins(:household).merge(Hmis::Hud::Household.viewable_by(user))
   end
 
-  scope :active, -> do
-    joins(:household).merge(Hmis::Hud::Household.active)
+  scope :open_on_date, ->(date = Date.current) do
+    joins(:household).merge(Hmis::Hud::Household.open_on_date(date))
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/6813
* Exclude fully exit households from the "My Dashboard" page.
* Households that are partially exited are still included.
* Households that exited **today** are still included. (They will roll off the next day). We didn't discuss this but it seems desirable to be able to see on your dashboard that you successfully exited them. The enrollment was "open" for part of the day.

## Type of change
Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [it does, but noted] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
