### PR TITLE
Add additional triggers for ServiceHistoryEnrollment processing

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -386,6 +386,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   private def warehouse_columns_changed?
+    # Re-process when there are changes to any fields used in GrdaWarehouse::Tasks::IdentifyDuplicates.match_existing
     (saved_changes.keys & ['FirstName', 'LastName', 'DOB', 'SSN', 'DateDeleted']).any?
   end
 

--- a/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
+++ b/drivers/hmis/app/models/hmis/hud/current_living_situation.rb
@@ -33,6 +33,7 @@ class Hmis::Hud::CurrentLivingSituation < Hmis::Hud::Base
   end
 
   private def warehouse_columns_changed?
+    # Re-process when there are changes to any fields used in GrdaWarehouse::Tasks::ServiceHistory rebuild_service_history
     (saved_changes.keys & ['InformationDate', 'DateDeleted']).any?
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -428,7 +428,16 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   end
 
   private def warehouse_columns_changed?
-    (saved_changes.keys & ['EntryDate', 'ProjectID', 'DateDeleted']).any?
+    # Re-process when there are changes to any fields used in GrdaWarehouse::Tasks::ServiceHistory rebuild_service_history
+    (saved_changes.keys & [
+      'EntryDate',
+      'ProjectID', # If Enrollment was moved from WIP=>non-WIP, or moved to a different Project
+      'HouseholdID', # If Enrollment was moved to a different Household
+      'RelationshipToHoH',
+      'MoveInDate',
+      'LivingSituation',
+      'DateDeleted',
+    ]).any?
   end
 
   include RailsDrivers::Extensions

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -40,6 +40,7 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
   end
 
   private def warehouse_columns_changed?
-    (saved_changes.keys & ['ExitDate', 'DateDeleted']).any?
+    # Re-process when there are changes to any fields used in GrdaWarehouse::Tasks::ServiceHistory rebuild_service_history
+    (saved_changes.keys & ['ExitDate', 'Destination', 'HousingAssessment', 'DateDeleted']).any?
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/service.rb
+++ b/drivers/hmis/app/models/hmis/hud/service.rb
@@ -45,6 +45,7 @@ class Hmis::Hud::Service < Hmis::Hud::Base
   end
 
   private def warehouse_columns_changed?
+    # Re-process when there are changes to any fields used in GrdaWarehouse::Tasks::ServiceHistory rebuild_service_history
     (saved_changes.keys & ['DateProvided', 'RecordType', 'TypeProvided', 'DateDeleted']).any?
   end
 end

