### PR TITLE
Make additional demographic fields available to Alt aha

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/alt_aha_calculator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/alt_aha_calculator.rb
@@ -11,6 +11,7 @@ module HmisExternalApis::AcHmis
     ALT_AHA_NAMESPACE = 'alt_aha'
     CLIENT_AGE_LINK_ID = 'client_demographics_age'
     CLIENT_GENDER_LINK_ID = 'client_demographics_gender'
+    CLIENT_SEX_LINK_ID = 'client_demographics_sex'
 
     # owner can be: an enrollment (when AHA score is calculated on an unsaved assessment), or an assessment (when the assessment is being saved)
     def initialize(values_by_link_id:, client:, user: nil, owner: nil, form_definition_identifier:)
@@ -18,6 +19,7 @@ module HmisExternalApis::AcHmis
         # inject values from client
         CLIENT_AGE_LINK_ID => client.age,
         CLIENT_GENDER_LINK_ID => client.gender_fields,
+        CLIENT_SEX_LINK_ID => client.sex,
       )
       @user = user
       @owner = owner

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/alt_aha_calculator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/alt_aha_calculator.rb
@@ -11,15 +11,13 @@ module HmisExternalApis::AcHmis
     ALT_AHA_NAMESPACE = 'alt_aha'
     CLIENT_AGE_LINK_ID = 'client_demographics_age'
     CLIENT_GENDER_LINK_ID = 'client_demographics_gender'
-    CLIENT_SEX_LINK_ID = 'client_demographics_sex'
 
     # owner can be: an enrollment (when AHA score is calculated on an unsaved assessment), or an assessment (when the assessment is being saved)
     def initialize(values_by_link_id:, client:, user: nil, owner: nil, form_definition_identifier:)
       @values_by_link_id = values_by_link_id.merge(
         # inject values from client
         CLIENT_AGE_LINK_ID => client.age,
-        CLIENT_GENDER_LINK_ID => client.gender_fields,
-        CLIENT_SEX_LINK_ID => client.sex,
+        CLIENT_GENDER_LINK_ID => determine_gender(client),
       )
       @user = user
       @owner = owner
@@ -63,6 +61,15 @@ module HmisExternalApis::AcHmis
     end
 
     private
+
+    # Merged gender value accommodates both FY24 and FY26 values
+    def determine_gender(client)
+      if client.sex == 0 || client.woman == 1
+        0
+      elsif client.sex == 1 && client.man == 1
+        1
+      end
+    end
 
     def calculate_components(values_by_link_id)
       {

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/alt_aha_calculator_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/alt_aha_calculator_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
   let(:client) { create(:hmis_hud_client, dob: Date.current - 42.years, Woman: 1) }
 
   describe '#calculate_score' do
-    let!(:baseline_rule_1) { create(:hmis_scoring_rule, algorithm: 'alt_aha_1') }
-    let!(:baseline_rule_2) { create(:hmis_scoring_rule, algorithm: 'alt_aha_2') }
-    let!(:baseline_rule_3) { create(:hmis_scoring_rule, algorithm: 'alt_aha_3') }
+    let!(:baseline_rule_1) { create(:hmis_scoring_rule, algorithm: 'alg_1') }
+    let!(:baseline_rule_2) { create(:hmis_scoring_rule, algorithm: 'alg_2') }
+    let!(:baseline_rule_3) { create(:hmis_scoring_rule, algorithm: 'alg_3') }
 
     describe 'exact match rule' do
       let!(:exact_match_rule) do
@@ -27,7 +27,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => 'Yes' },
           weight: 0.5,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 
@@ -42,9 +42,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.5')
-        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.5')
+        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::RANGE,
           criteria_config: { 'gte' => 3 },
           weight: 0.3,
-          algorithm: 'alt_aha_2',
+          algorithm: 'alg_2',
         )
       end
 
@@ -72,9 +72,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.3')
-        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.3')
+        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::VALUE,
           criteria_config: {},
           weight: 0.1,
-          algorithm: 'alt_aha_3',
+          algorithm: 'alg_3',
         )
       end
 
@@ -102,9 +102,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.4')
+        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.4')
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::INCLUDE,
           criteria_config: { 'include' => 'option_b' },
           weight: 0.6,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 
@@ -132,9 +132,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.6')
-        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.6')
+        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
       end
 
       it 'does not score when array does not include target value' do
