### PR TITLE
Fix failing test by resolving n+1 query

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_candidate.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_candidate.rb
@@ -15,8 +15,7 @@ module Types
     field :priority_score, Integer, null: false
 
     def client
-      # TODO(#7573) - fix n+1, see 'xit' test in drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
-      Hmis::Hud::Client.viewable_by(current_user).find_by(id: object.client_id)
+      load_ar_scope(scope: Hmis::Hud::Client.viewable_by(current_user), id: object.client_id)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -61,8 +61,7 @@ module Types
     end
 
     def client
-      # TODO(#7573) - fix n+1, see 'xit' test in drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
-      Hmis::Hud::Client.viewable_by(current_user).find_by(id: object.client_id)
+      load_ar_scope(scope: Hmis::Hud::Client.viewable_by(current_user), id: object.client_id)
     end
 
     def current_steps

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -248,7 +248,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
-    # TODO(#7573) - fix n+1 and reinstate this test
     context 'when the opportunity has lots of candidates' do
       before do
         200.times do
@@ -257,7 +256,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         end
       end
 
-      xit 'queries the db a reasonable amount' do
+      it 'queries the db a reasonable amount' do
         expect do
           response, result = post_graphql(**variables) { query }
           expect(response.status).to eq(200), result.inspect

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         )
       end
 
-      # TODO(#7573) - fix n+1 and reinstate this test
       context 'with many referrals' do
         before do
           30.times do
@@ -110,7 +109,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           end
         end
 
-        xit 'queries the db a reasonable amount' do
+        it 'queries the db a reasonable amount' do
           expect do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes test failure introduced by the merge of these 2 prs: https://github.com/greenriver/hmis-warehouse/pull/5360 / https://github.com/greenriver/hmis-warehouse/pull/5314

Summary:
- In the [data loader PR](https://github.com/greenriver/hmis-warehouse/pull/5314), I left some todos and 'xit' tests for n+1s to fix later
- Concurrently in the [CE admin screens](https://github.com/greenriver/hmis-warehouse/pull/5360) PR, I had added another test checking basically the same n+1 query. Once the dataloader work was merged into that, that test started to fail, and I didn't properly wait for all tests to rerun before merging.
- Revisiting the todos, I realized they were more straightforward to fix than I thought, using `load_ar_scope`. That's the fix I've added here

thanks, and sorry for my impatience!

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Test fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