--- a/drivers/hmis/spec/models/hmis/hud/service_history_processing_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/service_history_processing_spec.rb
@@ -1,0 +1,155 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../requests/hmis/login_and_permissions'
+require_relative '../../../support/hmis_base_setup'
+
+RSpec.describe 'ServiceHistory processing', type: :model do
+  include_context 'hmis base setup'
+
+  context 'Enrollment fields' do
+    let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: ds1) }
+    let!(:enrollment) { create(:hmis_hud_enrollment, data_source: ds1, project: p1, client: client, entry_date: 1.month.ago) }
+
+    before(:each) do
+      enrollment.update!(processed_as: 'PROCESSED', processed_hash: 'PROCESSED')
+      Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment').delete_all
+    end
+
+    context 'for open Enrollment' do
+      [
+        # fields that SHOULD trigger re-processing
+        ['EntryDate', 1.week.ago],
+        ['MoveInDate', 1.week.ago],
+        ['RelationshipToHoH', 99],
+        ['LivingSituation', 101],
+        ['HouseholdID', 'newhouseholdid'],
+        ['DateDeleted', Time.current],
+      ].each do |field, value|
+        it "change to Enrollment.#{field} triggers service history processing" do
+          enrollment.assign_attributes(field => value)
+
+          expect do
+            enrollment.save!
+            enrollment.reload
+          end.to change { enrollment.processed_as }.from('PROCESSED').to(nil).
+            and change { enrollment.processed_hash }.from('PROCESSED').to(nil).
+            and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
+        end
+      end
+
+      [
+        # fields that should NOT trigger re-processing
+        ['DateOfEngagement', 1.week.ago],
+        ['DisablingCondition', 8],
+      ].each do |field, value|
+        it "change to Enrollment.#{field} does not triggers service history processing" do
+          enrollment.assign_attributes(field => value)
+
+          expect do
+            enrollment.save!
+            enrollment.reload
+          end.to not_change { enrollment.processed_as }.
+            and not_change { enrollment.processed_hash }.
+            and not_change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count)
+        end
+      end
+    end
+
+    context 'for WIP Enrollment' do
+      let!(:enrollment) { create(:hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: client, processed_hash: 'abcde', processed_as: 'fghijk') }
+
+      it 'saving as non-WIP triggers service history processing' do
+        expect do
+          enrollment.save_not_in_progress!
+          enrollment.reload
+        end.to change { enrollment.processed_as }.to(nil).
+          and change { enrollment.processed_hash }.to(nil).
+          and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
+      end
+    end
+
+    context 'for Exited Enrollment' do
+      let!(:exit_record) { create(:hmis_hud_exit, data_source: ds1, enrollment: enrollment, client: client, exit_date: 2.days.ago) }
+
+      before(:each) do
+        enrollment.update!(processed_as: 'PROCESSED', processed_hash: 'PROCESSED')
+        Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment').delete_all
+      end
+
+      [
+        ['ExitDate', 1.week.ago],
+        ['Destination', 30], # no exit interview
+        ['HousingAssessment', 2], # Moved to new housing unit
+        ['DateDeleted', Time.current],
+      ].each do |field, value|
+        it "change to Exit.#{field} triggers service history processing" do
+          exit_record.assign_attributes(field => value)
+
+          expect do
+            exit_record.save!
+            exit_record.reload
+          end.to change { enrollment.processed_as }.from('PROCESSED').to(nil).
+            and change { enrollment.processed_hash }.from('PROCESSED').to(nil).
+            and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
+        end
+      end
+    end
+
+    context 'for CurrentLivingSituation' do
+      let!(:current_living_situation) { create(:hmis_current_living_situation, data_source: ds1, enrollment: enrollment, client: client, information_date: 1.week.ago) }
+
+      before(:each) do
+        enrollment.update!(processed_as: 'PROCESSED', processed_hash: 'PROCESSED')
+        Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment').delete_all
+      end
+
+      [
+        ['InformationDate', 1.day.ago],
+        ['DateDeleted', Time.current],
+      ].each do |field, value|
+        it "change to #{field} triggers service history processing" do
+          current_living_situation.assign_attributes(field => value)
+
+          expect do
+            current_living_situation.save!
+            current_living_situation.reload
+          end.to change { enrollment.processed_as }.from('PROCESSED').to(nil).
+            and change { enrollment.processed_hash }.from('PROCESSED').to(nil).
+            and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
+        end
+      end
+    end
+
+    context 'for Service' do
+      let!(:service) { create(:hmis_hud_service, data_source: ds1, enrollment: enrollment, client: client, date_provided: 1.week.ago) }
+
+      before(:each) do
+        enrollment.update!(processed_as: 'PROCESSED', processed_hash: 'PROCESSED')
+        Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment').delete_all
+      end
+
+      [
+        ['DateProvided', 1.day.ago],
+        ['RecordType', 141],
+        ['TypeProvided', 2],
+        ['DateDeleted', Time.current],
+      ].each do |field, value|
+        it "change to #{field} triggers service history processing" do
+          service.assign_attributes(field => value)
+
+          expect do
+            service.save!(validate: false) # ignore invalid TypeProvided/RecordType combo
+            service.reload
+          end.to change { enrollment.processed_as }.from('PROCESSED').to(nil).
+            and change { enrollment.processed_hash }.from('PROCESSED').to(nil).
+            and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
+        end
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/service_history_processing_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/service_history_processing_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe 'ServiceHistory processing', type: :model do
     end
 
     context 'for WIP Enrollment' do
-      let!(:enrollment) { create(:hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: client, processed_hash: 'abcde', processed_as: 'fghijk') }
+      let!(:enrollment) { create(:hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: client) }
 
       it 'saving as non-WIP triggers service history processing' do
         expect do
           enrollment.save_not_in_progress!
           enrollment.reload
-        end.to change { enrollment.processed_as }.to(nil).
-          and change { enrollment.processed_hash }.to(nil).
+        end.to change { enrollment.processed_as }.from('PROCESSED').to(nil).
+          and change { enrollment.processed_hash }.from('PROCESSED').to(nil).
           and change(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Enrollment'), :count).by(1)
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Issue: https://github.com/open-path/Green-River/issues/6884

* Add a few missing fields to `warehouse_columns_changed?` methods. These are fields that are referenced by ServiceHistoryEnrollment rebuild task.
* This fixes bug whereby changing certain fields in HMIS, like Move-in Date, would not be propagated to ServiceHistoryEnrollments and thereby would not be displayed in reporting.
* Also add comments and tests

### How to test
- change move-in date
- see if SHE build is queued
- when SHE build is done processing, the local SHE record should have updated move-in date value. (find by "enrollment_group_id"==Enrollment.EnrollmentID)

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [na] If adding a new endpoint / exposing data in a new way, I have:
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
