### PR TITLE
Fix for links to cohorts on client dashboard

### DIFF
--- a/app/views/clients/rollup/_cohorts.haml
+++ b/app/views/clients/rollup/_cohorts.haml
@@ -14,6 +14,6 @@
             %tbody
               - cohorts.uniq.each do |cohort|
                 %tr
-                  %td= link_to_if cohort.link && cohort.active?, cohort.name, cohort_path(cohort.id)
-                  %td= yes_no(cohort.active? == true)
+                  %td= link_to_if cohort.link && cohort.active, cohort.name, cohort_path(cohort.id)
+                  %td= yes_no(cohort.active == true)
                   %td= yes_no(cohort.recent_activity)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* The `cohort` object on the client dashboard view isn't a `GrdaWarehouse::Cohort` but a simple `OpenStruct`
* This fixes the view to use the `active` attribute instead of treating it like a full Cohort which responds to `active?`

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
