### PR TITLE
Override authentication salt to allow for forced logouts

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -14,8 +14,8 @@ module Admin
 
     def destroy
       user = User.find(params[:id])
-      user.unique_session_id = nil
-      user.save
+      user.force_logout!
+
       redirect_to({ action: :index }, notice: "Session ended for #{user.name}")
     end
   end

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -384,11 +384,16 @@ module UserConcern
     # Enforce a known value is included in the devise salt
     # this allows us to invalidate sessions even though they are stored in redis
     def authenticatable_salt
-      "#{super}#{session_token}"
+      base_salt = super
+      return base_salt if custom_session_invalidator.blank?
+
+      # Poison the salt to force the user to re-login by changing custom_session_invalidator
+      # Make sure the salt isn't changing length
+      Digest::MD5.hexdigest("#{base_salt}#{custom_session_invalidator}")[0, base_salt.length]
     end
 
     def force_logout!
-      update_attribute(:session_token, SecureRandom.hex)
+      update_attribute(:custom_session_invalidator, SecureRandom.hex)
     end
 
     # Dependent on devise expire_password_after being set to a value other than false
@@ -396,7 +401,7 @@ module UserConcern
       return false unless password_expiration_enabled?
 
       # Immediately logout the user
-      self.session_token = SecureRandom.hex
+      self.custom_session_invalidator = SecureRandom.hex
       # Force a password change on next login
       need_change_password! # calls save internally
 

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -381,12 +381,22 @@ module UserConcern
       end
     end
 
+    # Enforce a known value is included in the devise salt
+    # this allows us to invalidate sessions even though they are stored in redis
+    def authenticatable_salt
+      "#{super}#{session_token}"
+    end
+
+    def force_logout!
+      update_attribute(:session_token, SecureRandom.hex)
+    end
+
     # Dependent on devise expire_password_after being set to a value other than false
     def force_password_reset!
       return false unless password_expiration_enabled?
 
       # Immediately logout the user
-      self.unique_session_id = nil
+      self.session_token = SecureRandom.hex
       # Force a password change on next login
       need_change_password! # calls save internally
 

--- a/app/views/admin/users/index.haml
+++ b/app/views/admin/users/index.haml
@@ -40,8 +40,8 @@
       %tbody
         - @users.each do |user|
           %tr
-            %td= user.last_name
-            %td= user.first_name
+            %td= link_to user.last_name, edit_admin_user_path(id: user)
+            %td= link_to user.first_name, edit_admin_user_path(id: user)
             %td
               = user.email
               - if user.agency

--- a/db/migrate/20250217181347_add_session_token_to_users.rb
+++ b/db/migrate/20250217181347_add_session_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddSessionTokenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :session_token, :string
+  end
+end

--- a/db/migrate/20250218131829_rename_session_token.rb
+++ b/db/migrate/20250218131829_rename_session_token.rb
@@ -1,0 +1,10 @@
+class RenameSessionToken < ActiveRecord::Migration[7.0]
+  def change
+    # Renaming before it ever hit production, this is safe
+    safety_assured do
+      rename_column :users, :session_token, :custom_session_invalidator
+    end
+
+    change_column_comment :users, :custom_session_invalidator, 'Changing the value of this column will invalidate the current session for the user.'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3292,8 +3292,15 @@ CREATE TABLE public.users (
     superset_roles jsonb DEFAULT '[]'::jsonb,
     talent_lms_email character varying,
     training_courses jsonb,
-    session_token character varying
+    custom_session_invalidator character varying
 );
+
+
+--
+-- Name: COLUMN users.custom_session_invalidator; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.users.custom_session_invalidator IS 'Changing the value of this column will invalidate the current session for the user.';
 
 
 --
@@ -5186,6 +5193,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250124170335'),
 ('20250124171033'),
 ('20250208211846'),
-('20250217181347');
+('20250217181347'),
+('20250218131829');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3291,7 +3291,8 @@ CREATE TABLE public.users (
     permission_context character varying DEFAULT 'role_based'::character varying,
     superset_roles jsonb DEFAULT '[]'::jsonb,
     talent_lms_email character varying,
-    training_courses jsonb
+    training_courses jsonb,
+    session_token character varying
 );
 
 
@@ -5184,6 +5185,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20241211202350'),
 ('20250124170335'),
 ('20250124171033'),
-('20250208211846');
+('20250208211846'),
+('20250217181347');
 
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Fixes an issue in deployed environments where setting `unique_session_id` on a user isn't sufficient to force logout

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
