### PR TITLE
Captive Portal Updates

### DIFF
--- a/app/controllers/admin/talentlms_controller.rb
+++ b/app/controllers/admin/talentlms_controller.rb
@@ -59,6 +59,7 @@ module Admin
     def site_config_params
       params.require(:grda_warehouse_config).permit(
         :number_lms_courses_required,
+        :default_lms_email_to_warehouse_email,
       )
     end
 
@@ -67,6 +68,7 @@ module Admin
         :subdomain,
         :api_key,
         :create_new_accounts,
+        :allow_automatic_redirect_to_course,
       )
     end
   end

--- a/app/controllers/user_training_controller.rb
+++ b/app/controllers/user_training_controller.rb
@@ -61,27 +61,26 @@ class UserTrainingController < ApplicationController
             end
             course_url = lms.course_url(config, course_id, redirect_url, logout_talentlms_url)
 
-            course_redirects << course_url
+            course_redirects << { course: course, url: course_url }
             configs_with_required_courses << config
           end
         end
 
         account_exists_in_all_configs = config_logins.values.all?(true)
-        number_configs_with_courses_to_complete = configs_with_required_courses.uniq.count
 
-        # If we only have one config with trainings required, send the user directly to the training portal
-        if course_redirects.present? && number_configs_with_courses_to_complete == 1
+        # If the user only has one required training course to complete, and that course's config
+        # allows automatic redirects, send them directly to the training portal
+        if course_redirects.present? && course_redirects.count == 1 && course_redirects.first[:course].config.allow_automatic_redirect_to_course
           # redirect to the course training
-          redirect_to course_redirects.first, allow_other_host: true
+          redirect_to course_redirects.first[:url], allow_other_host: true
           return
-        # If the user has an account in all configs and has no trainings left to complete, allow them to navigate the warehouse
+        # If the user has an active account in all configs and has no trainings left to complete, allow them to navigate the warehouse
         elsif account_exists_in_all_configs && course_redirects.blank?
           # All trainings are completed and the user has an account in all training configs
           redirect_to after_sign_in_path_for(current_user)
           return
         end
-        # At least one config requires an account to be created for this user or multiple configs have been
-        # identified as requiring trainings. Send the user to the captive portal for additional training options.
+        # For all other cases, send the user to the captive portal
         render 'required_trainings'
       rescue RuntimeError => e
         @message = e.message

--- a/app/models/talentlms/facade.rb
+++ b/app/models/talentlms/facade.rb
@@ -49,6 +49,7 @@ module Talentlms
     # @return [String] email address to be used for generated users in TalentLMS
     def lms_email
       return @user.talent_lms_email if @user.talent_lms_email.present?
+      return @user.email if @user.email.present? && GrdaWarehouse::Config.get(:default_lms_email_to_warehouse_email)
 
       "#{lms_username}@#{ENV['FQDN']}"
     end
@@ -82,12 +83,12 @@ module Talentlms
       api_data.present?
     end
 
-    # Syncronize the user's local data with taht found in the config (subdomain)
+    # Get the account data for the user from the API
     #
     # @param api [Integer] Config ID for the config record that contains information about the subdomain where the user's account will be synced with the local data
     # @param login [Integer] Nullable ID for the Login record that contains local information about the user we are syncronizing.
     # @return [JSON] Account data returned from the API, nil if no account data is available
-    def sync_lms_account(api, login)
+    def get_lms_account_data(api, login)
       username = lms_username
       email_address = lms_email
 
@@ -99,6 +100,17 @@ module Talentlms
       # Talent does not have a record associated with this email address, check the default username. If we generated an
       # account for this user prior to allowing emails to be set, we should be able to find it this way.
       result ||= lms_find_user_by_username(api, username)
