### PR TITLE
Propose API fix for resolving unit rules

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/unit.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit.rb
@@ -139,14 +139,18 @@ module Types
     end
 
     def eligibility_requirements
-      return revivified_rules.filter(&:eligibility_requirement?) if latest_opportunity&.stale
+      # If the current opportunity is active and stale, return the eligibility requirements as they were
+      # when the opportunity was created.
+      return revivified_rules.filter(&:eligibility_requirement?) if latest_opportunity&.active? && latest_opportunity.stale
       return unless unit_group
 
       Hmis::Ce::Match::Rule.eligibility_requirement.for_entity(unit_group)
     end
 
     def priority_scheme
-      return revivified_rules.filter(&:priority_scheme?).first if latest_opportunity&.stale
+      # If the current opportunity is active and stale, return the priority scheme as it was
+      # when the opportunity was created.
+      return revivified_rules.filter(&:priority_scheme?).first if latest_opportunity&.active? && latest_opportunity.stale
       return unless unit_group
 
       Hmis::Ce::Match::Rule.priority_scheme.for_entity(unit_group).first

--- a/drivers/hmis/app/graphql/types/hmis_schema/unit.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit.rb
@@ -137,5 +137,36 @@ module Types
       # (The opportunity is open, so it shouldn't have an accepted referral. Possible referral statuses are either active or rejected.)
       load_ar_association(object, :active_referral).nil?
     end
+
+    def eligibility_requirements
+      return revivified_rules.filter(&:eligibility_requirement?) if latest_opportunity&.stale
+      return unless unit_group
+
+      Hmis::Ce::Match::Rule.eligibility_requirement.for_entity(unit_group)
+    end
+
+    def priority_scheme
+      return revivified_rules.filter(&:priority_scheme?).first if latest_opportunity&.stale
+      return unless unit_group
+
+      Hmis::Ce::Match::Rule.priority_scheme.for_entity(unit_group).first
+    end
+
+    private
+
+    # These rules are loaded from the state of the current Opportunity when it was assigned to its pool,
+    # ensuring historical accuracy. For "stale" Opportunities, these are the rules that are currently in effect
+    # for matching, so we display them on the Unit page (rather than displaying the current Unit Group rules.)
+    #
+    # Future UI improvement would be to resolve a flag indicating the the Unit's current Opportunity is stale,
+    # with an action to "refresh" it (destroy and recreate opportunity) if it doesn't have an open referral.
+    def revivified_rules
+      @revivified_rules ||= latest_opportunity.assignment_rules.map do |attrs|
+        record = Hmis::Ce::Match::Rule.new(attrs)
+        record.graphql_id = "#{object.id}.#{record.id}" # ensure graphql's client cache doesn't mix this up with the live record
+        record.freeze
+        record
+      end
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/unit.rb
+++ b/drivers/hmis/app/models/hmis/unit.rb
@@ -126,14 +126,6 @@ class Hmis::Unit < Hmis::HmisBase
     Hmis::ActiveRange.most_recent_for_entity(self)&.end_date
   end
 
-  def eligibility_requirements
-    Hmis::Ce::Match::Rule.eligibility_requirement.for_entity(self)
-  end
-
-  def priority_scheme
-    Hmis::Ce::Match::Rule.priority_scheme.for_entity(self).first # TODO enforce 1 priority scheme?
-  end
-
   # Class method so can use with data loader
   def self.display_name(id:, name: nil, unit_type: nil)
     return name if name.present?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Propose commit for https://github.com/greenriver/hmis-warehouse/pull/5638 to fix bug where match rules were no longer resolving correctly on unit (no test coverage).

This change makes it so that the rules listed on the Unit page now reflect the revivified rules IF (1) the unit has an active opportunity, and (2) that opportunity is stale.


Tested by changing Rules such that an opportunity becomes stale, and viewing unit page (eg https://hmis.dev.test:5173/projects/933/unit/834)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
