### PR TITLE
Save http code for logged involvement requests

### DIFF
--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/involvements_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/involvements_controller.rb
@@ -14,7 +14,6 @@ module HmisExternalApis::AcHmis
       involvement, json_payload = log_request_with_truncation do
         involvement = ClientInvolvement.new(client_params)
         involvement.validate_request!
-        # Return both involvement and its JSON representation as a tuple (array)
         [involvement, involvement.to_json]
       end
 

--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/involvements_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/ac_hmis/involvements_controller.rb
@@ -4,29 +4,28 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisExternalApis::AcHmis
   class InvolvementsController < HmisExternalApis::BaseController
     MAX_RESPONSE_SIZE_TO_SAVE = 1.kilobyte
 
     def client
-      involvement = nil
-
-      json_payload = log_request_with_truncation do
+      involvement, json_payload = log_request_with_truncation do
         involvement = ClientInvolvement.new(client_params)
         involvement.validate_request!
-        involvement.to_json
+        # Return both involvement and its JSON representation as a tuple (array)
+        [involvement, involvement.to_json]
       end
 
       render json: json_payload, status: (involvement.ok? ? :ok : :bad_request)
     end
 
     def program
-      involvement = nil
-
-      json_payload = log_request_with_truncation do
+      involvement, json_payload = log_request_with_truncation do
         involvement = ProgramInvolvement.new(program_params)
         involvement.validate_request!
-        involvement.to_json
+        [involvement, involvement.to_json]
       end
 
       render json: json_payload, status: (involvement.ok? ? :ok : :bad_request)
@@ -35,8 +34,11 @@ module HmisExternalApis::AcHmis
     protected
 
     def log_request_with_truncation &block
-      block.call.tap do |json_payload|
-        request_log.update!(response: json_payload.first(MAX_RESPONSE_SIZE_TO_SAVE))
+      block.call.tap do |involvement, json_payload|
+        request_log.update!(
+          response: json_payload.first(MAX_RESPONSE_SIZE_TO_SAVE),
+          http_status: involvement.ok? ? 200 : 400,
+        )
       end
     end
 

--- a/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
+++ b/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request do
@@ -36,7 +38,9 @@ RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request 
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['involvements']).to eq []
       expect(HmisExternalApis::ExternalRequestLog.count).to eq(1)
-      expect(HmisExternalApis::ExternalRequestLog.first.response).to match(/involvements/)
+      logged = HmisExternalApis::ExternalRequestLog.first
+      expect(logged.response).to match(/involvements/)
+      expect(logged.http_status).to match(200)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
**Before**: 
Involvement requests' `http_status` was not saved, so they would be returned by the [failed scope](https://github.com/greenriver/hmis-warehouse/blob/2da46301e94e995992335f6c2f8a437339b7156c/drivers/hmis_external_apis/app/models/hmis_external_apis/external_request_log.rb#L21) even when successful. These scopes are used only for debugging.

**After**:
Involvement requests' `http_status` is saved to the `HmisExternalApis::ExternalRequestLog` as 200 or 400 depending on the involvement's `status_message`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail - no, I only ran it in the spec test.
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