+
+      result
+    end
+
+    # Syncronize the user's local data with taht found in the config (subdomain)
+    #
+    # @param api [Integer] Config ID for the config record that contains information about the subdomain where the user's account will be synced with the local data
+    # @param login [Integer] Nullable ID for the Login record that contains local information about the user we are syncronizing.
+    # @return [JSON] Account data returned from the API, nil if no account data is available or account is inactive
+    def sync_lms_account(api, login)
+      result = get_lms_account_data(api, login)
       # Talent does not have a record associated with this user, create an account for them.
       result ||= create_account(api)
 
@@ -115,8 +127,23 @@ module Talentlms
         # With this saved, out local data will be synced with that in Talent for this user.
         create_or_update_local_login(api, result) if result.present?
       end
+      # Return nil when the user is not active. This will have the interface work as if the user was not found
+      # and could not be created (e.g. force a redirect to the captive portal)
+      return nil unless active_user?(api, login, result)
 
       result
+    end
+
+    # Return whether or not a user is active in a config
+    #
+    # @param api [Integer] Config ID for the config record that contains information about the subdomain where the user's account will be synced with the local data
+    # @param login [Integer] Nullable ID for the Login record that contains local information about the user we are syncronizing.
+    # @param api_resonse [JSON] include JSON data here to bypass API lookup. Including this data will prevent additional API calls.
+    # @return [JSON] Account data returned from the API, nil if no account data is available or account is inactive
+    def active_user?(api, login = nil, api_response = nil)
+      login = Login.find_by(config: api, user: @user) unless login.present?
+      api_response = get_lms_account_data(api, login) unless api_response.present?
+      api_response.present? && api_response['status'].downcase == 'active'
     end
 
     # Set the locally stored data for an lmls account

--- a/app/views/admin/talentlms/_form.haml
+++ b/app/views/admin/talentlms/_form.haml
@@ -1,3 +1,4 @@
 = f.input :subdomain
 = f.input :api_key, label: 'API Key'
-= f.input :create_new_accounts, label: 'Allow creation of new accounts'
+= f.input :create_new_accounts, label: 'Allow creation of new accounts', hint: 'This will allow accounts to be automatically generated if they do not already exists in the LMS system.'
+= f.input :allow_automatic_redirect_to_course, label: 'Allow automatic course redirects', hint: 'This will allow bypassing the training page when only one course requires training.'

--- a/app/views/admin/talentlms/_form.haml
+++ b/app/views/admin/talentlms/_form.haml
@@ -1,4 +1,4 @@
 = f.input :subdomain
 = f.input :api_key, label: 'API Key'
 = f.input :create_new_accounts, label: 'Allow creation of new accounts', hint: 'This will allow accounts to be automatically generated if they do not already exists in the LMS system.'
-= f.input :allow_automatic_redirect_to_course, label: 'Allow automatic course redirects', hint: 'This will allow bypassing the training page when only one course requires training.'
+= f.input :allow_automatic_redirect_to_course, label: 'Allow automatic course redirects', hint: 'When checked, users who only need to complete one course will be immediately redirected to TalentLMS upon login to the warehouse.  When unchecked or if a user needs to complete more than one course, a summary page will direct users to complete course with links to TalentLMS.'

--- a/app/views/admin/talentlms/index.haml
+++ b/app/views/admin/talentlms/index.haml
@@ -12,6 +12,7 @@
 .well
   = simple_form_for @site_configs, url: update_site_config_admin_talentlms_path(@site_configs), method: :post, remote: true do |f|
     = f.input :number_lms_courses_required, as: :select_two, collection: GrdaWarehouse::Config.available_number_lms_courses_required,  input_html: {class: :jRemoteSubmit}, label: 'TalentLMS Courses Completion Requirement'
+    = f.input :default_lms_email_to_warehouse_email, input_html: {class: :jRemoteSubmit}, label: 'Use warehouse email by default', hint: "When the TalentLMS email field is blank for a user, default to using the user's warehouse email address"
 .h2 
   Subdomians
 .well
@@ -26,6 +27,7 @@
         %tr
           %th Subdomain
           %th Can Create New Accounts in TalentLMS
