### PR TITLE
Update HMIS test date usage, remove TIME_FMT

### DIFF
--- a/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
+++ b/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
     let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1 }
     let!(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
     let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
-    let(:time_fmt) { '%Y-%m-%d %T.%3N'.freeze }
 
     # Full record set for Entry and Annual
     let!(:records_by_data_collaction_stage) do
@@ -74,9 +73,9 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
           # User should be the most recent updated
           expect(assessment.user).to eq(expected_records.max_by(&:date_updated).user)
           # Date created should be MIN from records
-          expect(assessment.date_created.strftime(time_fmt)).to eq(expected_records.map(&:date_created).min.strftime(time_fmt))
+          expect(assessment.date_created.to_fs(:db)).to eq(expected_records.map(&:date_created).min.to_fs(:db))
           # Date updated should be MAX from records
-          expect(assessment.date_updated.strftime(time_fmt)).to eq(expected_records.map(&:date_updated).max.strftime(time_fmt))
+          expect(assessment.date_updated.to_fs(:db)).to eq(expected_records.map(&:date_updated).max.to_fs(:db))
 
           related_records = [
             :health_and_dv,

--- a/drivers/hmis/spec/models/hmis/hud/household_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/household_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe Hmis::Hud::Household, type: :model do
 
   include_context 'hmis base setup'
 
+  let(:today) { Date.current }
+  let(:yesterday) { today - 1.day }
+
   describe 'basic tests' do
-    let!(:e1) { create(:hmis_hud_enrollment, project: p1, client: c1, user: u1, data_source: ds1, household_id: '123', entry_date: Date.current) }
+    let!(:e1) { create(:hmis_hud_enrollment, project: p1, client: c1, user: u1, data_source: ds1, household_id: '123', entry_date: today) }
 
     it 'has the right associations' do
       hh = Hmis::Hud::Household.first
@@ -31,19 +34,19 @@ RSpec.describe Hmis::Hud::Household, type: :model do
 
     describe 'scope tests' do
       let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1, first_name: 'Test', last_name: 'User' }
-      let!(:e2) { create :hmis_hud_enrollment, project: p1, client: c2, user: u1, data_source: ds1, household_id: '456', entry_date: Date.yesterday }
+      let!(:e2) { create :hmis_hud_enrollment, project: p1, client: c2, user: u1, data_source: ds1, household_id: '456', entry_date: yesterday }
 
       it 'should handle text search correctly' do
         expect(Hmis::Hud::Household.client_matches_search_term('user')).to contain_exactly(Hmis::Hud::Household.find_by(HouseholdID: e2.household_id))
       end
 
       it 'should handle open on correctly' do
-        e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: Date.current - 1.week, client: c2)
-        create(:hmis_hud_exit, data_source: ds1, enrollment: e3, client: c2, exit_date: Date.yesterday)
+        e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: today - 1.week, client: c2)
+        create(:hmis_hud_exit, data_source: ds1, enrollment: e3, client: c2, exit_date: yesterday)
 
-        expect(Hmis::Hud::Household.open_on_date(Date.current)).to contain_exactly(e1.household, e2.household)
-        expect(Hmis::Hud::Household.open_on_date(Date.yesterday)).to contain_exactly(e2.household, e3.household)
-        expect(Hmis::Hud::Household.open_on_date(Date.current - 3.days)).to contain_exactly(e3.household)
+        expect(Hmis::Hud::Household.open_on_date(today)).to contain_exactly(e1.household, e2.household)
+        expect(Hmis::Hud::Household.open_on_date(yesterday)).to contain_exactly(e2.household, e3.household)
+        expect(Hmis::Hud::Household.open_on_date(today - 3.days)).to contain_exactly(e3.household)
       end
 
       it 'should handle enrollment limit correctly' do
@@ -76,12 +79,12 @@ RSpec.describe Hmis::Hud::Household, type: :model do
     let!(:client_d) { create :hmis_hud_client, first_name: 'D', last_name: 'W', data_source: ds1, user: u1 }
 
     # A and D are enrolled together, A is the HoH
-    let!(:e_a) { create(:hmis_hud_enrollment, project: p1, client: client_a, user: u1, data_source: ds1, household_id: '1', RelationshipToHoH: 1, entry_date: Date.current) }
-    let!(:e_d) { create(:hmis_hud_enrollment, project: p1, client: client_d, user: u1, data_source: ds1, household_id: '1', RelationshipToHoH: 2, entry_date: Date.current) }
+    let!(:e_a) { create(:hmis_hud_enrollment, project: p1, client: client_a, user: u1, data_source: ds1, household_id: '1', RelationshipToHoH: 1, entry_date: today) }
+    let!(:e_d) { create(:hmis_hud_enrollment, project: p1, client: client_d, user: u1, data_source: ds1, household_id: '1', RelationshipToHoH: 2, entry_date: today) }
 
     # B and C are enrolled together, B is the HoH
