### PR TITLE
LSA Missing Projects Hotfix

### DIFF
--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -35,8 +35,8 @@ module HudReports
         remaining_questions: build_for_questions,
         user_id: filter.user_id,
         project_ids: filter.effective_project_ids,
-        start_date: filter.start.to_date,
-        end_date: filter.end.to_date,
+        start_date: filter.start&.to_date,
+        end_date: filter.end&.to_date,
         coc_codes: filter.coc_codes,
         options: filter.to_h,
       )


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Fixes a scenario where someone tries to look at missing projects from the LSA launch page, but has chosen to use the HIC scope.
<img width="1363" alt="Screenshot 2024-12-16 at 3 36 08 PM" src="https://github.com/user-attachments/assets/48f62ee4-5ce6-43c3-9fcf-19ad8ad0c8ae" />
The above settings[ caused a 500](https://green-river.sentry.io/issues/6065294785/?referrer=slack&notification_uuid=7d1f23d9-fd30-4346-848e-66f75fabdad0&environment=production&alert_rule_id=12523843&alert_type=issue) because the filter would throw out the start date based on the choice of a HIC LSA scope.


## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected