### PR TITLE
Patch project viewability granted by project group

### DIFF
--- a/drivers/hmis/app/models/hmis/group_viewable_entity.rb
+++ b/drivers/hmis/app/models/hmis/group_viewable_entity.rb
@@ -23,11 +23,16 @@ module Hmis
     has_many :projects, through: :group_viewable_entity_projects, source: :project
 
     scope :projects, -> { where(entity_type: Hmis::Hud::Project.sti_name) }
+    scope :project_groups, -> { where(entity_type: Hmis::ProjectGroup.sti_name) }
     scope :organizations, -> { where(entity_type: Hmis::Hud::Organization.sti_name) }
     scope :data_sources, -> { where(entity_type: GrdaWarehouse::DataSource.sti_name) }
 
     scope :includes_project, ->(project) do
       joins(:projects).where(p_t[:id].eq(project.id))
+    end
+
+    scope :includes_project_group, ->(project_group) do
+      where(entity: project_group)
     end
 
     scope :includes_organization, ->(organization) do
@@ -42,6 +47,8 @@ module Hmis
       case entity.class.name
       when Hmis::Hud::Project.name
         includes_project(entity)
+      when Hmis::ProjectGroup.name
+        includes_project_group(entity)
       when Hmis::Hud::Organization.name
         includes_organization(entity)
       when ::GrdaWarehouse::DataSource.name

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -74,6 +74,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   replace_scope :viewable_by, ->(user) do
     ids = user.viewable_projects.pluck(:id)
     ids += user.viewable_organizations.joins(:projects).pluck(p_t[:id])
+    ids += user.viewable_project_groups.joins(:projects).pluck(p_t[:id])
     ids += user.viewable_data_sources.joins(:projects).pluck(p_t[:id])
 
     where(id: ids, data_source_id: user.hmis_data_source_id)
