### PR TITLE
Move Advisory Locks to DJ for imports

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -57,9 +57,8 @@ class UploadsController < ApplicationController
       deidentified: @upload.deidentified,
       allowed_projects: @upload.project_whitelist,
     }
-    job_class = Importing::HudZip::HmisAutoMigrateJob
-    job = Delayed::Job.enqueue job_class.new(**options), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
-    @upload.update(delayed_job_id: job.id)
+    job = Importing::HudZip::HmisAutoMigrateJob.perform_later(**options)
+    @upload.update(delayed_job_id: job.provider_job_id)
   end
 
   private def upload_params

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -55,7 +55,7 @@ class UploadsController < ApplicationController
       upload_id: @upload.id,
       data_source_id: @upload.data_source_id,
       deidentified: @upload.deidentified,
-      project_whitelist: @upload.project_whitelist,
+      allowed_projects: @upload.project_whitelist,
     }
     job_class = Importing::HudZip::HmisAutoMigrateJob
     job = Delayed::Job.enqueue job_class.new(**options), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)

--- a/app/jobs/base_job.rb
+++ b/app/jobs/base_job.rb
@@ -61,4 +61,32 @@ class BaseJob < ApplicationJob
       WorkerStatus.new(job).conditional_exit!
     end
   end
+
+  # attempts to requeue this job for a later time
+  # This is somewhat brittle at this time and expects to be operating on
+  # an ActiveJob instance (something like an instance of Importing::HudZip::HmisAutoMigrateJob).
+  # Additionally, this expects the rails job backend to be Delayed::Job
+  def requeue_at(timestamp, message)
+    Rails.logger.info(message) if message.present?
+    new_job = delayed_job.dup
+    new_job.update(
+      locked_at: nil,
+      locked_by: nil,
+      run_at: timestamp,
+      attempts: calculated_attempts,
+    )
+  end
+
+  # Attempt to find the associated delayed job so we can use it
+  def delayed_job
+    job = Delayed::Job.jobs_for_class(job_id).first
+    raise 'Unable to find a related delayed job' unless job.present?
+
+    job
+  end
+
+  # Override as necessary to limit the number of times a job is tried
+  def calculated_attempts
+    0
+  end
 end

--- a/app/jobs/base_job.rb
+++ b/app/jobs/base_job.rb
@@ -80,7 +80,8 @@ class BaseJob < ApplicationJob
   # Attempt to find the associated delayed job so we can use it
   def delayed_job
     job = Delayed::Job.jobs_for_class(job_id).first
-    raise 'Unable to find a related delayed job' unless job.present?
+    # NOTE: job_id will probably be a UUID in the handler of the row
+    raise "Unable to find a related delayed job (ID: #{job_id})" unless job.present?
 
     job
   end

--- a/app/jobs/importing/hud_zip/fetch_and_import_job.rb
+++ b/app/jobs/importing/hud_zip/fetch_and_import_job.rb
@@ -7,18 +7,28 @@
 module Importing::HudZip
   class FetchAndImportJob < BaseJob
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
-    WAIT_MINUTES = 4
+    WAIT_MINUTES = 15
 
-    def perform(klass:, options:)
-      safe_klass = known_classes.detect { |m| klass == m }
+    attr_accessor :job
+
+    def initialize(klass:, options:)
+      @klass = klass
+      @options = options
+    end
+
+    def before(job)
+      self.job = job
+    end
+
+    def perform
+      safe_klass = known_classes.detect { |m| @klass == m }
       raise "Unknown import class: #{klass}; You must add it to the list of known classes in FetchAndImportJob" unless safe_klass.present?
 
-      data_source_id = options.with_indifferent_access[:data_source_id]
-      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock("#{klass}_#{data_source_id}", timeout_seconds: 10) do
-        safe_klass.constantize.new(**options).import!
+      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 60) do
+        safe_klass.constantize.new(**@options).import!
       end
 
-      requeue_job(data_source_id) unless lock_obtained
+      requeue_job unless lock_obtained
     end
 
     def max_attempts
@@ -31,13 +41,21 @@ module Importing::HudZip
       ].freeze
     end
 
-    private def requeue_job(data_source_id)
+    private def advisory_lock_name
+      GrdaWarehouse::DataSource.import_advisory_lock_name(data_source_id)
+    end
+
+    private def data_source_id
+      job.payload_object.instance_variable_get(:@data_source_id)
+    end
+
+    private def requeue_job
       # Re-queue this import for a few minutes later
       a_t = Delayed::Job.arel_table
       job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
       return unless job_object
 
