### PR TITLE
Remove duplicates from pathways file

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
@@ -92,12 +92,13 @@ module HmisExternalApis::AcHmis::Exporters
     end
 
     private def pathway_cded_key_to_id
-      @pathway_cded_key_to_id ||= Hmis::Hud::CustomDataElementDefinition.where(key: PATHWAY_KEYS).pluck(:key, :id).to_h
+      @pathway_cded_key_to_id ||= Hmis::Hud::CustomDataElementDefinition.where(key: PATHWAY_KEYS, owner_type: 'Hmis::Hud::Client').pluck(:key, :id).to_h
     end
 
     private def pathways_by_client_id
       @pathways_by_client_id ||= Hmis::Hud::CustomDataElement.
         where(data_element_definition_id: pathway_cded_key_to_id.values). # All Pathway-related definitions
+        where(owner_type: 'Hmis::Hud::Client').
         group_by(&:owner_id) # By Client ID
     end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
@@ -28,6 +28,7 @@ module HmisExternalApis::AcHmis::Exporters
       total = pathway_client_warehouse_id_to_client_ids.count
       Rails.logger.info "There are #{total} clients with pathways to export"
 
+      # Iterate through each Destination Client that has Source Client(s) with any Pathway values
       pathway_client_warehouse_id_to_client_ids.each do |warehouse_id, client_ids|
         # Find the pathway CDE that was most recently updated for this destination client
         most_recent_pathway_cde = client_ids.map { |id| pathways_by_client_id[id] }.flatten.max_by(&:date_updated)
@@ -102,9 +103,7 @@ module HmisExternalApis::AcHmis::Exporters
         group_by(&:owner_id) # By Client ID
     end
 
-    # { source client id => warehouse destination client id }
-    # This drops the source client id if there are multiple source clients with pathways,
-    # so that the resulting CSV does not have duplicated destination client IDs.
+    # { <warehouse destination client id> => [ <source client ids that have pathways> ] }
     private def pathway_client_warehouse_id_to_client_ids
       @pathway_client_warehouse_id_to_client_ids ||= Hmis::WarehouseClient.joins(:source).
         where(data_source_id: data_source.id).

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
@@ -7,6 +7,7 @@
 module HmisExternalApis::AcHmis::Exporters
   class PathwaysExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
