### PR TITLE
7357 bugfix de-duplication

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -670,29 +670,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "3d342c32e700e60dc9551f23ad6c5732655c46ef36e685463463b0a39dc71cb5",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb",
-      "line": 132,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "clients.joins(:client_projects).merge(PerformanceMeasurement::ClientProject.where(:period => period, :for_question => field).where.not(:project_id => nil)).group(:project_id).distinct.sum(\"#{period}_#{field}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PerformanceMeasurement::ResultCalculation",
-        "method": "client_sum"
-      },
-      "user_input": "period",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "3e7e0291a50a229015f6e9674412dd30aaa687e973bc11e005d95406444e97d9",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -1884,29 +1861,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "af5c8267f117f952e1192229d1d6f8def1abb6e9f781d720c6cdf30a85f5d776",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb",
-      "line": 125,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "clients.joins(:client_projects).merge(PerformanceMeasurement::ClientProject.where(:period => period, :for_question => field)).distinct.sum(\"#{period}_#{field}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PerformanceMeasurement::ResultCalculation",
-        "method": "client_sum"
-      },
-      "user_input": "period",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "b16f9b9fa5ec6ee98d24cc67ae42abf131bc179999e5d2a49491b67783f32dce",
       "check_name": "SQL",
       "message": "Possible SQL injection",
@@ -2161,7 +2115,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb",
-      "line": 147,
+      "line": 144,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "projects.joins(:hud_project).merge(GrdaWarehouse::Hud::Project.send(project_type)).group(:project_id).sum(\"#{period}_#{field}\")",
       "render_path": null,
@@ -2299,7 +2253,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb",
-      "line": 143,
+      "line": 140,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "projects.joins(:hud_project).merge(GrdaWarehouse::Hud::Project.send(project_type)).where(:project_id => client_projects.for_question(\"days_in_#{project_type}_bed_in_period\").where(:period => period).distinct.pluck(:project_id)).sum(\"#{period}_#{field}\")",
       "render_path": null,

--- a/drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/result_calculation.rb
@@ -120,16 +120,13 @@ module PerformanceMeasurement::ResultCalculation
       @client_count_present[column][project_id] || 0
     end
 
+    # Calculates the sum of a specific field across clients, properly deduplicating client records
     def client_sum(field, period, project_id: nil)
-      column = "#{period}_#{field}"
-      return clients.joins(:client_projects).merge(PerformanceMeasurement::ClientProject.where(period: period, for_question: field)).distinct.sum(column) if project_id.blank?
+      return PerformanceMeasurement::UniqueClientMetricsQuery.new(clients, field, period).execute_sum if project_id.blank?
 
       @client_sums ||= {}
-      @client_sums[column] ||= clients.joins(:client_projects).
-        merge(PerformanceMeasurement::ClientProject.where(period: period, for_question: field).where.not(project_id: nil)).
-        group(:project_id).
-        distinct.
-        sum(column)
+      column = "#{period}_#{field}"
+      @client_sums[column] ||= PerformanceMeasurement::UniqueClientMetricsQuery.new(clients, field, period, group_by_project: true).execute_sum
       @client_sums[column][project_id] || 0
     end
 
@@ -166,22 +163,26 @@ module PerformanceMeasurement::ResultCalculation
       @client_ids.dig(key, project_id) || []
     end
 
+    # Retrieves raw client data for a specific field, properly deduplicating client records
+    #
+    # @return [Array] An array of values for the specified field from deduplicated clients
     def client_data(field, period, project_id: nil)
       key = [period, field]
-      column = key.join('_')
-      return clients.joins(:client_projects).merge(PerformanceMeasurement::ClientProject.where(period: period, for_question: field)).pluck(column) if project_id.blank?
+
+      return PerformanceMeasurement::UniqueClientMetricsQuery.new(clients, field, period).execute_pluck if project_id.blank?
 
       @client_data ||= {}
       existing = @client_data.dig(key)
       return existing.dig(project_id) || [] if existing.present?
 
-      clients.joins(:client_projects).
-        merge(PerformanceMeasurement::ClientProject.where(period: period, for_question: field).where.not(project_id: nil)).
-        distinct.pluck(:project_id, column).each do |p_id, value|
-          @client_data[key] ||= {}
+      @client_data[key] ||= {}
+
+      PerformanceMeasurement::UniqueClientMetricsQuery.new(clients, field, period, group_by_project: true).
+        execute_pluck.each do |p_id, value|
           @client_data[key][p_id] ||= []
           @client_data[key][p_id] << value
         end
+
       @client_data.dig(key, project_id) || []
     end
 

