### PR TITLE
Increase production timeout to 10s for link api

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/link_api.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # To connect to the API, you need a remote credential for this endpoint. Replace
 # the empty strings below with values from the documentation.
 #
@@ -20,8 +22,8 @@
 
 module HmisExternalApis::AcHmis
   class LinkApi
-    SYSTEM_ID = 'ac_hmis_link'.freeze
-    CONNECTION_TIMEOUT_SECONDS = Rails.env.staging? ? 10 : 5
+    SYSTEM_ID = 'ac_hmis_link'
+    CONNECTION_TIMEOUT_SECONDS = 10
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to LINK')
 
     def self.enabled?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Have seen a significant upticks in timeouts that are ultimately successful on their end, but timeout for us, resulting in mismatching posting statuses between link and hmis. Try to mitigate this by just bumping the timeout. This integration will be removed soon (https://github.com/open-path/Green-River/issues/8143)

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
