### PR TITLE
Fix improperly deduplicated exit date errors

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/exit_validator.rb
@@ -89,7 +89,7 @@ class Hmis::Hud::Validators::ExitValidator < Hmis::Hud::Validators::BaseValidato
     super(record) do
       record.errors.add :other_destination, :required if record.destination == OTHER_DESTINATION && !record.other_destination.present?
       entry_date = record.enrollment&.entry_date
-      record.errors.add :exit_date, :invalid, message: self.class.before_entry_message(entry_date) if entry_date.present? && record.exit_date.present? && entry_date > record.exit_date
+      record.errors.add :exit_date, :out_of_range, message: self.class.before_entry_message(entry_date) if entry_date.present? && record.exit_date.present? && entry_date > record.exit_date
     end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -109,6 +109,7 @@ FactoryBot.define do
             type: 'DATE',
             link_id: 'exit_date',
             required: true,
+            text: 'Exit Date',
             warn_if_empty: false,
             assessment_date: true,
             mapping: {
@@ -119,6 +120,7 @@ FactoryBot.define do
           {
             type: 'CHOICE',
             link_id: 'exit_destination',
+            text: 'Exit Destination',
             mapping: {
               record_type: 'EXIT',
               field_name: 'destination',

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
@@ -211,9 +211,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         form_definition_id: fd1.id.to_s,
         values: {
           'exit_date' => today.to_fs(:db),
+          'exit_destination' => 'NO_EXIT_INTERVIEW_COMPLETED',
         },
         hud_values: {
           'Exit.exitDate' => today.to_fs(:db),
+          'Exit.destination' => 'NO_EXIT_INTERVIEW_COMPLETED',
         },
       }
     end
@@ -242,7 +244,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq(200), result.inspect
         errors = result.dig('data', 'submitAssessment', 'errors')
         expected = Hmis::Hud::Validators::BaseValidator.after_project_end_message(p1.operating_end_date)
-        expect(errors).to include(a_hash_including('message' => expected))
+        expect(errors).to contain_exactly(a_hash_including('message' => expected))
       end
     end
 
@@ -253,7 +255,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(response.status).to eq(200), result.inspect
         errors = result.dig('data', 'submitAssessment', 'errors')
         expected = Hmis::Hud::Validators::BaseValidator.before_project_start_message(p1.operating_start_date)
-        expect(errors).to include(a_hash_including('message' => expected))
+        expect(errors).to contain_exactly(a_hash_including('message' => expected))
+      end
+    end
+
+    # regression test for validation error being duplicated
+    context 'where proposed exit date is before entry date' do
+      let(:today) { 1.week.ago } # update test_input
+      before(:each) { e1.update!(entry_date: 2.days.ago) }
+      it 'should error if exit date is before entry date' do
+        response, result = post_graphql(input: { input: test_input }) { mutation }
+        expect(response.status).to eq(200), result.inspect
+        errors = result.dig('data', 'submitAssessment', 'errors')
+        expected = Hmis::Hud::Validators::BaseValidator.before_entry_message(e1.entry_date)
+        expect(errors).to contain_exactly(a_hash_including('message' => expected))
       end
     end
   end
@@ -390,7 +405,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           )
           a_hash_including(attrs)
         end
-        expect(errors).to match(expected_match)
+        expect(errors).to contain_exactly(*expected_match)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix [bug found in QA](https://github.com/open-path/Green-River/issues/7238#issuecomment-2666015435) where exit date validation displays twice. It wasn't properly deduplicated in `HmisErrors::Errors.deduplicate!` because the two errors (hmis_validate and AR validate) had different types, `out_of_range` and `invalid`.

There is a lot here that's brittle. This change just fixes the immediate bug, and adds a regression test.

<img width="449" alt="414318893-96451f9a-cb0d-4c31-a54d-63a98505fde6" src="https://github.com/user-attachments/assets/b973853b-5e45-41cc-90ca-a7c14391ac67" />


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
