### PR TITLE
Set timeout and maximumAge for PIT geolocation

### DIFF
--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_geolocation.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_geolocation.haml
@@ -97,7 +97,15 @@
       getLocationButton.click(function(event) {
         event.preventDefault();
         setLoading(true);
-        navigator.geolocation.getCurrentPosition(setPosition, onError);
+        navigator.geolocation.getCurrentPosition(
+          setPosition,
+          onError,
+          {
+            timeout: 10000, // wait up to 10 seconds before showing an error message
+            maximumAge: 180000, // allow the browser to use a cached location if it's less than 3 minutes old
+            // choosing not to enable `enableHighAccuracy` because it can be slow and drain battery
+          }
+        );
       });
 
       clearButton.click(function(event) {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Related Issue: https://github.com/open-path/Green-River/issues/6542

* Add 10s `timeout` so page doesn't infinitely appear "loading.." in some situation where browser fails to retrieve location. 
* Allow using cached locations up to 3 minutes. This is kind of arbitrary, but I figure if you are submitting multiple household members while staying in one location, it can speed things up or save battery by not requesting location repeatedly. Downside is that there is no obvious way for the user to "force" re-request location if it's returning a cached value, so that might be annoying.
* Add comment about enableHighAccuracy. Location accuracy is important, but I'm concerned about what I'm reading about performance and the effect on battery life.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
