### PR TITLE
Deprecate can_view_all_reports permission fo ACLs

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -704,8 +704,9 @@ class Role < ApplicationRecord
         category: 'Client Extras',
         sub_category: 'Auditing',
       },
+      # DEPRECATED, superseded by can_view_assigned_reports in combination with access controls
       can_view_all_reports: {
-        description: 'Access to all reports, regardless the user who ran the report',
+        description: 'Access to all reports, regardless the user who ran the report (Note: for Access Controls, this is superseded by "Can View Assigned Reports")',
         administrative: true,
         category: 'Reporting',
         sub_category: 'Report Access',


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
Deprecate permission for viewing warehouse reports when using ACLs. Update the description to match other deprecated permissions.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
