### PR TITLE
Preloader fix

### DIFF
--- a/drivers/hmis/app/graphql/sources/active_record_association.rb
+++ b/drivers/hmis/app/graphql/sources/active_record_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #

--- a/drivers/hmis/app/graphql/sources/active_record_association.rb
+++ b/drivers/hmis/app/graphql/sources/active_record_association.rb
@@ -15,16 +15,6 @@ class Sources::ActiveRecordAssociation < ::GraphQL::Dataloader::Source
   end
 
   def fetch(records)
-    # Rails.logger.info("preloading started #{records.first.class.name}.#{@association_name}") if records.any?
-    TodoOrDie('test behavior after rails upgrade, see #6019', if: Rails.version !~ /\A7\.0/)
-    # in rails 7.0, calling preloader more than once can cause unscoped queries, particularly with has-many-through.
-    # Resetting association before preload seems to address this
-    records.each do |record|
-      record.class.reflect_on_all_associations.each do |assoc|
-        record.association(assoc.name).reset
-      end
-    end
-
     ::ActiveRecord::Associations::Preloader.new(records: records, associations: [@association_name], scope: @scope).call
     results = records.map { |record| record.public_send(@association_name) }
     # Rails.logger.info("preloading complete #{records.first.class.name}.#{@association_name}") if records.any?

--- a/drivers/hmis/spec/models/active_record_preloader_spec.rb
+++ b/drivers/hmis/spec/models/active_record_preloader_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Sources::ActiveRecordAssociation do
+  describe 'preloader behavior' do
+    let!(:data_source) { create(:hmis_data_source) }
+    let!(:project) { create(:hmis_hud_project, data_source: data_source) }
+    let!(:project2) { create(:hmis_hud_project, data_source: data_source) }
+    let!(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, project: project) }
+    let!(:enrollment2) { create(:hmis_hud_enrollment, data_source: data_source, project: project) }
+    let!(:assessment) { create(:hmis_custom_assessment, data_source: data_source, enrollment: enrollment) }
+    let!(:assessment2) { create(:hmis_custom_assessment, data_source: data_source, enrollment: enrollment2) }
+
+    it 'handles multiple preloads without unscoped queries' do
+      records = [Hmis::Hud::CustomAssessment.find(assessment.id)]
+
+      # Warm up connections and table name caches
+      [Hmis::Hud::Project, Hmis::Hud::Enrollment, Hmis::Hud::CustomAssessment].each(&:connection)
+
+      queries = []
+      callback = ->(*, payload) { queries << payload[:sql] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        ActiveRecord::Associations::Preloader.new(records: records, associations: :project).call
+        ActiveRecord::Associations::Preloader.new(records: records, associations: :enrollment).call
+      end
+
+      enrollment_queries = queries.grep /"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/
+      expect(enrollment_queries.size).to eq(1)
+      project_queries = queries.grep /Project.*WHERE.*"Project"."id" = /
+      expect(project_queries.size).to eq(1)
+      expect(records.first.project).to eq(project)
+      expect(records.first.enrollment).to eq(enrollment)
+    end
+
+    it 'handles single preload with multiple associations' do
+      records = [Hmis::Hud::CustomAssessment.find(assessment.id)]
+
+      queries = []
+      callback = ->(*, payload) { queries << payload[:sql] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        ActiveRecord::Associations::Preloader.new(records: records, associations: [:project, :enrollment]).call
+      end
+
+      enrollment_queries = queries.grep /"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/
+      expect(enrollment_queries.size).to eq(1)
+      project_queries = queries.grep /Project.*WHERE.*"Project"."id" = /
+      expect(project_queries.size).to eq(1)
+      expect(records.first.project).to eq(project)
+      expect(records.first.enrollment).to eq(enrollment)
+    end
+  end
+end

--- a/drivers/hmis/spec/models/active_record_preloader_spec.rb
+++ b/drivers/hmis/spec/models/active_record_preloader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Sources::ActiveRecordAssociation do
@@ -24,9 +26,9 @@ RSpec.describe Sources::ActiveRecordAssociation do
         ActiveRecord::Associations::Preloader.new(records: records, associations: :enrollment).call
       end
 
-      enrollment_queries = queries.grep /"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/
+      enrollment_queries = queries.grep(/"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/)
       expect(enrollment_queries.size).to eq(1)
-      project_queries = queries.grep /Project.*WHERE.*"Project"."id" = /
+      project_queries = queries.grep(/Project.*WHERE.*"Project"."id" = /)
       expect(project_queries.size).to eq(1)
       expect(records.first.project).to eq(project)
       expect(records.first.enrollment).to eq(enrollment)
@@ -42,9 +44,9 @@ RSpec.describe Sources::ActiveRecordAssociation do
         ActiveRecord::Associations::Preloader.new(records: records, associations: [:project, :enrollment]).call
       end
 
-      enrollment_queries = queries.grep /"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/
+      enrollment_queries = queries.grep(/"Enrollment".*WHERE.*"EnrollmentID" = '#{enrollment.enrollment_id}'/)
       expect(enrollment_queries.size).to eq(1)
-      project_queries = queries.grep /Project.*WHERE.*"Project"."id" = /
+      project_queries = queries.grep(/Project.*WHERE.*"Project"."id" = /)
       expect(project_queries.size).to eq(1)
       expect(records.first.project).to eq(project)
       expect(records.first.enrollment).to eq(enrollment)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Remove association reset. This seems to have been causing unexpected issues with custom scopes (third arg to preload) being lost under some circumstances.

Trying to reproduce the behavior that the was originally patched in #4353 I could not longer replicate the extra query. Added a test against it;

## Testing
We should check that this doesn't cause a regression in performance due

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
