### PR TITLE
update to ubuntu-22.04

### DIFF
--- a/.github/workflows/asset_compilation.yml
+++ b/.github/workflows/asset_compilation.yml
@@ -57,7 +57,7 @@ jobs:
           - gha_production_load_17
           - gha_production_load_18
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: ruby:3.3.7-alpine3.20
 
     steps:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ jobs:
   # Label of the container job
   audit:
     # Containers must run in Linux based operating systems
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Docker Hub image that the job executes in
     container: ruby:3.3.7-alpine3.20

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{fromJson(needs.determine_matrix.outputs.matrix)}}
 
     # Containers must run in Linux based operating systems
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Docker Hub image that the job executes in
     # $RUBY_VERSION

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,7 +12,7 @@ jobs:
   rubocop:
     name: Rubocop
     # Containers must run in Linux based operating systems
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Docker Hub image that the job executes in
     container: ruby:3.3.7-alpine3.20

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: contains(github.event.head_commit.message, '[gh:rebuild_fixpoints]')
 
     # Docker Hub image that the job executes in


### PR DESCRIPTION
fixes 
> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101