### PR TITLE
Default sort for CE Referrals

### DIFF
--- a/drivers/hmis/app/graphql/types/application/user_dashboard.rb
+++ b/drivers/hmis/app/graphql/types/application/user_dashboard.rb
@@ -43,20 +43,19 @@ module Types
     def ce_referral_steps
       return Hmis::WorkflowExecution::Step.none unless show_referrals
 
-      step_scope = Hmis::WorkflowExecution::Step.
-        joins(:assignments).
-        merge(object.workflow_step_assignments).
-        open.
-        order(available_at: :desc, id: :desc)
+      # Scope to open steps that are assigned to the current user
+      step_scope = Hmis::WorkflowExecution::Step.open.
+        assigned_to(current_user.id)
 
       # Join to referrals for
       # - permission checking
       # - ensuring we only resolve CE steps and not other workflow types
       # For performance, rely on assumption that only active referrals have active steps.
       referral_scope = Hmis::Ce::Referral.active.viewable_by(current_user)
-      instance_ids = referral_scope.pluck(:workflow_instance_id).uniq
+      viewable_instance_ids = referral_scope.pluck(:workflow_instance_id).uniq
+      step_scope = step_scope.where(instance_id: viewable_instance_ids)
 
-      step_scope.where(instance_id: instance_ids)
+      step_scope.order_by_available_at
     end
 
     private

--- a/drivers/hmis/app/graphql/types/application/user_dashboard.rb
+++ b/drivers/hmis/app/graphql/types/application/user_dashboard.rb
@@ -43,7 +43,7 @@ module Types
     def ce_referral_steps
       return Hmis::WorkflowExecution::Step.none unless show_referrals
 
-      # Scope to open steps that are assigned to the current user
+      # Scope open steps that are assigned to the current user
       step_scope = Hmis::WorkflowExecution::Step.open.
         assigned_to(current_user.id)
 
@@ -55,7 +55,7 @@ module Types
       viewable_instance_ids = referral_scope.pluck(:workflow_instance_id).uniq
       step_scope = step_scope.where(instance_id: viewable_instance_ids)
 
-      step_scope.order_by_available_at
+      step_scope.order(available_at: :desc, id: :desc)
     end
 
     private

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
@@ -35,7 +35,7 @@ module Types
 
         scope = scope.viewable_by(user)
         scope = scope.apply_filters(filters) if filters.present?
-        scope.order(created_at: :desc, id: :asc)
+        scope.sorted_by_status
       end
     end
   end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
@@ -35,7 +35,7 @@ module Types
 
         scope = scope.viewable_by(user)
         scope = scope.apply_filters(filters) if filters.present?
-        scope.sorted_by_status
+        scope.order_by_status
       end
     end
   end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -587,7 +587,7 @@ module Types
     def ce_referrals(**args)
       access_denied! unless current_user.can_administrate_coordinated_entry?
 
-      resolve_ce_referrals(Hmis::Ce::Referral.viewable_by(current_user), **args)
+      resolve_ce_referrals(Hmis::Ce::Referral.all, **args)
     end
 
     field :unit_group, HmisSchema::UnitGroup, null: true do

--- a/drivers/hmis/app/models/hmis/ce/referral.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral.rb
@@ -33,28 +33,39 @@ module Hmis::Ce
       # - If they have can_view_referrals at the target project, OR
       # - If they have can_view_own_referrals, AND are assigned a step in the referral.
 
-      # Start with base scope that does all necessary joins, for structural compatibility when we `or` the scopes later
-      base_scope = joins(:target_project).left_outer_joins(steps: :assignments)
+      base_scope = joins(:target_project)
 
-      # Projects in which the user can_view_referrals
+      # Referrals that the user can view because they have can_view_referrals in the target project
       access_through_project = base_scope.
         merge(Hmis::Hud::Project.viewable_by(user).with_access(user, :can_view_referrals))
 
       # Referrals that have a step assigned to this user, in projects in which the user can_view_own_referrals.
+      # Referral only becomes viewable once the assigned step becomes available.
       # Note that the user does *not* need can_view_project in this case