+          %th Allow Automatic Course Redirect
           %th 
       %tbody
         - @configs.each do |config|
@@ -34,6 +36,9 @@
               = link_to config.unique_name, edit_admin_talentlm_path(config)
             %td
               - if config.create_new_accounts 
+                %i.icon-checkmark
+            %td
+              - if config.allow_automatic_redirect_to_course 
                 %i.icon-checkmark
             %td
               - if config.courses.count == 0 
@@ -93,13 +98,13 @@
           url: form.attr('action'),
           success: function(e) {
             console.debug('success')
-            var html = '<div class="jAjaxSave alert alert-success">Course completion requirement saved successfully.</div>';
+            var html = '<div class="jAjaxSave alert alert-success">TalentLMS configuration saved successfully.</div>';
             $('.utility').html(html);
             $('.jAjaxSave').delay(5000).fadeOut(250);
           },
           error: function(e) {
             console.debug('fail')
-            var html = '<div class="jAjaxSave alert alert-danger">Failed to save course completion requirement.</div>';
+            var html = '<div class="jAjaxSave alert alert-danger">Failed to save TalentLMS configuration.</div>';
             $('.utility').html(html);
             $('.jAjaxSave').delay(5000).fadeOut(250);
           }

--- a/app/views/user_training/required_trainings.haml
+++ b/app/views/user_training/required_trainings.haml
@@ -30,6 +30,10 @@
     %p 
       Domain:
       = link_to config.domain, "https://#{config.domain}"
+      - if ! lms.active_user?(config)
+        .font-italic
+          %i.icon-warning
+          No active account found in this domain
     .table-responsive
       %table.table.table-striped
         %thead

--- a/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
+++ b/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
@@ -1,6 +1,6 @@
 class TalentConfigurationFlags < ActiveRecord::Migration[7.0]
   def change
     add_column :configs, :default_lms_email_to_warehouse_email, :boolean
-    add_column :talentlms_configs, :allow_automatic_redirect_to_course, :boolean, default: true  
+    add_column :talentlms_configs, :allow_automatic_redirect_to_course, :boolean, default: true
   end
 end

--- a/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
+++ b/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
@@ -1,0 +1,6 @@
+class TalentConfigurationFlags < ActiveRecord::Migration[7.0]
+  def change
+    add_column :configs, :default_lms_email_to_warehouse_email, :boolean
+    add_column :talentlms_configs, :allow_automatic_redirect_to_course, :boolean
+  end
+end

--- a/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
+++ b/db/warehouse/migrate/20241216184819_talent_configuration_flags.rb
@@ -1,6 +1,6 @@
 class TalentConfigurationFlags < ActiveRecord::Migration[7.0]
   def change
     add_column :configs, :default_lms_email_to_warehouse_email, :boolean
-    add_column :talentlms_configs, :allow_automatic_redirect_to_course, :boolean
+    add_column :talentlms_configs, :allow_automatic_redirect_to_course, :boolean, default: true  
   end
 end

--- a/spec/models/talentlms/facade_spec.rb
+++ b/spec/models/talentlms/facade_spec.rb
@@ -73,6 +73,64 @@ RSpec.describe Talentlms::Facade, type: :model do
     end
   end
 
