### PR TITLE
Add data source to template

### DIFF
--- a/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
+++ b/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
@@ -1,0 +1,32 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddDataSourceIdToWfdTemplate < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do # not yet used in prod, so safety_assured is ok
+      add_column :wfd_templates, :data_source_id, :integer, null: true
+
+      add_index :wfd_templates, :data_source_id
+
+      # We want the column to be required, but need to fill in a default value on all the existing records.
+      # Since they are non-prod records that were populated by the starter pack,
+      # we can just rerun the starter pack later to get the actual correct data source ID in each environment,
+      # so for now just use 0.
+      reversible do |dir|
+        dir.up do
+          execute <<~SQL
+          UPDATE wfd_templates
+          SET data_source_id = 0
+        SQL
+        end
+      end
+
+      change_column_null :wfd_templates, :data_source_id, false
+    end
+  end
+end

--- a/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
+++ b/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
@@ -9,24 +9,7 @@
 class AddDataSourceIdToWfdTemplate < ActiveRecord::Migration[7.0]
   def change
     safety_assured do # not yet used in prod, so safety_assured is ok
-      add_column :wfd_templates, :data_source_id, :integer, null: true
-
-      add_index :wfd_templates, :data_source_id
-
-      # We want the column to be required, but need to fill in a default value on all the existing records.
-      # Since they are non-prod records that were populated by the starter pack,
-      # we can just rerun the starter pack later to get the actual correct data source ID in each environment,
-      # so for now just use 0.
-      reversible do |dir|
-        dir.up do
-          execute <<~SQL
-            UPDATE wfd_templates
-            SET data_source_id = 0
-          SQL
-        end
-      end
-
-      change_column_null :wfd_templates, :data_source_id, false
+      add_reference :wfd_templates, :data_source, foreign_key: true, null: true
     end
   end
 end

--- a/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
+++ b/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
@@ -20,9 +20,9 @@ class AddDataSourceIdToWfdTemplate < ActiveRecord::Migration[7.0]
       reversible do |dir|
         dir.up do
           execute <<~SQL
-          UPDATE wfd_templates
-          SET data_source_id = 0
-        SQL
+            UPDATE wfd_templates
+            SET data_source_id = 0
+          SQL
         end
       end
 

--- a/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
+++ b/db/warehouse/migrate/20250522193546_add_data_source_id_to_wfd_template.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-class AddDataSourceIdToWfdTemplate < ActiveRecord::Migration[7.0]
+class AddDataSourceIdToWfdTemplate < ActiveRecord::Migration[7.1]
   def change
     safety_assured do # not yet used in prod, so safety_assured is ok
       add_reference :wfd_templates, :data_source, foreign_key: true, null: true

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -29349,7 +29349,8 @@ CREATE TABLE public.wfd_templates (
     owner_type character varying,
     owner_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    data_source_id integer NOT NULL
 );
 
 
@@ -62295,6 +62296,13 @@ CREATE INDEX index_wfd_swimlanes_on_template_id ON public.wfd_swimlanes USING bt
 
 
 --
+-- Name: index_wfd_templates_on_data_source_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wfd_templates_on_data_source_id ON public.wfd_templates USING btree (data_source_id);
+
+
+--
 -- Name: index_wfd_templates_on_owner; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -65781,6 +65789,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250522193546'),
 ('20250516141401'),
 ('20250514150515'),
 ('20250512132201'),

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -29350,7 +29350,7 @@ CREATE TABLE public.wfd_templates (
     owner_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_source_id integer NOT NULL
+    data_source_id bigint
 );
 
 
@@ -65052,6 +65052,14 @@ ALTER TABLE ONLY public.ce_referrals
 
 ALTER TABLE ONLY public.hmis_external_referral_postings
     ADD CONSTRAINT fk_rails_41274b755e FOREIGN KEY (referral_request_id) REFERENCES public.hmis_external_referral_requests(id);
+
+
+--
+-- Name: wfd_templates fk_rails_43a090fe14; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wfd_templates
+    ADD CONSTRAINT fk_rails_43a090fe14 FOREIGN KEY (data_source_id) REFERENCES public.data_sources(id);
 
 
 --

