### PR TITLE
Fix color contrast in Disability form fragment

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/disability.json
+++ b/drivers/hmis/lib/form_data/default/fragments/disability.json
@@ -106,7 +106,7 @@
             {
               "type": "DISPLAY",
               "link_id": "q_4_06_2_info",
-              "text": "<i style='color:gray;'>Always considered a disabling condition.</i>"
+              "text": "<i style='color:#6E6E6E;'>Always considered a disabling condition.</i>"
             }
           ]
         },
@@ -171,7 +171,7 @@
             {
               "type": "DISPLAY",
               "link_id": "q_4_08_2_info",
-              "text": "<i style='color:gray;'>Always considered a disabling condition.</i>"
+              "text": "<i style='color:#6E6E6E;'>Always considered a disabling condition.</i>"
             }
           ]
         },


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- Re-seeding the form should run on deploy after this is released, I think.

## Description
GH issue: https://github.com/open-path/hmis-accessibility/issues/162

Summary of changes:
- `gray` text on white bg doesn't meet minimum contrast requirement, so I've replaced it with `#6e6e6e`, our `grayscale.main` color in HMIS

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Accessibility bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
