### PR TITLE
Revert fy2026 change to service collection

### DIFF
--- a/drivers/hmis/lib/form_data/default/services/service.json
+++ b/drivers/hmis/lib/form_data/default/services/service.json
@@ -123,17 +123,11 @@
           "type": "MAX",
           "question": "faEndDate"
         }
-      ]
-    },
-    {
-      "link_id": "date_provided_guidance",
-      "type": "DISPLAY",
-      "text": "Date Provided should reflect the date that the financial assistance was identified as a need.",
-      "enable_behavior": "ANY",
+      ],
       "enable_when": [
         {
           "local_constant": "$hudRecordType",
-          "operator": "EQUAL",
+          "operator": "NOT_EQUAL",
           "answer_code": "SSVF_FINANCIAL_ASSISTANCE"
         }
       ]


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Revert fy2026 change which started collecting Date provided for the V3 SSVF financial assistance service. This field should not be collected until the changeover.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
