### PR TITLE
PIT Chronicity Hotfix

### DIFF
--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/base.rb
@@ -142,7 +142,7 @@ module HudPit::Generators::Pit::Fy2024
             race_none: source_client.RaceNone,
             veteran: source_client.VeteranStatus,
             chronically_homeless: enrollment.chronically_homeless_at_start?(date: @generator.filter.on),
-            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :pit_chronic_status) || false,
+            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :chronic_status) || false,
             substance_use: disabilities_latest.detect(&:substance?)&.DisabilityResponse&.present?,
             substance_use_indefinite_impairing: disabilities_latest.detect { |d| d.indefinite_and_impairs? && d.substance? }&.DisabilityResponse.present?,
             domestic_violence: dv_record&.DomesticViolenceSurvivor,

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -131,7 +131,7 @@ module HudPit::Generators::Pit::Fy2025
             race_none: source_client.RaceNone,
             veteran: source_client.VeteranStatus,
             chronically_homeless: enrollment.chronically_homeless_at_start?(date: @generator.filter.on),
-            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :chronic_status) || false,
+            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :pit_chronic_status) || false,
             substance_use: disabilities_latest.detect(&:substance?)&.DisabilityResponse&.present?,
             substance_use_indefinite_impairing: disabilities_latest.detect { |d| d.indefinite_and_impairs? && d.substance? }&.DisabilityResponse.present?,
             domestic_violence: dv_record&.DomesticViolenceSurvivor,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The update for the chronicity of a client household based on the report date was added to the 2024 PIT version, not the 2025 version. This moves the change to the correct version and resets the previous version.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
