### PR TITLE
Fix bug with staff assignment after household join

### DIFF
--- a/drivers/hmis/app/graphql/mutations/join_household.rb
+++ b/drivers/hmis/app/graphql/mutations/join_household.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Mutations
   class JoinHousehold < CleanBaseMutation
     argument :receiving_household_id, ID, required: true
@@ -53,6 +55,12 @@ module Mutations
           enrollment.assign_unit(unit: receiving_unit, start_date: Date.current, user: current_user) if receiving_unit
 
           enrollment.save!
+        end
+
+        # If there are no remaining enrollments in the donor household, reassign any staff assignments to the receiving household.
+        unless remaining_enrollments.any?
+          staff_assignments = Hmis::StaffAssignment.where(household_id: donor_household.household_id)
+          staff_assignments.update_all(household_id: receiving_household_id)
         end
 
         receiving_household.reload

--- a/drivers/hmis/spec/requests/hmis/join_household_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/join_household_spec.rb
@@ -151,6 +151,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     end
   end
 
+  context 'when the donor household had a staff assignment' do
+    let!(:assignment) { create :hmis_staff_assignment, data_source: ds1, enrollment: donor_hoh }
+    let!(:assignee) { assignment.user }
+
+    it 'transfers the staff assignment to the receiving household' do
+      expect do
+        perform_mutation
+        assignment.reload
+        assignee.reload
+      end.to not_change(assignee.staff_assignments, :count).
+        and change(assignment, :household_id).from(donor_household_id).to(receiving_enrollment.household_id)
+    end
+  end
+
   describe 'unit assignment' do
     let!(:unit1) { create :hmis_unit, project: p1 }
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
This PR fixes a bug with joining households. When you join all members of a household to another household, the old household's ID is no longer valid, and should be updated in any associated records, like staff assignment.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) - See issue description for bug repro instructions

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
