### PR TITLE
Allow bulk reviewed submissions to succeed even when others fail

### DIFF
--- a/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
@@ -64,6 +64,12 @@ module Mutations
         base_message = "Bulk review failed on #{failed_to_review.size} of #{submissions.size} records."
         error_message = base_message + "\n" + failed_to_review.map { |id, message| "\tSubmission #{id}: #{message}" }.join("\n")
         display_message = base_message + ' This may indicate that the following submissions are spam: ' + failed_to_review.keys.join(', ')
+
+        # Raise, instead of returning a ValidationError, so we will get notified in Sentry, since either a bug with
+        # our implementation or an influx of spam would be interesting for us to get notified about.
+        # If this gets extremely noisy due to spam, we might be tempted to turn off the Sentry error and return a
+        # ValidationError instead. If we do that, we should take care to *keep* Sentry errors on for invalid
+        # client/enrollment errors (that would indicate an implementation problem and not bad/spammy data).
         raise HmisErrors::ApiError.new(error_message, display_message: display_message)
       end
 

--- a/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
@@ -43,14 +43,14 @@ module Mutations
 
         record.form_processor.save!
         record.save!
-      rescue StandardError => e # does it make sense to rescue all StandardError here or be specific?
+      rescue StandardError => e
         failed_to_review[record.id] = e.message
       end
 
       if failed_to_review.any?
         base_message = "Bulk review failed on #{failed_to_review.size} of #{submissions.size} records."
         error_message = base_message + "\n" + failed_to_review.map { |id, message| "\tSubmission #{id}: #{message}" }.join("\n")
-        display_message = base_message + ' This may indicate that the following submissions are spam: ' + failed_to_review.keys.join(', ')
+        display_message = base_message + ' This may indicate that the following submissions are spam, or have already been reviewed: ' + failed_to_review.keys.join(', ')
         raise HmisErrors::ApiError.new(error_message, display_message: display_message)
       end
 

--- a/drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb
@@ -54,10 +54,15 @@ RSpec.describe 'Bulk Review External Submission', type: :request do
       and not_change(Hmis::Hud::Enrollment, :count)
   end
 
-  it 'throws an error on already-reviewed submissions' do
+  it 'ignores already-reviewed submissions' do
     s1.status = 'reviewed'
     s1.save!
-    expect_gql_error perform_mutation
+    expect do
+      response, result = perform_mutation
+      expect(response.status).to eq(200), result.inspect
+      s1.reload
+    end.to not_change(s1, :status).
+      and not_change(s1, :updated_at)
   end
 
   it 'throws an error when submissions are from different forms' do
@@ -66,21 +71,16 @@ RSpec.describe 'Bulk Review External Submission', type: :request do
     expect_gql_error perform_mutation(ids: [s1.id, s2.id, other_submission.id])
   end
 
-  context 'when some submissions fail but others are fine' do
-    let!(:s3) { create(:hmis_external_form_submission, status: 'reviewed', definition: definition, raw_data: { 'your_name' => 'Barry' }) }
-    let!(:s4) { create(:hmis_external_form_submission, definition: definition, raw_data: { 'some_invalid_key' => 'Bad data!' }) }
+  context 'when some submissions are invalid but others are fine' do
+    let!(:s3) { create(:hmis_external_form_submission, definition: definition, raw_data: { 'some_invalid_key' => 'Bad data!' }) }
 
     it 'succeeds with the non-problematic submissions' do
       expect do
-        expect_gql_error perform_mutation(ids: [s1.id, s2.id, s3.id, s4.id]), message: /Bulk review failed on 2 of 4 records./
-        s1.reload
-        s2.reload
-        s3.reload
-        s4.reload
+        expect_gql_error perform_mutation(ids: [s1.id, s2.id, s3.id]), message: /Bulk review failed on 1 of 3 records./
+        [s1, s2, s3].map(&:reload)
       end.to change(s1, :status).from('new').to('reviewed').
         and change(s2, :status).from('new').to('reviewed').
-        and not_change(s3, :status).
-        and not_change(s4, :status)
+        and not_change(s3, :status)
     end
   end
 
@@ -128,6 +128,19 @@ RSpec.describe 'Bulk Review External Submission', type: :request do
       expect(s2.enrollment.client.first_name).to eq('Apples')
     end
 
+    context 'when some submissions are invalid but others are fine' do
+      let!(:s3) { create(:hmis_external_form_submission, definition: definition, raw_data: { 'Client.veteranStatus' => 'foobar' }) }
+
+      it 'succeeds with the non-problematic submissions' do
+        expect do
+          expect_gql_error perform_mutation(ids: [s1.id, s2.id, s3.id]), message: /Bulk review failed on 1 of 3 records./
+          [s1, s2, s3].map(&:reload)
+        end.to change(s1, :status).from('new').to('reviewed').
+          and change(s2, :status).from('new').to('reviewed').
+          and not_change(s3, :status)
+      end
+    end
+
     context 'when a submission in the list already has an enrollment' do
       let!(:c1) { create :hmis_hud_client, data_source: ds1, user: u1, first_name: 'Apples' }
       let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1 }
@@ -136,7 +149,7 @@ RSpec.describe 'Bulk Review External Submission', type: :request do
       it 'throws an error and does not process' do
         expect do
           response, result = perform_mutation(ids: [s3.id])
-          expect(response.status).to eq(500), result.inspect
+          expect(response.status).to eq(200), result.inspect
           s3.reload
         end.to not_change(s3, :status).
           and not_change(Hmis::Hud::Client, :count).


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

GH issue: https://github.com/open-path/Green-River/issues/6744

Previous behavior: If any submission failed bulk review, all the submissions in that batch would fail (keeping their 'new' status), and the user would not know which submission(s) caused the failure.

New behavior: If any submission fails in bulk review, the other submissions still succeed. The user gets an error message telling them which submissions they might want to consider investigating and marking as spam.

How to test: I ran the following in my local shell,
```
s = HmisExternalApis::ExternalForms::FormSubmission.where(status: 'new').last
s.raw_data = {"invalid key"=>"bad value"}
s.save!
```
This causes the submission to fail review in the External Form Submission UI.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Existing feature improvement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
