### PR TITLE
fix performance issue on project names in report filters

### DIFF
--- a/app/models/concerns/filter/control_sections.rb
+++ b/app/models/concerns/filter/control_sections.rb
@@ -124,37 +124,37 @@ module
             id: 'coc_codes',
             label: 'CoC Codes',
             short_label: 'CoC',
-            value: @filter.chosen_coc_codes,
+            value: -> {  @filter.chosen_coc_codes },
           )
         end
         section.add_control(
           id: 'funding_sources',
-          value: @filter.funder_names,
+          value: -> { @filter.funder_names },
         )
         section.add_control(
           id: 'funding_other_sources',
-          value: @filter.funder_others,
+          value: -> { @filter.funder_others },
         )
         section.add_control(
           id: 'data_sources',
-          value: @filter.data_source_names,
+          value: -> { @filter.data_source_names },
         )
         section.add_control(
           id: 'organizations',
-          value: @filter.organization_names,
+          value: -> { @filter.organization_names },
         )
         section.add_control(
           id: 'projects',
-          value: @filter.project_names,
+          value: -> { @filter.project_names },
         )
         section.add_control(
           id: 'project_groups',
-          value: @filter.project_groups,
+          value: -> { @filter.project_groups },
         )
         if GrdaWarehouse::Cohort.viewable_by(@filter.user).exists?
           section.add_control(
             id: 'cohorts',
-            value: @filter.cohorts,
+            value: -> { @filter.cohorts },
           )
         end
       end

--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -1522,6 +1522,8 @@ module Filters
     end
 
     def project_names(ids = project_ids)
+      return [] if ids.blank?
+
       project_options_for_select(user: user).
         values.
         flatten(1).

--- a/app/models/filters/ui_control_section.rb
+++ b/app/models/filters/ui_control_section.rb
@@ -28,15 +28,19 @@ module Filters
   end
 
   class UiControl
-    attr_accessor :id, :label, :short_label, :value, :required, :hint
+    attr_accessor :id, :label, :short_label, :possibly_lazy_value, :required, :hint
 
-    def initialize(id:, value:, label: nil, short_label: nil, required: false, hint: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(id:, value:, label: nil, short_label: nil, required: false, hint: nil)
       self.id = id
       self.label = label || id.humanize.titleize
       self.short_label = short_label || self.label
       self.required = required
       self.hint = hint
-      self.value = value
+      self.possibly_lazy_value = value
+    end
+
+    def value
+      possibly_lazy_value.is_a?(Proc) ? possibly_lazy_value.call : possibly_lazy_value
     end
 
     def report_period?

--- a/drivers/core_demographics_report/spec/requests/core_demogphics_report_spec.rb
+++ b/drivers/core_demographics_report/spec/requests/core_demogphics_report_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe CoreDemographicsReport::WarehouseReports::CoreController, type: :request do
+  let(:agency) { create :agency }
+  let(:role) { create :admin_role, can_view_projects: true }
+  let(:user) { create :user, agency: agency }
+  let!(:report) { create :core_demographics_report }
+
+  before do
+    GrdaWarehouse::Config.delete_all
+    GrdaWarehouse::Config.invalidate_cache
+    GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
+    AccessGroup.maintain_system_groups
+    sign_in user
+  end
+
+  let(:data_source) { create :source_data_source }
+  let(:organization) { create :hud_organization, data_source: data_source }
+  let(:projects) do
+    3.times.map do
+      create :grda_warehouse_hud_project, data_source: data_source, organization: organization
+    end
+  end
+
+  context 'with project and data set access' do
+    before(:each) do
+      user.legacy_roles = [role]
+      user.add_viewable(report)
+      user.add_viewable(organization)
+      projects.each { |p| user.add_viewable(p) }
+    end
+
+    it 'resolves index' do
+      get core_demographics_report_warehouse_reports_core_index_path
+      expect(response).to be_successful
+      expect(assigns(:report)).to be_an_instance_of(CoreDemographicsReport::Core)
+
+      # check queries once the cache is warm
+      expect do
+        get core_demographics_report_warehouse_reports_core_index_path
+      end.to make_database_queries(
+        count: 10..40,
+        matching: /\A(?!.*SELECT "translations".* FROM "translations")/, # exclude translations
+      )
+    end
+  end
+
+  context 'without any access' do
+    it 'denies access' do
+      get core_demographics_report_warehouse_reports_core_index_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Performance fix on report filters page; tested on core-demographics page

## Type of change
Bug fix

## Testing instructions
Check that the core demographics report filters are loading correctly. In particular the "Projects" filter

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
