### PR TITLE
Households are not getting counted in APR

### DIFF
--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -117,7 +117,7 @@ module HudReports::Households
     private def calculate_move_in_date(hh_id, she)
       move_in_date = she.move_in_date
       # If the move-in-date is valid, just use it
-      return move_in_date if move_in_date.present? && move_in_date >= she.first_date_in_program
+      return move_in_date if move_in_date.present? && move_in_date >= she.entry_date
 
       # Get HoH for further calculations
       household_members = households[hh_id]
@@ -134,12 +134,12 @@ module HudReports::Households
       # start date] <= head of household’s [housing move-in date]), the head of household’s [housing move-in date]
       # should be used as the individual’s [housing move-in date]. If the household member exited before the
       # household moved into housing, they do not inherit this [housing move-in date].
-      return hoh[:move_in_date] if (she.first_date_in_program..she.exit_date).include?(hoh[:move_in_date])
+      return hoh[:move_in_date] if (she.entry_date..she.exit_date).include?(hoh[:move_in_date])
 
       # When a household member joins the household after they are already housed (individual’s [project start
       # date] > head of household’s [housing move-in date]), the individual’s [project start date] should be used as
       # the individual’s [housing move-in date].
-      return she.first_date_in_program if she.first_date_in_program > hoh[:move_in_date]
+      return she.entry_date if she.entry_date > hoh[:move_in_date]
 
       # Otherwise this move-in is completely invalid
       nil

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -122,6 +122,7 @@ module HudReports::Households
       # Get HoH for further calculations
       household_members = households[hh_id]
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
+
       # HoH does not exist or does not have a move-in date - cannot do further calculations
       return nil unless hoh.present? && hoh[:move_in_date].present?
 

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -135,7 +135,7 @@ module HudReports::Households
       # start date] <= head of household’s [housing move-in date]), the head of household’s [housing move-in date]
       # should be used as the individual’s [housing move-in date]. If the household member exited before the
       # household moved into housing, they do not inherit this [housing move-in date].
-      return hoh[:move_in_date] if (she.entry_date..she.exit_date).include?(hoh[:move_in_date])
+      return hoh[:move_in_date] if (she.entry_date..she.exit_date).cover?(hoh[:move_in_date])
 
       # When a household member joins the household after they are already housed (individual’s [project start
       # date] > head of household’s [housing move-in date]), the individual’s [project start date] should be used as

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -115,18 +115,16 @@ module HudReports::Households
     end
 
     private def calculate_move_in_date(hh_id, she)
-      return nil unless she.move_in_date.present?
-
       move_in_date = she.move_in_date
       # If the move-in-date is valid, just use it
-      return move_in_date if move_in_date >= she.first_date_in_program
+      return move_in_date if move_in_date.present? && move_in_date >= she.first_date_in_program
 
       # If the client moved in before the entry date, and the HoH was present on the move-in date, use the
       # entry date as the move-in date.
       household_members = households[hh_id]
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
       return nil unless hoh.present?
-      return she.first_date_in_program if hoh[:entry_date] <= move_in_date
+      return she.first_date_in_program if hoh[:move_in_date].present? && hoh[:entry_date] <= (move_in_date || hoh[:move_in_date])
 
       # Otherwise this move-in is completely invalid
       nil
@@ -163,6 +161,7 @@ module HudReports::Households
               # Include dates for determining if someone was present at assessment date
               entry_date: enrollment.first_date_in_program,
               exit_date: enrollment.last_date_in_program,
+              move_in_date: enrollment.move_in_date,
             }.with_indifferent_access
           end
         end

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -122,7 +122,7 @@ module HudReports::Households
       # Get HoH for further calculations
       household_members = households[hh_id]
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
-      # HoH does not exist - cannot do further calculations
+      # HoH does not exist or does not have a move-in date - cannot do further calculations
       return nil unless hoh.present? && hoh[:move_in_date].present?
 
       # [Handling Housing Move-In Dates] - https://files.hudexchange.info/resources/documents/HMIS-Standard-Reporting-Terminology-Glossary-2024.pdf
@@ -134,7 +134,7 @@ module HudReports::Households
       # start date] <= head of household’s [housing move-in date]), the head of household’s [housing move-in date]
       # should be used as the individual’s [housing move-in date]. If the household member exited before the
       # household moved into housing, they do not inherit this [housing move-in date].
-      return hoh[:move_in_date] if she.first_date_in_program <= hoh[:move_in_date]
+      return hoh[:move_in_date] if (she.first_date_in_program..she.exit_date).include?(hoh[:move_in_date])
 
       # When a household member joins the household after they are already housed (individual’s [project start
       # date] > head of household’s [housing move-in date]), the individual’s [project start date] should be used as

--- a/app/models/grda_warehouse/tasks/service_history/enrollment.rb
+++ b/app/models/grda_warehouse/tasks/service_history/enrollment.rb
@@ -60,7 +60,11 @@ module GrdaWarehouse::Tasks::ServiceHistory
     end
 
     def invalidate_source_data!
-      update(processed_as: nil)
+      if self.HouseholdID.present?
+        self.class.where(data_source_id: data_source_id, HouseholdID: self.HouseholdID).update_all(processed_as: nil)
+      else
+        update(processed_as: nil)
+      end
     end
 
     def service_history_valid?

--- a/app/models/grda_warehouse/tasks/service_history/enrollment.rb
+++ b/app/models/grda_warehouse/tasks/service_history/enrollment.rb
@@ -60,6 +60,7 @@ module GrdaWarehouse::Tasks::ServiceHistory
     end
 
     def invalidate_source_data!
+      # Invalidate all enrollments for this household if this enrollment is being invalidated
       if self.HouseholdID.present?
         self.class.where(data_source_id: data_source_id, HouseholdID: self.HouseholdID).update_all(processed_as: nil)
       else

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/base.rb
@@ -578,11 +578,12 @@ module HudApr::Generators::Shared::Fy2024
           # enrollment.last_date_in_program ||= hoh_enrollment&.last_date_in_program
           enrolled = if enrollment.project_type.in?([3, 13]) || enrollment.enrollment.project.pay_for_success?
             # PSH/RRH OR project type 7 (other) with Funder 35 (Pay for Success)
+            move_in_date = calculate_move_in_date(enrollment.household_id, enrollment)
             enrollment.first_date_in_program <= pit_date &&
               (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) && # Exclude exit date
-              enrollment.move_in_date.present? && # Check that move in date is present and is before the PIT data and on or after the entry date
-              enrollment.move_in_date <= pit_date &&
-              enrollment.move_in_date >= enrollment.first_date_in_program
+              move_in_date.present? && # Check that move in date is present and is before the PIT data and on or after the entry date
+              move_in_date <= pit_date &&
+              move_in_date >= enrollment.first_date_in_program
           elsif enrollment.project_type.in?([0, 1, 2, 8, 9, 10]) # Other residential
             enrollment.first_date_in_program <= pit_date &&
               (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) # Exclude exit date
@@ -600,7 +601,7 @@ module HudApr::Generators::Shared::Fy2024
             last_date_in_program: enrollment.last_date_in_program,
             project_type: enrollment.project_type,
             project_tracking_method: enrollment.project_tracking_method,
-            move_in_date: enrollment.move_in_date,
+            move_in_date: calculate_move_in_date(enrollment.household_id, enrollment),
             relationship_to_hoh: enrollment.enrollment.relationship_to_hoh,
           }
         end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Update the HH Move In Date calculation so it doesn't leave out HH members without a move in date and instead correctly calculates and uses the HH move in date based on the entrry date & HoH move in date.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [X] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)
