### PR TITLE
Client Supplemental data bugfix

### DIFF
--- a/drivers/hmis_supplemental/app/controllers/hmis_supplemental/client_data_sets_controller.rb
+++ b/drivers/hmis_supplemental/app/controllers/hmis_supplemental/client_data_sets_controller.rb
@@ -39,9 +39,10 @@ module HmisSupplemental
     protected
 
     def source_clients
+      # order is important here, source_visible_to appears to clobber the data source condition
       @client.source_clients.
-        where(data_source_id: @data_set.data_source_id).
         source_visible_to(current_user).
+        where(data_source_id: @data_set.data_source_id).
         order(:id)
     end
 
@@ -55,20 +56,6 @@ module HmisSupplemental
 
     def load_authorized_data_set
       data_set_scope.find(params[:data_set_id])
-    end
-
-    def client_groups
-      # note: order is important here, source_visible_to appears to clobber the data source condition
-      clients = @client.source_clients.
-        source_visible_to(current_user).
-        where(data_source_id: @data_set.data_source_id).
-        order(:id)
-      clients.map do |client|
-        {
-          title: client.data_source.name,
-          values: @data_set.field_values.for_owner(@client).index_by(&:field_key),
-        }
-      end
     end
 
     def data_set_scope

--- a/drivers/hmis_supplemental/spec/requests/client_data_set_controller_spec.rb
+++ b/drivers/hmis_supplemental/spec/requests/client_data_set_controller_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe HmisSupplemental::ClientDataSetsController, type: :request do
+  let!(:user) { create :acl_user }
+  let(:user_group) { create(:user_group) }
+  let(:policy) { user.policy_for(destination_client) }
+  let(:collection) { create(:collection) }
+
+  let(:data_source) { create :source_data_source }
+  let(:source_client) { create :hud_client, data_source: data_source }
+  let(:project1) { create :grda_warehouse_hud_project, data_source: data_source }
+  let(:project2) { create :grda_warehouse_hud_project, data_source: data_source }
+  let!(:enrolment1) { create :hud_enrollment, data_source: data_source, client: source_client, project: project1 }
+  let!(:enrolment2) { create :hud_enrollment, data_source: data_source, client: source_client, project: project2 }
+
+  let(:data_source_other) { create :source_data_source }
+  let(:source_client_other) { create :hud_client, data_source: data_source_other }
+  let(:project_other) { create :grda_warehouse_hud_project, data_source: data_source_other }
+  let!(:enrolment_other) { create :hud_enrollment, data_source: data_source_other, client: source_client_other, project: project_other }
+
+  let!(:destination_data_source) { create :destination_data_source }
+  let!(:destination_client) { create :hud_client, data_source_id: destination_data_source.id }
+  let!(:warehouse_client) { create :warehouse_client, source_id: source_client.id, destination_id: destination_client.id }
+  let!(:warehouse_client_other) { create :warehouse_client, source_id: source_client_other.id, destination_id: destination_client.id }
+  let(:owner_type) { 'client' }
+  let(:data_set) { create(:hmis_supplemental_data_set, owner_type: owner_type, data_source: data_source) }
+
+  let(:role) do
+    create(
+      :admin_role,
+      can_view_supplemental_client_data: true,
+    )
+  end
+
+  before(:each) do
+    create(:access_control, role: role, collection: collection, user_group: user_group)
+    collection.set_viewables({ supplemental_data_sets: [data_set.id], data_sources: [data_source.id], projects: [project1.id, project2.id, project_other.id] })
+    sign_in(user)
+  end
+
+  context 'with access' do
+    before(:each) do
+      user_group.add(user)
+    end
+
+    it 'resolves one group for the client' do
+      get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
+
+      expect(response).to be_successful
+      expect(assigns(:groups)).to be_an(Array)
+      expect(assigns(:groups).first[:title]).to eq(data_source.name)
+      expect(assigns(:groups).size).to eq(1)
+    end
+
+    context 'with enrollment data set' do
+      let(:owner_type) { 'enrollment' }
+
+      it 'resolves one group for each enrollment' do
+        get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
+
+        expect(response).to be_successful
+        expect(assigns(:groups)).to be_an(Array)
+        expect(assigns(:groups).map { |h| h[:title] }).to include(
+          a_string_including(project1.name),
+          a_string_including(project2.name),
+        )
+        expect(assigns(:groups).size).to eq(2)
+      end
+    end
+  end
+
+  context 'without access' do
+    it 'denies access' do
+      get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/drivers/hmis_supplemental/spec/requests/client_data_set_controller_spec.rb
+++ b/drivers/hmis_supplemental/spec/requests/client_data_set_controller_spec.rb
@@ -2,16 +2,16 @@ require 'rails_helper'
 
 RSpec.describe HmisSupplemental::ClientDataSetsController, type: :request do
   let!(:user) { create :acl_user }
