### PR TITLE
7634-candidate-pool-generation-tail

### DIFF
--- a/drivers/hmis/app/jobs/hmis/ce/process_changes_job.rb
+++ b/drivers/hmis/app/jobs/hmis/ce/process_changes_job.rb
@@ -48,7 +48,7 @@ module Hmis::Ce
           @progress = progress
           reconcile_untracked_records
 
-          # get a the batch of dirty clients
+          # get a batch of dirty clients
           dirty_client_markers = Hmis::Ce::ChangeMarker.dirty.clients.batch(
             start_id: next_client_id,
             limit: 1_000,
@@ -60,7 +60,7 @@ module Hmis::Ce
           # load the dirty pools
           dirty_pool_markers = Hmis::Ce::ChangeMarker.dirty.pools.batch(
             start_id: next_pool_id,
-            limit: 50,
+            limit: 10,
           ).to_a
           # process dirty pools
           next_pool_id = process_dirty_pools(dirty_pool_markers)
@@ -105,13 +105,16 @@ module Hmis::Ce
     def process_dirty_pools(markers)
       return 0 if markers.empty?
 
-      candidate_pool_scope = ::Hmis::Ce::Match::CandidatePool.active.where(id: markers.map(&:trackable_id))
+      # we expect processing an individual pool to be expensive; load one pool at a time mark it as clean
+      # as soon as it's done
+      markers.each do |marker|
+        pool = ::Hmis::Ce::Match::CandidatePool.active.find_by(id: marker.trackable_id)
+        next unless pool
 
-      candidate_pool_scope.find_each do |pool|
         Hmis::Ce::Match::Engine.call(pool, progress: @progress)
+        marker.mark_processed
       end
 
-      Hmis::Ce::ChangeMarker.mark_processed(markers)
       markers.map(&:trackable_id).max + 1
     end
 

--- a/drivers/hmis/app/models/hmis/ce/change_marker.rb
+++ b/drivers/hmis/app/models/hmis/ce/change_marker.rb
@@ -75,5 +75,6 @@ class Hmis::Ce::ChangeMarker < GrdaWarehouseBase
     )
   end
 
+  def mark_processed = self.class.mark_processed([self])
   def dirty? = current_version > processed_version
 end

--- a/drivers/hmis/spec/jobs/hmis/ce/build_candidate_pools_job_spec.rb
+++ b/drivers/hmis/spec/jobs/hmis/ce/build_candidate_pools_job_spec.rb
@@ -17,9 +17,6 @@ RSpec.describe Hmis::Ce::BuildCandidatePoolsJob, type: :job do
     before do
       create(:hmis_ce_eligibility_requirement, owner: opportunity_1.project, expression: 'current_age = 50')
       create(:hmis_ce_eligibility_requirement, owner: opportunity_2.project, expression: 'current_age = 51')
-    end
-
-    before do
       # build the initial pools
       Hmis::Ce::Match::CandidatePoolBuilder.new(Hmis::Ce::Opportunity.active).perform
     end

--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -33,93 +33,98 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
   end
 
   def destination_clients_for(clients)
-    # create destination clients
-    GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+    # NOTE: GrdaWarehouse::Tasks::IdentifyDuplicates must be run before this method is called.
     # get the GrdaWarehouse::Hud::Client destination client for each source client
-    GrdaWarehouse::Hud::Client.where(id: clients.map { |c| c.destination_client.id })
+    GrdaWarehouse::Hud::Client.where(id: clients.map(&:destination_client).compact.map(&:id))
   end
 
   shared_context 'with demographic test clients' do
