### PR TITLE
Query for AHA score by other source clients' MCI UNIQ IDs

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -14,11 +14,16 @@ module HmisExternalApis::AcHmis
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to AHA')
 
     def fetch_score(client)
-      mci_uniq_id = client.ac_hmis_mci_unique_id
-      return nil unless mci_uniq_id.present?
+      # Collect MCI unique IDs for this client and all source clients with the same destination client
+      clients = [client, *client.destination_client&.source_clients&.to_a]
+      mci_uniq_ids = clients.compact.uniq.filter_map do |c|
+        c.ac_hmis_mci_unique_id&.value
+      end.uniq
+
+      return nil if mci_uniq_ids.empty?
 
       payload = {
-        'dw_client_id': mci_uniq_id.value.to_s,
+        'dw_client_id': mci_uniq_ids.join(','),
       }
 
       result = conn.post('api/v1/clients/scores/search/', payload).

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -1,0 +1,121 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
+  let!(:data_source) { create :hmis_primary_data_source }
+  let!(:client) { create(:hmis_hud_client, data_source: data_source) }
+
+  let!(:aha) { described_class.new }
+  let!(:mock_connection) { double('connection') }
+  let!(:remote_credential) { create(:ac_hmis_warehouse_credential) }
+
+  before do
+    # Mock the connection to avoid actual API calls
+    allow(aha).to receive(:conn).and_return(mock_connection)
+  end
+
+  context 'when client has no MCI unique ID' do
+    it 'returns nil' do
+      expect(aha.fetch_score(client)).to be_nil
+    end
+  end
+
+  context 'when client has MCI unique ID' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    before do
+      # Mock successful API response
+      mock_response = double(
+        'response',
+        error: false,
+        http_status: 200,
+        parsed_body: {
+          'data' => [
+            {
+              'dw_client_id' => mci_unique_id.value,
+              'scores' => [
+                {
+                  'score' => 8,
+                  'metadata' => { 'alt_aha_flag' => 0 },
+                  'generator' => 'test_generator',
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id': mci_unique_id.value }).and_return(mock_response)
+    end
+
+    it 'calls API with single MCI ID' do
+      result = aha.fetch_score(client)
+      expect(result.score).to eq(8)
+      expect(result.dw_client_id).to eq(mci_unique_id.value)
+    end
+  end
+
+  context 'when client has siblings with MCI unique IDs' do
+    let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: data_source) }
+
+    let!(:sibling1) { create(:hmis_hud_client, data_source: data_source) }
+    let!(:sibling2) { create(:hmis_hud_client, data_source: data_source) }
+    let!(:sibling3) { create(:hmis_hud_client, data_source: data_source) }
+
+    let!(:warehouse_client1) { create(:hmis_warehouse_client, source: sibling1, destination: client.destination_client, data_source: data_source) }
+    let!(:warehouse_client2) { create(:hmis_warehouse_client, source: sibling2, destination: client.destination_client, data_source: data_source) }
+    let!(:warehouse_client3) { create(:hmis_warehouse_client, source: sibling3, destination: client.destination_client, data_source: data_source) }
+
+    # client doesn't have mci_unique_id, but some of its siblings do
+    let!(:mci_unique_id1) { create(:mci_unique_id_external_id, source: sibling1, remote_credential: remote_credential) }
+    let!(:mci_unique_id2) { create(:mci_unique_id_external_id, source: sibling2, remote_credential: remote_credential) }
+
+    before do
+      # Mock successful API response
+      mock_response = double(
+        'response',
+        error: false,
+        http_status: 200,
+        parsed_body: {
+          'data' => [
+            {
+              'dw_client_id' => mci_unique_id1.value,
+              'scores' => [
+                {
+                  'score' => 6,
+                  'metadata' => { 'alt_aha_flag' => 0 },
+                  'generator' => 'test_generator',
+                },
+              ],
+            },
+            {
+              'dw_client_id' => mci_unique_id2.value,
+              'scores' => [
+                {
+                  'score' => 9,
+                  'metadata' => { 'alt_aha_flag' => 1 },
+                  'generator' => 'test_generator',
+                },
+              ],
+            },
+          ],
+        },
+      )
+
+      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id': "#{mci_unique_id1.value},#{mci_unique_id2.value}" }).and_return(mock_response)
+    end
+
+    it 'calls API with comma-separated list of all sibling MCI IDs' do
+      result = aha.fetch_score(client)
+      expect(result.score).to eq(9) # Returns the highest score
+      expect(result.alt_aha_flag).to be true
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- When querying for AHA score, check for MCI uniq id on all source clients of this destination client
- Add spec

How to test: Set up a client locally who doesn't have an MCI uniq id, but has a destination client with another source client that has one. The AHA score query should successfully return a response.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Feature build-out

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
