### PR TITLE
8008-one-for-column-helper-fix

### DIFF
--- a/app/models/concerns/arel_helper.rb
+++ b/app/models/concerns/arel_helper.rb
@@ -198,7 +198,14 @@ module ArelHelper
         source = scope.arel
         group_table = scope.arel_table
       else
-        source = table_model(source_arel_table).select(source_arel_table[:id]).arel # Referencing class to bring in Paranoia
+        # Respect soft-delete (acts_as_paranoid) automatically by excluding deleted rows
+        model_class = table_model(source_arel_table)
+        base_scope = model_class.all
+        if model_class.respond_to?(:paranoid?) && model_class.paranoid?
+          paranoia_col = model_class.paranoia_column&.to_sym
+          base_scope = base_scope.where(source_arel_table[paranoia_col].eq(nil)) if paranoia_col.present?
+        end
+        source = base_scope.select(source_arel_table[:id]).arel
         group_table = source_arel_table
       end
 

--- a/drivers/hmis/spec/models/hmis/workflow_definition/template_spec.rb
+++ b/drivers/hmis/spec/models/hmis/workflow_definition/template_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe Hmis::WorkflowDefinition::Template, type: :model do
                   identifier: identifier,
                   version: 2,
                   status: Hmis::Form::Definition::PUBLISHED)
-      v2.destroy!
-      v1.update!(status: Hmis::Form::Definition::PUBLISHED)
-
       # Soft-delete the highest version
+      v2.destroy!
+
+      # re-publish the old version
+      v1.update!(status: Hmis::Form::Definition::PUBLISHED)
 
       # Associate a UnitGroup by identifier; it should resolve to the latest non-deleted (v1)
       unit_group = create(:hmis_unit_group,
@@ -49,7 +50,7 @@ RSpec.describe Hmis::WorkflowDefinition::Template, type: :model do
                           workflow_template_identifier: identifier)
 
       # Expected: association finds v1, not nil, even though v2 is soft-deleted
-      expect(unit_group.workflow_template.id).to eq(v1.id)
+      expect(unit_group.workflow_template).to eq(v1)
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/workflow_definition/template_spec.rb
+++ b/drivers/hmis/spec/models/hmis/workflow_definition/template_spec.rb
@@ -21,4 +21,35 @@ RSpec.describe Hmis::WorkflowDefinition::Template, type: :model do
   describe 'paper trail' do
     it_behaves_like 'versioned model'
   end
+
+  describe 'latest_versions with acts_as_paranoid' do
+    it 'resolves latest non-deleted template in associations (UnitGroup -> workflow_template)' do
+      identifier = 'ce-template-for-assoc-test'
+      project = create(:hmis_hud_project, data_source: ds1)
+
+      v1 = create(:hmis_workflow_definition_template,
+                  data_source: ds1,
+                  identifier: identifier,
+                  version: 1,
+                  status: Hmis::Form::Definition::RETIRED)
+
+      v2 = create(:hmis_workflow_definition_template,
+                  data_source: ds1,
+                  identifier: identifier,
+                  version: 2,
+                  status: Hmis::Form::Definition::PUBLISHED)
+      v2.destroy!
+      v1.update!(status: Hmis::Form::Definition::PUBLISHED)
+
+      # Soft-delete the highest version
+
+      # Associate a UnitGroup by identifier; it should resolve to the latest non-deleted (v1)
+      unit_group = create(:hmis_unit_group,
+                          project: project,
+                          workflow_template_identifier: identifier)
+
+      # Expected: association finds v1, not nil, even though v2 is soft-deleted
+      expect(unit_group.workflow_template.id).to eq(v1.id)
+    end
+  end
 end

