### PR TITLE
tests for non-adult inclusion in spm m1b

### DIFF
--- a/drivers/hud_spm_report/spec/models/fy2024/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2024/measure_1b_spec.rb
@@ -885,7 +885,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: '2022-09-01'.to_date, # HoH date to street
         relationship_to_ho_h: 1, # Head of household
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create child enrollment with same entry date as HoH but NO date to street
@@ -896,7 +896,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil, # No date to street data
         relationship_to_ho_h: 3, # Child
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create adult member with same entry date but NO date to street
@@ -907,7 +907,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil, # No date to street data
         relationship_to_ho_h: 2, # Adult
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create unknown age member with same entry date but NO date to street
@@ -918,7 +918,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil, # No date to street data
         relationship_to_ho_h: 2, # Other household member
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Setup and run the report
@@ -980,7 +980,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: '2022-09-01'.to_date,
         relationship_to_ho_h: 1,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create child enrollment with DIFFERENT entry date than HoH
@@ -991,7 +991,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil, # No date to street data
         relationship_to_ho_h: 3,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Setup and run the report
@@ -1043,7 +1043,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: '2022-09-01'.to_date,
         relationship_to_ho_h: 1,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create younger child enrollment
@@ -1054,7 +1054,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil,
         relationship_to_ho_h: 3,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create older child enrollment (17 at entry)
@@ -1065,7 +1065,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil,
         relationship_to_ho_h: 3,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create client who turns 18 during enrollment
@@ -1076,7 +1076,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: nil,
         relationship_to_ho_h: 3,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Setup and run the report
@@ -1136,7 +1136,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: '2022-09-01'.to_date,
         relationship_to_ho_h: 1,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Create child enrollment WITH its own date to street
@@ -1147,7 +1147,7 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
         exit_date: '2023-01-15'.to_date,
         date_to_street_essh: '2022-10-01'.to_date, # Child has own date to street
         relationship_to_ho_h: 3,
-        household_id: household_id
+        household_id: household_id,
       )
 
       # Setup and run the report

--- a/drivers/hud_spm_report/spec/models/fy2024/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2024/measure_1b_spec.rb
@@ -862,4 +862,317 @@ RSpec.describe HudSpmReport::Generators::Fy2024::MeasureOne, type: :model do
       end
     end
   end
