### PR TITLE
Make workflow rake task qa-able

### DIFF
--- a/drivers/hmis/lib/tasks/ce_define_workflows.rake
+++ b/drivers/hmis/lib/tasks/ce_define_workflows.rake
@@ -593,7 +593,7 @@ task ce_define_workflows: [:environment] do
   ce_enabled.value = true
   ce_enabled.save! if ce_enabled.changed?
 
-  data_source = GrdaWarehouse::DataSource.hmis.sole
+  data_source = GrdaWarehouse::DataSource.hmis.order(:id).first
 
   HmisUtil::CeBuilder.create_state_machine_custom_statuses(data_source)
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Our QA env has multiple HMIS environments. To prevent the CE workflow definition rake task from raising, use the first one.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
