### PR TITLE
7579 Fix crash in performance measurement report

### DIFF
--- a/drivers/performance_measurement/app/models/performance_measurement/details.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/details.rb
@@ -97,15 +97,15 @@ module PerformanceMeasurement::Details
     end
 
     def detail_calculation_description_for(key)
-      detail_for(key)[:calculation_description]
+      detail_for(key)&.[](:calculation_description)
     end
 
     def detail_measure_for(key)
-      detail_for(key)[:measure]
+      detail_for(key)&.[](:measure)
     end
 
     def detail_column_for(key)
-      detail_for(key)[:column]
+      detail_for(key)&.[](:column)
     end
 
     def detail_denominator_label_for(key)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
dont crash on null value in  performance measurement report (see linked Issue 7579)

### Testing
Visit the "CoC Performance Measurement Dashboard", click "Download Report" -> PDF. Report should generate and not crash

## Type of change
Bugfix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code and it didn't crash



