### PR TITLE
Source Data Route Missing Type

### DIFF
--- a/app/controllers/source_data_controller.rb
+++ b/app/controllers/source_data_controller.rb
@@ -27,6 +27,15 @@ class SourceDataController < ApplicationController
   end
 
   def show
+    if @item.blank?
+      # When no type is provided, we'll get a blank @item as a result of the `set_item` method.
+      # Capture this in sentry and redirect to the index page with an error message for the user.
+      Sentry.capture_message('SourceDataController#show: @item not found')
+      flash[:error] = 'The requested record could not be found.'
+      redirect_to source_data_path
+      return
+    end
+
     @type = params[:type] if valid_class(params[:type]).present?
     @data_source = @item.data_source
     return unless RailsDrivers.loaded.include?(:hmis_csv_importer)

--- a/app/controllers/source_data_controller.rb
+++ b/app/controllers/source_data_controller.rb
@@ -27,15 +27,6 @@ class SourceDataController < ApplicationController
   end
 
   def show
-    if @item.blank?
-      # When no type is provided, we'll get a blank @item as a result of the `set_item` method.
-      # Capture this in sentry and redirect to the index page with an error message for the user.
-      Sentry.capture_message('SourceDataController#show: @item not found')
-      flash[:error] = 'The requested record could not be found.'
-      redirect_to source_data_path
-      return
-    end
-
     @type = params[:type] if valid_class(params[:type]).present?
     @data_source = @item.data_source
     return unless RailsDrivers.loaded.include?(:hmis_csv_importer)
@@ -100,7 +91,7 @@ class SourceDataController < ApplicationController
 
   private def set_item
     @klass = valid_class(params[:type])
-    return nil unless @klass.present?
+    raise ActiveRecord::RecordNotFound unless @klass.present?
 
     @item = item_scope.find(params[:id].to_i)
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
From within the Data > HMIS Source Data page and when hitting the #show route for a source, if the type url parameter is removed, the page will error out. This update will handle this scenario a bit more gracefully and redirect back to the index page (as we don't know the type). It will still send a notification to Sentry, but it looks like this was a result of URL manipulation and not something from within the app, itself.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
