### PR TITLE
Fix HMIS theme validation bug and add tests

### DIFF
--- a/app/models/grda_warehouse/theme.rb
+++ b/app/models/grda_warehouse/theme.rb
@@ -36,7 +36,10 @@ module GrdaWarehouse
     belongs_to :remote_credential, class_name: 'GrdaWarehouse::RemoteCredentials::S3', optional: true
 
     # Max 1 theme per HMIS origin
-    validates :hmis_origin, uniqueness: { scope: [:client] }, if: :hmis_theme?
+    validates_uniqueness_of :hmis_origin,
+                            scope: :client,
+                            if: :hmis_theme?, # only run validation if this is an HMIS theme
+                            conditions: -> { where.not(hmis_value: [nil, '']) } # only validate uniqueness against other HMIS themes
 
     def set_theme_defaults
       # Fetch files from S3 if available or use defaults

--- a/app/models/grda_warehouse/theme.rb
+++ b/app/models/grda_warehouse/theme.rb
@@ -54,7 +54,7 @@ module GrdaWarehouse
     def self.hmis_theme_for_origin(origin)
       hmis_themes = GrdaWarehouse::Theme.where(client: ENV['CLIENT']&.to_sym).filter(&:hmis_theme?)
 
-      # Look for theme that matches this HMIS origin
+      # Look for theme that matches this HMIS origin. The origin is the value of field `hmis` on the DataSource
       theme = hmis_themes.find { |t| t.hmis_origin == origin }
       return theme if theme
 

--- a/spec/factories/grda_warehouse/themes.rb
+++ b/spec/factories/grda_warehouse/themes.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :theme, class: 'GrdaWarehouse::Theme' do
+    client { 'test' }
+  end
+
+  factory :hmis_theme, parent: :theme do
+    hmis_value { { 'palette' => { 'primary' => { 'main' => '#41596B' } } } }
+  end
+end

--- a/spec/models/grda_warehouse/theme_spec.rb
+++ b/spec/models/grda_warehouse/theme_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Theme, type: :model do
+  describe 'HMIS theme validation' do
+    # cruft (non-HMIS themes that should not affect validation)
+    let!(:wh_theme1) { create(:theme) }
+    let!(:wh_theme2) { create(:theme, hmis_value: '') } # should be treated as non-HMIS theme
+
+    before(:all) do
+      ENV['CLIENT'] = 'test'
+    end
+
+    context 'when there are multiple HMIS themes with nil origin' do
+      let!(:theme1) { create(:hmis_theme, :skip_validate, hmis_origin: nil) }
+      let!(:theme2) { create(:hmis_theme, :skip_validate, hmis_origin: nil) }
+
+      it 'is invalid' do
+        expect(theme1).to be_invalid
+        expect(theme2).to be_invalid
+      end
+    end
+
+    context 'when there are multiple HMIS themes with the same origin' do
+      let!(:theme1) { create(:hmis_theme, :skip_validate, hmis_origin: 'test.dev') }
+      let!(:theme2) { create(:hmis_theme, :skip_validate, hmis_origin: 'test.dev') }
+
+      it 'is invalid' do
+        expect(theme1).to be_invalid
+        expect(theme2).to be_invalid
+      end
+    end
+
+    context 'when there are multiple HMIS themes with different origins' do
+      let!(:theme1) { create(:hmis_theme, :skip_validate, hmis_origin: 'test1.dev') }
+      let!(:theme2) { create(:hmis_theme, :skip_validate, hmis_origin: 'test2.dev') }
+      let!(:default_theme) { create(:hmis_theme, :skip_validate, hmis_origin: nil) }
+
+      it 'is valid' do
+        expect(theme1).to be_valid
+        expect(theme2).to be_valid
+        expect(default_theme).to be_valid
+      end
+
+      it 'chooses specific theme for origin (test1.dev)' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin(theme1.hmis_origin)).to eq(theme1)
+      end
+
+      it 'chooses specific theme for origin (test2.dev)' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin(theme2.hmis_origin)).to eq(theme2)
+      end
+
+      it 'chooses default theme for origin (test3.dev)' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin('test3.dev')).to eq(default_theme)
+      end
+    end
+
+    context 'when there is only a default theme' do
+      let!(:default_theme) { create(:hmis_theme, hmis_origin: nil) }
+
+      it 'chooses default theme for origin' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin('test1.dev')).to eq(default_theme)
+      end
+    end
+
+    context 'when there is only a specific theme for test1.dev' do
+      let!(:theme1) { create(:hmis_theme, hmis_origin: 'test1.dev') }
+
+      it 'chooses specific theme for origin (test1.dev)' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin('test1.dev')).to eq(theme1)
+      end
+      it 'fails to find theme for different origin' do
+        expect(GrdaWarehouse::Theme.hmis_theme_for_origin('test2.dev')).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
1. Fix validation error that would come up when there was a Warehouse (non-HMIS) theme existing alongside a default HMIS theme.
2. Add tests for `hmis_theme_for_origin` even though it's not used yet ( https://github.com/open-path/Green-River/issues/6774)


How to test:
- create a warehouse theme with no hmis value
- create another theme with an hmis_value but no hmis_origin. previously it was invalid, now it is valid

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- n/a If adding a new endpoint / exposing data in a new way, I have:
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
