### PR TITLE
Remove ability to queue old PIT reports

### DIFF
--- a/app/views/report_results/_breadcrumbs.haml
+++ b/app/views/report_results/_breadcrumbs.haml
@@ -1,4 +1,4 @@
 - if @report&.report_group_name.present?
   = content_for :crumbs do
-    = link_to hud_reports_lsas_path do
-      = "« " +  Translation.translate('LSA Reports')
+    = link_to hud_reports_path do
+      = "« " +  Translation.translate('HUD Reports')

--- a/app/views/report_results/index.haml
+++ b/app/views/report_results/index.haml
@@ -1,6 +1,5 @@
 = render partial: 'breadcrumbs'
 %h1= Translation.translate("Report Result: #{@report.name}")
-= render 'queue_form'
 
 :ruby
   columns = {'percent_complete' => 'Status', 'created_at' => 'Started'}


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* [Fixes an issue](https://green-river.sentry.io/issues/6190202142/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=03e5e6dd-0bfe-44ec-9f9f-8ab90f52730b&project=4503977346662400&referrer=slack) where queueing an old PIT report would fail by removing the queueing page (there are multiple newer versions of this report and only the history is needed at this point)
* Fixes a breadcrumb on the old PIT page

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail