### PR TITLE
Keep User Groups When Switching from Role-Based to ACLs

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -102,8 +102,10 @@ module Admin
           # The User Group data is not captured for update when using the Role-Based view. This means it will not be included
           # in the params when switching from Role-Based permissions to ACLs. In order to prevent wiping out any existing
           # user_group_id data, we need to ignore this param when changing to an ACL based permissions.
+          # The reverse is true for the access_group_ids field.
           params_to_update = user_params
           params_to_update = params_to_update.except(:user_group_ids) if changing_to_acls?
+          params_to_update = params_to_update.except(:access_group_ids) if changing_to_role_based?
           @user.update!(params_to_update)
 
           # if we have a user to copy user groups from, add them
@@ -157,6 +159,10 @@ module Admin
 
     private def changing_to_acls?
       params[:user][:permission_context] == 'acls' && @user.permission_context != params[:user][:permission_context]
+    end
+
+    private def changing_to_role_based?
+      params[:user][:permission_context] == 'role_based' && @user.permission_context != params[:user][:permission_context]
     end
 
     private def user_using_or_changing_to_acls?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -80,13 +80,15 @@ module Admin
       existing_health_roles = @user.health_roles.to_a
       begin
         User.transaction do
+          changing_to_acls = params[:user][:permission_context] == 'acls' && @user.permission_context != params[:user][:permission_context]
+          using_acls = @user.using_acls? || changing_to_acls
           @user.skip_reconfirmation!
           # Associations don't play well with acts_as_paranoid, so manually clean up user ACLs
-          @user.user_group_members.where.not(user_group_id: assigned_user_group_ids).destroy_all
+          @user.user_group_members.where.not(user_group_id: assigned_user_group_ids).destroy_all unless changing_to_acls
 
           # TODO: START_ACL remove when ACL transition complete
           # Associations don't play well with acts_as_paranoid, so manually clean up user roles
-          if ! @user.using_acls?
+          if ! using_acls
             @user.user_roles.where.not(role_id: user_params[:legacy_role_ids]&.select(&:present?)).destroy_all
             @user.access_groups.not_system.
               where.not(id: user_params[:access_group_ids]&.select(&:present?)).each do |g|
@@ -98,12 +100,19 @@ module Admin
           end
           # END_ACL
           @user.disable_2fa! if user_params[:otp_required_for_login] == 'false'
-          @user.update!(user_params)
+
+          # The User Group data is not captured for update when using the Role-Based view. This means it will not be included
+          # in the params when switching from Role-Based permissions to ACLs. In order to prevent wiping out any existing
+          # user_group_id data, we need to ignore this param when changing to an ACL based permissions.
+          params_to_update = user_params
+          params_to_update = params_to_update.except(:user_group_ids) if changing_to_acls
+          @user.update!(params_to_update)
+
           # if we have a user to copy user groups from, add them
-          copy_user_groups if @user.using_acls?
+          copy_user_groups if using_acls
           # TODO: START_ACL remove when ACL transition complete
           # Restore any health roles we previously had
-          if ! @user.using_acls?
+          if ! using_acls
             @user.legacy_roles = (@user.legacy_roles + existing_health_roles).uniq
             @user.set_viewables viewable_params
           end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -80,15 +80,13 @@ module Admin
       existing_health_roles = @user.health_roles.to_a
       begin
         User.transaction do
-          changing_to_acls = params[:user][:permission_context] == 'acls' && @user.permission_context != params[:user][:permission_context]
-          using_acls = @user.using_acls? || changing_to_acls
           @user.skip_reconfirmation!
           # Associations don't play well with acts_as_paranoid, so manually clean up user ACLs
-          @user.user_group_members.where.not(user_group_id: assigned_user_group_ids).destroy_all unless changing_to_acls
+          @user.user_group_members.where.not(user_group_id: assigned_user_group_ids).destroy_all unless changing_to_acls?
 
           # TODO: START_ACL remove when ACL transition complete
           # Associations don't play well with acts_as_paranoid, so manually clean up user roles
