### PR TITLE
PIT Chronic HH by Report Date (162)

### DIFF
--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # require 'get_process_mem'
 # Required concerns:
 #   HudReports::Ages
@@ -168,6 +170,8 @@ module HudReports::Households
 
             date = [enrollment.first_date_in_program, @report.start_date].max
             age = GrdaWarehouse::Hud::Client.age(date: date, dob: enrollment.enrollment.client.DOB&.to_date)
+            report_date = @generator&.filter&.on || enrollment.enrollment.EntryDate
+
             @households[get_hh_id(enrollment)] ||= []
             @households[get_hh_id(enrollment)] << {
               client_id: enrollment.client_id,
@@ -175,6 +179,9 @@ module HudReports::Households
               dob: enrollment.enrollment.client.DOB,
               age: age,
               veteran_status: enrollment.enrollment.client.VeteranStatus,
+              # Chronic status is calculated as of the report date, use the enrollment start date if no report date is provided
+              pit_chronic_status: enrollment.enrollment.chronically_homeless_at_start?(date: report_date),
+              # Chronic status is calculated as of the enrollment start date
               chronic_status: enrollment.enrollment.chronically_homeless_at_start?,
               chronic_detail: enrollment.enrollment.chronically_homeless_at_start,
               relationship_to_hoh: enrollment.enrollment.RelationshipToHoH,

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -170,7 +170,8 @@ module HudReports::Households
 
             date = [enrollment.first_date_in_program, @report.start_date].max
             age = GrdaWarehouse::Hud::Client.age(date: date, dob: enrollment.enrollment.client.DOB&.to_date)
-            report_date = @generator&.filter&.on || enrollment.enrollment.EntryDate
+            report_date = @generator.filter&.on if @generator.respond_to?(:filter) && @generator.filter.present?
+            report_date ||= enrollment.enrollment.EntryDate
 
             @households[get_hh_id(enrollment)] ||= []
             @households[get_hh_id(enrollment)] << {

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
@@ -142,7 +142,7 @@ module HudPit::Generators::Pit::Fy2024
             race_none: source_client.RaceNone,
             veteran: source_client.VeteranStatus,
             chronically_homeless: enrollment.chronically_homeless_at_start?(date: @generator.filter.on),
-            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :chronic_status) || false,
+            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :pit_chronic_status) || false,
             substance_use: disabilities_latest.detect(&:substance?)&.DisabilityResponse&.present?,
             substance_use_indefinite_impairing: disabilities_latest.detect { |d| d.indefinite_and_impairs? && d.substance? }&.DisabilityResponse.present?,
             domestic_violence: dv_record&.DomesticViolenceSurvivor,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The PIT CH Household calculation was using the default enrollment.EntryDate to determine HH CH status while the Client CH status was using the report.on date. This update sets the HH CH calculation to also use the PIT report date.

New PR targetting release-162

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
