### PR TITLE
Disallow same-day exit from residential projects

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -49,7 +49,7 @@ module Hmis
           Hmis::Hud::Base.transaction do
             # Auto-exit all household members together, setting the exit date equal to the most recent contact for any household member
             household.enrollments.each do |e|
-              auto_exit(e, most_recent_contact, project_type: project.project_type)
+              auto_exit(e, most_recent_contact, project: project)
             end
           end
         end
@@ -77,12 +77,12 @@ module Hmis
       end
     end
 
-    def auto_exit(enrollment, most_recent_contact, project_type:)
+    def auto_exit(enrollment, most_recent_contact, project:)
       exit_date = contact_date_for_entity(most_recent_contact)
       # If most recent contact was a Bed Night service, the Exit Date should be the day after they received service
       exit_date += 1.day if most_recent_contact.is_a?(Hmis::Hud::Service) && most_recent_contact.record_type == 200
       # If most recent contact was on Entry Date and this is a residential project, add 1 day to avoid Same-day-exit data quality errors
-      exit_date += 1.day if exit_date == enrollment.entry_date && HudUtility2024.residential_project_type_ids.include?(project_type)
+      exit_date += 1.day if exit_date == enrollment.entry_date && !project.allows_same_day_exit?
 
       user = Hmis::Hud::User.system_user(data_source_id: enrollment.data_source_id)
 

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -12,6 +12,7 @@ module Hmis
       Hmis::ProjectAutoExitConfig.exists?
     end
 
+    # todo add project id param
     def perform
       return unless self.class.enabled?
 
@@ -40,7 +41,7 @@ module Hmis
           Hmis::Hud::Base.transaction do
             # Auto-exit all household members together, setting the exit date equal to the most recent contact for any household member
             household.enrollments.each do |e|
-              auto_exit(e, most_recent_contact)
+              auto_exit(e, most_recent_contact, project_type: project.project_type)
             end
           end
         end
@@ -68,10 +69,13 @@ module Hmis
       end
     end
 
-    def auto_exit(enrollment, most_recent_contact)
+    def auto_exit(enrollment, most_recent_contact, project_type:)
       exit_date = contact_date_for_entity(most_recent_contact)
       # If most recent contact was a Bed Night service, the Exit Date should be the day after they received service
       exit_date += 1.day if most_recent_contact.is_a?(Hmis::Hud::Service) && most_recent_contact.record_type == 200
