### PR TITLE
Exclude clients from candidate pool if missing priority score

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_candidate.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_candidate.rb
@@ -12,7 +12,7 @@ module Types
     field :id, ID, null: false
     field :destination_client_id, ID, null: false
     field :client_name, String, null: false, description: 'Masked as "Candidate 123" unless the user has permission to view'
-    field :priority_score, Integer, null: false
+    field :priority_score, Integer, null: false, default_value: 0
     field :enrollments, HmisSchema::CeReferralSourceEnrollment.array_page_type, null: false
 
     def destination_client_id

--- a/drivers/hmis/app/models/hmis/ce/match/engine.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/engine.rb
@@ -35,6 +35,10 @@ module Hmis::Ce::Match
           next unless eligibility_evaluator.call(client)
 
           score = priority_evaluator.call(client)
+          # Client with nil score cannot be prioritized, so do not include them in the pool.
+          # If needing to include clients that don't have a score, expression should be set up like `IF(my_score = NULL, 0, my_score)`
+          next if score.nil?
+
           candidates << {
             candidate_pool_id: pool.id,
             client_proxy_id: proxies_by_client[[client.id, client.class.name]].id,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
* Update engine logic to exclude client from candidate pool if priority score is nil. see comment
* Update ce_candidate gql type to be consistent with database which allows nulls for priority score
* (maybe we should change nullability in the db, I'm not sure if there was a reason it was made nullable in the first place?)

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
