### PR TITLE
7667-rack-attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -178,8 +178,8 @@ class SentryNotificationRateLimiter
   end
 
   def notify(data)
-    matched = data.fetch('rack.attack.matched', 'no-match')
-    key = Digest::MD5.hexdigest(matched)
+    # the key should be constant; key off the name of matched rule
+    key = data.fetch('rack.attack.matched', 'no-match')
     @cache.fetch(key, expires_in: 10.seconds) do
       Sentry.capture_message('Rack attack event', extra: data)
       true # cached result we don't care about

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require 'memery'
+require 'singleton'
 
 # app-specific helper methods
 module RackAttackRequestHelpers
@@ -166,38 +167,72 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
-SlackSendMonitorClass = Struct.new(:sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts) do
-  def init
+class SlackNotificationRateLimiter
+  include Singleton
+  include Memery
+
+  attr_accessor :sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts
+
+  def initialize
+    @mutex = Mutex.new
     self.sends = 0
-    self.last_sent = Time.zone.now
+    self.last_sent = Time.current
     # Max sends to slack is once every 10 seconds per process
     self.throttle_window_seconds = 10
     self.max_sends = 1
     self.lifetime_sends = 0
     self.lifetime_attempts = 0
-    self
   end
 
   def percent_sent
-    return 0.0 if lifetime_attempts == 0
+    @mutex.synchronize do
+      return 0.0 if lifetime_attempts == 0
 
-    (lifetime_sends.to_f / lifetime_attempts * 100).round(1)
+      (lifetime_sends.to_f / lifetime_attempts * 100).round(1)
+    end
   end
 
   def needs_throttling?
-    (delta < throttle_window_seconds) && sends > max_sends
+    @mutex.synchronize do
+      (delta < throttle_window_seconds) && sends > max_sends
+    end
   end
 
   def needs_reset?
-    delta > throttle_window_seconds
+    @mutex.synchronize do
+      delta > throttle_window_seconds
+    end
   end
 
   def delta
-    Time.zone.now - SlackSendMonitor.last_sent
+    Time.current - last_sent
+  end
+
+  def increment_sends
+    @mutex.synchronize do
+      self.sends += 1
+      self.lifetime_sends += 1
+    end
+  end
+
+  def increment_attempts
+    @mutex.synchronize do
+      self.lifetime_attempts += 1
+    end
+  end
+
+  def update_last_sent
+    @mutex.synchronize do
+      self.last_sent = Time.current
+    end
+  end
+
+  def reset_sends
+    @mutex.synchronize do
+      self.sends = 0
+    end
   end
 end
-
-SlackSendMonitor = SlackSendMonitorClass.new.init
 
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish, _request_id, payload|
   request = payload[:request]
@@ -229,12 +264,13 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   # ... get a record on disk
   Rails.logger.warn JSON.generate(data)
 
-  SlackSendMonitor.lifetime_attempts += 1
-  next if SlackSendMonitor.needs_throttling?
+  monitor = SlackNotificationRateLimiter.instance
+  monitor.increment_attempts
+  next if monitor.needs_throttling?
 
-  SlackSendMonitor.sends = 0 if SlackSendMonitor.needs_reset?
+  monitor.reset_sends if monitor.needs_reset?
 
-  Rails.logger.debug { "Slack sending percentage is #{SlackSendMonitor.percent_sent}%" }
+  Rails.logger.debug { "Slack sending percentage is #{monitor.percent_sent}%" }
 
   # ... and now try to send to somewhere useful
   if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
@@ -261,7 +297,6 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   end
 
   # mark a send even if it's not enabled above to facilitate testing
-  SlackSendMonitor.last_sent = Time.zone.now
-  SlackSendMonitor.sends += 1
-  SlackSendMonitor.lifetime_sends += 1
+  monitor.update_last_sent
+  monitor.increment_sends
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -167,63 +167,22 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
-# Rate limits Slack notifications to prevent overwhelming the Slack API
-# - Enforces a maximum of 1 notification per 10 seconds per process
-# - Tracks lifetime statistics for monitoring notification patterns
-# - Thread-safe implementation using mutex for concurrent access
-class SlackNotificationRateLimiter
+# Rate limits Sentry notifications to prevent overwhelming the Sentry API
+# - Uses Rails cache to deduplicate similar notifications within a time window
+# - Thread-safe implementation using cache for concurrent access
+class SentryNotificationRateLimiter
   include Singleton
-  include Memery
-
-  attr_accessor :sends, :last_sent, :throttle_window_seconds, :max_sends, :lifetime_sends, :lifetime_attempts
 
   def initialize
