### PR TITLE
Remove can_manage_inventory permission

### DIFF
--- a/db/migrate/20241016202657_add_can_view_units_permission.rb
+++ b/db/migrate/20241016202657_add_can_view_units_permission.rb
@@ -2,6 +2,7 @@ class AddCanViewUnitsPermission < ActiveRecord::Migration[7.0]
   def up
     ::Hmis::Role.ensure_permissions_exist
     ::Hmis::Role.reset_column_information
+    ::Hmis::Role.where(can_manage_inventory: true).update_all(can_view_units: true, can_manage_units: true) if column_exists?(:hmis_roles, :can_manage_inventory)
   end
 
   def down

--- a/db/migrate/20241016202657_add_can_view_units_permission.rb
+++ b/db/migrate/20241016202657_add_can_view_units_permission.rb
@@ -2,7 +2,6 @@ class AddCanViewUnitsPermission < ActiveRecord::Migration[7.0]
   def up
     ::Hmis::Role.ensure_permissions_exist
     ::Hmis::Role.reset_column_information
-    ::Hmis::Role.where(can_manage_inventory: true).update_all(can_view_units: true, can_manage_units: true)
   end
 
   def down

--- a/db/migrate/20241028193644_remove_can_manage_inventory_permission.rb
+++ b/db/migrate/20241028193644_remove_can_manage_inventory_permission.rb
@@ -1,0 +1,13 @@
+class RemoveCanManageInventoryPermission < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      remove_column :hmis_roles, :can_manage_inventory
+    end
+  end
+
+  def down
+    # This won't really restore the column if it hasn't been added back in the rails code.
+    ::Hmis::Role.ensure_permissions_exist
+    ::Hmis::Role.reset_column_information
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1209,7 +1209,6 @@ CREATE TABLE public.hmis_roles (
     can_audit_clients boolean DEFAULT false NOT NULL,
     can_delete_clients boolean DEFAULT false NOT NULL,
     can_delete_assessments boolean DEFAULT false,
-    can_manage_inventory boolean DEFAULT false,
     can_manage_incoming_referrals boolean DEFAULT false,
     can_manage_outgoing_referrals boolean DEFAULT false,
     can_manage_denied_referrals boolean DEFAULT false,
@@ -5448,6 +5447,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241016202657'),
 ('20241018034506'),
 ('20241018140929'),
-('20241021194355');
-
-
+('20241021194355'),
+('20241028193644');

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9036,7 +9036,6 @@ type QueryAccess {
   canManageExternalFormSubmissions: Boolean!
   canManageForms: Boolean!
   canManageIncomingReferrals: Boolean!
-  canManageInventory: Boolean!
   canManageOutgoingReferrals: Boolean!
   canManageOwnClientFiles: Boolean!
   canManageScanCards: Boolean!

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -8584,7 +8584,6 @@ type ProjectAccess {
   canManageDeniedReferrals: Boolean!
   canManageExternalFormSubmissions: Boolean!
   canManageIncomingReferrals: Boolean!
-  canManageInventory: Boolean!
   canManageOutgoingReferrals: Boolean!
   canManageUnits: Boolean!
   canViewDob: Boolean!

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -99,7 +99,6 @@ module Types
       can :edit_enrollments
       can :delete_enrollments
       can :delete_assessments
-      can :manage_inventory
       can :manage_units
       can :view_units
       can :manage_incoming_referrals

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -155,13 +155,6 @@ class Hmis::Role < ::ApplicationRecord
         category: 'Project Access',
         sub_category: 'Management',
       },
-      can_manage_inventory: { # TODO: deprecated, remove in next release in favor of can_manage_units below
-        description: 'Ability to manage bed and unit capacity in the project. Deprecated in favor of "Can manage units" permission.',
-        administrative: false,
-        access: [:editable],
-        category: 'Project Access',
-        sub_category: 'Management',
-      },
       can_manage_units: {
         description: 'Ability to manage bed and unit capacity in the project',
         administrative: false,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

GH issue: https://github.com/open-path/Green-River/issues/6605

This follows up on the changes to unit management permissions deployed in release-138. It fully removes the `can_manage_inventory` permission/column.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