--- a/drivers/hmis/app/graphql/mutations/ce/create_ce_opportunity.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/create_ce_opportunity.rb
@@ -18,7 +18,10 @@ module Mutations
       project = Hmis::Hud::Project.viewable_by(current_user).find(project_id)
       access_denied! unless current_permission?(permission: :can_manage_units, entity: project)
 
-      template = Hmis::WorkflowDefinition::Template.viewable_by(current_user).find(input.template_id)
+      template = Hmis::WorkflowDefinition::Template.
+        published.viewable_by(current_user).
+        find_by(identifier: input.template_identifier)
+
       opportunity = nil
       project.with_lock do
         opportunity = Hmis::Ce::Opportunity.new(project: project)

--- a/drivers/hmis/app/graphql/mutations/ce/create_ce_opportunity.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/create_ce_opportunity.rb
@@ -12,7 +12,7 @@ module Mutations
     argument :input, Types::HmisSchema::CeOpportunityInput, required: true
     field :opportunity, Types::HmisSchema::CeOpportunity, null: false
 
-    def resolve(project_id:, input:) # TODO(#7522) - remove this mutation
+    def resolve(project_id:, input:) # TODO(#7529) - remove this mutation
       raise unless Hmis::Ce.configuration.enabled?
 
       project = Hmis::Hud::Project.viewable_by(current_user).find(project_id)

--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -24,7 +24,7 @@ module Mutations
       project = Hmis::Hud::Project.find_by(id: project_ids.first)
       access_denied! unless current_user.permissions_for?(project, :can_manage_units)
 
-      # TODO(#7522) - template should be determined by context (project, unit type, ...)
+      # TODO(#7529) - template should be determined by context (project, unit type, ...)
       # For now, if you are using the "starter pack," this picks the template that creates an enrollment
       template = Hmis::WorkflowDefinition::Template.last
       raise unless template.present?

--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -26,7 +26,7 @@ module Mutations
 
       # TODO(#7529) - template should be determined by context (project, unit type, ...)
       # For now, if you are using the "starter pack," this picks the template that creates an enrollment
