### PR TITLE
fix alias in remote creds

### DIFF
--- a/app/models/grda_warehouse/remote_credentials/s3.rb
+++ b/app/models/grda_warehouse/remote_credentials/s3.rb
@@ -11,7 +11,6 @@ require 'net/http'
 module GrdaWarehouse
   class RemoteCredentials::S3 < GrdaWarehouse::RemoteCredential
     alias_attribute :s3_access_key_id, :username
-    alias_method :s3_secret_access_key, :password
     alias_attribute :s3_prefix, :path
 
     # Can't use alias_attribute here due to deprecation warning. Using explicit getter/setter methods

--- a/app/models/grda_warehouse/remote_credentials/s3.rb
+++ b/app/models/grda_warehouse/remote_credentials/s3.rb
@@ -14,6 +14,12 @@ module GrdaWarehouse
     alias_method :s3_secret_access_key, :password
     alias_attribute :s3_prefix, :path
 
+    # Can't use alias_attribute here due to deprecation warning. Using explicit getter/setter methods
+    def s3_secret_access_key = password
+    def s3_secret_access_key=(value)
+      self.password = value
+    end
+
     validates :region, presence: true
     validates :bucket, presence: true
 

--- a/app/models/grda_warehouse/remote_credentials/s3.rb
+++ b/app/models/grda_warehouse/remote_credentials/s3.rb
@@ -15,6 +15,7 @@ module GrdaWarehouse
 
     # Can't use alias_attribute here due to RemoteCredential's use of attr_encrypted(:password)
     def s3_secret_access_key = password
+
     def s3_secret_access_key=(value)
       self.password = value
     end

--- a/app/models/grda_warehouse/remote_credentials/s3.rb
+++ b/app/models/grda_warehouse/remote_credentials/s3.rb
@@ -13,7 +13,7 @@ module GrdaWarehouse
     alias_attribute :s3_access_key_id, :username
     alias_attribute :s3_prefix, :path
 
-    # Can't use alias_attribute here due to deprecation warning. Using explicit getter/setter methods
+    # Can't use alias_attribute here due to RemoteCredential's use of attr_encrypted(:password)
     def s3_secret_access_key = password
     def s3_secret_access_key=(value)
       self.password = value

--- a/drivers/eccovia_data/app/models/eccovia_data/credential.rb
+++ b/drivers/eccovia_data/app/models/eccovia_data/credential.rb
@@ -15,6 +15,7 @@ module EccoviaData
 
     # Can't use alias_attribute here due to RemoteCredential's use of attr_encrypted(:password)
     def apikey = password
+
     def apikey=(value)
       self.password = value
     end

--- a/drivers/eccovia_data/app/models/eccovia_data/credential.rb
+++ b/drivers/eccovia_data/app/models/eccovia_data/credential.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -10,7 +12,13 @@ module EccoviaData
   class Credential < ::GrdaWarehouse::RemoteCredential
     # Docs: https://apidoc.eccovia.com/
     alias_attribute :subscriptionkey, :username
-    alias_attribute :apikey, :password
+
+    # Can't use alias_attribute here due to RemoteCredential's use of attr_encrypted(:password)
+    def apikey = password
+    def apikey=(value)
+      self.password = value
+    end
+
     PAGE_SIZE = 25
 
     # Note, CRQL queries are paginated at 25 by default, if more than 25 results are needed

--- a/drivers/hmis_supplemental/spec/requests/data_sets_controller_spec.rb
+++ b/drivers/hmis_supplemental/spec/requests/data_sets_controller_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe HmisSupplemental::DataSetsController, type: :request do
+  let(:user) { create(:acl_user) }
+  let(:data_source) { create(:hmis_data_source) }
+  let(:data_set) { create(:hmis_supplemental_data_set, data_source: data_source) }
+  let(:role) { create(:role, can_manage_config: true, can_edit_data_sources: true, can_view_projects: true) }
+  let(:user_group) { create(:user_group) }
+  let(:collection) { Collection.system_collection(:data_sources) }
+
+  before(:each) do
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get data_source_hmis_supplemental_data_sets_path(data_source)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns http success' do
+      get new_data_source_hmis_supplemental_data_set_path(data_source)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST #create' do
+    let(:valid_params) do
+      {
+        data_set: {
+          name: 'Test Data Set',
+          object_key: 'test.csv',
+          owner_type: 'client',
+          field_config: '[{"key":"widget","type":"float","label":"The Widget","multiValued":false}]',
+          sync_enabled: true,
+          remote_credential_attributes: {
+            region: 'us-east-1',
+            bucket: 'test-bucket',
+            s3_access_key_id: 'test-key',
+            s3_secret_access_key: 'test-secret',
+            s3_prefix: 'test/',
+          },
+        },
+      }
+    end
+
+    it 'creates a new data set' do
+      expect do
+        post data_source_hmis_supplemental_data_sets_path(data_source), params: valid_params
+      end.to change(HmisSupplemental::DataSet, :count).by(1)
+      expect(response).to redirect_to(data_source_hmis_supplemental_data_sets_path)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns http success' do
+      get edit_data_source_hmis_supplemental_data_set_path(data_source, data_set)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:update_params) do
+      {
+        data_set: {
+          name: 'Updated Data Set',
+        },
+      }
+    end
+
+    it 'updates the data set' do
+      patch data_source_hmis_supplemental_data_set_path(data_source, data_set), params: update_params
+      expect(response).to redirect_to(data_source_hmis_supplemental_data_sets_path)
+      expect(data_set.reload.name).to eq('Updated Data Set')
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the data set' do
+      url = data_source_hmis_supplemental_data_set_path(data_source, data_set)
+      expect { delete url }.to change(HmisSupplemental::DataSet, :count).by(-1)
+      expect(response).to redirect_to(data_source_hmis_supplemental_data_sets_path)
+    end
+  end
+end

