### PR TITLE
Add some frozen string literals comments

### DIFF
--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 # Stores the actual data that was collected during an assessment. 1:1 with CustomAssessments.
 #   If the assessment is WIP: The data is stored exclusively as JSON blobs in the "values”/”hud_values" cols.
 #   If the assessment is non-WIP: The HUD data is stored in records (IncomeBenefit, HealthAndDv, etc) that are referenced by this form_processor directly. (health_and_dv_id etc)

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 class Hmis::Hud::Enrollment < Hmis::Hud::Base
   include ::HmisStructure::Enrollment
   include ::Hmis::Hud::Concerns::Shared

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 # ==  Hmis::Hud::Processors::Base
 #
 # Base class for field processors. Responsible for processing a single form input

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 module Hmis::Hud::Processors
   class ClientProcessor < Base
     # DO NOT CHANGE: Frontend code sends these values

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 require 'csv'
 
 # Utility functions for cleaning up HMIS data during a migration.

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :hmis_form_definition, class: 'Hmis::Form::Definition' do
     version { 1 }

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../../../requests/hmis/login_and_permissions'
 require_relative '../../../support/hmis_base_setup'
@@ -18,7 +20,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
   let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
 
   HIDDEN = Hmis::Hud::Processors::Base::HIDDEN_FIELD_VALUE
-  INVALID = 'INVALID'.freeze # Invalid enum representation
+  INVALID = 'INVALID' # Invalid enum representation
 
   before(:all) do
     cleanup_test_environment

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../../support/hmis_base_setup'
 

--- a/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../../../requests/hmis/login_and_permissions'
 require_relative '../../../support/hmis_base_setup'

--- a/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../hmis/login_and_permissions'
 require_relative '../../support/hmis_base_setup'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

Fixes the rubocop errors I introduced on release-154 here: https://github.com/greenriver/hmis-warehouse/actions/runs/13548023304/job/37864394970#step:7:49

by adding `frozen_string_literal` comment to the files I touched in this PR: https://github.com/greenriver/hmis-warehouse/pull/5142/files

I added `frozen_string_literal: true` to spec files and `false` to others, even though I don't _think_ we are doing any string manipulation in any of these files, because I think at the moment I just want to appease rubocop and not troubleshoot file logic... does that sound like a reasonable approach?

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Rubocop fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
