### PR TITLE
Fix schema type for editor_user_ids form field

### DIFF
--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -77,7 +77,7 @@ class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
         # than raising an exception, just skip processing if we see a value this user doesn't have permission to edit.
         editor_user_ids = mapped_form_items["#{container}:#{field}"]&.editor_user_ids
         # If the item doesn't specify editor_user_ids, then everyone can edit it.
-        next if editor_user_ids && !editor_user_ids.include?(user.id)
+        next if editor_user_ids && !editor_user_ids.include?(user.id.to_s)
 
         if mapped_custom_form_fields[container].include?(field)
           # If this key can be identified as a CustomDataElement, set it and continue

--- a/drivers/hmis/spec/models/hmis/form/form_processor_editor_user_ids_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_editor_user_ids_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
           "mapping": {
             "custom_field_key": 'only_1_can_edit',
           },
-          "editor_user_ids": [hmis_user.id],
+          "editor_user_ids": [hmis_user.id.to_s],
         },
       ],
     }

--- a/drivers/hmis_external_apis/public/schemas/form_definition.json
+++ b/drivers/hmis_external_apis/public/schemas/form_definition.json
@@ -1106,7 +1106,7 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "type": "integer"
+                "type": ["string"]
               }
             }
           }

--- a/drivers/hmis_external_apis/public/schemas/form_definition.json
+++ b/drivers/hmis_external_apis/public/schemas/form_definition.json
@@ -1106,7 +1106,7 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "type": ["string"]
+                "type": "string"
               }
             }
           }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Issue: https://github.com/open-path/Green-River/issues/6843
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/4893

Fix a bug that is blocking the ability to edit forms that have editor_user_id fields. Note that this will cause any existing forms with numeric editor_user_id to fail validation. I think that is desirable (and manageable), it would be more confusing to support both strings and integers.

#### Bug reproduction (release-142)
- create a form
- using JSON editor, add editor_user_id integer values in the editor_user_ids field
- save (succeeds, passed validation)
- create a new draft
- make any form change and try to save -- it fails validation because editor_user_ids are strings. There is no way to resolve it in the UI. That happened because there was a mis-match in types. The JSON schema expected integers, but the GraphQL schema resolved strings (type `[ID]`).

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
