### PR TITLE
Fix flaky system test, hopefully

### DIFF
--- a/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
+++ b/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
@@ -179,6 +179,7 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
 
         expect do
           save_ignoring_warnings
+          e1.reload # todo @martha - this is the test that fails but not locally
         end.to change(e1.income_benefits, :count).by(1)
 
         expect(e1.income_benefits.sole.total_monthly_income).to eq(500)

--- a/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
+++ b/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
     first(:button, 'Submit').click
     assert_text 'Ignore Warnings'
     click_button 'Confirm'
+    assert_text "#{c1.full_name} Assessments" # waits, so we can be sure the mutation completes before reloading
     e1.reload
   end
 
@@ -179,7 +180,6 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
 
         expect do
           save_ignoring_warnings
-          e1.reload # todo @martha - this is the test that fails but not locally
         end.to change(e1.income_benefits, :count).by(1)
 
         expect(e1.income_benefits.sole.total_monthly_income).to eq(500)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Recently added system tests started failing on release branch 140: https://github.com/greenriver/hmis-warehouse/actions/runs/11599354190/job/32297313736?pr=4876

The failure is flaky (see e.g. [this successful build](https://github.com/greenriver/hmis-warehouse/actions/runs/11600479696/job/32301008596?pr=4882) on the first commit in this PR, which was a dummy change; I also wasn't able to repro the failure locally). But I _think_ that forcing capybara to wait and make sure it sees a successful mutation response, before we make any assertions on the data changed in the backend, should help with the flakiness.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
