### PR TITLE
Fix spec test issuse

### DIFF
--- a/drivers/hmis/spec/system/hmis/data_collection_features_spec.rb
+++ b/drivers/hmis/spec/system/hmis/data_collection_features_spec.rb
@@ -145,6 +145,8 @@ RSpec.feature 'Data collection features', type: :system do
       click_button 'Edit'
       fill_in 'Note', with: 'An updated legacy custom case note'
       click_button 'Save'
+      assert_text 'Displaying 1 of 1 case note'
+      assert_no_text 'Edit Case Note'
       case_note.reload
       expect(case_note.content).to eq('An updated legacy custom case note')
     end

--- a/drivers/hmis/spec/system/hmis/form_spec.rb
+++ b/drivers/hmis/spec/system/hmis/form_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Hmis Form behavior', type: :system do
     end
 
     it 'warns you of empty fields that have warn_if_empty, but still lets you submit' do
-      fill_in 'A required field', with: 'tomatoes'
+      fill_in 'A required field', with: '2'
       click_button 'Submit'
       assert_text 'Please confirm the following warnings.'
       assert_text '1 field was left empty'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
This PR fixes the following two recently introduced issues with spec tests:
- drivers/hmis/spec/system/hmis/data_collection_features_spec.rb
  - This is a race condition with a similar fix to https://github.com/greenriver/hmis-warehouse/pull/4882
- drivers/hmis/spec/system/hmis/form_spec.rb
  - This recent change caused this test to start failing: https://github.com/greenriver/hmis-frontend/pull/978
  - Example failure: https://github.com/greenriver/hmis-warehouse/actions/runs/11781366100/job/32814164102?pr=4901

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Test bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
