### PR TITLE
Strict Client Search Whitespace

### DIFF
--- a/app/models/concerns/client_search.rb
+++ b/app/models/concerns/client_search.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module ClientSearch
   extend ActiveSupport::Concern
   included do
@@ -13,7 +15,7 @@ module ClientSearch
     def self.text_searcher(text, sorted:, resolve_for_join_query: false)
       return none unless text.present?
 
-      text.strip!
+      text = text.strip
       sa = arel_table
       alpha_numeric = /[[[:alnum:]]-]+/.match(text).try(:[], 0) == text
       numeric = /[\d-]+/.match(text).try(:[], 0) == text
@@ -32,7 +34,7 @@ module ClientSearch
         return where(sa[:id].eq(matching_scan_card.client_id)) if matching_scan_card
       end
 
-      if alpha_numeric && (text.size == 32 || text.size == 36)
+      if alpha_numeric && [32, 36].include?(text.size)
         where = sa[:PersonalID].matches(text.gsub('-', ''))
       elsif social
         where = sa[:SSN].eq(text.gsub('-', ''))

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1779,13 +1779,13 @@ module GrdaWarehouse::Hud
 
       if first_name.present?
         first_name_ids = source.where(
-          nf('LOWER', [arel_table[:FirstName]]).eq(first_name.downcase),
+          nf('TRIM', [nf('LOWER', [arel_table[:FirstName]])]).eq(first_name.downcase),
         ).pluck(:id)
       end
 
       if last_name.present?
         last_name_ids = source.where(
-          nf('LOWER', [arel_table[:LastName]]).eq(last_name.downcase),
+          nf('TRIM', [nf('LOWER', [arel_table[:LastName]])]).eq(last_name.downcase),
         ).pluck(:id)
       end
 

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -1,3 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
 require 'rails_helper'
 include ActiveJob::TestHelper
 
@@ -58,6 +66,81 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
           raise ActiveRecord::Rollback
         end
       end.to not_change(client.versions, :count)
+    end
+  end
+
+  describe 'searching' do
+    let!(:client_no_whitespace) { create :authoritative_hud_client, first_name: 'HasNo', last_name: 'Whitespace', ssn: '123456789', dob: '2000-01-01'.to_date }
+    let!(:client_trailing_whitespace) { create :authoritative_hud_client, first_name: 'Trailing ', last_name: 'Whitespace ', ssn: '234567891', dob: '2000-01-02'.to_date }
+    let!(:client_leading_whitespace) { create :authoritative_hud_client, first_name: ' Leading', last_name: ' Whitespace', ssn: '345678912', dob: '2000-01-03'.to_date }
+
+    let!(:warehouse_client_no_whitespace) { create :warehouse_client, source: client_no_whitespace, destination: client_no_whitespace }
+    let!(:warehouse_client_trailing_whitespace) { create :warehouse_client, source: client_trailing_whitespace, destination: client_trailing_whitespace }
+    let!(:warehouse_client_leading_whitespace) { create :warehouse_client, source: client_leading_whitespace, destination: client_leading_whitespace }
+
+    describe 'text_search' do
+      def whitespace_text_search_expects(search_string, expected_clients)
+        expect(GrdaWarehouse::Hud::Client.text_search(search_string).to_a).to include(*expected_clients)
+        expect(GrdaWarehouse::Hud::Client.text_search("#{search_string} ").to_a).to include(*expected_clients)
+        expect(GrdaWarehouse::Hud::Client.text_search(" #{search_string} ").to_a).to include(*expected_clients)
+        expect(GrdaWarehouse::Hud::Client.text_search(" #{search_string} ").to_a).to include(*expected_clients)
+        expect(GrdaWarehouse::Hud::Client.text_search(search_string.gsub(' ', '   ')).to_a).to include(*expected_clients)
+      end
+
+      it 'searching last name returns clients regardless of included leading/trailing whitespace' do
+        whitespace_text_search_expects('Whitespace', [
+                                         client_no_whitespace,
+                                         client_trailing_whitespace,
+                                         client_leading_whitespace,
+                                       ])
+      end
+
+      it 'searching first name returns clients regardless of included leading/trailing whitespace' do
+        whitespace_text_search_expects('HasNo', client_no_whitespace)
+        whitespace_text_search_expects('Trailing', client_trailing_whitespace)
+        whitespace_text_search_expects('Leading', client_leading_whitespace)
+      end
+
+      it 'searching full name returns clients regardless of included leading/trailing whitespace' do
+        whitespace_text_search_expects('HasNo Whitespace', client_no_whitespace)
+        whitespace_text_search_expects('Trailing Whitespace', client_trailing_whitespace)
+        whitespace_text_search_expects('Leading Whitespace', client_leading_whitespace)
+      end
+    end
+
+    describe 'strict_search' do
+      def whitespace_strict_search_expects(client)
+        scope = GrdaWarehouse::Hud::Client
+        # Setup search criteria.
+        # Remove leading/trailing whitespaces to normalize the names before running through the tests
+        # We are not including dob as matching 3 will get a result, so don't want to match more than 3 criteria for these tests
+        criteria = {
+          first_name: client.first_name.strip,
+          last_name: client.last_name.strip,
+          ssn: client.ssn,
+          dob: nil,
+        }
+        search_criteria = criteria.dup
+        expect(GrdaWarehouse::Hud::Client.strict_search(search_criteria, client_scope: scope).to_a).to include(client)
+        search_criteria[:first_name] = "#{criteria[:first_name]} "
+        search_criteria[:last_name] = "#{criteria[:last_name]} "
+        expect(GrdaWarehouse::Hud::Client.strict_search(search_criteria, client_scope: scope).to_a).to include(client)
+        search_criteria[:first_name] = " #{criteria[:first_name]}"
+        search_criteria[:last_name] = " #{criteria[:last_name]}"
+        expect(GrdaWarehouse::Hud::Client.strict_search(search_criteria, client_scope: scope).to_a).to include(client)
+        search_criteria[:first_name] = " #{criteria[:first_name]} "
+        search_criteria[:last_name] = " #{criteria[:last_name]} "
+        expect(GrdaWarehouse::Hud::Client.strict_search(search_criteria, client_scope: scope).to_a).to include(client)
+        search_criteria[:first_name] = criteria[:first_name].gsub(' ', '   ')
+        search_criteria[:last_name] = criteria[:last_name].gsub(' ', '   ')
+        expect(GrdaWarehouse::Hud::Client.strict_search(search_criteria, client_scope: scope).to_a).to include(client)
+      end
+
+      it 'searching returns client regardless of leading/trailing whitespace in first/last name' do
+        whitespace_strict_search_expects(client_no_whitespace)
+        whitespace_strict_search_expects(client_trailing_whitespace)
+        whitespace_strict_search_expects(client_leading_whitespace)
+      end
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Trim the whitespace in the strict search db query to match the whitespace trimming being done on search field inputs. This will allow any clients with whitespace leading or trailing their first/last name to return in the strict search.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
