### PR TITLE
Fix rubocop slicing range issue

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -209,10 +209,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     searchable_to(user).where(id: source_id)
   end
 
-  def ssn_serial
-    self.SSN&.[](-4..)
-  end
-
   def warehouse_id
     warehouse_client_source&.destination_id
   end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 class Hmis::Hud::Client < Hmis::Hud::Base
   extend OrderAsSpecified
   include ::HmisStructure::Client
@@ -208,7 +210,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   def ssn_serial
-    self.SSN&.[](-4..-1)
+    self.SSN&.[](-4..)
   end
 
   def warehouse_id


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes rubocop:
```
Errors on lines you didn't modify:
/Users/medwards/Documents/hmis-warehouse/drivers/hmis/app/models/hmis/hud/client.rb:213:13: C: [Correctable] Style/SlicingWithRange: Prefer `-4..` over `-4..-1`.
```
Question: Searching `ssn_serial` in the codebase shows inputs, but unless I am missing something, I'm not sure this `ssn_serial` attribute on the client is actually used anywhere.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Rubocop cleanup

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail - I played with this in the console to make sure it still works as expected. 
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