-      Rails.logger.info("Import for Data Source #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      Rails.logger.info("Import of Data Source #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
       new_job = job_object.dup
       new_job.update(
         locked_at: nil,

--- a/app/jobs/importing/hud_zip/fetch_and_import_job.rb
+++ b/app/jobs/importing/hud_zip/fetch_and_import_job.rb
@@ -9,28 +9,22 @@ module Importing::HudZip
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
     WAIT_MINUTES = 15
 
-    attr_accessor :job
+    # When you call jobs with .perform_later, they are executed in the ActiveJob world, which doesn't
+    # obey they max_attempts for Delayed Job.  We'll adjust the attempts to give us what we want
+    after_enqueue :enforce_max_attempts
 
-    def initialize(klass:, options:)
-      @klass = klass
-      @options = options
-    end
-
-    def before(job)
-      self.job = job
-    end
-
-    def perform
-      safe_klass = known_classes.detect { |m| @klass == m }
+    def perform(klass:, options:)
+      safe_klass = known_classes.detect { |m| klass == m }
       raise "Unknown import class: #{klass}; You must add it to the list of known classes in FetchAndImportJob" unless safe_klass.present?
 
-      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 60) do
-        safe_klass.constantize.new(**@options).import!
+      data_source_id = options[:data_source_id]
+      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name(data_source_id), timeout_seconds: 60) do
+        safe_klass.constantize.new(**options).import!
         # To prevent re-running when called against the same files if run more than once in a day, yield true
         true
       end
 
-      requeue_job unless lock_obtained
+      requeue_at(Time.current + WAIT_MINUTES.minutes, "Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now") unless lock_obtained
     end
 
     def known_classes
@@ -39,33 +33,20 @@ module Importing::HudZip
       ].freeze
     end
 
-    private def advisory_lock_name
+    private def advisory_lock_name(data_source_id)
       GrdaWarehouse::DataSource.import_advisory_lock_name(data_source_id)
     end
 
-    private def data_source_id
-      job.payload_object.instance_variable_get(:@options)[:data_source_id]
+    def enforce_max_attempts
+      delayed_job.update!(attempts: calculated_attempts)
     end
 
-    private def requeue_job
-      # Re-queue this import before processing if another import is running for the same data_source
-      # This should help prevent tying up delayed job workers that are really just waiting
-      # for the previous import to complete
-      Rails.logger.info("Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
-      new_job = job.dup
-      new_job.update(
-        locked_at: nil,
-        locked_by: nil,
-        run_at: Time.current + WAIT_MINUTES.minutes,
-        attempts: 0,
-      )
-    end
+    def calculated_attempts
+      dj_max_attempts = Delayed::Worker.max_attempts
+      max_attempts = 1
+      return 0 if max_attempts >= dj_max_attempts
 
-    def enqueue(job)
-    end
-
-    def max_attempts
-      1
+      dj_max_attempts - max_attempts
     end
   end
 end

--- a/app/jobs/importing/hud_zip/fetch_and_import_job.rb
+++ b/app/jobs/importing/hud_zip/fetch_and_import_job.rb
@@ -42,11 +42,9 @@ module Importing::HudZip
     end
 
     def calculated_attempts
-      dj_max_attempts = Delayed::Worker.max_attempts
+      # How many times should we allow this job to fail before we fail permanently
       max_attempts = 1
-      return 0 if max_attempts >= dj_max_attempts
-
-      dj_max_attempts - max_attempts
+      [0, Delayed::Worker.max_attempts - max_attempts].max
     end
   end
 end

--- a/app/jobs/importing/hud_zip/fetch_and_import_job.rb
+++ b/app/jobs/importing/hud_zip/fetch_and_import_job.rb
@@ -26,13 +26,11 @@ module Importing::HudZip
 
       lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 60) do
         safe_klass.constantize.new(**@options).import!
+        # To prevent re-running when called against the same files if run more than once in a day, yield true
+        true
       end
 
       requeue_job unless lock_obtained
-    end
-
-    def max_attempts
-      1
     end
 
     def known_classes
@@ -46,23 +44,28 @@ module Importing::HudZip
     end
 
     private def data_source_id
