### PR TITLE
Allow deleting cohort options that aren't in use

### DIFF
--- a/app/controllers/cohort_column_options_controller.rb
+++ b/app/controllers/cohort_column_options_controller.rb
@@ -4,21 +4,47 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class CohortColumnOptionsController < ApplicationController
   include CohortAuthorization
   before_action :require_can_configure_cohorts!
-  before_action :set_cohort_column_option, only: [:edit, :update]
+  before_action :set_cohort_column_option, only: [:edit, :update, :destroy]
   before_action :set_cohort_column_options, only: [:index, :create]
 
   def index
     @cohort_column_options = @cohort_column_options.order(cohort_column: :desc, value: :asc)
-    @cohort_column_options_in_use = GrdaWarehouse::CohortColumnOption.new.cohort_columns.map do |cohort_column|
-      [
-        cohort_column.column,
-        GrdaWarehouse::CohortClient.where.not(cohort_column.column => nil).distinct.pluck(cohort_column.column),
-      ]
-    end.to_h
   end
+
+  # Fetch values for columns that are in use in a performant way
+  private def cohort_column_options_in_use
+    @cohort_column_options_in_use ||= begin
+      cohort_columns = GrdaWarehouse::CohortColumnOption.new.cohort_columns
+      column_names = cohort_columns.map(&:column)
+      found = {}
+      sub_queries = column_names.map do |column_name|
+        found[column_name] = []
+        quoted_column = GrdaWarehouse::CohortClient.connection.quote_column_name(column_name.to_s)
+
+        GrdaWarehouse::CohortClient.
+          select(Arel.sql("'#{column_name}' AS cohort_column, #{quoted_column} AS value")).
+          where.not(column_name => [nil, '']).
+          distinct
+      end
+
+      # Generate the SQL for each sub-query and join them with UNION ALL.
+      sql = sub_queries.map(&:to_sql).join(' UNION ALL ')
+
+      result = GrdaWarehouse::CohortClient.connection.execute(sql)
+
+      result.each do |row|
+        found[row['cohort_column']] << row['value']
+      end
+
+      found
+    end
+  end
+  helper_method :cohort_column_options_in_use
 
   def new
     @cohort_column_option = cohort_column_option_source.new
@@ -37,6 +63,17 @@ class CohortColumnOptionsController < ApplicationController
     @cohort_column_option.update(cohort_column_option_params)
     Rails.cache.delete("available_options_for_#{@cohort_column_option.cohort_column}")
     respond_with(@cohort_column_option, location: cohort_column_options_path)
+  end
+
+  def destroy
+    if cohort_column_options_in_use[@cohort_column_option.cohort_column]&.exclude?(@cohort_column_option.value)
+      @cohort_column_option.destroy
+      Rails.cache.delete("available_options_for_#{@cohort_column_option.cohort_column}")
+      respond_with(@cohort_column_option, location: cohort_column_options_path)
+    else
+      flash[:error] = "The option: #{@cohort_column_option.value} is in use and cannot be deleted."
+      redirect_to cohort_column_options_path
+    end
   end
 
   def set_cohort_column_option

--- a/app/views/cohort_column_options/index.haml
+++ b/app/views/cohort_column_options/index.haml
@@ -14,7 +14,7 @@
     #cohort-column-options.table-responsive.panel-group.panel-collapsible
       - @cohort_column_options.group_by(&:cohort_column).each do |column, options|
         - content_for :panel_collapse_content, flush: true do
-          %table.table.table-sm
+          %table.table.table-striped
             %thead
               %th{style: "width: 35%;"} Value
               %th{style: "width: 15%;"} Active?
@@ -25,11 +25,13 @@
                   %td= option.value
                   %td= checkmark_or_x option.active
                   %td
-
-                    - if !@cohort_column_options_in_use[column]&.include?(option.value)
-                      = link_to action: :edit, id: option do
+                    - if !cohort_column_options_in_use[column]&.include?(option.value)
+                      = link_to edit_cohort_column_option_path(option), class: 'btn btn-sm btn-secondary mr-2' do
                         %span.icon-pencil
                         Edit
+                      = link_to cohort_column_option_path(option), method: :delete, class: 'btn btn-sm btn-danger', data: { confirm: "Are you sure you want to delete the option: '#{option.value}'?" } do
+                        %span.icon-cross
+                        Delete
                     - else
                       in use
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -567,7 +567,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :cohort_column_options, except: [:destroy]
+  resources :cohort_column_options
 
   resources :cohort_column_names, only: [:new, :create]
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Adds an option to delete cohort column options that aren't in use
* Fetches used cohort options in one query

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
