### PR TITLE
Rack Attack Sentry Throttling

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -45,7 +45,7 @@ jobs:
             tags: |
               type=sha,prefix=githash-
               type=ref,event=branch,prefix=branch-
-              # type=raw,event=branch,value=branch-{{branch}}-{{sha}}
+              type=raw,event=branch,value=branch-{{branch}}-{{sha}}
 
     steps:
       - name: Checkout

--- a/config/deploy/docker/lib/cronjob.rb
+++ b/config/deploy/docker/lib/cronjob.rb
@@ -60,7 +60,7 @@ class Cronjob
   private
 
   def add_cron!
-    Rails.logger.info "Adding #{jobname} with capacity #{capacity_type}"
+    Rails.logger.info "Adding #{jobname} with capacity #{capacity_type} on schedule of #{schedule_expression}"
     crons.create_resource(materialized_cronjob)
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -173,7 +173,7 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
-class SlackSendMonitorClass < Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts)
+SlackSendMonitorClass = Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts) do
   def init
     self.sends = 0
     self.last_sent = Time.zone.now
@@ -186,17 +186,17 @@ class SlackSendMonitorClass < Struct.new(:sends, :last_sent, :throttle_window_se
   end
 
   def percent_sent
-    return 0.0 if self.lifetime_attempts == 0
+    return 0.0 if lifetime_attempts == 0
 
-    (self.lifetime_sends.to_f / self.lifetime_attempts * 100).round(1)
+    (lifetime_sends.to_f / lifetime_attempts * 100).round(1)
   end
 
   def needs_throttling?
-    (delta < self.throttle_window_seconds) && self.sends > self.max_sends
+    (delta < throttle_window_seconds) && sends > max_sends
   end
 
   def needs_reset?
-    self.delta > self.throttle_window_seconds
+    delta > throttle_window_seconds
   end
 
   def delta

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -173,14 +173,20 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
-SlackSendMonitor = Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts).new
-SlackSendMonitor.sends = 0
-SlackSendMonitor.last_sent = Time.zone.now
-# Max sends to slack is once every 10 seconds per process
-SlackSendMonitor.throttle_window_seconds = 10
-SlackSendMonitor.max_sends = 1
-SlackSendMonitor.lifetime_sends = 0
-SlackSendMonitor.lifetime_attempts = 0
+class SlackSendMonitorClass < Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts)
+  def init
+    self.sends = 0
+    self.last_sent = Time.zone.now
+    # Max sends to slack is once every 10 seconds per process
+    self.throttle_window_seconds = 10
+    self.max_sends = 1
+    self.lifetime_sends = 0
+    self.lifetime_attempts = 0
+    self
+  end
+end
+
+SlackSendMonitor = SlackSendMonitorClass.new.init
 
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish, _request_id, payload|
   request = payload[:request]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -173,6 +173,12 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
+slack_sends = 0
+last_sent = Time.zone.now
+# Max sends to slack is once every 10 seconds per process
+slack_throttle_window_seconds = 10
+slack_max_sends = 1
+
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish, _request_id, payload|
   request = payload[:request]
 
@@ -203,6 +209,11 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   # ... get a record on disk
   Rails.logger.warn JSON.generate(data)
 
+  delta = Time.zone.now - last_sent
+  next if (delta < slack_throttle_window_seconds) && slack_sends > slack_max_sends
+
+  slack_sends = 0 if delta > slack_throttle_window_seconds
+
   # ... and now try to send to somewhere useful
   if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
     notifier_config = Rails.application.config_for(:exception_notifier).fetch(:slack, nil)
@@ -225,5 +236,8 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
       attachments: [attachment],
       http_options: { open_timeout: 1 },
     )
+
+    last_sent = Time.zone.now
+    slack_sends += 1
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -184,6 +184,24 @@ class SlackSendMonitorClass < Struct.new(:sends, :last_sent, :throttle_window_se
     self.lifetime_attempts = 0
     self
   end
+
+  def percent_sent
+    return 0.0 if self.lifetime_attempts == 0
+
+    (self.lifetime_sends.to_f / self.lifetime_attempts * 100).round(1)
+  end
+
+  def needs_throttling?
+    (delta < self.throttle_window_seconds) && self.sends > self.max_sends
+  end
+
+  def needs_reset?
+    self.delta > self.throttle_window_seconds
+  end
+
+  def delta
+    Time.zone.now - SlackSendMonitor.last_sent
+  end
 end
 
 SlackSendMonitor = SlackSendMonitorClass.new.init
@@ -218,17 +236,12 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   # ... get a record on disk
   Rails.logger.warn JSON.generate(data)
 
-  now = Time.zone.now
-  delta = now - SlackSendMonitor.last_sent
   SlackSendMonitor.lifetime_attempts += 1
-  next if (delta < SlackSendMonitor.throttle_window_seconds) && SlackSendMonitor.sends > SlackSendMonitor.max_sends
+  next if SlackSendMonitor.needs_throttling?
 
-  SlackSendMonitor.sends = 0 if delta > SlackSendMonitor.throttle_window_seconds
+  SlackSendMonitor.sends = 0 if SlackSendMonitor.needs_reset?
 
-  Rails.logger.info do
-    pct = ((SlackSendMonitor.lifetime_sends.to_f / SlackSendMonitor.lifetime_attempts) * 100).round(1)
-    "Slack sending percentage is #{pct}%"
-  end
+  Rails.logger.debug { "Slack sending percentage is #{SlackSendMonitor.percent_sent}%" }
 
   # ... and now try to send to somewhere useful
   if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
@@ -255,7 +268,7 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   end
 
   # mark a send even if it's not enabled above to facilitate testing
-  SlackSendMonitor.last_sent = now
+  SlackSendMonitor.last_sent = Time.zone.now
   SlackSendMonitor.sends += 1
   SlackSendMonitor.lifetime_sends += 1
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -173,11 +173,14 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
-slack_sends = 0
-last_sent = Time.zone.now
+SlackSendMonitor = Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts).new
+SlackSendMonitor.sends = 0
+SlackSendMonitor.last_sent = Time.zone.now
 # Max sends to slack is once every 10 seconds per process