-      job.payload_object.instance_variable_get(:@data_source_id)
+      job.payload_object.instance_variable_get(:@options)[:data_source_id]
     end
 
     private def requeue_job
-      # Re-queue this import for a few minutes later
-      a_t = Delayed::Job.arel_table
-      job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
-      return unless job_object
-
-      Rails.logger.info("Import of Data Source #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
-      new_job = job_object.dup
+      # Re-queue this import before processing if another import is running for the same data_source
+      # This should help prevent tying up delayed job workers that are really just waiting
+      # for the previous import to complete
+      Rails.logger.info("Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      new_job = job.dup
       new_job.update(
         locked_at: nil,
         locked_by: nil,
         run_at: Time.current + WAIT_MINUTES.minutes,
         attempts: 0,
       )
+    end
+
+    def enqueue(job)
+    end
+
+    def max_attempts
+      1
     end
   end
 end

--- a/app/jobs/importing/hud_zip/fetch_and_import_job.rb
+++ b/app/jobs/importing/hud_zip/fetch_and_import_job.rb
@@ -7,12 +7,18 @@
 module Importing::HudZip
   class FetchAndImportJob < BaseJob
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+    WAIT_MINUTES = 4
 
     def perform(klass:, options:)
       safe_klass = known_classes.detect { |m| klass == m }
-      raise "Unknown import class: #{klass}; You must add it to the whitelist in FetchAndImportJob" unless safe_klass.present?
+      raise "Unknown import class: #{klass}; You must add it to the list of known classes in FetchAndImportJob" unless safe_klass.present?
 
-      safe_klass.constantize.new(**options).import!
+      data_source_id = options.with_indifferent_access[:data_source_id]
+      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock("#{klass}_#{data_source_id}", timeout_seconds: 10) do
+        safe_klass.constantize.new(**options).import!
+      end
+
+      requeue_job(data_source_id) unless lock_obtained
     end
 
     def max_attempts
@@ -23,6 +29,22 @@ module Importing::HudZip
       [
         'Importers::HmisAutoMigrate::S3',
       ].freeze
+    end
+
+    private def requeue_job(data_source_id)
+      # Re-queue this import for a few minutes later
+      a_t = Delayed::Job.arel_table
+      job_object = Delayed::Job.where(a_t[:handler].matches("%job_id: #{job_id}%").or(a_t[:id].eq(job_id))).first
+      return unless job_object
+
+      Rails.logger.info("Import for Data Source #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      new_job = job_object.dup
+      new_job.update(
+        locked_at: nil,
+        locked_by: nil,
+        run_at: Time.current + WAIT_MINUTES.minutes,
+        attempts: 0,
+      )
     end
   end
 end

--- a/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
+++ b/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
@@ -28,7 +28,7 @@ module Importing::HudZip
           data_source_id: @data_source_id,
           upload_id: @upload_id,
           deidentified: @deidentified,
-          allowed_projects: @project_whitelist,
+          allowed_projects: @allowed_projects,
         )
         importer.import!
       end

--- a/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
+++ b/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
@@ -9,61 +9,39 @@ module Importing::HudZip
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
     WAIT_MINUTES = 15
 
-    attr_accessor :job
+    # When you call jobs with .perform_later, they are executed in the ActiveJob world, which doesn't
+    # obey they max_attempts for Delayed Job.  We'll adjust the attempts to give us what we want
+    after_enqueue :enforce_max_attempts
 
-    def initialize(upload_id:, data_source_id:, deidentified: false, allowed_projects: false)
-      @upload_id = upload_id
-      @data_source_id = data_source_id
-      @deidentified = deidentified
-      @allowed_projects = allowed_projects
-    end
-
-    def before(job)
-      self.job = job
-    end
-
-    def perform
-      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 60) do
+    def perform(upload_id:, data_source_id:, deidentified: false, allowed_projects: false)
+      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name(data_source_id), timeout_seconds: 2) do
         importer = Importers::HmisAutoMigrate::UploadedZip.new(
-          data_source_id: @data_source_id,
-          upload_id: @upload_id,
-          deidentified: @deidentified,
-          allowed_projects: @allowed_projects,
+          data_source_id: data_source_id,
+          upload_id: upload_id,
+          deidentified: deidentified,
+          allowed_projects: allowed_projects,
         )
         importer.import!
       end
 
       # when this exits, it will remove the current job from the queue, so add a new one to replace it
