### PR TITLE
Superset Env Take Two

### DIFF
--- a/config/deploy/docker/lib/aws_sdk_helpers.rb
+++ b/config/deploy/docker/lib/aws_sdk_helpers.rb
@@ -130,8 +130,8 @@ module AwsSdkHelpers
 
     def self.superset_env_for_warehouse
       names = [
-        "/#{ENV.fetch('RAILS_ENV')}/tenant/#{ENV.fetch('CLIENT')}/app/superset-sync-jobs/SUPERSET_ADMIN_PASS",
-        "/#{ENV.fetch('RAILS_ENV')}/tenant/#{ENV.fetch('CLIENT')}/app/superset-sync-jobs/SUPERSET_ADMIN_USER",
+        "/#{ENV.fetch('RAILS_ENV')}/tenant/#{ENV.fetch('TF_TENANT')}/app/superset-sync-jobs/SUPERSET_ADMIN_PASS",
+        "/#{ENV.fetch('RAILS_ENV')}/tenant/#{ENV.fetch('TF_TENANT')}/app/superset-sync-jobs/SUPERSET_ADMIN_USER",
       ]
 
       params = AwsSdkHelpers::ClientMethods.ssm.get_parameters(


### PR DESCRIPTION
- **Use new tenant var that will always agree with the terraform client/tenant name**

## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Some tenants (clients) are labeled inconsistently between terraform and ansible. This variable change addresses that.

## Type of change
bugfix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
