### PR TITLE
Allow no CA during database upgrades with pgbouncer

### DIFF
--- a/docker/app/database.open-path-warehouse.yml
+++ b/docker/app/database.open-path-warehouse.yml
@@ -4,7 +4,7 @@ default: &default
   port: <%= ENV.fetch('DATABASE_PORT') { 5432 }.to_i  %>
   <% if ENV['RAILS_ENV'] == 'production' || ENV['RAILS_ENV'] == 'staging' %>
   sslmode: <%= ENV.fetch('SSLMODE', 'verify-full') %>
-  sslrootcert: /etc/ssl/certs/us-east-1-bundle.pem
+  sslrootcert: <%= ENV.fetch('SSLROOTCERT', '/etc/ssl/certs/us-east-1-bundle.pem') %>
   <% end %>
 
 <%= ENV.fetch('RAILS_ENV') { 'unknown' } %>:


### PR DESCRIPTION

## _Merging this PR_

## Description

We're using pgbouncer to facilitate database upgrades, and during this process,
we need to relax the sslmode to "require" since pgbouncer has a self-signed
cert. Rails doesn't like it when you also specify the path to the ca, even in
"require" mode, so we need to allow empty values and thus this new env
variable.

## Type of change

Backend database connection flexibility

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