--- a/drivers/performance_measurement/app/models/performance_measurement/unique_client_metrics_query.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/unique_client_metrics_query.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module PerformanceMeasurement
+  # UniqueClientMetricsQuery handles the deduplication of client records
+  # when calculating aggregated metrics across projects.
+  #
+  # This query object is used to solve the problem of correctly counting unique clients
+  # across multiple client-project relationships when performing metrics calculations.
+  # It uses PostgreSQL's DISTINCT ON feature with CTEs to ensure that clients are
+  # deduplicated properly before aggregations are performed.
+  #
+  class UniqueClientMetricsQuery
+    attr_reader :clients_scope, :field, :period, :group_by_project
+
+    # Initialize a new deduplication query
+    #
+    # @param clients_scope [ActiveRecord::Relation] The initial scope of clients
+    # @param field [String | Symbol] The question/metric field name
+    # @param period [String | Symbol] The reporting period identifier
+    # @param project_id [Boolean, Integer, nil] When true, group by all projects; when nil, ignore projects
+    def initialize(clients_scope, field, period, group_by_project: false)
+      @clients_scope = clients_scope
+      @field = field
+      @period = period
+      @group_by_project = group_by_project
+    end
+
+    # Execute the query and return sum(s) of the target column
+    #
+    # @return [Numeric, Hash] If project_id is blank, returns a single sum.
+    #                         Otherwise, returns a hash of sums keyed by project_id.
+    def execute_sum
+      return with_cte.group(:project_id).sum(column) if group_by_project
+
+      return with_cte.sum(column)
+    end
+
+    # Execute the query and return the raw values
+    #
+    # @return [Array] If project_id is blank, returns an array of values.
+    #                 Otherwise, returns an array of [project_id, value] pairs.
+    def execute_pluck
+      return with_cte.pluck(:project_id, column) if group_by_project
+
+      return with_cte.pluck(column)
+    end
+
+    private
+
+    def column
+      "#{period}_#{field}"
+    end
+
+    def with_cte
+      PerformanceMeasurement::Client.unscoped.with(dedup: dedup_query).from('dedup')
+    end
+
+    def dedup_query
+      base_query = clients_scope.
+        joins(:client_projects).
+        merge(ClientProject.where(period: period, for_question: field))
+
+      if group_by_project
+        # base_query = base_query.merge(ClientProject.where.not(project_id: nil))
+        distinct_columns = 'pm_clients.id, pm_client_projects.project_id'
+      else
+        distinct_columns = 'pm_clients.id'
+      end
+
+      base_query.select("DISTINCT ON (#{distinct_columns}) pm_clients.id, #{group_by_project ? 'pm_client_projects.project_id,' : ''} pm_clients.#{column}")
+    end
+  end
+end

--- a/drivers/performance_measurement/app/models/performance_measurement/unique_client_metrics_query.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/unique_client_metrics_query.rb
@@ -17,7 +17,7 @@ module PerformanceMeasurement
     # @param clients_scope [ActiveRecord::Relation] The initial scope of clients
     # @param field [String | Symbol] The question/metric field name
     # @param period [String | Symbol] The reporting period identifier
-    # @param project_id [Boolean, Integer, nil] When true, group by all projects; when nil, ignore projects
+    # @param group_by_project [Boolean] When true, group by all projects; when false, ignore projects
     def initialize(clients_scope, field, period, group_by_project: false)
       @clients_scope = clients_scope
       @field = field

--- a/drivers/performance_measurement/spec/models/performance_measurement/pm_spm_alignment_spec.rb
+++ b/drivers/performance_measurement/spec/models/performance_measurement/pm_spm_alignment_spec.rb
@@ -644,4 +644,267 @@ RSpec.describe 'Performance Measurement and SPM Alignment', type: :model do
       expect(pm_count).to eq(2) # 2 exits (client 2 from ES and client 4 from RRH)
     end
   end
