### PR TITLE
Validate form definition identifier

### DIFF
--- a/drivers/hmis/app/graphql/mutations/create_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/create_form_definition.rb
@@ -32,7 +32,10 @@ module Mutations
         **attrs,
       )
 
-      raise "Definition invalid: #{definition.errors.full_messages}" unless definition.valid?
+      unless definition.valid?
+        errors.add_ar_errors(definition.errors&.errors)
+        return { errors: errors }
+      end
 
       # validate without `role` to skip HUD requirement validation, since form has no content yet
       validation_errors = Hmis::Form::DefinitionValidator.perform(definition.definition, skip_cded_validation: true)

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -40,6 +40,8 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   # convenience attr for passing graphql args
   attr_accessor :filter_context
 
+  validates :identifier, format: { with: /\A[a-zA-Z][a-zA-Z0-9_-]*\z/, message: 'must contain only alphanumeric characters, underscores, and dashes, and must start with a letter' }
+
   # --- Relations by id ----
   has_many :form_processors, dependent: :restrict_with_exception
   has_many :external_form_submissions, class_name: 'HmisExternalApis::ExternalForms::FormSubmission', dependent: :restrict_with_exception

--- a/drivers/hmis/lib/form_data/static/form_definition.json
+++ b/drivers/hmis/lib/form_data/static/form_definition.json
@@ -40,7 +40,7 @@
         "field_name": "identifier"
       },
       "required": true,
-      "helper_text": "Unique system identifier for the form. This cannot be changed.",
+      "helper_text": "Unique system identifier for the form. This cannot be changed. It must contain only alphanumeric characters, underscores, and dashes, and must start with a letter.",
       "_comment": "Only shown when creating a new FormDefinition",
       "enable_behavior": "ALL",
       "enable_when": [

--- a/drivers/hmis/spec/requests/hmis/create_form_definition_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_form_definition_spec.rb
@@ -67,4 +67,18 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect(result.status).to eq(200)
     expect(response.dig('data', 'createFormDefinition', 'errors', 0, 'fullMessage')).to eq('Role must exist')
   end
+
+  it 'should fail to create a new form with an invalid identifier' do
+    input = {
+      definition: '',
+      role: 'CUSTOM_ASSESSMENT',
+      title: 'A new custom assessment',
+      identifier: '123_invalid!', # Invalid identifier
+    }
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'createFormDefinition', 'errors')).not_to be_empty
+    error_message = result.dig('data', 'createFormDefinition', 'errors', 0, 'message')
+    expect(error_message).to match(/must contain only alphanumeric characters, underscores, and dashes/i)
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
GH issue: https://github.com/open-path/Green-River/issues/6778#issuecomment-2400687969

This PR adds form definition identifier validation.

I've added the requirement that it should contain only alphanumeric characters, dashes, and underscores, and must start with a letter. But, please do let me know if you think it should be looser (allow any character to start? We have some examples of this in the qa db) or stricter (only underscores, no dashes, or vice versa?)

![Screenshot 2024-10-09 at 5 43 27 PM](https://github.com/user-attachments/assets/6e3d82e5-a6c3-4c61-80c0-9d4215fec538)

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