-    let(:client_adult_non_veteran) { create(:hmis_hud_client, veteran_status: 0, dob: 20.years.ago) }
-    let(:client_minor_non_veteran) { create(:hmis_hud_client, veteran_status: 0, dob: 10.years.ago) }
-    let(:client_adult_veteran) { create(:hmis_hud_client, veteran_status: 1, dob: 20.years.ago) }
-    let(:client_senior_veteran) { create(:hmis_hud_client, veteran_status: 1, dob: 68.years.ago) }
+    let!(:client_adult_non_veteran) { create(:hmis_hud_client, last_name: 'AdultNonVeteran', veteran_status: 0, dob: 20.years.ago) }
+    let!(:client_minor_non_veteran) { create(:hmis_hud_client, last_name: 'MinorNonVeteran', veteran_status: 0, dob: 10.years.ago) }
+    let!(:client_adult_veteran) { create(:hmis_hud_client, last_name: 'AdultVeteran', veteran_status: 1, dob: 20.years.ago) }
+    let!(:client_senior_veteran) { create(:hmis_hud_client, last_name: 'SeniorVeteran', veteran_status: 1, dob: 68.years.ago) }
 
     let(:clients) { [client_adult_non_veteran, client_minor_non_veteran, client_adult_veteran, client_senior_veteran] }
     let(:destination_clients) { destination_clients_for(clients) }
 
     let(:adult_clients) { destination_clients.where.not(id: client_minor_non_veteran.destination_client.id) }
+
+    before { GrdaWarehouse::Tasks::IdentifyDuplicates.new.run! }
   end
 
   shared_context 'with enrolled test clients' do
     let(:es_project) { create(:hmis_hud_project, data_source: data_source, project_type: 1) }
     let(:ce_project) { create(:hmis_hud_project, data_source: data_source, project_type: 14) }
     let(:ph_project) { create(:hmis_hud_project, data_source: data_source, project_type: 9) }
-    let(:client_enrolled_in_ce) do
-      client = create(:hmis_hud_client, data_source: data_source)
+    let!(:client_enrolled_in_ce) do
+      client = create(:hmis_hud_client, last_name: 'EnrolledInCE', data_source: data_source)
       create(:hmis_hud_enrollment, data_source: data_source, project: ce_project, exit_date: nil, client: client)
       create(:hmis_hud_enrollment, data_source: data_source, project: es_project, exit_date: nil, client: client) # cruft: ES enrollment
       client
     end
-    let(:client_wip_enrolled_in_ce) do
-      client = create(:hmis_hud_client, data_source: data_source)
+    let!(:client_wip_enrolled_in_ce) do
+      client = create(:hmis_hud_client, last_name: 'WipEnrolledInCE', data_source: data_source)
       create(:hmis_hud_wip_enrollment, data_source: data_source, project: ce_project, exit_date: nil, client: client)
       client
     end
-    let(:client_enrolled_in_es) do
-      client = create(:hmis_hud_client, data_source: data_source)
+    let!(:client_enrolled_in_es) do
+      client = create(:hmis_hud_client, last_name: 'EnrolledInES', data_source: data_source)
       create(:hmis_hud_enrollment, data_source: data_source, project: es_project, exit_date: nil, client: client)
       client
     end
-    let(:client_enrolled_in_ph) do
-      client = create(:hmis_hud_client, data_source: data_source)
+    let!(:client_enrolled_in_ph) do
+      client = create(:hmis_hud_client, last_name: 'EnrolledInPH', data_source: data_source)
       create(:hmis_hud_enrollment, data_source: data_source, project: ph_project, exit_date: nil, client: client)
       client
     end
-    let(:client_exited_from_ce) do
-      client = create(:hmis_hud_client, data_source: data_source)
+    let!(:client_exited_from_ce) do
+      client = create(:hmis_hud_client, last_name: 'ExitedFromCE', data_source: data_source)
       create(:hmis_hud_enrollment, data_source: data_source, project: ce_project, exit_date: 1.week.ago, client: client)
       client
     end
-    let(:client_unenrolled) { create(:hmis_hud_client, data_source: data_source) }
+    let!(:client_unenrolled) { create(:hmis_hud_client, last_name: 'Unenrolled', data_source: data_source) }
 
