### PR TITLE
Client Activity Report Timeout Hotfix

### DIFF
--- a/drivers/inactive_client_report/app/controllers/inactive_client_report/warehouse_reports/reports_controller.rb
+++ b/drivers/inactive_client_report/app/controllers/inactive_client_report/warehouse_reports/reports_controller.rb
@@ -25,10 +25,7 @@ module InactiveClientReport::WarehouseReports
     def index
       @excel_export = ::InactiveClientReport::DocumentExports::ReportExcelExport.new
       respond_to do |format|
-        format.html do
-          @pagy, @clients = pagy(@report.clients.order(:last_name, :first_name))
-          @report.client_ids = @clients.map(&:id)
-        end
+        format.html {}
         format.xlsx do
           @report.client_ids = @report.clients.map(&:id)
           filename = "#{@report.name} - #{Time.current.to_fs(:db)}.xlsx"

--- a/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_number_clients.haml
+++ b/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_number_clients.haml
@@ -1,0 +1,5 @@
+.d-flex.flex-wrap
+  .hero-prs1
+    .d-flex.align-items-center
+      .h1.hero-value-prs1.mr-3= number_with_delimiter @report.total_client_count
+      .hero-label-prs1.h5-prs1 Unique Clients

--- a/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_report.haml
+++ b/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_report.haml
@@ -1,3 +1,5 @@
+= render 'number_clients'
+= render 'report_download'
 .overflow-scroll
   - if @report.total_client_count.positive?
     = render 'common/pagination_top', item_name: 'client'

--- a/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_report_download.haml
+++ b/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/_report_download.haml
@@ -1,0 +1,8 @@
+.d-flex
+  .mr-4
+    .alert.alert-info
+      %i.icon-info.mr-4
+      Please note, while the clients included in the report are limited to those with enrollments in the chosen universe, some activitie are included that may be outside the chosen universe.
+  .ml-auto.mb-4
+    - params['filters'] = default_filter_options.with_indifferent_access['filters'] if params['filters'].blank?
+    = render 'report_downloads/report_download', export: nil, excel_export: @excel_export, excel_download_path: nil

--- a/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/index.haml
+++ b/drivers/inactive_client_report/app/views/inactive_client_report/warehouse_reports/reports/index.haml
@@ -12,20 +12,7 @@
       = render 'utility'
     .top-nav-prs1
       %h1.mb-5= title
-      .d-flex.flex-wrap
-        .hero-prs1
-          .d-flex.align-items-center
-            .h1.hero-value-prs1.mr-3= number_with_delimiter @report.total_client_count
-            .hero-label-prs1.h5-prs1 Unique Clients
     .main-inner-prs1
-      .d-flex
-        .mr-4
-          .alert.alert-info
-            %i.icon-info.mr-4
-            Please note, while the clients included in the report are limited to those with enrollments in the chosen universe, some activitie are included that may be outside the chosen universe.
-        .ml-auto.mb-4
-          - params['filters'] = default_filter_options.with_indifferent_access['filters'] if params['filters'].blank?
-          = render 'report_downloads/report_download', export: nil, excel_export: @excel_export, excel_download_path: nil
       - if params[:render_inline] == "1" && Rails.env.development?
         = render "report"
       - else


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
Fix Client Activity Report timeout after backgrounding the processing. There was still a piece of data (Total Unique Clients) running the long-running query. This has been moved to be processed inside the background job.

_Note: This has been pushed to [QA](https://qa-warehouse.openpath.host/inactive_client_report/warehouse_reports/reports) and verified there as well._

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
