### PR TITLE
Fix bug with auto-exiting HoH when HHMs are still active

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -25,19 +25,17 @@ module Hmis
         raise "Auto-exit config unusually low: #{config.length_of_absence_days}" if config.length_of_absence_days < 30
 
         project.enrollments.open_excluding_wip.each do |enrollment|
-          most_recent_contact = if project.es_nbn? # Night-by-night Emergency Shelter
-            # For NBN shelters, the most recent contact is the last bed night.
-            last_bed_night = enrollment.services.bed_nights.where.not(date_provided: nil).order(:date_provided).last
-            # If the client had no bed nights, or the last bed night is before enrollment entry (invalid), use the enrollment (entry date) as the last contact.
-            [last_bed_night, enrollment].compact.max_by { |entity| contact_date_for_entity(entity) }
+          # If this is a HoH of a multimember household, only exit them if they won't be leaving behind a headless household!
+          most_recent_contact = if enrollment.head_of_household? && enrollment.household_members.count > 1
+            # If any household member's enrollment is still in progress, don't exit the HoH
+            next if enrollment.household_members.any?(&:in_progress?)
+
+            # Look at most recent contact across all enrollments in this household when determining whether to exit the HoH
+            enrollment.household_members.
+              map { |hhm| get_most_recent_contact(hhm, project) }.
+              max_by { |entity| contact_date_for_entity(entity) }
           else
-            [
-              enrollment.services.where.not(date_provided: nil).order(:date_provided).last,
-              enrollment.custom_services.order(:date_provided).last,
-              enrollment.current_living_situations.order(:information_date).last,
-              enrollment.custom_assessments.order(:assessment_date).last,
-              enrollment,
-            ].compact.max_by { |entity| contact_date_for_entity(entity) }
+            get_most_recent_contact(enrollment, project)
           end
 
           most_recent_contact_date = contact_date_for_entity(most_recent_contact)
@@ -56,6 +54,23 @@ module Hmis
     end
 
     private
+
+    def get_most_recent_contact(enrollment, project)
+      if project.es_nbn? # Night-by-night Emergency Shelter
+        # For NBN shelters, the most recent contact is the last bed night.
+        last_bed_night = enrollment.services.bed_nights.where.not(date_provided: nil).order(:date_provided).last
+        # If the client had no bed nights, or the last bed night is before enrollment entry (invalid), use the enrollment (entry date) as the last contact.
+        [last_bed_night, enrollment].compact.max_by { |entity| contact_date_for_entity(entity) }
+      else
+        [
+          enrollment.services.where.not(date_provided: nil).order(:date_provided).last,
+          enrollment.custom_services.order(:date_provided).last,
+          enrollment.current_living_situations.order(:information_date).last,
+          enrollment.custom_assessments.order(:assessment_date).last,
+          enrollment,
+        ].compact.max_by { |entity| contact_date_for_entity(entity) }
+      end
+    end
 
     def auto_exit(enrollment, most_recent_contact)
       exit_date = contact_date_for_entity(most_recent_contact)

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -24,28 +24,27 @@ module Hmis
         next unless config.present?
         raise "Auto-exit config unusually low: #{config.length_of_absence_days}" if config.length_of_absence_days < 30
 
-        project.enrollments.open_excluding_wip.each do |enrollment|
-          # If this is a HoH of a multimember household, only exit them if they won't be leaving behind a headless household!
-          most_recent_contact = if enrollment.head_of_household? && enrollment.household_members.count > 1
-            # If any household member's enrollment is still in progress, don't exit the HoH
-            next if enrollment.household_members.any?(&:in_progress?)
+        project.households.each do |household|
+          # If any household member's enrollment is still in progress (no intake), don't auto-exit
+          next if household.enrollments.any?(&:in_progress?)
 
-            # Look at most recent contact across all enrollments in this household when determining whether to exit the HoH
-            enrollment.household_members.
-              map { |hhm| get_most_recent_contact(hhm, project) }.
-              max_by { |entity| contact_date_for_entity(entity) }
-          else
-            get_most_recent_contact(enrollment, project)
-          end
+          # Get the most recent contact date for the whole household
+          most_recent_contact = household.enrollments.
+            map { |hhm| get_most_recent_contact(hhm, project) }.
+            max_by { |entity| contact_date_for_entity(entity) }
 
           most_recent_contact_date = contact_date_for_entity(most_recent_contact)
           next unless most_recent_contact_date.present?
+          # If any household member has a most recent contact that's within the length_of_absence_days, don't exit anyone in the household
           next unless (Date.current - most_recent_contact_date).to_i >= config.length_of_absence_days
 
-          auto_exit_count += 1
+          auto_exit_count += household.enrollments.size
           auto_exit_projects.add(project.id)
           Hmis::Hud::Base.transaction do
-            auto_exit(enrollment, most_recent_contact)
+            # Auto-exit all household members together, setting the exit date equal to the most recent contact for any household member
+            household.enrollments.each do |e|
+              auto_exit(e, most_recent_contact)
+            end
           end
         end
       end

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -24,10 +24,7 @@ module Hmis
         next unless config.present?
         raise "Auto-exit config unusually low: #{config.length_of_absence_days}" if config.length_of_absence_days < 30
 
-        project.households.each do |household|
-          # If any household member's enrollment is still in progress (no intake), don't auto-exit
-          next if household.enrollments.any?(&:in_progress?)
-
+        project.households.active.not_in_progress.preload(:enrollments).each do |household|
           # Get the most recent contact date for the whole household
           most_recent_contact = household.enrollments.
             map { |hhm| get_most_recent_contact(hhm, project) }.

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -69,55 +69,54 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       expect(e1.exit_assessment&.data_collection_stage).to eq(3)
     end
 
