### PR TITLE
Patch income cleanup task user id

### DIFF
--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -545,6 +545,7 @@ module HmisDataCleanup
           raise unless record
 
           # skip records that were likely created by migrations
+          next if fp.values.nil?
           next if record.user_id.nil?
           next if record.user_id == system_hud_users.fetch(record.data_source_id)&.user_id
 

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -534,7 +534,10 @@ module HmisDataCleanup
         merge(data_sources).
         preload(:income_benefit)
 
-      system_hud_user = Hmis::Hud::User.from_user(Hmis::User.system_user)
+      system_hud_users = data_sources.map do |ds|
+        Hmis::Hud::User.system_user(data_source_id: ds.id)
+      end.index_by(&:data_source_id)
+
       messages = []
       Hmis::Hud::IncomeBenefit.transaction do
         scope.find_each do |fp|
@@ -542,7 +545,8 @@ module HmisDataCleanup
           raise unless record
 
           # skip records that were likely created by migrations
-          next if record.user_id.nil? || record.user_id == system_hud_user.user_id
+          next if record.user_id.nil?
+          next if record.user_id == system_hud_users.fetch(record.data_source_id)&.user_id
 
           messages += Hmis::Hud::DataIntegrity::TotalIncomeReconciler.call(record)
           record.save! if record.changed?

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -543,6 +543,85 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
+  context 'with incorrect total income via form processor' do
+    let!(:form_definition) { create(:hmis_form_definition) }
+    let!(:non_system_user) { create(:hmis_hud_user, data_source: hmis_ds) }
+    let!(:income_benefit) do
+      create(:hmis_income_benefit,
+             enrollment: e1,
+             client: e1.client,
+             user: non_system_user,
+             income_from_any_source: 1,
+             earned_amount: 100,
+             earned: 1,
+             ssi_amount: 200,
+             ssi: 1,
+             total_monthly_income: 250, # incorrect total
+             **default_enrollment_attrs)
+    end
+    let!(:custom_assessment) do
+      create(:hmis_custom_assessment,
+             enrollment: e1,
+             client: e1.client,
+             user: non_system_user,
+             data_source: hmis_ds,
+             definition: form_definition,
+             values: { 'test' => 'value' })
+    end
+    let!(:form_processor) do
+      custom_assessment.form_processor.tap do |fp|
+        fp.update!(income_benefit: income_benefit)
+      end
+    end
+
+    # Canary records that should be skipped
+    let!(:system_user) { Hmis::Hud::User.system_user(data_source_id: hmis_ds.id) }
+    let!(:income_with_system_user) do
+      create(:hmis_income_benefit,
+             enrollment: e2,
+             client: e2.client,
+             user: system_user,
+             income_from_any_source: 1,
+             earned: 1,
+             earned_amount: 50,
+             total_monthly_income: 75, # incorrect total, but should be skipped
+             **default_enrollment_attrs)
+    end
+    let!(:assessment_with_nil_values) do
+      create(:hmis_custom_assessment,
+             enrollment: e3,
+             client: e3.client,
+             user: non_system_user,
+             data_source: hmis_ds,
+             definition: form_definition,
+             values: nil) # nil values should be skipped
+    end
+    let!(:income_with_nil_values) do
+      create(:hmis_income_benefit,
+             enrollment: e3,
+             client: e3.client,
+             user: non_system_user,
+             income_from_any_source: 1,
+             earned_amount: 75,
+             earned: 1,
+             total_monthly_income: 100, # incorrect total, but should be skipped
+             **default_enrollment_attrs)
+    end
+    before do
+      assessment_with_nil_values.form_processor.update!(income_benefit: income_with_nil_values)
+    end
+
+    it 'corrects total income records via form processor' do
+      expect { HmisDataCleanup::Util.correct_total_income_records! }.to(
+        [
+          change { income_benefit.reload.total_monthly_income.to_i }.from(250).to(300),
+          not_change { income_with_system_user.reload.total_monthly_income.to_i },
+          not_change { income_with_nil_values.reload.total_monthly_income.to_i },
+        ].reduce(&:and),
+      )
+    end
+  end
+
   context 'with household ids duplicated across projects' do
     before(:each) do
       p2 = create(:hmis_hud_project, data_source: hmis_ds, organization: o1)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
The task had code to ignore income benefits that were migrated-in, but it wasn't working correctly because it didn't check for the HUD "system user" based on data source.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
