### PR TITLE
Add fields to support referral design updates

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -929,6 +929,8 @@ type CeReferralStep {
   stepId: ID
   submittedValues: JsonObject
   swimlane: String!
+  updatedAt: ISO8601DateTime
+  updatedBy: ApplicationUser
 }
 
 enum CeReferralStepStatus {

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -56,7 +56,15 @@ module Types
         next nil if node.conditional_inflows? # task is conditional, don't show it yet
 
         # initialize step to display in the UI
-        instance.steps.new(node: node).freeze
+        step = instance.steps.new(node: node).freeze
+
+        # If the step is unpersisted, assignees won't be persisted yet either,
+        # but we know the step's default assignees based on the referral participants, so return them
+        participants_by_swimlane_id[node.swimlane_id].each do |p|
+          step.assignments.new(user: p.user)
+        end
+
+        step
       end.compact
     end
 
@@ -123,9 +131,6 @@ module Types
       user_ids = object.participants.map(&:user_id).uniq
       users_by_id = Hmis::User.where(id: user_ids).index_by(&:id)
 
-      # Fetch participants and group them by swimlane
-      participants_by_swimlane_id = object.participants.group_by(&:swimlane_id)
-
       object.swimlanes.map do |swimlane|
         # For this swimlane, get all associated participants, and map to the user objects that were already fetched
         participants = (participants_by_swimlane_id[swimlane.id] || []).filter_map do |participant|
@@ -138,6 +143,12 @@ module Types
           participants: participants,
         )
       end
+    end
+
+    private
+
+    def participants_by_swimlane_id
+      @participants_by_swimlane_id ||= object.participants.group_by(&:swimlane_id)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -60,7 +60,7 @@ module Types
 
         # If the step is unpersisted, assignees won't be persisted yet either,
         # but we know the step's default assignees based on the referral participants, so return them
-        participants_by_swimlane_id[node.swimlane_id].each do |p|
+        participants_by_swimlane_id[node.swimlane_id]&.each do |p|
           step.assignments.new(user: p.user)
         end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
@@ -32,7 +32,11 @@ module Types
     end
 
     def assignees
-      load_ar_association(object, :assignments)&.map(&:user)
+      if object.persisted?
+        load_ar_association(object, :assignments)&.map(&:user)
+      else
+        object.assignments.map(&:user)
+      end
     end
 
     def form_definition # Don't resolve in batch

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
@@ -19,6 +19,8 @@ module Types
     field :submitted_values, JsonObject, null: true
     delegate :name, to: :workflow_task
     field :assignees, [Application::User], null: false, description: 'User(s) currently assigned to this step'
+    field :updated_by, Application::User, null: true
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
 
     def id
       # the step may not yet be persisted, such as when it isn't yet available in the workflow
@@ -40,6 +42,10 @@ module Types
 
       # Otherwise, get the definition identifier on the node, and return the latest published definition with this identifier
       workflow_task.form_definitions.published.order(version: :desc).first
+    end
+
+    def updated_by
+      load_last_user_from_versions(object)
     end
 
     private

--- a/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
+++ b/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
@@ -204,7 +204,7 @@ task ce_starter_pack_20250302: [:environment] do
   task_2 = create_task(review_denial_form_def, sequential_template,  'Provider Confirm', providers)
 
   start_workflow_event.connect_to!(task_1) unless start_workflow_event.outflows.where(target_node_id: task_1.id).exists?
-  task_1.connect_to!(task_2) unless start_workflow_event.outflows.where(target_node_id: task_2.id).exists?
+  task_1.connect_to!(task_2) unless task_1.outflows.where(target_node_id: task_2.id).exists?
   task_2.connect_to!(accept_workflow_event) unless task_2.outflows.where(target_node_id: accept_workflow_event.id).exists?
 
   puts '- Creating Enrollment Creator template, a template with tasks that have side effects.'

--- a/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
+++ b/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
@@ -193,6 +193,20 @@ task ce_starter_pack_20250302: [:environment] do
   admin_review_gateway.connect_to!(client_acceptance_task, condition: 'review_denial_decision = 0') unless admin_review_gateway.outflows.where(target_node_id: client_acceptance_task.id).exists?
   admin_review_gateway.connect_to!(reject_workflow_event, condition: 'review_denial_decision = 1') unless admin_review_gateway.outflows.where(target_node_id: reject_workflow_event.id).exists?
 
+  puts '- Creating Sequential template, a template with non-conditional tasks that are executed sequentially.'
+  sequential_template = create_template('Sequential', 'sequential')
+  case_managers = sequential_template.swimlanes.find_or_create_by!(name: 'Case Managers')
+  providers = sequential_template.swimlanes.find_or_create_by!(name: 'Providers')
+  start_workflow_event = create_start_event(sequential_template, 'start referral', 'start_workflow', 'start_referral')
+  accept_workflow_event = create_end_event(sequential_template, 'accept referral', 'end_workflow', 'accept_referral')
+
+  task_1 = create_task(client_accepts_form_def, sequential_template,  'Case Manager Confirm', case_managers)
+  task_2 = create_task(review_denial_form_def, sequential_template,  'Provider Confirm', providers)
+
+  start_workflow_event.connect_to!(task_1) unless start_workflow_event.outflows.where(target_node_id: task_1.id).exists?
+  task_1.connect_to!(task_2) unless start_workflow_event.outflows.where(target_node_id: task_2.id).exists?
+  task_2.connect_to!(accept_workflow_event) unless task_2.outflows.where(target_node_id: accept_workflow_event.id).exists?
+
   puts '- Creating Enrollment Creator template, a template with tasks that have side effects.'
 
   enrollment_creator_template = create_template('Enrollment Creator', 'enrollment_creator')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

Supports frontend PR: https://github.com/greenriver/hmis-frontend/pull/1155/files

Summary of changes
- Add schema fields `updatedAt` and `updatedBy` to CE referral step.
- Add another workflow to the starter pack, this one with sequential non-conditional steps, so we can see examples of locked (unavailable) steps in the ui.
- and belatedly: Return "fake" assignees on unpersisted steps. We can discuss this one more; I think maybe the need to do something like this points to a code smell related to something about the way we are persisting and returning unpersisted steps. But let me know what you think.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) - see frontend pr

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
