### PR TITLE
Fix Project Location map bug for merged clients

### DIFF
--- a/drivers/client_location_history/app/controllers/client_location_history/projects_controller.rb
+++ b/drivers/client_location_history/app/controllers/client_location_history/projects_controller.rb
@@ -11,7 +11,8 @@ module ClientLocationHistory
     before_action :require_can_view_project_locations!
 
     def map
-      @locations = @project.enrollment_location_histories.where(located_on: filter.range)
+      # find locations tied to Enrollments in the project. Join client to drop locations that don't have a client.
+      @locations = @project.enrollment_location_histories.joins(:client).where(located_on: filter.range)
       @markers = @locations.map { |l| l.as_marker(current_user, [:name, :seen_on]) }
       @bounds = ClientLocationHistory::Location.bounds(@locations)
       @options = {

--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -47,6 +47,7 @@ module Hmis
         merge_mci_ids
         merge_mci_unique_ids
         merge_scan_cards
+        merge_client_locations
 
         client_to_retain.reload
         dedup(client_to_retain.names, keepers: dedup(client_to_retain.names.where(primary: true)))
@@ -249,6 +250,14 @@ module Hmis
       # Update all Scan Cards for deleted clients to point to the retained client, including deactivated scan cards
       client_ids = clients_needing_reference_updates.map(&:id)
       Hmis::ScanCardCode.with_deleted.where(client_id: client_ids).update_all(client_id: client_to_retain.id)
+    end
+
+    def merge_client_locations
+      # Update all Client Locations for deleted clients to point to the retained client
+      # Note: for locations collected in HMIS these are probably also tied to an Enrollment via `source_id`, but the client_id
+      # reference is necessary to maintain for the warehouse reports
+      client_ids = clients_needing_reference_updates.map(&:id)
+      ::ClientLocationHistory::Location.where(client_id: client_ids).update_all(client_id: client_to_retain.id)
     end
 
     def delete_warehouse_clients

--- a/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
+++ b/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
@@ -230,6 +230,19 @@ RSpec.describe Hmis::MergeClientsJob, type: :model do
     end
   end
 
+  context 'with client location records' do
+    let!(:loc1) { create :clh_location, client_id: client1.id }
+    let!(:loc2) { create :clh_location, client_id: client2.id }
+
+    it 'moves all locations to retained client' do
+      expect do
+        Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id)
+      end.to change { loc2.reload.client_id }.from(client2.id).to(client1.id).
+        and not_change { loc1.reload.client_id }.
+        and change(client1.client_location_histories, :count).by(1)
+    end
+  end
+
   context 'with external referral records' do
     let!(:referral1) { create :hmis_external_api_ac_hmis_referral }
     let!(:referral1_hhm1) { create :hmis_external_api_ac_hmis_referral_household_member, client: client1, referral: referral1 }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

issue: https://github.com/open-path/Green-River/issues/7302

Fixes an issue where the Project Location Map would throw a 500 if there were at locations with `client_id` pointing to a deleted client, which would happen if 2 clients were merged.

- On Project Location Map in the Warehouse, drop an locations missing client -- to avoid errors when rendering the marker
  - This only hides the problem, of course. There is a one-off script in issue to update locations that were improperly merged, we should re-run it after this is deployed to make sure we catch everything.
- Update HMIS Merge Clients Job to update `client_id` references on location records

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
