### PR TITLE
7135-legacy-policy-bugfix

### DIFF
--- a/app/models/grda_warehouse/auth_policies/source_client_policy.rb
+++ b/app/models/grda_warehouse/auth_policies/source_client_policy.rb
@@ -74,6 +74,8 @@ class GrdaWarehouse::AuthPolicies::SourceClientPolicy < GrdaWarehouse::AuthPolic
     results
   end
 
+  BASIC_CLIENT_PII_PERMS = Set.new([:can_view_client_name, :can_view_client_photo, :can_view_full_dob]).freeze
+
   # Window data sources are a deprecated legacy client data sharing mechanic, replaced by a System Collection when using Access Controls-based permissions
   def add_legacy_data_source_permissions(results)
     # is this a user with legacy role-based perms?
@@ -83,7 +85,29 @@ class GrdaWarehouse::AuthPolicies::SourceClientPolicy < GrdaWarehouse::AuthPolic
     # is the client in a window data source?
     return unless context.legacy_window_data_source_ids.include?(client.data_source_id)
 
-    # check roi if the window config requires release (the "can_*_with_roi" permissions are not relevant in this case)
+    # Legacy visibility rules for client attributes:
+    # If a user has either 'can_view_clients' or 'can_search_all_clients' permission, AND they
+    # have another permission (like viewing names), then the user is granted that permission
+    # for ANY client in window data sources, bypassing ROI requirements.
+    #
+    # For example: A user with both 'can_view_clients' and 'can_view_name' permissions can
+    # see names of all clients in window data sources, regardless of the client's ROI.
+    #
+    # Historical context: This behavior comes from the legacy role-based system where client
+    # visibility was considered "global" if the user could access clients in either "search"
+    # or "view" contexts, but only for "window" data sources.
+    if legacy_permissions.include?(:can_view_clients)
+      # all the legacy perms apply to the client
+      results.merge(legacy_permissions)
+      # early return since there's no point in checking ROI
+      return
+    elsif legacy_permissions.include?(:can_search_all_clients)
+      # The can_search_all_clients confers a reduced set or permissions. This is more restricted
+      # than the historic permissions. This is okay since search has limited client details.
+      results.merge(legacy_permissions & BASIC_CLIENT_PII_PERMS)
+    end
+
+    # check ROI if the window config requires release (the "can_*_with_roi" permissions are not relevant in this case)
     return if context.legacy_window_access_requires_release? && !roi_authorized?
 
     results.merge(legacy_permissions)

--- a/app/models/grda_warehouse/auth_policies/source_client_policy.rb
+++ b/app/models/grda_warehouse/auth_policies/source_client_policy.rb
@@ -104,6 +104,10 @@ class GrdaWarehouse::AuthPolicies::SourceClientPolicy < GrdaWarehouse::AuthPolic
     elsif legacy_permissions.include?(:can_search_all_clients)
       # The can_search_all_clients confers a reduced set or permissions. This is more restricted
       # than the historic permissions. This is okay since search has limited client details.
+      #
+      # Notes
+      # - The client search controller (ClientAccessControl::ClientsController) also requires can_search_window || can_use_strict_search. We aren't enforcing that here.
+      # - See the searchable_to method in the Client extension (drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb) which includes all clients in the search scope if the user has the can_search_all_clients permission
       results.merge(legacy_permissions & BASIC_CLIENT_PII_PERMS)
     end
 

--- a/spec/models/auth_policies/source_client_policy_spec.rb
+++ b/spec/models/auth_policies/source_client_policy_spec.rb
@@ -118,14 +118,42 @@ RSpec.describe GrdaWarehouse::AuthPolicies::SourceClientPolicy, type: :model do
             create(:warehouse_client, source: window_client, data_source: window_data_source)
             create(:client_roi_authorization, destination_client: window_client.destination_client)
           end
-          it 'grants access through window data source' do
-            expect(policy.can_view_name?).to be true
-          end
+          include_examples 'pii permission checks with access'
         end
 
         context 'without release' do
-          it 'denies access' do
-            expect(policy.can_view?).to be false
+          include_examples 'pii permission checks without access'
+
+          context 'when user has "can_view_clients" permission' do
+            let(:permissions) do
+              {
+                can_view_clients: true,
+                can_view_client_name: true,
+                can_view_full_ssn: true,
+                can_view_full_dob: false,
+              }
+            end
+            it 'has expected PII permissions' do
+              expect(policy.can_view_name?).to be true
+              expect(policy.can_view_full_ssn?).to be true
+              expect(policy.can_view_full_dob?).to be false
+            end
+          end
+
+          context 'when user has "can_search_all_clients" permission' do
+            let(:permissions) do
+              {
+                can_search_all_clients: true,
+                can_view_client_name: true,
+                can_view_full_ssn: true,
+                can_view_full_dob: false,
+              }
+            end
+            it 'has expected PII permissions' do
+              expect(policy.can_view_name?).to be true
+              expect(policy.can_view_full_ssn?).to be false
+              expect(policy.can_view_full_dob?).to be false
+            end
           end
         end
       end
@@ -135,9 +163,7 @@ RSpec.describe GrdaWarehouse::AuthPolicies::SourceClientPolicy, type: :model do
           allow(GrdaWarehouse::Config).to receive(:get).with(:window_access_requires_release).and_return(false)
         end
 
-        it 'grants access through window data source' do
-          expect(policy.can_view_name?).to be true
-        end
+        include_examples 'pii permission checks with access'
       end
     end
   end
@@ -179,9 +205,7 @@ RSpec.describe GrdaWarehouse::AuthPolicies::SourceClientPolicy, type: :model do
     context 'with window data source' do
       let(:policy) { user.policy_for(window_client) }
 
-      it 'denies access' do
-        expect(policy.can_view_name?).to be false
-      end
+      include_examples 'pii permission checks without access'
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[GH Issue](https://github.com/open-path/Green-River/issues/7135)
Source client auth policy fix for legacy users with windowed data sources. Account for behavior of special global permissions 

## Testing Instructions

### Setup
1. In a project with a "windowed" data source:
   - Identify a client in that data source who **has no valid ROI** (Release of Information).  
2. Find a test user meeting the following criteria:
   - The user has **legacy role-based access**.  
   - The user has **no relationship** to the client (e.g., via access groups).  
   - The user initially has **no roles** with `can_view_client_name`, `can_view_clients` or `can_search_all_clients`.

### 1. Name Visibility on Search
1. Assign the user a role with the permission `can_search_all_clients`.  
2. Search for the client using their ID (or destination ID).  
   - Verify that the client search card displays the record with **"Name Redacted"**.  
3. Assign the user a role with the permission `can_view_client_name`.  
4. Search for the client again.  
   - Verify that the client search card now displays the record with the **full name**.  


### 2. Name and SSN Visibility on Dashboard
1. Assign the user roles that grant `can_view_clients` and `can_view_full_ssn`.  
2. Search for the client again.  
   - Click on the client in the search results to view their dashboard.  
3. Verify that the **client's name** and **SSN** are displayed on the dashboard.  


## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
