### PR TITLE
Rename step -> task in UI

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -874,7 +874,7 @@ type CeReferral {
 }
 
 input CeReferralFilterOptions {
-  onCurrentStepSince: ISO8601Date
+  onCurrentTaskSince: ISO8601Date
   organization: [ID!]
   project: [ID!]
   projectType: [ProjectType!]

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -38,7 +38,7 @@ module Types
       arg :project_type, [HmisSchema::Enums::ProjectType]
       arg :workflow_template, [String]
       arg :organization, [ID]
-      arg :on_current_step_since, GraphQL::Types::ISO8601Date # TODO - we will discuss this with design and probably make updates
+      arg :on_current_task_since, GraphQL::Types::ISO8601Date # TODO - we will discuss this with design and probably make updates
     end
 
     def steps # Don't resolve in batch

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -93,7 +93,7 @@ module Types
     )
     ce_referrals_field(
       :ce_referrals,
-      filter_args: { omit: [:workflow_template, :on_current_step_since], type_name: 'ClientCeReferral' },
+      filter_args: { omit: [:workflow_template, :on_current_task_since], type_name: 'ClientCeReferral' },
     )
 
     field :active_enrollment, Types::HmisSchema::Enrollment, null: true do

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -124,7 +124,7 @@ module Types
     field :service_types, [Types::HmisSchema::ServiceType], null: false, method: :available_service_types, description: 'Service types that are collected for this Project'
 
     ce_opportunities_field(:ce_opportunities, filter_args: { omit: [:project, :project_type, :organization, :available_on_date, :workflow_template], type_name: 'ProjectCeOpportunity' })
-    ce_referrals_field(:ce_referrals, filter_args: { omit: [:project, :project_type, :organization, :on_current_step_since, :workflow_template], type_name: 'ProjectCeReferral' })
+    ce_referrals_field(:ce_referrals, filter_args: { omit: [:project, :project_type, :organization, :on_current_task_since, :workflow_template], type_name: 'ProjectCeReferral' })
 
     def hud_id
       object.project_id

--- a/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
@@ -16,7 +16,7 @@ class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
       yield_self(&method(:with_projects)).
       yield_self(&method(:with_project_types)).
       yield_self(&method(:with_workflow_template_identifiers)).
-      yield_self(&method(:on_current_step_since)).
+      yield_self(&method(:on_current_task_since)).
       yield_self(&method(:clean_scope))
   end
 
@@ -44,10 +44,10 @@ class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
     end
   end
 
-  def on_current_step_since(scope)
-    with_filter(scope, :on_current_step_since) do
+  def on_current_task_since(scope)
+    with_filter(scope, :on_current_task_since) do
       scope.joins(:current_steps).
-        where(wfe_step_t[:available_at].lt(input.on_current_step_since)).
+        where(wfe_step_t[:available_at].lt(input.on_current_task_since)).
         distinct
     end
   end

--- a/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let(:variables) do
         {
           filters: {
-            onCurrentStepSince: 3.days.ago,
+            onCurrentTaskSince: 3.days.ago,
           },
         }
       end

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_spec.rb
@@ -7,6 +7,10 @@ require_relative '../../../support/hmis_base_setup'
 RSpec.describe Hmis::GraphqlController, type: :request do
   include_context 'hmis base setup'
 
+  before(:all) do
+    cleanup_test_environment
+  end
+
   before(:each) do
     allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
     hmis_login(user)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Per conversation with design, we should refer to referral steps as "tasks" in user-facing text.

Most instances where it should be updated are in the frontend codebase. This filter is the only example I could find of something needing to be renamed from the backend.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [n/a] I have provided testing instructions in this PR or the related issue (or not applicable)

