### PR TITLE
Fix assessment-related test failures on 136

### DIFF
--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -114,6 +114,14 @@ FactoryBot.define do
               field_name: 'exitDate',
             },
           },
+          {
+            type: 'CHOICE',
+            link_id: 'exit_destination',
+            mapping: {
+              record_type: 'EXIT',
+              field_name: 'destination',
+            },
+          },
         ],
       }
     end

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:a1) { create :hmis_custom_assessment, data_source: ds1, enrollment: e1, data_collection_stage: 3 }
     let!(:a2) { create :hmis_custom_assessment, data_source: ds1, enrollment: e2, data_collection_stage: 3 }
     let!(:a3) { create :hmis_custom_assessment, data_source: ds1, enrollment: e3, data_collection_stage: 3 }
-    let(:definition) { Hmis::Form::Definition.find_by(role: :EXIT) }
+    let!(:definition) { create :hmis_exit_assessment_definition }
     let(:input) do
       {
         submissions: submission_input(a1, a2, a3),

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:a1) { create :hmis_custom_assessment, data_source: ds1, enrollment: e1, data_collection_stage: 1 }
     let!(:a2) { create :hmis_custom_assessment, data_source: ds1, enrollment: e2, data_collection_stage: 1 }
     let!(:a3) { create :hmis_custom_assessment, data_source: ds1, enrollment: e3, data_collection_stage: 1 }
-    let(:definition) { Hmis::Form::Definition.find_by(role: :INTAKE) }
+    let!(:definition) { create :hmis_intake_assessment_definition }
     let(:input) do
       {
         submissions: submission_input(a1, a2, a3),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes test failures: https://github.com/greenriver/hmis-warehouse/actions/runs/11309250113/job/31452914339?pr=4762 which were introduced in release-136.

I don't know exactly what change introduced the test failures, but the problem was that it was relying on the pre-existence of a form definition that didn't exist in the test db. Instead, that definition should be created as part of the test.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Test bugfix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
