### PR TITLE
Prevent bug of auto-exiting already exited client

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -49,7 +49,7 @@ module Hmis
           Hmis::Hud::Base.transaction do
             # Auto-exit all household members together, setting the exit date equal to the most recent contact for any household member
             household.enrollments.each do |e|
-              auto_exit(e, most_recent_contact, project: project)
+              auto_exit(e, most_recent_contact, project: project) unless e.exit.present?
             end
           end
         end

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
 
     context 'with a multi member household' do
       let!(:c2) { create :hmis_hud_client, data_source: ds1, user: u1 }
+      let!(:c3) { create :hmis_hud_client, data_source: ds1, user: u1 }
       let!(:household_id) { Hmis::Hud::Base.generate_uuid }
       let!(:hoh_e) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: household_id, entry_date: Date.current - 2.months }
       let!(:hhm_e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
-      let!(:hhm_e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c2, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
+      let!(:hhm_e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c3, household_id: household_id, relationship_to_hoh: 2, entry_date: Date.current - 2.months }
 
       def expect_all_active
         hoh_e.household_members.each do |member|
@@ -115,6 +116,21 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
         it 'should not exit any member if another member has an incomplete enrollment' do
           Hmis::AutoExitJob.perform_now
           expect_all_active
+        end
+      end
+
+      context 'when one household member is already exited' do
+        let!(:hhm_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: hhm_e1, client: c2, exit_date: Date.current - 1.week }
+
+        it 'should only exit the clients that dont already have exit records' do
+          expected_exit_date = hoh_e.entry_date + 1.day
+          expect do
+            Hmis::AutoExitJob.perform_now
+            [hoh_e, hhm_e1, hhm_e2].each(&:reload)
+          end.to change { hoh_e.exit_date }.from(nil).to(expected_exit_date).
+            and change { hhm_e2.exit_date }.from(nil).to(expected_exit_date).
+            and(not_change { hhm_e1.exit_date }).
+            and(not_change { Hmis::Hud::Exit.where(enrollment_id: hhm_e1.enrollment_id, data_source_id: hhm_e1.data_source_id).count })
         end
       end
     end

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
       context 'when one household member is already exited' do
         let!(:hhm_exit) { create :hmis_hud_exit, data_source: ds1, enrollment: hhm_e1, client: c2, exit_date: Date.current - 1.week }
 
-        it 'should only exit the clients that dont already have exit records' do
+        it 'should only exit the clients that dont already have exit records (regression #7335)' do
           expected_exit_date = hoh_e.entry_date + 1.day
           expect do
             Hmis::AutoExitJob.perform_now


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
GH issue: https://github.com/open-path/Green-River/issues/7335

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