+  describe 'active_user?' do
+    it 'returns true if user is active and no api_response data is included' do
+      expect(lms.active_user?(config, lms_login)).to be_truthy
+    end
+
+    it 'returns true if user is active in provided api response' do
+      api_stub_response = lms.get_lms_account_data(config, lms_login)
+      expect(lms.active_user?(nil, nil, api_stub_response)).to be_truthy
+    end
+
+    it 'returns false if user is not active' do
+      stub_so_api_user_is_inactive(config: config)
+      expect(lms.active_user?(config, lms_login)).to be_falsey
+    end
+
+    it 'returns false if user is active in provided api response' do
+      stub_so_api_user_is_inactive(config: config)
+      api_stub_response = lms.get_lms_account_data(config, lms_login)
+      expect(lms.active_user?(nil, nil, api_stub_response)).to be_falsey
+    end
+  end
+
+  describe 'get_lms_account_data' do
+    it 'returns api data when no login data is sent' do
+      expected = {
+        'email' => DEFAULT_LMS_EMAIL,
+        'login' => DEFAULT_LMS_USERNAME,
+        'id' => DEFAULT_LMS_USER_ID,
+        'status' => 'active',
+      }
+      response = lms.get_lms_account_data(config, nil)
+      expect(response).to eq(expected)
+    end
+
+    it 'returns api data when local data exists that does not match api data' do
+      stub_so_api_user_does_not_matches_local_user(config: config)
+      expected = {
+        'email' => UPDATED_LMS_EMAIL,
+        'login' => UPDATED_LMS_USERNAME,
+        'id' => UPDATED_LMS_USER_ID,
+        'status' => 'active',
+      }
+      response = lms.get_lms_account_data(config, lms_login)
+      expect(response).to eq(expected)
+    end
+
+    it 'returns api data when local data exists that matches api data' do
+      expected = {
+        'email' => DEFAULT_LMS_EMAIL,
+        'login' => DEFAULT_LMS_USERNAME,
+        'id' => DEFAULT_LMS_USER_ID,
+        'status' => 'active',
+      }
+      response = lms.get_lms_account_data(config, lms_login)
+      expect(response).to eq(expected)
+    end
+  end
+
   describe 'sync_lms_account' do
     it 'local data remains the same when user data matches api data' do
       login = Talentlms::Login.where(user: user).first
@@ -360,6 +418,7 @@ RSpec.describe Talentlms::Facade, type: :model do
         'email' => DEFAULT_LMS_EMAIL,
         'login' => DEFAULT_LMS_USERNAME,
         'id' => DEFAULT_LMS_USER_ID,
+        'status' => 'active',
       },
     )
 
@@ -371,6 +430,7 @@ RSpec.describe Talentlms::Facade, type: :model do
         'email' => DEFAULT_LMS_EMAIL,
         'login' => DEFAULT_LMS_USERNAME,
         'id' => DEFAULT_LMS_USER_ID,
+        'status' => 'active',
       },
     )
   end
@@ -395,6 +455,21 @@ RSpec.describe Talentlms::Facade, type: :model do
         'email' => UPDATED_LMS_EMAIL,
         'login' => UPDATED_LMS_USERNAME,
         'id' => UPDATED_LMS_USER_ID,
+        'status' => 'active',
+      },
+    )
+  end
+
+  def stub_so_api_user_is_inactive(config:)
+    allow(config).to receive(:post).with(
+      'users',
+      anything,
+    ).and_return(
+      {
+        'email' => UPDATED_LMS_EMAIL,
+        'login' => UPDATED_LMS_USERNAME,
+        'id' => UPDATED_LMS_USER_ID,
+        'status' => 'This is anything but "active"',
       },
     )
   end

--- a/spec/models/talentlms/facade_spec.rb
+++ b/spec/models/talentlms/facade_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Talentlms::Facade, type: :model do
       expect(lms.active_user?(config, lms_login)).to be_falsey
     end
 
-    it 'returns false if user is active in provided api response' do
+    it 'returns false if user is not active in provided api response' do
       stub_so_api_user_is_inactive(config: config)
       api_stub_response = lms.get_lms_account_data(config, lms_login)
       expect(lms.active_user?(nil, nil, api_stub_response)).to be_falsey


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Updates for TalentLMS Captive Portal
- Users who are inactive in talentlms are always redirected to the captive portal
- Captive displays if an active account cannot be found for a domain
- Add site config flag to allow using warehouse email for talentlms by default
- Add talentlms::config flag to allow config to do an automatic redirect to the required course (if it is the only course required)
- Always show captive portal if more than one course is required

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
