### PR TITLE
Support printing CE workflow to console

### DIFF
--- a/drivers/hmis/app/models/hmis/workflow_definition/flow.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/flow.rb
@@ -7,5 +7,18 @@ module Hmis::WorkflowDefinition
     belongs_to :template, class_name: 'Hmis::WorkflowDefinition::Template'
     belongs_to :source_node, class_name: 'Hmis::WorkflowDefinition::Node'
     belongs_to :target_node, class_name: 'Hmis::WorkflowDefinition::Node'
+
+    def describe_as_string(source_only: false, target_only: false)
+      str = if source_only
+        source_node.name
+      elsif target_only
+        target_node.name
+      else
+        "#{source_node.name} -> #{target_node.name}"
+      end
+      str += " (IF #{condition})" if condition.present?
+      str += " (#{id})"
+      str
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/workflow_definition/node.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/node.rb
@@ -45,6 +45,15 @@ module Hmis::WorkflowDefinition
       inflows.map(&:condition).any?
     end
 
+    def describe_as_string
+      str = "[#{type.demodulize}] #{name} (#{id})"
+      inflow_descriptions = inflows.order(:position).map { |flow| flow.describe_as_string(source_only: true) }
+      str += "\n   Inflows:\n     #{inflow_descriptions.join("\n     ")}" if inflow_descriptions.any?
+      outflow_descriptions = outflows.order(:position).map { |flow| flow.describe_as_string(target_only: true) }
+      str += "\n   Outflows:\n     #{outflow_descriptions.join("\n     ")}" if outflow_descriptions.any?
+      str
+    end
+
     protected
 
     def check_trigger_config_format

--- a/drivers/hmis/app/models/hmis/workflow_definition/template.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/template.rb
@@ -56,6 +56,10 @@ module Hmis::WorkflowDefinition
       errors.add(:base, "There can only be one #{status} template for the identifier #{identifier}.")
     end
 
+    def describe_as_string
+      graph.walk.map(&:describe_as_string).join("\n")
+    end
+
     def validate
       # Run validations that don't run on lifecycle hooks. (See comments in WorkflowTemplateValidator)
       Hmis::WorkflowDefinition::Validators::WorkflowTemplateValidator.new.validate(self)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Add stringifier functions to workflow models to support printing out a summary of the workflow. This is to help debugging when building workflows by hand.

## Type of change
new dev tool


```
irb(main):034> reload!; puts Hmis::WorkflowDefinition::Template.all.last.describe_as_string

[StartEvent] start referral (84)
   Outflows:
     Initial Review (213)
[Task] Initial Review (87)
   Inflows:
     start referral (213)
   Outflows:
     Decline referral (IF review_decision = 0) (207)
     Shelter Agency Initial Review (214)
[Gateway] Decline referral (93)
   Inflows:
     Initial Review (IF review_decision = 0) (207)
     Shelter Agency Initial Review (IF review_decision = 0) (208)
     Housing Case Manager Initial Review (IF review_decision = 0) (209)
     Housing Case Manager Review Referral (IF review_decision = 0) (210)
     Indicate Move-in Date (IF review_decision = 0) (211)
     Confirm Referral Success (IF review_decision = 0) (212)
   Outflows:
     reject referral (206)
[EndEvent] reject referral (86)
   Inflows:
     Decline referral (206)
[Task] Shelter Agency Initial Review (88)
   Inflows:
     Initial Review (214)
   Outflows:
     Decline referral (IF review_decision = 0) (208)
     Housing Case Manager Initial Review (215)
[Task] Housing Case Manager Initial Review (89)
   Inflows:
     Shelter Agency Initial Review (215)
   Outflows:
     Decline referral (IF review_decision = 0) (209)
     Housing Case Manager Review Referral (216)
[Task] Housing Case Manager Review Referral (90)
   Inflows:
     Housing Case Manager Initial Review (216)
   Outflows:
     Decline referral (IF review_decision = 0) (210)
     Indicate Move-in Date (217)
[Task] Indicate Move-in Date (91)
   Inflows:
     Housing Case Manager Review Referral (217)
   Outflows:
     Decline referral (IF review_decision = 0) (211)
     Confirm Referral Success (218)
[Task] Confirm Referral Success (92)
   Inflows:
     Indicate Move-in Date (218)
   Outflows:
     Decline referral (IF review_decision = 0) (212)
     accept referral (219)
[EndEvent] accept referral (85)
   Inflows:
     Confirm Referral Success (219)
```

## Checklist before requesting review

- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
