### PR TITLE
Add assertions for household tabs navigation (hmis system test)

### DIFF
--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -84,13 +84,16 @@ RSpec.feature 'Enrollment/household management', type: :system do
         assert_text(c1.brief_name)
 
         # first assessment
+        mui_expect_selected_tab('#tab-1')
         complete_individual_assessment
         click_button 'Next'
 
         # second assessment
+        mui_expect_selected_tab('#tab-2')
         complete_individual_assessment
         click_button 'Next'
 
+        mui_expect_selected_tab('#tab-summary')
         assert_text "Complete Entry to #{p1.project_name}"
 
         # Intakes are created as WIP

--- a/spec/support/e2e_setup.rb
+++ b/spec/support/e2e_setup.rb
@@ -95,6 +95,10 @@ RSpec.shared_context 'SystemSpecHelper' do
     end
   end
 
+  def mui_expect_selected_tab(tab_selector)
+    expect(page).to have_css("#{tab_selector}[role=\"tab\"][aria-selected=\"true\"]")
+  end
+
   def with_hidden
     last_value = Capybara.ignore_hidden_elements
     begin


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Add some more assertions to make it clearer if tab navigation on Household Assessments failed. The navigation has some complicated logic (can trigger background saves), and there was a failure with this recently.

No frontend dependency.

## Type of change
test enhancement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
