### PR TITLE
Dont require hmis audit permission for user permission report

### DIFF
--- a/drivers/user_permission_report/app/controllers/user_permission_report/warehouse_reports/reports_controller.rb
+++ b/drivers/user_permission_report/app/controllers/user_permission_report/warehouse_reports/reports_controller.rb
@@ -8,6 +8,7 @@
 
 module UserPermissionReport::WarehouseReports
   class ReportsController < ApplicationController
+    include WarehouseReportAuthorization
     before_action :set_group_associations
 
     def index

--- a/drivers/user_permission_report/app/models/user_permission_report/report.rb
+++ b/drivers/user_permission_report/app/models/user_permission_report/report.rb
@@ -17,7 +17,6 @@ module UserPermissionReport
     # Data for HMIS sheet in excel export
     def hmis_data
       return unless HmisEnforcement.hmis_enabled?
-      return unless @current_user.as_hmis_user.can_audit_users?
 
       hmis_users = Hmis::User.order(:last_name, :first_name).
         includes(access_controls: [:access_group, :user_group, :role])


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/5237

Previously, the HMIS `can_audit_users` permission was required to include the HMIS user ACL information on the User Permission Report.

After some discussion with customers, we determined this is not appropriate because:
- It is helpful to grant the User Permission Report to Site Managers so they can review access for their staff. OTOH those Site Managers should NOT have permission to audit all HMIS users activity.
- The HMIS `can_audit_users` permission grants access to audit ALL users in HMIS, including seeing which clients they have viewed and which edits they have made, which necessarily involves exposing sensitive client data. The User Permission Report, however, does not expose any client data. 
- There is no need to hide the HMIS ACL summary from Warehouse-only users. A little uncertain here, but this seems right to me since it's technically the same user list.

## Type of change
permission change

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