+
+  describe 'result_calculation#client_sum method' do
+    include_context 'SPM test setup'
+
+    before do
+      # Create projects
+      @es_project = create_project(project_type: 0) # ES-EE
+      @th_project = create_project(project_type: 2) # TH
+
+      # Create two clients
+      @client1 = create_client_with_warehouse_link
+      @client2 = create_client_with_warehouse_link
+
+      # Create enrollments for the clients
+      create_enrollment(
+        client: @client1,
+        project: @es_project,
+        entry_date: test_start_date + 10.days,
+        exit_date: test_start_date + 40.days,
+      )
+
+      create_enrollment(
+        client: @client2,
+        project: @th_project,
+        entry_date: test_start_date + 50.days,
+        exit_date: test_start_date + 80.days,
+      )
+
+      # Setup report with these projects
+      @spm_report, @pm_report = setup_reports(projects: [@es_project, @th_project])
+
+      # Add different values for days homeless to demonstrate the issue
+      @client_record1 = @pm_report.clients.find_by(client_id: @client1.destination_client.id)
+      @client_record2 = @pm_report.clients.find_by(client_id: @client2.destination_client.id)
+
+      # Use the same value for both clients to demonstrate the issue with DISTINCT
+      @days_homeless_value = 30
+      @client_record1.update(reporting_days_homeless_es_sh_th: @days_homeless_value)
+      @client_record2.update(reporting_days_homeless_es_sh_th: @days_homeless_value)
+
+      # Create client_projects records
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client1.id,
+        project_id: @es_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client2.id,
+        project_id: @th_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+    end
+
+    it 'should correctly sum values from different clients with the same value' do
+      # Get the result from client_sum for the days_homeless_es_sh_th field
+      sum_result = @pm_report.client_sum(:days_homeless_es_sh_th, :reporting)
+
+      # What we should get is the sum of all client values, even if they're the same
+      expected_result = @days_homeless_value * 2 # 60
+
+      # Check that we're getting the correct sum (both clients' values)
+      expect(sum_result).to eq(expected_result),
+                            "Expected sum to be #{expected_result} (sum of all client values), but got #{sum_result} " +
+                            '(which suggests only distinct values are being summed)'
+    end
+  end
+
+  describe 'result_calculation#client_sum project-level calculation' do
+    include_context 'SPM test setup'
+
+    before do
+      # Create two projects
+      @es_project = create_project(project_type: 0) # ES-EE
+      @th_project = create_project(project_type: 2) # TH
+
+      # Create clients
+      @client1 = create_client_with_warehouse_link
+      @client2 = create_client_with_warehouse_link
+
+      # Create enrollments
+      create_enrollment(
+        client: @client1,
+        project: @es_project,
+        entry_date: test_start_date + 10.days,
+        exit_date: test_start_date + 40.days,
+      )
+
+      create_enrollment(
+        client: @client2,
+        project: @th_project,
+        entry_date: test_start_date + 50.days,
+        exit_date: test_start_date + 80.days,
+      )
+
+      # Setup report with these projects
+      @spm_report, @pm_report = setup_reports(projects: [@es_project, @th_project])
+
+      # Set days homeless values
+      @client_record1 = @pm_report.clients.find_by(client_id: @client1.destination_client.id)
+      @client_record2 = @pm_report.clients.find_by(client_id: @client2.destination_client.id)
+
+      @es_days_value = 30
+      @th_days_value = 40
+      @client_record1.update(reporting_days_homeless_es_sh_th: @es_days_value)
+      @client_record2.update(reporting_days_homeless_es_sh_th: @th_days_value)
+
+      # Create client_projects records
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client1.id,
+        project_id: @es_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client2.id,
+        project_id: @th_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+    end
+
+    it 'should correctly calculate sums per project' do
+      # Test each project's sum separately
+      es_sum = @pm_report.client_sum(:days_homeless_es_sh_th, :reporting, project_id: @es_project.id)
+      th_sum = @pm_report.client_sum(:days_homeless_es_sh_th, :reporting, project_id: @th_project.id)
+
+      # Verify project sums
+      expect(es_sum).to eq(@es_days_value),
+                        "Expected ES project sum to be #{@es_days_value}, but got #{es_sum}"
+      expect(th_sum).to eq(@th_days_value),
+                        "Expected TH project sum to be #{@th_days_value}, but got #{th_sum}"
+
+      # Also verify system-level sum still works
+      system_sum = @pm_report.client_sum(:days_homeless_es_sh_th, :reporting)
+      expect(system_sum).to eq(@es_days_value + @th_days_value),
+                            "Expected system sum to be #{@es_days_value + @th_days_value}, but got #{system_sum}"
+    end
+  end
+
+  describe 'result_calculation#client_data method' do
+    include_context 'SPM test setup'
+
+    before do
+      # Create two projects
+      @es_project = create_project(project_type: 0) # ES-EE
+      @th_project = create_project(project_type: 2) # TH
+
+      # Create clients
+      @client1 = create_client_with_warehouse_link
+      @client2 = create_client_with_warehouse_link
+
+      # Create enrollments
+      create_enrollment(
+        client: @client1,
+        project: @es_project,
+        entry_date: test_start_date + 10.days,
+        exit_date: test_start_date + 40.days,
+      )
+
+      create_enrollment(
+        client: @client2,
+        project: @th_project,
+        entry_date: test_start_date + 50.days,
+        exit_date: test_start_date + 80.days,
+      )
+
+      # Setup report with these projects
+      @spm_report, @pm_report = setup_reports(projects: [@es_project, @th_project])
+
+      # Set days homeless values
+      @client_record1 = @pm_report.clients.find_by(client_id: @client1.destination_client.id)
+      @client_record2 = @pm_report.clients.find_by(client_id: @client2.destination_client.id)
+
+      @es_days_value = 30
+      @th_days_value = 40
+      @client_record1.update(reporting_days_homeless_es_sh_th: @es_days_value)
+      @client_record2.update(reporting_days_homeless_es_sh_th: @th_days_value)
+
+      # Create client_projects records
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client1.destination_client.id,
+        project_id: @es_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client2.destination_client.id,
+        project_id: @th_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+
+      # Create duplicate client_project record to test the issue
+      PerformanceMeasurement::ClientProject.create!(
+        report_id: @pm_report.id,
+        client_id: @client1.destination_client.id,
+        project_id: @es_project.id,
+        for_question: :days_homeless_es_sh_th,
+        period: :reporting,
+      )
+    end
+
+    it 'should not return duplicate values for the same client in system-level client_data' do
+      # Get the data from client_data for the days_homeless_es_sh_th field
+      data_result = @pm_report.client_data(:days_homeless_es_sh_th, :reporting)
+
+      # Count occurrences of each value
+      value_counts = data_result.group_by(&:itself).transform_values(&:count)
+
+      # Check if we have duplicates for the es_days_value
+      expect(value_counts[@es_days_value]).to eq(1),
+                                              "Expected value #{@es_days_value} to appear exactly once, but it appears #{value_counts[@es_days_value]} times"
+
+      # Verify the returned array has the correct total length
+      expect(data_result.length).to eq(2),
+                                    "Expected 2 values (one per client), but got #{data_result.length}"
+
+      # Verify the returned array has both expected values
+      expect(data_result).to include(@es_days_value, @th_days_value),
+                             "Expected data to include both #{@es_days_value} and #{@th_days_value}"
+    end
+
+    it 'should correctly retrieve data per project' do
+      # Get project-specific data
+      es_data = @pm_report.client_data(:days_homeless_es_sh_th, :reporting, project_id: @es_project.id)
+      th_data = @pm_report.client_data(:days_homeless_es_sh_th, :reporting, project_id: @th_project.id)
+
+      # Verify project data
+      expect(es_data).to eq([@es_days_value]),
+                         "Expected ES project data to be [#{@es_days_value}], but got #{es_data}"
+      expect(th_data).to eq([@th_days_value]),
+                         "Expected TH project data to be [#{@th_days_value}], but got #{th_data}"
+
+      # Verify each value appears only once in the project data
+      expect(es_data.count(@es_days_value)).to eq(1),
+                                               "Expected value #{@es_days_value} to appear exactly once in ES data"
+    end
+
+    it 'should handle the median calculation correctly with deduplicated data' do
+      # Calculate the median manually with the expected values
+      expected_values = [@es_days_value, @th_days_value]
+      expected_median = expected_values.sum / 2 # median of a 2 value array is the average
+
+      # Get the data from client_data and calculate median
+      data_result = @pm_report.client_data(:days_homeless_es_sh_th, :reporting)
+      actual_median = @pm_report.send(:median, data_result)
+
+      # Verify the median calculation
+      expect(actual_median).to eq(expected_median),
+                               "Expected median to be #{expected_median}, but got #{actual_median}"
+    end
+  end
 end

