### PR TITLE
Include inherited CoCs for filter options more correctly

### DIFF
--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -818,8 +818,8 @@ module Filters
       all_funders_scope.options_for_select_other(user: user)
     end
 
-    def coc_code_options_for_select(user:)
-      GrdaWarehouse::Lookups::CocCode.options_for_select(user: user)
+    def coc_code_options_for_select(user:, permission: :can_view_assigned_reports)
+      GrdaWarehouse::Lookups::CocCode.options_for_select(user: user, permission: permission)
     end
 
     def project_groups_options_for_select(user:)

--- a/app/models/grda_warehouse/lookups/coc_code.rb
+++ b/app/models/grda_warehouse/lookups/coc_code.rb
@@ -35,6 +35,7 @@ class GrdaWarehouse::Lookups::CocCode < GrdaWarehouseBase
     active_coc_codes = []
     active_coc_codes = active.distinct.pluck(:coc_code) if coc_codes_inherited_from_projects.blank?
     # Intersected with the user's since the active_coc_codes returned all CoC codes at the projects
+    visible_coc_codes = []
     visible_coc_codes = active_coc_codes & user.coc_codes if user.coc_codes.present?
     visible_coc_codes += coc_codes_inherited_from_projects
 

--- a/app/models/grda_warehouse/lookups/coc_code.rb
+++ b/app/models/grda_warehouse/lookups/coc_code.rb
@@ -42,8 +42,8 @@ class GrdaWarehouse::Lookups::CocCode < GrdaWarehouseBase
     active.where(coc_code: visible_coc_codes)
   end
 
-  def self.options_for_select(user:)
-    viewable_by(user).
+  def self.options_for_select(user:, permission: :can_view_projects)
+    viewable_by(user, permission: permission).
       distinct.
       order(:coc_code).
       map(&:as_select_option)

--- a/app/models/grda_warehouse/lookups/coc_code.rb
+++ b/app/models/grda_warehouse/lookups/coc_code.rb
@@ -13,18 +13,30 @@ class GrdaWarehouse::Lookups::CocCode < GrdaWarehouseBase
     where(active: true)
   end
 
-  # NOTE: this is only used for generating filters, it is not to be used when calculating
-  # client visibility
+  ##
+  # Returns all active CoC codes that the given user can view based on permissions.
+  #
+  # NOTE: This scope is primarily used for generating filters and should **not** be used for calculating
+  # client visibility.
+  #
+  # @param user [User] The user whose permissions will be checked.
+  # @param permission [Symbol] The permission used to determine if the user can view the CoC codes.
+  #   Defaults to `:can_view_projects`.
+  # @return [ActiveRecord::Relation<GrdaWarehouse::Lookups::CocCode>] an ActiveRecord::Relation of CoC codes
+  #   that the user is allowed to view.
+  #
   scope :viewable_by, ->(user, permission: :can_view_projects) do
     # any code the user could possibly have access to, and the project associated
-    visible_coc_codes = GrdaWarehouse::Hud::ProjectCoc.joins(:project).
+    coc_codes_inherited_from_projects = GrdaWarehouse::Hud::ProjectCoc.joins(:project).
       merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: permission)).distinct.
       pluck(:CoCCode)
     # If the user can't see any CoC Codes from the above query, it's probably that they don't have any
     # access to view projects. We'll fix that with different permissions in the future, for now return all
-    visible_coc_codes = active.distinct.pluck(:coc_code) if visible_coc_codes.blank?
-    # Intersected with the user's since the visible_coc_codes returned all CoC codes at the projects
-    visible_coc_codes &= user.coc_codes if user.coc_codes.present?
+    active_coc_codes = []
+    active_coc_codes = active.distinct.pluck(:coc_code) if coc_codes_inherited_from_projects.blank?
+    # Intersected with the user's since the active_coc_codes returned all CoC codes at the projects
+    visible_coc_codes = active_coc_codes & user.coc_codes if user.coc_codes.present?
+    visible_coc_codes += coc_codes_inherited_from_projects
 
     active.where(coc_code: visible_coc_codes)
   end

