### PR TITLE
Add published scope to form instance with_role usages

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8925,7 +8925,6 @@ type Query {
   """
   enrollment(id: ID!): Enrollment
   esgFundingReport(clientIds: [ID!]!): [EsgFundingService!]!
-  externalFormDefinition(identifier: String!): FormDefinition @deprecated(reason: "use definition from the individual submission to display")
   externalFormSubmission(id: ID!): ExternalFormSubmission
   file(id: ID!): File
   formDefinition(id: ID!): FormDefinition

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -452,7 +452,7 @@ module Types
       return [] unless project.present?
 
       # External forms can only be enabled by Project-level instances
-      Hmis::Form::Instance.for_project(project).active.
+      Hmis::Form::Instance.for_project(project).active.published.
         with_role(:EXTERNAL_FORM).
         preload(:definition).
         order(:id).

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -409,15 +409,6 @@ module Types
       Hmis::Form::Definition.find(id)
     end
 
-    field :external_form_definition, Types::Forms::FormDefinition, null: true, deprecation_reason: 'use definition from the individual submission to display' do
-      argument :identifier, String, required: true
-    end
-    def external_form_definition(identifier:)
-      raise 'Access denied' unless current_user.can_manage_external_form_submissions?
-
-      Hmis::Form::Definition.with_role(:EXTERNAL_FORM).where(identifier: identifier).order(version: :desc).first
-    end
-
     field :external_form_submission, Types::HmisSchema::ExternalFormSubmission, null: true do
       argument :id, ID, required: true
     end

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -324,6 +324,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
     where(status: PUBLISHED)
   end
 
+  scope :published_or_retired, -> do
+    where(status: [PUBLISHED, RETIRED])
+  end
+
   validate :validate_external_form_object_key
   def validate_external_form_object_key
     return unless role == 'EXTERNAL_FORM' && external_form_object_key.present?

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -50,6 +50,7 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   scope :with_role, ->(role) { joins(:definition).where(fd_t[:role].in(role)) }
 
   scope :published, -> { joins(:definition).merge(Hmis::Form::Definition.published) }
+  scope :published_or_retired, -> { joins(:definition).merge(Hmis::Form::Definition.published_or_retired) }
 
   # Find instances that are for a specific Project
   scope :for_project, ->(project_id) { for_projects.where(entity_id: project_id) }

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -221,8 +221,10 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   def data_collection_features
     # Create OpenStruct for each enabled feature
     Hmis::Form::Definition::DATA_COLLECTION_FEATURE_ROLES.map do |role|
-      # To discuss: We don't currently support retiring forms, but if we do, this would break in a way that we might not catch right away.
-      # What's the most graceful way to future proof this? e.g. published_or_retired scope; reuse valid_status_for_submit?
+      # We don't currently support fully retiring forms (form definition gets retired with no newer published version).
+      # But if we do in the future, this should return instances for retired forms, same as it returns inactive instances.
+      # In https://github.com/open-path/Green-River/issues/6159 we outline switching this to always show a feature if
+      # there is any data for it, in addition to checking the form rules.
       base_scope = Hmis::Form::Instance.with_role(role).published_or_retired
       # Service instances must specify a service type or category.
       base_scope = base_scope.for_services if role == :SERVICE

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -223,7 +223,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     Hmis::Form::Definition::DATA_COLLECTION_FEATURE_ROLES.map do |role|
       # To discuss: We don't currently support retiring forms, but if we do, this would break in a way that we might not catch right away.
       # What's the most graceful way to future proof this? e.g. published_or_retired scope; reuse valid_status_for_submit?
-      base_scope = Hmis::Form::Instance.with_role(role).published
+      base_scope = Hmis::Form::Instance.with_role(role).published_or_retired
       # Service instances must specify a service type or category.
       base_scope = base_scope.for_services if role == :SERVICE
 

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       expect(selected_instances.size).to eq(0)
     end
 
+    it 'returns none if form is draft' do
+      create(:hmis_form_definition, role: :REFERRAL, identifier: 'bad-referral-form', status: :draft)
+      create(:hmis_form_instance, role: role, entity: nil, definition_identifier: 'bad-referral-form')
+      expect(selected_instances.size).to eq(0)
+    end
+
     it 'chooses default instance, prefers active > inactive' do
       default_inst = create(:hmis_form_instance, role: role, entity: nil)
       create(:hmis_form_instance, role: role, entity: nil, active: false) # not chosen
@@ -205,6 +211,13 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       doe_org = create(:hmis_form_instance, role: role, entity: project.organization, definition_identifier: doe_default.definition_identifier)
 
       expect(selected_instances).to contain_exactly(mid_project, doe_org)
+    end
+
+    it 'does not return draft forms, even for active instances' do
+      create(:hmis_form_definition, role: role, identifier: 'abc-assessment', status: :draft)
+      create(:hmis_form_instance, role: role, entity: project, definition_identifier: 'abc-assessment')
+
+      expect(selected_instances).to be_empty
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -82,6 +82,13 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       expect(selected_instances.size).to eq(0)
     end
 
+    it 'returns the instance if form is retired' do
+      create(:hmis_form_definition, role: role, identifier: 'fully-retired-form', status: :retired)
+      inst_for_retired = create(:hmis_form_instance, role: role, entity: nil, definition_identifier: 'fully-retired-form')
+
+      expect(selected_instances).to contain_exactly(inst_for_retired)
+    end
+
     it 'chooses default instance, prefers active > inactive' do
       default_inst = create(:hmis_form_instance, role: role, entity: nil)
       create(:hmis_form_instance, role: role, entity: nil, active: false) # not chosen

--- a/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_access_denied post_graphql(destination_project_id: source_project.id, source_enrollment_id: source_enrollment.id) { project_can_accept_referral_query }
     end
 
+    it 'raises an error when the referral form instance exists, but definition is a draft' do
+      create(:hmis_form_definition, role: :REFERRAL, identifier: 'bad-referral-form', status: :draft)
+      create(:hmis_form_instance, role: :REFERRAL, entity: source_project, definition_identifier: 'bad-referral-form')
+
+      expect_access_denied post_graphql(destination_project_id: source_project.id, source_enrollment_id: source_enrollment.id) { project_can_accept_referral_query }
+    end
+
     it 'raises an error when the user does not have can_manage_outgoing_referrals permission for the source project' do
       remove_permissions(access_control, :can_manage_outgoing_referrals)
       create_access_control(hmis_user, p1) # even when they have permissions at some other project


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
GH issue: https://github.com/open-path/Green-River/issues/6793

I searched for usages of the `FormInstance.with_role` scope to catch more places we need to add `.published` in order to return the correct set of forms. It's a followup to [this bugfix](https://github.com/greenriver/hmis-warehouse/pull/4793/files#diff-88f6bf8063dd5dfb242c415dbb41b8bd2d36fdb621d555ef684f15adf99a10c4R504). I didn't find exactly the 21 usages mentioned in the ticket, but here is a catalog of usages with my decisions and testing instructions:

`Instance.with_role` usages:
- [QueryType form_rules](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L451-L459) should continue to return all instances
- [QueryType client_detail_forms](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L501-L505) - this is the one that's fixed in the PR linked above.
- [PickListOption external_form_types_for_project](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/forms/pick_list_option.rb#L451-L460) updated in this PR
  - To test, go to the config tool and create a new external form type in draft. Add a rule enabling it in a project. Navigate to the project.
  - If it was the only external form rule for this project, then External Forms should not be available in the project left nav
  - If there is exactly one other, then navigating to External Forms for this project should auto-select that other one (and not show you a dropdown where you can select this one)
  - If there are multiple others, this one should not be present in the dropdown
- [PickListOption assessment_names_for_project](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/forms/pick_list_option.rb#L504-L519) - used for filtering existing assessments, so no change needed
- [HmisSchema::Project external_form_submissions](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/project.rb#L233-L247) - no change needed, since this is just used for getting the definition identifiers to look for. If the form is in draft, there wouldn't be any submissions, but if there were, it wouldn't be a bug to include them.
- [Project.receiving_referrals and receives_referrals](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/models/hmis/hud/project.rb#L137) - updated in this PR
  - To test, go to the admin UI and create a new Referral form type in draft. Add a rule enabling it in a project.
  - Go to a project that can make outgoing referrals and click New Referral. The project should not appear in the dropdown of available projects receiving referrals.
- [project.data_collection_features](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/models/hmis/hud/project.rb#L224) - updated in this PR, but see inline comment; let's discuss
  - To test, create a draft data collection feature form (for example, CLS or CE event) and add a rule to enable it in a project. Navigate to an enrollment dashboard in that project, you should not see the data collection feature in the left-hand nav.
- [project.occurrence_point_form_instances](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/models/hmis/hud/project.rb#L278) - updated in this PR
  - To test, create a draft Occurrence Point Form and add a rule enabling it in a project.
  - Visit an enrollment dashboard in that project. On release-137 you will see an error thrown, "Unable to load definition for instance". This is because we added the `published` scope [here in the `OccurrencePointForm` schema type](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/occurrence_point_form.rb#L29-L30), but didn't yet add it to the query for form instances. This branch fixes the issue. You should not see an error, and should also not see the draft occurrence point form.
  - We should either push this whole PR to release-137 or factor this specific change out into a separate PR so that it goes out with 137.

`Definition.with_role` usages:
- [QueryType static_form_definition](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L241-L248) - to discuss. Should we change this to use the published scope on Definition?
- [QueryType external_form_definition](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L412-L419) - I just removed the whole query, since it was deprecated on release-135
- [QueryType form_identifiers](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb#L439-L449) - `latest_versions` scope is already applied so this won't return duplicates. It should continue to return unpublished forms.
- [CreateFormDefinition mutation](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/graphql/mutations/create_form_definition.rb#L18) - no change needed since we are checking for duplicate identifiers, which should be unique regardless of publication status of the form
- [Definition for_project](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/models/hmis/form/definition.rb#L261-L263) and [definition_for_role](https://github.com/greenriver/hmis-warehouse/blob/release-137/drivers/hmis/app/models/hmis/form/definition.rb#L346-L349) already includes published scope

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