+      # If most recent contact was on Entry Date and this is a residential project, add 1 day to avoid Same-day-exit data quality errors
+      exit_date += 1.day if exit_date == enrollment.entry_date && HudUtility2024.residential_project_type_ids.include?(project_type)
+
       user = Hmis::Hud::User.system_user(data_source_id: enrollment.data_source_id)
 
       exit_record = Hmis::Hud::Exit.new(

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -12,15 +12,23 @@ module Hmis
       Hmis::ProjectAutoExitConfig.exists?
     end
 
-    # todo add project id param
-    def perform
+    def perform(project_ids: nil, data_source_id: nil)
       return unless self.class.enabled?
 
       setup_notifier('HMIS Auto-Exit')
       auto_exit_projects = Set.new
       auto_exit_count = 0
 
-      Hmis::Hud::Project.hmis.each do |project|
+      project_scope = if project_ids.present?
+        Hmis::Hud::Project.hmis.where(id: project_ids)
+      elsif data_source_id
+        Hmis::Hud::Project.hmis.where(data_source_id: data_source_id)
+      else
+        # By default, run against all HMIS data sources
+        Hmis::Hud::Project.hmis
+      end
+
+      project_scope.each do |project|
         config = Hmis::ProjectAutoExitConfig.detect_best_config_for_project(project)
         next unless config.present?
         raise "Auto-exit config unusually low: #{config.length_of_absence_days}" if config.length_of_absence_days < 30

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -183,6 +183,23 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     Hmis::Form::Instance.active.published.with_role(:REFERRAL).any? { |instance| instance.project_match(self) }
   end
 
+  def services_only_rrh?
+    # Project Type PH-RRH (13) with RRHSubType 'RRH: Services Only' (1) indicate that the project only provides services
+    project_type == 13 && rrh_sub_type == 1
+  end
+
+  # Whether Enrollments are allowed to have EntryDate==ExitDate in this project.
+  # HUD specifies that certain Residential projects do not allow same-day exits.
+  def allows_same_day_exit?
+    if services_only_rrh?
+      true # RRH-Services-Only projects allow same-day exit
+    elsif HudUtility2024.residential_project_type_ids.include?(project_type)
+      false # Residential projects do not allow same-day exit
+    else
+      true # Non-residential projects allow same-day exit
+    end
+  end
+
   def active
     return true unless operating_end_date.present?
 

--- a/drivers/hmis/app/models/hmis/hud/validators/base_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/base_validator.rb
@@ -44,6 +44,10 @@ class Hmis::Hud::Validators::BaseValidator < ActiveModel::Validator
     "cannot be before entry date (#{entry_date.strftime('%m/%d/%Y')})"
   end
 
+  def self.on_entry_message(entry_date)
+    "must be after entry date (#{entry_date.strftime('%m/%d/%Y')})"
+  end
+
   def self.after_exit_message(exit_date)
     "cannot be after exit date (#{exit_date.strftime('%m/%d/%Y')})"
   end

--- a/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
@@ -47,9 +47,9 @@ class Hmis::Hud::Validators::ExitValidator < Hmis::Hud::Validators::BaseValidato
     errors.add(:exit_date, :out_of_range, message: after_project_end_message(project_end_date), **options) if project_end_date&.< exit_date
     errors.add :exit_date, :out_of_range, message: before_entry_message(entry_date), **options if entry_date.present? && entry_date > exit_date
 
-    # Residential projects do not allow same-day exit
+    # Some projects do not allow same-day exit
     # rubocop:disable Style/IfUnlessModifier
-    if entry_date.present? && entry_date == exit_date && HudUtility2024.residential_project_type_ids.include?(enrollment.project.project_type)
+    if entry_date.present? && entry_date == exit_date && !enrollment.project.allows_same_day_exit?
       errors.add :exit_date, :out_of_range, message: on_entry_message(entry_date), **options
     end
     # rubocop:enable Style/IfUnlessModifier

--- a/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
@@ -46,6 +46,14 @@ class Hmis::Hud::Validators::ExitValidator < Hmis::Hud::Validators::BaseValidato
     errors.add(:exit_date, :out_of_range, message: before_project_start_message(project_start_date), **options) if project_start_date&.> exit_date
     errors.add(:exit_date, :out_of_range, message: after_project_end_message(project_end_date), **options) if project_end_date&.< exit_date
     errors.add :exit_date, :out_of_range, message: before_entry_message(entry_date), **options if entry_date.present? && entry_date > exit_date
+
+    # Residential projects do not allow same-day exit
+    # rubocop:disable Style/IfUnlessModifier
+    if entry_date.present? && entry_date == exit_date && HudUtility2024.residential_project_type_ids.include?(enrollment.project.project_type)
+      errors.add :exit_date, :out_of_range, message: on_entry_message(entry_date), **options
+    end
+    # rubocop:enable Style/IfUnlessModifier
+
     errors.add :exit_date, :information, severity: :warning, message: over_thirty_days_ago_message, **options if exit_date < (Date.current - 30.days)
     errors.add :exit_date, :out_of_range, message: before_dob_message, **options if dob.present? && dob > exit_date
     return errors.errors if errors.any?

--- a/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
@@ -23,11 +23,13 @@ FactoryBot.define do
       values { {} }
       hud_values { {} }
       definition { nil }
+      project { nil }
     end
     after(:build) do |assessment, evaluator|
       assessment.form_processor = build(:hmis_form_processor, owner: assessment, values: evaluator.values, hud_values: evaluator.hud_values)
       assessment.form_processor.definition = evaluator.definition if evaluator.definition
       assessment.data_collection_stage = Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[evaluator.definition.role.to_sym] if evaluator.definition
+      assessment.enrollment.project = evaluator.project if evaluator.project
     end
     after(:create) do |assessment, evaluator|
       assessment.build_form_processor(values: evaluator.values, hud_values: evaluator.hud_values, definition: evaluator.definition)
@@ -39,14 +41,17 @@ FactoryBot.define do
 
   factory :hmis_intake_assessment, parent: :hmis_custom_assessment do
     DataCollectionStage { 1 }
-    # transient do
-    #   definition { build(:hmis_intake_assessment_definition) }
-    # end
+    definition { association :hmis_form_definition, role: :INTAKE }
     after(:create) do |assessment, _evaluator|
       assessment.update!(assessment_date: assessment.enrollment.entry_date)
       assessment.update!(date_created: assessment.enrollment.date_created)
       assessment.update!(date_updated: assessment.enrollment.date_updated)
     end
+  end
+
+  factory :hmis_exit_assessment, parent: :hmis_custom_assessment do
+    DataCollectionStage { 3 }
+    definition { association :hmis_form_definition, role: :EXIT }
   end
 
   factory :hmis_wip_custom_assessment, parent: :hmis_custom_assessment do

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       expect(e2.exit_assessment&.data_collection_stage).to eq(3)
     end
 
-    it 'should exit based on entry date if client had no bed nights' do
+    it 'should exit based on entry date +1 if client had no bed nights' do
       e1 = create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: Date.current - 2.months
 
       Hmis::AutoExitJob.perform_now
 
       expect(Hmis::Hud::Enrollment.exited).to include(e1)
-      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
+      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date + 1.day, destination: 30)
       expect(e1.exit_assessment).to be_present
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       create :hmis_hud_service, :skip_validate, data_source: ds1, client: c1, enrollment: e1, record_type: 200, date_provided: nil
 
       Hmis::AutoExitJob.perform_now
