### PR TITLE
fix_db_prep_script_for_dev_env

### DIFF
--- a/bin/db_prep
+++ b/bin/db_prep
@@ -18,8 +18,8 @@ def db(db_section)
   @db ||=
     begin
       path = APP_ROOT.join( ENV.fetch("DB_YAML_PATH", "config/database.yml") ).to_s
-      env = ENV["RAILS_ENV"]
-      parsed = if Rails.env.development?
+      env = ENV["RAILS_ENV"].presence || 'development'
+      parsed = if env == 'development'
         YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)
       else
         YAML.load_file(path)

--- a/bin/db_prep
+++ b/bin/db_prep
@@ -20,7 +20,7 @@ def db(db_section)
       path = APP_ROOT.join( ENV.fetch("DB_YAML_PATH", "config/database.yml") ).to_s
       env = ENV["RAILS_ENV"]
       parsed = if Rails.env.development?
-        YAML.safe_load(ERB.new(File.read(Rails.root.join(path))).result, aliases: true)
+        YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)
       else
         YAML.load_file(path)
       end

--- a/bin/db_prep
+++ b/bin/db_prep
@@ -7,6 +7,7 @@ require 'pathname'
 require 'fileutils'
 require 'pg'
 require 'yaml'
+require 'erb'
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('..', __dir__)
@@ -18,7 +19,7 @@ def db(db_section)
   @db ||=
     begin
       path = APP_ROOT.join( ENV.fetch("DB_YAML_PATH", "config/database.yml") ).to_s
-      env = ENV["RAILS_ENV"].presence || 'development'
+      env = ENV["RAILS_ENV"] || 'development'
       parsed = if env == 'development'
         YAML.safe_load(ERB.new(File.read(path)).result, aliases: true)
       else

--- a/bin/db_prep
+++ b/bin/db_prep
@@ -19,7 +19,12 @@ def db(db_section)
     begin
       path = APP_ROOT.join( ENV.fetch("DB_YAML_PATH", "config/database.yml") ).to_s
       env = ENV["RAILS_ENV"]
-      YAML.load_file(path)[env]
+      parsed = if Rails.env.development?
+        YAML.safe_load(ERB.new(File.read(Rails.root.join(path))).result, aliases: true)
+      else
+        YAML.load_file(path)
+      end
+      parsed[env]
     end
 
   payload = {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

*Add support for irb and yaml aliases in our db prep script when running in  dev mode

Our dev setup script instructs us to run `bin/setup` which invokes `bin/db_prep`. However it seems like the db_prep script does not handle our current `config/database.yml` file which has aliases and irb interpolated values.

__Note:__ I'm not fixing the rubocop violations in the script to keep the diff small

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