-    @mutex = Mutex.new
-    self.sends = 0
-    self.last_sent = Time.current
-    # Max sends to slack is once every 10 seconds per process
-    self.throttle_window_seconds = 10
-    self.max_sends = 1
-    self.lifetime_sends = 0
-    self.lifetime_attempts = 0
+    @cache = ActiveSupport::Cache::MemoryStore.new
   end
 
-  def lifetime_percent_sent
-    @mutex.synchronize do
-      return 0.0 if lifetime_attempts == 0
-
-      (lifetime_sends.to_f / lifetime_attempts * 100).round(1)
-    end
-  end
-
-  def needs_throttling?
-    @mutex.synchronize do
-      self.lifetime_attempts += 1
-      now = Time.current
-      if (now - last_sent) > throttle_window_seconds
-        self.sends = 0
-        self.last_sent = now
-        false
-      else
-        sends >= max_sends
-      end
-    end
-  end
-
-  def track_record_send
-    @mutex.synchronize do
-      self.sends += 1
-      self.lifetime_sends += 1
-      self.last_sent = Time.current
-    end
-  end
-
-  def reset
-    @mutex.synchronize do
-      self.sends = 0
-      self.last_sent = Time.current
-      self.lifetime_sends = 0
-      self.lifetime_attempts = 0
+  def notify(data)
+    matched = data.fetch('rack.attack.matched', 'no-match')
+    key = Digest::MD5.hexdigest(matched)
+    @cache.fetch(key, expires_in: 10.seconds) do
+      Sentry.capture_message('Rack attack event', extra: data)
+      true # cached result we don't care about
     end
   end
 end
@@ -258,35 +217,6 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   # ... get a record on disk
   Rails.logger.warn JSON.generate(data)
 
-  monitor = SlackNotificationRateLimiter.instance
-  next if monitor.needs_throttling?
-
-  Rails.logger.debug { "Slack sending percentage is #{monitor.lifetime_percent_sent}%" }
-
-  # ... and now try to send to somewhere useful
-  if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
-    notifier_config = Rails.application.config_for(:exception_notifier).fetch(:slack, nil)
-    notifier = Slack::Notifier.new(
-      notifier_config[:webhook_url],
-      channel: notifier_config[:channel],
-      username: 'Rack-Attack',
-    )
-
-    fields = data.map do |k, v|
-      { title: k.to_s, value: v.to_s }
-    end
-    attachment = {
-      fallback: JSON.pretty_generate(data),
-      color: :warning,
-      fields: fields,
-    }
-    notifier.ping(
-      text: '*Rack attack event*',
-      attachments: [attachment],
-      http_options: { open_timeout: 1 },
-    )
-  end
-
-  # mark a send even if it's not enabled above to facilitate testing
-  monitor.track_record_send
+  # Send to Sentry with rate limiting
+  SentryNotificationRateLimiter.instance.notify(data)
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -167,6 +167,10 @@ end
 #   [ 429, headers, ["Throttled\n"]]
 # end
 
+# Rate limits Slack notifications to prevent overwhelming the Slack API
+# - Enforces a maximum of 1 notification per 10 seconds per process
+# - Tracks lifetime statistics for monitoring notification patterns
+# - Thread-safe implementation using mutex for concurrent access
 class SlackNotificationRateLimiter
   include Singleton
   include Memery
@@ -184,7 +188,7 @@ class SlackNotificationRateLimiter
     self.lifetime_attempts = 0
   end
 
-  def percent_sent
+  def lifetime_percent_sent
     @mutex.synchronize do
       return 0.0 if lifetime_attempts == 0
 
@@ -194,42 +198,32 @@ class SlackNotificationRateLimiter
 
   def needs_throttling?
     @mutex.synchronize do
-      (delta < throttle_window_seconds) && sends > max_sends
+      self.lifetime_attempts += 1
+      now = Time.current
+      if (now - last_sent) > throttle_window_seconds
+        self.sends = 0
+        self.last_sent = now
+        false
+      else
+        sends >= max_sends
+      end
     end
   end
 
-  def needs_reset?
-    @mutex.synchronize do
-      delta > throttle_window_seconds
-    end
-  end
-
-  def delta
-    Time.current - last_sent
-  end
-
-  def increment_sends
+  def track_record_send
     @mutex.synchronize do
       self.sends += 1
       self.lifetime_sends += 1
-    end
-  end
-
-  def increment_attempts
-    @mutex.synchronize do
-      self.lifetime_attempts += 1
-    end
-  end
-
-  def update_last_sent
-    @mutex.synchronize do
       self.last_sent = Time.current
     end
   end
 
