### PR TITLE
Remove PITCount from PIT report, hide entirely for OP HMIS projects

### DIFF
--- a/app/views/projects/show.haml
+++ b/app/views/projects/show.haml
@@ -11,7 +11,7 @@
 .row.mb-6
   .col-sm-4
     .card
-      %table.table.table-striped.table-hover.mb-0
+      %table.table.table-striped.mb-0
         %tr
           %th Project Type
           %td
@@ -82,7 +82,7 @@
 
   .col-sm-4
     .card
-      %table.table.table-striped.table-hover.mb-0
+      %table.table.table-striped.mb-0
         %tr
           %th Project ID
           %td
@@ -103,9 +103,11 @@
           %td
             %span{data: {toggle: :tooltip, title: 'Determined based on related inventory files'}}
               = @project.main_population
-        %tr
-          %th PIT Count
-          %td= @project.PITCount
+        - unless @project.data_source.hmis?
+          %tr
+            %th
+              %span{data: {toggle: :tooltip, title: 'PITCount value from most recent Project.csv import'}} PIT Count
+            %td= @project.PITCount
   .col-sm-4.text-right
     - if project_policy.can_edit?
       .mb-4

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
@@ -6,12 +6,6 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-###
-# Copyright 2016 - 2023 Green River Data Analysis, LLC
-#
-# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
-###
-
 # PIT Notes
 #   CoCs should report on people based on where they are sleeping on the night of the count, as opposed to the program they are enrolled in.
 #    RRH + PH (don't count)
@@ -159,7 +153,8 @@ module HudPit::Generators::Pit::Fy2024
             project_type: last_service_history_enrollment.project_type,
             project_name: last_service_history_enrollment.project_name,
             project_id: last_service_history_enrollment.project.id,
-            project_hmis_pit_count: last_service_history_enrollment.project.PITCount,
+            # PITCount from Project.csv no longer shown. It is used mainly for non-HMIS participating projects (if at all). See issue #7497
+            # project_hmis_pit_count: last_service_history_enrollment.project.PITCount,
             entry_date: last_service_history_enrollment.entry_date,
             exit_date: last_service_history_enrollment.exit_date,
           }

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/projects.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/projects.rb
@@ -4,6 +4,11 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: false
+
+# Project-level PIT counts.
+#
+# This is NOT part of the HUD PIT reporting requirements; we do not expect them to be uploaded to HDX.
 module HudPit::Generators::Pit::Fy2024
   class Projects < Base
     QUESTION_NUMBER = 'Projects'.freeze
@@ -28,16 +33,15 @@ module HudPit::Generators::Pit::Fy2024
           'Project Name',
           'Client Count',
           'Household Count',
-          'PITCount from HMIS',
         ],
         row_labels: [],
         first_column: 'A',
-        last_column: 'E',
+        last_column: 'D',
         first_row: 2,
       }
 
       client_counts = universe.members.distinct.
-        group(:project_id, :project_name, :project_hmis_pit_count).
+        group(:project_id, :project_name).
         count(:client_id)
       household_counts = universe.members.distinct.
         group(:project_id, :project_name).
@@ -46,9 +50,9 @@ module HudPit::Generators::Pit::Fy2024
       metadata[:last_row] = client_counts.count + 1
       @report.answer(question: table_name).update(metadata: metadata)
       # there will always be at least as many clients as households, so loop over those
-      client_counts.each.with_index do |((project_id, project_name, pit_count), client_count), row_num|
+      client_counts.each.with_index do |((project_id, project_name), client_count), row_num|
         household_count = household_counts[[project_id, project_name]] || 0
-        [project_id, project_name, client_count, household_count, pit_count].each.with_index do |value, column_num|
+        [project_id, project_name, client_count, household_count].each.with_index do |value, column_num|
           cell = "#{(column_num + 1).to_csv_column}#{row_num + 2}"
 
           members = universe.members.where(a_t[:project_id].eq(project_id))

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/projects.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/projects.rb
@@ -4,14 +4,14 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 # Project-level PIT counts.
 #
 # This is NOT part of the HUD PIT reporting requirements; we do not expect them to be uploaded to HDX.
 module HudPit::Generators::Pit::Fy2024
   class Projects < Base
-    QUESTION_NUMBER = 'Projects'.freeze
+    QUESTION_NUMBER = 'Projects'
 
     def self.filter_pending_associations(pending_associations)
       pending_associations


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/7497

* Remove `PITCount in HMIS` column from the 2024 PIT. This was causing confusion. It is often unused or used only for non-hmis-participating projects.
* Hide PITCount on the project page for HMIS-managed projects, since we dont maintain the field so it will be out of date. For imported projects, continue to show it and add a tooltip.
* Fix tables that used `table-hover` and cursor pointer even though the rows are not clickable. (accessibility fix)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
