### PR TITLE
Relax schema requirements on inbound ac referral api

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/create_referral_job.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisExternalApis::AcHmis
   class CreateReferralJob < BaseJob
     queue_as ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)
@@ -188,15 +190,16 @@ module HmisExternalApis::AcHmis
       old_addresses = client.addresses
       new_addresses = []
       params[:addresses].to_a.each do |values|
+        address_use = normalize_address_use(values[:use])
         address = Hmis::Hud::CustomClientAddress.new(
           postal_code: values[:zip],
           district: values[:county],
+          use: address_use,
           **values.slice(
             :line1,
             :line2,
             :city,
             :state,
-            :use,
           ),
           **common_client_attrs(client),
         )
@@ -298,6 +301,19 @@ module HmisExternalApis::AcHmis
       end.to_h
       attributes[:RaceNone] = (codes & [8, 9, 99]).first || 99 if attributes.values.sum.zero?
       attributes
+    end
+
+    private def normalize_address_use(use_str)
+      return unless use_str
+
+      value = use_str.downcase
+      expected_values = Hmis::Hud::CustomClientAddress::USE_VALUES.map(&:to_s)
+      if expected_values.include?(value)
+        value
+      elsif value == 'mailing'
+        'mail'
+      end
+      # ignore unknown values
     end
   end
 end

--- a/drivers/hmis_external_apis/public/schemas/referral.json
+++ b/drivers/hmis_external_apis/public/schemas/referral.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "referral_id": { "type": ["integer", "string"] },
-    "score": { "type": ["integer", "null"], "minimum": 1, "maximum": 10 },
+    "score": { "type": ["integer", "null"], "minimum": 0, "maximum": 10 },
     "needs_wheelchair_accessible_unit": { "type": ["boolean", "null"] },
     "referral_notes": { "type": ["string", "null"] },
     "resource_coordinator_notes": { "type": ["string", "null"] },
@@ -34,7 +34,7 @@
           "state": { "type": ["string", "null"] },
           "zip": { "type": ["string", "null"] },
           "county": { "type": ["string", "null"] },
-          "use": { "enum": ["home", "work", "mail", null] }
+          "use": { "type": ["string", "null"] }
         }
       }
     },

--- a/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/referral_spec.rb
+++ b/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/referral_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'faker'
 
@@ -83,7 +85,16 @@ RSpec.describe HmisExternalApis::AcHmis::ReferralsController, type: :request do
             state: 'VT',
             county: '',
             zip: '05301',
-            use: 'work',
+            use: 'home',
+          },
+          {
+            line1: '456 Main st',
+            line2: '',
+            city: 'Brattleboro',
+            state: 'VT',
+            county: '',
+            zip: '05301',
+            use: 'Mailing',
           },
         ],
         phone_numbers: [
@@ -309,7 +320,9 @@ RSpec.describe HmisExternalApis::AcHmis::ReferralsController, type: :request do
       expect(referral.household_members.size).to(eq(household.size))
       client = mci.find_client_by_mci(mci_id)
       expect(client).to(be_present)
-      expect(client.addresses.size).to(eq(1))
+      expect(client.addresses.size).to(eq(2))
+      expect(client.addresses.where(use: 'mail').count).to eq(1)
+      expect(client.addresses.where(use: 'home').count).to eq(1)
       expect(client.contact_points.group_by(&:system)['phone'].size).to(eq(1))
       expect(client.contact_points.group_by(&:system)['email'].size).to(eq(1))
 
@@ -358,7 +371,7 @@ RSpec.describe HmisExternalApis::AcHmis::ReferralsController, type: :request do
         end
       end
       expect(client.names.size).to(eq(2))
-      expect(client.addresses.size).to(eq(1))
+      expect(client.addresses.size).to(eq(2))
       expect(client.contact_points.group_by(&:system)['phone'].size).to(eq(1))
       expect(client.contact_points.group_by(&:system)['email'].size).to(eq(1))
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
- Remove constraint saying that `score` can't be zero. we get some requests like this that we reject. this schema was based on initial constraints they provided, but there is no reason we can't store zero.
- Remove enum constraint on address "use" field, do some more lenient parsing. We have received unexpected values `"Home"` and `"Mailing"` which we have previously rejected, but not can accept.

The first issue was identified via customer support issue. I tacked the second one on because it has occurred in previous failed requests. How to find failed requests:
```
 HmisExternalApis::ExternalRequestLog.incoming.url_like("referral").failed.where(requested_at: 6.months.ago..).group(:response).count
```
## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