-      requeue_job unless lock_obtained
+      requeue_at(Time.current + WAIT_MINUTES.minutes, "Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now") unless lock_obtained
     end
 
-    private def advisory_lock_name
+    private def advisory_lock_name(data_source_id)
       GrdaWarehouse::DataSource.import_advisory_lock_name(data_source_id)
     end
 
-    private def data_source_id
-      job.payload_object.instance_variable_get(:@data_source_id)
+    def enforce_max_attempts
+      delayed_job.update!(attempts: calculated_attempts)
     end
 
-    private def requeue_job
-      # Re-queue this import before processing if another import is running for the same data_source
-      # This should help prevent tying up delayed job workers that are really just waiting
-      # for the previous import to complete
-      Rails.logger.info("Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
-      new_job = job.dup
-      new_job.update(
-        locked_at: nil,
-        locked_by: nil,
-        run_at: Time.current + WAIT_MINUTES.minutes,
-        attempts: 0,
-      )
-    end
+    def calculated_attempts
+      dj_max_attempts = Delayed::Worker.max_attempts
+      max_attempts = 1
+      return 0 if max_attempts >= dj_max_attempts
 
-    def enqueue(job)
-    end
-
-    def max_attempts
-      1
+      dj_max_attempts - max_attempts
     end
   end
 end

--- a/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
+++ b/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
@@ -32,10 +32,9 @@ module Importing::HudZip
         )
         importer.import!
       end
-      return if lock_obtained
 
       # when this exits, it will remove the current job from the queue, so add a new one to replace it
-      requeue_job
+      requeue_job unless lock_obtained
     end
 
     private def advisory_lock_name

--- a/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
+++ b/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
@@ -11,11 +11,11 @@ module Importing::HudZip
 
     attr_accessor :job
 
-    def initialize(upload_id:, data_source_id:, deidentified: false, project_whitelist: false)
+    def initialize(upload_id:, data_source_id:, deidentified: false, allowed_projects: false)
       @upload_id = upload_id
       @data_source_id = data_source_id
       @deidentified = deidentified
-      @project_whitelist = project_whitelist
+      @allowed_projects = allowed_projects
     end
 
     def before(job)
@@ -23,7 +23,7 @@ module Importing::HudZip
     end
 
     def perform
