### PR TITLE
Make permissions_with_descriptions not touch db in test env

### DIFF
--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -99,6 +99,10 @@ class Hmis::Role < ::ApplicationRecord
   def self.permissions_by_group
     {}.tap do |perms|
       permissions_with_descriptions.each do |key, role|
+        # proc is optional; if it evaluates to false, then hide this permission.
+        # (If it's nil, still include the permission)
+        next if role[:proc] == false
+
         perms[role[:category]] ||= {}
         perms[role[:category]][role[:sub_category]] ||= {}
         perms[role[:category]][role[:sub_category]][key] = role
@@ -175,6 +179,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: false,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -179,7 +179,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: false,
+        proc: Hmis::Ce.configuration.enabled?,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -99,10 +99,6 @@ class Hmis::Role < ::ApplicationRecord
   def self.permissions_by_group
     {}.tap do |perms|
       permissions_with_descriptions.each do |key, role|
-        # proc is optional; if it evaluates to false, then hide this permission.
-        # (If it's nil, still include the permission)
-        next if role[:proc] == false
-
         perms[role[:category]] ||= {}
         perms[role[:category]][role[:sub_category]] ||= {}
         perms[role[:category]][role[:sub_category]][key] = role
@@ -179,7 +175,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',
@@ -187,7 +182,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_view_referrals: {
         description: 'Ability to view all referrals to the project',
@@ -195,7 +189,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_view_own_referrals: {
         description: 'Grants the same permissions as "Can view referrals", but only for referrals in which this user has at least one assigned, available task',
@@ -203,7 +196,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_perform_any_referral_tasks: {
         description: 'Ability to start and submit any referral task, and add referral notes, on all referrals to the project',
@@ -211,7 +203,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_perform_own_referral_tasks: {
         description: 'Grants the same permission as "Can perform any referral tasks," but only for referrals in which this user has at least one assigned, available task. This permission informs the dropdown of users available for assignment to referral swimlanes.',
@@ -219,7 +210,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_view_client_eligible_opportunities: {
         description: 'Ability to view the Client page showing all Opportunities a client is eligible for. This is a global permission (not per-project).',
@@ -228,7 +218,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Administration',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_administrate_coordinated_entry: {
         description: 'Ability to manage global CE configurations, and view CE admin screens. This is a global permission.',
@@ -237,7 +226,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Administration',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_assign_referral_tasks: {
         description: 'Ability to assign contacts for any referral to the project that the user can view',
@@ -245,7 +233,6 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
       },
       can_manage_incoming_referrals: { # TODO - Deprecate and delete
         description: 'Ability to accept/deny incoming referrals in the Project',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -110,6 +110,12 @@ class Hmis::Role < ::ApplicationRecord
     end
   end
 
+  def self.show_ce_permissions?
+    # Show CE permissions if CE is enabled
+    # In test env on CI, permissions_by_group is called before the database is loaded(?)
+    ENV['RAILS_ENV'] == 'test' || Hmis::Ce.configuration.enabled?
+  end
+
   # List permissions that are granted by this role
   def granted_permissions
     self.class.permissions_with_descriptions.keys.select { |perm| send(perm) }
@@ -179,7 +185,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: ENV['RAILS_ENV'] == 'test' || Hmis::Ce.configuration.enabled?,
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',
@@ -187,6 +193,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_view_referrals: {
         description: 'Ability to view all referrals to the project',
@@ -194,6 +201,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_view_own_referrals: {
         description: 'Grants the same permissions as "Can view referrals", but only for referrals in which this user has at least one assigned, available task',
@@ -201,6 +209,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_perform_any_referral_tasks: {
         description: 'Ability to start and submit any referral task, and add referral notes, on all referrals to the project',
@@ -208,6 +217,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_perform_own_referral_tasks: {
         description: 'Grants the same permission as "Can perform any referral tasks," but only for referrals in which this user has at least one assigned, available task. This permission informs the dropdown of users available for assignment to referral swimlanes.',
@@ -215,6 +225,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_view_client_eligible_opportunities: {
         description: 'Ability to view the Client page showing all Opportunities a client is eligible for. This is a global permission (not per-project).',
@@ -223,6 +234,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Administration',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_administrate_coordinated_entry: {
         description: 'Ability to manage global CE configurations, and view CE admin screens. This is a global permission.',
@@ -231,6 +243,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Administration',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_assign_referral_tasks: {
         description: 'Ability to assign contacts for any referral to the project that the user can view',
@@ -238,6 +251,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:editable],
         category: 'Project Access',
         sub_category: 'Referrals',
+        proc: Hmis::Role.show_ce_permissions?,
       },
       can_manage_incoming_referrals: { # TODO - Deprecate and delete
         description: 'Ability to accept/deny incoming referrals in the Project',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -179,7 +179,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: Hmis::Ce.configuration.enabled?,
+        proc: RailsDrivers.loaded.include?(:hmis) && Hmis::Ce.configuration.enabled?,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -179,7 +179,7 @@ class Hmis::Role < ::ApplicationRecord
         access: [:viewable],
         category: 'Project Access',
         sub_category: 'Referrals',
-        proc: RailsDrivers.loaded.include?(:hmis) && Hmis::Ce.configuration.enabled?,
+        proc: ENV['RAILS_ENV'] == 'test' || Hmis::Ce.configuration.enabled?,
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',


### PR DESCRIPTION
This reverts commit aeae41af91bb44edc117129eb90785145b9d72c7.

## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
