### PR TITLE
Fix staff assignment bug for limited visibility enrollments

### DIFF
--- a/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
+++ b/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Concern shared across query resolves (BaseObject) and mutations (BaseMutation/CleanBaseMutation)
 module GraphqlApplicationHelper
   extend ActiveSupport::Concern
@@ -35,7 +37,16 @@ module GraphqlApplicationHelper
   # Use data loader to load an ActiveRecord association.
   # Note: 'scope' is intended for ordering or to modify the default
   # association in a way that is constant with respect to the resolver,
-  # for example `scope: FooBar.order(:name)`. It is NOT used to filter down results.
+  #
+  # Examples of "constant with respect to the resolver" scopes:
+  #
+  # OK:
+  #   load_ar_association(object, :foo_bar, scope: FooBar.where(foo: true))
+  #   load_ar_association(object, :foo_bar, scope: FooBar.viewable_by(current_user))
+  #
+  # Not OK:
+  #   load_ar_association(object, :foo_bar, scope: FooBar.where(bar: object.bar))
+  #
   def load_ar_association(object, association_name, scope: nil)
     raise "object must be an ApplicationRecord, got #{object.class.name}" unless object.is_a?(ApplicationRecord)
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3568,6 +3568,7 @@ type Enrollment {
   Present if this household was enrolled as the result of a referral from another project.
   """
   sourceReferralPosting: ReferralPosting
+  staffAssignments: [StaffAssignment!]
   status: EnrollmentStatus!
   subsidyAtRisk: NoYesMissing
   targetScreenReqd: NoYesMissing

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5338,6 +5338,7 @@ type HmisParticipationsPaginated {
 type Household {
   anyInProgress: Boolean!
   assessments(filters: AssessmentsForHouseholdFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
+  currentStaffAssignments: [StaffAssignment!]!
   earliestEntryDate: ISO8601Date!
   householdClients: [HouseholdClient!]!
   householdSize: Int!

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -120,6 +120,8 @@ module Types
     field :household_short_id, ID, null: false
     field :household, HmisSchema::Household, null: false
     field :household_size, Integer, null: false
+    field :staff_assignments, [Types::HmisSchema::StaffAssignment], null: true
+
     # Associated records. These automatically require the "can_view_enrollment_details" permission
     # because they use the overridden 'field' class method.
     assessments_field filter_args: { omit: [:project, :project_type], type_name: 'AssessmentsForEnrollment' }
@@ -497,6 +499,10 @@ module Types
         contact_date: contact_date,
         contact_type: contact_type,
       }
+    end
+
+    def staff_assignments
+      load_ar_association(object, :staff_assignments, scope: Hmis::StaffAssignment.order(created_at: :desc, id: :desc))
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -14,6 +14,9 @@ module Types
     field :short_id, ID, null: false
     field :household_clients, [HmisSchema::HouseholdClient], null: false
     field :household_size, Int, null: false
+
+    field :current_staff_assignments, [HmisSchema::StaffAssignment], null: false
+    # historical paginated staff assignments. no longer used to fetch "current" staff assignments because of performance reasons, the currentStaffAssignments field is used instead.
     field :staff_assignments, HmisSchema::StaffAssignment.page_type, null: true do
       argument :is_currently_assigned, Boolean, required: false
     end
@@ -54,16 +57,20 @@ module Types
       resolve_assessments(**args)
     end
 
+    def current_staff_assignments
+      load_ar_association(object, :staff_assignments, scope: Hmis::StaffAssignment.order(created_at: :desc, id: :desc))
+    end
+
+    # This field results in N+1 because it is paginated. It is used for displaying the staff assignment history
+    # for a particular household. When loading staff assignments on a batch of households,
+    # use the 'current_staff_assignments' field instead.
     def staff_assignments(is_currently_assigned: true)
-      # There's no current use case for returning all (both currently assigned and formerly assigned)
-      # in the same query, but we could update this to support that use case if it arises.
-      scope = load_ar_association(object, :staff_assignments).
-        viewable_by(current_user).
-        order(created_at: :desc, id: :desc)
+      scope = object.staff_assignments.order(created_at: :desc, id: :desc)
+
       if is_currently_assigned
         scope
       else
-        scope.with_deleted.where.not(deleted_at: nil).order(created_at: :desc, deleted_at: :desc, id: :desc)
+        scope.only_deleted.order(created_at: :desc, deleted_at: :desc, id: :desc)
       end
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/household.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/household.rb
@@ -61,17 +61,15 @@ module Types
       load_ar_association(object, :staff_assignments, scope: Hmis::StaffAssignment.order(created_at: :desc, id: :desc))
     end
 
-    # This field results in N+1 because it is paginated. It is used for displaying the staff assignment history
-    # for a particular household. When loading staff assignments on a batch of households,
-    # use the 'current_staff_assignments' field instead.
+    # This field results in N+1 because it is paginated.
+    # It is only used for displaying the staff assignment history for a particular household,
+    # so 'is_currently_assigned: false' is always passed from the frontend.
+    # When loading staff assignments on a *batch* of households, use the 'current_staff_assignments' field instead.
     def staff_assignments(is_currently_assigned: true)
       scope = object.staff_assignments.order(created_at: :desc, id: :desc)
+      return scope if is_currently_assigned
 
-      if is_currently_assigned
-        scope
-      else
-        scope.only_deleted.order(created_at: :desc, deleted_at: :desc, id: :desc)
-      end
+      scope.only_deleted.order(created_at: :desc, deleted_at: :desc, id: :desc)
     end
 
     def any_in_progress

--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -86,6 +86,8 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_one :current_unit, through: :active_unit_occupancy, class_name: 'Hmis::Unit', source: :unit
   has_one :current_unit_type, through: :current_unit, class_name: 'Hmis::UnitType', source: :unit_type
 
+  has_many :staff_assignments, class_name: 'Hmis::StaffAssignment', primary_key: [:data_source_id, :HouseholdID], foreign_key: [:data_source_id, :household_id]
+
   # Cached chronically homeless at entry
   has_one :ch_enrollment, class_name: 'Hmis::ChEnrollment', dependent: :destroy
 

--- a/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect do
           _, result = post_graphql(**adjusted_variables) { query }
           expect(result.dig('data', 'project', 'enrollments', 'nodes').size).to eq(enrollments.size), result.inspect
-        end.to make_database_queries(count: 10..50)
+        end.to make_database_queries(count: 10..55) # Query count is high due to optional fields, especially "last contact date". Can maybe optimize further
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
@@ -1,0 +1,198 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  before(:all) do
+    cleanup_test_environment
+  end
+
+  let!(:enrollments) do
+    10.times.map do
+      hoh_enrollment = create(:hmis_hud_enrollment, data_source: ds1, project: p1)
+      other_enrollment = create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: hoh_enrollment.household_id)
+
+      # add some services and staff assignments to test n+1 for optional columns
+      3.times { create :hmis_hud_service, data_source: ds1, project: p1, enrollment: hoh_enrollment, user: u1 }
+      3.times { create :hmis_custom_service, data_source: ds1, project: p1, enrollment: hoh_enrollment, user: u1 }
+      3.times { create :hmis_staff_assignment, data_source: ds1, enrollment: hoh_enrollment }
+
+      [hoh_enrollment, other_enrollment]
+    end.flatten
+  end
+
+  let!(:ds_access_control) do
+    create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
+  end
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  describe 'project enrollments' do
+    # Tests the query fetched from the HMIS frontend Project Enrollments table.
+    # This should be updated periodically to ensure it reflects the current query. The below query and variables are copied from browser dev tools network tab.
+    let(:query) do
+      <<~GRAPHQL
+        query GetProjectEnrollments($id: ID!, $filters: EnrollmentsForProjectFilterOptions, $sortOrder: EnrollmentSortOption, $limit: Int = 10, $offset: Int = 0, $includeStaffAssignment: Boolean = false, $includeMoveInDate: Boolean = false, $includeLastContact: Boolean = false) {
+          project(id: $id) {
+            id
+            enrollments(
+              limit: $limit
+              offset: $offset
+              sortOrder: $sortOrder
+              filters: $filters
+            ) {
+              offset
+              limit
+              nodesCount
+              nodes {
+                ...ProjectEnrollmentQueryEnrollmentFields
+                __typename
+              }
+              __typename
+            }
+            __typename
+          }
+        }
+
+        fragment ProjectEnrollmentQueryEnrollmentFields on Enrollment {
+          ...ProjectEnrollmentFields
+          ...EnrollmentWithOptionalFields
+          __typename
+        }
+
+        fragment ProjectEnrollmentFields on Enrollment {
+          id
+          lockVersion
+          entryDate
+          exitDate
+          autoExited
+          inProgress
+          relationshipToHoH
+          enrollmentCoc
+          householdId
+          householdShortId
+          householdSize
+          client {
+            id
+            ...ClientNameDobVet
+            ...ClientIdentificationFields
+            __typename
+          }
+          __typename
+        }
+
+        fragment ClientNameDobVet on Client {
+          ...ClientName
+          dob
+          veteranStatus
+          __typename
+        }
+
+        fragment ClientName on Client {
+          id
+          lockVersion
+          firstName
+          middleName
+          lastName
+          nameSuffix
+          __typename
+        }
+
+        fragment ClientIdentificationFields on Client {
+          id
+          lockVersion
+          dob
+          age
+          gender
+          pronouns
+          __typename
+        }
+
+        fragment EnrollmentWithOptionalFields on Enrollment {
+          moveInDate @include(if: $includeMoveInDate)
+          lastContact @include(if: $includeLastContact) {
+            contactDate
+            contactType
+            __typename
+          }
+          staffAssignments @include(if: $includeStaffAssignment) {
+            ...StaffAssignmentDetails
+            __typename
+          }
+          __typename
+        }
+
+        fragment StaffAssignmentDetails on StaffAssignment {
+          id
+          user {
+            id
+            name
+            __typename
+          }
+          staffAssignmentRelationship
+          assignedAt
+          unassignedAt
+          __typename
+        }
+      GRAPHQL
+    end
+
+    let(:variables) do
+      {
+        "id": p1.id.to_s,
+        "limit": 25,
+        "offset": 0,
+        "includeStaffAssignment": false,
+        "includeMoveInDate": false,
+        "includeLastContact": false,
+        "filters": {},
+        "sortOrder": 'MOST_RECENT',
+      }
+    end
+
+    it 'minimizes n+1 queries' do
+      expect do
+        _, result = post_graphql(**variables) { query }
+        expect(result.dig('data', 'project', 'enrollments', 'nodes').size).to eq(enrollments.size), result.inspect
+      end.to make_database_queries(count: 10..30)
+    end
+
+    it 'is responsive' do
+      expect do
+        _, result = post_graphql(**variables) { query }
+        expect(result.dig('data', 'project', 'enrollments', 'nodes').size).to eq(enrollments.size), result.inspect
+      end.to perform_under(300).ms
+    end
+
+    describe 'with optional columns' do
+      it 'minimizes n+1 queries' do
+        adjusted_variables = variables.merge({
+                                               "includeStaffAssignment": true,
+                                               "includeMoveInDate": true,
+                                               "includeLastContact": true,
+                                             })
+
+        expect do
+          _, result = post_graphql(**adjusted_variables) { query }
+          expect(result.dig('data', 'project', 'enrollments', 'nodes').size).to eq(enrollments.size), result.inspect
+        end.to make_database_queries(count: 10..50)
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
@@ -17,8 +19,15 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   let!(:enrollments) do
     10.times.map do
-      client = create :hmis_hud_client_complete, data_source: ds1, user: u1
-      create :hmis_hud_enrollment, data_source: ds1, project: p1, client: client, user: u1
+      hoh_enrollment = create(:hmis_hud_enrollment, data_source: ds1, project: p1)
+      create(:hmis_hud_enrollment, data_source: ds1, project: p1, household_id: hoh_enrollment.household_id)
+
+      # add some services and staff assignments to test n+1 for optional columns
+      3.times { create :hmis_hud_service, data_source: ds1, project: p1, enrollment: hoh_enrollment, user: u1 }
+      3.times { create :hmis_custom_service, data_source: ds1, project: p1, enrollment: hoh_enrollment, user: u1 }
+      3.times { create :hmis_staff_assignment, data_source: ds1, enrollment: hoh_enrollment }
+
+      hoh_enrollment
     end
   end
 
@@ -31,9 +40,11 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   describe 'project households' do
+    # Tests the query fetched from the HMIS frontend Project Households table.
+    # This should be updated periodically to ensure it reflects the current query. The below query and variables are copied from browser dev tools network tab.
     let(:query) do
       <<~GRAPHQL
-        query GetProjectHouseholds($id: ID!, $filters: HouseholdFilterOptions, $sortOrder: HouseholdSortOption, $limit: Int = 10, $offset: Int = 0) {
+          query GetProjectHouseholds($id: ID!, $filters: HouseholdFilterOptions, $sortOrder: HouseholdSortOption, $limit: Int = 10, $offset: Int = 0, $includeStaffAssignment: Boolean = false, $includeMoveInDate: Boolean = false, $includeLastContact: Boolean = false) {
           project(id: $id) {
             id
             households(
@@ -63,6 +74,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             ...ProjectEnrollmentsHouseholdClientFields
             __typename
           }
+          ...HouseholdWithStaffAssignments @include(if: $includeStaffAssignment)
           __typename
         }
 
@@ -77,15 +89,25 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           }
           enrollment {
             id
+            lockVersion
             entryDate
             exitDate
             inProgress
+            autoExited
+            moveInDate @include(if: $includeMoveInDate)
+            lastContact @include(if: $includeLastContact) {
+              contactDate
+              contactType
+              __typename
+            }
             __typename
           }
           __typename
         }
 
         fragment ClientName on Client {
+          id
+          lockVersion
           firstName
           middleName
           lastName
@@ -95,15 +117,33 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
         fragment ClientIdentificationFields on Client {
           id
+          lockVersion
           dob
           age
-          ssn
-          access {
-            id
-            canViewFullSsn
-            canViewPartialSsn
+          gender
+          pronouns
+          __typename
+        }
+
+        fragment HouseholdWithStaffAssignments on Household {
+          id
+          currentStaffAssignments {
+            ...StaffAssignmentDetails
             __typename
           }
+          __typename
+        }
+
+        fragment StaffAssignmentDetails on StaffAssignment {
+          id
+          user {
+            id
+            name
+            __typename
+          }
+          staffAssignmentRelationship
+          assignedAt
+          unassignedAt
           __typename
         }
       GRAPHQL
@@ -121,6 +161,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           ],
         },
         "sortOrder": 'MOST_RECENT',
+        "includeStaffAssignment": false,
+        "includeMoveInDate": false,
+        "includeLastContact": false,
       }
     end
 
@@ -149,6 +192,28 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         _, result = post_graphql({ id: p2.id.to_s, filters: { status: ['ACTIVE', 'INCOMPLETE'] } }) { query }
         expect(Hmis::Hud::Household.where(household_id: '1').count).to eq(1)
         expect(result.dig('data', 'project', 'households', 'nodes').count).to eq(1), result.inspect
+      end
+    end
+
+    describe 'with optional columns' do
+      let(:variables) do
+        {
+          "id": p1.id.to_s,
+          "limit": 10,
+          "offset": 0,
+          "filters": {},
+          "sortOrder": 'MOST_RECENT',
+          "includeStaffAssignment": true,
+          "includeMoveInDate": true,
+          "includeLastContact": true,
+        }
+      end
+
+      it 'minimizes n+1 queries' do
+        expect do
+          _, result = post_graphql(**variables) { query }
+          expect(result.dig('data', 'project', 'households', 'nodes').size).to eq(enrollments.size), result.inspect
+        end.to make_database_queries(count: 10..50) # Query count is high due to optional fields, especially "last contact date". Can maybe optimize further
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/7563
Frontend PR: https://github.com/greenriver/hmis-frontend/pull/1134 (check out for testing)

* Fix bug where client enrollment table would crash when viewing enrollments with limited access, by resolving staff assignments on the Enrollment rather than on the Household. Staff assignment will always resolve as null for limited-access enrollments. This also improves performance because we do not need to resolve the household type at all.
* Fix N+1 performance issue when resolving staff assignments on the Project Households and Project Enrollments tables
* Add/update performance tests for project enrollments & project households. Queries reflect current state on the linked frontend PR

See issue for testing instructions.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
