### PR TITLE
Update some CE fields to be optional in schema

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9261,8 +9261,8 @@ type Query {
     role: AssessmentRole
   ): FormDefinition
   ceOpportunity(id: ID!): CeOpportunity
-  ceReferral(id: ID!): CeReferral!
-  ceReferralStep(id: ID!): CeReferralStep!
+  ceReferral(id: ID!): CeReferral
+  ceReferralStep(id: ID!): CeReferralStep
 
   """
   Client lookup

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9260,7 +9260,7 @@ type Query {
     """
     role: AssessmentRole
   ): FormDefinition
-  ceOpportunity(id: ID!): CeOpportunity!
+  ceOpportunity(id: ID!): CeOpportunity
   ceReferral(id: ID!): CeReferral!
   ceReferralStep(id: ID!): CeReferralStep!
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -526,14 +526,14 @@ module Types
       end
     end
 
-    field :ce_referral, Types::HmisSchema::CeReferral, null: false do
+    field :ce_referral, Types::HmisSchema::CeReferral, null: true do
       argument :id, ID, required: true
     end
 
     def ce_referral(id:)
       raise unless Hmis::Ce.configuration.enabled?
 
-      Hmis::Ce::Referral.viewable_by(current_user).find(id)
+      Hmis::Ce::Referral.viewable_by(current_user).find_by(id: id)
     end
 
     field :ce_opportunity, HmisSchema::CeOpportunity, null: true do
@@ -546,13 +546,13 @@ module Types
       Hmis::Ce::Opportunity.viewable_by(current_user).find_by(id: id)
     end
 
-    field :ce_referral_step, HmisSchema::CeReferralStep, null: false do
+    field :ce_referral_step, HmisSchema::CeReferralStep, null: true do
       argument :id, ID, required: true
     end
     def ce_referral_step(id:)
       raise unless Hmis::Ce.configuration.enabled?
 
-      Hmis::WorkflowExecution::Step.viewable_by(current_user).find(id)
+      Hmis::WorkflowExecution::Step.viewable_by(current_user).find_by(id: id)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -536,14 +536,14 @@ module Types
       Hmis::Ce::Referral.viewable_by(current_user).find(id)
     end
 
-    field :ce_opportunity, HmisSchema::CeOpportunity, null: false do
+    field :ce_opportunity, HmisSchema::CeOpportunity, null: true do
       argument :id, ID, required: true
     end
 
     def ce_opportunity(id:)
       raise unless Hmis::Ce.configuration.enabled?
 
-      Hmis::Ce::Opportunity.viewable_by(current_user).find(id)
+      Hmis::Ce::Opportunity.viewable_by(current_user).find_by(id: id)
     end
 
     field :ce_referral_step, HmisSchema::CeReferralStep, null: false do

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -315,5 +315,19 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(candidate2.dig('clientId')).to eq(permissioned_client.id.to_s)
       end
     end
+
+    context 'querying for an opportunity that doesnt exist' do
+      let(:variables) do
+        {
+          id: 9999,
+        }
+      end
+
+      it 'does not throw, but returns no opportunity' do
+        response, result = post_graphql(**variables) { query }
+        expect(response.status).to eq(200), result.inspect
+        expect(result.dig('data', 'ceOpportunity')).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes minor bug described here: https://github.com/open-path/Green-River/issues/7417#issuecomment-2819193161

Reproduction:

- In QA, mark a unit Available. 
- Command-click "View Opportunity" to open in a new tab
- Back in tab 1, mark that same unit as Unavailable
- Reload tab 2. It will raise an error. Instead it should just say "Not found"

I also applied the same logic to Referral and Step, even though there's no currently supported way for users to delete those models, to try to follow our general pattern of returning "Not found" gracefully instead of throwing an error.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
