### PR TITLE
Add custom ac HMIS Case Note feed

### DIFF
--- a/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
@@ -4,14 +4,17 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 FactoryBot.define do
   factory :hmis_hud_custom_case_note, class: 'Hmis::Hud::CustomCaseNote' do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
-    DateCreated { Date.parse('2019-01-01') }
-    DateUpdated { Date.parse('2019-01-01') }
+    information_date { Date.current }
+    date_created { Time.current }
+    date_updated { Time.current }
     content { 'test note' }
   end
 end

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
@@ -59,6 +59,7 @@ module HmisExternalApis::AcHmis
         'posting_export',
         'custom_fields_export',
         'pathways_export',
+        'case_note_export',
       ].freeze
     end
 
@@ -199,6 +200,23 @@ module HmisExternalApis::AcHmis
         io_streams: [
           OpenStruct.new(
             name: 'Pathways.csv',
+            io: export.output,
+          ),
+        ],
+      )
+
+      uploader.run!
+    end
+
+    def case_note_export
+      export = HmisExternalApis::AcHmis::Exporters::CaseNoteExport.new
+      export.run!
+
+      uploader = Exporters::DataWarehouseUploader.new(
+        filename_format: '%Y-%m-%d-case-notes.zip',
+        io_streams: [
+          OpenStruct.new(
+            name: 'CaseNotes.csv',
             io: export.output,
           ),
         ],

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -1,0 +1,62 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: false
+
+module HmisExternalApis::AcHmis::Exporters
+  class CaseNoteExport
+    include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
+
+    def run!
+      Rails.logger.info 'Generating content of case note export'
+
+      write_row(columns)
+      total = case_notes.count
+
+      Rails.logger.error "There are #{total} addresses to export. That doesn't look right" if total < 10
+
+      case_notes.find_each.with_index do |case_note, i|
+        Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?
+
+        warehouse_id = case_note.client.warehouse_id
+        next unless warehouse_id.present? # Client doesn't have a destination client ID yet. Skip since it wont be in Client.csv anyway.
+
+        values = [
+          warehouse_id, # Matches PersonalID in HMIS CSV Export
+          case_note.enrollment.id, # Matches EnrollmentID in HMIS CSV Export
+          case_note.id,
+          case_note.content,
+          case_note.information_date,
+          case_note.user.id, # Matches User.csv in HMIS CSV Export
+          case_note.date_created,
+          case_note.date_updated,
+        ]
+        write_row(values)
+      end
+    end
+
+    def columns
+      [
+        'PersonalID',       # PersonalID matching HMIS CSV export (warehouse destination id)
+        'EnrollmentID',     # EnrollmentID matching HMIS CSV export (database id)
+        'CaseNoteID',       # Unique internal identifier for this note. Will be consistent between exports.
+        'NoteContent',      # Content of the note
+        'InformationDate',  # Information Date collected with the note
+        'UserID',           # User who most recently updated the note. Join with User.csv in HMIS CSV Export to find name and email.
+        'DateCreated',      # Timestamp when the note was created
+        'DateUpdated',      # Timestamp when the note was last updated
+      ]
+    end
+
+    private def case_notes
+      Hmis::Hud::CustomCaseNote.where(data_source: data_source).
+        joins(:enrollment).
+        merge(Hmis::Hud::Enrollment.not_in_progress). # drop WIP Enrollments, which won't be present in Enrollment.csv export
+        preload(:enrollment, :user, client: :warehouse_client_source). # preload to get client destination id
+        distinct
+    end
+  end
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -19,7 +19,7 @@ module HmisExternalApis::AcHmis::Exporters
       case_notes.find_each.with_index do |case_note, i|
         Rails.logger.info "Processed #{i} of #{total}" if (i % 1_000).zero?
 
-        warehouse_id = case_note.client.warehouse_id
+        warehouse_id = case_note.client&.warehouse_id
         next unless warehouse_id.present? # Client doesn't have a destination client ID yet. Skip since it wont be in Client.csv anyway.
 
         values = [

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module HmisExternalApis::AcHmis::Exporters
   class CaseNoteExport
@@ -16,10 +16,8 @@ module HmisExternalApis::AcHmis::Exporters
       write_row(columns)
       total = case_notes.count
 
-      Rails.logger.error "There are #{total} case notes to export. That doesn't look right" if total < 10
-
       case_notes.find_each.with_index do |case_note, i|
-        Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?
+        Rails.logger.info "Processed #{i} of #{total}" if (i % 1_000).zero?
 
         warehouse_id = case_note.client.warehouse_id
         next unless warehouse_id.present? # Client doesn't have a destination client ID yet. Skip since it wont be in Client.csv anyway.

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -16,7 +16,7 @@ module HmisExternalApis::AcHmis::Exporters
       write_row(columns)
       total = case_notes.count
 
-      Rails.logger.error "There are #{total} addresses to export. That doesn't look right" if total < 10
+      Rails.logger.error "There are #{total} case notes to export. That doesn't look right" if total < 10
 
       case_notes.find_each.with_index do |case_note, i|
         Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -40,7 +40,7 @@ module HmisExternalApis::AcHmis::Exporters
 
     def columns
       [
-        'CaseNoteID',       # Unique internal identifier for this note. Will be consistent between exports.
+        'CaseNoteID',       # Unique internal id for this note. Matches RecordId in CustomFieldValues.csv
         'EnrollmentID',     # EnrollmentID matching HMIS CSV export (database id)
         'PersonalID',       # PersonalID matching HMIS CSV export (warehouse destination id)
         'InformationDate',  # Information Date collected with the note

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/case_note_export.rb
@@ -25,14 +25,14 @@ module HmisExternalApis::AcHmis::Exporters
         next unless warehouse_id.present? # Client doesn't have a destination client ID yet. Skip since it wont be in Client.csv anyway.
 
         values = [
-          warehouse_id, # Matches PersonalID in HMIS CSV Export
-          case_note.enrollment.id, # Matches EnrollmentID in HMIS CSV Export
           case_note.id,
-          case_note.content,
+          case_note.enrollment.id, # Matches EnrollmentID in HMIS CSV Export
+          warehouse_id, # Matches PersonalID in HMIS CSV Export
           case_note.information_date,
-          case_note.user.id, # Matches User.csv in HMIS CSV Export
+          case_note.content,
           case_note.date_created,
           case_note.date_updated,
+          case_note.user.id, # Matches User.csv in HMIS CSV Export
         ]
         write_row(values)
       end
@@ -40,18 +40,20 @@ module HmisExternalApis::AcHmis::Exporters
 
     def columns
       [
-        'PersonalID',       # PersonalID matching HMIS CSV export (warehouse destination id)
-        'EnrollmentID',     # EnrollmentID matching HMIS CSV export (database id)
         'CaseNoteID',       # Unique internal identifier for this note. Will be consistent between exports.
-        'NoteContent',      # Content of the note
+        'EnrollmentID',     # EnrollmentID matching HMIS CSV export (database id)
+        'PersonalID',       # PersonalID matching HMIS CSV export (warehouse destination id)
         'InformationDate',  # Information Date collected with the note
-        'UserID',           # User who most recently updated the note. Join with User.csv in HMIS CSV Export to find name and email.
+        'NoteContent',      # Content of the note
         'DateCreated',      # Timestamp when the note was created
         'DateUpdated',      # Timestamp when the note was last updated
+        'UserID',           # User who most recently updated the note. Join with User.csv in HMIS CSV Export to find name and email.
       ]
     end
 
-    private def case_notes
+    private
+
+    def case_notes
       Hmis::Hud::CustomCaseNote.where(data_source: data_source).
         joins(:enrollment).
         merge(Hmis::Hud::Enrollment.not_in_progress). # drop WIP Enrollments, which won't be present in Enrollment.csv export

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/move_in_address_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/move_in_address_export.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
 module HmisExternalApis::AcHmis::Exporters
   class MoveInAddressExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
@@ -20,7 +22,7 @@ module HmisExternalApis::AcHmis::Exporters
         Rails.logger.info "Processed #{i} of #{total}" if (i % 1000).zero?
 
         warehouse_id = address.client.warehouse_id
-        next unless warehouse_id.present?
+        next unless warehouse_id.present? # Client doesn't have a destination client ID yet. Skip since it wont be in Client.csv anyway.
 
         values = [
           warehouse_id, # PersonalID matching HMIS CSV export
@@ -45,8 +47,8 @@ module HmisExternalApis::AcHmis::Exporters
       Hmis::Hud::CustomClientAddress.where(data_source: data_source).
         move_in.
         joins(:enrollment).
-        merge(Hmis::Hud::Enrollment.not_in_progress).
-        preload(:enrollment, client: :warehouse_client_source).
+        merge(Hmis::Hud::Enrollment.not_in_progress). # drop WIP Enrollments, which won't be present in Enrollment.csv export
+        preload(:enrollment, client: :warehouse_client_source). # preload to get client destination id
         distinct
     end
   end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/move_in_address_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/move_in_address_export.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module HmisExternalApis::AcHmis::Exporters
   class MoveInAddressExport

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CaseNoteExport, type: :model
     result = CSV.parse(output, headers: true)
     expect(result.length).to eq(1)
 
-    expect(result.first['PersonalID']).to eq(client.warehouse_id.to_s)
-    expect(result.first['EnrollmentID']).to eq(enrollment.id.to_s)
     expect(result.first['CaseNoteID']).to eq(case_note_1.id.to_s)
+    expect(result.first['EnrollmentID']).to eq(enrollment.id.to_s)
+    expect(result.first['PersonalID']).to eq(client.warehouse_id.to_s)
     expect(result.first['NoteContent']).to eq(case_note_1.content)
   end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
@@ -1,0 +1,50 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: false
+
+require 'rails_helper'
+
+RSpec.describe HmisExternalApis::AcHmis::Exporters::CaseNoteExport, type: :model do
+  let!(:ds) { create(:hmis_data_source) }
+  let!(:p1) { create(:hmis_hud_project, data_source: ds) }
+  let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: ds) }
+  let!(:enrollment) { create(:hmis_hud_enrollment, data_source: ds, client: client, project: p1) }
+  let!(:case_note_1) { create(:hmis_hud_custom_case_note, data_source: ds, client: client, enrollment: enrollment) }
+
+  let(:subject) { HmisExternalApis::AcHmis::Exporters::CaseNoteExport.new }
+  let(:output) do
+    subject.output.rewind
+    subject.output.read
+  end
+
+  it 'gets case notes' do
+    subject.run!
+    expect(subject.send(:case_notes).length).to eq(1)
+  end
+
+  it 'makes a csv' do
+    subject.run!
+    result = CSV.parse(output, headers: true)
+    expect(result.length).to eq(1)
+
+    expect(result.first['PersonalID']).to eq(client.warehouse_id.to_s)
+    expect(result.first['EnrollmentID']).to eq(enrollment.id.to_s)
+    expect(result.first['CaseNoteID']).to eq(case_note_1.id.to_s)
+    expect(result.first['NoteContent']).to eq(case_note_1.content)
+  end
+
+  it 'quotes newlines' do
+    case_note_1.update!(content: "first\nsecond")
+
+    subject.run!
+
+    result = CSV.parse(output, headers: true)
+
+    expect(result.length).to eq(1)
+    expect(result.first['NoteContent']).to eq(case_note_1.content)
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require 'rails_helper'
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Add a new feed for case notes.

How to test:
- I tested in the rails console by running in the console: `export = HmisExternalApis::AcHmis::Exporters::CaseNoteExport.new; export.run!` and writing `export.output` to a csv

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
