### PR TITLE
better handling for delayed job with dynamic scaling/deployments

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,12 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.sleep_delay = 5
-Delayed::Worker.max_attempts = 3
+Delayed::Worker.max_attempts = 6
 Delayed::Worker.max_run_time = 30.hours
+
+# Handle shutdown signals
+# This will cause the worker to catch SIGTERM and raise an error, allowing the job to be requeued
+# Note, this means deployments and auto-scaling will now consume a job's retry attempts
+Delayed::Worker.raise_signal_exceptions = :term
 
 Delayed::Worker.default_queue_name = 'default_priority'
 Delayed::Worker.read_ahead = 2


### PR DESCRIPTION
## Description

Hypothesis: delayed job by default does not stop the current job when it receives SIGTERM. When containers are terminated (during deploy or scaling), k8 sends term, gives the container 30 seconds (or something) to exit, then sends SIGKILL. When delayed job receives sigkill, it does not unlock the job, resulting in stale records that remain locked.

We can change this behavior using dj config option `raise_signal_exceptions` - however when this is enabled, dj's retry logic triggers, so max_attempts should be increased to compensate.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


