### PR TITLE
Code Demo Project Export Comparison Columns - Hotfix

### DIFF
--- a/drivers/core_demographics_report/app/models/core_demographics_report/projects.rb
+++ b/drivers/core_demographics_report/app/models/core_demographics_report/projects.rb
@@ -58,11 +58,12 @@ module
     end
 
     def enrollment_data_for_export(rows, report_index = 0)
+      column_headers = ['Project', 'Project Type', 'Organization', 'Count']
+      columns_per_report = column_headers.count
       projects = project_names
       rows['_Clients in Projects'] ||= []
       rows['*Clients in Projects'] ||= []
-      rows['*Clients in Projects'] += ['Project', 'Project Type', 'Organization', 'Count']
-      header_column_count = rows['*Clients in Projects'].count
+      rows['*Clients in Projects'] += column_headers
 
       # Use project IDs for row keys to ensure same project appears on same row across reports
       # Add report_index to ensure proper column alignment
@@ -74,7 +75,7 @@ module
         # If this is not the first report, we need to pad with nil values to align columns
         if report_index > 0 && rows[row_key].empty?
           # Pad with nil values for previous reports
-          rows[row_key] += [nil] * (report_index * header_column_count)
+          rows[row_key] += [nil] * (report_index * columns_per_report)
         end
 
         rows[row_key] += [


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (
List any new dependencies or relevant ADRs)

The padding being set for the Projects in a comparison years in the Core Demo export were being padded with 2x the columns needed. This was due to the `header_column_count` being calculated after the additional header cells were added. This change pulls that out into a more static count.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
