### PR TITLE
rubocop fixes for client expiration PR and ruby 3.3.7 string literals

### DIFF
--- a/app/controllers/clients/notes_controller.rb
+++ b/app/controllers/clients/notes_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 module Clients
   class NotesController < ApplicationController
     include AjaxModalRails::Controller

--- a/app/models/grda_warehouse/client_notes/base.rb
+++ b/app/models/grda_warehouse/client_notes/base.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 module GrdaWarehouse::ClientNotes
   class Base < GrdaWarehouseBase
     self.table_name = :client_notes

--- a/db/warehouse/migrate/20250221151129_add_expiration_date_to_client_note.rb
+++ b/db/warehouse/migrate/20250221151129_add_expiration_date_to_client_note.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 class AddExpirationDateToClientNote < ActiveRecord::Migration[7.0]
   def change
     add_column :client_notes, :expiration_date, :date

--- a/spec/factories/grda_warehouse/client_notes/grda_warehouse_client_notes_alerts.rb
+++ b/spec/factories/grda_warehouse/client_notes/grda_warehouse_client_notes_alerts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 FactoryBot.define do
   factory :grda_warehouse_client_notes_expired_alert, class: 'GrdaWarehouse::ClientNotes::Alert' do
     association :client, factory: :grda_warehouse_hud_client

--- a/spec/models/grda_warehouse/client_notes/client_note_spec.rb
+++ b/spec/models/grda_warehouse/client_notes/client_note_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'rails_helper'
 
 # Included Base before ChronicJustification and WindowNote to fix circular dependency issue


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Make rubocop happy after the client note expiration PR

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
