### PR TITLE
Fix N+1 on household reminders query

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -441,5 +441,13 @@ module Types
     def move_in_addresses
       load_ar_association(object, :move_in_addresses)
     end
+
+    def intake_assessment
+      load_ar_association(object, :intake_assessment)
+    end
+
+    def exit_assessment
+      load_ar_association(object, :exit_assessment)
+    end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/reminder.rb
@@ -18,6 +18,7 @@ module Types
     field :assessment_id, ID, null: true, description: 'Relevant existing assessment, if any'
 
     def client
+      # note: client and enrollment are preloaded by ReminderGenerator
       object.enrollment.client
     end
 

--- a/drivers/hmis/spec/requests/hmis/reminder_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/reminder_spec.rb
@@ -19,12 +19,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     hmis_login(user)
   end
 
+  let(:household_size) { 5 }
   let!(:enrollment) do
     client = create :hmis_hud_client_complete, data_source: ds1, user: u1
     hoh = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: client, user: u1, relationship_to_hoh: 1
-    3.times do
+    # Create N enrollments. Each will be missing an intake, so should have 1 reminder.
+    (household_size - 1).times do
       member = create :hmis_hud_client_complete, data_source: ds1, user: u1
-      create :hmis_hud_enrollment, data_source: ds1, project: p1, client: member, user: u1, relationship_to_hoh: 99
+      create(:hmis_hud_enrollment, household_id: hoh.household_id, data_source: ds1, project: p1, client: member, relationship_to_hoh: 6)
     end
     hoh
   end
@@ -42,6 +44,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               overdue
               enrollment {
                 id
+                intakeAssessment {
+                  id
+                }
+                exitAssessment {
+                  id
+                }
               }
               client {
                 id
@@ -60,14 +68,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'minimizes n+1 queries' do
       expect do
         _, result = post_graphql(**variables) { query }
-        expect(result.dig('data', 'enrollment', 'reminders').size).to eq(1)
-      end.to make_database_queries(count: 10..30)
+        expect(result.dig('data', 'enrollment', 'reminders').size).to eq(household_size)
+      end.to make_database_queries(count: 10..35)
     end
 
     it 'is responsive' do
       expect do
         _, result = post_graphql(**variables) { query }
-        expect(result.dig('data', 'enrollment', 'reminders').size).to eq(1)
+        expect(result.dig('data', 'enrollment', 'reminders').size).to eq(household_size)
       end.to perform_under(300).ms
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/6980

Fix perf issue that was surfaced in sentry in QA.

Add data loading and regression test. The frontend loads the intake/exit assessment for each enrollment with a reminder.

It could probably be improved so that the relevant assessment (if any) is loaded directly on the reminder. But this change fixes the performance problem while preserving the existing api.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
