### PR TITLE
Support rough-out of CE frontend pages and add CE starter pack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       momentjs-rails (>= 2.8.1)
     brakeman (7.0.0)
       racc
-    browser (6.2.0)
+    browser (5.3.1)
     builder (3.3.0)
     bumbler (0.9.0)
     bundler-audit (0.9.2)
@@ -1115,7 +1115,7 @@ GEM
       yabeda (~> 0.8)
     yajl-ruby (1.4.3)
     yaml-safe_load_stream3 (0.1.2)
-    zeitwerk (2.7.2)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   arm64-darwin-22
@@ -1437,7 +1437,7 @@ CHECKSUMS
   bootstrap (4.6.2) sha256=9cf03810728007eff8cfb8210e9ab92ecf2b10fe250e419d9e9488e4796bc342
   bootstrap3-datetimepicker-rails (4.17.47) sha256=ee87a9bad74c140729f6a1ea2a7f3f2d9aaefa7e9defbe31b4edd27ff64689a2
   brakeman (7.0.0) sha256=1a0122b0c70f17519a61548a53a332c0acc19e3aa10b445e15e025a4b13b8577
-  browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
+  browser (5.3.1) sha256=62745301701ff2c6c5d32d077bb12532b20be261929dcb52c6781ed0d5658b3c
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bumbler (0.9.0) sha256=5fff255c01d4e6eb50a342a3cac7cf967a0fefd863349248d40ddd8c7785fd2a
   bundler-audit (0.9.2) sha256=73051daa09865c436450a35c4d87ceef15f3f9777f4aad4fd015cc6f1f2b1048
@@ -1793,7 +1793,7 @@ CHECKSUMS
   yabeda-rails (0.9.0) sha256=6011bfa1e282456dbb4f0d6571267ad57108b54fab0de37ae3b70653fa9582da
   yajl-ruby (1.4.3) sha256=8c974d9c11ae07b0a3b6d26efea8407269b02e4138118fbe3ef0d2ec9724d1d2
   yaml-safe_load_stream3 (0.1.2) sha256=fd4f63ffe57e65ec8fd5a314064151f843e83239ff87bfc6b2fdbdba81e7e481
-  zeitwerk (2.7.2) sha256=842e067cb11eb923d747249badfb5fcdc9652d6f20a1f06453317920fdcd4673
+  zeitwerk (2.6.18) sha256=bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781
 
 BUNDLED WITH
-   2.6.3
+   2.6.5

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -715,12 +715,34 @@ type CeCandidate {
   priorityScore: Int!
 }
 
+type CeCandidatesPaginated {
+  hasMoreAfter: Boolean!
+  hasMoreBefore: Boolean!
+  limit: Int!
+  nodes: [CeCandidate!]!
+  nodesCount: Int!
+  offset: Int!
+  pagesCount: Int!
+}
+
+type CeOpportunitiesPaginated {
+  hasMoreAfter: Boolean!
+  hasMoreBefore: Boolean!
+  limit: Int!
+  nodes: [CeOpportunity!]!
+  nodesCount: Int!
+  offset: Int!
+  pagesCount: Int!
+}
+
 type CeOpportunity {
+  acceptedReferral: CeReferral
   activeReferral: CeReferral
-  candidates: [CeCandidate!]!
+  candidates(limit: Int, offset: Int): CeCandidatesPaginated!
   expiresAt: ISO8601DateTime
   id: ID!
   name: String!
+  projectId: ID!
   status: String!
 }
 
