### PR TITLE
Remove unused methods

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_assessments.rb
@@ -27,10 +27,6 @@ module Types
         end
       end
 
-      def resolve_assessments_with_loader(association_name = :custom_assessments, **args)
-        load_ar_association(object, association_name, scope: scoped_assessments(Hmis::Hud::CustomAssessment, **args))
-      end
-
       def resolve_assessments(scope = object.custom_assessments, **args)
         scoped_assessments(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
@@ -23,10 +23,6 @@ module Types
         end
       end
 
-      def resolve_clients_with_loader(association_name = :clients, **args)
-        load_ar_association(object, association_name, scope: scoped_clients(Hmis::Hud::Client, **args))
-      end
-
       def resolve_clients(scope = object.clients, **args)
         scoped_clients(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
@@ -31,10 +31,6 @@ module Types
         end
       end
 
-      def resolve_enrollments_with_loader(association_name = :enrollments, **args)
-        load_ar_association(object, association_name, scope: scoped_enrollments(Hmis::Hud::Enrollment, **args))
-      end
-
       def resolve_enrollments(scope = object.enrollments, **args)
         scoped_enrollments(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_events.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_events.rb
@@ -22,10 +22,6 @@ module Types
         end
       end
 
-      def resolve_events_with_loader(association_name = :events, **args)
-        load_ar_association(object, association_name, scope: scoped_events(Hmis::Hud::Event, **args))
-      end
-
       def resolve_events(scope = object.events, **args)
         scoped_events(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_files.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_files.rb
@@ -22,11 +22,6 @@ module Types
         end
       end
 
-      # not currently used, because we are only querying for files on 1 client at a time
-      def resolve_files_with_loader(association_name = :files, **args)
-        load_ar_association(object, association_name, scope: scoped_files(Hmis::File, **args))
-      end
-
       def resolve_files(scope = object.files, **args)
         scoped_files(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_funders.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_funders.rb
@@ -22,10 +22,6 @@ module Types
         end
       end
 
-      def resolve_funders_with_loader(association_name = :funders, **args)
-        load_ar_association(object, association_name, scope: scoped_funders(Hmis::Hud::Funder, **args))
-      end
-
       def resolve_funders(scope = object.funders, **args)
         scoped_funders(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_households.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_households.rb
@@ -23,10 +23,6 @@ module Types
         end
       end
 
-      def resolve_households_with_loader(association_name = :households, **args)
-        load_ar_association(object, association_name, scope: scoped_households(Hmis::Hud::Enrollment, **args))
-      end
-
       def resolve_households(scope = object.households, **args)
         scoped_households(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_inventories.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_inventories.rb
@@ -22,10 +22,6 @@ module Types
         end
       end
 
-      def resolve_inventories_with_loader(association_name = :inventories, **args)
-        load_ar_association(object, association_name, scope: scoped_inventories(Hmis::Hud::Inventory, **args))
-      end
-
       def resolve_inventories(scope = object.inventories, **args)
         scoped_inventories(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_organizations.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_organizations.rb
@@ -23,10 +23,6 @@ module Types
         end
       end
 
-      def resolve_organizations_with_loader(association_name = :organizations, **args)
-        load_ar_association(object, association_name, scope: scoped_organizations(Hmis::Hud::Organization, **args))
-      end
-
       def resolve_organizations(scope = object.organizations, **args)
         scoped_organizations(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_project_cocs.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_project_cocs.rb
@@ -21,10 +21,6 @@ module Types
         end
       end
 
-      def resolve_project_cocs_with_loader(association_name = :project_cocs, **args)
-        load_ar_association(object, association_name, scope: scoped(Hmis::Hud::ProjectCoc, **args))
-      end
-
       def resolve_project_cocs(scope = object.project_cocs, **args)
         scoped_arguments(scope, **args)
       end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_projects.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_projects.rb
@@ -24,10 +24,6 @@ module Types
       end
 
       included do
-        def resolve_projects_with_loader(association_name = :projects, **args)
-          load_ar_association(object, association_name, scope: scoped_projects(Hmis::Hud::Project, **args))
-        end
-
         def resolve_projects(scope = object.projects, **args)
           scoped_projects(scope, **args)
         end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_referral_requests.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_referral_requests.rb
@@ -21,12 +21,6 @@ module Types
         end
       end
 
-      # FIXME: combining the extra scope isn't working here- perhaps rails 6 bug
-      # def resolve_referral_requests_with_loader(association_name, **args)
-      #   scope = scoped_referral_requests(HmisExternalApis::AcHmis::ReferralRequest.all, **args)
-      #   load_ar_association(object, association_name, scope: scope)
-      # end
-
       def scoped_referral_requests(scope, sort_order: nil)
         scope = scope.active.viewable_by(current_user)
         sort_order.present? ? scope.sort_by_option(sort_order) : scope

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_services.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_services.rb
@@ -23,10 +23,6 @@ module Types
         end
       end
 
-      def resolve_services_with_loader(association_name = :hmis_services, **args)
-        load_ar_association(object, association_name, scope: scoped_services(Hmis::Hud::HmisService, **args))
-      end
-
       def resolve_services(scope = object.hmis_services, **args)
         scoped_services(scope, **args)
       end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Remove data-loader methods on concerns that are not used. It's a good thing we don't use them because of the bug described in https://github.com/open-path/Green-River/issues/7571 - which is maybe why we didn't use them in the first place. I don't know why they were added. Data loading is not needed for these concerns because we don't resolve them in batch.

## Type of change
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
