### PR TITLE
PIT CH Household calculation

### DIFF
--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -83,7 +83,7 @@ module HudReports::Households
     # NOTE: Client CH status is only inherited if the client was present at the start of the enrollment.
     # per HUD guidance, the HoH should always be present for the entire stay, so we'll compare start dates to them
     # see AirTable Issue ID 30
-    private def household_chronic_status(hh_id, client_id)
+    private def calculate_household_chronic_status(hh_id, client_id, chronic_status: :chronic_status)
       household_members = households[hh_id]
       # we couldn't find a household
       return false unless household_members.present?
@@ -91,16 +91,31 @@ module HudReports::Households
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
       current_member = household_members.detect { |hm| hm[:client_id] == client_id }
 
+      # When no specific client_id is provided (PIT), use the HoH as the current_memberfor the household calculation
+      # This will allow the entire HH to have the same chronic status
+      current_member ||= hoh
+
+      current_member_entry_date = current_member[:entry_date] if current_member.present?
+      # The current_member will not exist in cases where client_id is not provided (PIT) and the household does not have a HoH
+      # We will still want to check for a chronic adult in this case, so we'll use the earliest entry date in the HH
+      current_member_entry_date ||= household_members.map { |hm| hm[:entry_date] }.compact.min
+
       # HoH if they are chronically homeless
-      return hoh if hoh.present? && hoh[:chronic_status] && hoh[:entry_date] == current_member[:entry_date]
+      return hoh if hoh.present? && hoh[chronic_status] && hoh[:entry_date] == current_member_entry_date
 
       chronic_adult = household_members.detect do |hm|
         next false unless hm[:age].present?
 
-        hm[:age] >= 18 && hm[:chronic_status] && hm[:entry_date] == current_member[:entry_date]
+        adult_is_chronic = hm[:age] >= 18 && hm[chronic_status]
+        adult_matches_entry_date = hm[:entry_date] == current_member_entry_date
+
+        adult_is_chronic && adult_matches_entry_date
       end
       # if not, use any other adult who is (with the same entry date)
       return chronic_adult if chronic_adult.present?
+
+      # Return false if we don't have a valid member to check
+      return false unless current_member.present?
 
       # if no adults are either yes or no, use self for adults
       return current_member if current_member[:age].present? && current_member[:age] >= 18
@@ -116,6 +131,14 @@ module HudReports::Households
       current_member
     end
 
+    private def household_chronic_status(hh_id, client_id)
+      calculate_household_chronic_status(hh_id, client_id)
+    end
+
+    private def pit_household_chronic_status(hh_id)
+      calculate_household_chronic_status(hh_id, nil, chronic_status: :pit_chronic_status)
+    end
+
     private def calculate_hh_move_in_date(hh_id, she)
       # Get HoH for further calculations
       household_members = households[hh_id]
@@ -129,15 +152,15 @@ module HudReports::Households
       # Heads of household with [housing move-in dates] prior to their [project start dates] should have the [housing move-in dates] disregarded entirely.
       return nil unless hoh[:entry_date] <= hoh[:move_in_date]
 
-      # When a household member was already in the household when they became housed (individual’s [project
-      # start date] <= head of household’s [housing move-in date]), the head of household’s [housing move-in date]
-      # should be used as the individual’s [housing move-in date]. If the household member exited before the
+      # When a household member was already in the household when they became housed (individual's [project
+      # start date] <= head of household's [housing move-in date]), the head of household's [housing move-in date]
+      # should be used as the individual's [housing move-in date]. If the household member exited before the
       # household moved into housing, they do not inherit this [housing move-in date].
       return hoh[:move_in_date] if (she.entry_date..she.exit_date).cover?(hoh[:move_in_date])
 
-      # When a household member joins the household after they are already housed (individual’s [project start
-      # date] > head of household’s [housing move-in date]), the individual’s [project start date] should be used as
-      # the individual’s [housing move-in date].
+      # When a household member joins the household after they are already housed (individual's [project start
+      # date] > head of household's [housing move-in date]), the individual's [project start date] should be used as
+      # the individual's [housing move-in date].
       return she.entry_date if she.entry_date > hoh[:move_in_date]
 
       # Otherwise this move-in is completely invalid

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -91,23 +91,23 @@ module HudReports::Households
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
       current_member = household_members.detect { |hm| hm[:client_id] == client_id }
 