@@ -6962,6 +6984,11 @@ enum PickListType {
   User accounts. Deprecated in favor of AUDITABLE_USERS
   """
   USERS
+
+  """
+  Templates for CE workflow definitions
+  """
+  WORKFLOW_DEFINITION_TEMPLATES
 }
 
 """
@@ -8776,6 +8803,7 @@ type Project {
   active: Boolean!
   affiliatedProjects: [Project!]!
   assessments(filters: AssessmentsForProjectFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
+  ceOpportunities(limit: Int, offset: Int): CeOpportunitiesPaginated!
   ceParticipations(limit: Int, offset: Int): CeParticipationsPaginated!
   contactInformation: String
   continuumProject: NoYes
@@ -9317,6 +9345,7 @@ type QueryAccess {
   canViewClientName: Boolean!
   canViewClientPhoto: Boolean!
   canViewClients: Boolean!
+  canViewCoordinatedEntry: Boolean!
   canViewDob: Boolean!
   canViewEnrollmentDetails: Boolean!
   canViewEnrollmentLocationMap: Boolean!

--- a/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
@@ -51,5 +51,6 @@ module Types
     value 'ELIGIBLE_STAFF_ASSIGNMENT_USERS', 'Current users who are eligible for staff assignment'
     value 'AUDITABLE_USERS', 'Current and historical user accounts'
     value 'CONTINUUM_PROJECTS', 'Continuum Projects'
+    value 'WORKFLOW_DEFINITION_TEMPLATES', 'Templates for CE workflow definitions'
   end
 end

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -161,6 +161,12 @@ module Types
           pluck(:OtherFunder).uniq.sort.map do |other_funder|
             { code: other_funder, label: other_funder }
           end
+      when 'WORKFLOW_DEFINITION_TEMPLATES'
+        return [] unless Hmis::Ce.configuration.enabled?
+
+        Hmis::WorkflowDefinition::Template.all.map do |template|
+          { code: template.id, label: template.name }
+        end
       end
     end
 

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -164,6 +164,7 @@ module Types
       when 'WORKFLOW_DEFINITION_TEMPLATES'
         return [] unless Hmis::Ce.configuration.enabled?
 
+        # FIXME - templates are shared across data sources. For now this is acceptable since GR manages templates
         Hmis::WorkflowDefinition::Template.all.map do |template|
           { code: template.id, label: template.name }
         end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity.rb
@@ -13,17 +13,22 @@ module Types
     field :status, String, null: false
     field :expires_at, GraphQL::Types::ISO8601DateTime, null: true
     field :active_referral, Types::HmisSchema::CeReferral, null: true
-    field :candidates, [Types::HmisSchema::CeCandidate], null: false
+    field :accepted_referral, Types::HmisSchema::CeReferral, null: true
+    field :candidates, Types::HmisSchema::CeCandidate.page_type, null: false
+    field :project_id, ID, null: false
 
     def candidates
       Hmis::Ce::Match::Candidate.
         for_opportunity(object).
-        order(priority_score: :desc, client_id: :desc).
-        limit(50) # FIXME: add pagination. Just limit to top 50 for now
+        order(priority_score: :desc, client_id: :desc)
     end
 
     def active_referral
       object.referrals.order(:id).viewable_by(current_user).active.first
+    end
+
+    def accepted_referral
+      object.referrals.order(:id).viewable_by(current_user).accepted.first
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -113,6 +113,7 @@ module Types
     field :data_collection_features, [Types::HmisSchema::DataCollectionFeature], null: false, description: 'Occurrence Point data collection features that are enabled for this Project (e.g. Current Living Situations, Events)'
     field :occurrence_point_forms, [Types::HmisSchema::OccurrencePointForm], null: false, method: :occurrence_point_form_instances, description: 'Forms for individual data elements that are collected at occurrence for this Project (e.g. Move-In Date)'
     field :service_types, [Types::HmisSchema::ServiceType], null: false, method: :available_service_types, description: 'Service types that are collected for this Project'
+    field :ce_opportunities, Types::HmisSchema::CeOpportunity.page_type, null: false
 
     def hud_id
       object.project_id
@@ -250,6 +251,12 @@ module Types
       form_definition_identifier = args.delete(:form_definition_identifier)
       scope = scope.where(definition: { identifier: form_definition_identifier }) if form_definition_identifier
       resolve_external_form_submissions(scope, **args)
+    end
+
+    def ce_opportunities
+      raise unless Hmis::Ce.configuration.enabled?
+
+      load_ar_association(object, :ce_opportunities)
     end
 
     private def check_enrollment_details_access

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -294,11 +294,13 @@ module Types
         root_can perm
       end
       field :can_view_my_dashboard, Boolean, null: false
+      field :can_view_coordinated_entry, Boolean, null: false
     end
 
     def access
       {
         can_view_my_dashboard: current_user.can_view_my_dashboard?,
+        can_view_coordinated_entry: Hmis::Ce.configuration.enabled?,
       }
     end
 

--- a/drivers/hmis/app/models/hmis/ce/configuration.rb
+++ b/drivers/hmis/app/models/hmis/ce/configuration.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # accessor API for CE configuration
 module Hmis::Ce
   class Configuration
@@ -27,11 +29,11 @@ module Hmis::Ce
     def values
       @values ||= AppConfigProperty.
         where(key: PROPERTIES.map { |attr| key_for(attr) }).
-        index_by { |p| p.key.to_sym }
+        index_by(&:key)
     end
 
-    def value_for(_attr)
-      values[key_for(:enabled)]
+    def value_for(attr)
+      values[key_for(attr)]
     end
 
     def key_for(attr)

--- a/drivers/hmis/app/models/hmis/ce/match/opportunity_applicability.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/opportunity_applicability.rb
@@ -4,6 +4,9 @@
 # @attr [Object] owner Entity that owns/manages this applicability rule
 # @attr [Array<String>] project_types List of valid project types
 # @attr [Array<String>] project_funders List of valid project funder IDs
+
+# frozen_string_literal: true
+
 module Hmis::Ce::Match
   OpportunityApplicability = Struct.new(:owner, :project_types, :project_funders, keyword_init: true) do
     def call(opportunity)
@@ -18,12 +21,12 @@ module Hmis::Ce::Match
 
     def matches_owner?(opportunity)
       owner == opportunity ||
-      owner == owner.project ||
-      owner == owner.project.organization
+      owner == opportunity.project ||
+      owner == opportunity.project.organization
     end
 
     def matches_project_type?(project)
-      project_type.blank? || project.project_type.in(project_types)
+      project_types.blank? || project.project_type.in(project_types)
     end
 
     def matches_project_funders?(project)

--- a/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
+++ b/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
@@ -1,0 +1,98 @@
+desc 'Script to populate local dev databases with "starter-pack" CE records like templates, swimlanes, and tasks'
+# rails driver:hmis:ce_starter_pack_20250302
+task ce_starter_pack_20250302: [:environment] do
+  puts "Enabling CE in AppConfigProperty"
+  ce_enabled = AppConfigProperty.find_or_initialize_by(
+    key: 'hmis_ce/enabled',
+  )
+  ce_enabled.value = true
+  ce_enabled.save! if ce_enabled.changed?
+
+  puts 'Creating a starter pack of task templates'
+  # Create a starter pack of task templates
+  # First, a simple template that doesn't have any tasks - just a start event and referral acceptance
+  no_task_template = Hmis::WorkflowDefinition::Template.find_or_initialize_by(
+    identifier: 'no_tasks',
+    status: 'published'
+  )
+  no_task_template.name ||= 'No Tasks'
+  no_task_template.version ||= 0
+  no_task_template.save! if no_task_template.changed?
+  case_managers = no_task_template.swimlanes.find_or_create_by!(name: 'Case Managers')
+
+  start_workflow_event = Hmis::WorkflowDefinition::StartEvent.find_or_initialize_by(
+    name: 'start referral',
+    template_id: no_task_template.id,
+  )
+  start_workflow_event.swimlane_id = case_managers.id
+  start_workflow_event.trigger_config = [
+    {
+      event: 'start_workflow',
+      message: 'start_referral',
+    },
+  ]
+  start_workflow_event.save!
+
+  accept_workflow_event = Hmis::WorkflowDefinition::EndEvent.find_or_initialize_by(
+    name: 'accept workflow',
+    template_id: no_task_template.id,
+  )
+  accept_workflow_event.swimlane_id = case_managers.id
+  accept_workflow_event.trigger_config = [
+    {
+      event: 'end_workflow',
+      message: 'accept_referral',
+    },
+  ]
+  accept_workflow_event.save!
+
+  start_workflow_event.connect_to!(accept_workflow_event) unless start_workflow_event.outflows.where(target_node_id: accept_workflow_event.id).exists?
+
+  # TODO(#7309) - here, add a more complicated workflow template that has several tasks, form definitions, more dependencies, multiple swimlanes etc.
+
+  # Next, create a new organization and project to use for CE. This isn't strictly necessary -- devs will already have
+  # orgs and projects in their local dbs they can use for testing -- but it's helpful for the sake of the starter pack
+  # to have this script create a project/org whose existence it can rely on
+  puts 'Creating CE Test Org and Ce Test Project'
+  hmis_ds = GrdaWarehouse::DataSource.hmis.first
+  system_user = Hmis::Hud::User.system_user(data_source_id: hmis_ds.id)
+  ce_org = Hmis::Hud::Organization.find_or_initialize_by(
+    data_source_id: hmis_ds.id,
+    organization_name: 'CE Test Org',
+  )
+  ce_org.user = system_user
+  ce_org.victim_service_provider = false
+  ce_org.save! if ce_org.changed?
+
+  ce_project = Hmis::Hud::Project.find_or_initialize_by(
+    data_source_id: hmis_ds.id,
+    project_name: 'CE Test Project',
+  )
+  ce_project.organization = ce_org
+  ce_project.user ||= system_user
+  ce_project.continuum_project ||= true
+  ce_project.operating_start_date ||= 4.weeks.ago
+  ce_project.project_type ||= 3
+  ce_project.save! if ce_project.changed?
+
+  # Set up match rules in this project
+  puts 'Creating match rules'
+  ce_match_rule = Hmis::Ce::Match::Rule.find_or_initialize_by(
+    name: 'Over 18',
+    owner: ce_project,
+  )
+  ce_match_rule.rule_type = 'eligibility_requirement'
+  ce_match_rule.expression = 'current_age >= 18'
+  ce_match_rule.applicability_config ||= {}
+  ce_match_rule.save! if ce_match_rule.changed?
+
+  # Create candidates for opportunities. First create some opportunities using the frontend
+  puts 'Building a candidate pool'
+  Hmis::Ce::Match::CandidatePoolBuilder.new.perform
+
+  puts 'Running the CE match engine'
+  clients = Hmis::Hud::Client.all.limit(100) # modify this if you want to include different or specific clients
+  Hmis::Ce::Match::CandidatePool.all.each do |pool|
+    Hmis::Ce::Match::Engine.call(pool, clients)
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/ce/ce_client_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_client_opportunities_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../login_and_permissions'
 require_relative '../../../support/hmis_base_setup'
@@ -101,10 +103,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               status
               expiresAt
               candidates {
-                id
-                priorityScore
-                client {
+                nodes {
                   id
+                  priorityScore
+                  client {
+                    id
+                  }
                 }
               }
             }
@@ -139,8 +143,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(opportunity_ids).not_to include(closed_opportunity.id.to_s)
 
         first_opportunity = opportunities.first
-        expect(first_opportunity['candidates']).to be_an(Array)
-        expect(first_opportunity['candidates'].first).to include(
+        expect(first_opportunity['candidates']['nodes']).to be_an(Array)
+        expect(first_opportunity['candidates']['nodes'].first).to include(
           'priorityScore' => kind_of(Integer),
           'client' => { 'id' => client.id.to_s },
         )

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../login_and_permissions'
 require_relative '../../../support/hmis_base_setup'
@@ -83,14 +85,16 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             status
             expiresAt
             candidates {
-              id
-              priorityScore
-              client {
+              nodes {
                 id
-                firstName
-                lastName
-                dateOfBirth: dob
-                veteranStatus
+                priorityScore
+                client {
+                  id
+                  firstName
+                  lastName
+                  dateOfBirth: dob
+                  veteranStatus
+                }
               }
             }
             activeReferral {
@@ -119,7 +123,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           'status' => opportunity.status,
         )
 
-        candidates = result.dig('data', 'ceOpportunity', 'candidates')
+        candidates = result.dig('data', 'ceOpportunity', 'candidates', 'nodes')
 
         expect(candidates).to be_an(Array)
         expect(candidates.length).to eq(2) # Should only include 2 candidates (excluding the one with active referral)
@@ -146,7 +150,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       it 'excludes clients with active referrals' do
         _, result = post_graphql(**variables) { query }
-        candidates = result.dig('data', 'ceOpportunity', 'candidates')
+        candidates = result.dig('data', 'ceOpportunity', 'candidates', 'nodes')
 
         candidate_client_ids = candidates.map { |c| c.dig('client', 'id') }
         expect(candidate_client_ids).not_to include(client_with_active_referral.id.to_s)
@@ -174,7 +178,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       it 'returns an empty candidates array' do
         _, result = post_graphql(**empty_pool_variables) { query }
-        candidates = result.dig('data', 'ceOpportunity', 'candidates')
+        candidates = result.dig('data', 'ceOpportunity', 'candidates', 'nodes')
 
         expect(candidates).to be_an(Array)
         expect(candidates).to be_empty


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Summary of changes:
- Add a "CE starter pack" which isn't meant to be run in production, but can be run in dev databases to generate some basic CE records like templates, swimlanes, and tasks. My understanding is that these should all eventually be configurable by users in-app, but for now, it's helpful to have a quick and re-runnable script that we can share.
- Add a pick list of Workflow Definition Templates to enable selecting a template when creating an opportunity
- for Opportunity schema object,
  - Add pagination to Opportunity Candidates schema field
  - Add accepted referral, alongside active referral
- for Project schema object,
  - add paginated CE Opportunities schema field
- Add `can_view_coordinated_entry` to root access, which is true if CE is enabled in config
- Fix bugs in `Hmis::Ce::Configuration` and `Hmis::Ce::Match::Applicability`

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
- New feature
- Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [na] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [na] I have updated the documentation (or not applicable)
- [na] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