@@ -148,9 +148,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
       end
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => 'Yes' },
           weight: 0.5,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 
@@ -177,7 +177,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => nil },
           weight: 0.3,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 
@@ -189,7 +189,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::RANGE,
           criteria_config: { 'gte' => 3 },
           weight: 0.4,
-          algorithm: 'alt_aha_2',
+          algorithm: 'alg_2',
         )
       end
 
@@ -200,7 +200,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           form_definition_identifier: 'test_form',
           criteria_type: Hmis::Scoring::Rule::VALUE,
           weight: 0.1,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 
@@ -210,9 +210,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           link_id: 'client_demographics_gender',
           form_definition_identifier: 'test_form',
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
-          criteria_config: { 'match_value' => 'Female' },
+          criteria_config: { 'match_value' => 0 },
           weight: 0.2,
-          algorithm: 'alt_aha_1',
+          algorithm: 'alg_1',
         )
       end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/alt_aha_calculator_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/alt_aha_calculator_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
   let(:client) { create(:hmis_hud_client, dob: Date.current - 42.years, Woman: 1) }
 
   describe '#calculate_score' do
-    let!(:baseline_rule_1) { create(:hmis_scoring_rule, algorithm: 'alg_1') }
-    let!(:baseline_rule_2) { create(:hmis_scoring_rule, algorithm: 'alg_2') }
-    let!(:baseline_rule_3) { create(:hmis_scoring_rule, algorithm: 'alg_3') }
+    let!(:baseline_rule_1) { create(:hmis_scoring_rule, algorithm: 'alt_aha_1') }
+    let!(:baseline_rule_2) { create(:hmis_scoring_rule, algorithm: 'alt_aha_2') }
+    let!(:baseline_rule_3) { create(:hmis_scoring_rule, algorithm: 'alt_aha_3') }
 
     describe 'exact match rule' do
       let!(:exact_match_rule) do
@@ -27,7 +27,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => 'Yes' },
           weight: 0.5,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 
@@ -42,9 +42,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.5')
-        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.5')
+        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::RANGE,
           criteria_config: { 'gte' => 3 },
           weight: 0.3,
-          algorithm: 'alg_2',
+          algorithm: 'alt_aha_2',
         )
       end
 
@@ -72,9 +72,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.3')
-        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.3')
+        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::VALUE,
           criteria_config: {},
           weight: 0.1,
-          algorithm: 'alg_3',
+          algorithm: 'alt_aha_3',
         )
       end
 
@@ -102,9 +102,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.4')
+        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.4')
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::INCLUDE,
           criteria_config: { 'include' => 'option_b' },
           weight: 0.6,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 
@@ -132,9 +132,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.6')
-        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.6')
+        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
       end
 
       it 'does not score when array does not include target value' do
@@ -148,9 +148,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
         )
 
         _score, log = calculator.calculate_score
-        expect(log.calculation_details['alg_1']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_2']['raw_score']).to eq('0.0')
-        expect(log.calculation_details['alg_3']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_1']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_2']['raw_score']).to eq('0.0')
+        expect(log.calculation_details['alt_aha_3']['raw_score']).to eq('0.0')
       end
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => 'Yes' },
           weight: 0.5,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 
@@ -177,7 +177,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
           criteria_config: { 'match_value' => nil },
           weight: 0.3,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 
@@ -189,7 +189,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           criteria_type: Hmis::Scoring::Rule::RANGE,
           criteria_config: { 'gte' => 3 },
           weight: 0.4,
-          algorithm: 'alg_2',
+          algorithm: 'alt_aha_2',
         )
       end
 
@@ -200,7 +200,7 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           form_definition_identifier: 'test_form',
           criteria_type: Hmis::Scoring::Rule::VALUE,
           weight: 0.1,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 
@@ -210,9 +210,9 @@ RSpec.describe HmisExternalApis::AcHmis::AltAhaCalculator, type: :model do
           link_id: 'client_demographics_gender',
           form_definition_identifier: 'test_form',
           criteria_type: Hmis::Scoring::Rule::EXACT_MATCH,
-          criteria_config: { 'match_value' => 0 },
+          criteria_config: { 'match_value' => 'Female' },
           weight: 0.2,
-          algorithm: 'alg_1',
+          algorithm: 'alt_aha_1',
         )
       end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Make additional demographics available to alt aha

## Type of change
new feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
