### PR TITLE
Fix HMIS Project Group search partial

### DIFF
--- a/drivers/hmis/app/views/hmis_admin/project_groups/index.haml
+++ b/drivers/hmis/app/views/hmis_admin/project_groups/index.haml
@@ -6,7 +6,7 @@
 - @prompt = "Search project groups..."
 .row.mb-4
   .col-sm-8
-    = render 'search_form'
+    = render_generic_search_form
   .col-sm-4.text-right
     = link_to new_hmis_admin_project_group_path, class: 'btn btn-primary mb-2' do
       %span.icon-plus


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fixes search on HMIS Project Groups page.
Patch merge conflict between https://github.com/greenriver/hmis-warehouse/pull/5387 and https://github.com/greenriver/hmis-warehouse/pull/5398

Test by visiting https://hmis-warehouse.dev.test/hmis_admin/project_groups

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