-    let(:all_clients) do
+    let!(:all_clients) do
       [client_enrolled_in_ce, client_wip_enrolled_in_ce, client_enrolled_in_es, client_enrolled_in_ph, client_exited_from_ce, client_unenrolled]
     end
 
     let(:clients) { Hmis::Hud::Client.where(id: all_clients.map(&:id)) }
     let(:destination_clients) { destination_clients_for(clients) }
     let(:clients_not_enrolled_in_ph) { clients.where.not(id: client_enrolled_in_ph.id) }
+
+    before { GrdaWarehouse::Tasks::IdentifyDuplicates.new.run! }
   end
 
   shared_context 'with referred test clients' do
     let(:ph_project) { create(:hmis_hud_project, data_source: data_source, project_type: 9) }
     let(:es_project) { create(:hmis_hud_project, data_source: data_source, project_type: 1) }
-    let(:client_referred_to_ph) do
-      client = create(:hmis_hud_client, data_source: data_source, with_enrollment_at: es_project)
+    let!(:client_referred_to_ph) do
+      client = create(:hmis_hud_client, last_name: 'ReferredToPH', data_source: data_source, with_enrollment_at: es_project)
       create(:hmis_ce_referral, data_source: data_source, project: ph_project, client: client, status: 'in_progress')
       create(:hmis_ce_referral, data_source: data_source, project: es_project, client: client, status: 'in_progress') # additional referral to ES
       client
     end
-    let(:client_referred_to_es) do
-      client = create(:hmis_hud_client, data_source: data_source, with_enrollment_at: es_project)
+    let!(:client_referred_to_es) do
+      client = create(:hmis_hud_client, last_name: 'ReferredToES', data_source: data_source, with_enrollment_at: es_project)
       create(:hmis_ce_referral, data_source: data_source, project: es_project, client: client, status: 'in_progress')
       client
     end
-    let(:client_previously_referred_to_ph) do
-      client = create(:hmis_hud_client, data_source: data_source, with_enrollment_at: es_project)
+    let!(:client_previously_referred_to_ph) do
+      client = create(:hmis_hud_client, last_name: 'PreviouslyReferredToPH', data_source: data_source, with_enrollment_at: es_project)
       create(:hmis_ce_referral, data_source: data_source, project: ph_project, client: client, status: 'rejected') # previous referral, should be ignored
       create(:hmis_ce_referral, data_source: data_source, project: es_project, client: client, status: 'in_progress') # additional referral to ES
       client
     end
 
-    let(:all_clients) do
+    let!(:all_clients) do
       [client_referred_to_ph, client_previously_referred_to_ph, client_referred_to_es]
     end
 
     let(:clients) { Hmis::Hud::Client.where(id: all_clients.map(&:id)) }
     let(:destination_clients) { destination_clients_for(clients) }
     let(:clients_not_referred_to_ph) { clients.where.not(id: client_referred_to_ph.id) }
+
+    before { GrdaWarehouse::Tasks::IdentifyDuplicates.new.run! }
   end
 
   shared_context 'with CDE assessment setup' do
@@ -139,7 +144,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
 
     def create_assessment_with_cde(client, cde_values)
       enrollment = create(:hmis_hud_enrollment, data_source: data_source, project: project, client: client)