-slack_throttle_window_seconds = 10
-slack_max_sends = 1
+SlackSendMonitor.throttle_window_seconds = 10
+SlackSendMonitor.max_sends = 1
+SlackSendMonitor.lifetime_sends = 0
+SlackSendMonitor.lifetime_attempts = 0
 
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish, _request_id, payload|
   request = payload[:request]
@@ -209,10 +212,17 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   # ... get a record on disk
   Rails.logger.warn JSON.generate(data)
 
-  delta = Time.zone.now - last_sent
-  next if (delta < slack_throttle_window_seconds) && slack_sends > slack_max_sends
+  now = Time.zone.now
+  delta = now - SlackSendMonitor.last_sent
+  SlackSendMonitor.lifetime_attempts += 1
+  next if (delta < SlackSendMonitor.throttle_window_seconds) && SlackSendMonitor.sends > SlackSendMonitor.max_sends
 
-  slack_sends = 0 if delta > slack_throttle_window_seconds
+  SlackSendMonitor.sends = 0 if delta > SlackSendMonitor.throttle_window_seconds
+
+  Rails.logger.info do
+    pct = ((SlackSendMonitor.lifetime_sends.to_f / SlackSendMonitor.lifetime_attempts) * 100).round(1)
+    "Slack sending percentage is #{pct}%"
+  end
 
   # ... and now try to send to somewhere useful
   if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
@@ -236,8 +246,10 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
       attachments: [attachment],
       http_options: { open_timeout: 1 },
     )
-
-    last_sent = Time.zone.now
-    slack_sends += 1
   end
+
+  # mark a send even if it's not enabled above to facilitate testing
+  SlackSendMonitor.last_sent = now
+  SlackSendMonitor.sends += 1
+  SlackSendMonitor.lifetime_sends += 1
 end

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -230,6 +230,7 @@ services:
       #   DB_DATA_VOLUME=./dev/db_data
       - ${DB_DATA_VOLUME:-dbdata_pg16}:/var/lib/postgresql/data
       - ./tmp/dumps:/tmp/dumps
+      - ./db:/mnt
     ports:
       - 5432
     expose:

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -154,15 +154,13 @@ RSpec.describe Rack::Attack, type: :request do
 
   context 'being kind to the sentry api' do
     let(:path) { '/' }
-    # let(:headers) do
-    #   { 'HTTP_USER_AGENT' => 'ELB-HealthChecker/2.0' }
-    # end
 
     it 'does not send api requests to sentry for every throttle event' do
-      throttled_at = 30
+      throttled_at = 50
       till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
+      expect(SlackSendMonitor.lifetime_attempts).to be > 20
+      expect(SlackSendMonitor.lifetime_sends).to be > 1
       expect(SlackSendMonitor.lifetime_sends.to_f / SlackSendMonitor.lifetime_attempts).to be < 0.1
-      # expect(requests_sent).to be_nil
     end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -151,4 +151,18 @@ RSpec.describe Rack::Attack, type: :request do
       expect(requests_sent).to be_nil
     end
   end
+
+  context 'being kind to the sentry api' do
+    let(:path) { '/' }
+    # let(:headers) do
+    #   { 'HTTP_USER_AGENT' => 'ELB-HealthChecker/2.0' }
+    # end
+
+    it 'does not send api requests to sentry for every throttle event' do
+      throttled_at = 30
+      till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
+      expect(SlackSendMonitor.lifetime_sends.to_f / SlackSendMonitor.lifetime_attempts).to be < 0.1
+      # expect(requests_sent).to be_nil
+    end
+  end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Rack::Attack, type: :request do
       till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
       expect(SlackSendMonitor.lifetime_attempts).to be > 20
       expect(SlackSendMonitor.lifetime_sends).to be > 1
-      expect(SlackSendMonitor.lifetime_sends.to_f / SlackSendMonitor.lifetime_attempts).to be < 0.1
+      expect(SlackSendMonitor.percent_sent).to be < 10
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_

## Description
Rack attack throttled requests are by their nature excessive, so don't pass that along to Sentry.

## Type of change
Bugfix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
