### PR TITLE
Allow AG-Grid to set column widths after load

### DIFF
--- a/app/javascript/cohorts.ts
+++ b/app/javascript/cohorts.ts
@@ -42,10 +42,6 @@ interface GridOptions {
     filter: boolean;
     resizable: boolean;
   };
-  SizeColumnsToContentStrategy: {
-    type: 'fitCellContents',
-    skipHeader?: true,
-  }
   singleClickEdit: boolean;
   rowSelection: {
     mode: string;

--- a/app/javascript/cohorts.ts
+++ b/app/javascript/cohorts.ts
@@ -19,7 +19,6 @@ interface CohortOptions {
   column_order: string[];
   column_headers: Array<{ headerName: string; headerTooltip: string; field: string; editable: boolean; renderer?: string; available_options?: string[]; }>;
   column_options: any;
-  column_widths: number[];
   size_toggle_class: string;
   include_inactive: boolean;
   client_path: string;
@@ -43,6 +42,10 @@ interface GridOptions {
     filter: boolean;
     resizable: boolean;
   };
+  SizeColumnsToContentStrategy: {
+    type: 'fitCellContents',
+    skipHeader?: true,
+  }
   singleClickEdit: boolean;
   rowSelection: {
     mode: string;
@@ -78,7 +81,6 @@ window.App.Cohorts.Cohort = class Cohort {
   private column_order: string[];
   private column_headers: Array<{ headerName: string; headerTooltip: string; field: string; editable: boolean; renderer?: string; available_options?: string[]; }>;
   private column_options: any;
-  private column_widths: number[];
   private size_toggle_class: string;
   private include_inactive: boolean;
   private client_path: string;
@@ -127,7 +129,6 @@ window.App.Cohorts.Cohort = class Cohort {
     this.column_order = options['column_order'];
     this.column_headers = options['column_headers'];
     this.column_options = options['column_options'];
-    this.column_widths = options['column_widths'];
     this.size_toggle_class = options['size_toggle_class'];
     this.include_inactive = options['include_inactive'];
     this.client_path = options['client_path'];
@@ -360,6 +361,7 @@ window.App.Cohorts.Cohort = class Cohort {
     return this.load_page().then(() => {
       $(this.loading_selector).addClass('hidden');
       this.table.setGridOption('rowData', this.raw_data);
+      this.resize_columns();
       this.set_rank_order();
 
       const refresh_rate = 10000;

--- a/app/models/cohort_columns/client_notes.rb
+++ b/app/models/cohort_columns/client_notes.rb
@@ -53,7 +53,7 @@ module CohortColumns
       # Sort pattern
       html = content_tag(:div, class: 'd-flex') do
         content_tag(:span, "#{max_updated_at} #{note_count}", class: 'hidden') + link_to(pluralize(note_count, 'note'), path, class: 'badge badge-primary py-1 px-2 mr-auto', data: { loads_in_pjax_modal: true, cohort_client_id: cohort_client.id, column: column }) +
-        content_tag(:span, " #{updated_at&.to_date}", style: 'height: 16px;')
+        content_tag(:span, " #{updated_at&.to_date}", style: 'height: 16px;', class: 'ml-4')
       end
       html
     end

--- a/app/models/cohort_columns/notes.rb
+++ b/app/models/cohort_columns/notes.rb
@@ -53,7 +53,7 @@ module CohortColumns
       # Sort pattern
       html = content_tag(:div, class: 'd-flex') do
         content_tag(:span, "#{max_updated_at} #{note_count}", class: 'hidden') + link_to(pluralize(note_count, 'note'), path, class: 'badge badge-primary py-1 px-2 mr-auto', data: { loads_in_pjax_modal: true, cohort_client_id: cohort_client.id, column: column }) +
-        content_tag(:span, " #{updated_at&.to_date}", style: 'height: 16px;')
+        content_tag(:span, " #{updated_at&.to_date}", style: 'height: 16px;', class: 'ml-4')
       end
       html
     end

--- a/app/views/cohorts/_cohorts_js.haml
+++ b/app/views/cohorts/_cohorts_js.haml
@@ -12,7 +12,6 @@
           column_order: #{(@visible_columns.map(&:column)).to_json.html_safe},
           column_headers: #{@column_headers.to_json.html_safe},
           column_options: #{@column_options.to_json.html_safe},
-          column_widths: #{(@visible_columns.map(&:width)).to_json.html_safe},
           size_toggle_class: '.jToggleFontSize',
           include_inactive: #{params[:inactive].present?},
           client_path: "#{cohort_cohort_clients_path(@cohort)}",


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Hotfix for cohort column sizes

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
