### PR TITLE
limit pdf history counts to lookback date

### DIFF
--- a/app/models/client_history.rb
+++ b/app/models/client_history.rb
@@ -34,16 +34,20 @@ class ClientHistory
     dates.keys.sort
   end
 
+  def lookback_date
+    @lookback_date ||= Date.current - years.years
+  end
+
   def chronic
     ::GrdaWarehouse::Config.get(:chronic_definition).to_sym == :chronics ? client.potentially_chronic?(on_date: Date.current) : client.hud_chronic?(on_date: Date.current)
   end
 
   def organization_counts
-    dates.values.flatten.group_by { |en| HudUtility2024.project_type en[:organization_name] }.transform_values(&:count)
+    dates.select { |d| d > lookback_date }.values.flatten.group_by { |en| HudUtility2024.project_type en[:organization_name] }.transform_values(&:count)
   end
 
   def project_type_counts
-    dates.values.flatten.group_by { |en| HudUtility2024.project_type en[:project_type] }.transform_values(&:count)
+    dates.select { |d| d > lookback_date }.values.flatten.group_by { |en| HudUtility2024.project_type en[:project_type] }.transform_values(&:count)
   end
 
   def generate_service_history_pdf

--- a/app/models/client_history.rb
+++ b/app/models/client_history.rb
@@ -30,7 +30,7 @@ class ClientHistory
   end
 
   def lookback_date
-    @lookback_date ||= Date.current - years
+    @lookback_date ||= Date.current - years.years
   end
 
   def chronic

--- a/app/models/client_history.rb
+++ b/app/models/client_history.rb
@@ -6,12 +6,7 @@
 
 class ClientHistory
   attr_reader :client, :user, :requesting_user, :years
-  def initialize(
-    client_id:,
-    user_id:,
-    years:
-  )
-
+  def initialize(client_id:, user_id:, years: 3)
     @user = User.system_user
 
     # The user that requested the PDF generation. If job was kicked off from CAS, this is nil.
@@ -35,7 +30,7 @@ class ClientHistory
   end
 
   def lookback_date
-    @lookback_date ||= Date.current - years.years
+    @lookback_date ||= Date.current - years
   end
 
   def chronic
@@ -100,12 +95,7 @@ class ClientHistory
     end
   end
 
-  def set_pdf_dates(
-    client:,
-    requesting_user:,
-    dates: {},
-    years: 3
-  )
+  def set_pdf_dates(client:, requesting_user:, dates: {}, years: 3)
     client.enrollments_for_verified_homeless_history(user: requesting_user).
       homeless.
       enrollment_open_in_prior_years(years: years).

--- a/app/models/grda_warehouse/service_history_enrollment.rb
+++ b/app/models/grda_warehouse/service_history_enrollment.rb
@@ -192,7 +192,7 @@ class GrdaWarehouse::ServiceHistoryEnrollment < GrdaWarehouseBase
   }
 
   scope :enrollment_open_in_prior_years, ->(years: 3) do
-    lookback_date = DateTime.current - years
+    lookback_date = DateTime.current - years.years
     where(
       arel_table[:last_date_in_program].eq(nil).
       or(arel_table[:first_date_in_program].gt(lookback_date)).

--- a/app/models/grda_warehouse/service_history_enrollment.rb
+++ b/app/models/grda_warehouse/service_history_enrollment.rb
@@ -192,10 +192,11 @@ class GrdaWarehouse::ServiceHistoryEnrollment < GrdaWarehouseBase
   }
 
   scope :enrollment_open_in_prior_years, ->(years: 3) do
-    t = DateTime.current - years.years
-    at = arel_table
+    lookback_date = DateTime.current - years
     where(
-      at[:last_date_in_program].eq(nil).or(at[:first_date_in_program].gt(t)).or(at[:last_date_in_program].gt(t)),
+      arel_table[:last_date_in_program].eq(nil).
+      or(arel_table[:first_date_in_program].gt(lookback_date)).
+      or(arel_table[:last_date_in_program].gt(lookback_date)),
     )
   end
 

--- a/drivers/client_access_control/app/controllers/client_access_control/history_controller.rb
+++ b/drivers/client_access_control/app/controllers/client_access_control/history_controller.rb
@@ -54,7 +54,13 @@ module ClientAccessControl
     end
 
     def pdf
-      @client_history = ClientHistory.new(client_id: params[:client_id].to_i, user_id: params[:user_id].to_i, years: params[:years]&.to_i)
+      options = {
+        client_id: params[:client_id].to_i,
+        user_id: params[:user_id].to_i,
+      }
+      options[:years] = params[:years].to_i if params[:years].present?
+
+      @client_history = ClientHistory.new(**options)
       # set @client for when this method is called outside of the controller context.
       @client ||= @client_history.client
 

--- a/drivers/client_access_control/app/views/client_access_control/history/pdf.haml
+++ b/drivers/client_access_control/app/views/client_access_control/history/pdf.haml
@@ -20,13 +20,13 @@
       %li= "Does not include any possible current Rapid Re-Housing enrollment"
     .history__counts
       .history__counts-by-org
-        %strong Total number of Bed Nights across all Residential Programs at each organization
+        %strong Total number of Bed Nights across all Residential Programs at each organization since #{@client_history.lookback_date}
         %ul
           - @client_history.organization_counts.each do |org_name, count|
             %li
               #{org_name}: #{pluralize count, 'days'}
       .history__counts-by-type
-        %strong Total number of Bed Nights across all Residential Programs in each project type
+        %strong Total number of Bed Nights across all Residential Programs in each project type since #{@client_history.lookback_date}
         %ul
           - @client_history.project_type_counts.each do |type, count|
             %li


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Limit client history pdf counts to only dates starting after the lookback year

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [] I have updated the documentation (or not applicable)
- [] I have added spec tests (or not applicable)
- [] I have provided testing instructions in this PR or the related issue (or not applicable)
