### PR TITLE
Fix bug with Client Assessments rollup where form processor is nil

### DIFF
--- a/app/views/clients/rollup/_assessments.html.haml
+++ b/app/views/clients/rollup/_assessments.html.haml
@@ -12,7 +12,7 @@
   -# remove any CE assessments for which we have a matching HMIS custom assessment.  The custom assessment will give better fidelity
   -# we'll add back the ce assessment details on the show page
   - custom_hmis_assessments.each do |assessment|
-    - ce_assessments.delete_if { |ce| ce.id == assessment.form_processor.ce_assessment_id }
+    - ce_assessments.delete_if { |ce| ce.id == assessment.form_processor&.ce_assessment_id }
   - custom_hmis_assessments = custom_hmis_assessments.group_by(&:title)
 
 - ce_assessments = ce_assessments.group_by(&:name)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
GH issue: https://github.com/open-path/Green-River/issues/7178
Sentry link: https://green-river.sentry.io/issues/6202297210/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=d4c20e4f-37d5-4368-8c4e-62405c3c0b92&project=4503977346662400&referrer=slack

Bug: Assessment form processors may be nil, in migrated-in data. But the client assessments rollup doesn't flexibly allow for that. It's throwing an error when checking Custom Assessments against CE Assessments to deduplicate them in the view. 

I reproduced the bug and confirmed the fix locally by `destroy`ing a form processor, to make the assessment look like migrated-in data.

Question: I think this is sufficient to avoid the bug, but is this sufficient to maintain the desired functionality of de-duping CE Assessments? Let's say there is a migrated-in Custom Assessment that doesn't have a form processor, but does correspond to a migrated-in CE Assessment? Would that ever happen? 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
