### PR TITLE
Fix raise if submissions are from different forms

### DIFF
--- a/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_review_external_submissions.rb
@@ -15,7 +15,7 @@ module Mutations
 
       # Submissions could come from different definitions (versions), but should be all the same form identifier
       identifiers = definitions.pluck(:identifier).uniq
-      error_out('Cannot bulk process submissions from multiple form identifiers: ' + identifiers.inspect) unless identifiers.one?
+      raise "Cannot bulk process submissions from multiple form identifiers: #{identifiers}" unless identifiers.one?
 
       project = submissions.first.parent_project # can check first submission because we know they all have the same form identifier
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Fix bug where `error_out` was not defined. It is appropriate to raise here because the frontend should not support attempting to process submissions from different form types.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- n/a If adding a new endpoint / exposing data in a new way, I have:
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
