### PR TITLE
Fix more frozen string literals

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 module Hmis
   class AutoExitJob < BaseJob
     include NotifierConfig

--- a/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'

--- a/drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
1. Follow-up to https://github.com/greenriver/hmis-warehouse/pull/5153
2. Similar to https://github.com/greenriver/hmis-warehouse/pull/5168
3. Fixes https://github.com/greenriver/hmis-warehouse/actions/runs/13566399495/job/37920394635#step:7:28

Question/observation: This failed after I merged to release-154 (3), even though the Rubocop CI step went green on that PR before merging (1). I think the same thing happened before (2), which I thought was just a fluke; after seeing it happen twice, I investigated a little. I found that the Rubocop CI step [didn't recognize these as files changed](https://github.com/greenriver/hmis-warehouse/actions/runs/13557019168/job/37893201665). I think this is because though they were changed by that PR, they were not changed by the most recent commit.

Would we want to make a change so that the changed-files step compares against the base branch, not against the previous commit? I think our `changed-files` action would do this by default if we run it on `pull_request` instead of on `push`: https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-pull_request-

Edit: Opened https://github.com/greenriver/hmis-warehouse/pull/5171 so we can discuss that separately!

## Type of change
Rubocop

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [na] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [na] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [na] I have updated the documentation (or not applicable)
- [na] I have added spec tests (or not applicable)
- [na] I have provided testing instructions in this PR or the related issue (or not applicable)

