### PR TITLE
7536 enable redis connection pooling, for rails cache and notifier

### DIFF
--- a/app/models/application_notifier.rb
+++ b/app/models/application_notifier.rb
@@ -31,7 +31,10 @@ class ApplicationNotifier < Slack::Notifier
     !!@insert_log_url # coerce bool
   end
 
+  require 'singleton'
+
   class NullRedis
+    include Singleton
     def ping = true
     def get(*) = nil
     def set(*) = nil
@@ -42,10 +45,13 @@ class ApplicationNotifier < Slack::Notifier
 
   # use the same redis instance we use for caching
   def self.redis
-    if Rails.env.test?
+    case Rails.cache
+    when ActiveSupport::Cache::NullStore
+      NullRedis.instance
+    when ActiveSupport::Cache::RedisCacheStore
       Rails.cache.redis
     else
-      NullRedis.new
+      raise 'Rails cache not supported'
     end
   end
 

--- a/app/models/application_notifier.rb
+++ b/app/models/application_notifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -31,10 +33,7 @@ class ApplicationNotifier < Slack::Notifier
 
   # use the same redis instance we use for caching
   def self.redis
-    Redis.new Rails.application.config_for(:cache_store).merge(
-      timeout: 1,
-      ssl: (ENV.fetch('CACHE_SSL') { 'false' }) == 'true',
-    )
+    Rails.cache.redis
   end
 
   # prefix all keys with a CLIENT specific key

--- a/app/models/application_notifier.rb
+++ b/app/models/application_notifier.rb
@@ -31,9 +31,22 @@ class ApplicationNotifier < Slack::Notifier
     !!@insert_log_url # coerce bool
   end
 
+  class NullRedis
+    def ping = true
+    def get(*) = nil
+    def set(*) = nil
+    def rpush(*) = nil
+    def lpop(*) = nil
+    def keys(*) = []
+  end
+
   # use the same redis instance we use for caching
   def self.redis
-    Rails.cache.redis
+    if Rails.env.test?
+      Rails.cache.redis
+    else
+      NullRedis.new
+    end
   end
 
   # prefix all keys with a CLIENT specific key

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,16 @@ Rails.application.configure do
 
     cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
     cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-hmis"
-    redis_config = Rails.application.config_for(:cache_store).merge({ expires_in: 5.minutes, race_condition_ttl: 1.minute, ssl: cache_ssl, namespace: cache_namespace })
+    redis_config = Rails.application.config_for(:cache_store).merge(
+      {
+        expires_in: 5.minutes,
+        race_condition_ttl: 1.minute,
+        ssl: cache_ssl,
+        namespace: cache_namespace,
+        pool_size: 10,
+        pool_timeout: 5,
+      },
+    )
     config.cache_store = :redis_cache_store, redis_config
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
@@ -95,7 +97,16 @@ Rails.application.configure do
 
   cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
   cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-hmis"
-  redis_config = Rails.application.config_for(:cache_store).merge({ expires_in: 8.hours, race_condition_ttl: 1.minute, ssl: cache_ssl, namespace: cache_namespace })
+  redis_config = Rails.application.config_for(:cache_store).merge(
+    {
+      expires_in: 8.hours,
+      race_condition_ttl: 1.minute,
+      ssl: cache_ssl,
+      namespace: cache_namespace,
+      pool_size: 10,
+      pool_timeout: 5,
+    },
+  )
   config.cache_store = :redis_cache_store, redis_config
 
   config.action_controller.perform_caching = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
@@ -95,7 +97,16 @@ Rails.application.configure do
 
   cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
   cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-hmis"
-  redis_config = Rails.application.config_for(:cache_store).merge({ expires_in: 8.hours, race_condition_ttl: 1.minute, ssl: cache_ssl, namespace: cache_namespace })
+  redis_config = Rails.application.config_for(:cache_store).merge(
+    {
+      expires_in: 8.hours,
+      race_condition_ttl: 1.minute,
+      ssl: cache_ssl,
+      namespace: cache_namespace,
+      pool_size: 10,
+      pool_timeout: 5,
+    },
+  )
   config.cache_store = :redis_cache_store, redis_config
 
   config.action_controller.perform_caching = true


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Adjust configuration to try and fix IO errors when connecting to redis. A theory is that forking behavior in delayed job doesn't properly maintain redis connections. Using a pool should help with this 
* use a connection pool for redis caching
* share the connection pool with application notifier

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

