### PR TITLE
Expose user login chart on HMIS user admin page

### DIFF
--- a/drivers/hmis/app/models/hmis/activity_log.rb
+++ b/drivers/hmis/app/models/hmis/activity_log.rb
@@ -34,4 +34,26 @@ class Hmis::ActivityLog < ApplicationRecord
   def response_time
     resolved_at - created_at if resolved_at
   end
+
+  # increment can be: minute, hour, day, week, month, year
+  def self.for_chart(increment: 'hour', range: 1.weeks.ago..Time.current)
+    return [] unless valid_increments.include?(increment)
+
+    data = {}
+    where(created_at: range).
+      group(:created_at_trunc, :user_id).
+      pluck(Arel.sql("date_trunc('#{increment}', created_at) as created_at_trunc"), :user_id).
+      each do |time, _user_id|
+        data[time.strftime('%Y-%m-%d %H:%M')] ||= 0
+        data[time.strftime('%Y-%m-%d %H:%M')] += 1
+      end
+    [
+      ['x'] + data.keys,
+      ['Active Users'] + data.values,
+    ]
+  end
+
+  def self.valid_increments
+    ['minute', 'hour', 'day', 'week', 'month', 'year']
+  end
 end

--- a/drivers/hmis/app/views/hmis_admin/users/_login_chart.haml
+++ b/drivers/hmis/app/views/hmis_admin/users/_login_chart.haml
@@ -1,0 +1,38 @@
+#jUserActivityChart
+
+= content_for :page_js do
+  :javascript
+    var user_activity = bb.generate({
+      size: {
+        height: 100
+      },
+      legend: {
+        hide: true
+      },
+      data: {
+        x: 'x',
+        xFormat: '%Y-%m-%d %H:%M',
+        columns: #{raw Hmis::ActivityLog.for_chart()}
+      },
+      axis: {
+        x: {
+          type: 'timeseries',
+          tick: {
+            format: '%Y-%m-%d %H:%M',
+            show: false,
+            text: {
+              show: false
+            }
+          }
+        },
+        y: {
+          tick: {
+            show: false,
+            text: {
+              show: false
+            }
+          }
+        }
+      },
+      bindto: '#jUserActivityChart'
+    });

--- a/drivers/hmis/app/views/hmis_admin/users/index.haml
+++ b/drivers/hmis/app/views/hmis_admin/users/index.haml
@@ -1,6 +1,7 @@
 - content_for :title, 'HMIS User Administration'
 %h1= content_for :title
 = render 'hmis_admin/tabs', active_tab: :users
+= render 'login_chart'
 - @prompt = 'Search users...'
 .o-page__controls
   .o-page__search


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
This adds a chart to the HMIS User administration page similar to the warehouse version that lists concurrent users by hour, but for HMIS instead of the warehouse.
<img width="1204" alt="Screenshot 2024-11-20 at 12 58 07 PM" src="https://github.com/user-attachments/assets/877dc125-7659-4dba-9b9e-18e9d548d3a9">

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