-      own_referrals = base_scope.
+      assigned_step_ids = user.workflow_step_assignments.pluck(:step_id)
+      own_referral_ids = base_scope.joins(:steps).
         merge(Hmis::Hud::Project.with_access(user, :can_view_own_referrals)).
-        merge(
-          Hmis::WorkflowExecution::Step.
-            where(Hmis::WorkflowExecution::StepAssignment.arel_table[:user_id].eq(user.id)).
-            where.not(status: 'unavailable'),
-        )
+        merge(Hmis::WorkflowExecution::Step.where(id: assigned_step_ids).excluding_unavailable).
+        pluck(:id) # pluck to avoid duplicates in resulting scope (from the step join)
 
-      access_through_project.or(own_referrals).distinct
+      access_through_project.or(base_scope.where(id: own_referral_ids))
     end
 
     scope :active, -> { where.not(status: ['accepted', 'rejected']) }
     scope :active_or_accepted, -> { where.not(status: 'rejected') }
+
+    # Default sort for displaying referrals. Floats 'in_progress' and 'initialized' to the top,
+    # then sorts by updated_at descending.
+    # This is used in the frontend to display referrals in a consistent order.
+    scope :sorted_by_status, -> do
+      conditions = [
+        [arel_table[:status].eq('initialized'), 1],
+        [arel_table[:status].eq('in_progress'), 1],
+        [arel_table[:status].eq('accepted'), 2],
+        [arel_table[:status].eq('rejected'), 2],
+      ]
+      order(acase(conditions, elsewise: 3), updated_at: :desc, id: :asc)
+    end
 
     validates :workflow_instance, uniqueness: true
     validate :unique_referral_per_opportunity

--- a/drivers/hmis/app/models/hmis/ce/referral.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral.rb
@@ -42,13 +42,17 @@ module Hmis::Ce
       # Referrals that have a step assigned to this user, in projects in which the user can_view_own_referrals.
       # Referral only becomes viewable once the assigned step becomes available.
       # Note that the user does *not* need can_view_project in this case
-      assigned_step_ids = user.workflow_step_assignments.pluck(:step_id)
-      own_referral_ids = base_scope.joins(:steps).
+      own_referral_ids = base_scope.with_available_step_assigned_to(user).
         merge(Hmis::Hud::Project.with_access(user, :can_view_own_referrals)).
-        merge(Hmis::WorkflowExecution::Step.where(id: assigned_step_ids).excluding_unavailable).
         pluck(:id) # pluck to avoid duplicates in resulting scope (from the step join)
 
       access_through_project.or(base_scope.where(id: own_referral_ids))
+    end
+
+    # Referrals that have a step assigned to the specified user. Excludes referrals if the assigned step(s) are unavailable.
+    scope :with_available_step_assigned_to, ->(user) do
+      assigned_step_ids = user.workflow_step_assignments.pluck(:step_id)
+      joins(:steps).merge(Hmis::WorkflowExecution::Step.where(id: assigned_step_ids).excluding_unavailable)
     end
 
     scope :active, -> { where.not(status: ['accepted', 'rejected']) }
@@ -57,7 +61,7 @@ module Hmis::Ce
     # Default sort for displaying referrals. Floats 'in_progress' and 'initialized' to the top,
     # then sorts by updated_at descending.
     # This is used in the frontend to display referrals in a consistent order.
