### PR TITLE
Run rubocop on pull_request instead of on push

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,6 @@
 name: Rubocop
 on:
-  push:
+  pull_request:
     branches:
       - '*'
       - '**/*'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
This PR proposes changing our Rubocop GH action to run on PR, instead of on Push, so that it checks all files changed in the PR, not just the files changed on the latest commit. This change is motivated by my comment [here](https://github.com/greenriver/hmis-warehouse/pull/5169#issue-2884454452).

I played around with the behavior a little on this closed PR: https://github.com/greenriver/hmis-warehouse/pull/5170

- Commit 1: [Rubocop fails](https://github.com/greenriver/hmis-warehouse/actions/runs/13567001535/job/37922249499?pr=5170)  
- Commit 2: [Rubocop succeeds](https://github.com/greenriver/hmis-warehouse/actions/runs/13567143424/job/37922693160?pr=5170), even though the problem file from Commit 1 is still not fixed  
- Commit 3 (same as this change): [Rubocop correctly fails](https://github.com/greenriver/hmis-warehouse/actions/runs/13567207096/job/37922903413?pr=5170), because the problem file from Commit 1 is part of the PR diff, even though it's not part of the most recent commit.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
CI change

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [na] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [na] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [na] I have updated the documentation (or not applicable)
- [na] I have added spec tests (or not applicable)
- [na] I have provided testing instructions in this PR or the related issue (or not applicable)