### PR TITLE
fix edge case where all trainings required of a user are inactive

### DIFF
--- a/app/models/talentlms/facade.rb
+++ b/app/models/talentlms/facade.rb
@@ -338,6 +338,10 @@ module Talentlms
         training_required << training_required?(course.config, course.courseid)
       end
 
+      # No training is required if there are no training courses required of this user.
+      # This can occur when all courses (default or assigned) are inactive.
+      return false if training_required.empty?
+
       # If a number of courses required to be completed is set, use that, otherwise, all courses are required to be completed.
       # IF number_courses_required is -1, all courses are required
       number_courses_required = GrdaWarehouse::Config.get(:number_lms_courses_required)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixes issue with TalentLMS redirects (to captive portal or lms course) for users when courses are required of a user (default or assigned) but all of these courses are inactive (out of active date range).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
