### PR TITLE
Use RRH sub-type to determine RRH enrollment status for CAS

### DIFF
--- a/app/models/concerns/cas_client_data.rb
+++ b/app/models/concerns/cas_client_data.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module CasClientData
   extend ActiveSupport::Concern
   included do
@@ -714,14 +716,20 @@ module CasClientData
         GrdaWarehouse::ServiceHistoryEnrollment.where(client_id: client_ids).
           ongoing.
           joins(:project).
-          pluck(:client_id, p_t[:id], GrdaWarehouse::ServiceHistoryEnrollment.project_type_column, :move_in_date).
-          each do |c_id, p_id, p_type, move_in_date|
+          pluck(:client_id, p_t[:id], p_t[:project_type], :move_in_date, p_t[:RRHSubType]).
+          each do |c_id, p_id, p_type, move_in_date, rrh_sub_type|
             ids[c_id] ||= []
-            ids[c_id] << OpenStruct.new(project_id: p_id, project_type: p_type, move_in_date: move_in_date)
+            ids[c_id] << OpenStruct.new(
+              project_id: p_id,
+              project_type: p_type,
+              move_in_date: move_in_date,
+              rrh_sub_type: rrh_sub_type,
+            )
           end
       end
     end
 
+    # Enrolled in RRH WITH a move-in date
     def enrolled_in_rrh(ongoing_enrollments)
       return false unless ongoing_enrollments
 
@@ -732,6 +740,7 @@ module CasClientData
       end.any?
     end
 
+    # Enrolled in PSH WITH a move-in date
     def enrolled_in_psh(ongoing_enrollments)
       return false unless ongoing_enrollments
 
@@ -742,6 +751,7 @@ module CasClientData
       end.any?
     end
 
+    # Enrolled in PH WITH a move-in date
     def enrolled_in_ph(ongoing_enrollments)
       return false unless ongoing_enrollments
 
@@ -752,16 +762,20 @@ module CasClientData
       end.any?
     end
 
+    # Enrolled in RRH WITHOUT a move-in date and not in services-only RRH
     def enrolled_in_rrh_pre_move_in(ongoing_enrollments)
       return false unless ongoing_enrollments
 
       project_type_codes = [13]
       ongoing_enrollments.select do |en|
         en.project_type.in?(project_type_codes) &&
-        en.move_in_date.blank?
+
+          en.move_in_date.blank? && # no move-in date
+          en.rrh_sub_type != HudUtility2024.rrh_sub_type_sso_only # not services only
       end.any?
     end
 
+    # Enrolled in PSH WITHOUT a move-in date
     def enrolled_in_psh_pre_move_in(ongoing_enrollments)
       return false unless ongoing_enrollments
 
@@ -772,6 +786,7 @@ module CasClientData
       end.any?
     end
 
+    # Enrolled in PH WITHOUT a move-in date
     def enrolled_in_ph_pre_move_in(ongoing_enrollments)
       return false unless ongoing_enrollments
 

--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -88,6 +88,10 @@ module HudUtility2024
     no_yes_reasons_for_missing_data(*args)
   end
 
+  def rrh_sub_type_sso_only
+    1
+  end
+
   def project_type_with_sub_type(type, sub_type = nil)
     [
       project_type(type),

--- a/spec/models/cas_client_data_spec.rb
+++ b/spec/models/cas_client_data_spec.rb
@@ -1,0 +1,87 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https: //github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CasClientData do
+  let(:client) { create(:grda_warehouse_hud_client) }
+  let(:project_type_codes) { [13] } # RRH project type
+
+  describe '#enrolled_in_rrh_pre_move_in' do
+    let(:ongoing_enrollments) do
+      [
+        OpenStruct.new(
+          project_type: project_type,
+          move_in_date: move_in_date,
+          rrh_sub_type: rrh_sub_type,
+        ),
+      ]
+    end
+
+    context 'when ongoing_enrollments is nil' do
+      let(:ongoing_enrollments) { nil }
+      let(:project_type) { nil }
+      let(:move_in_date) { nil }
+      let(:rrh_sub_type) { nil }
+
+      it 'returns false' do
+        expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be false
+      end
+    end
+
+    context 'when client is enrolled in RRH' do
+      let(:project_type) { 13 }
+
+      context 'with no move-in date and not services-only' do
+        let(:move_in_date) { nil }
+        let(:rrh_sub_type) { 2 }
+
+        it 'returns true' do
+          expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be true
+        end
+      end
+
+      context 'with no move-in date but services-only' do
+        let(:move_in_date) { nil }
+        let(:rrh_sub_type) { 1 }
+
+        it 'returns false' do
+          expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be false
+        end
+      end
+
+      context 'with move-in date and not services-only' do
+        let(:move_in_date) { Date.current }
+        let(:rrh_sub_type) { 2 }
+
+        it 'returns false' do
+          expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be false
+        end
+      end
+
+      context 'with move-in date and services-only' do
+        let(:move_in_date) { Date.current }
+        let(:rrh_sub_type) { 1 }
+
+        it 'returns false' do
+          expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be false
+        end
+      end
+    end
+
+    context 'when client is not enrolled in RRH' do
+      let(:project_type) { 3 } # PSH project type
+      let(:move_in_date) { nil }
+      let(:rrh_sub_type) { nil }
+
+      it 'returns false' do
+        expect(client.enrolled_in_rrh_pre_move_in(ongoing_enrollments)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Removes RRH SSO from the calculation of if someone is enrolled in RRH pre-move-in

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* change

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