-    let!(:e_b) { create(:hmis_hud_enrollment, project: p1, client: client_b, user: u1, data_source: ds1, household_id: '2', RelationshipToHoH: 1, entry_date: Date.current) }
-    let!(:e_c) { create(:hmis_hud_enrollment, project: p1, client: client_c, user: u1, data_source: ds1, household_id: '2', RelationshipToHoH: 2, entry_date: Date.current) }
+    let!(:e_b) { create(:hmis_hud_enrollment, project: p1, client: client_b, user: u1, data_source: ds1, household_id: '2', RelationshipToHoH: 1, entry_date: today) }
+    let!(:e_c) { create(:hmis_hud_enrollment, project: p1, client: client_c, user: u1, data_source: ds1, household_id: '2', RelationshipToHoH: 2, entry_date: today) }
 
     it 'should sort by head of household first name' do
       ordered = Hmis::Hud::Household.sort_by_option(:hoh_first_name_a_to_z)

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   include_context 'hmis base setup'
 
-  TIME_FMT = '%Y-%m-%d %T.%3N'.freeze
-
   let(:today) { Date.current }
+  let(:yesterday) { today - 1.day }
   let!(:access_control) { create_access_control(hmis_user, p1) }
   let(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
-  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1 }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: 2.weeks.ago, date_updated: Time.current - 6.hours }
 
   before(:each) do
     hmis_login(user)
@@ -112,7 +111,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     [:INTAKE, :UPDATE, :ANNUAL, :EXIT].each do |role|
       it "#{role}: sets and updates assessment date and entry/exit dates as appropriate" do
         definition = Hmis::Form::Definition.find_by(role: role)
-        e1.update(entry_date: 2.weeks.ago)
         enrollment_date_updated = e1.date_updated
 
         # Create the initial assessment (submit)
@@ -134,30 +132,34 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expected_exit_date: role == :EXIT ? initial_assessment_date : nil,
         )
         # DateUpdate on the Enrollment should have changed
-        expect(assessment.enrollment.date_updated.strftime(TIME_FMT)).not_to eq(enrollment_date_updated.strftime(TIME_FMT))
+        expect(assessment.enrollment.date_updated.to_fs(:db)).not_to eq(enrollment_date_updated.to_fs(:db))
         enrollment_date_updated = assessment.enrollment.date_updated
 
         # Update the assessment (submit)
-        new_assessment_date = Date.yesterday.strftime('%Y-%m-%d')
+        new_assessment_date = yesterday.strftime('%Y-%m-%d')
         input = {
           assessment_id: assessment.id,
           enrollment_id: assessment.enrollment.id,
           form_definition_id: definition.id,
           **build_minimum_values(definition, assessment_date: new_assessment_date),
         }
-        _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
-        errors = result.dig('data', 'submitAssessment', 'errors')
-        expect(errors).to be_empty
 
-        assessment.reload
-        expect_assessment_dates(
-          assessment,
-          expected_assessment_date: new_assessment_date,
-          expected_entry_date: role == :INTAKE ? new_assessment_date : e1.entry_date,
-          expected_exit_date: role == :EXIT ? new_assessment_date : nil,
-        )
-        # DateUpdate on the Enrollment should have changed
-        expect(assessment.enrollment.date_updated.strftime(TIME_FMT)).not_to eq(enrollment_date_updated.strftime(TIME_FMT))
+        # Jump ahead to make sure DateUpdated changes
+        Timecop.travel(Time.current + 5.minutes) do
+          _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
+          errors = result.dig('data', 'submitAssessment', 'errors')
+          expect(errors).to be_empty
+
+          assessment.reload
+          expect_assessment_dates(
+            assessment,
+            expected_assessment_date: new_assessment_date,
+            expected_entry_date: role == :INTAKE ? new_assessment_date : e1.entry_date,
+            expected_exit_date: role == :EXIT ? new_assessment_date : nil,
+          )
+          # DateUpdated on the Enrollment should have changed
+          expect(assessment.enrollment.date_updated.to_fs(:db)).not_to eq(enrollment_date_updated.to_fs(:db))
+        end
       end
     end
   end
@@ -166,7 +168,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     [:INTAKE, :UPDATE, :ANNUAL, :EXIT].each do |role|
       it "#{role}: sets and updates assessment date and entry/exit dates as appropriate" do
         definition = Hmis::Form::Definition.find_by(role: role)
-        e1.update(entry_date: 2.weeks.ago)
         enrollment_date_updated = e1.date_updated
 
         # Create the initial assessment (save as WIP)
@@ -187,10 +188,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expected_entry_date: e1.entry_date,
           expected_exit_date: nil,
         )
-        expect(assessment.enrollment.date_updated.strftime(TIME_FMT)).to eq(enrollment_date_updated.strftime(TIME_FMT))
+        expect(assessment.enrollment.date_updated.to_fs(:db)).to eq(enrollment_date_updated.to_fs(:db))
 
         # Update the assessment (submit)
