### PR TITLE
APR Q4a residential affiliation mapping

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_four.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2024/question_four.rb
@@ -75,10 +75,10 @@ module HudApr::Generators::Shared::Fy2024
           project.ProjectType,
           project.RRHSubType,
           # Coordinated Entry Access Point
-          (ce_participation&.AccessPoint || 0),
+          ce_participation&.AccessPoint || 0,
           # (If 2.02.6 =6 or (13 and 2.02.6A = 1)), then 0 or 1
           (project.ProjectType == 6 || (project.ProjectType == 13 && project.RRHSubType == 1) ? project.ResidentialAffiliation : 0),
-          if project.ProjectType == 6 && project.ResidentialAffiliation == 1 then project.residential_affiliations.map(&:ResProjectID).join(', ') else ' ' end,
+          if project.ProjectType == 6 && project.ResidentialAffiliation == 1 then project.residential_projects.map(&:ProjectID).join(', ') else ' ' end,
           project.project_cocs.map(&:effective_coc_code).join(', '),
           project.project_cocs.map(&:effective_geocode).join(', '),
           if project.VictimServicesProvider.present? then project.VictimServicesProvider else 0 end,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Update APR Q4a to pull affiliated residential projects using `residential_projects` instead of `residential_affiliations`. `residential_projects` appears to be bringing back the residential projects that are affiliated with said project as opposed to `residential_affiliations` which appears to be looking for projects that a residential project is affiliated with.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
