### PR TITLE
Roles UI

### DIFF
--- a/app/javascript/role_manager.js
+++ b/app/javascript/role_manager.js
@@ -85,7 +85,11 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
   }
 
   fetchColumnState() {
-    return JSON.parse(window.localStorage.getItem(this.columnStateKey))
+    try {
+      return JSON.parse(window.localStorage.getItem(this.columnStateKey));
+    } catch (error) {
+      console.error('Error parsing localStorage item:', error);
+    }
   }
 
   toggleAdmin(e) {

--- a/app/javascript/role_manager.js
+++ b/app/javascript/role_manager.js
@@ -157,17 +157,18 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
     let changed = 0
     $.each(this.currentState, (key, value) => {
       const input = $(`input[name="${key}"]`)
-      const input_wrapper = input.closest('.form-check')
+      const input_status = input.closest('.form-check').find('.input-status')
+      const dirty_note = '<div class="dirty-note d-flex"><div class="ml-auto"><i>change pending</i></div></div>';
       if (this.initialState[key] != value) {
         changed += 1
         input.addClass('dirty')
         // ensure we only get the pending note once
-        input_wrapper.find('.dirty-note').remove()
-        input_wrapper.append('<div class="dirty-note d-flex"><div class="ml-auto"><i>change pending</i></div></div>')
+        input_status.find('.dirty-note').remove()
+        input_status.append(dirty_note)
       }
       else {
         input.removeClass('dirty')
-        input_wrapper.find('.dirty-note').remove()
+        input_status.find('.dirty-note').remove()
       }
     })
     if (changed == 0) {

--- a/app/javascript/role_manager.js
+++ b/app/javascript/role_manager.js
@@ -31,7 +31,6 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
     this.columnStateKey = 'roleManagerState'
     this.enabledColumns = []
     this.enabledColumns = this.setInitialColumns()
-    console.log(this.enabledColumns);
 
     this.setInitialState()
   }
@@ -60,6 +59,7 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
 
     // toggle the visibility of the associated roleColumn
     if($(input).val() == 'show') {
+      // add this role to the visible columns
       this.enabledColumns.push(target_role)
       this.roleColumnTargets.forEach((column) => {
         if (target_role == $(column).data('roleManagerRoleValue')) {
@@ -69,8 +69,8 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
         this.showSearchPermissions(search_string, false)
       });
     } else {
-      //FIXME: this isn't correctly removing the target role
-      this.enabledColumns = this.enabledColumns.splice(this.enabledColumns.indexOf(target_role), 1)
+      // remove this role from the visible columns
+      this.enabledColumns = this.enabledColumns.filter(element => element !== target_role)
       this.roleColumnTargets.forEach((column) => {
         if (target_role == $(column).data('roleManagerRoleValue')) {
           $(column).addClass('hide')
@@ -82,6 +82,10 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
 
   storeColumnState() {
     window.localStorage.setItem(this.columnStateKey, JSON.stringify(this.enabledColumns));
+  }
+
+  fetchColumnState() {
+    return JSON.parse(window.localStorage.getItem(this.columnStateKey))
   }
 
   toggleAdmin(e) {
@@ -151,13 +155,18 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
 
   // enable columns that were previously enabled
   setInitialColumns() {
-    let visibleColumns = JSON.parse(window.localStorage.getItem(this.columnStateKey)) || $(this.roleToggleTargets).map((i) => {
+    let visibleColumns = this.fetchColumnState() || $(this.roleToggleTargets).map((i) => {
+      // by default, show the first 3 roles
+      // this is slightly awkward because we only work on the "show" input, and calculate the
+      // state for the "hide" input, so we ignore odd values
       if(i > 5 || i % 2 == 1) {
         return
       }
       return this.valueForTarget(this.roleToggleTargets[i])
     }).get()
     $(this.roleToggleTargets).each((i) => {
+      // this is slightly awkward because we only work on the "show" input, and calculate the
+      // state for the "hide" input, so we ignore odd values
       if (i % 2 == 1) {
         return
       }
@@ -177,7 +186,6 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
     const inputs = $(this.roleColumnTargets).find('input')
     $(inputs).each((i) => {
       const input = inputs[i]
-      // console.log(inputs[i])
       if ($(input).is(':checked')) {
         variable[$(input).attr('name')] = '1'
       } else {
@@ -213,14 +221,14 @@ App.StimulusApp.register('role-manager', class extends Stimulus.Controller {
       }
     })
     if (changed == 0) {
-      $(this.changeCountTarget).text('')
-      $(this.changeButtonTarget).addClass('hide')
+      $(this.changeCountTargets).text('')
+      $(this.changeButtonTargets).addClass('hide')
     } else if (changed == 1) {
-      $(this.changeCountTarget).text(`${changed} change pending`)
-      $(this.changeButtonTarget).removeClass('hide')
+      $(this.changeCountTargets).text(`${changed} change pending`)
+      $(this.changeButtonTargets).removeClass('hide')
     } else {
-      $(this.changeCountTarget).text(`${changed} changes pending`)
-      $(this.changeButtonTarget).removeClass('hide')
+      $(this.changeCountTargets).text(`${changed} changes pending`)
+      $(this.changeButtonTargets).removeClass('hide')
     }
   }
 });

--- a/app/views/admin/roles/_role_column.haml
+++ b/app/views/admin/roles/_role_column.haml
@@ -31,6 +31,7 @@
             - if permission[:description]
               .ml-6
                 %small.form-text= permission[:description]
+            .input-status{ style: 'height: 2em' }
 
       -# = f.input key, label: label, hint: permission.try(:[], :description)
   = render 'common/panel_collapse', id: category_slug, title: category, content: "_#{category_slug}", wrapper_class: '', arrow_icon: 'icon-angle', heading_data: { action: 'role-manager#toggleSection', 'role-manager' => { target: 'permissionCategory', 'category-value' => category_value }}

--- a/app/views/admin/roles/_role_manager.haml
+++ b/app/views/admin/roles/_role_manager.haml
@@ -32,15 +32,9 @@
           - @roles.each.with_index do |role, i|
             - role_color_class = "role-color-#{i+1 % 50}"
             - show = nil
-            - hide = nil
             - show_class = nil
-            - hide_class = nil
-            - if i < 3
-              - show = :checked
-              - show_class = :active
-            - else
-              - hide = :checked
-              - hide_class = :active
+            - hide = :checked
+            - hide_class = :active
             %li.list-group-item.d-flex{ class: role_color_class }
               .btn-group.btn-group-toggle{data: {toggle: :buttons}, aria: {label: "Toggle #{role.name} visibility"}}
                 %label.btn.btn-secondary.btn-xs{class: show_class, data: { 'role-manager' => { target: 'roleToggle', 'role-value' => role.id }, action: 'click->role-manager#toggleColumn'}}
@@ -56,7 +50,7 @@
         .d-flex
           - @roles.each.with_index do |role, i|
             - role_color_class = "role-color-#{i+1 % 50}"
-            - show_class = if i < 3 then nil else :hide end
+            - show_class = :hide
             .role-column{class: show_class, data: { 'role-manager' => { target: 'roleColumn', 'role-value' => role.id }}}
               .role-name-header.role-column.d-flex{class: [show_class, role_color_class], data: { 'role-manager' => { target: 'roleColumn', 'role-value' => role.id }}}
                 %h3= role.name

--- a/app/views/admin/roles/_role_manager.haml
+++ b/app/views/admin/roles/_role_manager.haml
@@ -55,3 +55,6 @@
               .role-name-header.role-column.d-flex{class: [show_class, role_color_class], data: { 'role-manager' => { target: 'roleColumn', 'role-value' => role.id }}}
                 %h3= role.name
               = render 'admin/roles/role_column', role: role, permissions: permissions
+    .d-flex.w-100.p-2
+      .form-change-count.mr-4.my-auto.ml-auto{ data: { 'role-manager' => { target: 'changeCount' }}}
+      .mr-2.my-auto.hide{ data: { 'role-manager' => { target: 'changeButton' }}}= f.submit 'Save Changes', class: 'btn btn-sm'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Fixes some oddities of the role manager UI:
- When you change a permission, the column no longer gets shifted because of the changed indicator
- State of visible columns is now stored in the cookie and will persist
- There is a new button at the bottom of the page to save changes so you don't have to scroll back up

I'm very open to any yak shaving of the JS code, it is functional, but could definitely be more clear.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Feature Update

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
