### PR TITLE
Support multiple state geocodes in pick list

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -284,15 +284,16 @@ module Types
     end
 
     def self.geocodes_picklist
-      # NOTE: HMIS currently only supports one state installations
-      state = GrdaWarehouse::Config.relevant_state_codes&.first
-      Rails.cache.fetch(['GEOCODES', state], expires_in: 1.days) do
-        JSON.parse(File.read("drivers/hmis/lib/pick_list_data/geocodes/geocodes-#{state}.json"))
-      end.map do |obj|
-        {
-          code: obj['geocode'],
-          label: "#{obj['geocode']} - #{obj['name']}",
-        }
+      GrdaWarehouse::Config.relevant_state_codes.flat_map do |state|
+        Rails.cache.fetch(['GEOCODES', state], expires_in: 1.days) do
+          JSON.parse(File.read("drivers/hmis/lib/pick_list_data/geocodes/geocodes-#{state}.json"))
+        end.map do |obj|
+          {
+            code: obj['geocode'],
+            label: "#{obj['geocode']} - #{obj['name']}",
+            group_label: state,
+          }
+        end
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -151,6 +151,26 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     expect(response.status).to eq 200
     options = result.dig('data', 'pickList')
     expect(options[0]['code']).to eq('509001')
+    expected_size = JSON.parse(File.read('drivers/hmis/lib/pick_list_data/geocodes/geocodes-VT.json')).size
+    expect(options.size).to eq(expected_size)
+  end
+
+  context 'when there are multiple relevant states' do
+    before do
+      GrdaWarehouse::Config.instance_variable_set(:@relevant_state_codes, nil) # reset the cached instance variable
+      allow(GrdaWarehouse::Config).to receive(:get).with(:relevant_state_codes).and_return('VT,MA')
+    end
+
+    it 'returns geocodes grouped by state' do
+      response, result = post_graphql(pick_list_type: 'GEOCODE') { query }
+      expect(response.status).to eq 200
+      options = result.dig('data', 'pickList')
+      vt_size = JSON.parse(File.read('drivers/hmis/lib/pick_list_data/geocodes/geocodes-VT.json')).size
+      ma_size = JSON.parse(File.read('drivers/hmis/lib/pick_list_data/geocodes/geocodes-MA.json')).size
+      expect(options.size).to eq(vt_size + ma_size)
+      expect(options.first['groupLabel']).to eq('VT')
+      expect(options.last['groupLabel']).to eq('MA')
+    end
   end
 
   it 'returns grouped service type pick list' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Support county geocodes from multiple states.

How to test locally:
- In local db, set `config` `relevant_state_codes` to a comma-separated list of multiple states. For example `"MA,VT"`
- Restart app
- In an "Edit Project CoC" form, you should be able to select any county geocode from either of the two states.

![Screenshot 2025-05-07 at 2 58 48 PM](https://github.com/user-attachments/assets/fac1acb7-cf29-4c0c-bc60-cef9ea12b7f0)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