--- a/app/models/grda_warehouse/lookups/coc_code.rb
+++ b/app/models/grda_warehouse/lookups/coc_code.rb
@@ -26,7 +26,7 @@ class GrdaWarehouse::Lookups::CocCode < GrdaWarehouseBase
   #   that the user is allowed to view.
   #
   scope :viewable_by, ->(user, permission: :can_view_projects) do
-    # any code the user could possibly have access to, and the project associated
+    # Fetch all CoC codes that are indirectly accessible to the user via projects they have permission to view.
     coc_codes_inherited_from_projects = GrdaWarehouse::Hud::ProjectCoc.joins(:project).
       merge(GrdaWarehouse::Hud::Project.viewable_by(user, permission: permission)).distinct.
       pluck(:CoCCode)
@@ -34,7 +34,8 @@ class GrdaWarehouse::Lookups::CocCode < GrdaWarehouseBase
     # access to view projects. We'll fix that with different permissions in the future, for now return all
     active_coc_codes = []
     active_coc_codes = active.distinct.pluck(:coc_code) if coc_codes_inherited_from_projects.blank?
-    # Intersected with the user's since the active_coc_codes returned all CoC codes at the projects
+    # Intersect the active CoC codes with the specific CoC codes explicitly assigned to the user.
+    # This ensures the user can only see codes they have explicit access to, in addition to inherited ones.
     visible_coc_codes = []
     visible_coc_codes = active_coc_codes & user.coc_codes if user.coc_codes.present?
     visible_coc_codes += coc_codes_inherited_from_projects

--- a/spec/factories/grda_warehouse/lookups/coc_codes.rb
+++ b/spec/factories/grda_warehouse/lookups/coc_codes.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :lookup_coc, class: 'GrdaWarehouse::Lookups::CocCode' do
+    # these are required by db schema
+    active { true }
+    sequence(:official_name) { |n| "Fake CoC 5#{n.to_s.rjust(2, '0')}" }
+    sequence(:coc_code) { |n| "XX-5#{n.to_s.rjust(2, '0')}" }
+  end
+end

--- a/spec/models/grda_warehouse/lookups/coc_code_spec.rb
+++ b/spec/models/grda_warehouse/lookups/coc_code_spec.rb
@@ -12,28 +12,64 @@ RSpec.describe GrdaWarehouse::Lookups::CocCode, type: :model do
   let!(:user) { create :user }
   let!(:coc_codes) { create_list :lookup_coc, 5 }
   let(:expected_cocs) { ['XX-500', 'XX-501'].sort }
-  before do
-    # User should have access to:
-    # * XX-500 through project 1
-    # * XX-501 through a CoC code assignment
-    # * no access to XX-502
-    user.add_viewable(project_1)
-    user.coc_codes = ['XX-501']
+  describe 'legacy permissions' do
+    before do
+      # User should have access to:
+      # * XX-500 through project 1
+      # * XX-501 through a CoC code assignment
+      # * no access to XX-502
+      user.add_viewable(project_1)
+      user.coc_codes = ['XX-501']
+    end
+
+    it 'user can view 2 projects' do
+      scope = GrdaWarehouse::Hud::Project.viewable_by(user)
+      expect(scope.count).to eq(2)
+    end
+
+    it 'CoC Code viewable_by includes expected CoCs' do
+      scope = GrdaWarehouse::Lookups::CocCode.viewable_by(user)
+      expect(scope.count).to eq(2)
+      expect(scope.pluck(:coc_code).sort).to eq(expected_cocs)
+    end
+
+    it 'Filter only presents expected CoC Codes' do
+      filter = Filters::FilterBase.new(user_id: user.id)
+      expect(filter.coc_code_options_for_select(user: user).map(&:last).sort).to eq(expected_cocs)
+    end
   end
 
-  it 'user can view 2 projects' do
-    scope = GrdaWarehouse::Hud::Project.viewable_by(user)
-    expect(scope.count).to eq(2)
-  end
+  describe 'access control permissions' do
+    let!(:acl_user) { create :acl_user }
+    let!(:role) { create :assigned_report_viewer }
+    let!(:user_group) { create :user_group }
+    let!(:collection) { create :collection }
+    let!(:project_access_control) { create :access_control, role: role, collection: collection, user_group: user_group }
 