-  def reset_sends
+  def reset
     @mutex.synchronize do
       self.sends = 0
+      self.last_sent = Time.current
+      self.lifetime_sends = 0
+      self.lifetime_attempts = 0
     end
   end
 end
@@ -265,12 +259,9 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   Rails.logger.warn JSON.generate(data)
 
   monitor = SlackNotificationRateLimiter.instance
-  monitor.increment_attempts
   next if monitor.needs_throttling?
 
-  monitor.reset_sends if monitor.needs_reset?
-
-  Rails.logger.debug { "Slack sending percentage is #{monitor.percent_sent}%" }
+  Rails.logger.debug { "Slack sending percentage is #{monitor.lifetime_percent_sent}%" }
 
   # ... and now try to send to somewhere useful
   if defined?(Slack::Notifier) && ENV['EXCEPTION_WEBHOOK_URL'].present?
@@ -297,6 +288,5 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish,
   end
 
   # mark a send even if it's not enabled above to facilitate testing
-  monitor.update_last_sent
-  monitor.increment_sends
+  monitor.track_record_send
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -185,6 +185,10 @@ class SentryNotificationRateLimiter
       true # cached result we don't care about
     end
   end
+
+  def reset
+    @cache.clear
+  end
 end
 
 ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, start, _finish, _request_id, payload|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -55,25 +55,17 @@ module RackAttackRequestHelpers
   end
 
   def authenticated?
-    warden_user.present?
+    # If we explicitly added a parameter to avoid updating last_request_at, honor it
+    return false if env['QUERY_STRING'].include?('skip_trackable=true')
+
+    rack_session = env['rack.session']
+    return false unless rack_session
+
+    # Check session variable to check if the user is logged in. This avoids db queries
+    rack_session['warden.user.user.key'].present? || rack_session['warden.user.hmis_user.key'].present?
   end
 
   protected
-
-  WARDEN_CHECK_EXCLUDE_URLS = ['/hmis/app_settings', '/hmis/user', '/messages/poll'].to_set.freeze
-  private_constant :WARDEN_CHECK_EXCLUDE_URLS
-  memoize def warden_user
-    # Avoid calling warden for user status endpoints. Calling warden here bumps
-    # last_request_at, regardless of skip_trackable in the controller. This means
-    # sessions may not expire as expected
-    strip_path = path.split('.', 2)[0]
-    return nil if strip_path.in?(WARDEN_CHECK_EXCLUDE_URLS)
-
-    # If we explicitly added a parameter to avoid updating last_request_at, honor it
-    return nil if env['QUERY_STRING'].include?('skip_trackable=true')
-
-    env['warden']&.user.presence || env['warden']&.user(:hmis_user).presence
-  end
 
   def internal_lb_check?
     env['HTTP_USER_AGENT'] == 'ELB-HealthChecker/2.0' && path.include?('status') && trusted_proxy?

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -119,6 +119,33 @@ RSpec.describe Rack::Attack, type: :request do
       sign_in user
     end
 
+    describe 'status endpoints' do
+      let(:excluded_paths) { ['/messages/poll'] }
+      let(:session_timeout) { Devise.timeout_in }
+
+      it 'does not extend session lifetime for excluded paths' do
+        excluded_paths.each do |path|
+          # First request to establish session
+          get path, xhr: true
+          expect(response).to be_successful
+
+          # Move time forward
+          travel(session_timeout - 1.minutes)
+
+          # Should still be logged in
+          get path, xhr: true
+          expect(response).to be_successful
+
+          # Move time forward 2 more minutes (past the timeout)
+          travel 2.minutes
+
+          # Should be logged out
+          get path, xhr: true
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
     describe 'and hitting the homepage' do
       let(:path) { root_path }
 

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -188,9 +188,10 @@ RSpec.describe Rack::Attack, type: :request do
     it 'does not send api requests to sentry for every throttle event' do
       throttled_at = 50
       till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
-      expect(SlackSendMonitor.lifetime_attempts).to be > 20
-      expect(SlackSendMonitor.lifetime_sends).to be > 1
-      expect(SlackSendMonitor.percent_sent).to be < 11
+      monitor = SlackNotificationRateLimiter.instance
+      expect(monitor.lifetime_attempts).to be > 20
+      expect(monitor.lifetime_sends).to be > 1
+      expect(monitor.percent_sent).to be < 12 # fuzzy, we see timing variation in CI
     end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -185,6 +185,10 @@ RSpec.describe Rack::Attack, type: :request do
   context 'sentry notification rate limiting' do
     let(:path) { '/' }
 