-      assessment = create(:hmis_custom_assessment, data_source: data_source, enrollment: enrollment, definition: fd)
+      assessment = create(:hmis_custom_assessment, data_source: data_source, enrollment: enrollment, client: client, definition: fd)
 
       Array(cde_values).each do |value|
         assessment.custom_data_elements.create!(
@@ -159,7 +164,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       let(:requirement_expression) { '1=0' }
 
       it 'returns no candidates' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to be_empty
       end
     end
@@ -168,7 +173,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       let(:requirement_expression) { '1=1' }
 
       it 'returns all candidates' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq(destination_clients.map(&:id).sort)
       end
     end
@@ -177,7 +182,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       let(:requirement_expression) { 'current_age > 18' }
 
       it 'excludes minors from candidates' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq(adult_clients.map(&:id).sort)
       end
     end
@@ -186,24 +191,25 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       let(:requirement_expression) { 'current_age >= 65 AND veteran_status = 1' }
 
       it 'only includes senior veterans' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq([client_senior_veteran.destination_client.id])
       end
 
       it 'updates the candidates_generated_at timestamp' do
         freeze_time do
           expect do
-            generate_candidates(pool, clients: destination_clients)
+            generate_candidates(pool)
           end.to change(pool, :candidates_generated_at).from(nil).to(Time.current)
         end
       end
     end
 
     describe 'with missing demographic data' do
-      let!(:client_with_missing_dob) { create(:hmis_hud_client, veteran_status: 1, dob: nil) }
-      let!(:client_with_missing_veteran_status) { create(:hmis_hud_client, veteran_status: nil, dob: 20.years.ago) }
+      let!(:client_with_missing_dob) { create(:hmis_hud_client, last_name: 'MissingDob', veteran_status: 1, dob: nil) }
+      let!(:client_with_missing_veteran_status) { create(:hmis_hud_client, last_name: 'MissingVeteranStatus', veteran_status: nil, dob: 20.years.ago) }
 
       let(:clients_with_missing_data) do
+        GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
         GrdaWarehouse::Hud::Client.where(id: destination_clients.map(&:id) + [client_with_missing_dob.destination_client.id, client_with_missing_veteran_status.destination_client.id])
       end
 
@@ -246,20 +252,21 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
     include_context 'with CDE assessment setup'
 
     let(:cde_key) { 'hat_client_interested_in_ph' }
-    let(:client_interested_in_ph) { create(:hmis_hud_client, data_source: data_source) }
-    let(:client_not_interested_in_ph) { create(:hmis_hud_client, data_source: data_source) }
+    let!(:client_interested_in_ph) { create(:hmis_hud_client, last_name: 'InterestedInPH', data_source: data_source) }
+    let!(:client_not_interested_in_ph) { create(:hmis_hud_client, last_name: 'NotInterestedInPH', data_source: data_source) }
     let(:destination_clients) { destination_clients_for([client_interested_in_ph, client_not_interested_in_ph]) }
 
     before do
       create_assessment_with_cde(client_interested_in_ph, '1')
       create_assessment_with_cde(client_not_interested_in_ph, '0')
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
     end
 
     describe 'CDE field matching' do
       let(:requirement_expression) { "`cde.custom_assessment.hat_client_interested_in_ph` = '1'" }
 
       it 'filters based on CDE value' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq([client_interested_in_ph.destination_client.id])
       end
     end
@@ -270,20 +277,20 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
 
     let(:cde_key) { 'primary_languages' }
     let(:multi_valued_cde) { true }
-    let(:client_english_spanish) { create(:hmis_hud_client, data_source: data_source) }
-    let(:client_french_only) { create(:hmis_hud_client, data_source: data_source) }
-    let(:destination_clients) { destination_clients_for([client_english_spanish, client_french_only]) }
+    let!(:client_english_spanish) { create(:hmis_hud_client, last_name: 'EnglishSpanish', data_source: data_source) }
+    let!(:client_french_only) { create(:hmis_hud_client, last_name: 'FrenchOnly', data_source: data_source) }
 
     before do
       create_assessment_with_cde(client_english_spanish, ['English', 'Spanish'])
       create_assessment_with_cde(client_french_only, 'French')
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
     end
 
     describe 'multi-valued CDE inclusion matching' do
       let(:requirement_expression) { "INCLUDES(`cde.custom_assessment.primary_languages`, 'English')" }
 
       it 'matches clients with the specified language among multiple values' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq([client_english_spanish.destination_client.id])
       end
     end
@@ -292,7 +299,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       let(:requirement_expression) { "EXCLUDES(`cde.custom_assessment.primary_languages`, 'French')" }
 
       it 'excludes clients who have the specified language' do
-        results = generate_candidates(pool, clients: destination_clients)
+        results = generate_candidates(pool)
         expect(results).to eq([client_english_spanish.destination_client.id])
       end
     end
@@ -307,23 +314,23 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
         let(:requirement_expression) { 'INCLUDES(open_enrollment_project_types, PROJECT_TYPE("CE"))' }
 
         it 'includes clients with open enrollments at the correct project type' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expected_clients = [client_enrolled_in_ce, client_wip_enrolled_in_ce]
           expect(results.sort).to eq(expected_clients.map { |c| c.destination_client.id }.sort)
         end
 
         it 'excludes clients with exited enrollments at the correct project type' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).not_to include(client_exited_from_ce.destination_client.id)
         end
 
         it 'excludes clients with no enrollments' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).not_to include(client_unenrolled.destination_client.id)
         end
 
         it 'excludes clients that are only enrolled in projects of other types' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).not_to include(client_enrolled_in_es.destination_client.id)
         end
       end