-  it 'CoC Code viewable_by includes expected CoCs' do
-    scope = GrdaWarehouse::Lookups::CocCode.viewable_by(user)
-    expect(scope.count).to eq(2)
-    expect(scope.pluck(:coc_code).sort).to eq(expected_cocs)
-  end
+    before do
+      # User should have access to:
+      # * XX-500 through project 1
+      # * XX-501 through a CoC code assignment
+      # * no access to XX-502
+      collection.set_viewables({ projects: [project_1.id] })
+      collection.update(coc_codes: ['XX-501'])
+      user_group.add(acl_user)
+    end
 
-  it 'Filter only presents expected CoC Codes' do
-    filter = Filters::FilterBase.new(user_id: user.id)
-    expect(filter.coc_code_options_for_select(user: user).map(&:last).sort).to eq(expected_cocs)
+    it 'user can view 2 projects' do
+      scope = GrdaWarehouse::Hud::Project.viewable_by(acl_user, permission: :can_view_assigned_reports)
+      expect(scope.count).to eq(2)
+    end
+
+    it 'CoC Code viewable_by includes expected CoCs' do
+      scope = GrdaWarehouse::Lookups::CocCode.viewable_by(acl_user, permission: :can_view_assigned_reports)
+      expect(scope.count).to eq(2)
+      expect(scope.pluck(:coc_code).sort).to eq(expected_cocs)
+    end
+
+    it 'Filter only presents expected CoC Codes' do
+      filter = Filters::FilterBase.new(user_id: acl_user.id)
+      expect(filter.coc_code_options_for_select(user: acl_user, permission: :can_view_assigned_reports).map(&:last).sort).to eq(expected_cocs)
+    end
   end
 end

--- a/spec/models/grda_warehouse/lookups/coc_code_spec.rb
+++ b/spec/models/grda_warehouse/lookups/coc_code_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Lookups::CocCode, type: :model do
+  let!(:data_source) { create :data_source_fixed_id }
+  let!(:organization) { create :grda_warehouse_hud_organization }
+  let!(:project_1) { create :grda_warehouse_hud_project, ProjectType: 1, OrganizationID: organization.OrganizationID }
+  let!(:project_coc_coc_1) { create :grda_warehouse_hud_project_coc, ProjectID: project_1.ProjectID, data_source_id: data_source.id, CoCCode: 'XX-500' }
+  let!(:project_2) { create :grda_warehouse_hud_project, ProjectType: 3, OrganizationID: organization.OrganizationID }
+  let!(:project_coc_coc_2) { create :grda_warehouse_hud_project_coc, ProjectID: project_2.ProjectID, data_source_id: data_source.id, CoCCode: 'XX-501' }
+  let!(:project_3) { create :grda_warehouse_hud_project, ProjectType: 3, OrganizationID: organization.OrganizationID }
+  let!(:project_coc_coc_3) { create :grda_warehouse_hud_project_coc, ProjectID: project_3.ProjectID, data_source_id: data_source.id, CoCCode: 'XX-502' }
+  let!(:user) { create :user }
+  let!(:coc_codes) { create_list :lookup_coc, 5 }
+  let(:expected_cocs) { ['XX-500', 'XX-501'].sort }
+  before do
+    # User should have access to:
+    # * XX-500 through project 1
+    # * XX-501 through a CoC code assignment
+    # * no access to XX-502
+    user.add_viewable(project_1)
+    user.coc_codes = ['XX-501']
+  end
+
+  it 'user can view 2 projects' do
+    scope = GrdaWarehouse::Hud::Project.viewable_by(user)
+    expect(scope.count).to eq(2)
+  end
+
+  it 'CoC Code viewable_by includes expected CoCs' do
+    scope = GrdaWarehouse::Lookups::CocCode.viewable_by(user)
+    expect(scope.count).to eq(2)
+    expect(scope.pluck(:coc_code).sort).to eq(expected_cocs)
+  end
+
+  it 'Filter only presents expected CoC Codes' do
+    filter = Filters::FilterBase.new(user_id: user.id)
+    expect(filter.coc_code_options_for_select(user: user).map(&:last).sort).to eq(expected_cocs)
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Fixes https://github.com/open-path/Green-River/issues/7224
* Ensures CoC Codes that are inherited from projects are correctly available in the filter options when running background reports
 
## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