-          if ! using_acls
+          if ! user_using_or_changing_to_acls?
             @user.user_roles.where.not(role_id: user_params[:legacy_role_ids]&.select(&:present?)).destroy_all
             @user.access_groups.not_system.
               where.not(id: user_params[:access_group_ids]&.select(&:present?)).each do |g|
@@ -105,14 +103,14 @@ module Admin
           # in the params when switching from Role-Based permissions to ACLs. In order to prevent wiping out any existing
           # user_group_id data, we need to ignore this param when changing to an ACL based permissions.
           params_to_update = user_params
-          params_to_update = params_to_update.except(:user_group_ids) if changing_to_acls
+          params_to_update = params_to_update.except(:user_group_ids) if changing_to_acls?
           @user.update!(params_to_update)
 
           # if we have a user to copy user groups from, add them
-          copy_user_groups if using_acls
+          copy_user_groups if user_using_or_changing_to_acls?
           # TODO: START_ACL remove when ACL transition complete
           # Restore any health roles we previously had
-          if ! using_acls
+          if ! user_using_or_changing_to_acls?
             @user.legacy_roles = (@user.legacy_roles + existing_health_roles).uniq
             @user.set_viewables viewable_params
           end
@@ -155,6 +153,14 @@ module Admin
 
     def title_for_index
       'User List'
+    end
+
+    private def changing_to_acls?
+      params[:user][:permission_context] == 'acls' && @user.permission_context != params[:user][:permission_context]
+    end
+
+    private def user_using_or_changing_to_acls?
+      @user.using_acls? || changing_to_acls?
     end
 
     private def adding_admin?

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -47,5 +47,21 @@ RSpec.describe Admin::UsersController, type: :request do
         expect(updated_user.reload.notify_on_client_added).to be true
       end
     end
+
+    context 'when updating user to ACLs' do
+      let!(:legacy_user) { create :user }
+      let!(:user_group)  { create :user_group }
+
+      it 'updated user keeps assigned user groups' do
+        user_group.add(legacy_user)
+        # Ensure the orignal user is using role-based permissions and is assigned the user group
+        expect(legacy_user.permission_context).to eq('role_based')
+        expect(legacy_user.user_group_ids).to eq([user_group.id])
+        patch admin_user_path(legacy_user), params: { user: { permission_context: 'acls' } }
+        # Ensure the updated user is using ACLs and is still assigned the user group
+        expect(legacy_user.reload.permission_context).to eq('acls')
+        expect(legacy_user.reload.user_group_ids).to eq([user_group.id])
+      end
+    end
   end
 end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::UsersController, type: :request do
       end
     end
 
-    context 'when updating user to ACLs' do
+    context 'when updating user from Role-Based to ACLs' do
       let!(:legacy_user) { create :user }
       let!(:user_group)  { create :user_group }
 
@@ -57,10 +57,30 @@ RSpec.describe Admin::UsersController, type: :request do
         # Ensure the orignal user is using role-based permissions and is assigned the user group
         expect(legacy_user.permission_context).to eq('role_based')
         expect(legacy_user.user_group_ids).to eq([user_group.id])
+        # The Role-Based user edit form does not include a field for user_group_ids. As a result, it will
+        # not be included in the parameters sent when switching from Role-Based permissions to ACLs
         patch admin_user_path(legacy_user), params: { user: { permission_context: 'acls' } }
         # Ensure the updated user is using ACLs and is still assigned the user group
         expect(legacy_user.reload.permission_context).to eq('acls')
         expect(legacy_user.reload.user_group_ids).to eq([user_group.id])
