### PR TITLE
6956 hmis chronic uses ch enrollment

### DIFF
--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -4,7 +4,13 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# persist the HUD calculation for chronic homelessness at the enrollment level
+# ChEnrolment persist the HUD calculation for chronic homelessness at the enrollment level
+#
+# Details:
+# - Rows are calculated on a schedule via GrdaWarehouse::ChEnrollment.maintain!
+# - Each ChEnrollment represents the status of it's associated enrollment based on self-reported data
+# - The status is calculated as-of the current date when the ch_enrollment is generated
+# - The data that is stored will represent CH at Project Start for non-homeless projects (which is actually the same thing as CH at a Point In Time since you don't acquire homeless time being in a non-homeless project. BUT, in homeless projects, you do acquire days for every day you are there. So joining ChEnrollment is the equivalent of CH at a Point In Time for each enrollment.
 module GrdaWarehouse
   class ChEnrollment < GrdaWarehouseBase
     include ArelHelper
@@ -53,7 +59,8 @@ module GrdaWarehouse
               chronically_homeless_at_entry: chronically_homeless_at_start?(enrollment, date: date),
             }
           end
-          import(batch)
+          result = import(batch)
+          raise "failed to import ChEnrollments: #{result.inspect}" if result.failed_instances.present?
         end
     end
 
@@ -72,13 +79,14 @@ module GrdaWarehouse
             chronically_homeless_at_entry: chronically_homeless_at_start?(enrollment, date: date),
           }
         end