+    include ::Hmis::Concerns::HmisArelHelper
 
     PATHWAY_KEYS = [
       'client_pathway_1',
@@ -24,16 +25,19 @@ module HmisExternalApis::AcHmis::Exporters
       Rails.logger.info 'Generating content of pathways export'
 
       write_row(columns)
-      total = clients_with_pathways.count
+      total = pathway_client_warehouse_id_to_client_ids.count
       Rails.logger.info "There are #{total} clients with pathways to export"
 
-      clients_with_pathways.find_each.with_index do |client, i|
-        Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?
-        next unless client.warehouse_id.present?
+      pathway_client_warehouse_id_to_client_ids.each do |warehouse_id, client_ids|
+        # Find the pathway CDE that was most recently updated for this destination client
+        most_recent_pathway_cde = client_ids.map { |id| pathways_by_client_id[id] }.flatten.max_by(&:date_updated)
 
-        pathways = pathways_by_client_id[client.id]
+        # Collect all pathways for the source client that most recently had any pathway updated.
+        # This makes it so that we don't mix-and-match pathways values from different source clients.
+        pathways = pathways_by_client_id[most_recent_pathway_cde.owner_id]
+
         values = [
-          client.warehouse_id, # Matches PersonalID in HMIS CSV export
+          warehouse_id, # Matches PersonalID in HMIS CSV export
           find_pathway(pathways, 'client_pathway_1'),
           find_pathway(pathways, 'client_pathway_1_date'),
           find_pathway(pathways, 'client_pathway_1_narrative'),
@@ -97,8 +101,16 @@ module HmisExternalApis::AcHmis::Exporters
         group_by(&:owner_id) # By Client ID
     end
 
-    private def clients_with_pathways
-      @clients_with_pathways ||= Hmis::Hud::Client.where(id: pathways_by_client_id.keys).preload(:warehouse_client_source)
+    # { source client id => warehouse destination client id }
+    # This drops the source client id if there are multiple source clients with pathways,
+    # so that the resulting CSV does not have duplicated destination client IDs.
+    private def pathway_client_warehouse_id_to_client_ids
+      @pathway_client_warehouse_id_to_client_ids ||= Hmis::WarehouseClient.joins(:source).
+        where(data_source_id: data_source.id).
+        where(source_id: pathways_by_client_id.keys). # Only include clients that have Pathways
+        group(:destination_id).
+        select('"destination_id", array_agg("source_id") as source_ids').
+        map { |r| [r.destination_id, r.source_ids] }.to_h
     end
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/pathways_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/pathways_export_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::PathwaysExport, type: :model
   it 'collects clients with pathways' do
     create(:hmis_custom_data_element, owner: client, data_element_definition: pathway_definitions['client_pathway_1'])
     subject.run!
-    expect(subject.send(:clients_with_pathways)).to contain_exactly(client)
+    expect(subject.send(:pathway_client_warehouse_id_to_client_ids)).to contain_exactly([client.warehouse_id, [client.id]])
   end
 
   it 'doesnt fail if no clients have pathways' do
     subject.run!
-    expect(subject.send(:clients_with_pathways).length).to eq(0)
+    expect(subject.send(:pathway_client_warehouse_id_to_client_ids).length).to eq(0)
   end
 
   it 'makes a csv' do
@@ -73,5 +73,52 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::PathwaysExport, type: :model
     expect(result.first['Pathway3_Date']).to be_nil
     expect(result.first['Pathway3_Narrative']).to be_nil
     expect(result.first['Pathway3_DateUpdated']).to be_nil
+  end
+
+  context 'when source client does not have a destination client yet' do
+    let!(:client) { create(:hmis_hud_client, data_source: ds) }
+    let!(:pathway1) { create(:hmis_custom_data_element, value_string: 'value', owner: client, data_element_definition: pathway_definitions['client_pathway_1']) }
+
+    it 'does not export the client' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+      expect(result.length).to eq(0)
+    end
+  end
+
+  context 'when there are multiple pathway clients with the same destination id' do
+    # Two Pathway 1 CDEs, with different source clients but same dest client
+    let!(:pathway1) { create(:hmis_custom_data_element, value_string: 'retained', owner: client, data_element_definition: pathway_definitions['client_pathway_1']) }
+    let!(:pathway1_dup) { create(:hmis_custom_data_element, value_string: 'dropped', date_updated: 1.week.ago, owner: client2, data_element_definition: pathway_definitions['client_pathway_1']) }
+    # One Pathway 2, dropped because it will only export `client`
+    let!(:pathway2) { create(:hmis_custom_data_element, value_string: 'dropped', owner: client2, data_element_definition: pathway_definitions['client_pathway_2']) }
+    # Two Pathway 3 CDEs, with different source clients but same dest client
+    let!(:pathway3) { create(:hmis_custom_data_element, value_string: 'retained', owner: client, data_element_definition: pathway_definitions['client_pathway_3']) }
+    let!(:pathway3_dup) { create(:hmis_custom_data_element, value_string: 'dropped', owner: client3, date_updated: 1.week.ago, data_element_definition: pathway_definitions['client_pathway_3']) }
+
+    before(:each) do
+      warehouse_id = client.warehouse_id
+      client2.warehouse_client_source.update!(destination_id: warehouse_id)
+      client3.warehouse_client_source.update!(destination_id: warehouse_id)
+    end
+
+    it 'maps pathway_client_warehouse_id_to_client_ids correctly' do
+      expect(subject.send(:pathway_client_warehouse_id_to_client_ids)).to contain_exactly(
+        [client.warehouse_id, containing_exactly(client.id, client2.id, client3.id)],
+      )
+    end
+
+    it 'only exports one row for all destination client pathways, choosing recently updated value when there are multiples' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['PersonalID']).to eq(client.warehouse_id.to_s)
+      expect(result.first['Pathway1']).to eq(pathway1.value_string)
+      expect(result.first['Pathway1_DateUpdated']).to eq(pathway1.date_updated.strftime('%Y-%m-%d %H:%M:%S'))
+      expect(result.first['Pathway2']).to eq(nil) # pathway2 not included because it's tied to client2
+      expect(result.first['Pathway3']).to eq(pathway3.value_string)
+      expect(result.first['Pathway3_DateUpdated']).to eq(pathway3.date_updated.strftime('%Y-%m-%d %H:%M:%S'))
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy

## Description
Issue (customer req): https://github.com/open-path/Green-River/issues/7094

Adjusting this export so that we don't export "duplicate" values for the same Warehouse Client.

For situations where a destination client has multiple HMIS clients, _AND_ multiple of those HMIS clients has Pathways custom fields, we used to export all of the pathway data for each source client –– resulting in duplicate destination IDs in the export. With this change, we now choose to only export Pathways from **one** of those HMIS clients. We select the HMIS client who's pathways have been most recently updated.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