+      end
+    end
+
+    context 'when updating user from ACLs to Role-Based' do
+      let!(:acl_user)   { create(:acl_user) }
+      let!(:user_group) { create :user_group }
+
+      it 'updated user keeps assigned user groups' do
+        user_group.add(acl_user)
+        # Ensure the orignal user is using role-based permissions and is assigned the user group
+        expect(acl_user.permission_context).to eq('acls')
+        expect(acl_user.user_group_ids).to eq([user_group.id])
+        # The ACL user edit form includes a field for user_group_ids. As a result, it will be
+        # included in the parameters sent when switching from ACLs to Role-Based permissions
+        patch admin_user_path(acl_user), params: { user: { permission_context: 'role_based', user_group_ids: [user_group.id] } }
+        # Ensure the updated user is using ACLs and is still assigned the user group
+        expect(acl_user.reload.permission_context).to eq('role_based')
+        expect(acl_user.reload.user_group_ids).to eq([user_group.id])
       end
     end
   end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -49,38 +49,56 @@ RSpec.describe Admin::UsersController, type: :request do
     end
 
     context 'when updating user from Role-Based to ACLs' do
-      let!(:legacy_user) { create :user }
-      let!(:user_group)  { create :user_group }
+      let!(:legacy_user)  { create :user }
+      let!(:user_group)   { create :user_group }
+      let!(:role)         { create :role }
+      let!(:access_group) { create :access_group }
 
-      it 'updated user keeps assigned user groups' do
+      it 'updated user keeps fields' do
         user_group.add(legacy_user)
+        legacy_user.legacy_roles << role
+        legacy_user.access_groups << access_group
+        legacy_user.save!
         # Ensure the orignal user is using role-based permissions and is assigned the user group
         expect(legacy_user.permission_context).to eq('role_based')
         expect(legacy_user.user_group_ids).to eq([user_group.id])
+        expect(legacy_user.legacy_role_ids).to eq([role.id])
+        expect(legacy_user.access_group_ids.include?(access_group.id)).to be true
         # The Role-Based user edit form does not include a field for user_group_ids. As a result, it will
         # not be included in the parameters sent when switching from Role-Based permissions to ACLs
-        patch admin_user_path(legacy_user), params: { user: { permission_context: 'acls' } }
+        patch admin_user_path(legacy_user), params: { user: { permission_context: 'acls', access_group_ids: [access_group.id] } }
         # Ensure the updated user is using ACLs and is still assigned the user group
         expect(legacy_user.reload.permission_context).to eq('acls')
         expect(legacy_user.reload.user_group_ids).to eq([user_group.id])
+        expect(legacy_user.reload.legacy_role_ids).to eq([role.id])
+        expect(legacy_user.reload.access_group_ids.include?(access_group.id)).to be true
       end
     end
 
     context 'when updating user from ACLs to Role-Based' do
       let!(:acl_user)   { create(:acl_user) }
       let!(:user_group) { create :user_group }
+      let!(:role)       { create :role }
+      let!(:access_group) { create :access_group }
 
-      it 'updated user keeps assigned user groups' do
+      it 'updated user keeps fields' do
         user_group.add(acl_user)
+        acl_user.legacy_roles << role
+        acl_user.access_groups << access_group
+        acl_user.save!
         # Ensure the orignal user is using role-based permissions and is assigned the user group
         expect(acl_user.permission_context).to eq('acls')
         expect(acl_user.user_group_ids).to eq([user_group.id])
+        expect(acl_user.legacy_role_ids).to eq([role.id])
+        expect(acl_user.access_group_ids.include?(access_group.id)).to be true
         # The ACL user edit form includes a field for user_group_ids. As a result, it will be
         # included in the parameters sent when switching from ACLs to Role-Based permissions
         patch admin_user_path(acl_user), params: { user: { permission_context: 'role_based', user_group_ids: [user_group.id] } }
         # Ensure the updated user is using ACLs and is still assigned the user group
         expect(acl_user.reload.permission_context).to eq('role_based')
         expect(acl_user.reload.user_group_ids).to eq([user_group.id])
+        expect(acl_user.reload.legacy_role_ids).to eq([role.id])
+        expect(acl_user.reload.access_group_ids.include?(access_group.id)).to be true
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
When switching a user account from Role-Based permissions to ACLs, before it was dropping any User Groups already tied to the user. This update will keep the user assigned to those user groups.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