--- a/drivers/ma_reports/app/models/ma_reports/csg_engage/credential.rb
+++ b/drivers/ma_reports/app/models/ma_reports/csg_engage/credential.rb
@@ -16,6 +16,7 @@ module MaReports::CsgEngage
 
     # Can't use alias_method here due to RemoteCredential's use of attr_encrypted(:password)
     def apikey = password
+
     def apikey=(value)
       self.password = value
     end

--- a/drivers/ma_reports/app/models/ma_reports/csg_engage/credential.rb
+++ b/drivers/ma_reports/app/models/ma_reports/csg_engage/credential.rb
@@ -12,8 +12,13 @@ require 'net/http/post/multipart'
 module MaReports::CsgEngage
   class Credential < ::GrdaWarehouse::RemoteCredential
     # Docs: TODO
-    alias_method :apikey, :password
     alias_attribute :options, :additional_headers
+
+    # Can't use alias_method here due to RemoteCredential's use of attr_encrypted(:password)
+    def apikey = password
+    def apikey=(value)
+      self.password = value
+    end
 
     DEFAULT_HOUR = 4
     DEFAULT_READ_TIMEOUT = 7_200 # 2 hours

--- a/spec/models/built_for_zero_report/credential_spec.rb
+++ b/spec/models/built_for_zero_report/credential_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BuiltForZeroReport::Credential do
       credential = described_class.new(
         endpoint: 'https://api.example.com',
         apikey: 'key123',
-        community_id: 'comm123'
+        community_id: 'comm123',
       )
       expect(credential.apikey).to eq('key123')
       expect(credential.community_id).to eq('comm123')

--- a/spec/models/built_for_zero_report/credential_spec.rb
+++ b/spec/models/built_for_zero_report/credential_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BuiltForZeroReport::Credential do
+  describe 'attribute assignment' do
+    it 'assigns aliased attributes correctly' do
+      credential = described_class.new(
+        endpoint: 'https://api.example.com',
+        apikey: 'key123',
+        community_id: 'comm123'
+      )
+      expect(credential.apikey).to eq('key123')
+      expect(credential.community_id).to eq('comm123')
+    end
+  end
+end

--- a/spec/models/eccovia_data/credential_spec.rb
+++ b/spec/models/eccovia_data/credential_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EccoviaData::Credential do
+  describe 'attribute assignment' do
+    it 'assigns apikey correctly' do
+      credential = described_class.new(
+        endpoint: 'https://api.example.com',
+        subscriptionkey: 'sub123',
+        apikey: 'key123'
+      )
+      expect(credential.apikey).to eq('key123')
+    end
+  end
+end

--- a/spec/models/eccovia_data/credential_spec.rb
+++ b/spec/models/eccovia_data/credential_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe EccoviaData::Credential do
       credential = described_class.new(
         endpoint: 'https://api.example.com',
         subscriptionkey: 'sub123',
-        apikey: 'key123'
+        apikey: 'key123',
       )
       expect(credential.apikey).to eq('key123')
     end

--- a/spec/models/grda_warehouse/remote_credentials/external_link_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/external_link_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GrdaWarehouse::RemoteCredentials::ExternalLink do
   describe 'attribute assignment' do
     it 'assigns aliased attributes correctly' do
       link = described_class.new(
-        link_base: 'https://example.com'
+        link_base: 'https://example.com',
       )
       expect(link.link_base).to eq('https://example.com')
     end

--- a/spec/models/grda_warehouse/remote_credentials/external_link_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/external_link_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::ExternalLink do
+  describe 'attribute assignment' do
+    it 'assigns aliased attributes correctly' do
+      link = described_class.new(
+        link_base: 'https://example.com'
+      )
+      expect(link.link_base).to eq('https://example.com')
+    end
+  end
+end

--- a/spec/models/grda_warehouse/remote_credentials/oauth_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/oauth_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GrdaWarehouse::RemoteCredentials::Oauth do
         client_secret: 'secret123',
         token_url: 'https://oauth.example.com/token',
         base_url: 'https://api.example.com',
-        oauth_scope: 'read write'
+        oauth_scope: 'read write',
       )
       expect(oauth.client_secret).to eq('secret123')
     end

