### PR TITLE
7229 enforce validation on Account creation; allow invalid accounts to be deactivated

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -145,7 +145,8 @@ module Admin
 
     def destroy
       @user.paper_trail_event = 'deactivate'
-      @user.update(active: false)
+      # update_column() allows us to update the user even if the record is invalid
+      @user.update_column(:active, false)
       redirect_to({ action: :index }, notice: "User #{@user.name} deactivated")
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -56,7 +56,10 @@ module Admin
 
       @redirecting = true
       update
-      redirect_to({ action: :edit }, notice: 'User updated') and return
+      # early return if the response body was set by update(), avoid double-render error
+      return if performed?
+
+      redirect_to({ action: :edit }, notice: 'User updated')
     end
 
     def impersonate

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -23,6 +23,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   # POST /resource/invitation
   def create
+    # if the account will be an admin, check that the current user has confirmed this action with their password
     if creating_admin? && current_user.confirm_password_for_admin_actions? && !current_user.valid_password?(confirmation_params[:confirmation_password])
       flash[:error] = 'User not updated. Incorrect password'
       @user = User.new
@@ -30,23 +31,42 @@ class Users::InvitationsController < Devise::InvitationsController
       return
     end
 
-    @user = User.with_deleted.find_by_email(invite_params[:email]).restore if User.with_deleted.find_by_email(invite_params[:email]).present?
-    @user = User.invite!(invite_params.except(:legacy_role_ids), current_user) do |u|
-      u.skip_invitation = invite_params[:skip_invitation]&.to_i == 1
+    # create the new user account and send an invitation. Note that we are sending an email within a tx here which
+    # isn't ideal. This assumes a robust and responsive delivery service such as aws ses
+    @user = nil
+    User.transaction do
+      @user = invite_and_find_or_create_user
+      raise ActiveRecord::Rollback if @user.errors.any?
     end
-    # Roles need to be added as a second pass
-    @user.update(invite_params)
-    @user&.set_viewables(viewable_params.to_h.map { |k, a| [k.to_sym, a] }.to_h) # TODO: START_ACL remove when ACL transition complete
-    # if we have a user to copy user groups from, add them
-    copy_user_groups if @user.using_acls?
 
-    if resource.errors.empty?
-      set_flash_message :notice, :send_instructions, email: resource.email if is_flashing_format? && resource.invitation_sent_at
+    # handle errors from devise
+    if @user.errors.empty?
+      set_flash_message :notice, :send_instructions, email: @user.email if is_flashing_format? && @user.invitation_sent_at
       redirect_to admin_users_path
     else
       @agencies = Agency.order(:name)
       render :new
     end
+  end
+
+  private def invite_and_find_or_create_user
+    # if a deleted account matches the email, restore it so devise's invitable will find it
+    email = invite_params[:email]
+    User.with_deleted.find_by_email(email)&.restore
+
+    # will find or create a user record
+    user = User.invite!(invite_params.except(:legacy_role_ids), current_user) do |u|
+      # I guess we use invite for the side-effect of user creation in this case
+      u.skip_invitation = invite_params[:skip_invitation]&.to_i == 1
+    end
+    return user if user.errors.present?
+
+    # Roles need to be added as a second pass
+    user.update!(invite_params)
+    user.set_viewables(viewable_params.to_h.map { |k, a| [k.to_sym, a] }.to_h) # TODO: START_ACL remove when ACL transition complete
+    # if we have a user to copy user groups from, add them
+    copy_user_groups if user.using_acls?
+    return user
   end
 
   private def copy_user_groups

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -56,12 +56,14 @@ class Users::InvitationsController < Devise::InvitationsController
 
     # will find or create a user record
     user = User.invite!(invite_params.except(:legacy_role_ids), current_user) do |u|
-      # I guess we use invite for the side-effect of user creation in this case
+      # If the user creating the account explicitly indicated they didn't need to send an invitation 
+      # skip sending the invitation.  This is used when bulk creating accounts ahead of when 
+      # someone should be given access to the application.
       u.skip_invitation = invite_params[:skip_invitation]&.to_i == 1
     end
     return user if user.errors.present?
 
-    # Roles need to be added as a second pass
+    # Roles need to be added as a second pass since devise invitable doesn't know how to handle them
     user.update!(invite_params)
     user.set_viewables(viewable_params.to_h.map { |k, a| [k.to_sym, a] }.to_h) # TODO: START_ACL remove when ACL transition complete
     # if we have a user to copy user groups from, add them

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -56,8 +56,8 @@ class Users::InvitationsController < Devise::InvitationsController
 
     # will find or create a user record
     user = User.invite!(invite_params.except(:legacy_role_ids), current_user) do |u|
-      # If the user creating the account explicitly indicated they didn't need to send an invitation 
-      # skip sending the invitation.  This is used when bulk creating accounts ahead of when 
+      # If the user creating the account explicitly indicated they didn't need to send an invitation
+      # skip sending the invitation.  This is used when bulk creating accounts ahead of when
       # someone should be given access to the application.
       u.skip_invitation = invite_params[:skip_invitation]&.to_i == 1
     end

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -60,7 +60,7 @@ module UserConcern
     after_save :create_access_group
     # END_ACL
 
-    validates :email, presence: true, uniqueness: true, email_format: { check_mx: true }, length: { maximum: 250 }, on: :update
+    validates :email, presence: true, uniqueness: true, email_format: { check_mx: true }, length: { maximum: 250 }
     validate :password_cannot_be_sequential, on: :update
     validates :last_name, presence: true, length: { maximum: 40 }
     validates :first_name, presence: true, length: { maximum: 40 }

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Users::InvitationsController, type: :controller do
+  let(:admin_user) { create(:acl_user) }
+  let(:admin_role) { create :admin_role }
+  let(:no_data_source_collection) { create :collection }
+
+  let(:agency) { create(:agency) } # Assuming a factory for Agency
+  let(:valid_params) do
+    {
+      user: {
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john.doe@example.com',
+        phone: '123-456-7890',
+        agency_id: agency.id,
+        legacy_role_ids: [],
+        user_group_ids: [],
+      },
+    }
+  end
+
+  let(:invalid_params) do
+    {
+      user: {
+        email: '',
+        first_name: '',
+        last_name: '',
+      },
+    }
+  end
+
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    sign_in admin_user
+    setup_access_control(admin_user, admin_role, no_data_source_collection)
+  end
+
+  describe 'POST #create' do
+    context 'with valid parameters' do
+      it 'creates a new user and redirects to admin_users_path' do
+        expect do
+          post :create, params: valid_params, format: :html
+        end.to change(User, :count).by(1)
+
+        expect(response).to redirect_to(admin_users_path)
+        expect(flash[:notice]).to eq('An invitation email has been sent to john.doe@example.com.')
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'does not create a new user and re-renders the new template' do
+        expect do
+          post :create, params: invalid_params, format: :html
+        end.not_to change(User, :count)
+
+        expect(response).to render_template(:new)
+        expect(assigns(:user).errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
   let(:admin_role) { create :admin_role }
   let(:no_data_source_collection) { create :collection }
 
-  let(:agency) { create(:agency) } # Assuming a factory for Agency
+  let(:agency) { create(:agency) } 
   let(:valid_params) do
     {
       user: {

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
   let(:admin_role) { create :admin_role }
   let(:no_data_source_collection) { create :collection }
 
-  let(:agency) { create(:agency) } 
+  let(:agency) { create(:agency) }
   let(:valid_params) do
     {
       user: {

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe Admin::UsersController, type: :request do
     end
   end
 
+  describe 'DELETE disable' do
+    context 'when the user is valid' do
+      it 'disables the user' do
+        expect do
+          delete admin_user_path(user)
+        end.to change { User.active.count }.by(-1)
+
+        user.reload
+        expect(user.active).to eq(false)
+      end
+    end
+
+    context 'when the user is invalid' do
+      before do
+        user.update_column(:email, 'invalid-email') # skip validations
+      end
+
+      it 'still disables the user' do
+        delete admin_user_path(user)
+
+        user.reload
+        expect(user.active).to eq(false)
+      end
+    end
+  end
+
   describe 'PUT update' do
     context 'when updating vi-spdat notifications' do
       let(:updated_user) { User.not_system.first }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[GH Issue](https://github.com/open-path/Green-River/issues/7229)

changes:
- enforce email validation on account creation, not just update
- allows accounts to be disabled even if they are not valid (due to bad email addresses)
- create accounts in a transaction so we don't create partial or incomplete accounts
- fixes double-render error when trying to save changes to an admin user under some circumstances
- add tests

## Test instructions
- as an admin, try to create an account with an invalid email address domain (foo@some-crazydomainthatdoesntexist). It should show you the form and prompt to fix the issue. A new account should not be created
- find an user with an invalid email address. Attempt to deactivate the user, it should succeed. 

## Type of change
Bugfix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)