-        import!(
+        result = import!(
           batch,
           on_duplicate_key_update: {
             conflict_target: [:id],
             columns: [:processed_as, :chronically_homeless_at_entry],
           },
         )
+        raise "failed to import ChEnrollments: #{result.inspect}" if result.failed_instances.present?
       end
     end
 

--- a/app/models/grda_warehouse/ch_enrollment.rb
+++ b/app/models/grda_warehouse/ch_enrollment.rb
@@ -4,6 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# persist the HUD calculation for chronic homelessness at the enrollment level
 module GrdaWarehouse
   class ChEnrollment < GrdaWarehouseBase
     include ArelHelper

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -795,6 +795,10 @@ type Client {
   firstName: String
   gender: [Gender!]!
   healthAndDvs(limit: Int, offset: Int): HealthAndDvsPaginated!
+
+  """
+  Meets the definition for HUD chronically homeless as of today (time of API request)
+  """
   hudChronic: Boolean
   id: ID!
   image: ClientImage

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -340,12 +340,14 @@ module Types
     def hud_chronic
       return unless current_permission?(permission: :can_view_hud_chronic_status, entity: object)
 
+      # We are intentionally not checking enrollment visibility. The can_view_hud_chronic_status
+      # permission grants visibility into HUD Chronic status across all the client's enrollments
       open_enrollments = object.enrollments.open_excluding_wip.preload(:ch_enrollment, :project)
 
       # Check if there's an open enrollment at a residential project with a move in date that has occurred
       today = Date.current
       client_is_housed = open_enrollments.any? do |enrollment|
-        enrollment.project.project_type.in?(HudUtility2024.residential_project_type_ids) && (enrollment.move_in_date&.<= today)
+        enrollment.project.project_type.in?(HudUtility2024.permanent_housing_project_types) && (enrollment.move_in_date&.<= today)
       end
       return false if client_is_housed
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -339,9 +339,7 @@ module Types
     def hud_chronic
       return unless current_permission?(permission: :can_view_hud_chronic_status, entity: object)
 
-      # causes n+1 queries
-      enrollments = object.enrollments.where(data_source_id: current_user.hmis_data_source_id)
-      !!object.destination_client&.as_warehouse&.hud_chronic?(scope: enrollments)
+      load_ar_association(object, :enrollments_with_chronic_homelessness).any?
     end
 
     def audit_history(filters: nil)

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -82,7 +82,7 @@ module Types
     field :contact_points, [HmisSchema::ClientContactPoint], null: false
     field :phone_numbers, [HmisSchema::ClientContactPoint], null: false
     field :email_addresses, [HmisSchema::ClientContactPoint], null: false
-    field :hud_chronic, Boolean, null: true
+    field :hud_chronic, Boolean, null: true, description: 'Meets the definition for HUD chronically homeless as of today (time of API request)'
 
     field :active_enrollment, Types::HmisSchema::Enrollment, null: true do
       argument :project_id, ID, required: true
@@ -336,10 +336,23 @@ module Types
       load_ar_association(object, :alerts, scope: Hmis::ClientAlert.active).sort_by(&:created_at).reverse
     end
 
+    # not optimized for batch queries, causes n+1 queries
     def hud_chronic
       return unless current_permission?(permission: :can_view_hud_chronic_status, entity: object)
 
-      load_ar_association(object, :enrollments_with_chronic_homelessness).any?
+      open_enrollments = object.enrollments.open_excluding_wip.preload(:ch_enrollment, :project)
+
+      # Check if there's an open enrollment at a residential project with a move in date that has occurred
+      today = Date.current
+      client_is_housed = open_enrollments.any? do |enrollment|
+        enrollment.project.project_type.in?(HudUtility2024.residential_project_type_ids) && (enrollment.move_in_date&.<= today)
+      end
+      return false if client_is_housed
+
+      # Check chronic status at open enrollments for homeless project types
+      open_enrollments.any? do |enrollment|
+        enrollment.project.project_type.in?(HudUtility2024.chronic_project_types) && enrollment.ch_enrollment&.chronically_homeless?
+      end
     end
 
     def audit_history(filters: nil)

--- a/drivers/hmis/app/models/hmis/ch_enrollment.rb
+++ b/drivers/hmis/app/models/hmis/ch_enrollment.rb
@@ -1,0 +1,14 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# persist the HUD calculation for chronic homelessness at the enrollment level
+# see GrdaWarehouse::ChEnrollment for details
+module Hmis
+  class ChEnrollment < GrdaWarehouseBase
+    self.table_name = 'ch_enrollments'
+    belongs_to :enrollment, class_name: 'Hmis::Hud::Enrollment'
+  end
+end

--- a/drivers/hmis/app/models/hmis/ch_enrollment.rb
+++ b/drivers/hmis/app/models/hmis/ch_enrollment.rb
@@ -10,5 +10,10 @@ module Hmis
   class ChEnrollment < GrdaWarehouseBase
     self.table_name = 'ch_enrollments'
     belongs_to :enrollment, class_name: 'Hmis::Hud::Enrollment'
+
+    # the chronically_homeless_at_entry is poorly named
+    def chronically_homeless?
+      chronically_homeless_at_entry?
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -54,6 +54,10 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   has_many :hmis_services, through: :enrollments # All services (HUD and Custom)
   has_many :services, through: :enrollments # HUD Services only
   has_many :custom_services, through: :enrollments # Custom Services only
+  has_many :enrollments_with_chronic_homelessness,
+           -> { where(chronically_homeless_at_entry: true) },
+           through: :enrollments,
+           source: :ch_enrollment
 
   # History of merges into this client
   has_many :merge_histories, class_name: 'Hmis::ClientMergeHistory', primary_key: :id, foreign_key: :retained_client_id

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -54,10 +54,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   has_many :hmis_services, through: :enrollments # All services (HUD and Custom)
   has_many :services, through: :enrollments # HUD Services only
   has_many :custom_services, through: :enrollments # Custom Services only
-  has_many :enrollments_with_chronic_homelessness,
-           -> { where(chronically_homeless_at_entry: true) },
-           through: :enrollments,
-           source: :ch_enrollment
 
   # History of merges into this client
   has_many :merge_histories, class_name: 'Hmis::ClientMergeHistory', primary_key: :id, foreign_key: :retained_client_id

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -83,6 +83,9 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_one :active_unit_occupancy, -> { active }, class_name: 'Hmis::UnitOccupancy', inverse_of: :enrollment
   has_one :current_unit, through: :active_unit_occupancy, class_name: 'Hmis::Unit', source: :unit
 
+  # Cached chronically homeless at entry
+  has_one :ch_enrollment, class_name: 'GrdaWarehouse::ChEnrollment', dependent: :destroy
+
   accepts_nested_attributes_for :move_in_addresses, allow_destroy: true
 
   before_validation :set_hud_project_id_from_project_pk_unless_wip, if: :project_pk_changed?

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -84,7 +84,7 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_one :current_unit, through: :active_unit_occupancy, class_name: 'Hmis::Unit', source: :unit
 
   # Cached chronically homeless at entry
-  has_one :ch_enrollment, class_name: 'GrdaWarehouse::ChEnrollment', dependent: :destroy
+  has_one :ch_enrollment, class_name: 'Hmis::ChEnrollment', dependent: :destroy
 
   accepts_nested_attributes_for :move_in_addresses, allow_destroy: true
 

--- a/drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb
@@ -1,0 +1,92 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  before(:all) do
+    cleanup_test_environment
+  end
+  after(:all) do
+    cleanup_test_environment
+  end
+
+  include_context 'hmis base setup'
+  include_context 'file upload setup'
+
+  before(:each) do
+    hmis_login(user)
+  end
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+
+  let(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1, user: u1 }
+
+  let(:query) do
+    <<~GRAPHQL
+      query Client($id: ID!) {
+        client(id: $id) {
+          id
+          hudChronic
+        }
+      }
+    GRAPHQL
+  end
+
+  shared_context 'with enrollment setup' do |times_homeless:, exit_date: nil|
+    let!(:enrollment) do
+      create(:hmis_hud_enrollment,
+             data_source: ds1,
+             project: p1,
+             client: c1,
+             DisablingCondition: 1,
+             MonthsHomelessPastThreeYears: 112, # see MonthsHomelessPastThreeYears enum
+             TimesHomelessPastThreeYears: times_homeless,
+             exit_date: exit_date)
+    end
+  end
+
+  shared_examples 'chronic status check' do |expected_status:|
+    before do
+      # simulate periodic processing of chronic status
+      GrdaWarehouse::Tasks::ServiceHistory::Enrollment.where(id: enrollment.id).each(&:rebuild_service_history!)
+      GrdaWarehouse::ChEnrollment.maintain!
+    end
+    it 'returns the correct chronic status' do
+      response, result = post_graphql(id: c1.id) { query }
+      expect(response.status).to eq 200
+      expect(result.dig('data', 'client', 'hudChronic')).to eq(expected_status)
+    end
+  end
+
+  describe 'HUD chronic status determination' do
+    context 'when client has less than four months homeless' do
+      include_context 'with enrollment setup', times_homeless: 3
+      include_examples 'chronic status check', expected_status: false
+    end
+
+    context 'when client has four or months homeless' do
+      include_context 'with enrollment setup', times_homeless: 4
+      include_examples 'chronic status check', expected_status: true
+
+      context 'and client has moved to permanent housing' do
+        before do
+          ph_project = create :hmis_hud_project, data_source: ds1, organization: o1, user: u1, project_type: 13
+          create(:hmis_hud_enrollment, data_source: ds1, project: ph_project, move_in_date: 2.days.ago, client: c1)
+        end
+        include_examples 'chronic status check', expected_status: false
+      end
+
+      context 'but has exited' do
+        before do
+          create(:hmis_base_hud_exit, enrollment: enrollment, data_source: ds1)
+        end
+        include_examples 'chronic status check', expected_status: false
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -177,37 +177,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect(result.dig('data', 'client', 'hudChronic')).to eq(false)
   end
 
-  [
-    ['with a client who is not chronically homeless per HUD definition', 3, false],
-    ['with a client who is chronically homeless per HUD definition', 4, true],
-  ].each do |chronic_status, times_homeless_past_three_years, expected_hud_chronic|
-    context chronic_status do
-      let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
-      let!(:e1) do
-        create :hmis_hud_enrollment,
-               data_source: ds1,
-               project: p1,
-               client: c1,
-               DisablingCondition: 1,
-               MonthsHomelessPastThreeYears: 112, # see MonthsHomelessPastThreeYears enum
-               TimesHomelessPastThreeYears: times_homeless_past_three_years
-      end
-      let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
-
-      before do
-        # simulate periodic processing of chronic status
-        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.where(id: e1.id).each(&:rebuild_service_history!)
-        GrdaWarehouse::ChEnrollment.maintain!
-      end
-
-      it 'should return chronic status correctly' do
-        response, result = post_graphql(id: c1.id) { query }
-        expect(response.status).to eq 200
-        expect(result.dig('data', 'client', 'hudChronic')).to eq(expected_hud_chronic)
-      end
-    end
-  end
-
   it 'should return client if can view clients and client is unenrolled' do
     e1.destroy!
     response, result = post_graphql(id: c1.id) { query }

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -177,23 +177,34 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect(result.dig('data', 'client', 'hudChronic')).to eq(false)
   end
 
-  context 'with a client who is chronically homeless per HUD definition' do
-    let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
-    let!(:e1) do
-      create :hmis_hud_enrollment,
-             data_source: ds1,
-             project: p1,
-             client: c1,
-             DisablingCondition: 1,
-             MonthsHomelessPastThreeYears: 112, # see MonthsHomelessPastThreeYears enum
-             TimesHomelessPastThreeYears: 4
-    end
-    let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
+  [
+    ['with a client who is not chronically homeless per HUD definition', 3, false],
+    ['with a client who is chronically homeless per HUD definition', 4, true],
+  ].each do |chronic_status, times_homeless_past_three_years, expected_hud_chronic|
+    context chronic_status do
+      let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1 }
+      let!(:e1) do
+        create :hmis_hud_enrollment,
+               data_source: ds1,
+               project: p1,
+               client: c1,
+               DisablingCondition: 1,
+               MonthsHomelessPastThreeYears: 112, # see MonthsHomelessPastThreeYears enum
+               TimesHomelessPastThreeYears: times_homeless_past_three_years
+      end
+      let!(:disability) { create :hmis_disability, client: c1, enrollment: e1 }
 
-    it 'should return chronic status correctly' do
-      response, result = post_graphql(id: c1.id) { query }
-      expect(response.status).to eq 200
-      expect(result.dig('data', 'client', 'hudChronic')).to eq(true)
+      before do
+        # simulate periodic processing of chronic status
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.where(id: e1.id).each(&:rebuild_service_history!)
+        GrdaWarehouse::ChEnrollment.maintain!
+      end
+
+      it 'should return chronic status correctly' do
+        response, result = post_graphql(id: c1.id) { query }
+        expect(response.status).to eq 200
+        expect(result.dig('data', 'client', 'hudChronic')).to eq(expected_hud_chronic)
+      end
     end
   end
 


### PR DESCRIPTION
## Merging this PR
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Replace `client.hud_chronic?` with `enrollment.ch_enrollment` to determine chronic homless status in the HMIS. This should mean:
* better performance
* uses a different implementation of chronic calculation. It's unclear what the functional difference is other than the ch_enrollment seems like newer code.

[GH Issue](https://github.com/open-path/Green-River/issues/6956)

## Testing
The chronic status on the HMIS enrollment dashboard should reflect our new logic. Note that the `can_view_hud_chronic_status` permission is required to access. 

The status is updated by a job every night so there is a lag in the status appearing.

New logic:
* Client is __not__ CH is they have an open PH project (3, 9, 10, 13) with a move in date that has occurred on or before the current date
* Client is CH if they have any open enrollments at project types (0, 1, 4, 8) that meet the criteria of CH (DisablingCondition:1, MonthsHomelessPastThreeYears: 1 year+, TimesHomelessPastThreeYears: 4+)


## Type of change
Bug fix, Performance improvement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
