### PR TITLE
Cast float to string when saving form field

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -268,7 +268,7 @@ class Hmis::Hud::Processors::Base
       case value
       when String
         value&.presence&.strip
-      when Integer
+      when Integer, Float
         value.to_s
       else
         raise "unexpected value \"#{value}\""


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

This form snippet is saving the result of a calculation, but it's saved on the CDED as a string. So at some point, it needs to be cast to a string. I'm suggesting to cast it here, on the backend when receiving the value, as opposed to the frontend, because on the frontend within the form logic we might want to compare the value to another and show/hide some form logic based on that. (We are not doing this currently, it is just an example.) Let me know what you think about this!

Form snippet to test with:
```
{
  "text": "AMI",
  "type": "STRING",
  "link_id": "ami",
  "read_only": true,
  "autofill_values": [
    {
      "formula": "ROUNDTO((monthly_household_income / ami_constant) * 100, 2)",
      "autofill_when": [
        {
          "operator": "EXISTS",
          "question": "monthly_household_income",
          "answer_boolean": true
        },
        {
          "operator": "EXISTS",
          "question": "ami_constant",
          "answer_boolean": true
        }
      ],
      "autofill_behavior": "ALL",
      "autofill_readonly": true
    }
  ],
  "disabled_display": "HIDDEN"
},
```
## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [n/a] If adding a new endpoint / exposing data in a new way, I have:
  - [n/a] ensured the API can't leak data from other data sources
  - [n/a] ensured this does not introduce N+1s
  - [n/a] ensured permissions and visibility checks are performed in the right places
- [n/a] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [n/a] I have updated the documentation (or not applicable)
- [n/a] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
