### PR TITLE
Fix missing Open HMIS link for some users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -181,7 +181,7 @@ class User < ApplicationRecord
   end
 
   def can_access_hmis_data_source?(data_source_id)
-    as_hmis_user&.data_source_ids&.include?(data_source_id)
+    as_hmis_user&.can_access_hmis_data_source?(data_source_id)
   end
 
   # list any cohort this user has some level of access to

--- a/drivers/hmis/app/models/hmis/group_viewable_entity.rb
+++ b/drivers/hmis/app/models/hmis/group_viewable_entity.rb
@@ -53,5 +53,14 @@ module Hmis
     scope :includes_entities, ->(entities) do
       where(id: Array(entities).flat_map { |entity| includes_entity(entity).pluck(:id) })
     end
+
+    scope :includes_any_entity_in_data_source, ->(data_source) do
+      project_ids = data_source.projects.select(:id)
+      organization_ids = data_source.organizations.select(:id)
+
+      where(entity: data_source).
+        or(where(entity_type: Hmis::Hud::Project.sti_name, entity_id: project_ids)).
+        or(where(entity_type: Hmis::Hud::Organization.sti_name, entity_id: organization_ids))
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -245,17 +245,20 @@ class Hmis::User < ApplicationRecord
     Hmis::Filter::ApplicationUserFilter.new(input).filter_scope(self)
   end
 
-  # list any data sources the user has some level of access to
-  def data_source_ids
-    ids_for_relations(:data_source_ids)
-  end
+  # Determine whether this user has _any_ access to a given HMIS data source.
+  # Returns true even if they can only access 1 project or org within the DS.
+  # This doesn't check for permissions (so, they don't necessarily have can_view_projects within the DS).
+  def can_access_hmis_data_source?(data_source_id)
+    @accessible_data_source_ids ||= {}
+    return @accessible_data_source_ids[data_source_id] if @accessible_data_source_ids.key?(data_source_id)
 
-  # memoize some id lookups to prevent N+1s (copied from warehouse User)
-  private def ids_for_relations(relation)
-    @ids_for_relations ||= {}
-    return @ids_for_relations[relation] if @ids_for_relations.key?(relation)
+    data_source = GrdaWarehouse::DataSource.hmis.find(data_source_id)
+    can_access_ds = Hmis::GroupViewableEntity.
+      where(collection_id: access_controls.pluck(:access_group_id)).
+      includes_any_entity_in_data_source(data_source).exists?
 
-    @ids_for_relations[relation] = access_groups.flat_map(&relation).uniq
-    @ids_for_relations[relation]
+    @accessible_data_source_ids[data_source_id] = can_access_ds
+
+    can_access_ds
   end
 end

--- a/drivers/hmis/spec/models/hmis/access_control_spec.rb
+++ b/drivers/hmis/spec/models/hmis/access_control_spec.rb
@@ -75,4 +75,53 @@ RSpec.describe Hmis::AccessControl, type: :model do
       expect(hmis_user.can_view_full_ssn_for?(p2)).to eq(false)
     end
   end
+
+  describe 'can_access_hmis_data_source? checker' do
+    let!(:ds2) { create :hmis_data_source } # add a second data source
+    let!(:ds2_organization) { create :hmis_hud_organization, data_source: ds2 }
+    let!(:ds2_project) { create :hmis_hud_project, data_source: ds2, organization: ds2_organization }
+
+    it 'is false when no access control is present' do
+      expect(hmis_user.can_access_hmis_data_source?(ds1.id)).to eq(false)
+    end
+
+    it 'is true when user has access to a project in the data source' do
+      create_access_control(hmis_user, p1)
+      expect(hmis_user.can_access_hmis_data_source?(ds1.id)).to eq(true)
+    end
+
+    it 'is true when user has access to an organization in the data source' do
+      create_access_control(hmis_user, o1)
+      expect(hmis_user.can_access_hmis_data_source?(ds1.id)).to eq(true)
+    end
+
+    it 'is true when user has access to the data source' do
+      create_access_control(hmis_user, ds1)
+      expect(hmis_user.can_access_hmis_data_source?(ds1.id)).to eq(true)
+    end
+
+    describe 'when there are multiple HMIS data sources' do
+      let!(:ds2) { create :hmis_data_source } # add a second data source
+      let!(:ds2_organization) { create :hmis_hud_organization, data_source: ds2 }
+      let!(:ds2_project) { create :hmis_hud_project, data_source: ds2, organization: ds2_organization }
+
+      it 'returns true for ds2 and false for ds1' do
+        create_access_control(hmis_user, ds2_project)
+
+        expect(hmis_user.can_access_hmis_data_source?(ds1.id)).to eq(false)
+        expect(hmis_user.can_access_hmis_data_source?(ds2.id)).to eq(true)
+      end
+
+      it 'does not re-calculate for the same ds' do
+        create_access_control(hmis_user, p1)
+        create_access_control(hmis_user, ds2_project)
+
+        expect { hmis_user.can_access_hmis_data_source?(ds2.id) }.to make_database_queries
+        expect { hmis_user.can_access_hmis_data_source?(ds2.id) }.not_to make_database_queries
+
+        expect { hmis_user.can_access_hmis_data_source?(ds1.id) }.to make_database_queries
+        expect { hmis_user.can_access_hmis_data_source?(ds1.id) }.not_to make_database_queries
+      end
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
This is a follow-up to https://github.com/greenriver/hmis-warehouse/pull/4745 which had the wrong logic. It was only showing "Open HMIS" link from the Warehouse if the user had any Access Control with a group that contained an entire Data Source. It _should_ show the link to a user that has access to ANY projects or orgs within the DS, which is what this change does.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## How to test
* impersonate a user that only has access to one project or org in hmis. they should see the Open HMIS link.

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- n/a If adding a new endpoint / exposing data in a new way, I have:
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