-    let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1 }
+    context 'with a multi member household' do
+      let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1 }
+      let!(:household_id) { Hmis::Hud::Base.generate_uuid }
+      let!(:hoh_e) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months }
+      let!(:hhm_e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
+      let!(:hhm_e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
 
-    it 'should not exit the HoH if household members are still active' do
-      household_id = Hmis::Hud::Base.generate_uuid
-      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
-      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+      def expect_all_active
+        hoh_e.household_members.each do |member|
+          expect(member.exit).to be_nil
+        end
+      end
 
-      # non-hoh has a recent bed night and won't get auto-exited
-      create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hhm_e, user: u1, record_type: 200, date_provided: Date.current - 2.days
+      context 'when a household member has a recent contact' do
+        let!(:hhm_service) { create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hhm_e1, user: u1, record_type: 200, date_provided: Date.current - 2.days }
 
-      Hmis::AutoExitJob.perform_now
+        it 'should not exit the HoH or other members' do
+          Hmis::AutoExitJob.perform_now
+          expect_all_active
+        end
+      end
 
-      expect(hhm_e.exit).to be_nil
-      expect(hoh_e.exit).to be_nil # HOH shouldn't get exited
-    end
+      context 'when there is a WIP enrollment in the household' do
+        let!(:hhm_e1) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
 
-    it 'should not exit the HoH if household members have incomplete enrollments' do
-      household_id = Hmis::Hud::Base.generate_uuid
-      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
-      hhm_e = create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+        it 'should not exit the HoH or any household member' do
+          Hmis::AutoExitJob.perform_now
+          expect_all_active
+        end
+      end
 
-      Hmis::AutoExitJob.perform_now
+      context 'when the HoH has a recent contact' do
+        let!(:hoh_service) { create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hoh_e, user: u1, record_type: 200, date_provided: Date.current - 2.days }
 
-      expect(hhm_e.exit).to be_nil
-      expect(hoh_e.exit).to be_nil # HOH shouldn't get exited
-    end
+        it 'should not exit the HoH or any household member' do
+          Hmis::AutoExitJob.perform_now
+          expect_all_active
+        end
+      end
 
-    it 'should not exit any member if another member is still active' do
-      household_id = Hmis::Hud::Base.generate_uuid
-      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
-      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+      context 'when the HoH has an incomplete enrollment' do
+        let!(:hoh_e) { create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, entry_date: Date.current - 2.months }
 
-      create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hoh_e, user: u1, record_type: 200, date_provided: Date.current - 2.days
-
-      Hmis::AutoExitJob.perform_now
-
-      expect(hhm_e.exit).to be_nil
-      expect(hoh_e.exit).to be_nil
-    end
-
-    it 'should not exit any member if another member has an incomplete enrollment' do
-      household_id = Hmis::Hud::Base.generate_uuid
-      hoh_e = create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
-      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
-
-      Hmis::AutoExitJob.perform_now
-
-      expect(hhm_e.exit).to be_nil
-      expect(hoh_e.exit).to be_nil
+        it 'should not exit any member if another member has an incomplete enrollment' do
+          Hmis::AutoExitJob.perform_now
+          expect_all_active
+        end
+      end
     end
   end
 

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       expect(hhm_e.exit).to be_nil
       expect(hoh_e.exit).to be_nil # HOH shouldn't get exited
     end
+
+    it 'should not exit any member if another member is still active' do
+      household_id = Hmis::Hud::Base.generate_uuid
+      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
+      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+
+      create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hoh_e, user: u1, record_type: 200, date_provided: Date.current - 2.days
+
+      Hmis::AutoExitJob.perform_now
+
+      expect(hhm_e.exit).to be_nil
+      expect(hoh_e.exit).to be_nil
+    end
+
+    it 'should not exit any member if another member has an incomplete enrollment' do
+      household_id = Hmis::Hud::Base.generate_uuid
+      hoh_e = create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
+      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+
+      Hmis::AutoExitJob.perform_now
+
+      expect(hhm_e.exit).to be_nil
+      expect(hoh_e.exit).to be_nil
+    end
   end
 
   describe 'for other project types (not ES NBN)' do

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -68,6 +68,33 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       expect(e1.exit_assessment&.assessment_date).to eq(e1.entry_date)
       expect(e1.exit_assessment&.data_collection_stage).to eq(3)
     end
+
+    let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1 }
+
+    it 'should not exit the HoH if household members are still active' do
+      household_id = Hmis::Hud::Base.generate_uuid
+      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
+      hhm_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+
+      # non-hoh has a recent bed night and won't get auto-exited
+      create :hmis_hud_service, data_source: ds1, client: c2, enrollment: hhm_e, user: u1, record_type: 200, date_provided: Date.current - 2.days
+
+      Hmis::AutoExitJob.perform_now
+
+      expect(hhm_e.exit).to be_nil
+      expect(hoh_e.exit).to be_nil # HOH shouldn't get exited
+    end
+
+    it 'should not exit the HoH if household members have incomplete enrollments' do
+      household_id = Hmis::Hud::Base.generate_uuid
+      hoh_e = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months
+      hhm_e = create :hmis_hud_wip_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months
+
+      Hmis::AutoExitJob.perform_now
+
+      expect(hhm_e.exit).to be_nil
+      expect(hoh_e.exit).to be_nil # HOH shouldn't get exited
+    end
   end
 
   describe 'for other project types (not ES NBN)' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
GH issue: https://github.com/open-path/Green-River/issues/7188 
- Prevent the Auto Exit job from exiting a household member if anyone else in their household shouldn't be exited:
  - If someone else in the household has a more recent "last contact date"
  - If someone else in the household has an incomplete enrollment
- Add spec tests

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