@@ -333,12 +340,12 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
         let(:requirement_expression) { 'INCLUDES(open_enrollment_project_types_excluding_incomplete, PROJECT_TYPE("CE"))' }
 
         it 'excludes clients with WIP (incomplete) enrollments at the project type' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).not_to include(client_wip_enrolled_in_ce.destination_client.id)
         end
 
         it 'includes clients with open enrollments at the correct project type' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results.sort).to eq([client_enrolled_in_ce.destination_client.id])
         end
       end
@@ -348,7 +355,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
         let(:requirement_expression) { 'EXCLUDES(open_enrollment_project_types, PROJECT_TYPE("PH_PSH")) AND EXCLUDES(open_enrollment_project_types, PROJECT_TYPE("PH_PH")) AND EXCLUDES(open_enrollment_project_types, PROJECT_TYPE("PH_OPH")) AND EXCLUDES(open_enrollment_project_types, PROJECT_TYPE("PH_RRH"))' }
 
         it 'excludes client with open enrollment in PH ' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results.sort).to eq(clients_not_enrolled_in_ph.map { |c| c.destination_client.id }.sort)
           expect(results).not_to include(client_enrolled_in_ph.destination_client.id)
         end
@@ -358,17 +365,18 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
 
   context 'when evaluating referral-based policies' do
     include_context 'with referred test clients'
+    before { GrdaWarehouse::Tasks::IdentifyDuplicates.new.run! }
 
     describe 'project-type-based filtering' do
       describe 'when requiring no open referral in a PH (9) project' do
         let(:requirement_expression) { 'EXCLUDES(open_referral_project_types, PROJECT_TYPE("PH_PH"))' }
 
         it 'excludes clients with open referrals to PH (9) projects' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).not_to include(client_referred_to_ph.destination_client.id)
         end
         it 'includes clients without open referrals to PH (9) projects' do
-          results = generate_candidates(pool, clients: destination_clients)
+          results = generate_candidates(pool)
           expect(results).to eq(clients_not_referred_to_ph.map { |c| c.destination_client.id })
         end
       end
@@ -389,7 +397,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
 
     it 'deduplicates on the waitlist' do
       expect(destination_clients.count).to eq(1)
-      results = generate_candidates(pool, clients: destination_clients)
+      results = generate_candidates(pool)
       expect(results.size).to eq(1)
       expect(results.sole).to eq(destination_clients.sole.id)
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Minor adjustments to [PR 5536](https://github.com/greenriver/hmis-warehouse/pull/5536) 

* ce change processing job
  * reduce number of dirty pools the job will process before exiting
  * mark pools as clean as soon as they are done for better recovery
* match engine test fixes
  * add uniq names to clients to prevent duplicate-merge,
  * adjust some tests to use full rather than incremental mode
  * don't use lazy client creation to avoid missing destination clients

## Type of change
Minor fixes, tests

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