+    before do
+      SentryNotificationRateLimiter.instance.reset
+    end
+
     it 'rate limits notifications to Sentry' do
       throttled_at = 20 # throttled at 10 currently
       allow(Sentry).to receive(:capture_message)

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Rack::Attack, type: :request do
         block.arity == 1 ? yield(cnt) : yield
         requests_sent += 1
         status_encountered = response.status == throttled_status
-        # puts [cnt, response.status, SlackNotificationRateLimiter.instance.lifetime_sends, SlackNotificationRateLimiter.instance.lifetime_attempts].inspect
         break if status_encountered
       end
     ensure

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe Rack::Attack, type: :request do
     status_encountered = false
 
     case mode
+    when :frozen
+      time_advance = 0
+      freeze_time
     when :slow
       time_advance = 1
     when :default
@@ -42,10 +45,11 @@ RSpec.describe Rack::Attack, type: :request do
     begin
       (requests_to_send + 1).times do |cnt|
         # travel to hour boundary so we always start at 00:00, manually advancing time every loop
-        travel_to(Time.current.beginning_of_hour + (cnt * time_advance).seconds)
+        travel_to(Time.current.beginning_of_hour + (cnt * time_advance).seconds) unless time_advance.zero?
         block.arity == 1 ? yield(cnt) : yield
         requests_sent += 1
         status_encountered = response.status == throttled_status
+        # puts [cnt, response.status, SlackNotificationRateLimiter.instance.lifetime_sends, SlackNotificationRateLimiter.instance.lifetime_attempts].inspect
         break if status_encountered
       end
     ensure
@@ -186,12 +190,17 @@ RSpec.describe Rack::Attack, type: :request do
     let(:path) { '/' }
 
     it 'does not send api requests to sentry for every throttle event' do
-      throttled_at = 50
-      till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
+      throttled_at = 20
       monitor = SlackNotificationRateLimiter.instance
-      expect(monitor.lifetime_attempts).to be > 20
-      expect(monitor.lifetime_sends).to be > 1
-      expect(monitor.percent_sent).to be < 12 # fuzzy, we see timing variation in CI
+      monitor.reset
+      till_throttled(requests_to_send: throttled_at, throttled_status: -999, mode: :frozen) { get(path, headers: headers) }
+      aggregate_failures 'checking response' do
+        expect(monitor.lifetime_attempts).to(eq(11)) # (throttled_at + 1 (21)) - allowed requests (10)
+        expect(monitor.lifetime_sends).to(eq(1)) # we expect send to occur once per 10 seconds
+        expect(monitor.lifetime_percent_sent).to(eq(
+          ((1.0/11) * 100).round(1)
+        ))
+      end
     end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -31,9 +31,6 @@ RSpec.describe Rack::Attack, type: :request do
     status_encountered = false
 
     case mode
-    when :frozen
-      time_advance = 0
-      freeze_time
     when :slow
       time_advance = 1
     when :default
@@ -186,21 +183,18 @@ RSpec.describe Rack::Attack, type: :request do
     end
   end
 
-  context 'being kind to the sentry api' do
+  context 'sentry notification rate limiting' do
     let(:path) { '/' }
 
-    it 'does not send api requests to sentry for every throttle event' do
-      throttled_at = 20
-      monitor = SlackNotificationRateLimiter.instance
-      monitor.reset
-      till_throttled(requests_to_send: throttled_at, throttled_status: -999, mode: :frozen) { get(path, headers: headers) }
-      aggregate_failures 'checking response' do
-        expect(monitor.lifetime_attempts).to(eq(11)) # (throttled_at + 1 (21)) - allowed requests (10)
-        expect(monitor.lifetime_sends).to(eq(1)) # we expect send to occur once per 10 seconds
-        expect(monitor.lifetime_percent_sent).to(eq(
-          ((1.0/11) * 100).round(1)
-        ))
-      end
+    it 'rate limits notifications to Sentry' do
+      throttled_at = 20 # throttled at 10 currently
+      allow(Sentry).to receive(:capture_message)
+
+      # Send multiple requests in quick succession
+      till_throttled(requests_to_send: throttled_at, throttled_status: -999) { get(path, headers: headers) }
+
+      # Verify that Sentry was called only once for similar events
+      expect(Sentry).to have_received(:capture_message).once
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
* eliminate query side-effects in rack attack. The query may be causing issues the the connection pool 
* add tests for interaction with session expiration
* replaced SlackSendMonitor with notifications to sentry
 

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