-      template = Hmis::WorkflowDefinition::Template.last
+      template = Hmis::WorkflowDefinition::Template.viewable_by(current_user).last
       raise unless template.present?
 
       candidate_pool_resolver = Hmis::Ce::Match::CandidatePoolResolver.new

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -7114,6 +7114,11 @@ enum PickListType {
   CE_EVENTS
 
   """
+  Templates for CE workflow definitions
+  """
+  CE_WORKFLOW_TEMPLATE_IDENTIFIERS
+
+  """
   Templates for CE workflow definitions, including fully retired workflows
   """
   CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED
@@ -7215,11 +7220,6 @@ enum PickListType {
   User accounts. Deprecated in favor of AUDITABLE_USERS
   """
   USERS
-
-  """
-  Templates for CE workflow definitions
-  """
-  WORKFLOW_DEFINITION_TEMPLATES
 }
 
 """

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -790,7 +790,7 @@ input CeOpportunityFilterOptions {
 
 input CeOpportunityInput {
   name: String!
-  templateId: ID!
+  templateIdentifier: String!
 }
 
 """

--- a/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
@@ -52,7 +52,7 @@ module Types
     value 'ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS', 'Users who can be assigned to referral steps in the specified project'
     value 'AUDITABLE_USERS', 'Current and historical user accounts'
     value 'CONTINUUM_PROJECTS', 'Continuum Projects'
-    value 'WORKFLOW_DEFINITION_TEMPLATES', 'Templates for CE workflow definitions'
+    value 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS', 'Templates for CE workflow definitions'
     value 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED', 'Templates for CE workflow definitions, including fully retired workflows'
   end
 end

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -163,21 +163,22 @@ module Types
           pluck(:OtherFunder).uniq.sort.map do |other_funder|
             { code: other_funder, label: other_funder }
           end
-      when 'WORKFLOW_DEFINITION_TEMPLATES'
-        # TODO(#7522) - rename CE_WORKFLOW_TEMPLATE_IDENTIFIERS;
-        #  return identifiers and not IDs; only return published templates; only return CE templates
-        # TODO(#7502) - templates are shared across data sources
+      when 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS'
         # Unique ce workflow template identifiers that are currently published.
-        # Used for configuring which template to use for a project/resource/group/etc
+        # Used for configuring which template to use for a resource group
         return [] unless Hmis::Ce.configuration.enabled?
 
-        Hmis::WorkflowDefinition::Template.all.map do |template|
-          { code: template.id, label: template.name }
-        end
+        Hmis::WorkflowDefinition::Template.published.ce.
+          where(data_source_id: user.hmis_data_source_id).
+          map do |template|
+            { code: template.identifier, label: template.name }
+          end
       when 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED'
         # Unique CE workflow template identifiers, including retired workflows with no currently published version.
         # Used for filtering on existing/historical referrals.
-        base_scope = Hmis::WorkflowDefinition::Template.where(template_type: :ce_referral)
+        return [] unless Hmis::Ce.configuration.enabled?
+
+        base_scope = Hmis::WorkflowDefinition::Template.ce.where(data_source_id: user.hmis_data_source_id)
         base_scope.published.or(base_scope.retired).group_by(&:identifier).map do |identifier, templates|
           description = templates.find { |t| t.status.to_sym == :published }&.name || templates.max_by(&:version).name
           { code: identifier, label: description }

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -168,8 +168,7 @@ module Types
         # Used for configuring which template to use for a resource group
         return [] unless Hmis::Ce.configuration.enabled?
 
-        Hmis::WorkflowDefinition::Template.published.ce.
-          where(data_source_id: user.hmis_data_source_id).
+        Hmis::WorkflowDefinition::Template.published.ce.viewable_by(user).
           map do |template|
             { code: template.identifier, label: template.name }
           end
@@ -178,7 +177,7 @@ module Types
         # Used for filtering on existing/historical referrals.
         return [] unless Hmis::Ce.configuration.enabled?
 
-        base_scope = Hmis::WorkflowDefinition::Template.ce.where(data_source_id: user.hmis_data_source_id)
+        base_scope = Hmis::WorkflowDefinition::Template.ce.viewable_by(user)
         base_scope.published.or(base_scope.retired).group_by(&:identifier).map do |identifier, templates|
           description = templates.find { |t| t.status.to_sym == :published }&.name || templates.max_by(&:version).name
           { code: identifier, label: description }

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_opportunity_input.rb
@@ -8,7 +8,7 @@
 
 module Types
   class HmisSchema::CeOpportunityInput < Types::BaseInputObject
-    argument :template_id, ID, required: true
+    argument :template_identifier, String, required: true
     argument :name, String, required: true
     # TBD
     # expiration

--- a/drivers/hmis/app/models/hmis/ce/opportunity.rb
+++ b/drivers/hmis/app/models/hmis/ce/opportunity.rb
@@ -24,6 +24,7 @@ module Hmis::Ce
 
     validates :name, presence: true
     validate :unique_opportunity_per_unit
+    validate :consistent_data_source
 
     state_machine_config column: 'status' do
       state :open, initial: true
@@ -121,6 +122,12 @@ module Hmis::Ce
       return unless conflicting_opportunity_exists
 
       errors.add(:owner, 'can only have one opportunity')
+    end
+
+    def consistent_data_source
+      return if project.data_source == workflow_template.data_source
+
+      errors.add(:project, 'must be in same data source as workflow template')
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/workflow_definition/template.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/template.rb
@@ -33,6 +33,7 @@ module Hmis::WorkflowDefinition
       end
     end
 
+    scope :viewable_by, ->(user) { where(data_source_id: user.hmis_data_source_id) }
     scope :ce, -> { where(template_type: 'ce_referral') }
     scope :published, -> { where(status: 'published') }
 

--- a/drivers/hmis/app/models/hmis/workflow_definition/template.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/template.rb
@@ -12,6 +12,7 @@ module Hmis::WorkflowDefinition
     has_many :instances, class_name: 'Hmis::WorkflowExecution::Instance', dependent: :restrict_with_exception, foreign_key: 'template_id'
     has_many :swimlanes, class_name: 'Hmis::WorkflowDefinition::Swimlane', dependent: :restrict_with_exception, foreign_key: 'template_id'
     has_many :ce_opportunities, class_name: 'Hmis::Ce::Opportunity', dependent: :restrict_with_exception
+    belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
     validates :name, presence: true
     validates :status, presence: true
@@ -32,7 +33,8 @@ module Hmis::WorkflowDefinition
       end
     end
 
-    scope :viewable_by, ->(_user) { all }
+    scope :ce, -> { where(template_type: 'ce_referral') }
+    scope :published, -> { where(status: 'published') }
 
     def graph(preloads: nil) # Caller can optionally pass additional attributes to preload, to avoid n+1s
       Hmis::WorkflowDefinition::Graph.new(nodes.preload(:outflows, *preloads))

--- a/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
+++ b/drivers/hmis/lib/tasks/ce_starter_pack_20250302.rake
@@ -7,6 +7,7 @@ def create_template(name, identifier)
   template.template_type = 'ce_referral'
   template.name = name
   template.version = 0
+  template.data_source = GrdaWarehouse::DataSource.hmis.first
   template.save! if template.changed?
   template
 end

--- a/drivers/hmis/spec/factories/hmis/ce/match_candidate_pools.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/match_candidate_pools.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :hmis_ce_match_candidate_pool, class: 'Hmis::Ce::Match::CandidatePool' do
     requirement_expression { 'TRUE' }
-    priority_expression { '0' }
+    sequence(:priority_expression, &:to_s)
     configuration_updated_at { Date.new(2024, 1, 1) }
   end
 end

--- a/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
@@ -6,9 +6,12 @@ FactoryBot.define do
     association(:project, factory: :hmis_hud_project)
     association(:workflow_template, factory: :hmis_workflow_definition_template)
 
-    before(:create) do |instance|
-      # Ensure data source consistency
-      instance.workflow_template.data_source = instance.project.data_source if instance.project.data_source != instance.workflow_template.data_source
+    after(:build) do |opportunity|
+      # Ensure data source consistency. FactoryBot unfortunately doesn't expose a way to know which of these was
+      # passed as an argument to the factory, and which was generated from the default associations.
+      # Since we don't know, we just pick one -- the project -- but this does mean that if workflow_template is
+      # provided and NOT project, the factory won't work correctly.
+      opportunity.workflow_template.data_source = opportunity.project.data_source if opportunity.project.data_source != opportunity.workflow_template.data_source
     end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     sequence(:name) { |n| "Opportunity #{n}" }
     association(:project, factory: :hmis_hud_project)
     association(:workflow_template, factory: :hmis_workflow_definition_template)
+
+    before(:create) do |instance|
+      # Ensure data source consistency
+      instance.workflow_template.data_source = instance.project.data_source if instance.project.data_source != instance.workflow_template.data_source
+    end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -10,16 +10,23 @@ FactoryBot.define do
     association(:workflow_instance, factory: :hmis_workflow_execution_instance)
     association(:client, factory: :hmis_hud_client)
     association(:referred_by, factory: :hmis_user)
-    after(:create) do |instance, evaluator|
-      instance.opportunity.project = evaluator.project if evaluator.project.present?
 
-      if evaluator.workflow_template.present?
-        instance.opportunity.workflow_template = evaluator.workflow_template
-        instance.workflow_instance.template = evaluator.workflow_template
+    after(:create) do |referral, evaluator|
+      if evaluator.project.present?
+        referral.opportunity.project = evaluator.project
+        # Update the workflow template data source to match, unless a workflow template has also been explicitly passed
+        referral.opportunity.workflow_template.data_source = evaluator.project.data_source unless evaluator.workflow_template.present?
       end
 
-      instance.opportunity.save! if instance.opportunity.changed?
-      instance.workflow_instance.save! if instance.workflow_instance.changed?
+      if evaluator.workflow_template.present?
+        referral.opportunity.workflow_template = evaluator.workflow_template
+        referral.workflow_instance.template = evaluator.workflow_template
+        # Update the project data source to match, unless a project has also been explicitly passed
+        referral.opportunity.project.data_source = evaluator.workflow_template.data_source unless evaluator.project.present?
+      end
+
+      referral.opportunity.save! if referral.opportunity.changed?
+      referral.workflow_instance.save! if referral.workflow_instance.changed?
     end
   end
 end

--- a/drivers/hmis/spec/factories/hmis/workflow_definition/templates.rb
+++ b/drivers/hmis/spec/factories/hmis/workflow_definition/templates.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :hmis_workflow_definition_template, class: 'Hmis::WorkflowDefinition::Template' do
     sequence(:name) { |n| "Workflow #{n}" }
     sequence(:identifier) { |n| "workflow_#{n}" }
+    association(:data_source, factory: :hmis_data_source)
     template_type { 'ce_referral' }
     version { 0 }
     status { 'published' }

--- a/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     hmis_login(user)
   end
 
-  let!(:workflow_template_1) { create(:hmis_workflow_definition_template, identifier: 'wft_1') }
-  let!(:workflow_template_2) { create(:hmis_workflow_definition_template, identifier: 'wft_2') }
+  let!(:workflow_template_1) { create(:hmis_workflow_definition_template, identifier: 'wft_1', data_source: ds1) }
+  let!(:workflow_template_2) { create(:hmis_workflow_definition_template, identifier: 'wft_2', data_source: ds1) }
 
   let!(:access_control) { create_access_control(hmis_user, ds1) }
 
@@ -72,19 +72,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     it 'raises if the user does not have permission' do
       remove_permissions(access_control, :can_administrate_coordinated_entry)
       expect_gql_error(post_graphql { query }, message: 'access denied')
-    end
-
-    context 'with referrals across data sources' do
-      let!(:referral_in_another_data_source) { create(:hmis_ce_referral) }
-
-      it 'does not return referrals from a different data source' do
-        response, result = post_graphql { query }
-        expect(response.status).to eq(200), result.inspect
-
-        referrals = result.dig('data', 'ceReferrals', 'nodes')
-        expect(referrals.size).to eq(1)
-        expect(referrals).to contain_exactly(a_hash_including('id' => referral.id.to_s))
-      end
     end
 
     context 'when querying by workflow template' do

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
 
     context 'when the opportunity has some candidates the current user lacks permission to view' do
-      let(:candidate_pool_with_anonymous) { create :hmis_ce_match_candidate_pool }
+      let(:candidate_pool_with_anonymous) { create :hmis_ce_match_candidate_pool, priority_expression: '1' } # overwrite priority expression with a different dummy value to avoid duplicate key
       let(:opportunity) { create :hmis_ce_opportunity, project: project, candidate_pool: candidate_pool_with_anonymous }
 
       let!(:permissioned_project) { create :hmis_hud_project, data_source: ds1, user: u1 }

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
 
     context 'when the opportunity has some candidates the current user lacks permission to view' do
-      let(:candidate_pool_with_anonymous) { create :hmis_ce_match_candidate_pool, priority_expression: '1' } # overwrite priority expression with a different dummy value to avoid duplicate key
+      let(:candidate_pool_with_anonymous) { create :hmis_ce_match_candidate_pool }
       let(:opportunity) { create :hmis_ce_opportunity, project: project, candidate_pool: candidate_pool_with_anonymous }
 
       let!(:permissioned_project) { create :hmis_hud_project, data_source: ds1, user: u1 }

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   # Basic setup
-  let(:project) { create :hmis_hud_project, data_source: ds1, user: u1 }
-  let(:candidate_pool) { create :hmis_ce_match_candidate_pool }
-  let(:opportunity) { create :hmis_ce_opportunity, project: project, candidate_pool: candidate_pool }
+  let!(:project) { create :hmis_hud_project, data_source: ds1, user: u1 }
+  let!(:candidate_pool) { create :hmis_ce_match_candidate_pool }
+  let!(:opportunity) { create :hmis_ce_opportunity, project: project, candidate_pool: candidate_pool }
 
   let!(:access_control) { create_access_control(hmis_user, project, with_permission: [:can_view_project, :can_view_units, :can_view_prioritized_client_lists, :can_view_referrals]) }
 

--- a/drivers/hmis/spec/requests/hmis/ce/create_ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_ce_opportunity_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Mutations::Ce::CreateCeOpportunity, type: :request do
   end
 
   let(:project) { create :hmis_hud_project, data_source: ds1 }
-  let(:workflow_template) { create :hmis_workflow_definition_template, status: 'published' }
+  let(:workflow_template) { create :hmis_workflow_definition_template, status: 'published', data_source: ds1 }
 
   describe 'create opportunity mutation' do
     let(:mutation) do
@@ -59,29 +59,23 @@ RSpec.describe Mutations::Ce::CreateCeOpportunity, type: :request do
     end
 
     context 'with valid input' do
-      it 'creates a new opportunity' do
-        expect do
-          post_graphql(**variables) { mutation }
-        end.to change(Hmis::Ce::Opportunity, :count).by(1)
-      end
-
       it 'returns the created opportunity' do
-        _, result = post_graphql(**variables) { mutation }
-        opportunity_data = result.dig('data', 'createCeOpportunity', 'opportunity')
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+          opportunity_data = result.dig('data', 'createCeOpportunity', 'opportunity')
 
-        expect(opportunity_data).to include(
-          'name' => 'Housing Opportunity #1',
-          'status' => 'open',
-        )
-      end
+          expect(opportunity_data).to include(
+            'name' => 'Housing Opportunity #1',
+            'status' => 'open',
+          )
 
-      it 'associates opportunity with correct project and template' do
-        _, result = post_graphql(**variables) { mutation }
-        opportunity_id = result.dig('data', 'createCeOpportunity', 'opportunity', 'id')
-        opportunity = Hmis::Ce::Opportunity.find(opportunity_id)
+          opportunity_id = result.dig('data', 'createCeOpportunity', 'opportunity', 'id')
+          opportunity = Hmis::Ce::Opportunity.find(opportunity_id)
 
-        expect(opportunity.project).to eq(project)
-        expect(opportunity.workflow_template).to eq(workflow_template)
+          expect(opportunity.project).to eq(project)
+          expect(opportunity.workflow_template).to eq(workflow_template)
+        end.to change(Hmis::Ce::Opportunity, :count).by(1)
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/ce/create_ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_ce_opportunity_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Mutations::Ce::CreateCeOpportunity, type: :request do
         projectId: project.id,
         input: {
           name: 'Housing Opportunity #1',
-          templateId: workflow_template.id,
+          templateIdentifier: workflow_template.identifier,
         },
       }
     end

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
 
   let!(:access_control) { create_access_control(hmis_user, ds1) }
   let!(:project) { create :hmis_hud_project, data_source: ds1 }
-  let!(:template) { create :hmis_workflow_definition_template, status: 'published' }
+  let!(:template) { create :hmis_workflow_definition_template, status: 'published', data_source: ds1 }
   let!(:unit_type) { create :hmis_unit_type, description: '1 Bedroom Apartment' }
   let!(:unit) { create :hmis_unit, project: project, unit_type: unit_type }
 

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -434,23 +434,44 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
 
-  describe 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED' do
-    let!(:apples_retired) { create(:hmis_workflow_definition_template, identifier: 'apples', name: 'Apples 1', version: 0, status: :retired) }
-    let!(:apples_published) { create(:hmis_workflow_definition_template, identifier: 'apples', name: 'Apples 2', version: 1, status: :published) }
-    let!(:bananas_retired1) { create(:hmis_workflow_definition_template, identifier: 'bananas', name: 'Bananas 1', version: 0, status: :retired) }
-    let!(:bananas_retired2) { create(:hmis_workflow_definition_template, identifier: 'bananas', name: 'Bananas 2', version: 1, status: :retired) }
-    let!(:broccoli_not_ce) { create(:hmis_workflow_definition_template, identifier: 'broccoli', template_type: 'not_ce') }
-    let!(:beans_retired_not_ce) { create(:hmis_workflow_definition_template, identifier: 'beans', status: :retired, template_type: 'not_ce') }
+  describe 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS' do
+    let!(:apples_retired) { create(:hmis_workflow_definition_template, identifier: 'apples', name: 'Apples 1', version: 0, status: :retired, data_source: ds1) }
+    let!(:apples_published) { create(:hmis_workflow_definition_template, identifier: 'apples', name: 'Apples 2', version: 1, status: :published, data_source: ds1) }
+    let!(:bananas_retired1) { create(:hmis_workflow_definition_template, identifier: 'bananas', name: 'Bananas 1', version: 0, status: :retired, data_source: ds1) }
+    let!(:bananas_retired2) { create(:hmis_workflow_definition_template, identifier: 'bananas', name: 'Bananas 2', version: 1, status: :retired, data_source: ds1) }
+    let!(:broccoli_not_ce) { create(:hmis_workflow_definition_template, identifier: 'broccoli', template_type: 'not_ce', data_source: ds1) }
+    let!(:beans_retired_not_ce) { create(:hmis_workflow_definition_template, identifier: 'beans', status: :retired, template_type: 'not_ce', data_source: ds1) }
+    let!(:coconut_wrong_data_source) { create(:hmis_workflow_definition_template, identifier: 'coconut', status: :published) }
 
-    it 'should return all templates including fully retired workflows, and not return non-ce templates' do
-      response, result = post_graphql(pick_list_type: 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED') { query }
-      expect(response.status).to eq 200
-      options = result.dig('data', 'pickList')
-      expect(options.size).to eq(2)
-      expect(options).to contain_exactly(
-        a_hash_including('code' => 'apples', 'label' => 'Apples 2'),
-        a_hash_including('code' => 'bananas', 'label' => 'Bananas 2'),
-      )
+    before(:each) do
+      allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
+    end
+
+    context 'published only' do
+      let(:pick_list_type) { 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS' }
+
+      it 'should return all published templates, and not return non-ce or unpublished templates' do
+        response, result = post_graphql(pick_list_type: pick_list_type) { query }
+        expect(response.status).to eq 200
+        options = result.dig('data', 'pickList')
+        expect(options.size).to eq(1)
+        expect(options).to contain_exactly(a_hash_including('code' => 'apples', 'label' => 'Apples 2'))
+      end
+    end
+
+    context '_INCLUDING_RETIRED' do
+      let(:pick_list_type) { 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED' }
+
+      it 'should return all templates including fully retired workflows, and not return non-ce templates' do
+        response, result = post_graphql(pick_list_type: pick_list_type) { query }
+        expect(response.status).to eq 200
+        options = result.dig('data', 'pickList')
+        expect(options.size).to eq(2)
+        expect(options).to contain_exactly(
+          a_hash_including('code' => 'apples', 'label' => 'Apples 2'),
+          a_hash_including('code' => 'bananas', 'label' => 'Bananas 2'),
+        )
+      end
     end
   end
 

--- a/drivers/hmis/spec/support/ce_spec_helper.rb
+++ b/drivers/hmis/spec/support/ce_spec_helper.rb
@@ -24,11 +24,11 @@ RSpec.shared_context 'ce spec helper' do
     allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
   end
 
-  let(:client) { create :hmis_hud_client_complete, data_source: ds1, user: u1 }
-  let(:project) { create :hmis_hud_project, data_source: ds1, user: u1 }
-  let(:opportunity) { create :hmis_ce_opportunity, project: project }
-  let(:workflow_template) { opportunity.workflow_template }
-  let(:workflow_instance) { workflow_template.instances.create! }
+  let!(:client) { create :hmis_hud_client_complete, data_source: ds1, user: u1 }
+  let!(:project) { create :hmis_hud_project, data_source: ds1, user: u1 }
+  let!(:workflow_template) { create(:hmis_workflow_definition_template, data_source: ds1) }
+  let!(:opportunity) { create :hmis_ce_opportunity, project: project, workflow_template: workflow_template }
+  let!(:workflow_instance) { workflow_template.instances.create! }
 
   let!(:start_event) do
     create(


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Summary of changes:
- Add migration to add `data_source_id` col to `wfd_template` table
- Update the `Hmis::WorkflowDefinition::Template.viewable_by` scope to check the data source ID against the current user
- Update both Template picklists to only return templates in the current data source
  - Also update the published Template picklist, so it now returns template Identifiers instead of database IDs. This is a breaking API change, but ok because these features aren't yet used in prod
- Add validation on Opportunity to enforce that the template is in the same data source as the target project

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)
