### PR TITLE
Add bounds to year entered service

### DIFF
--- a/drivers/hmis/app/models/hmis/form/numeric_input_validator.rb
+++ b/drivers/hmis/app/models/hmis/form/numeric_input_validator.rb
@@ -38,7 +38,7 @@ class Hmis::Form::NumericInputValidator
     return [] if item.bounds.blank?
 
     item.bounds.each_with_object([]) do |bound, errors|
-      next unless bound.severity == 'error'
+      next if bound.severity == 'warning'
       # bound.value_number can be nil in the case where the bound is against a local constant or another question
       next unless bound.value_number
 

--- a/drivers/hmis/lib/form_data/default/fragments/client_demographics.json
+++ b/drivers/hmis/lib/form_data/default/fragments/client_demographics.json
@@ -193,7 +193,19 @@
           "mapping": {
             "record_type": "CLIENT",
             "field_name": "yearEnteredService"
-          }
+          },
+          "bounds": [
+            {
+              "id": "min-year",
+              "type": "MIN",
+              "value_number": 1900
+            },
+            {
+              "id": "max-year",
+              "type": "MAX",
+              "value_number": 2080
+            }
+          ]
         },
         {
           "type": "INTEGER",
@@ -203,7 +215,21 @@
           "mapping": {
             "record_type": "CLIENT",
             "field_name": "yearSeparated"
-          }
+          },
+          "bounds": [
+            {
+              "id": "min-year",
+              "type": "MIN",
+              "severity": "error",
+              "value_number": 1900
+            },
+            {
+              "id": "max-year",
+              "type": "MAX",
+              "severity": "error",
+              "value_number": 2080
+            }
+          ]
         },
         {
           "type": "GROUP",


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Issue: https://github.com/open-path/Green-River/issues/7264

* add bounds to year fields
  * future improvement would be to add a "current year" local constant, but doing the minimum to fix bug (eg no frontend changes)
* assume severity is `error` if missing. we already [have that logic](https://github.com/greenriver/hmis-warehouse/blob/014e5a2595c02f5181f96561810d383d1b699f8e/drivers/hmis/app/graphql/types/forms/value_bound.rb#L25-L27) in the resolver

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
