### PR TITLE
Fix bug with display text on Prior Living Situation component

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/prior_living_situation_b.json
+++ b/drivers/hmis/lib/form_data/default/fragments/prior_living_situation_b.json
@@ -87,7 +87,6 @@
         {
           "type": "DISPLAY",
           "link_id": "q_3_917B_A",
-          "read_only": true,
           "text": "Client stayed 90+ days in an institutional setting. This is considered a \"break\" according to the HUD definition of chronic homelessness. Stopping data collection for 3.917 Prior Living Situation.",
           "readonly_text": "Client does not meet the HUD definition of chronic at entry.",
           "enable_behavior": "ALL",

--- a/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
+++ b/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
@@ -111,10 +111,10 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
 
         # Temporarily select 90+ days indicates 'break' in chronic homelessness
         mui_select '90 days or more but less than one year', from: 'Length of stay in prior living situation'
-        assert_text 'Client does not meet the HUD definition of chronic at entry.'
+        assert_text 'Client stayed 90+ days in an institutional setting. This is considered a "break" according to the HUD definition of chronic homelessness.'
 
         mui_select 'One month or more, but less than 90 days', from: 'Length of stay in prior living situation'
-        assert_no_text 'Client does not meet the HUD definition of chronic at entry.'
+        assert_no_text 'This is considered a "break" according to the HUD definition of chronic homelessness.'
         assert_text 'On the night before entering the Institutional/Temporary/Permanent/Other housing situation, did the client stay on the streets, ES or SH?'
 
         # Temporarily select YES to night-before question, to confirm form logic


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
I noticed this bug out of the corner of my eye while I was working on system tests (https://github.com/open-path/Green-River/issues/6806). It has since been on my list to investigate/confirm there is a bug and make a bugfix.

**To reproduce:** 
- Open an assessment that renders the more complex version of the Prior Living Situation HUD component (such as an intake in non-SO, ES, or SH projects). [QA example](https://qa-hmis.openpath.host/client/==RTE1YkNaQ0V1SHg5UFZ6NTFDd0NBdz09/enrollments/==OU1LRlRiRmY3YmcrZG1XTTk3UURmQT09/assessments/new/==V2pCMG1TdWNJZGFhOW1FdTFzK0RZQT09)
- Scroll to Prior Living Situation and select any Institutional Situation as the PLS
- For Length of Stay, select "90 days or more" or "One year or longer"
- You see text show up that says "Client does not meet the HUD definition of chronic at entry." This is the text that is only supposed to show up on the Read-Only view of this assessment, like when you've already submitted the intake. On the editable version of the assessment, the [more detailed text](https://github.com/greenriver/hmis-warehouse/blob/release-141/drivers/hmis/lib/form_data/default/fragments/prior_living_situation_b.json#L91) should appear.

**This PR:** removes the "readonly" flag added (probably erroneously?) to that form item, which was what was causing the readonly text to always appear even on editable forms. (You can see elsewhere in the json file that other similar display elements don't have this flag)

**Impact:** This is just a mistake in the instructional text we were showing to users. They should see the more detailed version. But it doesn't impact data collection in any way.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
