### PR TITLE
6350-bulk-client-merge-performance

### DIFF
--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -17,7 +17,7 @@ module Hmis
 
       self.actor = User.find(actor_id)
       self.clients = Hmis::Hud::Client.
-        preload(:names, :contact_points, :addresses).
+        preload(:names, :contact_points, :addresses, :custom_data_elements).
         find(client_ids).
         map do |client|
           # set some defaults
@@ -25,7 +25,7 @@ module Hmis
           client.DateUpdated ||= 10.years.ago.to_date
           client
         end.
-        sort_by { |client| client.DateCreated.to_datetime }
+        sort_by { |client| [client.DateCreated.to_datetime, client.id] }
 
       self.client_to_retain = clients[0]
       self.clients_needing_reference_updates = clients[1..]
@@ -298,7 +298,13 @@ module Hmis
 
     def destroy_merged_clients
       Rails.logger.info 'soft-deleting merged clients'
-      clients_needing_reference_updates.map(&:reload).map(&:destroy!)
+      ids = clients_needing_reference_updates.map(&:id)
+      scope = Hmis::Hud::Client.where(id: ids)
+      # preload associations to reduce n+1 when destroying a batch
+      preloads = Hmis::Hud::Client.reflect_on_all_associations.
+        filter { |a| a.options[:dependent] == :destroy }.
+        map(&:name)
+      scope.preload(*preloads).each(&:destroy!)
     end
   end
 end

--- a/drivers/hmis/spec/jobs/merge_clients_job_perf_spec.rb
+++ b/drivers/hmis/spec/jobs/merge_clients_job_perf_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Hmis::MergeClientsJob, type: :model do
+  context 'performance with larger client sets' do
+    let(:data_source) { create(:hmis_data_source) }
+    let!(:user) { create(:hmis_hud_user, data_source: data_source) }
+    let!(:actor) { create(:user) }
+    let(:cded_lang) { create(:hmis_custom_data_element_definition_for_primary_language, data_source: data_source) }
+    let(:cded_color) { create(:hmis_custom_data_element_definition_for_color, data_source: data_source) }
+    let(:now) { Time.current }
+
+    let!(:projects) do
+      3.times.map { create(:hmis_hud_project, data_source: data_source) }
+    end
+
+    # Create clients with associated records
+    let!(:clients) do
+      20.times.map do |i|
+        client = create(:hmis_hud_client_complete,
+                        pronouns: "they-#{i}",
+                        date_created: now - i.days,
+                        data_source: data_source)
+
+        # Create associated records for each client
+        create(:hmis_hud_custom_client_name, client: client, data_source: data_source)
+        create(:hmis_hud_custom_client_contact_point, client: client, data_source: data_source)
+        create(:hmis_hud_custom_client_address, client: client, data_source: data_source)
+
+        # Create enrollment and file records
+        create(:hmis_hud_enrollment, client: client, data_source: data_source)
+        create(:client_file, client_id: client.id, data_source: data_source)
+
+        # Create custom data elements
+        create(:hmis_custom_data_element,
+               owner: client,
+               value_string: "Language-#{i}",
+               data_element_definition: cded_lang,
+               data_source: data_source)
+
+        create(:hmis_custom_data_element,
+               owner: client,
+               value_string: "Color-#{i}",
+               data_element_definition: cded_color,
+               data_source: data_source)
+
+        create :hmis_scan_card_code, client: client
+
+        projects.each do |project|
+          create(:hmis_hud_wip_enrollment, client: client, project: project, data_source: data_source)
+        end
+
+        client
+      end
+    end
+
+    let(:client_ids) { clients.map(&:id) }
+
+    it 'completes merge operation within reasonable time' do
+      expect do
+        Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id)
+      end.to perform_under(500).ms.sample(1).times.warmup(0)
+    end
+
+    it 'performs a reasonable number of database queries' do
+      expect do
+        Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id)
+      end.to make_database_queries(count: 100..160)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description

[GH Issue](https://github.com/open-path/Green-River/issues/6350)
I couldn't find any significant inefficiency in the merge steps. However the job does result in a large number of queries. Particularly the batch destruction of the merged clients. I added some preloads to reduce n+1 queries which seems to help.

* performance tests for bulk client merge
* preload to reduce n+1

#### Testing
Should be no functional difference. QA probably not needed.
To test, login as admin and review duplicates
    
## Type of change
Performance optimization, tests

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
