### PR TITLE
Support the Project CE page with referrals queue

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -749,6 +749,7 @@ type CeOpportunity {
   acceptedReferral: CeReferral
   activeReferral: CeReferral
   candidates(limit: Int, offset: Int): CeCandidatesPaginated!
+  categories: [String!]!
   eligibilityRequirements: [CeMatchRule!]
   expiresAt: ISO8601DateTime
   id: ID!
@@ -757,6 +758,10 @@ type CeOpportunity {
   projectId: ID!
   projectName: String!
   status: CeOpportunityStatus!
+}
+
+input CeOpportunityFilterOptions {
+  status: [CeOpportunityStatus!]
 }
 
 input CeOpportunityInput {
@@ -800,10 +805,16 @@ type CeParticipationsPaginated {
 type CeReferral {
   client: Client
   clientId: ID!
+  currentStep: CeReferralStep
+  dateStarted: ISO8601Date!
   id: ID!
   opportunity: CeOpportunity!
   status: CeReferralStatus!
   steps: [CeReferralStep!]!
+}
+
+input CeReferralFilterOptions {
+  status: [CeReferralStatus!]
 }
 
 input CeReferralInput {
@@ -845,6 +856,16 @@ enum CeReferralStepStatus {
   completed
   in_progress
   unavailable
+}
+
+type CeReferralsPaginated {
+  hasMoreAfter: Boolean!
+  hasMoreBefore: Boolean!
+  limit: Int!
+  nodes: [CeReferral!]!
+  nodesCount: Int!
+  offset: Int!
+  pagesCount: Int!
 }
 
 """
@@ -8838,8 +8859,9 @@ type Project {
   active: Boolean!
   affiliatedProjects: [Project!]!
   assessments(filters: AssessmentsForProjectFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
-  ceOpportunities(limit: Int, offset: Int): CeOpportunitiesPaginated!
+  ceOpportunities(filters: CeOpportunityFilterOptions, limit: Int, offset: Int): CeOpportunitiesPaginated!
   ceParticipations(limit: Int, offset: Int): CeParticipationsPaginated!
+  ceReferrals(filters: CeReferralFilterOptions, limit: Int, offset: Int): CeReferralsPaginated!
   contactInformation: String
   continuumProject: NoYes
   createdBy: ApplicationUser

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -805,8 +805,8 @@ type CeParticipationsPaginated {
 type CeReferral {
   client: Client
   clientId: ID!
-  currentStep: CeReferralStep
-  dateStarted: ISO8601Date!
+  createdAt: ISO8601DateTime!
+  currentStepName: String
   id: ID!
   opportunity: CeOpportunity!
   status: CeReferralStatus!

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity.rb
@@ -19,6 +19,11 @@ module Types
     field :project_name, String, null: false
     field :eligibility_requirements, [HmisSchema::CeMatchRule], null: true
     field :priority_scheme, HmisSchema::CeMatchRule, null: true
+    field :categories, [String], null: false
+
+    available_filter_options do
+      arg :status, [HmisSchema::Enums::CeOpportunityStatus]
+    end
 
     def candidates
       Hmis::Ce::Match::Candidate.
@@ -46,6 +51,10 @@ module Types
     def priority_scheme
       # not to be used in batch
       Hmis::Ce::Match::Rule.priority_scheme.for_opportunity(object).first # there should only be 1
+    end
+
+    def categories
+      load_ar_association(object, :categories, scope: Hmis::Ce::OpportunityCategory.order(:name)).map(&:name)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -8,12 +8,19 @@
 
 module Types
   class HmisSchema::CeReferral < Types::BaseObject
+    # object is a Hmis::Ce::Referral
     field :id, ID, null: false
     field :opportunity, HmisSchema::CeOpportunity, null: false
     field :steps, [HmisSchema::CeReferralStep], null: false
     field :status, HmisSchema::Enums::CeReferralStatus, null: false
     field :client_id, ID, null: false
     field :client, Types::HmisSchema::Client, null: true
+    field :date_started, GraphQL::Types::ISO8601Date, null: false, method: :created_at
+    field :current_step, Types::HmisSchema::CeReferralStep, null: true
+
+    available_filter_options do
+      arg :status, [HmisSchema::Enums::CeReferralStatus]
+    end
 
     def steps
       instance = object.workflow_instance
@@ -36,6 +43,16 @@ module Types
 
     def client
       load_ar_association(object, :client, scope: Hmis::Hud::Client.viewable_by(current_user))
+    end
+
+    def current_step
+      instance = load_ar_association(object, :workflow_instance)
+      steps = load_ar_association(instance, :steps, scope: Hmis::WorkflowExecution::Step.where(status: ['available', 'in_progress']))
+      steps.first # There can be multiple steps currently in progress, but we're only going to show one in the project referrals table
+    end
+
+    def opportunity
+      load_ar_association(object, :opportunity)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -15,8 +15,8 @@ module Types
     field :status, HmisSchema::Enums::CeReferralStatus, null: false
     field :client_id, ID, null: false
     field :client, Types::HmisSchema::Client, null: true
-    field :date_started, GraphQL::Types::ISO8601Date, null: false, method: :created_at
-    field :current_step, Types::HmisSchema::CeReferralStep, null: true
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :current_step_name, String, null: true
 
     available_filter_options do
       arg :status, [HmisSchema::Enums::CeReferralStatus]
@@ -45,10 +45,20 @@ module Types
       load_ar_association(object, :client, scope: Hmis::Hud::Client.viewable_by(current_user))
     end
 
-    def current_step
+    def current_step_name # There can be multiple steps currently in progress, but we're only going to show one in the project referrals table
       instance = load_ar_association(object, :workflow_instance)
-      steps = load_ar_association(instance, :steps, scope: Hmis::WorkflowExecution::Step.where(status: ['available', 'in_progress']))
-      steps.first # There can be multiple steps currently in progress, but we're only going to show one in the project referrals table
+
+      step_t = Hmis::WorkflowExecution::Step.arel_table
+      step_scope = Hmis::WorkflowExecution::Step.
+        where(status: ['available', 'in_progress']).
+        # Prefer to return a step that is in_progress over available
+        order(Arel::Nodes::Case.new.when(step_t[:status].eq('in_progress')).then(1).else(2)).
+        order(step_t[:id]) # Also sort by ID, to make sure this resolves deterministically
+
+      step = load_ar_association(instance, :steps, scope: step_scope).first
+      return if step.nil?
+
+      load_ar_association(step, :node)&.name
     end
 
     def opportunity

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -113,7 +113,13 @@ module Types
     field :data_collection_features, [Types::HmisSchema::DataCollectionFeature], null: false, description: 'Occurrence Point data collection features that are enabled for this Project (e.g. Current Living Situations, Events)'
     field :occurrence_point_forms, [Types::HmisSchema::OccurrencePointForm], null: false, method: :occurrence_point_form_instances, description: 'Forms for individual data elements that are collected at occurrence for this Project (e.g. Move-In Date)'
     field :service_types, [Types::HmisSchema::ServiceType], null: false, method: :available_service_types, description: 'Service types that are collected for this Project'
-    field :ce_opportunities, Types::HmisSchema::CeOpportunity.page_type, null: false
+
+    field :ce_opportunities, Types::HmisSchema::CeOpportunity.page_type, null: false do
+      argument(:filters, Types::HmisSchema::CeOpportunity.filter_options_type, required: false)
+    end
+    field :ce_referrals, Types::HmisSchema::CeReferral.page_type, null: false do
+      argument(:filters, Types::HmisSchema::CeReferral.filter_options_type, required: false)
+    end
 
     def hud_id
       object.project_id
@@ -253,10 +259,20 @@ module Types
       resolve_external_form_submissions(scope, **args)
     end
 
-    def ce_opportunities
+    def ce_opportunities(filters: nil)
       raise unless Hmis::Ce.configuration.enabled?
 
-      load_ar_association(object, :ce_opportunities)
+      scope = load_ar_association(object, :ce_opportunities)
+      scope = scope.where(status: filters&.status) if filters&.status.present?
+      scope.order(created_at: :desc)
+    end
+
+    def ce_referrals(filters: nil)
+      raise unless Hmis::Ce.configuration.enabled?
+
+      scope = load_ar_association(object, :ce_referrals)
+      scope = scope.where(status: filters&.status) if filters&.status.present?
+      scope.order(created_at: :desc)
     end
 
     private def check_enrollment_details_access

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -259,7 +259,7 @@ module Types
       resolve_external_form_submissions(scope, **args)
     end
 
-    def ce_opportunities(filters: nil)
+    def ce_opportunities(filters: nil) # not for batch
       raise unless Hmis::Ce.configuration.enabled?
 
       scope = object.ce_opportunities
@@ -267,10 +267,10 @@ module Types
       scope.order(created_at: :desc)
     end
 
-    def ce_referrals(filters: nil)
+    def ce_referrals(filters: nil) # not for batch
       raise unless Hmis::Ce.configuration.enabled?
 
-      scope = load_ar_association(object, :ce_referrals)
+      scope = object.ce_referrals
       scope = scope.where(status: filters&.status) if filters&.status.present?
       scope.order(created_at: :desc)
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -262,7 +262,7 @@ module Types
     def ce_opportunities(filters: nil)
       raise unless Hmis::Ce.configuration.enabled?
 
-      scope = load_ar_association(object, :ce_opportunities)
+      scope = object.ce_opportunities
       scope = scope.where(status: filters&.status) if filters&.status.present?
       scope.order(created_at: :desc)
     end

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -56,6 +56,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :current_living_situations, through: :enrollments
   has_many :project_staff_assignment_configs, class_name: 'Hmis::ProjectStaffAssignmentConfig'
   has_many :ce_opportunities, class_name: 'Hmis::Ce::Opportunity', foreign_key: :project_id, dependent: :destroy, inverse_of: :project
+  has_many :ce_referrals, class_name: 'Hmis::Ce::Referral', through: :ce_opportunities, source: :referrals
 
   has_one :warehouse_project, class_name: 'GrdaWarehouse::Hud::Project', foreign_key: :id, primary_key: :id
 

--- a/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
+++ b/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
@@ -264,4 +264,21 @@ task ce_starter_pack_20250302: [:environment] do
   Hmis::Ce::Match::CandidatePool.all.each do |pool|
     Hmis::Ce::Match::Engine.call(pool, clients)
   end
+
+  if Hmis::Ce::Opportunity.open.any?
+    # Create some opportunities with Opportunity Categories, just to show how it looks in the UI
+    sro = Hmis::Ce::OpportunityCategory.create!(name: 'SRO')
+    sro_opportunity = Hmis::Ce::Opportunity.open.first
+    Hmis::Ce::OpportunityCategorization.create!(
+      opportunity: sro_opportunity,
+      category: sro
+    )
+
+    accessible_sro = Hmis::Ce::OpportunityCategory.create!(name: 'Accessible SRO')
+    accessible_sro_opportunity = Hmis::Ce::Opportunity.open.last
+    Hmis::Ce::OpportunityCategorization.create!(
+      opportunity: accessible_sro_opportunity,
+      category: accessible_sro
+    )
+  end
 end

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -2,7 +2,10 @@
 
 FactoryBot.define do
   factory :hmis_ce_referral, class: 'Hmis::Ce::Referral' do
-    association(:opportunity, factory: :hmis_ce_opportunity)
+    transient do
+      project { nil }
+    end
+    opportunity { build(:hmis_ce_opportunity, project: project) }
     association(:workflow_instance, factory: :hmis_workflow_execution_instance)
     association(:client, factory: :hmis_hud_client)
     association(:referred_by, factory: :hmis_user)

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -4,10 +4,22 @@ FactoryBot.define do
   factory :hmis_ce_referral, class: 'Hmis::Ce::Referral' do
     transient do
       project { nil }
+      workflow_template { nil }
     end
-    opportunity { build(:hmis_ce_opportunity, project: project) }
+    association(:opportunity, factory: :hmis_ce_opportunity)
     association(:workflow_instance, factory: :hmis_workflow_execution_instance)
     association(:client, factory: :hmis_hud_client)
     association(:referred_by, factory: :hmis_user)
+    after(:create) do |instance, evaluator|
+      instance.opportunity.project = evaluator.project if evaluator.project.present?
+
+      if evaluator.workflow_template.present?
+        instance.opportunity.workflow_template = evaluator.workflow_template
+        instance.workflow_instance.template = evaluator.workflow_template
+      end
+
+      instance.opportunity.save! if instance.opportunity.changed?
+      instance.workflow_instance.save! if instance.workflow_instance.changed?
+    end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#  Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+#  License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+#
+
+require 'rails_helper'
+require_relative '../login_and_permissions'
+require_relative './ce_spec_helper'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'ce spec helper'
+
+  describe 'project ceOpportunities query' do
+    let(:query) do
+      <<~GRAPHQL
+        query GetProjectCeOpportunities($id: ID!, $limit: Int = 25, $offset: Int = 0, $filters: CeOpportunityFilterOptions = null) {
+          project(id: $id) {
+            id
+            ceOpportunities(limit: $limit, offset: $offset, filters: $filters) {
+              offset
+              limit
+              nodesCount
+              nodes {
+                id
+                name
+                categories
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:variables) do
+      {
+        id: project.id,
+      }
+    end
+
+    it "returns the project's opportunities" do
+      response, result = post_graphql(**variables) { query }
+      expect(response.status).to eq(200), result.inspect
+
+      opportunities = result.dig('data', 'project', 'ceOpportunities', 'nodes')
+      expect(opportunities.count).to eq(1)
+
+      returned_opportunity = opportunities[0]
+      expect(returned_opportunity['id']).to eq(opportunity.id.to_s)
+    end
+
+    context 'when filtering for open referrals' do
+      let(:variables) do
+        {
+          id: project.id,
+          filters: {
+            status: ['open'],
+          },
+        }
+      end
+
+      let(:opportunity) { create :hmis_ce_opportunity, project: project }
+      let(:closed_opportunity) { create :hmis_ce_opportunity, project: project, status: :closed }
+      let(:locked_opportunity) { create :hmis_ce_opportunity, project: project, status: :locked }
+
+      it 'returns only active referrals' do
+        response, result = post_graphql(**variables) { query }
+        expect(response.status).to eq(200), result.inspect
+
+        opportunities = result.dig('data', 'project', 'ceOpportunities', 'nodes')
+        expect(opportunities.count).to eq(1)
+
+        expect(opportunities).to contain_exactly(
+          a_hash_including('id' => opportunity.id.to_s),
+        )
+      end
+
+      context 'with many opportunities' do
+        before do
+          100.times do
+            create :hmis_ce_opportunity, project: project
+          end
+        end
+
+        it 'queries the db a reasonable amount' do
+          expect do
+            response, result = post_graphql(**variables) { query }
+            expect(response.status).to eq(200), result.inspect
+            expect(result.dig('data', 'project', 'ceOpportunities', 'nodesCount')).to eq(101)
+          end.to make_database_queries(count: 15..20)
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
-            expect(result.dig('data', 'project', 'ceOpportunities', 'nodesCount')).to eq(101)
+            expect(result.dig('data', 'project', 'ceOpportunities', 'nodesCount')).to eq(41)
           end.to make_database_queries(count: 15..20)
         end
       end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       context 'with many opportunities' do
         before do
-          100.times do
+          40.times do
             create :hmis_ce_opportunity, project: project
           end
         end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -25,14 +25,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               nodes {
                 id
                 status
-                dateStarted
+                createdAt
                 opportunity {
                   id
                   name
                 }
-                currentStep {
-                  name
-                }
+                currentStepName
               }
             }
           }
@@ -90,9 +88,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         before do
           50.times do
             create(:hmis_ce_referral, project: project)
-            create(:hmis_ce_referral, status: :in_progress, project: project)
             create(:hmis_ce_referral, status: :accepted, project: project)
             create(:hmis_ce_referral, status: :rejected, project: project)
+
+            in_progress_referral = create(:hmis_ce_referral, project: project, workflow_template: workflow_template)
+            in_progress_referral.workflow_engine.start_workflow!(user: hmis_user) # start workflow so that it has a step in progress
           end
         end
 
@@ -101,7 +101,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(102)
-          end.to make_database_queries(count: 20..25)
+          end.to make_database_queries(count: 15..20)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+#  Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+#  License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+#
+
+require 'rails_helper'
+require_relative '../login_and_permissions'
+require_relative './ce_spec_helper'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'ce spec helper'
+
+  describe 'project ceReferrals query' do
+    let(:query) do
+      <<~GRAPHQL
+        query GetProjectCeReferrals($id: ID!, $limit: Int = 25, $offset: Int = 0, $filters: CeReferralFilterOptions = null) {
+          project(id: $id) {
+            id
+            ceReferrals(limit: $limit, offset: $offset, filters: $filters) {
+              offset
+              limit
+              nodesCount
+              nodes {
+                id
+                status
+                dateStarted
+                opportunity {
+                  id
+                  name
+                }
+                currentStep {
+                  name
+                }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let(:variables) do
+      {
+        id: project.id,
+      }
+    end
+
+    it "returns the project's referrals" do
+      response, result = post_graphql(**variables) { query }
+      expect(response.status).to eq(200), result.inspect
+
+      referrals = result.dig('data', 'project', 'ceReferrals', 'nodes')
+      expect(referrals.count).to eq(1)
+
+      returned_referral = referrals[0]
+      expect(returned_referral['id']).to eq(referral.id.to_s)
+      expect(returned_referral['status']).to eq('initialized')
+    end
+
+    context 'when filtering for active referrals' do
+      let(:variables) do
+        {
+          id: project.id,
+          filters: {
+            status: ['initialized', 'in_progress'],
+          },
+        }
+      end
+
+      let!(:referral) { create(:hmis_ce_referral, project: project) }
+      let!(:in_progress_referral) { create(:hmis_ce_referral, status: :in_progress, project: project) }
+      let!(:accepted_referral) { create(:hmis_ce_referral, status: :accepted, project: project) }
+      let!(:rejected_referral) { create(:hmis_ce_referral, status: :rejected, project: project) }
+
+      it 'returns only active referrals' do
+        response, result = post_graphql(**variables) { query }
+        expect(response.status).to eq(200), result.inspect
+
+        referrals = result.dig('data', 'project', 'ceReferrals', 'nodes')
+        expect(referrals.count).to eq(2)
+
+        expect(referrals).to contain_exactly(
+          a_hash_including('id' => referral.id.to_s),
+          a_hash_including('id' => in_progress_referral.id.to_s),
+        )
+      end
+
+      context 'with many referrals' do
+        before do
+          50.times do
+            create(:hmis_ce_referral, project: project)
+            create(:hmis_ce_referral, status: :in_progress, project: project)
+            create(:hmis_ce_referral, status: :accepted, project: project)
+            create(:hmis_ce_referral, status: :rejected, project: project)
+          end
+        end
+
+        it 'queries the db a reasonable amount' do
+          expect do
+            response, result = post_graphql(**variables) { query }
+            expect(response.status).to eq(200), result.inspect
+            expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(102)
+          end.to make_database_queries(count: 20..25)
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -86,11 +86,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       context 'with many referrals' do
         before do
-          50.times do
-            create(:hmis_ce_referral, project: project)
-            create(:hmis_ce_referral, status: :accepted, project: project)
-            create(:hmis_ce_referral, status: :rejected, project: project)
-
+          30.times do
             in_progress_referral = create(:hmis_ce_referral, project: project, workflow_template: workflow_template)
             in_progress_referral.workflow_engine.start_workflow!(user: hmis_user) # start workflow so that it has a step in progress
           end
@@ -100,7 +96,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
-            expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(102)
+            expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(32)
           end.to make_database_queries(count: 15..20)
         end
       end


### PR DESCRIPTION
## _Merging this PR_
- squash-merge into the long lived feature branch `tt-ce-spike-3`

## Description
GH issue: https://github.com/open-path/Green-River/issues/7350

Summary of changes:
- Add `ce_referrals` on `project` schema object.
- Add `status` filter option to both Opportunity and Referral schema objects.
- Add `categories` to Opportunity schema object.
- Add `date_started` and `current_step` to Referral schema object
  -  Maybe we should discuss Current Step a bit more. In reality, there can be >1 current step, though the [WIP mocks](https://www.figma.com/board/axGI9vwmuBRC4uZ11ZJ3RP/OP-HMIS-%2F-Coordinated-Entry-%2F-FigJam?node-id=2821-78000&t=LtaE21FnWaZml1Rw-0) don't currently reflect that.
- In the starter pack, add some example Opportunity Categories
- Add spec

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Feature build-out

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources - I _think_ this is true in this PR
  - [x] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places - todo in CE Permissions ticket
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
