### PR TITLE
validate hmis permission mode

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -159,11 +159,11 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   #
   # Note: use "replace_scope" hide previous declaration of :viewable_by
   replace_scope :viewable_by, ->(user, include_limited_access_enrollments: false) do
-    return with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all') unless include_limited_access_enrollments
-    return none unless user.permissions?(:can_view_enrollment_details, :can_view_limited_enrollment_details, mode: 'any')
+    return with_access(user, :can_view_enrollment_details, :can_view_project, mode: :all) unless include_limited_access_enrollments
+    return none unless user.permissions?(:can_view_enrollment_details, :can_view_limited_enrollment_details, mode: :any)
 
     # Projects where the user has full enrollment access
-    full_access_project_ids = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all').pluck(:id)
+    full_access_project_ids = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: :all).pluck(:id)
     # Projects where the user has limited enrollment access
     limited_access_project_ids = Hmis::Hud::Project.with_access(user, :can_view_limited_enrollment_details).pluck(:id)
 

--- a/drivers/hmis/app/models/hmis/hud/household.rb
+++ b/drivers/hmis/app/models/hmis/hud/household.rb
@@ -27,7 +27,7 @@ class Hmis::Hud::Household < Hmis::Hud::Base
     p_t = Hmis::Hud::Project.arel_table
     hh_t = Hmis::Hud::Household.arel_table
     cond = p_t[:ProjectID].eq(hh_t[:ProjectID]).and(p_t[:data_source_id].eq(hh_t[:data_source_id]))
-    projects = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: 'all').where(cond)
+    projects = Hmis::Hud::Project.with_access(user, :can_view_enrollment_details, :can_view_project, mode: :all).where(cond)
     where(projects.arel.exists)
   end
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -82,7 +82,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   end
 
   # Includes any HMIS projects where the user has the specified permission(s)
-  # NOTE: Pass kwarg "mode: 'all'" if all permissions must be present. Default is 'any'.
+  # NOTE: Pass kwarg "mode: :all" if all permissions must be present. Default is 'any'.
   #
   # WARNING! This will include projects that the user does not have access to view (e.g. they lack can_view_projects)
   scope :with_access, ->(user, *permissions, **kwargs) do

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -137,6 +137,8 @@ class Hmis::User < ApplicationRecord
   end
 
   private def check_permissions_with_mode(*permissions, mode: :any)
+    raise ArgumentError, "unknown mode #{mode.inspect}" unless mode&.in?([:all, :any])
+
     method_name = mode == :all ? :all? : :any?
     permissions.send(method_name) { |perm| yield(perm) }
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Bug Fix & Consistency. Previously, using the string 'all' would have incorrectly defaulted to :any behavior. This change corrects that bug and enforces consistency.

## Type of change
Bug fix 

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