-        new_assessment_date = Date.yesterday.strftime('%Y-%m-%d')
+        new_assessment_date = yesterday.strftime('%Y-%m-%d')
         input = {
           assessment_id: assessment.id,
           enrollment_id: assessment.enrollment.id,
@@ -208,28 +209,31 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expected_entry_date: role == :INTAKE ? new_assessment_date : e1.entry_date,
           expected_exit_date: role == :EXIT ? new_assessment_date : nil,
         )
-        expect(assessment.enrollment.date_updated.strftime(TIME_FMT)).not_to eq(enrollment_date_updated.strftime(TIME_FMT))
+        expect(assessment.enrollment.date_updated.to_fs(:db)).not_to eq(enrollment_date_updated.to_fs(:db))
 
         # Update the assessment again (submit)
-        new_assessment_date = Date.yesterday.strftime('%Y-%m-%d')
+        new_assessment_date = yesterday.strftime('%Y-%m-%d')
         input = {
           assessment_id: assessment.id,
           enrollment_id: assessment.enrollment.id,
           form_definition_id: definition.id,
           **build_minimum_values(definition, assessment_date: new_assessment_date),
         }
-        _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
-        errors = result.dig('data', 'submitAssessment', 'errors')
-        expect(errors).to be_empty
+        # Jump ahead to make sure DateUpdated changes
+        Timecop.travel(Time.current + 5.minutes) do
+          _resp, result = post_graphql(input: { input: input }) { submit_assessment_mutation }
+          errors = result.dig('data', 'submitAssessment', 'errors')
+          expect(errors).to be_empty
 
-        assessment = Hmis::Hud::CustomAssessment.find(assessment_id)
-        expect_assessment_dates(
-          assessment,
-          expected_assessment_date: new_assessment_date,
-          expected_entry_date: role == :INTAKE ? new_assessment_date : e1.entry_date,
-          expected_exit_date: role == :EXIT ? new_assessment_date : nil,
-        )
-        expect(assessment.enrollment.date_updated.strftime(TIME_FMT)).not_to eq(enrollment_date_updated.strftime(TIME_FMT))
+          assessment = Hmis::Hud::CustomAssessment.find(assessment_id)
+          expect_assessment_dates(
+            assessment,
+            expected_assessment_date: new_assessment_date,
+            expected_entry_date: role == :INTAKE ? new_assessment_date : e1.entry_date,
+            expected_exit_date: role == :EXIT ? new_assessment_date : nil,
+          )
+          expect(assessment.enrollment.date_updated.to_fs(:db)).not_to eq(enrollment_date_updated.to_fs(:db))
+        end
       end
     end
   end
@@ -240,7 +244,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   it 'Can update the Exit Date when submitting a NEW Exit assessment on an Enrollment that has already been exited (edge case)' do
     definition = Hmis::Form::Definition.find_by(role: :EXIT)
-    new_exit_date = Date.yesterday.strftime('%Y-%m-%d')
+    new_exit_date = yesterday.strftime('%Y-%m-%d')
     input = {
       enrollment_id: exited_enrollment.id,
       form_definition_id: definition.id,
@@ -267,7 +271,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     )
     expect do
       definition = Hmis::Form::Definition.find_by(role: :EXIT)
-      new_exit_date = Date.yesterday.strftime('%Y-%m-%d')
+      new_exit_date = yesterday.strftime('%Y-%m-%d')
       input = {
         enrollment_id: exited_enrollment.id,
         form_definition_id: definition.id,

--- a/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/submit_form_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   include_context 'hmis service setup'
   include_context 'file upload setup'
 
-  TIME_FMT = '%Y-%m-%d %T.%3N'.freeze
-
   let(:today) { Date.current }
   let!(:access_control) { create_access_control(hmis_user, ds1) }
   let!(:c2) { create :hmis_hud_client_complete, data_source: ds1 }

--- a/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
@@ -417,13 +417,13 @@ RSpec.describe 'Update External Form Submission', type: :request do
             and change(ClientLocationHistory::Location, :count).by(1)
 
           submission.reload
-          expect(submission.enrollment.entry_date).to eq(Date.current)
+          expect(submission.enrollment.entry_date).to eq(today)
 
           clh = submission.enrollment.as_warehouse.enrollment_location_histories.first
           expect(clh.client_id).to eq(submission.enrollment.client.id)
           expect(clh.lat).to eq(40.812497)
           expect(clh.lon).to eq(-77.882926)
-          expect(clh.located_on).to eq(Date.yesterday)
+          expect(clh.located_on).to eq(submission.submitted_at.to_date)
           expect(clh.located_at).to eq(submission.submitted_at)
         end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
* Remove the TIME_FMT thing because there were warnings about repeated declarations and we don't need it
* Update some tests to use the pattern of setting `today`/`yesterday` as vars to use throughout the test, so they are more robust to running near midnight

## Type of change
Cleanup

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
 
