### PR TITLE
Move custom HUD service form to patch

### DIFF
--- a/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/append_hud_service_note.json
+++ b/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/append_hud_service_note.json
@@ -1,0 +1,15 @@
+[
+  {
+    "form_identifier": "service",
+    "append_items": [
+      {
+        "text": "Note",
+        "type": "TEXT",
+        "link_id": "hud_service_note",
+        "mapping": {
+          "custom_field_key": "hud_service_note"
+        }
+      }
+    ]
+  }
+]

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -4,12 +4,14 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisUtil
   class JsonForms
     JsonFormException = Class.new(StandardError)
     private_constant :JsonFormException
 
-    DATA_DIR = 'drivers/hmis/lib/form_data'.freeze
+    DATA_DIR = 'drivers/hmis/lib/form_data'
 
     def initialize(env_key: nil)
       @env_key = env_key if env_key.presence # allow override for testing
@@ -183,7 +185,7 @@ module HmisUtil
     def apply_form_patches(definition, patches, identifier:)
       result = definition.deep_dup
       applied_patches = []
-      patches.filter { |patch| patch['form_identifier'] == identifier && !patch.key?('link_id')}.each do |patch|
+      patches.filter { |patch| patch['form_identifier'] == identifier && !patch.key?('link_id') }.each do |patch|
         result['item'].unshift(*patch['prepend_items']) if patch['prepend_items'].present?
         result['item'].push(*patch['append_items']) if patch['append_items'].present?
         applied_patches << patch['form_identifier']

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -143,7 +143,11 @@ module HmisUtil
       end
     end
 
-    def apply_patches(tree, patches)
+    # Apply applicable patches to the "tree" which is a top-level item in the form definition.
+    # The patches passed may not apply to this tree. They are only applied if the `link_id` matches
+    # an item in the tree.
+    # Patches can override item attributes (such as "text") or append/prepend items to Group items.
+    def apply_item_patches(tree, patches)
       nodes_by_id = {}
       result = tree.deep_dup
       walk_nodes(result) do |node|
@@ -173,13 +177,36 @@ module HmisUtil
       [result, applied_patches]
     end
 
+    # Similar to apply_item_patches, but applies patches to the overall form
+    # instead of to an individual item. This was added to support appending an item
+    # to the Service form.
+    def apply_form_patches(definition, patches, identifier:)
+      result = definition.deep_dup
+      applied_patches = []
+      patches.filter { |patch| patch['form_identifier'] == identifier && !patch.key?('link_id')}.each do |patch|
+        result['item'].unshift(*patch['prepend_items']) if patch['prepend_items'].present?
+        result['item'].push(*patch['append_items']) if patch['append_items'].present?
+        applied_patches << patch['form_identifier']
+      end
+      [result, applied_patches]
+    end
+
     def apply_all_patches!(definition, identifier:)
       applied_patches = []
       Dir.glob("#{DATA_DIR}/#{env_key}/fragments/patches/*.json") do |file_path|
-        # patch_name = File.basename(file_path, '.json')
         file = File.read(file_path)
+        patches = JSON.parse(file)
+        # Split patches into "item patches" and "form patches"
+        item_patches, form_patches = patches.partition { |h| h.key?('link_id') }
+
+        # Apply form-level patches (appending and prepending items to system forms)
+        result, applied = apply_form_patches(definition, form_patches, identifier: identifier)
+        definition.replace(result)
+        applied_patches.push(*applied)
+
+        # Apply item-level patches (overriding item attributes, and appending/prepending items to groups)
         definition['item'].each do |item|
-          result, applied = apply_patches(item, JSON.parse(file))
+          result, applied = apply_item_patches(item, item_patches)
           item.replace(result)
           applied_patches.push(*applied)
         end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Issue: https://github.com/open-path/Green-River/issues/7921

Add a "patch" to append a custom note field to the HUD Service Form. This is currently implemented in an environment as a non-managed-in-version-control form, which means its not automatically updated when the system service form changes.

When this change is deployed, we should be able to delete that "custom" HUD Service form from the environment.

I needed to add some new code to patching to support appending items to a form.


How to test: `CLIENT=client_name rails driver:hmis:seed_definitions`
## Type of change
new feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
