### PR TITLE
Fix auto-exit bug when service date is before entry

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -27,8 +27,9 @@ module Hmis
         project.enrollments.open_excluding_wip.each do |enrollment|
           most_recent_contact = if project.es_nbn? # Night-by-night Emergency Shelter
             # For NBN shelters, the most recent contact is the last bed night.
-            # If the client had no bed nights, use the enrollment (entry date) as the last contact.
-            enrollment.services.bed_nights.where.not(date_provided: nil).order(:date_provided).last || enrollment
+            last_bed_night = enrollment.services.bed_nights.where.not(date_provided: nil).order(:date_provided).last
+            # If the client had no bed nights, or the last bed night is before enrollment entry (invalid), use the enrollment (entry date) as the last contact.
+            [last_bed_night, enrollment].compact.max_by { |entity| contact_date_for_entity(entity) }
           else
             [
               enrollment.services.where.not(date_provided: nil).order(:date_provided).last,
@@ -81,6 +82,9 @@ module Hmis
         enrollment_id: enrollment.enrollment_id,
       )
       assessment.build_form_processor(exit: exit_record)
+
+      raise ActiveRecord::RecordInvalid, exit_record if exit_record.invalid?
+
       assessment.save!
 
       # Release the unit that was assigned to this Enrollment (if applicable)

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       Hmis::AutoExitJob.perform_now
       expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
     end
+
+    it 'should not fail if enrollment has contact date before entry (regression #7178)' do
+      e1 = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: Date.current - 2.months
+      # most recent bed night is before enrollment entry, which is a DQ issue, but should not cause the AutoExitJob to break.
+      # It should auto-exit the enrollment with the entry date as its exit date.
+      create :hmis_hud_service, data_source: ds1, client: c1, enrollment: e1, user: u1, record_type: 200, date_provided: Date.current - 3.months
+
+      Hmis::AutoExitJob.perform_now
+
+      expect(Hmis::Hud::Enrollment.exited).to include(e1)
+      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
+      expect(e1.exit_assessment&.assessment_date).to eq(e1.entry_date)
+      expect(e1.exit_assessment&.data_collection_stage).to eq(3)
+    end
   end
 
   describe 'for other project types (not ES NBN)' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
GH issue: https://github.com/open-path/Green-River/issues/7178

- When determining the auto-exit date for NBN shelters, take the max of the last service date and the enrollment entry date. This avoids the AutoExitJob failing due to data quality issues.
- Add an explicit check for validity of the exit record before saving the assessment. This avoids the AutoExitJob silently failing to create the Exit record even thought the Exit Assessment does get saved.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
