### PR TITLE
Patch: exclude clients from pool if any priority scores are NULL

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/match/internal/client_pool_evaluator.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/internal/client_pool_evaluator.rb
@@ -12,8 +12,15 @@ module Hmis::Ce::Match::Internal
 
     # simple evaluation result object
     Result = Struct.new(:client_values, :priority_scores) do
-      # no priority_scores indicates the client is not eligible for the pool
-      def failed? = priority_scores.nil? || priority_scores.empty?
+      # Determines if the client evaluation failed based on priority scores.
+      #
+      # Client is ineligible for Pool if:
+      # - Priority scores are nil or empty. This indicates that prioritization never ran, because client was ineligible. Or,
+      # - Any value in the priority scores array is nil. NOTE: To include clients with missing prioritization values,
+      #   use a coalescing priority expression such as `IF(my_score = NULL, 0, my_score)`
+      def failed?
+        priority_scores.nil? || priority_scores.empty? || priority_scores.any?(&:nil?)
+      end
     end
     private_constant :Result
 
@@ -41,10 +48,8 @@ module Hmis::Ce::Match::Internal
     def call(client)
       client_values = @client_field_values[client.id] || {}
 
-      # Client without a score cannot be prioritized
-      #   * To be eligible priority score must be non-empty AND the eligibility requirement must pass
-      #   * To include clients with empty scores, use a coalescing priority expression such as
-      #     `{IF(my_score = NULL, 0, my_score)}`
+      # Only run priority evaluation if eligibility evaluation passed.
+      # To be eligible, client's priority scores must all be non-null AND the eligibility requirement must pass.
       priority_scores = eval_priority(client_values) if eval_requirement(client_values)
       Result.new(client_values, priority_scores)
     end

--- a/drivers/hmis/spec/models/hmis/ce/match/internal/client_pool_evaluator_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/internal/client_pool_evaluator_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe Hmis::Ce::Match::Internal::ClientPoolEvaluator, type: :model do
       end
     end
 
+    context 'when a client does not have values for prioritization' do
+      # simplified pool, prioritized by age. client should be excluded if age is missing.
+      let(:pool) do
+        create(
+          :hmis_ce_match_candidate_pool,
+          requirement_expression: 'veteran_status = 1',
+          priority_expression: '{current_age}',
+        )
+      end
+      let!(:client_vet_missing_dob) { create(:hmis_hud_client_with_warehouse_client, dob: nil, veteran_status: 1) }
+      let!(:destination_client1) { client_vet_missing_dob.destination_client }
+
+      it 'returns a failed result' do
+        result = evaluator.call(destination_client1)
+
+        expect(result).to be_failed
+      end
+    end
+
     describe 'batch loading behavior' do
       # This test inspects the internal state of the evaluator to confirm that
       # it correctly pre-fetches and caches the required data for all clients in the batch.


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/5616
Patch bug that caused clients with any NULL priority_scores to be included in candidate pool.

See 5616 for testing instructions. This bug appears if there is any client that is otherwise eligible for the pool but has a null value for any priority schemes.


## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
