### PR TITLE
fix-redis-config-deprecations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,8 +46,7 @@ Rails.application.configure do
         race_condition_ttl: 1.minute,
         ssl: cache_ssl,
         namespace: cache_namespace,
-        pool_size: 10,
-        pool_timeout: 5,
+        pool: { size: 10, timeout: 5 },
       },
     )
     config.cache_store = :redis_cache_store, redis_config

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,8 +111,7 @@ Rails.application.configure do
       race_condition_ttl: 1.minute,
       ssl: cache_ssl,
       namespace: cache_namespace,
-      pool_size: 10,
-      pool_timeout: 5,
+      pool: { size: 10, timeout: 5 },
     },
   )
   config.cache_store = :redis_cache_store, redis_config

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -111,8 +111,7 @@ Rails.application.configure do
       race_condition_ttl: 1.minute,
       ssl: cache_ssl,
       namespace: cache_namespace,
-      pool_size: 10,
-      pool_timeout: 5,
+      pool: { size: 10, timeout: 5 },
     },
   )
   config.cache_store = :redis_cache_store, redis_config


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
rails 7.1 deprecated the pool syntax for some reason. Adjusting

