### PR TITLE
Move to bigints for task run memory logging

### DIFF
--- a/db/warehouse/migrate/20250703125916_update_memory_storage_integers.rb
+++ b/db/warehouse/migrate/20250703125916_update_memory_storage_integers.rb
@@ -1,0 +1,8 @@
+class UpdateMemoryStorageIntegers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_column :system_maintenance_task_runs, :memory_allocated, :bigint
+      change_column :system_maintenance_task_runs, :memory_retained, :bigint
+    end
+  end
+end

--- a/db/warehouse/migrate/20250703125916_update_memory_storage_integers.rb
+++ b/db/warehouse/migrate/20250703125916_update_memory_storage_integers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateMemoryStorageIntegers < ActiveRecord::Migration[7.1]
   def change
     safety_assured do

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -30821,8 +30821,8 @@ CREATE TABLE public.system_maintenance_task_runs (
     system_maintenance_task_id bigint,
     started_at timestamp(6) without time zone NOT NULL,
     completed_at timestamp(6) without time zone,
-    memory_allocated integer,
-    memory_retained integer,
+    memory_allocated bigint,
+    memory_retained bigint,
     allocation_count integer
 );
 
@@ -74118,6 +74118,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250703125916'),
 ('20250623193057'),
 ('20250619125706'),
 ('20250612192906'),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Updates storage type for memory use

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail