### PR TITLE
7865-rm-memory-profiler-x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -258,7 +258,7 @@ gem 'hashdiff'
 # https://github.com/k8s-ruby/k8s-ruby/pull/57
 gem 'k8s-ruby', github: 'k8s-ruby/k8s-ruby', branch: 'master'
 
-gem 'memory_profiler', require: false
+gem 'get_process_mem', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -289,8 +289,8 @@ group :development do
   gem 'list_matcher', require: false # for the forms:desmush rake task
 
   gem 'ruby-prof', require: false
+  gem 'memory_profiler', require: false
 
-  gem 'get_process_mem', require: false
   gem 'rack-mini-profiler', require: false
   gem 'flamegraph', require: false
   gem 'stackprof', require: false

--- a/app/models/grda_warehouse/tasks/task_instrumentation.rb
+++ b/app/models/grda_warehouse/tasks/task_instrumentation.rb
@@ -16,7 +16,11 @@ class GrdaWarehouse::Tasks::TaskInstrumentation
       profile_data = PeakMemorySampler.profile do
         block.call(run)
       end
-      run.update!(memory_allocated: profile_data[:relative_memory_bytes])
+      run.update!(
+        memory_allocated: profile_data[:relative_peak_memory_bytes],
+        memory_retained: profile_data[:retained_memory_bytes],
+        # allocation_count is not supported
+      )
     end
   end
 

--- a/app/models/grda_warehouse/tasks/task_instrumentation.rb
+++ b/app/models/grda_warehouse/tasks/task_instrumentation.rb
@@ -16,7 +16,7 @@ class GrdaWarehouse::Tasks::TaskInstrumentation
       profile_data = PeakMemorySampler.profile do
         block.call(run)
       end
-      run.update!(memory_allocated: profile_data[:peak_memory_bytes])
+      run.update!(memory_allocated: profile_data[:relative_memory_bytes])
     end
   end
 

--- a/app/models/grda_warehouse/tasks/task_instrumentation.rb
+++ b/app/models/grda_warehouse/tasks/task_instrumentation.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'memory_profiler'
 class GrdaWarehouse::Tasks::TaskInstrumentation
   include Singleton
 
@@ -10,17 +9,14 @@ class GrdaWarehouse::Tasks::TaskInstrumentation
   def call(name, alert_threshold:, &block)
     task = find_or_create_maintenance_task(name, alert_threshold: alert_threshold)
     run = task.system_maintenance_task_runs.create!(started_at: Time.current)
+
     if Rails.env.production?
       block.call(run)
     else
-      report = MemoryProfiler.report do
+      profile_data = PeakMemorySampler.profile do
         block.call(run)
       end
-      run.update!(
-        memory_allocated: report.total_allocated_memsize,
-        memory_retained: report.total_retained_memsize,
-        allocation_count: report.total_allocated,
-      )
+      run.update!(memory_allocated: profile_data[:peak_memory_bytes])
     end
   end
 

--- a/drivers/hmis/config/initializers/hmis_feature.rb
+++ b/drivers/hmis/config/initializers/hmis_feature.rb
@@ -23,10 +23,3 @@ Rails.application.config.queued_tasks[:hmis_disabling_condition_and_race_cleanup
   HmisDataCleanup::Util.fix_disabling_condition_nils!
   HmisDataCleanup::Util.fix_race_gender_99s!
 end
-
-TodoOrDie('Remove one-time job', by: '2025-07-01')
-if ENV['ENABLE_HMIS_API'] == 'true'
-  Rails.application.config.queued_tasks[:hmis_correct_total_income_20250602] = -> do
-    HmisDataCleanup::Util.correct_total_income_records!
-  end
-end

--- a/lib/util/peak_memory_sampler.rb
+++ b/lib/util/peak_memory_sampler.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'get_process_mem'
+
+# Samples peak memory usage of a block of code using a polling thread.
+# This is a lightweight alternative to memory_profiler for environments
+# where profiling overhead should be minimized.
+module PeakMemorySampler
+  def self.current_mem_bytes
+    GetProcessMem.new.bytes
+  end
+
+  # @return [Hash] with keys :result and :peak_memory_bytes
+  def self.profile(poll_interval: 0.5)
+    return { peak_memory_bytes: 0 } unless block_given?
+
+    monitor_state = { running: true, peak_memory_bytes: 0 }
+
+    monitor_thread = Thread.new do
+      while monitor_state[:running]
+        current_mem = current_mem_bytes
+        monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+        sleep(poll_interval)
+      end
+      # One final check after the loop to catch a last-second spike
+      current_mem = current_mem_bytes
+      monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+    end
+
+    begin
+      yield
+      { peak_memory_bytes: monitor_state[:peak_memory_bytes] }
+    ensure
+      # This ensures the monitor stops even if the block raises an error
+      monitor_state[:running] = false
+      # Wait for the thread to finish its current loop and exit
+      monitor_thread.join
+    end
+  end
+end

--- a/lib/util/peak_memory_sampler.rb
+++ b/lib/util/peak_memory_sampler.rb
@@ -10,34 +10,48 @@ module PeakMemorySampler
     GetProcessMem.new.bytes
   end
 
-  # @return [Hash] with keys :result and :peak_memory_bytes
-  def self.profile(poll_interval: 0.5)
+  # @return [Hash] Memory usage statistics:
+  #   - peak_memory_bytes: [Integer] Maximum absolute memory usage during execution
+  #   - relative_peak_memory_bytes: [Integer] Peak memory minus initial memory (memory growth)
+  #   - retained_memory_bytes: [Integer] Memory difference after GC (memory not freed, leaks)
+  def self.profile(poll_interval: 0.1)
     raise ArgumentError, 'a block is required' unless block_given?
 
     initial_memory_bytes = current_mem_bytes
     monitor_state = { running: true, peak_memory_bytes: initial_memory_bytes }
+    mutex = Mutex.new
 
     monitor_thread = Thread.new do
-      while monitor_state[:running]
+      while mutex.synchronize { monitor_state[:running] }
         current_mem = current_mem_bytes
-        monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+        mutex.synchronize do
+          monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+        end
         sleep(poll_interval)
       end
       # One final check after the loop to catch a last-second spike
       current_mem = current_mem_bytes
-      monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+      mutex.synchronize do
+        monitor_state[:peak_memory_bytes] = current_mem if current_mem > monitor_state[:peak_memory_bytes]
+      end
     end
 
     begin
       yield
-      peak_memory = monitor_state[:peak_memory_bytes]
+      peak_memory = mutex.synchronize { monitor_state[:peak_memory_bytes] }
+
+      # Force garbage collection and measure retained memory
+      GC.start
+      final_memory_bytes = current_mem_bytes
+
       {
         peak_memory_bytes: peak_memory,
-        relative_memory_bytes: peak_memory - initial_memory_bytes,
+        relative_peak_memory_bytes: peak_memory - initial_memory_bytes,
+        retained_memory_bytes: final_memory_bytes - initial_memory_bytes,
       }
     ensure
       # This ensures the monitor stops even if the block raises an error
-      monitor_state[:running] = false
+      mutex.synchronize { monitor_state[:running] = false }
       # Wait for the thread to finish its current loop and exit
       monitor_thread.join
     end

--- a/lib/util/peak_memory_sampler.rb
+++ b/lib/util/peak_memory_sampler.rb
@@ -12,9 +12,10 @@ module PeakMemorySampler
 
   # @return [Hash] with keys :result and :peak_memory_bytes
   def self.profile(poll_interval: 0.5)
-    return { peak_memory_bytes: 0 } unless block_given?
+    raise ArgumentError, 'a block is required' unless block_given?
 
-    monitor_state = { running: true, peak_memory_bytes: 0 }
+    initial_memory_bytes = current_mem_bytes
+    monitor_state = { running: true, peak_memory_bytes: initial_memory_bytes }
 
     monitor_thread = Thread.new do
       while monitor_state[:running]
@@ -29,7 +30,11 @@ module PeakMemorySampler
 
     begin
       yield
-      { peak_memory_bytes: monitor_state[:peak_memory_bytes] }
+      peak_memory = monitor_state[:peak_memory_bytes]
+      {
+        peak_memory_bytes: peak_memory,
+        relative_memory_bytes: peak_memory - initial_memory_bytes,
+      }
     ensure
       # This ensures the monitor stops even if the block raises an error
       monitor_state[:running] = false

--- a/spec/lib/peak_memory_sampler_spec.rb
+++ b/spec/lib/peak_memory_sampler_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: false
+
+require 'rails_helper'
+
+RSpec.describe PeakMemorySampler do
+  describe '.profile' do
+    it 'records a peak memory usage value' do
+      profiled = described_class.profile do # Allocate a small string
+        @test_str = 'test-result'
+        sleep(0.6)
+      end
+      expect(profiled[:peak_memory_bytes]).to be > 0
+    end
+
+    it 'captures the approximate peak memory of the process' do
+      base_mem = GetProcessMem.new.bytes
+      string_size = 10 * 1024 * 1024 # 10MB string
+
+      profiled = described_class.profile do
+        @test_str = 'a' * string_size
+
+        # The sampler thread runs in the background. Sleep to capture the peak allocation.
+        sleep(0.6)
+      end
+
+      peak_mem = profiled[:peak_memory_bytes]
+
+      # Assert that the recorded peak memory is at least the size of the
+      # baseline memory plus a significant fraction (95%) of the string,
+      # making the test less brittle.
+      expected_minimum = base_mem + (string_size * 0.95)
+      expect(peak_mem).to be >= expected_minimum
+    end
+
+    it 'returns 0 for peak memory and if no-op is given' do
+      profiled = described_class.profile do
+        sleep(0.6)
+      end
+      expect(profiled[:peak_memory_bytes]).to eq(0)
+    end
+  end
+end

--- a/spec/lib/peak_memory_sampler_spec.rb
+++ b/spec/lib/peak_memory_sampler_spec.rb
@@ -4,43 +4,34 @@ require 'rails_helper'
 
 RSpec.describe PeakMemorySampler do
   describe '.profile' do
-    it 'records a peak memory usage value' do
-      profiled = described_class.profile do # Allocate a small string
-        @test_str = 'test-result'
-        sleep(0.6)
-      end
-      expect(profiled[:peak_memory_bytes]).to be > 0
-      expect(profiled[:relative_memory_bytes]).to be >= 0
-    end
-
     it 'captures the approximate peak memory of the process' do
+      GC.start
       base_mem = GetProcessMem.new.bytes
-      string_size = 10 * 1024 * 1024 # 10MB string
+      array_size = 10 * 1024 * 1024 # 10MB array
 
       profiled = described_class.profile do
-        @test_str = 'a' * string_size
+        ['a'] * array_size # rubocop:disable Lint/Void
 
         # The sampler thread runs in the background. Sleep to capture the peak allocation.
         sleep(0.6)
       end
 
       peak_mem = profiled[:peak_memory_bytes]
-      relative_mem = profiled[:relative_memory_bytes]
+      relative_mem = profiled[:relative_peak_memory_bytes]
 
+      expect(peak_mem).to be >= (base_mem)
       # Assert that the recorded peak memory is at least the size of the
-      # baseline memory plus a significant fraction (95%) of the string,
-      # making the test less brittle.
-      expected_minimum = base_mem + (string_size * 0.95)
-      expect(peak_mem).to be >= expected_minimum
+      # baseline memory plus some fraction of the array
+      expect(relative_mem).to be >= array_size * 0.9
 
-      # Assert that relative memory is a significant fraction of the new allocation
-      expect(relative_mem).to be >= (string_size * 0.95)
+      # Assert that retained memory is tracked
+      retained_mem = profiled[:retained_memory_bytes]
+      expect(retained_mem).to be >= 0
     end
 
-    it 'returns a value greater than 0 for peak memory if a no-op is given' do
+    it 'returns a value for peak memory if a no-op is given' do
       profiled = described_class.profile { true }
       expect(profiled[:peak_memory_bytes]).to be > 0
-      expect(profiled[:relative_memory_bytes]).to be >= 0
     end
 
     it 'raises an error if no block is given' do

--- a/spec/lib/peak_memory_sampler_spec.rb
+++ b/spec/lib/peak_memory_sampler_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe PeakMemorySampler do
         sleep(0.6)
       end
       expect(profiled[:peak_memory_bytes]).to be > 0
+      expect(profiled[:relative_memory_bytes]).to be >= 0
     end
 
     it 'captures the approximate peak memory of the process' do
@@ -24,19 +25,28 @@ RSpec.describe PeakMemorySampler do
       end
 
       peak_mem = profiled[:peak_memory_bytes]
+      relative_mem = profiled[:relative_memory_bytes]
 
       # Assert that the recorded peak memory is at least the size of the
       # baseline memory plus a significant fraction (95%) of the string,
       # making the test less brittle.
       expected_minimum = base_mem + (string_size * 0.95)
       expect(peak_mem).to be >= expected_minimum
+
+      # Assert that relative memory is a significant fraction of the new allocation
+      expect(relative_mem).to be >= (string_size * 0.95)
     end
 
-    it 'returns 0 for peak memory and if no-op is given' do
-      profiled = described_class.profile do
-        sleep(0.6)
-      end
-      expect(profiled[:peak_memory_bytes]).to eq(0)
+    it 'returns a value greater than 0 for peak memory if a no-op is given' do
+      profiled = described_class.profile { true }
+      expect(profiled[:peak_memory_bytes]).to be > 0
+      expect(profiled[:relative_memory_bytes]).to be >= 0
+    end
+
+    it 'raises an error if no block is given' do
+      expect do
+        described_class.profile
+      end.to raise_error(ArgumentError, 'a block is required')
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
* Replaced memory_profiler with PeakMemorySampler. 
* This runs in a background thread, sampling peak memory usage of a given block of code with minimal performance impact. 
* It uses the get_process_mem gem which was already in the Gemfile

task profiling:
* The meaning of memory_allocated is changing from "total allocated during execution" to "peak increase from baseline"
* no longer supporting allocation_count

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail

