### PR TITLE
Bugfix and cleanup in AC Warehouse custom data element exporter

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cde_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cde_export.rb
@@ -78,12 +78,13 @@ module HmisExternalApis::AcHmis::Exporters
     end
 
     # { source client id => destination warehouse id }
-    # only includes source clients that are the Owner of any CDEs in scope
+    # only includes source clients that are the Owner of any CDEs
     def client_id_to_warehouse_id
-      @client_id_to_warehouse_id ||= begin
-        source_client_ids = cdes.where(data_element_definition: { owner_type: 'Hmis::Hud::Client' }).pluck(:owner_id)
-        Hmis::Hud::Client.where(id: source_client_ids).joins(:warehouse_client_source).pluck(c_t[:id], wc_t[:destination_id]).to_h
-      end
+      @client_id_to_warehouse_id ||=
+        Hmis::Hud::Client.where(data_source: data_source).
+          joins(:custom_data_elements).    # Only include clients that have CDEs
+          joins(:warehouse_client_source). # Join to Warehouse Client to get destination ID
+          pluck(c_t[:id], wc_t[:destination_id]).to_h
     end
 
     def write_auto_exits

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cde_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cde_export.rb
@@ -12,6 +12,7 @@
 module HmisExternalApis::AcHmis::Exporters
   class CdeExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
+    include ::Hmis::Concerns::HmisArelHelper
 
     UNIT_TYPE_KEY = 'unit_type'.freeze
     AUTO_EXIT_KEY = 'auto_exit'.freeze
@@ -24,11 +25,17 @@ module HmisExternalApis::AcHmis::Exporters
 
       cdes.each.with_index do |cde, i|
         Rails.logger.info "Processed #{i} of #{total}" if (i % 100).zero?
+
+        owner_id = cde.owner_id
+        owner_id = client_id_to_warehouse_id[owner_id] if cde.data_element_definition.owner_type == 'Hmis::Hud::Client'
+        # Skip if there is no owner ID. Could happen if client doesn't have a destination client yet.
+        next unless owner_id
+
         values = [
           cde.id,
           cde.data_element_definition.key,
           cde.data_element_definition.owner_type.demodulize,
-          cde.owner_id,
+          owner_id,
           cde.value,
           cde.date_created,
           cde.date_updated,
@@ -59,11 +66,24 @@ module HmisExternalApis::AcHmis::Exporters
     def cdes
       @cdes ||= Hmis::Hud::CustomDataElement.
         where(data_source: data_source).
+        joins(:data_element_definition).
+        # Exclude some Custom Data Elements that are exported in other files. It would be simpler to
+        # just export them here, but customer prefers to keep dedicated file (which was added first).
+        where.not(data_element_definition: { key: HmisExternalApis::AcHmis::Exporters::CdedExport::EXCLUDED_CUSTOM_DATA_ELEMENT_KEYS }).
         preload(:data_element_definition)
     end
 
     def walk_in_cded
       @walk_in_cded ||= Hmis::Hud::CustomDataElementDefinition.where(data_source: data_source, key: :direct_entry, owner_type: 'Hmis::Hud::Project').first!
+    end
+
+    # { source client id => destination warehouse id }
+    # only includes source clients that are the Owner of any CDEs in scope
+    def client_id_to_warehouse_id
+      @client_id_to_warehouse_id ||= begin
+        source_client_ids = cdes.where(data_element_definition: { owner_type: 'Hmis::Hud::Client' }).pluck(:owner_id)
+        Hmis::Hud::Client.where(id: source_client_ids).joins(:warehouse_client_source).pluck(c_t[:id], wc_t[:destination_id]).to_h
+      end
     end
 
     def write_auto_exits

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cded_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cded_export.rb
@@ -13,6 +13,18 @@ module HmisExternalApis::AcHmis::Exporters
   class CdedExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
 
+    EXCLUDED_CUSTOM_DATA_ELEMENT_KEYS = [
+      'client_pathway_1',
+      'client_pathway_2',
+      'client_pathway_3',
+      'client_pathway_1_date',
+      'client_pathway_2_date',
+      'client_pathway_3_date',
+      'client_pathway_1_narrative',
+      'client_pathway_2_narrative',
+      'client_pathway_3_narrative',
+    ].freeze
+
     def run!
       Rails.logger.info 'Generating CDED report'
       write_row(columns)
@@ -41,7 +53,8 @@ module HmisExternalApis::AcHmis::Exporters
     end
 
     def cdeds
-      @cdeds ||= Hmis::Hud::CustomDataElementDefinition.where(data_source: data_source)
+      @cdeds ||= Hmis::Hud::CustomDataElementDefinition.where(data_source: data_source).
+        where.not(key: EXCLUDED_CUSTOM_DATA_ELEMENT_KEYS)
     end
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/cde_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/cde_export_spec.rb
@@ -117,4 +117,35 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CdeExport, type: :model do
       a_hash_including({ 'ResponseID' => exit1.id.to_s, 'RecordId' => e1.id.to_s, 'Response' => 'true' }),
     )
   end
+
+  context 'when there are excluded CDEs' do
+    let!(:cded) { create :hmis_custom_data_element_definition, data_source: ds, owner_type: 'Hmis::Hud::Service', field_type: :string, key: 'client_pathway_3' }
+
+    it 'excludes pathways cdes' do
+      subject.run!
+      expect(subject.send(:cdes).length).to eq(0)
+    end
+  end
+
+  context 'when there is a CDE with a Client owner type' do
+    let!(:cded) { create :hmis_custom_data_element_definition_for_color, data_source: ds }
+    let!(:cde1) { create :hmis_custom_data_element, data_element_definition: cded, owner: c1, data_source: ds, value_string: 'Pink', DateCreated: creation_time, DateUpdated: creation_time }
+
+    it 'excludes CDE if Client doesn\'t have a destination client' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+      expect(result.length).to eq(0)
+    end
+
+    context 'when client has a destination' do
+      let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds }
+
+      it 'exports warehouse destination client ID, not source ID' do
+        subject.run!
+        result = CSV.parse(output, headers: true)
+        expect(result.length).to eq(1)
+        expect(result.first['RecordId']).to eq(c1.warehouse_id.to_s)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Issue: https://github.com/open-path/Green-River/issues/7094

- Remove "Pathways" from the custom data element export. It is already exported in another file which they prefer to use.
- Add logic to CDE export to translate Source Client IDs into Destination IDs before exporting. Source Client IDs are not understood by the party importing because they only have destination ids.
  - This is only applicable to CDEs where the owner type is client. This is future-proofing for future CDEs more than anything, since we are removing the Pathways. There is one remaining Client-tied CDE in this file which is the "has active referrals in LINK", which I don't believe is being looked at.

## Type of change
Bug fix, cleanup

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
