### PR TITLE
7551-fix-double-render

### DIFF
--- a/drivers/client_access_control/app/controllers/client_access_control/history_controller.rb
+++ b/drivers/client_access_control/app/controllers/client_access_control/history_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -75,6 +77,9 @@ module ClientAccessControl
       head :ok
     end
 
+    # Finds and sets @client based on params[:client_id].
+    # Redirects to the merged client if applicable, or raises if not found.
+    # Returns @client. Used both as a before_action and standalone method.
     def set_client
       if current_user.blank? && @user.blank?
         not_authorized!
@@ -94,6 +99,8 @@ module ClientAccessControl
           @client = destination_searchable_client_scope.find(params[:client_id].to_i)
         end
       end
+      # note, the return value is significant when called outside of before_action
+      return @client
     end
 
     def client_needing_processing?(client: @client)

--- a/drivers/client_access_control/spec/requests/clients_history_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_history_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -53,6 +55,20 @@ RSpec.describe ClientAccessControl::HistoryController, type: :request do
         expect(response).to have_http_status(200)
         expect(destination.client_files.count).to eq(1)
       end
+    end
+  end
+
+  describe 'logged in' do
+    let!(:user) { create(:acl_user) }
+    before do
+      sign_in user
+    end
+
+    it 'redirects to merged client' do
+      merged_id = destination.id + 1
+      allow_any_instance_of(::GrdaWarehouse::ClientMergeHistory).to receive(:current_destination).and_return(merged_id)
+      get client_history_path(destination.id)
+      expect(response).to redirect_to(controller: 'history', action: 'show', client_id: merged_id)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fix double-render error when accessing client history. 

### Details:
Here's my understanding of what's happening: The history controller calls `require_can_see_this_client_demographics?` which calls `set_client`. The code expects set_client to return falsy if the client is not found. However it `set_client` returns truthy if it redirects causing the `require_can_see_this_client_demographics` to raise `not_authorized` which performs a second redirect, resulting in a double render

### testing
Log in, visit a client history page for a merged client (see linked issue for an example). You should be redirected to the most recent client

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have added spec tests (or not applicable)