-      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
+      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date + 1.day, destination: 30)
     end
 
     it 'should not fail if enrollment has contact date before entry (regression #7178)' do
@@ -64,8 +64,8 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       Hmis::AutoExitJob.perform_now
 
       expect(Hmis::Hud::Enrollment.exited).to include(e1)
-      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
-      expect(e1.exit_assessment&.assessment_date).to eq(e1.entry_date)
+      expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date + 1.day, destination: 30)
+      expect(e1.exit_assessment&.assessment_date).to eq(e1.entry_date + 1.day)
       expect(e1.exit_assessment&.data_collection_stage).to eq(3)
     end
 
@@ -221,5 +221,31 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
     expect { Hmis::AutoExitJob.perform_now }.to raise_error('Auto-exit config unusually low: 29')
 
     expect(e1.exit).to be_nil
+  end
+
+  describe 'for enrollment with no contacts' do
+    let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+    let!(:aec) { create :hmis_project_auto_exit_config, length_of_absence_days: 30, organization: o1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, entry_date: 2.months.ago }
+
+    context 'residential project type' do
+      # PH project (9)
+      let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, project_type: 9 }
+      it 'uses EntryDate+1 as ExitDate' do
+        expect do
+          Hmis::AutoExitJob.perform_now
+        end.to change { e1.reload.exit&.exit_date }.from(nil).to(e1.entry_date + 1.day)
+      end
+    end
+
+    context 'non-residential project type' do
+      # Services Only project (6)
+      let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, project_type: 6 }
+      it 'uses EntryDate as ExitDate' do
+        expect do
+          Hmis::AutoExitJob.perform_now
+        end.to change { e1.reload.exit&.exit_date }.from(nil).to(e1.entry_date)
+      end
+    end
   end
 end

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -248,4 +248,41 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       end
     end
   end
+
+  describe 'can run for specific projects or data sources' do
+    # ds1 with 1 project set up to auto-exit, and 1 eligible enrollment
+    let!(:ds1) { create(:hmis_data_source) }
+    let!(:p1) { create :hmis_hud_project, data_source: ds1 }
+    let!(:aec) { create :hmis_project_auto_exit_config, length_of_absence_days: 30, project: p1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.months.ago }
+
+    let!(:ds2) { create(:hmis_data_source) }
+    let!(:p2) { create :hmis_hud_project, data_source: ds2 }
+    let!(:aec2) { create :hmis_project_auto_exit_config, length_of_absence_days: 30, project: p2 }
+    let!(:e2) { create :hmis_hud_enrollment, data_source: ds2, project: p2, entry_date: 2.months.ago }
+
+    it 'should only auto-exit enrollments for the specified data source' do
+      expect do
+        Hmis::AutoExitJob.perform_now(data_source_id: ds1.id)
+      end.to change { e1.reload.exit&.exit_date }.from(nil).to(be_present).
+        and change(Hmis::Hud::Exit, :count).by(1)
+
+      expect do
+        Hmis::AutoExitJob.perform_now(data_source_id: ds2.id)
+      end.to change { e2.reload.exit&.exit_date }.from(nil).to(be_present).
+        and change(Hmis::Hud::Exit, :count).by(1)
+    end
+
+    it 'should only auto-exit enrollments for the specified project' do
+      expect do
+        Hmis::AutoExitJob.perform_now(project_ids: [p1.id])
+      end.to change { e1.reload.exit&.exit_date }.from(nil).to(be_present).
+        and change(Hmis::Hud::Exit, :count).by(1)
+
+      expect do
+        Hmis::AutoExitJob.perform_now(project_ids: [p2.id])
+      end.to change { e2.reload.exit&.exit_date }.from(nil).to(be_present).
+        and change(Hmis::Hud::Exit, :count).by(1)
+    end
+  end
 end

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -86,73 +86,65 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
   end
 
   describe 'custom assessment validator' do
