### PR TITLE
Disable pg hero stats

### DIFF
--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -355,7 +355,9 @@ namespace :grda_warehouse do
 
     BuildTranslationCacheJob.perform_later
 
-    PgheroCollectStatsJob.perform_later(clean: DateTime.current.hour == 5) if !Rails.env.production? && PgHero.query_stats_enabled?
+    # Disabled pg-hero status job for now. This doesn't have the required permissions
+    # to run in RDS. Note, pg-hero still works without it
+    # PgheroCollectStatsJob.perform_later(clean: DateTime.current.hour == 5) if !Rails.env.production? && PgHero.query_stats_enabled?
   end
 
   desc 'Mark the first residential service history record for clients for whom this has not yet been done; if you set the parameter to *any* value, all clients will be reset'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Disable's pghero's broken stats job. [Resolves sentry issue](https://green-river.sentry.io/issues/6113108363/events/1f600bc5f25047a3a18d9acd438f8b24/).

I'm leaving the job in place for now as it seem like could be a useful tool for future db optimization work

## Type of change
Housekeeping 

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:

