### PR TITLE
Handle duplicate medicaid ids more appropriately

### DIFF
--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -2257,59 +2257,71 @@ module GrdaWarehouse::Hud
       setup_notifier('PatientMerger') unless @notifier
       moved = []
       to_clean = [id]
-      transaction do
-        # get the existing destination client for other_client
-        prev_destination_client = if other_client.destination_client
-          other_client.destination_client
-        elsif other_client.destination?
-          to_clean << other_client.id
-          other_client
-        end
-        # if it had sources then move those over to us
-        # and say who made the decision and when
-        other_client.source_clients.each do |m|
-          m.warehouse_client_source.update!(
-            destination_id: id,
-            reviewed_at: reviewed_at,
-            reviewd_by: reviewed_by.id,
-            client_match_id: client_match_id,
-          )
-          moved << m
-        end
-        # if we are a source, move us
-        if other_client.warehouse_client_source
-          other_client.warehouse_client_source.update!(
-            destination_id: id,
-            reviewed_at: reviewed_at,
-            reviewd_by: reviewed_by.id,
-            client_match_id: client_match_id,
-          )
-          moved << other_client
-        end
-        # clean up the previous destination
-        if prev_destination_client
-          # move any CAS column data
-          previous_cas_columns = prev_destination_client.attributes.slice(*self.class.cas_columns.keys.map(&:to_s))
-          current_cas_columns = attributes.slice(*self.class.cas_columns.keys.map(&:to_s))
-          current_cas_columns.merge!(previous_cas_columns) { |_k, old, new| old.presence || new }
-          update(current_cas_columns)
-          save!
-
-          prev_destination_client.force_full_service_history_rebuild
-          prev_destination_client.source_clients.reload
-          if prev_destination_client.source_clients.empty?
-            # Create a client_merge_history record so we can keep links working
-            GrdaWarehouse::ClientMergeHistory.create(merged_into: id, merged_from: prev_destination_client.id)
-            prev_destination_client.destroy
+      begin
+        transaction do
+          # get the existing destination client for other_client
+          prev_destination_client = if other_client.destination_client
+            other_client.destination_client
+          elsif other_client.destination?
+            to_clean << other_client.id
+            other_client
           end
+          # if it had sources then move those over to us
+          # and say who made the decision and when
+          other_client.source_clients.each do |m|
+            m.warehouse_client_source.update!(
+              destination_id: id,
+              reviewed_at: reviewed_at,
+              reviewd_by: reviewed_by.id,
+              client_match_id: client_match_id,
+            )
+            moved << m
+          end
+          # if we are a source, move us
+          if other_client.warehouse_client_source
+            other_client.warehouse_client_source.update!(
+              destination_id: id,
+              reviewed_at: reviewed_at,
+              reviewd_by: reviewed_by.id,
+              client_match_id: client_match_id,
+            )
+            moved << other_client
+          end
+          # clean up the previous destination
+          if prev_destination_client
+            # move any CAS column data
+            previous_cas_columns = prev_destination_client.attributes.slice(*self.class.cas_columns.keys.map(&:to_s))
+            current_cas_columns = attributes.slice(*self.class.cas_columns.keys.map(&:to_s))
+            current_cas_columns.merge!(previous_cas_columns) { |_k, old, new| old.presence || new }
+            update(current_cas_columns)
+            save!
 
-          move_dependent_items(prev_destination_client.id, id)
-          to_clean << prev_destination_client.id
+            prev_destination_client.force_full_service_history_rebuild
+            prev_destination_client.source_clients.reload
+            if prev_destination_client.source_clients.empty?
+              # Create a client_merge_history record so we can keep links working
+              GrdaWarehouse::ClientMergeHistory.create(merged_into: id, merged_from: prev_destination_client.id)
+              prev_destination_client.destroy
+            end
+
+            move_dependent_items(prev_destination_client.id, id)
+            to_clean << prev_destination_client.id
+          end
+          # and invalidate our own service history
+          force_full_service_history_rebuild
+          # and invalidate any cache for these clients
+          self.class.clear_view_cache(prev_destination_client.id) if prev_destination_client.present?
         end
-        # and invalidate our own service history
-        force_full_service_history_rebuild
-        # and invalidate any cache for these clients
-        self.class.clear_view_cache(prev_destination_client.id) if prev_destination_client.present?
+      rescue Health::MedicaidIdConflict => e
+        @notifier.ping(
+          'Non-matching Medicaid IDs on patient merge',
+          {
+            exception: e,
+          },
+        )
+        # add a split record to prevent these client being merged automatically in the future
+        GrdaWarehouse::ClientSplitHistory.create(split_from: other_client.id, split_into: id)
+        return []
       end
       self.class.clear_view_cache(id)
       self.class.clear_view_cache(other_client.id)
@@ -2322,13 +2334,6 @@ module GrdaWarehouse::Hud
       end
       ClientCleanupJob.set(priority: 6).perform_later(to_clean.uniq) if cleanup
       moved
-    rescue Health::MedicaidIdConflict => e
-      @notifier.ping(
-        'Non-matching Medicaid IDs on patient merge',
-        {
-          exception: e,
-        },
-      )
     end
 
     def move_dependent_hmis_items(previous_id, new_id)

--- a/spec/models/grda_warehouse/hud/client_merge_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_merge_spec.rb
@@ -177,4 +177,103 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       end
     end
   end
+
+  describe 'when handling medicaid conflicts during merge' do
+    let!(:user) { create :user }
+    let!(:organization) { create(:hud_organization, data_source: source_ds) }
+    let!(:project) { create(:hud_project, project_type: 1, organization: organization, data_source: source_ds) }
+    let!(:source_a) { create :hud_client, FirstName: 'Same', LastName: 'Name', DOB: '2000-01-01', SSN: '1111', data_source: source_ds }
+    let!(:source_b) { create :hud_client, FirstName: 'Same', LastName: 'Name', DOB: '2000-01-01', SSN: '1111', data_source: source_ds }
+    let!(:dest_initial) { create :hud_client, data_source: destination_ds }
+    let!(:enrollments) do
+      [source_a, source_b].each do |client|
+        create(:hud_enrollment, client: client, project: project, data_source: source_ds)
+      end
+    end
+
+    before do
+      GrdaWarehouse::WarehouseClient.create!(destination: dest_initial, source: source_a, id_in_source: source_a.PersonalID)
+      GrdaWarehouse::WarehouseClient.create!(destination: dest_initial, source: source_b, id_in_source: source_b.PersonalID)
+      allow(GrdaWarehouse::Config).to receive(:get).and_call_original
+      allow(GrdaWarehouse::Config).to receive(:get).with(:enable_auto_deduplication).and_return(true)
+    end
+
+    # Helper to spy on the medicaid conflict exception
+    def expect_medicaid_conflict_handling
+      conflict_raised = false
+      allow_any_instance_of(GrdaWarehouse::Hud::Client).to receive(:move_dependent_health_items).and_wrap_original do |original_method, *args|
+        original_method.call(*args)
+      rescue Health::MedicaidIdConflict
+        conflict_raised = true
+        raise # Re-raise for the application to handle
+      end
+
+      yield
+
+      conflict_raised
+    ensure
+      # Restore original method to avoid mock leakage into other tests
+      allow_any_instance_of(GrdaWarehouse::Hud::Client).to receive(:move_dependent_health_items).and_call_original
+    end
+
+    it 'tests the full split/merge cycle with medicaid conflicts' do
+      # 1. split two clients with the same PII
+      dest_initial.split([source_b.id], source_b.id, source_b.id, user)
+      GrdaWarehouse::Tasks::ClientCleanup.new.run!
+      expect(dest_initial.source_clients.count).to eq(1)
+      expect(dest_initial.source_clients.first.id).to eq(source_a.id)
+      dest_b = source_b.reload.destination_client
+      expect(dest_b).not_to be_nil
+      expect(dest_b.id).not_to eq(dest_initial.id)
+      expect(GrdaWarehouse::ClientSplitHistory.count).to eq(1)
+
+      # 2. remove the created ClientSplitHistory
+      GrdaWarehouse::ClientSplitHistory.destroy_all
+      expect(GrdaWarehouse::ClientSplitHistory.count).to eq(0)
+
+      # 3. run identify duplicates, confirm a re-merge
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.match_existing!
+      expect(dest_initial.reload.source_clients.count).to eq(2)
+      # dest_b should have been destroyed after merge
+      expect(GrdaWarehouse::Hud::Client.find_by(id: dest_b.id)).to be_nil
+
+      # 4. split them again, and remove the ClientSplitHistory
+      dest_initial.split([source_b.id], source_b.id, source_b.id, user)
+      GrdaWarehouse::Tasks::ClientCleanup.new.run!
+      dest_b = source_b.reload.destination_client
+      GrdaWarehouse::ClientSplitHistory.destroy_all
+      expect(GrdaWarehouse::ClientSplitHistory.count).to eq(0)
+
+      # 5. Update associated patients to raise Health::MedicaidIdConflict
+      create(:patient, client: dest_initial, medicaid_id: 'CONFLICT_1')
+      create(:patient, client: dest_b, medicaid_id: 'CONFLICT_2')
+
+      # 6. run identify duplicates, confirm a Health::MedicaidIdConflict is raised and handled without re-merging
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+      conflict_in_step_6 = expect_medicaid_conflict_handling do
+        GrdaWarehouse::Tasks::IdentifyDuplicates.new.match_existing!
+      end
+      expect(conflict_in_step_6).to be(true)
+
+      expect(dest_initial.reload.source_clients.count).to eq(1)
+      expect(dest_b.reload.source_clients.count).to eq(1)
+      expect(GrdaWarehouse::ClientSplitHistory.count).to eq(1)
+
+      # 7. Remove the conflicting medicaid ids that cause the raise in the transaction
+      dest_b.patient.update!(medicaid_id: 'CONFLICT_1')
+      # and remove the split history to allow merge
+      GrdaWarehouse::ClientSplitHistory.destroy_all
+
+      # 8. run identify duplicates, confirm a re-merge and no conflict is raised
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+      conflict_in_step_8 = expect_medicaid_conflict_handling do
+        GrdaWarehouse::Tasks::IdentifyDuplicates.new.match_existing!
+      end
+      expect(conflict_in_step_8).to be(false)
+      expect(dest_initial.reload.source_clients.count).to eq(2)
+      expect(GrdaWarehouse::Hud::Client.find_by(id: dest_b.id)).to be_nil
+      expect(GrdaWarehouse::ClientSplitHistory.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* If a client merge is attempted where the clients both have patient records and the medicaid ids don't match, don't fail completely.
* Mark the two clients as distinct, and carry on
* tests 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
