### PR TITLE
Make form def id in custom case note nullable

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1962,7 +1962,7 @@ type CustomCaseNote {
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
   enrollment: Enrollment!
-  formDefinitionId: ID!
+  formDefinitionId: ID
   id: ID!
   informationDate: ISO8601Date
   user: ApplicationUser

--- a/drivers/hmis/app/graphql/types/hmis_schema/custom_case_note.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/custom_case_note.rb
@@ -17,7 +17,7 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :content, String, null: false
     field :information_date, GraphQL::Types::ISO8601Date, null: true
-    field :form_definition_id, ID, null: false
+    field :form_definition_id, ID, null: true
     custom_data_elements_field
 
     def enrollment


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Bugfix followup to https://github.com/open-path/Green-River/issues/6779; see https://greenriver.slack.com/archives/C061SAW3LFJ/p1728675727245539

To test, I went in my local DB and deleted the definition ID from a case note form processor. But I think that to test on QA we should verify that the case note in the linked thread no longer throws an error.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
