### PR TITLE
Fix error message formatting

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -47,7 +47,7 @@ module Hmis::Ce
 
     def project_to_event_type(project)
       event_type = HudUtility2026.project_to_ce_event_type(project)
-      raise "Unable to determine CE Event Type for project type #{project_type} on project #{project.id} for referral #{referral.id}" unless event_type
+      raise "Unable to determine CE Event Type for project type #{project.project_type} on project #{project.id} for referral #{referral.id}" unless event_type
 
       event_type
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Background: error described here: https://github.com/open-path/Green-River/issues/7961#issuecomment-3156396015

With this fix: The expected error should be thrown instead of `undefined local variable or method 'project_type'`
https://green-river.sentry.io/issues/6791818478/?referrer=slack&notification_uuid=47df73c8-3e10-4e80-8d7a-23fc079697e2&environment=staging&alert_rule_id=14733065&alert_type=issue

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