+
+  context 'with propagation of date to street from HoH to child household members' do
+    before do
+      # Create an ES project
+      @es_project = create_project(project_type: 0) # ES-EE
+
+      # Create household members: HoH, child, and adult
+      @head_of_household = create_client_with_warehouse_link(dob: '1980-01-01')
+      @child = create_client_with_warehouse_link(dob: '2015-01-01') # Age 7-8 during report period
+      @adult_member = create_client_with_warehouse_link(dob: '1990-01-01')
+      @unknown_age_member = create_client_with_warehouse_link(dob: nil) # No DOB = unknown age
+
+      # Create household ID
+      household_id = 'test_household_456'
+
+      # Create head of household enrollment with prior living situation date
+      create_enrollment(
+        client: @head_of_household,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: '2022-09-01'.to_date, # HoH date to street
+        relationship_to_ho_h: 1, # Head of household
+        household_id: household_id
+      )
+
+      # Create child enrollment with same entry date as HoH but NO date to street
+      create_enrollment(
+        client: @child,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date, # Same entry date as HoH
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil, # No date to street data
+        relationship_to_ho_h: 3, # Child
+        household_id: household_id
+      )
+
+      # Create adult member with same entry date but NO date to street
+      create_enrollment(
+        client: @adult_member,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date, # Same entry date as HoH
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil, # No date to street data
+        relationship_to_ho_h: 2, # Adult
+        household_id: household_id
+      )
+
+      # Create unknown age member with same entry date but NO date to street
+      create_enrollment(
+        client: @unknown_age_member,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date, # Same entry date as HoH
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil, # No date to street data
+        relationship_to_ho_h: 2, # Other household member
+        household_id: household_id
+      )
+
+      # Setup and run the report
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2024::MeasureOne)
+    end
+
+    it 'propagates date to street from HoH to children but not to adults or unknown age members' do
+      # Verify that all members are in the universe
+      expect(@report.universe('m1b1').members.count).to eq(4)
+
+      # Find episodes for each household member
+      episodes = @report.universe('m1b1').members.map(&:universe_membership)
+      hoh_episode = episodes.find { |e| e.client_id == @head_of_household.destination_client.id }
+      child_episode = episodes.find { |e| e.client_id == @child.destination_client.id }
+      adult_episode = episodes.find { |e| e.client_id == @adult_member.destination_client.id }
+      unknown_age_episode = episodes.find { |e| e.client_id == @unknown_age_member.destination_client.id }
+
+      # Expected first date for head of household: Sep 1 (prior living situation)
+      expect(hoh_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Child should inherit HoH's prior living situation date
+      # Expected first date for child: Sep 1 (inherited from HoH)
+      expect(child_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Adult should NOT inherit HoH's prior living situation date
+      # Instead should use entry date as first date
+      expect(adult_episode.first_date).to eq('2022-11-01'.to_date)
+
+      # Unknown age should NOT inherit HoH's prior living situation date
+      # Instead should use entry date as first date
+      expect(unknown_age_episode.first_date).to eq('2022-11-01'.to_date)
+
+      # Days homeless calculation should reflect the appropriate start dates
+      expect(hoh_episode.days_homeless).to eq(136) # 2022-09-01 to 2023-01-14 = 136 days
+      expect(child_episode.days_homeless).to eq(136) # Should match HoH
+      expect(adult_episode.days_homeless).to eq(75) # 2022-11-01 to 2023-01-14 = 75 days
+      expect(unknown_age_episode.days_homeless).to eq(75) # Same as adult
+    end
+  end
+
+  context 'with child joining household after HoH entry' do
+    before do
+      # Create an ES project
+      @es_project = create_project(project_type: 0) # ES-EE
+
+      # Create household members
+      @head_of_household = create_client_with_warehouse_link(dob: '1980-01-01')
+      @child = create_client_with_warehouse_link(dob: '2015-01-01')
+
+      # Create household ID
+      household_id = 'test_household_789'
+
+      # Create head of household enrollment with prior living situation date
+      create_enrollment(
+        client: @head_of_household,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: '2022-09-01'.to_date,
+        relationship_to_ho_h: 1,
+        household_id: household_id
+      )
+
+      # Create child enrollment with DIFFERENT entry date than HoH
+      create_enrollment(
+        client: @child,
+        project: @es_project,
+        entry_date: '2022-12-01'.to_date, # Different entry date than HoH
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil, # No date to street data
+        relationship_to_ho_h: 3,
+        household_id: household_id
+      )
+
+      # Setup and run the report
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2024::MeasureOne)
+    end
+
+    it 'does not propagate date to street from HoH to child with different entry date' do
+      # Verify that all members are in the universe
+      expect(@report.universe('m1b1').members.count).to eq(2)
+
+      # Find episodes for each household member
+      episodes = @report.universe('m1b1').members.map(&:universe_membership)
+      hoh_episode = episodes.find { |e| e.client_id == @head_of_household.destination_client.id }
+      child_episode = episodes.find { |e| e.client_id == @child.destination_client.id }
+
+      # Expected first date for head of household: Sep 1 (prior living situation)
+      expect(hoh_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Child should NOT inherit HoH's prior living situation date because entry dates differ
+      # Expected first date for child: Dec 1 (own entry date)
+      expect(child_episode.first_date).to eq('2022-12-01'.to_date)
+
+      # Days homeless calculation should reflect the appropriate start dates
+      expect(hoh_episode.days_homeless).to eq(136) # 2022-09-01 to 2023-01-14 = 136 days
+      expect(child_episode.days_homeless).to eq(45) # 2022-12-01 to 2023-01-14 = 45 days
+    end
+  end
+
+  context 'with multiple children of different ages in household' do
+    before do
+      # Create an ES project
+      @es_project = create_project(project_type: 0) # ES-EE
+
+      # Create household members
+      @head_of_household = create_client_with_warehouse_link(dob: '1980-01-01')
+      @younger_child = create_client_with_warehouse_link(dob: '2015-01-01') # Age 7-8
+      @older_child = create_client_with_warehouse_link(dob: '2005-01-01') # Age 17-18
+      @adult_turning_18 = create_client_with_warehouse_link(dob: '2004-11-15') # Turns 18 during enrollment
+
+      # Create household ID
+      household_id = 'test_household_101'
+
+      # Create head of household enrollment
+      create_enrollment(
+        client: @head_of_household,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: '2022-09-01'.to_date,
+        relationship_to_ho_h: 1,
+        household_id: household_id
+      )
+
+      # Create younger child enrollment
+      create_enrollment(
+        client: @younger_child,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil,
+        relationship_to_ho_h: 3,
+        household_id: household_id
+      )
+
+      # Create older child enrollment (17 at entry)
+      create_enrollment(
+        client: @older_child,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil,
+        relationship_to_ho_h: 3,
+        household_id: household_id
+      )
+
+      # Create client who turns 18 during enrollment
+      create_enrollment(
+        client: @adult_turning_18,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: nil,
+        relationship_to_ho_h: 3,
+        household_id: household_id
+      )
+
+      # Setup and run the report
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2024::MeasureOne)
+    end
+
+    it 'propagates date to street to all children, even if they turn 18 during enrollment' do
+      # Verify that all members are in the universe
+      expect(@report.universe('m1b1').members.count).to eq(4)
+
+      # Find episodes for each household member
+      episodes = @report.universe('m1b1').members.map(&:universe_membership)
+      hoh_episode = episodes.find { |e| e.client_id == @head_of_household.destination_client.id }
+      younger_child_episode = episodes.find { |e| e.client_id == @younger_child.destination_client.id }
+      older_child_episode = episodes.find { |e| e.client_id == @older_child.destination_client.id }
+      adult_turning_18_episode = episodes.find { |e| e.client_id == @adult_turning_18.destination_client.id }
+
+      # Expected first date for head of household: Sep 1 (prior living situation)
+      expect(hoh_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Younger child should inherit HoH's prior living situation date
+      expect(younger_child_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Older child should inherit HoH's prior living situation date (was 17 at entry)
+      expect(older_child_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Client who turns 18 during enrollment should inherit HoH's prior living situation date
+      # Age at entry is what matters (17), not age during entire enrollment
+      expect(adult_turning_18_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # All should have the same days homeless calculation
+      expect(hoh_episode.days_homeless).to eq(136)
+      expect(younger_child_episode.days_homeless).to eq(136)
+      expect(older_child_episode.days_homeless).to eq(136)
+      expect(adult_turning_18_episode.days_homeless).to eq(136)
+    end
+  end
+
+  context 'with child having their own date to street value' do
+    before do
+      # Create an ES project
+      @es_project = create_project(project_type: 0) # ES-EE
+
+      # Create household members
+      @head_of_household = create_client_with_warehouse_link(dob: '1980-01-01')
+      @child_with_data = create_client_with_warehouse_link(dob: '2015-01-01')
+
+      # Create household ID
+      household_id = 'test_household_202'
+
+      # Create head of household enrollment
+      create_enrollment(
+        client: @head_of_household,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: '2022-09-01'.to_date,
+        relationship_to_ho_h: 1,
+        household_id: household_id
+      )
+
+      # Create child enrollment WITH its own date to street
+      create_enrollment(
+        client: @child_with_data,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2023-01-15'.to_date,
+        date_to_street_essh: '2022-10-01'.to_date, # Child has own date to street
+        relationship_to_ho_h: 3,
+        household_id: household_id
+      )
+
+      # Setup and run the report
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2024::MeasureOne)
+    end
+
+    it 'uses child\'s own date to street value when it exists' do
+      # Verify that all members are in the universe
+      expect(@report.universe('m1b1').members.count).to eq(2)
+
+      # Find episodes for each household member
+      episodes = @report.universe('m1b1').members.map(&:universe_membership)
+      hoh_episode = episodes.find { |e| e.client_id == @head_of_household.destination_client.id }
+      child_episode = episodes.find { |e| e.client_id == @child_with_data.destination_client.id }
+
+      # Expected first date for head of household: Sep 1 (prior living situation)
+      expect(hoh_episode.first_date).to eq('2022-09-01'.to_date)
+
+      # Child should use its own date to street, not inherit from HoH
+      expect(child_episode.first_date).to eq('2022-10-01'.to_date)
+
+      # Days homeless calculation should reflect the appropriate start dates
+      expect(hoh_episode.days_homeless).to eq(136) # 2022-09-01 to 2023-01-14 = 136 days
+      expect(child_episode.days_homeless).to eq(106) # 2022-10-01 to 2023-01-14 = 106 days
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
tests for non-adult inclusion in spm m1b. Checks the following behavior described in the spec:
```md
If the HMIS also collects this element on children and unknown-age household members, their data should be used in measure 1b.  If the HMIS does not collect this element on child household members:
* The data from the head of household’s response to 3.917 should be propagated to these children for the purposes of measure 1b. 
* This applies to any household member whose age is <= 17 (calculated according to the HMIS Reporting Glossary), regardless of their relationship to the head of household, but not clients of unknown age.
* Only propagate the head of household’s data to children with the same [project start date] as the head of household.
```

## Type of change
tests
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code


