### PR TITLE
Go through warehouse client for chronicity

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -339,9 +339,9 @@ module Types
     def hud_chronic
       return unless current_permission?(permission: :can_view_hud_chronic_status, entity: object)
 
-      # client.hud_chronic causes n+1 queries
-      enrollments = object.enrollments.hmis
-      !!object.hud_chronic?(scope: enrollments)
+      # causes n+1 queries
+      enrollments = object.enrollments.where(data_source_id: current_user.hmis_data_source_id)
+      !!object.destination_client&.as_warehouse&.hud_chronic?(scope: enrollments)
     end
 
     def audit_history(filters: nil)

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -106,7 +106,7 @@ module Types
       return unless current_permission?(permission: :can_view_hud_chronic_status, entity: project)
 
       # client.hud_chronic causes n+1 queries, only use when resolving 1 posting
-      !!referred_hoh_client.hud_chronic?(scope: referred_hoh_client.enrollments)
+      !!referred_hoh_client.destination_client&.as_warehouse&.hud_chronic?(scope: referred_hoh_client.enrollments)
     end
 
     def referred_from

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -10,7 +10,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   include ::Hmis::Hud::Concerns::Shared
   include ::Hmis::Hud::Concerns::FormSubmittable
   include ::HudConcerns::Client
-  include ::HudChronicDefinition
   include ClientSearch
 
   has_paper_trail(meta: { client_id: :id })

--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -73,7 +73,8 @@ FactoryBot.define do
   # HMIS Source Client that is linked to a destination client (Via WarehouseClient)
   factory :hmis_hud_client_with_warehouse_client, parent: :hmis_hud_base_client do
     after(:create) do |client|
-      create(:hmis_warehouse_client, data_source: client.data_source, source: client)
+      destination = create(:destination_client, personal_id: client.personal_id)
+      create(:hmis_warehouse_client, data_source: client.data_source, source: client, destination: destination)
     end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -57,13 +57,20 @@ FactoryBot.define do
     end
   end
 
+  # Client that is in the Warehouse destination data source (not the HMIS data source)
+  factory :destination_client, parent: :hmis_hud_base_client do
+    data_source { association :destination_data_source }
+  end
+
+  # WarehouseClient that links the source HMIS client to the destination client
   factory :hmis_warehouse_client, class: 'Hmis::WarehouseClient' do
     data_source { association :hmis_data_source }
-    destination { association :hmis_hud_base_client, data_source: data_source }
+    destination { association :destination_client }
     source { association :hmis_hud_base_client, data_source: data_source }
     sequence(:id_in_source, 100)
   end
 
+  # HMIS Source Client that is linked to a destination client (Via WarehouseClient)
   factory :hmis_hud_client_with_warehouse_client, parent: :hmis_hud_base_client do
     after(:create) do |client|
       create(:hmis_warehouse_client, data_source: client.data_source, source: client)

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   context 'with a client who is chronically homeless per HUD definition' do
-    let!(:client) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
-    let!(:enrollment) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: client, DisablingCondition: 1, MonthsHomelessThisTime: 13 }
+    let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, DisablingCondition: 1, MonthsHomelessThisTime: 13 }
 
     it 'should return chronic status correctly' do
       response, result = post_graphql(id: c1.id) { query }

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
              project: p1,
              client: c1,
              DisablingCondition: 1,
-             MonthsHomelessThisTime: 13,
-             DateToStreetESSH: 13.months.ago
+             MonthsHomelessPastThreeYears: 112, # see MonthsHomelessPastThreeYears enum
+             TimesHomelessPastThreeYears: 4
     end
     let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
 

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -174,11 +174,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       'emailAddresses' => [{ 'value' => 'email@e.mail', 'use' => 'home', 'system' => 'email' }],
     )
     expect(result.dig('data', 'client', 'image')).not_to be_nil
+    expect(result.dig('data', 'client', 'hudChronic')).to eq(false)
   end
 
   context 'with a client who is chronically homeless per HUD definition' do
     let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
     let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, DisablingCondition: 1, MonthsHomelessThisTime: 13 }
+    let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
 
     it 'should return chronic status correctly' do
       response, result = post_graphql(id: c1.id) { query }

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -179,7 +179,15 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   context 'with a client who is chronically homeless per HUD definition' do
     let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
-    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, DisablingCondition: 1, MonthsHomelessThisTime: 13, DateToStreetESSH: 13.months.ago }
+    let!(:e1) do
+      create :hmis_hud_enrollment,
+             data_source: ds1,
+             project: p1,
+             client: c1,
+             DisablingCondition: 1,
+             MonthsHomelessThisTime: 13,
+             DateToStreetESSH: 13.months.ago
+    end
     let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
 
     it 'should return chronic status correctly' do

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -177,46 +177,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   context 'with a client who is chronically homeless per HUD definition' do
-    let!(:warehouse_ds) { create :destination_data_source }
-    let!(:client) { create :grda_warehouse_hud_client, data_source_id: warehouse_ds.id }
-    let!(:project) do
-      create(
-        :grda_warehouse_hud_project,
-        project_id: 50000,
-        ProjectType: 1,
-        data_source_id: ds1.id,
-      )
-    end
-    let!(:source_client) do
-      create(
-        :grda_warehouse_hud_client,
-        data_source_id: ds1.id,
-        PersonalID: client.PersonalID,
-      )
-    end
-    let!(:warehouse_client) do
-      create(
-        :warehouse_client,
-        destination: client,
-        source: source_client,
-        data_source_id: source_client.data_source_id,
-      )
-    end
-    let!(:source_enrollment) do
-      create(
-        :hud_enrollment,
-        EnrollmentID: 'a',
-        ProjectID: project.ProjectID,
-        EntryDate: Date.new(2014, 4, 1),
-        DisablingCondition: 1,
-        data_source_id: source_client.data_source_id,
-        PersonalID: source_client.PersonalID,
-      )
-    end
-
-    before(:each) do
-      Rails.cache.delete('chronically_disabled_clients')
-    end
+    let!(:client) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
+    let!(:enrollment) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: client, DisablingCondition: 1, MonthsHomelessThisTime: 13 }
 
     it 'should return chronic status correctly' do
       response, result = post_graphql(id: c1.id) { query }

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   context 'with a client who is chronically homeless per HUD definition' do
     let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
-    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, DisablingCondition: 1, MonthsHomelessThisTime: 13 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, DisablingCondition: 1, MonthsHomelessThisTime: 13, DateToStreetESSH: 13.months.ago }
     let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
 
     it 'should return chronic status correctly' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
GH issue https://github.com/open-path/Green-River/issues/6812
This PR fixes the bug outlined/confirmed in the issue.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s - Yes, no new N+1s are introduced. `hud_chronic` has an existing n+1 problem documented in comments, which is ok in the HMIS context since we only fetch it for 1 client at a time on the enrollment dashboard (?)
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