-    include_context 'hmis base setup'
-    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.weeks.ago, relationship_to_ho_h: 1 }
-    let!(:e1_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: e1, client: e1.client }
-    let!(:assessment) { create(:hmis_custom_assessment, data_source: ds1, enrollment: e1) }
-
-    def apply_assessment_date(date)
-      assessment.assessment_date = date
-      assessment.enrollment.entry_date = date if assessment.intake?
-      assessment.enrollment.exit.exit_date = date if assessment.exit?
-    end
+    let!(:p1) { create :hmis_hud_project, data_source: ds1, project_type: 6 } # services only (non-residential)
 
     [:INTAKE, :UPDATE, :ANNUAL, :EXIT].each do |role|
-      before(:each) do
-        assessment.update(data_collection_stage: Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[role])
-        e1.update(entry_date: 2.weeks.ago)
-        e1_exit.update(exit_date: 1.week.ago)
-      end
+      context "for #{role} assessments" do
+        let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.weeks.ago, relationship_to_ho_h: 1 }
+        let!(:e1_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: e1, client: e1.client, exit_date: 1.week.ago }
+        let!(:assessment) { create(:hmis_custom_assessment, data_source: ds1, enrollment: e1, data_collection_stage: Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[role]) }
 
-      it "should error if assessment date is missing (#{role})" do
-        apply_assessment_date(nil)
-        validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        expect(validations).to contain_exactly(a_hash_including(severity: :error, type: :required))
-      end
-
-      it "should succeed if assessment date is the same as entry date (#{role})" do
-        apply_assessment_date(e1.entry_date)
-        validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        expect(validations).to be_empty
-      end
-
-      it "should maybe error if assessment date is before entry date (#{role})" do
-        apply_assessment_date(e1.entry_date - 1.day)
-        validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        if assessment.intake?
-          expect(validations).to be_empty
-        else
-          expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.before_entry_message(e1.entry_date)))
+        def apply_assessment_date(date)
+          assessment.assessment_date = date
+          assessment.enrollment.entry_date = date if assessment.intake?
+          assessment.enrollment.exit.exit_date = date if assessment.exit?
         end
-      end
 
-      it "should maybe error if assessment date is after exit date (#{role})" do
-        apply_assessment_date(e1_exit.exit_date + 1.day)
-        validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
-        if assessment.exit?
+        it "should error if assessment date is missing (#{role})" do
+          apply_assessment_date(nil)
+          validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
+          expect(validations).to contain_exactly(a_hash_including(severity: :error, type: :required))
+        end
+
+        it "should succeed if assessment date is the same as entry date (#{role})" do
+          apply_assessment_date(e1.entry_date)
+          validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
           expect(validations).to be_empty
-        else
-          expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.after_exit_message(e1_exit.exit_date)))
+        end
+
+        it "should maybe error if assessment date is before entry date (#{role})" do
+          apply_assessment_date(e1.entry_date - 1.day)
+          validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
+          if assessment.intake?
+            expect(validations).to be_empty
+          else
+            expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.before_entry_message(e1.entry_date)))
+          end
+        end
+
+        it "should maybe error if assessment date is after exit date (#{role})" do
+          apply_assessment_date(e1_exit.exit_date + 1.day)
+          validations = Hmis::Hud::Validators::CustomAssessmentValidator.validate_assessment_date(assessment).map(&:to_h)
+          if assessment.exit?
+            expect(validations).to be_empty
+          else
+            expect(validations).to contain_exactly(a_hash_including(severity: :error, message: Hmis::Hud::Validators::BaseValidator.after_exit_message(e1_exit.exit_date)))
+          end
         end
       end
     end
 
     describe 'for household exits' do