-  let(:user_group) { create(:user_group) }
   let(:policy) { user.policy_for(destination_client) }
-  let(:collection) { create(:collection) }
 
   let(:data_source) { create :source_data_source }
   let(:source_client) { create :hud_client, data_source: data_source }
   let(:project1) { create :grda_warehouse_hud_project, data_source: data_source }
   let(:project2) { create :grda_warehouse_hud_project, data_source: data_source }
+  let(:project3) { create :grda_warehouse_hud_project, data_source: data_source }
   let!(:enrolment1) { create :hud_enrollment, data_source: data_source, client: source_client, project: project1 }
   let!(:enrolment2) { create :hud_enrollment, data_source: data_source, client: source_client, project: project2 }
+  let!(:enrolment3) { create :hud_enrollment, data_source: data_source, client: source_client, project: project3 }
 
   let(:data_source_other) { create :source_data_source }
   let(:source_client_other) { create :hud_client, data_source: data_source_other }
@@ -25,22 +25,28 @@ RSpec.describe HmisSupplemental::ClientDataSetsController, type: :request do
   let(:owner_type) { 'client' }
   let(:data_set) { create(:hmis_supplemental_data_set, owner_type: owner_type, data_source: data_source) }
 
-  let(:role) do
-    create(
-      :admin_role,
-      can_view_supplemental_client_data: true,
-    )
-  end
+  let(:project_role) { create(:role, can_view_supplemental_client_data: true, can_view_clients: true) }
+  let(:project_user_group) { create(:user_group) }
+  let(:project_collection) { create(:collection) }
+
+  let(:ds_role) { create(:role, can_view_supplemental_client_data: true) }
+  let(:ds_user_group) { create(:user_group) }
+  let(:ds_collection) { create(:collection) }
 
   before(:each) do
-    create(:access_control, role: role, collection: collection, user_group: user_group)
-    collection.set_viewables({ supplemental_data_sets: [data_set.id], data_sources: [data_source.id], projects: [project1.id, project2.id, project_other.id] })
+    create(:access_control, role: project_role, collection: project_collection, user_group: project_user_group)
+    project_collection.set_viewables({ projects: [project1.id, project2.id, project_other.id] })
+
+    create(:access_control, role: ds_role, collection: ds_collection, user_group: ds_user_group)
+    ds_collection.set_viewables({ supplemental_data_sets: [data_set.id] })
+
     sign_in(user)
   end
 
-  context 'with access' do
+  context 'with project and data set access' do
     before(:each) do
-      user_group.add(user)
+      project_user_group.add(user)
+      ds_user_group.add(user)
     end
 
     it 'resolves one group for the client' do
@@ -69,7 +75,25 @@ RSpec.describe HmisSupplemental::ClientDataSetsController, type: :request do
     end
   end
 
-  context 'without access' do
+  context 'with only project set access' do
+    before(:each) do
+      project_user_group.add(user)
+      expect do
+        get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'with only data set access' do
+    before(:each) do
+      ds_user_group.add(user)
+      expect do
+        get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'without any access' do
     it 'denies access' do
       get hmis_supplemental_data_set_client_data_set_path(data_set, destination_client)
       expect(response).to redirect_to(root_path)

--- a/spec/factories/grda_warehouse/hud/grda_warehouse_hud_projects.rb
+++ b/spec/factories/grda_warehouse/hud/grda_warehouse_hud_projects.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :grda_warehouse_hud_project, class: 'GrdaWarehouse::Hud::Project' do
     data_source_id { 1 } # :data_source_fixed_id
     sequence(:ProjectID, 200)
+    sequence(:ProjectName) { |n| "Project#{n}" }
     DateCreated { Date.parse('2019-01-01') }
     DateUpdated { Date.parse('2019-01-01') }
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Looks like the previous bugfix wasn't correctly applied. Fix and add tests to prove it. We were still seeing the behavior of too many source clients shown on a the client data source

## Type of change
Bug fix

## testing
visit [QA client page](https://qa-warehouse.openpath.host/hmis_supplemental/data_sets/1/client_data_sets/19574). Should only one set of values for a given client in the data source 

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