-    scope :sorted_by_status, -> do
+    scope :order_by_status, -> do
       conditions = [
         [arel_table[:status].eq('initialized'), 1],
         [arel_table[:status].eq('in_progress'), 1],

--- a/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
@@ -49,8 +49,7 @@ class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
       # Convert input to application timezone for proper comparison with database timestamps
       filter_time = Time.zone.parse(input.on_current_task_since.to_s)
       scope.joins(:current_steps).
-        where(wfe_step_t[:available_at].lt(filter_time)).
-        distinct
+        where(wfe_step_t[:available_at].lt(filter_time))
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/workflow_execution/step.rb
+++ b/drivers/hmis/app/models/hmis/workflow_execution/step.rb
@@ -17,6 +17,12 @@ module Hmis::WorkflowExecution
     has_many :assignments, class_name: 'Hmis::WorkflowExecution::StepAssignment', dependent: :destroy
 
     scope :open, -> { where(status: ['available', 'in_progress']) }
+    scope :excluding_unavailable, -> { where.not(status: 'unavailable') }
+    scope :assigned_to, ->(user_id) do
+      sa_t = Hmis::WorkflowExecution::StepAssignment.arel_table
+      joins(:assignments).where(sa_t[:user_id].eq(user_id))
+    end
+    scope :order_by_available_at, -> { order(available_at: :desc, id: :desc) }
 
     def open?
       [:available, :in_progress].include?(status.to_sym)

--- a/drivers/hmis/app/models/hmis/workflow_execution/step.rb
+++ b/drivers/hmis/app/models/hmis/workflow_execution/step.rb
@@ -22,7 +22,6 @@ module Hmis::WorkflowExecution
       sa_t = Hmis::WorkflowExecution::StepAssignment.arel_table
       joins(:assignments).where(sa_t[:user_id].eq(user_id))
     end
-    scope :order_by_available_at, -> { order(available_at: :desc, id: :desc) }
 
     def open?
       [:available, :in_progress].include?(status.to_sym)

--- a/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
@@ -75,6 +75,33 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
 
     context 'when querying by workflow template' do
+    end
+
+    context 'when referrals have varying statuses' do
+      let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, status: 'in_progress', updated_at: 1.month.ago) }
+      let!(:referral_accepted) { create(:hmis_ce_referral, project: project, data_source: ds1, status: 'accepted', updated_at: 1.week.ago) }
+      let!(:referral_rejected) { create(:hmis_ce_referral, project: project, data_source: ds1, status: 'rejected', updated_at: 1.day.ago) }
+
+      it 'sorts referrals by status, then by date updated' do
+        response, result = post_graphql { query }
+        expect(response.status).to eq(200), result.inspect
+
+        referrals = result.dig('data', 'ceReferrals', 'nodes')
+        expect(referrals.map { |r| r['status'] }).to eq(['in_progress', 'rejected', 'accepted'])
+      end
+
+      it 'supports filtering referrals by status' do
+        variables = { filters: { status: ['accepted'] } }
+        response, result = post_graphql(**variables) { query }
+        expect(response.status).to eq(200), result.inspect
+
+        referrals = result.dig('data', 'ceReferrals', 'nodes')
+        expect(referrals.size).to eq(1)
+        expect(referrals.first['status']).to eq('accepted')
+      end
+    end
+
+    context 'when querying by workflow template' do
       let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_1) }
       let!(:referral2) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_1) }
       let!(:referral3) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_2) }

--- a/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
@@ -74,9 +74,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_gql_error(post_graphql { query }, message: 'access denied')
     end
 
-    context 'when querying by workflow template' do
-    end
-
     context 'when referrals have varying statuses' do
       let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, status: 'in_progress', updated_at: 1.month.ago) }
       let!(:referral_accepted) { create(:hmis_ce_referral, project: project, data_source: ds1, status: 'accepted', updated_at: 1.week.ago) }

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(result.dig('data', 'project', 'ceOpportunities', 'nodes')).to be_empty
     end
 
-    context 'when filtering for open referrals' do
+    context 'when filtering for opportunities with open referrals' do
       let(:variables) do
         {
           id: project.id,
@@ -74,7 +74,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let(:closed_opportunity) { create :hmis_ce_opportunity, project: project, data_source: ds1, status: :closed }
       let(:locked_opportunity) { create :hmis_ce_opportunity, project: project, data_source: ds1, status: :locked }
 
-      it 'returns only active referrals' do
+      it 'returns only opportunities with active referrals' do
         response, result = post_graphql(**variables) { query }
         expect(response.status).to eq(200), result.inspect
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/7838

* Add a default sort for referrals that floats In Progress referrals to the top
* To get sorted to work, I needed to remove the `distinct` from the viewable_by scope
* Add some convenience scopes for user assignment

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