-      let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.weeks.ago, relationship_to_ho_h: 2, household_id: e1.household_id }
-      let!(:e2_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: e2, client: e2.client }
-      let!(:assessment2) { create(:hmis_custom_assessment, data_source: ds1, enrollment: e2) }
-      before(:each) do
-        assessment.update(data_collection_stage: Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[:EXIT])
-        assessment2.update(data_collection_stage: Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[:EXIT])
-        e1.update(entry_date: 2.weeks.ago)
-        e2.update(entry_date: 2.weeks.ago)
-        e1_exit.update(exit_date: 1.week.ago)
-        e2_exit.update(exit_date: 1.week.ago)
-      end
+      # HoH, exited
+      let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.weeks.ago, exit_date: 1.week.ago, relationship_to_ho_h: 1 }
+      let!(:assessment) { create(:hmis_exit_assessment, data_source: ds1, enrollment: e1, assessment_date: 1.week.ago) }
+      # Other member, also exited
+      let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, entry_date: 2.weeks.ago, exit_date: 1.week.ago, relationship_to_ho_h: 2, household_id: e1.household_id }
+      let!(:assessment2) { create(:hmis_exit_assessment, data_source: ds1, enrollment: e2, assessment_date: 1.week.ago) }
 
       it 'should warn if HoH exit date is before other members (persisted)' do
-        apply_assessment_date(1.week.ago) # HoH exits 1 week ago
-        assessment2.update(assessment_date: 3.days.ago) # Other member exits 3 days ago
+        # Other member exits 3 days ago
+        assessment2.update!(assessment_date: 3.days.ago)
         assessment2.enrollment.exit.update(exit_date: 3.days.ago)
 
         # Validate HoH

--- a/drivers/hmis/spec/models/hmis/hud/household_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/household_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe Hmis::Hud::Household, type: :model do
       end
 
       it 'should handle open on correctly' do
-        e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: today - 1.week, client: c2)
-        create(:hmis_hud_exit, data_source: ds1, enrollment: e3, client: c2, exit_date: yesterday)
+        e3 = create(:hmis_hud_enrollment, project: p1, user: u1, data_source: ds1, household_id: '789', entry_date: today - 1.week, client: c2, exit_date: yesterday)
 
         expect(Hmis::Hud::Household.open_on_date(today)).to contain_exactly(e1.household, e2.household)
         expect(Hmis::Hud::Household.open_on_date(yesterday)).to contain_exactly(e2.household, e3.household)

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   include_context 'hmis base setup'
   let!(:access_control) { create_access_control(hmis_user, ds1) }
-  let(:assessment1) { create :hmis_wip_custom_assessment, data_source: ds1 }
-  let(:assessment2) { create :hmis_wip_custom_assessment, data_source: ds1 }
-  let(:assessment3) { create :hmis_wip_custom_assessment, data_source: ds1 }
+
+  let!(:project) { create :hmis_hud_project, data_source: ds1, project_type: 6 } # services only (non-residential)
+  let!(:assessment1) { create :hmis_wip_custom_assessment, data_source: ds1, project: p1 }
+  let!(:assessment2) { create :hmis_wip_custom_assessment, data_source: ds1, project: p1 }
+  let!(:assessment3) { create :hmis_wip_custom_assessment, data_source: ds1, project: p1 }
   let(:submit_assessment_mutation) do
     <<~GRAPHQL
       mutation SubmitHouseholdAssessments($input: SubmitHouseholdAssessmentsInput!) {
@@ -43,7 +45,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     [assessment1, assessment2, assessment3].each do |assessment|
       enrollment = assessment.enrollment
-      project = assessment1.enrollment.project # all use the same project
       enrollment.update!(household_id: assessment1.enrollment.household_id, project_id: project.project_id, project_pk: project.id)
 
       # Save enrollment as WIP


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue and QA instructions: https://github.com/open-path/Green-River/issues/7238

* Prevent Auto-exit from creating same-day exits in residential projects
* Update AutoExitJob to allow passing scope (projects or data source)
* Prevent manual same-day exits in HMIS for residential projects


## Type of change
Bug fix, HUD compliance

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
