### PR TITLE
Adjust state picklist in case of multiple states

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -310,14 +310,15 @@ module Types
     end
 
     def self.state_picklist
+      relevant_states = GrdaWarehouse::Config.relevant_state_codes
+
       Rails.cache.fetch('STATE_OPTION_LIST', expires_in: 1.days) do
         JSON.parse(File.read('drivers/hmis/lib/pick_list_data/states.json'))
       end.map do |obj|
         {
           code: obj['abbreviation'],
           # label: "#{obj['abbreviation']} - #{obj['name']}",
-          # NOTE: HMIS currently only supports one state installations
-          initial_selected: obj['abbreviation'].in?(GrdaWarehouse::Config.relevant_state_codes&.first),
+          initial_selected: relevant_states&.size == 1 && obj['abbreviation'] == relevant_states.first,
         }
       end
     end

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -171,6 +171,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(options.first['groupLabel']).to eq('VT')
       expect(options.last['groupLabel']).to eq('MA')
     end
+
+    it 'returns states with no state auto-selected' do
+      response, result = post_graphql(pick_list_type: 'STATE') { query }
+      expect(response.status).to eq 200
+      options = result.dig('data', 'pickList')
+      expect(options.none? { |o| o['initialSelected'] }).to be_truthy
+    end
   end
 
   it 'returns grouped service type pick list' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

When there are multiple relevant states for an installation, prevent the State picklist from auto-selecting the first one in the list.

How to test: Go to the Add/Edit CoC interface for a multi state installation. I mimicked this locally by setting `configs.relevant_state_codes` to a two-state comma separated string, like "VT,MA". Confirm that a state is not auto-selected in the pick list dropdown.

Other impacts: I think the only other place we are using the State picklist is on the Client Address form. I believe there's no impact there because that form already does not respect `initialSelected` (it is not a `DynamicForm`).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Followup to new feature (supporting multi state installations)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
