### PR TITLE
Single Log Out with OP Analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -204,8 +204,17 @@ class ApplicationController < ActionController::Base
     user = request.env['last_user']
     if user
       provider = cookies.signed[:active_provider]
-      identity = OauthIdentity.for_user(user).where(provider: provider).first if provider
-      identity&.idp_signout_url(post_logout_redirect_uri: root_url) || root_url
+      if provider
+        # If a provider exists, user is from Okta, due to the complexity of single log-out, we'll
+        # just log you out of okta in this case
+        identity = OauthIdentity.for_user(user).where(provider: provider).first
+        identity&.idp_signout_url(post_logout_redirect_uri: root_url) || root_url
+      else
+        # If no provider exists, attempt to log the user out of superset (if they have access)
+        # this will redirect back to the warehouse
+        superset_logout = "#{Superset.superset_base_url}/logout/?next=#{CGI.escape(root_url)}" if RailsDrivers.loaded.include?(:superset) && Superset.available_to_user?(user)
+        superset_logout || root_url
+      end
     else
       root_url
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class Users::SessionsController < Devise::SessionsController
   include AuthenticatesWithTwoFactor
   # Start the time log before other methods are called in the authentication stack so we can get the server begin time for the login attempt
@@ -85,12 +87,16 @@ class Users::SessionsController < Devise::SessionsController
     user_params[:otp_attempt].gsub(/[^0-9a-z]/, '')
   end
 
-  # override devise to add 'allow_other_host: true' so we can redirect to okta
-  if ENV['OKTA_DOMAIN']
-    def respond_to_on_destroy
-      respond_to do |format|
-        format.all { head :no_content }
-        format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: Devise.responder.redirect_status, allow_other_host: true }
+  # override devise to add 'allow_other_host: true' so we can redirect to okta or superset
+  def respond_to_on_destroy
+    respond_to do |format|
+      format.all { head :no_content }
+      format.any(*navigational_formats) do
+        redirect_to(
+          after_sign_out_path_for(resource_name),
+          status: Devise.responder.redirect_status,
+          allow_other_host: true,
+        )
       end
     end
   end

--- a/app/models/menu/menu.rb
+++ b/app/models/menu/menu.rb
@@ -76,7 +76,7 @@ class Menu::Menu
   def op_analytics_menu
     Menu::Item.new(
       user: user,
-      visible: ->(user) { RailsDrivers.loaded.include?(:superset) && Superset.available? && GrdaWarehouse::WarehouseReports::ReportDefinition.viewable_by(user).where(url: 'superset/warehouse_reports/reports').exists? },
+      visible: ->(user) { RailsDrivers.loaded.include?(:superset) && Superset.available_to_user?(user) },
       path: Superset.warehouse_login_url,
       title: Translation.translate('OP Analytics'),
       id: 'superset',

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -27,6 +27,10 @@ module Superset
     Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
   end
 
+  def self.available_to_user?(user)
+    available? && GrdaWarehouse::WarehouseReports::ReportDefinition.viewable_by(user).where(url: 'superset/warehouse_reports/reports').exists?
+  end
+
   # NOTE: this needs to be kept in sync with
   # https://github.com/greenriver/superset-sync/blob/main/docker/superset/superset_config.py
   def self.available_superset_roles

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -1,3 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Users::SessionsController, type: :request do
@@ -142,6 +150,33 @@ RSpec.describe Users::SessionsController, type: :request do
           post user_session_path(user: { email: user_2fa.email, password: user_2fa.password })
           expect(response).to render_template('devise/sessions/two_factor')
         end
+      end
+    end
+  end
+
+  describe 'Logout redirect behavior' do
+    before do
+      sign_in user
+    end
+
+    context 'when Superset is available to the user' do
+      it 'redirects to Superset logout with next pointing to the warehouse root' do
+        allow(Superset).to receive(:available_to_user?).with(user).and_return(true)
+        allow(Superset).to receive(:superset_base_url).and_return('https://superset.example.com')
+
+        delete destroy_user_session_path
+
+        expect(response).to redirect_to('https://superset.example.com/logout/?next=http%3A%2F%2Fwww.example.com%2F')
+      end
+    end
+
+    context 'when Superset is not available to the user' do
+      it 'redirects to the warehouse root' do
+        allow(Superset).to receive(:available_to_user?).with(user).and_return(false)
+
+        delete destroy_user_session_path
+
+        expect(response).to redirect_to(root_url)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Depends on https://github.com/greenriver/superset-sync/pull/318
* Implements a sequential logout for logging out of both the warehouse and OP Analytics
  * Logs the user out of the warehouse
  * Redirects to the superset logout url with a `next` parameter to return to the warehouse homepage
  * [Changes in Superset](https://github.com/greenriver/superset-sync/pull/318) look for the `next` parameter and redirect back to the warehouse after logout
* One consequence, you lose the flash message that says something like "you have been logged out"
* One caveat, this isn't currently implemented if the warehouse is using Okta as an IDP through OmniAuth.  We'll tackle the multi-logout with other IDP as part of our IDP re-factor 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
