### PR TITLE
522-improve-unique-name-generation

### DIFF
--- a/app/models/unique_name.rb
+++ b/app/models/unique_name.rb
@@ -36,7 +36,10 @@ class UniqueName < ApplicationRecord
           inserts << UniqueName.new(name: name, double_metaphone: double_metaphone)
         end
       end
-      UniqueName.import(inserts, raise_error: true) if inserts.any?
+      next if inserts.empty?
+
+      result = UniqueName.import(inserts)
+      raise "Failed to import UniqueName: #{result.inspect}" if result.failed_instances.present?
     end
 
     # remove names that are no longer used

--- a/app/models/unique_name.rb
+++ b/app/models/unique_name.rb
@@ -5,21 +5,47 @@
 ###
 
 class UniqueName < ApplicationRecord
-  def self.update!
+  # Build double metaphone representations for all names in the database
+  def self.update!(...)
+    with_advisory_lock('UniqueNameUpdate', timeout_seconds: 0) { _update!(...) }
+  end
+
+  def self._update!(batch_size: 5_000)
     Rails.logger.info 'Updating the unique names table'
 
-    # Build double metaphone representations for all names in the database
-    existing_names = UniqueName.pluck(:name)
-    all_names = GrdaWarehouse::Hud::Client.source.distinct.where.not(FirstName: [nil, '']).pluck('FirstName').map(&:downcase) +
-      GrdaWarehouse::Hud::Client.source.distinct.where.not(LastName: [nil, '']).pluck('LastName').map(&:downcase)
-    new_names = all_names - existing_names
-    name_objects = []
-    new_names.uniq.each do |name|
-      next unless name.present?
-
-      double_metaphone = Text::Metaphone.double_metaphone(name)
-      name_objects << UniqueName.new(name: name, double_metaphone: double_metaphone)
+    existing_names = {}
+    UniqueName.all.pluck_in_batches(:name, batch_size: batch_size) do |batch|
+      batch.each { |name| existing_names[name] = false }
     end
-    UniqueName.import name_objects
+
+    name_cols = [:first_name, :last_name]
+    GrdaWarehouse::Hud::Client.source.pluck_in_batches(name_cols, batch_size: batch_size) do |batch|
+      inserts = []
+      batch.each do |row|
+        row.each do |name|
+          next if name.blank?
+
+          name = name.strip.downcase
+          next if name.length > 100
+
+          name_exists = name.in?(existing_names)
+          existing_names[name] = true
+          next if name_exists
+
+          double_metaphone = Text::Metaphone.double_metaphone(name)
+          inserts << UniqueName.new(name: name, double_metaphone: double_metaphone)
+        end
+      end
+      UniqueName.import(inserts, raise_error: true) if inserts.any?
+    end
+
+    # remove names that are no longer used
+    missing_names = []
+    existing_names.filter do |name, exists|
+      missing_names << name unless exists
+    end
+    missing_names.each_slice(batch_size) do |batch|
+      UniqueName.where(name: batch).delete_all
+    end
   end
 end

--- a/spec/models/uniq_names_spec.rb
+++ b/spec/models/uniq_names_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe UniqueName, type: :model do
+  describe '.update!' do
+    let!(:ds) { create :source_data_source }
+    let!(:warehouse_data_source) { create :grda_warehouse_data_source, source_type: nil }
+    let!(:client1) { create(:grda_warehouse_hud_client, FirstName: 'Joe', LastName: 'Smith', data_source: ds) }
+    let!(:client2) { create(:grda_warehouse_hud_client, FirstName: 'Jane', LastName: 'Doe', data_source: ds) }
+    let!(:existing_name) { UniqueName.create!(name: 'joe', double_metaphone: ['J', 'A']) }
+    let!(:unused_name) { UniqueName.create!(name: 'bob', double_metaphone: ['PP', nil]) }
+
+    before do
+      UniqueName.update!
+    end
+
+    it 'creates new unique names' do
+      expect(UniqueName.where(name: ['smith', 'jane', 'doe']).count).to eq(3)
+    end
+
+    it 'keeps existing names that are still in use' do
+      expect(UniqueName.find_by(name: 'joe')).to eq(existing_name)
+    end
+
+    it 'removes names no longer in use' do
+      expect(UniqueName.find_by(id: unused_name.id)).to be_nil
+    end
+
+    it 'generates double metaphone for new names' do
+      expect(UniqueName.find_by(name: 'smith').double_metaphone).to be_present
+    end
+
+    it 'handles empty/nil names' do
+      create(:grda_warehouse_hud_client, FirstName: '', LastName: nil)
+      expect { UniqueName.update! }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[GH Issue](https://github.com/open-path/Green-River/issues/522)

## Testing
Unique name is used to for fuzzy name matching (double metaphone):
- Identifying potential matches across client records
- In client search by name

test from the console:
```
> GrdaWarehouse::Hud::Client.where(GrdaWarehouse::Hud::Client.metaphone_search(GrdaWarehouse::Hud::Client.arel_table[:id].eq(0), :FirstName, first_name_query_string)).pluck(:first_name
).sort.uniq
```

Improve UniqueName nightly update performance and features
* advisory lock
* batching
* cleanup unused records
* add spec

## Type of change
Enhancement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)

