### PR TITLE
HUD Report Version Tabs

### DIFF
--- a/drivers/hud_apr/app/controllers/hud_apr/dq/dq_concern.rb
+++ b/drivers/hud_apr/app/controllers/hud_apr/dq/dq_concern.rb
@@ -70,6 +70,14 @@ module HudApr::Dq::DqConcern
       super
     end
 
+    def available_report_versions
+      versions = super.except('FY 2023')
+      # The parent version has the FY 2022 slug as :fy2021, but the DQ report uses :fy2022
+      versions['FY 2022'][:slug] = :fy2022
+      versions.freeze
+    end
+    helper_method :available_report_versions
+
     def generator
       @generator ||= possible_generator_classes[report_version]
     end

--- a/drivers/hud_spm_report/app/controllers/hud_spm_report/base_controller.rb
+++ b/drivers/hud_spm_report/app/controllers/hud_spm_report/base_controller.rb
@@ -82,6 +82,12 @@ module HudSpmReport
     end
     helper_method :path_for_new
 
+    def available_report_versions
+      # We only want to show the versions that have a matching generator class
+      super.select { |_, v| possible_generator_classes.keys.include?(v[:slug]) }
+    end
+    helper_method :available_report_versions
+
     private def possible_generator_classes
       {
         fy2020: HudSpmReport::Generators::Fy2020::Generator,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix an issue where tabs were showing up for SPM and DQ Tool HUD Reports that didn't have corresponding generator versions. Trying to open these tabs was resulting in a server error.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
