### PR TITLE
Fix HOPWA Services TypeProvided data type

### DIFF
--- a/db/warehouse/migrate/20250729183312_ensure_type_provided_type.rb
+++ b/db/warehouse/migrate/20250729183312_ensure_type_provided_type.rb
@@ -1,3 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
 class EnsureTypeProvidedType < ActiveRecord::Migration[7.1]
   def up
     safety_assured do

--- a/db/warehouse/migrate/20250729183312_ensure_type_provided_type.rb
+++ b/db/warehouse/migrate/20250729183312_ensure_type_provided_type.rb
@@ -1,0 +1,7 @@
+class EnsureTypeProvidedType < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      change_column :hopwa_caper_services, :type_provided, :integer, using: 'type_provided::integer'
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -75078,6 +75078,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250729183312'),
 ('20250716131246'),
 ('20250716131240'),
 ('20250716123853'),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Revert `hopwa_caper_services.type_provided` to integer, it was mistakenly converted to a bigint in some installations

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
