### PR TITLE
Fix bug for client locations without destination client

### DIFF
--- a/drivers/client_location_history/app/models/client_location_history/location.rb
+++ b/drivers/client_location_history/app/models/client_location_history/location.rb
@@ -49,16 +49,14 @@ module ClientLocationHistory
 
     private def name_for_label(user)
       client_name = client.pii_provider(user: user).full_name
-      if user.can_view_clients?
-        # These can be source clients, so make sure any link is going to their destination client
-        destination = client
-        destination = client.destination_client unless client.destination?
-        return client_name unless destination # if no destination client yet, just show name
+      return client_name unless user.can_view_clients?
 
-        link_for(client_path(destination), client_name)
-      else
-        client_name
-      end
+      # These can be source clients, so make sure any link is going to their destination client
+      destination = client
+      destination = client.destination_client unless client.destination?
+      return client_name unless destination # if no destination client yet, just show name
+
+      link_for(client_path(destination), client_name)
     end
 
     private def link_for(path, text)

--- a/drivers/client_location_history/app/models/client_location_history/location.rb
+++ b/drivers/client_location_history/app/models/client_location_history/location.rb
@@ -48,13 +48,16 @@ module ClientLocationHistory
     end
 
     private def name_for_label(user)
+      client_name = client.pii_provider(user: user).full_name
       if user.can_view_clients?
         # These can be source clients, so make sure any link is going to their destination client
         destination = client
         destination = client.destination_client unless client.destination?
-        link_for(client_path(destination), client.pii_provider(user: user).full_name)
+        return client_name unless destination # if no destination client yet, just show name
+
+        link_for(client_path(destination), client_name)
       else
-        client.pii_provider(user: user).full_name
+        client_name
       end
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix bug where the project locations and client locations maps would crash if there were any locations tied to source clients that **did not yet have destination clients**. We can't assume that a source client always has a destination client. In this case the client processing is/was broken in demo, so destination clients weren't being created.

issue: https://github.com/open-path/Green-River/issues/7535
sentry error https://green-river.sentry.io/issues/6257102300/?project=4503977346662400&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=5

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
