### PR TITLE
Don't require MCI Clearance for 'Other' project type 

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
@@ -69,7 +69,6 @@ module HmisExternalApis::AcHmis
                                  mci_id: mci_id,
                                  score: score,
                                  client: MciPayload.build_client(clearance_result),
-                                 # TODO: if no exact match by MCI ID, look for match by MCI Unique ID
                                  existing_client_id: find_client_by_mci(mci_id)&.id,
                                })
       end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # To connect to the API, you need a remote credential labeled 'mci'. Replace
 # the empty strings below with values from the documentation.
 #
@@ -24,10 +26,14 @@
 
 module HmisExternalApis::AcHmis
   class Mci
-    SYSTEM_ID = 'ac_hmis_mci'.freeze
-    PROJECT_TYPES_NOT_REQUIRING_CLEARANCE = [1, 4].freeze # SO, ES NBN
-    MCI_REQUIRED_MSG = 'MCI clearance is required'.freeze
-    MCI_REQUIRED_FOR_ENROLLMENT_MSG = 'MCI clearance is required before this client can be enrolled'.freeze
+    SYSTEM_ID = 'ac_hmis_mci'
+    PROJECT_TYPES_NOT_REQUIRING_CLEARANCE = [
+      1, # Emergency Shelter - Night-by-Night
+      4, # Street Outreach
+      7, # Other (used for Link project)
+    ].freeze
+    MCI_REQUIRED_MSG = 'MCI clearance is required'
+    MCI_REQUIRED_FOR_ENROLLMENT_MSG = 'MCI clearance is required before this client can be enrolled'
 
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to MCI')
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/8048

how to test: in MCI-configured environment, enroll a new client in an Other project. MCI clearance should be available but not required.

## Type of change
integration

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)-- spec tests cover SO/ES behavior are sufficient
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
