### PR TITLE
Bump db query range in some hmis tests

### DIFF
--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             expect do
               response, result = post_graphql(**variables) { query }
               expect(response.status).to eq(200), result.inspect
-            end.to make_database_queries(count: 20..30)
+            end.to make_database_queries(count: 20..35)
           end
         end
       end
@@ -357,7 +357,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               _, result = post_graphql(**variables) { query }
               steps = result.dig('data', 'ceReferral', 'steps')
               expect(steps.map { |step| step.dig('access', 'canPerformStep') }).to all(be false)
-            end.to make_database_queries(count: 25..30)
+            end.to make_database_queries(count: 25..35)
           end
         end
       end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(32), result.inspect
-          end.to make_database_queries(count: 25..30)
+          end.to make_database_queries(count: 25..35)
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix tests that were broken from https://github.com/greenriver/hmis-warehouse/pull/5387 (maybe from a merge conflict) which added 1 db query to all access checks because of the additional query to `hmis_project_groups`.

Opening as a separate PR since this is affecting several open PRs

## Type of change
Test fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