-      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 0) do
+      lock_obtained = GrdaWarehouse::DataSource.with_advisory_lock(advisory_lock_name, timeout_seconds: 60) do
         importer = Importers::HmisAutoMigrate::UploadedZip.new(
           data_source_id: @data_source_id,
           upload_id: @upload_id,
@@ -39,16 +39,18 @@ module Importing::HudZip
     end
 
     private def advisory_lock_name
-      "hud_import_auto_migrate_#{@data_source_id}"
+      GrdaWarehouse::DataSource.import_advisory_lock_name(data_source_id)
+    end
+
+    private def data_source_id
+      job.payload_object.instance_variable_get(:@data_source_id)
     end
 
     private def requeue_job
       # Re-queue this import before processing if another import is running for the same data_source
       # This should help prevent tying up delayed job workers that are really just waiting
       # for the previous import to complete
-      @data_source_id = job.payload_object.instance_variable_get(:@data_source_id)
-
-      Rails.logger.info("Import of Data Source: #{@data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
+      Rails.logger.info("Import of Data Source: #{data_source_id} already running...re-queuing job for #{WAIT_MINUTES} minutes from now")
       new_job = job.dup
       new_job.update(
         locked_at: nil,

--- a/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
+++ b/app/jobs/importing/hud_zip/hmis_auto_migrate_job.rb
@@ -37,11 +37,9 @@ module Importing::HudZip
     end
 
     def calculated_attempts
-      dj_max_attempts = Delayed::Worker.max_attempts
+      # How many times should we allow this job to fail before we fail permanently
       max_attempts = 1
-      return 0 if max_attempts >= dj_max_attempts
-
-      dj_max_attempts - max_attempts
+      [0, Delayed::Worker.max_attempts - max_attempts].max
     end
   end
 end

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -534,6 +534,10 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     min_completion_time.to_date
   end
 
+  def self.import_advisory_lock_name(data_source_id)
+    "enforce_sequential_data_source_imports_for_#{data_source_id}"
+  end
+
   def self.stalled_imports?(user)
     Rails.cache.fetch(['data_source_stalled_imports', user], expires_in: 1.hours) do
       stalled = false

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
@@ -68,7 +68,7 @@ module HmisCsvImporter::Importer
 
     # Needs to return an import_log instance
     def import!(import_log = nil)
-      # log that we're waiting, but then continue on.
+      # log that we're waiting and requeue for a few minutes later
       already_running_for_data_source?
 
       GrdaWarehouse::DataSource.with_advisory_lock("hud_import_#{data_source.id}") do

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
@@ -68,27 +68,22 @@ module HmisCsvImporter::Importer
 
     # Needs to return an import_log instance
     def import!(import_log = nil)
-      # log that we're waiting and requeue for a few minutes later
-      already_running_for_data_source?
-
-      GrdaWarehouse::DataSource.with_advisory_lock("hud_import_#{data_source.id}") do
-        start_import
-        @import_log = import_log
-        log_timing :analyze_tables
-        log_timing :pre_process!
-        log_timing :validate_data_set!
-        log_timing :aggregate!
-        log_timing :cleanup_data_set!
-        log_timing :analyze_tables
-        # refuse to proceed with the import if there are any errors and that setting is in effect
-        if should_pause?
-          pause_import
-        else
-          ingest!
-          log_timing :invalidate_aggregated_enrollments!
-          complete_import
-          post_process
-        end
+      start_import
+      @import_log = import_log
+      log_timing :analyze_tables
+      log_timing :pre_process!
+      log_timing :validate_data_set!
+      log_timing :aggregate!
+      log_timing :cleanup_data_set!
+      log_timing :analyze_tables
+      # refuse to proceed with the import if there are any errors and that setting is in effect
+      if should_pause?
+        pause_import
+      else
+        ingest!
+        log_timing :invalidate_aggregated_enrollments!
+        complete_import
+        post_process
       end
     end
 
@@ -728,12 +723,6 @@ module HmisCsvImporter::Importer
         where.not(id: export_record.id).
         maximum(:ExportDate).to_date
       export_record.ExportDate.to_date >= previous_date
-    end
-
-    def already_running_for_data_source?
-      running = GrdaWarehouse::DataSource.advisory_lock_exists?("hud_import_#{data_source.id}")
-      log("Import of Data Source: #{data_source.short_name} already running...waiting") if running
-      running
     end
 
     def pause_import

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -142,6 +142,7 @@ namespace :grda_warehouse do
       conf.possible_files.each do |file_name|
         options[:file_name] = file_name
         job_class = Importing::HudZip::FetchAndImportJob
+
         Delayed::Job.enqueue job_class.new(klass: 'Importers::HmisAutoMigrate::S3', options: options), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
       end
     end

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -141,7 +141,8 @@ namespace :grda_warehouse do
       # Deal with fetching more than one file
       conf.possible_files.each do |file_name|
         options[:file_name] = file_name
-        Importing::HudZip::FetchAndImportJob.perform_later(klass: 'Importers::HmisAutoMigrate::S3', options: options)
+        job_class = Importing::HudZip::FetchAndImportJob
+        Delayed::Job.enqueue job_class.new(klass: 'Importers::HmisAutoMigrate::S3', options: options), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
       end
     end
   end

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -141,9 +141,7 @@ namespace :grda_warehouse do
       # Deal with fetching more than one file
       conf.possible_files.each do |file_name|
         options[:file_name] = file_name
-        job_class = Importing::HudZip::FetchAndImportJob
-
-        Delayed::Job.enqueue job_class.new(klass: 'Importers::HmisAutoMigrate::S3', options: options), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+        Importing::HudZip::FetchAndImportJob.perform_later(klass: 'Importers::HmisAutoMigrate::S3', options: options)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* This moves an advisory lock out of the importer and up to the calling delayed jobs. 
* It standardizes the delayed job structure for the two importers and enforces one run per data source regardless of which method is used to kick off the import
* Fixes a situation where imports could time out waiting for an advisory lock

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix
* Code clean-up

## Testing instructions
1. Upload more than one HMIS CSV Zip file to a single data source
2. Confirm the first runs and the subsequent ones are pushed out 15 minutes
3. Upload to another data source while the first is running and confirm it is picked up within a few minutes
4. Test S3 setup - Find a data source that is setup to import from S3 and set it to more than one file.
5. When it runs, the files should be imported sequentially (the first should finish before the second starts.)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
