### PR TITLE
Prevent failure from duplicate rows in a batch on import

### DIFF
--- a/app/models/grda_warehouse/tasks/identify_duplicates.rb
+++ b/app/models/grda_warehouse/tasks/identify_duplicates.rb
@@ -90,7 +90,7 @@ module GrdaWarehouse::Tasks
           )
         end
         GrdaWarehouse::Hud::Client.import(
-          destination_client_updates,
+          destination_client_updates.index_by { |m| m[:id] }.values, # index to ensure no duplicate rows
           on_duplicate_key_update: {
             conflict_target: [:id],
             columns: [:SSN, :DOB],

--- a/app/models/grda_warehouse/tasks/identify_duplicates.rb
+++ b/app/models/grda_warehouse/tasks/identify_duplicates.rb
@@ -90,7 +90,7 @@ module GrdaWarehouse::Tasks
           )
         end
         GrdaWarehouse::Hud::Client.import(
-          destination_client_updates.index_by { |m| m[:id] }.values, # index to ensure no duplicate rows
+          destination_client_updates.uniq { |m| m[:id] }, # ensure no duplicate rows
           on_duplicate_key_update: {
             conflict_target: [:id],
             columns: [:SSN, :DOB],


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
[Fixes an issue](https://green-river.sentry.io/issues/5995418503/?referrer=slack&notification_uuid=11c832dc-cfa4-434f-84dc-a028f2c8dd29&environment=production&alert_rule_id=12523843&alert_type=issue) in identify duplicates when the destination client is included twice in the batch.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
