### PR TITLE
Fix bug in CLS proc introduced by StrictAttributes

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/current_living_situation_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/current_living_situation_processor.rb
@@ -24,8 +24,8 @@ module Hmis::Hud::Processors
       # See the hack described in HmisSchema::CurrentLivingSituation for more detail on why this works this way.
 
       # First check if the value is an integer; otherwise Hmis::Hud::Project.find_by will raise due to StrictAttributes
-      project_to_check = Hmis::StrictInteger::INT_RGX.match?(verified_by_project_id.to_s) ? verified_by_project_id : nil
-      verified_by_project = Hmis::Hud::Project.find_by(id: verified_by_project_id) if project_to_check
+      is_valid_int = Hmis::StrictInteger::INT_RGX.match?(verified_by_project_id.to_s)
+      verified_by_project = Hmis::Hud::Project.find_by(id: verified_by_project_id) if is_valid_int
 
       if verified_by_project
         # We collect project ID onto the non-HUD field `verified_by_project_id`,

--- a/drivers/hmis/app/models/hmis/hud/processors/current_living_situation_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/current_living_situation_processor.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Hmis::Hud::Processors
   class CurrentLivingSituationProcessor < Base
     def process(field, value)
@@ -15,12 +17,15 @@ module Hmis::Hud::Processors
       # convert HIDDEN to nil
       verified_by_project_id = value == Base::HIDDEN_FIELD_VALUE ? nil : value
 
-      verified_by_project = Hmis::Hud::Project.find_by(id: verified_by_project_id) if verified_by_project_id
       # Don't raise if we can't find the project. Migrated-in CLS in the DB would have `verified_by` set to a string and
       # null `verified_by_project_id`. HOWEVER, if then a migrated-in CLS form is ever re-submitted without changes to
-      # the "Verified By" dropdown, the `verified_by_project_id` field will be set to the `verified_by` string
+      # the "Verified By" dropdown, the `verified_by_project_id` field will be submitted as the `verified_by` string
       # (not a project ID). In that case, we leave everything as-is without any db changes to either verified-by field.
       # See the hack described in HmisSchema::CurrentLivingSituation for more detail on why this works this way.
+
+      # First check if the value is an integer; otherwise Hmis::Hud::Project.find_by will raise due to StrictAttributes
+      project_to_check = Hmis::StrictInteger::INT_RGX.match?(verified_by_project_id.to_s) ? verified_by_project_id : nil
+      verified_by_project = Hmis::Hud::Project.find_by(id: verified_by_project_id) if project_to_check
 
       if verified_by_project
         # We collect project ID onto the non-HUD field `verified_by_project_id`,

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -2221,11 +2221,12 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         end
 
         context 'when verified_by already exists, but verified_by_project_id is null' do
+          let(:migrated_in_project_name) { 'Some random value with no relation to a project that probably came from a migration' }
           let!(:cls) do
             create(
               :hmis_current_living_situation,
               client: c1, enrollment: e1, data_source: ds1, user: u1,
-              VerifiedBy: 'Some random value with no relation to a project that probably came from a migration'
+              VerifiedBy: migrated_in_project_name
             )
           end
 
@@ -2245,7 +2246,7 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
           end
 
           it 'should not raise when verified_by_project_id is unrecognized' do
-            values = hud_values.merge({ 'CurrentLivingSituation.verifiedByProjectId' => '1' }) # a random ID that doesn't correspond to a project
+            values = hud_values.merge({ 'CurrentLivingSituation.verifiedByProjectId' => migrated_in_project_name })
 
             expect do
               process_record(record: cls, hud_values: values, user: hmis_user, definition: definition)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fix bug introduced here https://github.com/greenriver/hmis-warehouse/pull/5227#discussion_r2031187620
- Thanks to `StrictAttributes`, `Hmis::Hud::Project.find_by(id: 'random string')` will now fail with an `ArgumentError`.

## Type of change
Bug fix (bug not on prod)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
