### PR TITLE
adjust-sentry-trace-rate-on-delayed-jobs

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -39,7 +39,13 @@ if sentry_dsn
             end
           when /delayed_job/
             # delayed job
-            1.0
+            case transaction_context[:name]
+            when 'Confidence::AddEnrollmentChangeHistoryJob'
+              # reduce rate on some jobs
+              0.001
+            else
+              1.0
+            end
           else
             0.0 # ignore all other transactions
           end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Confidence::AddEnrollmentChangeHistoryJob is using too much of our our sentry trace quota

NOTE: deployed to qa-hmis on 11/3 to keep preserve our quota

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

