### PR TITLE
7576-search-fix

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -10,7 +10,8 @@ module Hmis::Hud::Concerns::Shared
   extend ActiveSupport::Concern
   include Hmis::Hud::Concerns::HasEnums
   include ::HmisStructure::Shared
-  include ::Hmis::Hud::Concerns::WithStrictAttributes
+  # FIXME: #7576
+  # include ::Hmis::Hud::Concerns::WithStrictAttributes
 
   included do
     # Filter down scope to only HMIS records. Helpful for finding records in the

--- a/drivers/hmis/app/models/hmis/hud/income_benefit.rb
+++ b/drivers/hmis/app/models/hmis/hud/income_benefit.rb
@@ -11,6 +11,8 @@ class Hmis::Hud::IncomeBenefit < Hmis::Hud::Base
   self.sequence_name = "public.\"#{table_name}_id_seq\""
   include ::HmisStructure::IncomeBenefit
   include ::Hmis::Hud::Concerns::Shared
+  # FIXME: #7576
+  include ::Hmis::Hud::Concerns::WithStrictAttributes
   include ::Hmis::Hud::Concerns::EnrollmentRelated
   include ::Hmis::Hud::Concerns::ClientProjectEnrollmentRelated
   include ::Hmis::Hud::Concerns::FormSubmittable

--- a/drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -84,6 +86,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         households = result.dig('data', 'project', 'households', 'nodes')
         expect(households.map { |r| r.fetch('id') }).to eq expected
       end
+    end
+
+    it 'does not crash if term contains a hyphen' do
+      filters = { searchTerm: '000-0' }
+      response, result = post_graphql(id: p1.id, filters: filters) { query }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'project', 'households', 'nodes')).to eq([])
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
fixes household search crash when search string contains hyphens. This is a hotfix and a more robust patch is needed. 

Ref:
7f891c55dff669701ec4e70a4e6760bdc9de12ac

## Type of change
 Bug fix

## Testing instructions
navigate to the enrollments page of a project. In the 'Search Clients' bar type numeric input with a hyphen: '123-4'. The search should not crash.

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)