@@ -86,6 +87,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   scope :with_access, ->(user, *permissions, **kwargs) do
     ids = user.entities_with_permissions(Hmis::Hud::Project, *permissions, **kwargs).pluck(:id)
     ids += user.entities_with_permissions(Hmis::Hud::Organization, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
+    ids += user.entities_with_permissions(Hmis::ProjectGroup, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
     ids += user.entities_with_permissions(GrdaWarehouse::DataSource, *permissions, **kwargs).joins(:projects).pluck(p_t[:id])
 
     where(id: ids, data_source_id: user.hmis_data_source_id)

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -179,6 +179,10 @@ class Hmis::User < ApplicationRecord
     viewable Hmis::Hud::Organization
   end
 
+  def viewable_project_groups
+    viewable Hmis::ProjectGroup
+  end
+
   def viewable_projects
     viewable Hmis::Hud::Project
   end

--- a/drivers/hmis/spec/factories/hmis/project_groups.rb
+++ b/drivers/hmis/spec/factories/hmis/project_groups.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
         instance.inclusion_criteria = {
           project_ids: evaluator.with_projects.map(&:id).map(&:to_s),
         }.to_json
+        instance.save!
       end
 
       # Maintain project group to populate `project_groups.projects` association

--- a/drivers/hmis/spec/factories/hmis/project_groups.rb
+++ b/drivers/hmis/spec/factories/hmis/project_groups.rb
@@ -12,7 +12,18 @@ FactoryBot.define do
     data_source { association :hmis_data_source }
     inclusion_criteria { {}.to_json } # no projects included
     exclusion_criteria { nil }
-    after(:create) do |instance, _evaluator|
+    transient do
+      with_projects { [] } # projects to include in the group. overrides inclusion_criteria
+    end
+    after(:create) do |instance, evaluator|
+      # Add projects to the group if specified
+      if evaluator.with_projects.present?
+        instance.inclusion_criteria = {
+          project_ids: evaluator.with_projects.map(&:id).map(&:to_s),
+        }.to_json
+      end
+
+      # Maintain project group to populate `project_groups.projects` association
       instance.maintain_projects!
     end
   end

--- a/drivers/hmis/spec/models/hmis/access_control_spec.rb
+++ b/drivers/hmis/spec/models/hmis/access_control_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Hmis::AccessControl, type: :model do
 
     it 'should apply correctly when attached to a project group' do
       create_access_control(hmis_user, pg1)
-      # binding.pry
       expect(hmis_user.can_view_full_ssn_for?(p1)).to eq(false)
       expect(hmis_user.can_view_full_ssn_for?(p2)).to eq(true)
       expect(hmis_user.can_view_full_ssn_for?(p3)).to eq(true)

--- a/drivers/hmis/spec/models/hmis/access_group_spec.rb
+++ b/drivers/hmis/spec/models/hmis/access_group_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../../requests/hmis/login_and_permissions'
 require_relative '../../support/hmis_base_setup'
@@ -22,7 +24,8 @@ RSpec.describe Hmis::AccessGroup, type: :model do
   let!(:o1) { create :hmis_hud_organization, data_source: ds1 }
   let!(:o2) { create :hmis_hud_organization, data_source: ds2 }
   let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1 }
-  let!(:p2) { create :hmis_hud_project, data_source: ds1, organization: o2 }
+  let!(:p2) { create :hmis_hud_project, data_source: ds2, organization: o2 }
+  let!(:project_group) { create(:hmis_project_group, data_source: ds1, with_projects: [p1]) }
 
   describe 'contains_with_inherited scope' do
     it 'should return correct access groups when permission is granted on whole data source' do
@@ -36,12 +39,25 @@ RSpec.describe Hmis::AccessGroup, type: :model do
 
       expect(Hmis::AccessGroup.contains_with_inherited(p1).count).to eq(1)
       expect(Hmis::AccessGroup.contains_with_inherited(p2).count).to eq(0)
+
+      expect(Hmis::AccessGroup.contains_with_inherited(project_group).count).to eq(0)
     end
 
     it 'should return access groups when permission is granted on organization' do
       create_access_control(hmis_user, o1)
       expect(Hmis::AccessGroup.contains_with_inherited(ds2).count).to eq(0)
       expect(Hmis::AccessGroup.contains_with_inherited(o1).count).to eq(1)
+      expect(Hmis::AccessGroup.contains_with_inherited(p1).count).to eq(1)
+      expect(Hmis::AccessGroup.contains_with_inherited(p2).count).to eq(0)
+
+      expect(Hmis::AccessGroup.contains_with_inherited(project_group).count).to eq(0)
+    end
+
+    it 'should return access groups when permission is granted on project group' do
+      create_access_control(hmis_user, project_group)
+      expect(Hmis::AccessGroup.contains_with_inherited(ds2).count).to eq(0)
+      expect(Hmis::AccessGroup.contains_with_inherited(o1).count).to eq(0)
+      expect(Hmis::AccessGroup.contains_with_inherited(project_group).count).to eq(1)
       expect(Hmis::AccessGroup.contains_with_inherited(p1).count).to eq(1)
       expect(Hmis::AccessGroup.contains_with_inherited(p2).count).to eq(0)
     end

--- a/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_access_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require_relative '../../../requests/hmis/login_and_permissions'
 
@@ -70,6 +72,23 @@ RSpec.describe Hmis::Hud::Project, type: :model do
     it 'excludes projects where I dont have can_view_project, even if I have other permissions there' do
       viewable_projects = Hmis::Hud::Project.viewable_by(user_with_limited_access)
       expect(viewable_projects).to be_empty
+    end
+  end
+
+  context 'when access is granted via project group' do
+    let!(:project_group) { create(:hmis_project_group, data_source: ds1, with_projects: [p2]) }
+    let!(:pg_collection) { create(:hmis_access_group, name: 'project group collection', with_entities: project_group) }
+    let!(:user_with_pg_access) do
+      user = create(:hmis_user, data_source: ds1)
+      create(:hmis_access_control, role: project_viewer, access_group: pg_collection, with_users: user)
+      user
+    end
+
+    it 'projects in project group are viewable' do
+      expect(project_group.projects).to contain_exactly(p2) # confirm project group setup
+
+      viewable_projects = Hmis::Hud::Project.viewable_by(user_with_pg_access)
+      expect(viewable_projects).to contain_exactly(p2)
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             expect(response.status).to eq(200), result.inspect
             count = result.dig('data', 'client', 'eligibleCeOpportunities', 'nodesCount')
             expect(count).to eq(32)
-          end.to make_database_queries(count: 15..20)
+          end.to make_database_queries(count: 15..25)
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/5387 which was incomplete because it didn't support granting access to project viewability via Project Groups. I had mistakenly only tested it for Client access.

QA comment: https://github.com/open-path/Green-River/issues/7353#issuecomment-2917365199

## Type of change
Bug fix 

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
