### PR TITLE
Update ServiceProcessor to be compatible with both FY24 and FY26 SSVF

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/service_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/service_processor.rb
@@ -16,13 +16,6 @@ module Hmis::Hud::Processors
       service = @processor.service_factory
 
       attributes = case attribute_name
-      when 'fa_start_date'
-        # If FA Start Date is present, the Date Provided should match it
-        if attribute_value.present?
-          { attribute_name => attribute_value, 'date_provided' => attribute_value }
-        else
-          { attribute_name => attribute_value }
-        end
       when 'sub_type_provided'
         # Enum value is set up like "144:4:6" (record type : type provided : sub type provided)
         { attribute_name => attribute_value&.split(':')&.last }
@@ -42,6 +35,19 @@ module Hmis::Hud::Processors
     end
 
     def information_date(_)
+    end
+
+    # This post-processing step provides functionality needed for the FY2024 service form. It can be removed after FY2026 changes
+    # have been deployed.
+    #
+    # FY2024 service form collects FA Start Date for SSVF Financial Assistance, and does NOT collect Date Provided. (Needs processor to store FA Start Date in Date Provided field)
+    # FY2026 service form collects both Date Provided and FA Start Date independently for SSVF Financial Assistance
+    def post_process
+      service = @processor.send(factory_name)
+
+      # Overwrite the DateProvided field if FA Start Date was submitted and Date Provided was not
+      date_provided_submitted = @hud_values.key?('dateProvided') && @hud_values['dateProvided'] != HIDDEN_FIELD_VALUE
+      service.date_provided = service.fa_start_date if service.fa_start_date.present? && !date_provided_submitted
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -2039,6 +2039,15 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         'faAmount' => 200,
       }
     end
+    let(:initialized_hud_service) do
+      Hmis::Hud::Service.new(
+        data_source: ds1,
+        enrollment_id: e1.enrollment_id,
+        personal_id: e1.personal_id,
+        record_type: hud_service.record_type,
+        type_provided: hud_service.type_provided,
+      )
+    end
 
     let(:custom_service_values) do
       {
@@ -2048,19 +2057,40 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     end
 
     it 'creates and updates all fields on a HUD Service' do
-      new_record = Hmis::Hud::Service.new(
-        data_source: ds1,
-        enrollment_id: e1.enrollment_id,
-        personal_id: e1.personal_id,
-        record_type: hud_service.record_type,
-        type_provided: hud_service.type_provided,
-      )
-
-      [hud_service, new_record].each do |record|
+      [hud_service, initialized_hud_service].each do |record|
         process_record(record: record, hud_values: hud_service_values, user: hmis_user, definition: definition)
 
         expect(record.fa_amount).to eq(200)
         expect(record.date_provided.strftime('%Y-%m-%d')).to eq('2023-03-13')
+      end
+    end
+
+    # Test FY2024 behavior, where only FAStartDate is collected for SSVF (and processed onto DateProvided)
+    it 'processes FA Start Date onto Date Provided if missing' do
+      hud_values = {
+        'faStartDate' => '2024-01-01',
+        'faAmount' => 200,
+      }
+      [hud_service, initialized_hud_service].each do |record|
+        process_record(record: record, hud_values: hud_values, user: hmis_user, definition: definition)
+
+        expect(record.date_provided.strftime('%Y-%m-%d')).to eq('2024-01-01')
+        expect(record.fa_start_date.strftime('%Y-%m-%d')).to eq('2024-01-01')
+      end
+    end
+
+    # Test FY2026 behavior, where both FAStartDate and DateProvided are collected for SSVF
+    it 'processes FA Start Date and Date Provided if both present' do
+      hud_values = {
+        'dateProvided' => '2024-01-01',
+        'faStartDate' => '2024-02-01',
+        'faAmount' => 200,
+      }
+      [hud_service, initialized_hud_service].each do |record|
+        process_record(record: record, hud_values: hud_values, user: hmis_user, definition: definition)
+
+        expect(record.date_provided.strftime('%Y-%m-%d')).to eq('2024-01-01')
+        expect(record.fa_start_date.strftime('%Y-%m-%d')).to eq('2024-02-01')
       end
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Follow-up to hotfix https://github.com/greenriver/hmis-warehouse/pull/5550

https://github.com/open-path/Green-River/issues/8121

This makes the ServiceProcessor behavior compatible with both FY24 and FY26 service forms. This removes the need to have any service processor code changes on a deploy branch.

How I tested:
- Create/Update SSVF service using FY24 form, ensure FA Start Date is propagated onto Date Provided
- Create/Update SSVF service using FY26 form, ensure FA Start Date and Date Provided are collected independently (using form from https://github.com/greenriver/hmis-warehouse/pull/5669)

## Type of change
new feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