--- a/spec/models/grda_warehouse/remote_credentials/oauth_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/oauth_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::Oauth do
+  describe 'attribute assignment' do
+    it 'assigns client_secret correctly' do
+      oauth = described_class.new(
+        client_id: 'client123',
+        client_secret: 'secret123',
+        token_url: 'https://oauth.example.com/token',
+        base_url: 'https://api.example.com',
+        oauth_scope: 'read write'
+      )
+      expect(oauth.client_secret).to eq('secret123')
+    end
+  end
+end

--- a/spec/models/grda_warehouse/remote_credentials/s3_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/s3_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::S3 do
+  describe 'attribute assignment' do
+    it 'assigns s3_secret_access_key correctly' do
+      s3 = described_class.new(
+        bucket: 'foobar1',
+        region: 'us-east-1',
+        s3_access_key_id: '12311212',
+        s3_secret_access_key: '1212111',
+      )
+      expect(s3.s3_secret_access_key).to eq('1212111')
+    end
+  end
+end

--- a/spec/models/grda_warehouse/remote_credentials/sftp_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/sftp_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GrdaWarehouse::RemoteCredentials::Sftp do
       sftp = described_class.new(
         host: 'sftp.example.com',
         private_key: 'key123',
-        port: '22'
+        port: '22',
       )
       expect(sftp.host).to eq('sftp.example.com')
       expect(sftp.private_key).to eq('key123')

--- a/spec/models/grda_warehouse/remote_credentials/sftp_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/sftp_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::Sftp do
+  describe 'attribute assignment' do
+    it 'assigns aliased attributes correctly' do
+      sftp = described_class.new(
+        host: 'sftp.example.com',
+        private_key: 'key123',
+        port: '22'
+      )
+      expect(sftp.host).to eq('sftp.example.com')
+      expect(sftp.private_key).to eq('key123')
+      expect(sftp.port).to eq('22')
+    end
+  end
+end

--- a/spec/models/grda_warehouse/remote_credentials/smtp_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/smtp_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::Smtp do
+  describe 'attribute assignment' do
+    it 'assigns aliased attributes correctly' do
+      smtp = described_class.new(
+        server: 'smtp.example.com',
+        from: 'noreply@example.com'
+      )
+      expect(smtp.server).to eq('smtp.example.com')
+      expect(smtp.from).to eq('noreply@example.com')
+    end
+  end
+end

--- a/spec/models/grda_warehouse/remote_credentials/smtp_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/smtp_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GrdaWarehouse::RemoteCredentials::Smtp do
     it 'assigns aliased attributes correctly' do
       smtp = described_class.new(
         server: 'smtp.example.com',
-        from: 'noreply@example.com'
+        from: 'noreply@example.com',
       )
       expect(smtp.server).to eq('smtp.example.com')
       expect(smtp.from).to eq('noreply@example.com')

--- a/spec/models/grda_warehouse/remote_credentials/symmetric_encryption_key_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/symmetric_encryption_key_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe GrdaWarehouse::RemoteCredentials::SymmetricEncryptionKey do
     it 'assigns key_hex correctly' do
       key = described_class.new(
         algorithm: 'AES-256-CBC',
-        key_hex: '0123456789abcdef'
+        key_hex: '0123456789abcdef',
       )
       expect(key.key_hex).to eq('0123456789abcdef')
     end

--- a/spec/models/grda_warehouse/remote_credentials/symmetric_encryption_key_spec.rb
+++ b/spec/models/grda_warehouse/remote_credentials/symmetric_encryption_key_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::RemoteCredentials::SymmetricEncryptionKey do
+  describe 'attribute assignment' do
+    it 'assigns key_hex correctly' do
+      key = described_class.new(
+        algorithm: 'AES-256-CBC',
+        key_hex: '0123456789abcdef'
+      )
+      expect(key.key_hex).to eq('0123456789abcdef')
+    end
+  end
+end

--- a/spec/models/ma_reports/csg_engage/credential_spec.rb
+++ b/spec/models/ma_reports/csg_engage/credential_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MaReports::CsgEngage::Credential do
+  describe 'attribute assignment' do
+    it 'assigns apikey correctly' do
+      credential = described_class.new(
+        endpoint: 'https://api.example.com',
+        apikey: 'key123'
+      )
+      expect(credential.apikey).to eq('key123')
+    end
+  end
+end

--- a/spec/models/ma_reports/csg_engage/credential_spec.rb
+++ b/spec/models/ma_reports/csg_engage/credential_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MaReports::CsgEngage::Credential do
     it 'assigns apikey correctly' do
       credential = described_class.new(
         endpoint: 'https://api.example.com',
-        apikey: 'key123'
+        apikey: 'key123',
       )
       expect(credential.apikey).to eq('key123')
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
* fixes issue caused by change to aliases in rails 7.1 upgrade
* add specs for all remote cred subclasses
* add controller test for supplemental data sets controller

## Type of change
Bug fix,

### test
visit data-sources, supplemental data sets. Create a new data source with s3 creds. Data source should be created and it should not crash

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have added spec tests (or not applicable)

