### PR TITLE
Enforce CoC Code selection on export of Enrollment

### DIFF
--- a/app/models/concerns/export/scopes.rb
+++ b/app/models/concerns/export/scopes.rb
@@ -74,6 +74,12 @@ module Export::Scopes
       when 1
         # no-op
       end
+      # limit enrollment coc to the cocs chosen, and any random thing that's not a valid coc
+      if @coc_codes.present?
+        e_scope = e_scope.where(EnrollmentCoC: @coc_codes).
+          or(e_scope.where(EnrollmentCoC: nil)).
+          or(e_scope.where.not(EnrollmentCoC: HudUtility2024.cocs.keys))
+      end
       e_scope.where(
         e_t[:PersonalID].eq(c_t[:PersonalID]).
           and(e_t[:data_source_id].eq(c_t[:data_source_id])),

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
@@ -42,10 +42,6 @@ module HmisCsvTwentyTwentyFour::Exporter
           modified_within_range(range: (export.start_date..export.end_date))
       end
 
-      # Limit to the chosen CoC codes if any are specified
-      filter = export.filter
-      export_scope = export_scope.where(EnrollmentCoC: filter.coc_codes) if filter.coc_codes.any?
-
       note_involved_user_ids(scope: export_scope, export: export)
 
       export_scope.distinct.preload(:user, :project, client: :warehouse_client_source)

--- a/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/app/models/hmis_csv_twenty_twenty_four/exporter/enrollment.rb
@@ -42,6 +42,10 @@ module HmisCsvTwentyTwentyFour::Exporter
           modified_within_range(range: (export.start_date..export.end_date))
       end
 
+      # Limit to the chosen CoC codes if any are specified
+      filter = export.filter
+      export_scope = export_scope.where(EnrollmentCoC: filter.coc_codes) if filter.coc_codes.any?
+
       note_involved_user_ids(scope: export_scope, export: export)
 
       export_scope.distinct.preload(:user, :project, client: :warehouse_client_source)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Previously we only enforced CoC Code on ProjectCoC exports, this adjusts the logic so that Enrollments are also filtered for CoC code if chosen, though it also allows empty CoC Codes on enrollment.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
