### PR TITLE
7572 validate date format

### DIFF
--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -1634,6 +1634,8 @@ module Filters
       case val.presence
       when Date, nil
         return val
+      when DateTime, Time, ActiveSupport::TimeWithZone
+        return val.to_date
       when String
         return Date.strptime(val, '%b %d, %Y') if val.match?(/\A\w{3} +\d{1,2}, +\d{4}\z/)
         return Date.strptime(val, '%Y-%m-%d') if val.match?(/\A\d{4}-\d{2}-\d{2}\z/)

--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -105,9 +105,9 @@ module Filters
 
       filters = filters.to_h.with_indifferent_access
 
-      self.on = filters.dig(:on)&.to_date || on
-      self.start = filters.dig(:start)&.to_date || start
-      self.end = filters.dig(:end)&.to_date || self.end
+      self.on = parse_strict_date(filters.dig(:on)) || on
+      self.start = parse_strict_date(filters.dig(:start)) || start
+      self.end = parse_strict_date(filters.dig(:end)) || self.end
       # Allow multi-year filters if we explicitly passed in something that isn't truthy
       enforce_range = filters.dig(:enforce_one_year_range)
       self.enforce_one_year_range = enforce_range.in?(['1', 'true', true]) unless enforce_range.nil?
@@ -192,6 +192,17 @@ module Filters
       self
     end
     alias set_from_params update
+
+    private def safe_to_date(val)
+      case val.presence
+      when Date, nil
+        return val
+      when String
+        return Date.strptime(val, '%b %d, %Y') if val.match?(/\A\w{3} +\d{1,2}, +\d{4}\z/)
+        return Date.strptime(val, '%Y-%m-%d') if val.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+      raise ArgumentError, "Invalid date format: #{val.inspect}"
+    end
 
     def for_params
       {
@@ -1610,6 +1621,24 @@ module Filters
       else
         [start_date, end_date]
       end
+    end
+
+    # Strict date parser for filter params.
+    # Accepts:
+    #   - Date objects (returns as-is)
+    #   - nil (returns nil)
+    #   - Strings in 'Mon dd, yyyy' (e.g. 'Apr 27, 2025')
+    #   - Strings in 'YYYY-mm-dd' (e.g. '2025-04-27')
+    # Raises ArgumentError for anything else.
+    private def parse_strict_date(val)
+      case val.presence
+      when Date, nil
+        return val
+      when String
+        return Date.strptime(val, '%b %d, %Y') if val.match?(/\A\w{3} +\d{1,2}, +\d{4}\z/)
+        return Date.strptime(val, '%Y-%m-%d') if val.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+      raise ArgumentError, "Invalid date format: #{val.inspect}"
     end
   end
 end

--- a/spec/models/filters/filter_base_spec.rb
+++ b/spec/models/filters/filter_base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Filters::FilterBase, type: :model do
@@ -17,8 +19,7 @@ RSpec.describe Filters::FilterBase, type: :model do
 
   describe 'FilterBase' do
     it 'defaults to nothing if nothing is specified' do
-      filter_params = {
-      }
+      filter_params = {}
       filter = Filters::FilterBase.new(user_id: user.id).update(filter_params)
       expect(filter.effective_project_ids).not_to include psh_project.id
       expect(filter.effective_project_ids).not_to include es_project.id
@@ -55,8 +56,7 @@ RSpec.describe Filters::FilterBase, type: :model do
 
   describe 'HudFilterBase' do
     it 'HUD filter does not include any projects if nothing is specified' do
-      filter_params = {
-      }
+      filter_params = {}
       filter = Filters::HudFilterBase.new(user_id: user.id).update(filter_params)
       expect(filter.effective_project_ids).not_to include psh_project.id
       expect(filter.effective_project_ids).not_to include es_project.id
@@ -99,6 +99,53 @@ RSpec.describe Filters::FilterBase, type: :model do
       filter = Filters::HudFilterBase.new(user_id: user.id).update(filter_params)
       expect(filter.effective_project_ids_during_range('2021-01-01'.to_date .. '2021-02-01'.to_date)).not_to include psh_project.id
       expect(filter.effective_project_ids_during_range('2021-01-01'.to_date .. '2021-02-01'.to_date)).to include es_project.id
+    end
+  end
+
+  describe 'date parsing for :on param' do
+    let!(:today) { Date.current }
+    let(:base) { Filters::FilterBase.new(user_id: user.id) }
+    let(:test_date) { Date.new(2025, 4, 27) }
+
+    it 'accepts Date object' do
+      expect { base.update(on: test_date) }.not_to raise_error
+      expect(base.on).to eq test_date
+    end
+
+    it 'accepts US string format' do
+      us_str = test_date.strftime('%b %d, %Y')
+      expect { base.update(on: us_str) }.not_to raise_error
+      expect(base.on).to eq test_date
+    end
+
+    it 'accepts ISO string format' do
+      iso_str = test_date.strftime('%Y-%m-%d')
+      expect { base.update(on: iso_str) }.not_to raise_error
+      expect(base.on).to eq test_date
+    end
+
+    it 'raises on garbage string' do
+      expect { base.update(on: 'notadate') }.to raise_error(ArgumentError)
+    end
+
+    it 'raises on slash date string' do
+      slash_str = test_date.strftime('%m/%d/%Y')
+      expect { base.update(on: slash_str) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises on slash ISO date string' do
+      slash_iso_str = test_date.strftime('%Y/%m/%d')
+      expect { base.update(on: slash_iso_str) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises on alternative US date string' do
+      alt_us_str = test_date.strftime('%d %b %Y')
+      expect { base.update(on: alt_us_str) }.to raise_error(ArgumentError)
+    end
+
+    it 'accepts nil' do
+      expect { base.update(on: nil) }.not_to raise_error
+      expect(base.on).to eq(today)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Stricter date parsing in filter params, raise an exception for ambiguous date formats. See linked issue for exception details; it looks like there might be an ambiguous param for the `:on` param in the exception. This PR is a bit of a guess at a solution, I couldn't get the form date-picker to actually send and invalid format.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] added tests