--- a/drivers/performance_measurement/spec/models/performance_measurement/pm_spm_alignment_spec.rb
+++ b/drivers/performance_measurement/spec/models/performance_measurement/pm_spm_alignment_spec.rb
@@ -710,9 +710,16 @@ RSpec.describe 'Performance Measurement and SPM Alignment', type: :model do
       expected_result = @days_homeless_value * 2 # 60
 
       # Check that we're getting the correct sum (both clients' values)
-      expect(sum_result).to eq(expected_result),
-                            "Expected sum to be #{expected_result} (sum of all client values), but got #{sum_result} " +
-                            '(which suggests only distinct values are being summed)'
+      expect(sum_result).to eq(expected_result)
+    end
+
+    it 'should correctly sum values from different clients with different values' do
+      @pm_report.clients.first.update!(reporting_days_homeless_es_sh_th: @days_homeless_value - 1)
+      sum_result = @pm_report.client_sum(:days_homeless_es_sh_th, :reporting)
+
+      expected_result = (@days_homeless_value * 2) - 1
+
+      expect(sum_result).to eq(expected_result)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
* fixes handling of duplicates in client_sum and client data. Previous use of 'distinct' was summing / plucking the distinct values of `column` whereas the intention was to sum/pluck `column` on distinct clients
* adds tests to prove fix
* uses a 'query' object pattern to clean up code
* comments

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