-      # When no specific client_id is provided (PIT), use the HoH as the current_memberfor the household calculation
+      # When no specific client_id is provided (PIT), use the HoH as the current_member for the household calculation
       # This will allow the entire HH to have the same chronic status
       current_member ||= hoh
 
       current_member_entry_date = current_member[:entry_date] if current_member.present?
-      # The current_member will not exist in cases where client_id is not provided (PIT) and the household does not have a HoH
-      # We will still want to check for a chronic adult in this case, so we'll use the earliest entry date in the HH
-      current_member_entry_date ||= household_members.map { |hm| hm[:entry_date] }.compact.min
+      hoh_entry_date = hoh[:entry_date] if hoh.present?
 
       # HoH if they are chronically homeless
-      return hoh if hoh.present? && hoh[chronic_status] && hoh[:entry_date] == current_member_entry_date
+      return hoh if hoh.present? && hoh[chronic_status] && hoh_entry_date == current_member_entry_date
 
+      # If the HoH is not chronically homeless, check if any other adult is
+      # The HH CH status will inherit from a CH adultas long as they have the same entry date as the HoH
       chronic_adult = household_members.detect do |hm|
         next false unless hm[:age].present?
 
         adult_is_chronic = hm[:age] >= 18 && hm[chronic_status]
-        adult_matches_entry_date = hm[:entry_date] == current_member_entry_date
+        adult_matches_entry_date = hm[:entry_date] == hoh_entry_date
 
         adult_is_chronic && adult_matches_entry_date
       end

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -158,7 +158,6 @@ module HudPit::Generators::Pit::Fy2025
             columns: pending_associations.values.first&.changes&.keys || [],
           },
         )
-        # binding.pry
 
         # Attach PIT Clients to relevant questions
         @report.build_for_questions.each do |question_number|

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -131,7 +131,7 @@ module HudPit::Generators::Pit::Fy2025
             race_none: source_client.RaceNone,
             veteran: source_client.VeteranStatus,
             chronically_homeless: enrollment.chronically_homeless_at_start?(date: @generator.filter.on),
-            chronically_homeless_household: household_chronic_status(hh_id, client.id).try(:[], :pit_chronic_status) || false,
+            chronically_homeless_household: pit_household_chronic_status(hh_id).try(:[], :pit_chronic_status) || false,
             substance_use: disabilities_latest.detect(&:substance?)&.DisabilityResponse&.present?,
             substance_use_indefinite_impairing: disabilities_latest.detect { |d| d.indefinite_and_impairs? && d.substance? }&.DisabilityResponse.present?,
             domestic_violence: dv_record&.DomesticViolenceSurvivor,
@@ -158,6 +158,7 @@ module HudPit::Generators::Pit::Fy2025
             columns: pending_associations.values.first&.changes&.keys || [],
           },
         )
+        # binding.pry
 
         # Attach PIT Clients to relevant questions
         @report.build_for_questions.each do |question_number|

--- a/drivers/hud_pit/spec/models/questions/adult_and_child.rb
+++ b/drivers/hud_pit/spec/models/questions/adult_and_child.rb
@@ -47,7 +47,7 @@ RSpec.shared_context 'adult and child', shared_context: :metadata do
       'Multi-Racial & Hispanic/Latina/e/o' => [1, 0, 0],
       'Multi-Racial (all other)' => [18, 4, 0],
       'Chronically Homeless: Total number of households' => [3, 1, 0],
-      'Chronically Homeless: Total number of persons' => [7, 3, 0],
+      'Chronically Homeless: Total number of persons' => [8, 3, 0],
     }
 
     results.each_with_index do |(category, data), row_index|

--- a/drivers/hud_pit/spec/models/questions/parenting_youth.rb
+++ b/drivers/hud_pit/spec/models/questions/parenting_youth.rb
@@ -46,7 +46,7 @@ RSpec.shared_context 'parenting youth', shared_context: :metadata do
       'Multi-Racial & Hispanic/Latina/e/o' => [2, 0, 0],
       'Multi-Racial (all other)' => [0, 0, 0],
       'Chronically Homeless: Total number of households' => [0, 0, 0],
-      'Chronically Homeless: Total number of persons' => [1, 0, 0],
+      'Chronically Homeless: Total number of persons' => [0, 0, 0],
     }
 
     results.each_with_index do |(category, data), row_index|


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

PIT CH HH calculation was returning different values for different HH members when the child was CH and rest of the HH was not. This update has the HH evaluated based on the household makeup and not a per-member basis.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
