### PR TITLE
Fix Hmis::File duplicate versions regression

### DIFF
--- a/drivers/hmis/app/models/hmis/file.rb
+++ b/drivers/hmis/app/models/hmis/file.rb
@@ -4,9 +4,12 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-class Hmis::File < GrdaWarehouse::File
+class Hmis::File < GrdaWarehouseBase
+  self.table_name = :files
   include ClientFileBase
   include ::Hmis::Hud::Concerns::FormSubmittable
+
+  acts_as_paranoid
   has_paper_trail(
     meta: {
       enrollment_id: :enrollment_id,
@@ -16,6 +19,12 @@ class Hmis::File < GrdaWarehouse::File
   )
 
   acts_as_taggable
+
+  # Need to set 'type' directly because we don't subclass GrdaWarehouse::File (because we needed to define has_paper_trail differently)
+  after_initialize :set_default_type, if: :new_record?
+  def set_default_type
+    self.type ||= self.class.sti_name
+  end
 
   # These are not used, they're here so that we won't get an error trying to get/set the data source
   attr_accessor :data_source_id
@@ -27,8 +36,6 @@ class Hmis::File < GrdaWarehouse::File
     :date_created,
     :date_updated,
   ].freeze
-
-  self.table_name = :files
 
   belongs_to :enrollment, class_name: '::Hmis::Hud::Enrollment', optional: true
   belongs_to :client, class_name: '::Hmis::Hud::Client'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Fix bug introduced to release-139 by https://github.com/greenriver/hmis-warehouse/pull/4857/files#r1819961086 whereby duplicate PaperTrail versions were created for `Hmis::File`s, because has_paper_trail was defined on the parent class too. This is currently causing test failures on CI.

See linked comment for full context

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
