### PR TITLE
6887-source-visible-to

### DIFF
--- a/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
@@ -15,7 +15,10 @@ module ClientAccessControl::GrdaWarehouse::Hud
         return current_scope || all if user.system_user?
 
         filtered = arbiter(user).clients_destination_visible_to(user, source_client_ids: source_client_ids)
-        current_scope.nil? ? filtered : where(id: filtered.select(:id))
+
+        return filtered if current_scope.nil?
+
+        return current_scope.where(id: filtered.select(:id))
       end
 
       # hide previous declaration of :source_visible_to, we'll use this one
@@ -23,11 +26,16 @@ module ClientAccessControl::GrdaWarehouse::Hud
         return current_scope || all if user.system_user?
 
         filtered = arbiter(user).clients_source_visible_to(user, client_ids: client_ids)
-        current_scope.nil? ? filtered : where(id: filtered.select(:id))
+
+        return filtered if current_scope.nil?
+
+        return current_scope.where(id: filtered.select(:id))
       end
 
       # hide previous declaration of :searchable_to, we'll use this one
       # can search even if no ROI
+      #
+      # Note, this may return either source or destination clients
       replace_scope :searchable_to, ->(user, client_ids: nil) do
         # TODO: START_ACL cleanup after ACL migration is complete
         limited_scope = if user.using_acls?
@@ -41,7 +49,10 @@ module ClientAccessControl::GrdaWarehouse::Hud
         end
         # END_ACL
         limited_scope = limited_scope.where(id: client_ids) if client_ids.present?
-        current_scope.nil? ? limited_scope : where(id: limited_scope.select(:id))
+
+        return limited_scope if current_scope.nil?
+
+        return current_scope.where(id: limited_scope.select(:id))
       end
 
       scope :destination_from_searchable_to, ->(user) do

--- a/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
@@ -12,22 +12,18 @@ module ClientAccessControl::GrdaWarehouse::Hud
     included do
       # hide previous declaration of :destination_visible_to, we'll use this one
       replace_scope :destination_visible_to, ->(user, source_client_ids: nil) do
-        limited_scope = if user.system_user?
-          current_scope || all
-        else
-          arbiter(user).clients_destination_visible_to(user, source_client_ids: source_client_ids)
-        end
-        merge(limited_scope)
+        return current_scope || all if user.system_user?
+
+        filtered = arbiter(user).clients_destination_visible_to(user, source_client_ids: source_client_ids)
+        current_scope.nil? ? filtered : where(id: filtered.select(:id))
       end
 
       # hide previous declaration of :source_visible_to, we'll use this one
       replace_scope :source_visible_to, ->(user, client_ids: nil) do
-        limited_scope = if user.system_user?
-          current_scope || all
-        else
-          arbiter(user).clients_source_visible_to(user, client_ids: client_ids)
-        end
-        merge(limited_scope)
+        return current_scope || all if user.system_user?
+
+        filtered = arbiter(user).clients_source_visible_to(user, client_ids: client_ids)
+        current_scope.nil? ? filtered : where(id: filtered.select(:id))
       end
 
       # hide previous declaration of :searchable_to, we'll use this one

--- a/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
+++ b/drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb
@@ -41,7 +41,7 @@ module ClientAccessControl::GrdaWarehouse::Hud
         end
         # END_ACL
         limited_scope = limited_scope.where(id: client_ids) if client_ids.present?
-        merge(limited_scope)
+        current_scope.nil? ? limited_scope : where(id: limited_scope.select(:id))
       end
 
       scope :destination_from_searchable_to, ->(user) do

--- a/drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb
+++ b/drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
         end
         it 'user can see all clients' do
           expect(GrdaWarehouse::Hud::Client.source.source_visible_to(user).count).to eq(4)
-          expect(GrdaWarehouse::Hud::Client.destination.destination_visible_to(user).count).to eq(4)
+          expect(GrdaWarehouse::Hud::Client.destination.destination_visible_to(user).count).to eq(3)
         end
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -188,7 +188,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -259,7 +259,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -331,7 +331,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -513,7 +513,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can search own clients' do

--- a/drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb
+++ b/drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
         end
         it 'user can see all clients' do
           expect(GrdaWarehouse::Hud::Client.source.source_visible_to(user).count).to eq(4)
-          expect(GrdaWarehouse::Hud::Client.destination.destination_visible_to(user).count).to eq(4)
+          expect(GrdaWarehouse::Hud::Client.destination.destination_visible_to(user).count).to eq(3)
         end
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -195,7 +195,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -267,7 +267,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -344,7 +344,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can view window clients' do
@@ -532,7 +532,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
       it 'user can see all clients' do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(4)
-        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(4)
+        expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(3)
       end
     end
     describe 'and the user has a role granting can search own clients' do

--- a/drivers/client_access_control/spec/models/visibility_spec.rb
+++ b/drivers/client_access_control/spec/models/visibility_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
         expect(GrdaWarehouse::Hud::Client.source_visible_to(user).count).to eq(1)
         expect(GrdaWarehouse::Hud::Client.destination_visible_to(user).count).to eq(1)
       end
+
+      it '#source_visible_to does not clobber conditions' do
+        count = GrdaWarehouse::Hud::Client.where(data_source: -1).source_visible_to(user).count
+        expect(count).to eq(0)
+      end
+
+      it '#destination_visible_to does not clobber conditions' do
+        count = GrdaWarehouse::Hud::Client.where(data_source: -1).destination_visible_to(user).count
+        expect(count).to eq(0)
+      end
     end
 
     describe 'and the user has permission to see limited dashboard, but not any data assignments' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[GH Issue](https://github.com/open-path/Green-River/issues/6887)

- fix issue where  Client.destination_visible_to was returning duplicate clients due to join
- clean up client destination_visible_to and source_visible_to
- adjust client visibility to use a subquery instead of a merge. This may be less efficient but avoids possible overwrite of conditions on calling scope

## Test instructions
There should be no user-facing behavior change.
- verify expected client visibility permissions client dashboard (should not show source/destination clients that the user does not have permission to) 
- verify expected client search results are returned for client search (should not show search results for clients that the user does not have permission to) 

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)