--- a/spec/models/concerns/arel_helper/one_for_column_spec.rb
+++ b/spec/models/concerns/arel_helper/one_for_column_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ArelHelper.one_for_column' do
+  before(:all) do
+    ActiveRecord::Schema.define do
+      create_table :arel_helper_specs, force: true do |t|
+        t.string :identifier
+        t.integer :version
+        t.datetime :deleted_at
+        t.datetime :discarded_at
+      end
+      create_table :arel_helper_owners, force: true do |t|
+        t.string :thing_identifier
+      end
+    end
+
+    class NonParanoidThing < ActiveRecord::Base
+      self.table_name = 'arel_helper_specs'
+      include ArelHelper
+    end
+
+    class ParanoidThing < ActiveRecord::Base
+      self.table_name = 'arel_helper_specs'
+      include ArelHelper
+      acts_as_paranoid
+    end
+
+    class ParanoidCustomColThing < ActiveRecord::Base
+      self.table_name = 'arel_helper_specs'
+      include ArelHelper
+      acts_as_paranoid column: :discarded_at
+    end
+
+    class ThingOwner < ActiveRecord::Base
+      self.table_name = 'arel_helper_owners'
+      belongs_to :thing,
+                 -> { one_for_column([:version], source_arel_table: ParanoidThing.arel_table, group_on: :identifier) },
+                 class_name: 'ParanoidThing',
+                 foreign_key: :thing_identifier,
+                 primary_key: :identifier,
+                 optional: true
+    end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :NonParanoidThing)
+    Object.send(:remove_const, :ParanoidThing)
+    Object.send(:remove_const, :ParanoidCustomColThing)
+    Object.send(:remove_const, :ThingOwner)
+    ActiveRecord::Schema.define do
+      drop_table :arel_helper_specs, force: true
+      drop_table :arel_helper_owners, force: true
+    end
+  end
+
+  def rows_for(klass, identifier:, versions:, soft_delete: nil)
+    versions.each { |v| klass.create!(identifier: identifier, version: v) }
+    return unless soft_delete
+
+    return unless klass.respond_to?(:paranoid?) && klass.paranoid?
+
+    col = klass.paranoia_column
+    klass.where(identifier: identifier, version: soft_delete).update_all(col => Time.current)
+  end
+
+  it 'excludes soft-deleted rows for paranoid models (default deleted_at)' do
+    rows_for(ParanoidThing, identifier: 'x', versions: [1, 2], soft_delete: 2)
+    rel = ParanoidThing.one_for_column([:version], source_arel_table: ParanoidThing.arel_table, group_on: :identifier)
+    expect(rel.where(identifier: 'x').pluck(:version)).to eq([1])
+  end
+
+  it 'does not exclude rows for non-paranoid models' do
+    rows_for(NonParanoidThing, identifier: 'y', versions: [1, 2])
+    rel = NonParanoidThing.one_for_column([:version], source_arel_table: NonParanoidThing.arel_table, group_on: :identifier)
+    expect(rel.where(identifier: 'y').pluck(:version)).to eq([2])
+  end
+
+  it 'respects custom paranoia_column' do
+    rows_for(ParanoidCustomColThing, identifier: 'z', versions: [1, 2], soft_delete: 2)
+    rel = ParanoidCustomColThing.one_for_column([:version], source_arel_table: ParanoidCustomColThing.arel_table, group_on: :identifier)
+    expect(rel.where(identifier: 'z').pluck(:version)).to eq([1])
+  end
+
+  it 'uses provided scope in subquery, but outer relation still respects paranoia (deleted winner yields no rows)' do
+    rows_for(ParanoidThing, identifier: 's', versions: [1, 2], soft_delete: 2)
+    scope = ParanoidThing.unscoped # intentionally bypass paranoia
+    rel = ParanoidThing.one_for_column([:version], source_arel_table: ParanoidThing.arel_table, group_on: :identifier, scope: scope)
+    expect(rel.where(identifier: 's').pluck(:version)).to eq([])
+  end
+
+  it 'resolves latest non-deleted row via association when highest version is soft-deleted' do
+    rows_for(ParanoidThing, identifier: 'edge', versions: [1, 2], soft_delete: 2)
+    v1 = ParanoidThing.find_by!(identifier: 'edge', version: 1)
+    owner = ThingOwner.create!(thing_identifier: 'edge')
+    expect(owner.thing&.id).to eq(v1.id)
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- **Summary**: Ensure `ArelHelper.one_for_column` skips soft-deleted rows for `acts_as_paranoid` models, fixing cases where the highest version is deleted.
- **Why**: Associations (e.g., `UnitGroup -> workflow_template`) should resolve to the latest non-deleted version instead of nil/wrong record.
- **Approach**: Detect paranoid models, respect custom `paranoia_column`, and filter subquery rows where the paranoia column is NULL; leave non-paranoid behavior unchanged.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


