### PR TITLE
Require view waitlist perm for starting referrals

### DIFF
--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -183,7 +183,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_start_referrals: {
         description: 'Ability to initiate referrals from the client waitlist in the project',
-        requirements: [:can_view_referrals],
+        requirements: [:can_view_referrals, :can_view_prioritized_client_lists],
         administrative: false,
         access: [:editable],
         category: 'Referrals',

--- a/drivers/hmis/spec/models/hmis/auth_policies/ce_opportunity_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/ce_opportunity_policy_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Hmis::AuthPolicies::CeOpportunityPolicy, type: :model do
     let(:client) { create(:hmis_hud_client_complete, data_source: data_source) }
 
     context 'when user has :can_start_referrals permission' do
-      before { create_access_control(user, project, with_permission: [:can_start_referrals, :can_view_referrals]) }
+      before { create_access_control(user, project, with_permission: [:can_start_referrals, :can_view_referrals, :can_view_prioritized_client_lists]) }
 
       it 'returns true if client is in the same data source' do
         expect(policy.can_create_referral?(client: client)).to be true

--- a/drivers/hmis/spec/models/hmis/auth_policies/context_loaders/hmis_permission_loader_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/context_loaders/hmis_permission_loader_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hmis::AuthPolicies::ContextLoaders::HmisPermissionLoader, type: :
 
     context 'with permission requirements' do
       it 'includes permissions when requirements are met' do
-        access_control = create_access_control(user, project, with_permission: [:can_view_project, :can_view_referrals, :can_start_referrals])
+        access_control = create_access_control(user, project, with_permission: [:can_view_project, :can_view_referrals, :can_start_referrals, :can_view_prioritized_client_lists])
 
         result = loader.for_access_group_ids([access_control.access_group.id])
 

--- a/drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::Ce::CreateCeReferral, type: :request do
         :can_view_units,
         :can_start_referrals,
         :can_view_referrals,
+        :can_view_prioritized_client_lists,
       ],
     )
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
Add permission requirement: In order to start referrals, you must have permission to view prioritized client waitlists. This is already enforced by the frontend since the "Start Referral" button is only available from the waitlist.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
