### PR TITLE
Update CreateUnits mutation to infer unit type from group

### DIFF
--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -29,6 +29,9 @@ module Mutations
       return { errors: errors.errors } if errors.any?
 
       unit_group = project.unit_groups.find(input.unit_group_id) if input.unit_group_id.present?
+      # If no unit type specified, use the first unit type from the group (if specified)
+      # TODO(#7814) make this mutation more strict to always expect unit group, and expect constraint of max 1 unit type per group
+      unit_type ||= unit_group&.unit_types&.order(:id)&.first
 
       # Create Units
       common = { user_id: current_user.id, created_at: Time.now, updated_at: Time.now }
@@ -36,7 +39,7 @@ module Mutations
         Hmis::Unit.new(
           project_id: project.id,
           unit_type_id: unit_type&.id,
-          hmis_unit_group_id: unit_group&.id, # optional
+          hmis_unit_group_id: unit_group&.id,
           **common,
         )
       end

--- a/drivers/hmis/app/models/hmis/unit_group.rb
+++ b/drivers/hmis/app/models/hmis/unit_group.rb
@@ -21,6 +21,7 @@ module Hmis
     belongs_to :project, class_name: 'Hmis::Hud::Project'
     belongs_to :candidate_pool, class_name: 'Hmis::Ce::Match::CandidatePool', optional: true
     has_many :units, class_name: 'Hmis::Unit', dependent: :destroy, foreign_key: :hmis_unit_group_id
+    has_many :unit_types, through: :units
     has_many :opportunities, class_name: 'Hmis::Ce::Opportunity', through: :units
 
     # The workflow template to use to fill CE Opportunities for Units belonging to this Unit Group


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8124
Frontend PR: https://github.com/greenriver/hmis-frontend/pull/1242
## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
