### PR TITLE
7814 Part 1 - Migrate all units to Unit Groups

### DIFF
--- a/db/warehouse/migrate/20250828205652_add_unit_type_to_unit_group.rb
+++ b/db/warehouse/migrate/20250828205652_add_unit_type_to_unit_group.rb
@@ -1,0 +1,15 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddUnitTypeToUnitGroup < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      add_reference :hmis_unit_groups, :unit_type, null: true, foreign_key: { to_table: :hmis_unit_types }
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -24420,7 +24420,8 @@ CREATE TABLE public.hmis_unit_groups (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone,
     candidate_pool_id bigint,
-    ce_event_type integer
+    ce_event_type integer,
+    unit_type_id bigint
 );
 
 
@@ -66389,6 +66390,13 @@ CREATE INDEX index_hmis_unit_groups_on_project_id ON public.hmis_unit_groups USI
 
 
 --
+-- Name: index_hmis_unit_groups_on_unit_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hmis_unit_groups_on_unit_type_id ON public.hmis_unit_groups USING btree (unit_type_id);
+
+
+--
 -- Name: index_hmis_unit_occupancy_on_enrollment_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -74603,6 +74611,14 @@ ALTER TABLE ONLY public.wfe_step_assignments
 
 
 --
+-- Name: hmis_unit_groups fk_rails_4af3f4cb4a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.hmis_unit_groups
+    ADD CONSTRAINT fk_rails_4af3f4cb4a FOREIGN KEY (unit_type_id) REFERENCES public.hmis_unit_types(id);
+
+
+--
 -- Name: wfd_swimlanes fk_rails_4de79171d1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -75345,6 +75361,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250828205652'),
 ('20250821194338'),
 ('20250821182429'),
 ('20250820220743'),

--- a/drivers/hmis/app/graphql/mutations/create_unit_group.rb
+++ b/drivers/hmis/app/graphql/mutations/create_unit_group.rb
@@ -21,11 +21,7 @@ module Mutations
       errors = HmisErrors::Errors.new
       errors.add :unit_type_id, :required unless input.unit_type_id.present?
 
-      unit_type_scope = Hmis::UnitType.all
-      # If the project has any unit type mappings, require that this unit type is among them
-      unit_type_ids = project.unit_type_mappings.active.pluck(:unit_type_id)
-      unit_type_scope = unit_type_scope.where(id: unit_type_ids) if unit_type_ids.any?
-      unit_type = unit_type_scope.find_by(id: input.unit_type_id)
+      unit_type = project.possible_unit_types.find_by(id: input.unit_type_id)
       errors.add :unit_type_id, :invalid unless unit_type.present?
       return { errors: errors.errors } if errors.any?
 

--- a/drivers/hmis/app/graphql/mutations/create_unit_group.rb
+++ b/drivers/hmis/app/graphql/mutations/create_unit_group.rb
@@ -19,20 +19,20 @@ module Mutations
       access_denied! unless current_user.permissions_for?(project, :can_manage_units)
 
       errors = HmisErrors::Errors.new
+      errors.add :unit_type_id, :required unless input.unit_type_id.present?
+      return { errors: errors.errors } if errors.any?
 
-      # unit_type = Hmis::UnitType.find_by(id: input.unit_type_id)
-      # raise 'Invalid unit type' if input.unit_type_id.present? && !unit_type.present?
-
-      # errors.add :count, :required unless input.count.present?
-      # errors.add :count, :out_of_range, message: 'must be positive' if input.count&.negative?
-      # errors.add :count, :out_of_range, message: 'must be non-zero' if input.count&.zero?
-      # return { errors: errors.errors } if errors.any?
+      # Validate unit_type exists
+      unit_type = Hmis::UnitType.find_by(id: input.unit_type_id)
+      errors.add :unit_type_id, :invalid unless unit_type.present?
+      return { errors: errors.errors } if errors.any?
 
       unit_group = Hmis::UnitGroup.new(
         project_id: project.id,
         workflow_template_identifier: input.workflow_template_identifier,
         name: input.name,
         ce_event_type: input.ce_event_type,
+        unit_type: unit_type,
       )
 
       if unit_group.valid?

--- a/drivers/hmis/app/graphql/mutations/create_unit_group.rb
+++ b/drivers/hmis/app/graphql/mutations/create_unit_group.rb
@@ -20,17 +20,21 @@ module Mutations
 
       errors = HmisErrors::Errors.new
       errors.add :unit_type_id, :required unless input.unit_type_id.present?
-      return { errors: errors.errors } if errors.any?
 
-      # Validate unit_type exists
-      unit_type = Hmis::UnitType.find_by(id: input.unit_type_id)
+      unit_type_scope = Hmis::UnitType.all
+      unit_type_ids = project.unit_type_mappings.active.pluck(:unit_type_id)
+      unit_type_scope = unit_type_scope.where(id: unit_type_ids) if unit_type_ids.any? # only restrict if any mappings exist
+      unit_type = unit_type_scope.find_by(id: input.unit_type_id)
       errors.add :unit_type_id, :invalid unless unit_type.present?
       return { errors: errors.errors } if errors.any?
 
+      workflow_template = Hmis::WorkflowDefinition::Template.published.find_by(identifier: input.workflow_template_identifier)
+      errors.add :workflow_template_identifier, :invalid unless workflow_template.present?
+
       unit_group = Hmis::UnitGroup.new(
-        project_id: project.id,
-        workflow_template_identifier: input.workflow_template_identifier,
         name: input.name,
+        project: project,
+        workflow_template_identifier: input.workflow_template_identifier,
         ce_event_type: input.ce_event_type,
         unit_type: unit_type,
       )

--- a/drivers/hmis/app/graphql/mutations/create_unit_group.rb
+++ b/drivers/hmis/app/graphql/mutations/create_unit_group.rb
@@ -22,8 +22,9 @@ module Mutations
       errors.add :unit_type_id, :required unless input.unit_type_id.present?
 
       unit_type_scope = Hmis::UnitType.all
+      # If the project has any unit type mappings, require that this unit type is among them
       unit_type_ids = project.unit_type_mappings.active.pluck(:unit_type_id)
-      unit_type_scope = unit_type_scope.where(id: unit_type_ids) if unit_type_ids.any? # only restrict if any mappings exist
+      unit_type_scope = unit_type_scope.where(id: unit_type_ids) if unit_type_ids.any?
       unit_type = unit_type_scope.find_by(id: input.unit_type_id)
       errors.add :unit_type_id, :invalid unless unit_type.present?
       return { errors: errors.errors } if errors.any?
@@ -34,7 +35,7 @@ module Mutations
       unit_group = Hmis::UnitGroup.new(
         name: input.name,
         project: project,
-        workflow_template_identifier: input.workflow_template_identifier,
+        workflow_template: workflow_template,
         ce_event_type: input.ce_event_type,
         unit_type: unit_type,
       )

--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -30,7 +30,6 @@ module Mutations
 
       unit_group = project.unit_groups.find(input.unit_group_id) if input.unit_group_id.present?
       # If no unit type specified, use the first unit type from the group (if specified)
-      # todo @martha
       # TODO(#7814) make this mutation more strict to always expect unit group, and expect constraint of max 1 unit type per group
       unit_type ||= unit_group&.unit_types&.order(:id)&.first
 

--- a/drivers/hmis/app/graphql/mutations/create_units.rb
+++ b/drivers/hmis/app/graphql/mutations/create_units.rb
@@ -30,6 +30,7 @@ module Mutations
 
       unit_group = project.unit_groups.find(input.unit_group_id) if input.unit_group_id.present?
       # If no unit type specified, use the first unit type from the group (if specified)
+      # todo @martha
       # TODO(#7814) make this mutation more strict to always expect unit group, and expect constraint of max 1 unit type per group
       unit_type ||= unit_group&.unit_types&.order(:id)&.first
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -12645,7 +12645,7 @@ type UnitGroup {
   Unit type for this group
   """
   unitType: UnitTypeObject
-  unitTypes: [UnitTypeCapacity!]!
+  unitTypes: [UnitTypeCapacity!] @deprecated(reason: "All units in group should have the same type")
   units(filters: UnitFilterOptions, limit: Int, offset: Int): UnitsPaginated!
   workflowTemplateIdentifier: String
   workflowTemplateName: String

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -12640,6 +12640,11 @@ type UnitGroup {
   name: String!
   priorityScheme: CeMatchRule @deprecated(reason: "Replaced by prioritySchemes")
   prioritySchemes: [CeMatchRule!]
+
+  """
+  Unit type for this group
+  """
+  unitType: UnitTypeObject
   unitTypes: [UnitTypeCapacity!]!
   units(filters: UnitFilterOptions, limit: Int, offset: Int): UnitsPaginated!
   workflowTemplateIdentifier: String
@@ -12650,6 +12655,7 @@ input UnitGroupInput {
   ceEventType: EventType
   name: String
   projectId: ID
+  unitTypeId: ID
   workflowTemplateIdentifier: String
 }
 

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -303,19 +303,10 @@ module Types
         end
     end
 
-    # UNIT_TYPES pick list should only return types that are "mapped" for this project. If there are
-    # no mappings it should return all unit types, which is the default behavior.
     def self.possible_unit_types_for_project(project)
       return [] unless project.present?
 
-      unit_type_scope = Hmis::UnitType.all
-      unit_type_ids = project.unit_type_mappings.active.pluck(:unit_type_id)
-      if unit_type_ids.any?
-        unit_type_ids += project.units.distinct.pluck(:unit_type_id) # include unit types for existing units
-        unit_type_scope = unit_type_scope.where(id: unit_type_ids)
-      end
-
-      unit_type_scope.
+      project.possible_unit_types.
         order(:description, :id).
         map(&:to_pick_list_option)
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
@@ -15,8 +15,9 @@ module Types
     field :name, String, null: false
     field :capacity, Integer, null: false, description: 'Total number of units in the group'
     field :availability, Integer, null: false, description: 'Number of units in this group that are currently unoccupied'
-    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false
+    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false # todo @martha - Deprecated, to remove
     units_field
+    field :unit_type, Types::HmisSchema::UnitTypeObject, null: true, description: 'Unit type for this group'
 
     # CE fields
     field :eligibility_requirements, [HmisSchema::CeMatchRule], null: true

--- a/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
@@ -15,7 +15,7 @@ module Types
     field :name, String, null: false
     field :capacity, Integer, null: false, description: 'Total number of units in the group'
     field :availability, Integer, null: false, description: 'Number of units in this group that are currently unoccupied'
-    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false # todo @martha - Deprecated, to remove
+    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false # TODO(#7814) - remove
     units_field
     field :unit_type, Types::HmisSchema::UnitTypeObject, null: true, description: 'Unit type for this group'
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit_group.rb
@@ -15,7 +15,7 @@ module Types
     field :name, String, null: false
     field :capacity, Integer, null: false, description: 'Total number of units in the group'
     field :availability, Integer, null: false, description: 'Number of units in this group that are currently unoccupied'
-    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false # TODO(#7814) - remove
+    field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: true, deprecation_reason: 'All units in group should have the same type' # TODO(#7814) - remove
     units_field
     field :unit_type, Types::HmisSchema::UnitTypeObject, null: true, description: 'Unit type for this group'
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/unit_group_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/unit_group_input.rb
@@ -12,8 +12,6 @@ module Types
     argument :name, String, required: false
     argument :workflow_template_identifier, String, required: false
     argument :ce_event_type, HmisSchema::Enums::Hud::EventType, required: false
-    # argument :count, Integer, 'Number of units to create', required: false
-    # argument :prefix, String, 'Prefix for unit names', required: false
-    # argument :unit_type_id, ID, required: false
+    argument :unit_type_id, ID, required: false
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -372,5 +372,19 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     coc_code_arg
   end
 
+  def possible_unit_types
+    unit_type_scope = Hmis::UnitType.all
+
+    # Only return types that are "mapped" for this project. If there are
+    # no mappings it should return all unit types, which is the default behavior.
+    unit_type_ids = unit_type_mappings.active.pluck(:unit_type_id)
+    if unit_type_ids.any?
+      unit_type_ids += units.distinct.pluck(:unit_type_id) # include unit types for existing units
+      unit_type_scope = unit_type_scope.where(id: unit_type_ids)
+    end
+
+    unit_type_scope
+  end
+
   include RailsDrivers::Extensions
 end

--- a/drivers/hmis/app/models/hmis/unit_group.rb
+++ b/drivers/hmis/app/models/hmis/unit_group.rb
@@ -20,6 +20,7 @@ module Hmis
 
     belongs_to :project, class_name: 'Hmis::Hud::Project'
     belongs_to :candidate_pool, class_name: 'Hmis::Ce::Match::CandidatePool', optional: true
+    belongs_to :unit_type, class_name: 'Hmis::UnitType', optional: true # todo @martha - make required after migration
     has_many :units, class_name: 'Hmis::Unit', dependent: :destroy, foreign_key: :hmis_unit_group_id
     has_many :unit_types, through: :units
     has_many :opportunities, class_name: 'Hmis::Ce::Opportunity', through: :units
@@ -36,6 +37,7 @@ module Hmis
     validate :workflow_template_is_valid
     validate :workflow_template_is_stable
     validate :project_is_not_changed, on: :update
+    validate :unit_type_is_stable
 
     after_create :rebuild_candidate_pool
 
@@ -80,6 +82,13 @@ module Hmis
       return if workflow_template_identifier_was.nil?
 
       errors.add(:workflow_template_identifier, 'cannot be changed once set')
+    end
+
+    def unit_type_is_stable
+      return unless unit_type_id_changed?
+      return if unit_type_id_was.nil?
+
+      errors.add(:unit_type_id, 'cannot be changed once set')
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/unit_group.rb
+++ b/drivers/hmis/app/models/hmis/unit_group.rb
@@ -20,7 +20,7 @@ module Hmis
 
     belongs_to :project, class_name: 'Hmis::Hud::Project'
     belongs_to :candidate_pool, class_name: 'Hmis::Ce::Match::CandidatePool', optional: true
-    belongs_to :unit_type, class_name: 'Hmis::UnitType', optional: true # todo @martha - make required after migration
+    belongs_to :unit_type, class_name: 'Hmis::UnitType', optional: true # TODO(#7814) - optional: false after migration
     has_many :units, class_name: 'Hmis::Unit', dependent: :destroy, foreign_key: :hmis_unit_group_id
     has_many :unit_types, through: :units
     has_many :opportunities, class_name: 'Hmis::Ce::Opportunity', through: :units

--- a/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
+++ b/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+desc 'One time data migration to generate Unit Groups for existing units'
+# rails driver:hmis:migrate_unit_groups_20250828
+task migrate_unit_groups_20250828: [:environment] do
+  Hmis::UnitGroup.transaction do
+    OneTimeMigration20250828.new.perform
+    # raise ActiveRecord::Rollback # uncomment to test rollback
+  end
+end
+
+class OneTimeMigration20250828
+  def perform
+    puts 'Creating unit groups for projects with existing units'
+
+    # Find all project/unit_type combinations that have units but no unit groups
+    projects_without_unit_groups = Hmis::Hud::Project.
+      joins(:units).
+      left_joins(:unit_groups).
+      where(hmis_unit_groups: { id: nil }).
+      distinct.
+      includes(:units)
+
+    projects_processed = 0
+    unit_groups_created = 0
+    units_updated = 0
+
+    puts "#{projects_without_unit_groups} projects to process"
+
+    projects_without_unit_groups.find_each do |project|
+      # Get all distinct unit types for units in this project
+      unit_type_ids = project.units.pluck(:unit_type_id).uniq
+      unit_types = Hmis::UnitType.where(id: unit_type_ids)
+
+      unit_types.each do |unit_type|
+        # Create a unit group for this unit_type in this project
+        unit_group = Hmis::UnitGroup.create!(
+          project: project,
+          unit_type: unit_type,
+          name: "#{unit_type.description}",
+        )
+        unit_groups_created += 1
+
+        # Update all units of this type in this project to belong to the new unit group
+        units_to_update = project.units.where(unit_type: unit_type)
+        updated_count = units_to_update.update_all(
+          hmis_unit_group_id: unit_group.id
+        )
+        units_updated += updated_count
+      end
+
+      projects_processed += 1
+
+      # Progress reporting every 10 projects
+      if projects_processed % 10 == 0
+        puts "Processed #{projects_processed} of #{projects_without_unit_groups} projects so far"
+      end
+    end
+
+    puts "Migration complete!"
+    puts "Processed #{projects_processed} projects"
+    puts "Created #{unit_groups_created} unit groups"
+    puts "Updated #{units_updated} units"
+  end
+end

--- a/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
+++ b/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
@@ -1,17 +1,69 @@
 # frozen_string_literal: true
 
-desc 'One time data migration to generate Unit Groups for existing units'
+desc 'One time data migration to generate Unit Groups for existing units and fix existing unit groups without unit_type'
 # rails driver:hmis:migrate_unit_groups_20250828
 task migrate_unit_groups_20250828: [:environment] do
   Hmis::UnitGroup.transaction do
     OneTimeMigration20250828.new.perform
-    # raise ActiveRecord::Rollback # uncomment to test rollback
+    raise ActiveRecord::Rollback # uncomment to test rollback
   end
 end
 
 class OneTimeMigration20250828
   def perform
-    puts 'Creating unit groups for projects with existing units'
+    # First, fix existing unit groups that don't have unit_type set
+    add_unit_type_to_unit_groups
+
+    # Then, create unit groups for projects that don't have any yet
+    create_unit_groups_for_projects
+
+    puts "Migration complete!"
+  end
+
+  private
+
+  def add_unit_type_to_unit_groups
+    puts "Fixing existing unit groups without unit_type"
+
+    # Find all unit groups that don't have a unit_type set
+    unit_groups_without_type = Hmis::UnitGroup.where(unit_type: nil).includes(:units)
+
+    unit_groups_updated = 0
+    warnings_logged = 0
+
+    puts "Found #{unit_groups_without_type.count} unit groups without unit_type"
+
+    unit_groups_without_type.find_each do |unit_group|
+      units = unit_group.units.where.not(unit_type: nil)
+
+      if units.empty?
+        puts "WARNING: Unit group #{unit_group.id} (#{unit_group.name}) has no units with unit_type"
+        warnings_logged += 1
+        next
+      end
+
+      # Get all distinct unit types for units in this unit group
+      unit_type_ids = units.distinct.pluck(:unit_type_id)
+
+      if unit_type_ids.size > 1
+        unit_types = Hmis::UnitType.where(id: unit_type_ids).pluck(:description)
+        puts "WARNING: Unit group #{unit_group.id} (#{unit_group.name}) has units with different unit types: #{unit_types.join(', ')}"
+        warnings_logged += 1
+        next
+      end
+
+      # All units have the same unit_type, set it on the unit group
+      unit_type = Hmis::UnitType.find(unit_type_ids.first)
+      unit_group.update!(unit_type: unit_type)
+      unit_groups_updated += 1
+    end
+
+    puts "Updated #{unit_groups_updated} unit groups"
+    puts "#{warnings_logged} warnings logged, needing additional investigation"
+  end
+
+  def create_unit_groups_for_projects
+    puts "Creating unit groups for projects that have units without groups"
 
     # Find all project/unit_type combinations that have units but no unit groups
     projects_without_unit_groups = Hmis::Hud::Project.
@@ -25,7 +77,7 @@ class OneTimeMigration20250828
     unit_groups_created = 0
     units_updated = 0
 
-    puts "#{projects_without_unit_groups} projects to process"
+    puts "Found #{projects_without_unit_groups.count} projects to process"
 
     projects_without_unit_groups.find_each do |project|
       # Get all distinct unit types for units in this project
@@ -53,11 +105,10 @@ class OneTimeMigration20250828
 
       # Progress reporting every 10 projects
       if projects_processed % 10 == 0
-        puts "Processed #{projects_processed} of #{projects_without_unit_groups} projects so far"
+        puts "Processed #{projects_processed} of #{projects_without_unit_groups.count} projects so far"
       end
     end
 
-    puts "Migration complete!"
     puts "Processed #{projects_processed} projects"
     puts "Created #{unit_groups_created} unit groups"
     puts "Updated #{units_updated} units"

--- a/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
+++ b/drivers/hmis/lib/tasks/one_time_migration_20250828.rake
@@ -5,7 +5,7 @@ desc 'One time data migration to generate Unit Groups for existing units and fix
 task migrate_unit_groups_20250828: [:environment] do
   Hmis::UnitGroup.transaction do
     OneTimeMigration20250828.new.perform
-    raise ActiveRecord::Rollback # uncomment to test rollback
+    # raise ActiveRecord::Rollback # uncomment to test rollback
   end
 end
 

--- a/drivers/hmis/spec/factories/hmis/project_unit_type_mappings.rb
+++ b/drivers/hmis/spec/factories/hmis/project_unit_type_mappings.rb
@@ -1,0 +1,15 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :project_unit_type_mapping, class: 'Hmis::ProjectUnitTypeMapping' do
+    project { association :hmis_hud_project }
+    unit_type { association :hmis_unit_type }
+    active { true }
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/create_unit_group_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_unit_group_spec.rb
@@ -72,47 +72,69 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
     expect(unit_group.unit_type_id).to eq(unit_type.id)
   end
 
-  context 'validation errors' do
-    context 'when name is missing' do
-      let(:input_without_name) { base_input.deep_merge(input: { name: nil }) }
+  context 'when name is missing' do
+    let(:input_without_name) { base_input.deep_merge(input: { name: nil }) }
 
-      it 'returns validation error' do
-        response, result = post_graphql(input_without_name) { mutation }
-        expect(response.status).to eq(200), result.inspect
+    it 'returns validation error' do
+      response, result = post_graphql(input_without_name) { mutation }
+      expect(response.status).to eq(200), result.inspect
 
-        errors = result.dig('data', 'createUnitGroup', 'errors')
-        expect(errors).not_to be_empty
-        expect(errors.first['attribute']).to eq('name')
-        expect(errors.first['type']).to eq('required')
-      end
+      errors = result.dig('data', 'createUnitGroup', 'errors')
+      expect(errors).not_to be_empty
+      expect(errors.first['attribute']).to eq('name')
+      expect(errors.first['type']).to eq('required')
+    end
+  end
+
+  context 'when name is not unique within project' do
+    let!(:existing_unit_group) { create(:hmis_unit_group, project: p1, name: 'Existing Group Name') }
+    let(:input_with_duplicate_name) { base_input.deep_merge(input: { name: 'Existing Group Name' }) }
+
+    it 'returns validation error' do
+      response, result = post_graphql(input_with_duplicate_name) { mutation }
+      expect(response.status).to eq(200), result.inspect
+
+      errors = result.dig('data', 'createUnitGroup', 'errors')
+      expect(errors).not_to be_empty
+      expect(errors.first['fullMessage']).to eq('Name must be unique in the project')
+    end
+  end
+
+  context 'when unit type is missing' do
+    let(:input_without_unit_type) { base_input.deep_merge(input: { unitTypeId: nil }) }
+
+    it 'returns validation error' do
+      response, result = post_graphql(input_without_unit_type) { mutation }
+      expect(response.status).to eq(200), result.inspect
+
+      errors = result.dig('data', 'createUnitGroup', 'errors')
+      expect(errors).not_to be_empty
+      expect(errors.first['attribute']).to eq('unitTypeId')
+      expect(errors.first['type']).to eq('required')
+    end
+  end
+
+  context 'when project has restricted unit types' do
+    let!(:restricted_unit_type) { create(:hmis_unit_type, description: 'Restricted Type') }
+    let!(:project_mapping) { create(:project_unit_type_mapping, project: p1, unit_type: unit_type) }
+
+    it 'succeeds with allowed unit type' do
+      response, result = post_graphql(base_input) { mutation }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'createUnitGroup', 'errors')).to be_empty
+      created_group = result.dig('data', 'createUnitGroup', 'unitGroup')
+      expect(created_group['unitType']['id']).to eq(unit_type.id.to_s)
     end
 
-    context 'when name is not unique within project' do
-      let!(:existing_unit_group) { create(:hmis_unit_group, project: p1, name: 'Existing Group Name') }
-      let(:input_with_duplicate_name) { base_input.deep_merge(input: { name: 'Existing Group Name' }) }
+    it 'returns validation error with incorrect unit type' do
+      input = base_input.deep_merge(input: { unitTypeId: restricted_unit_type.id })
+      response, result = post_graphql(input) { mutation }
+      expect(response.status).to eq(200), result.inspect
 
-      it 'returns validation error' do
-        response, result = post_graphql(input_with_duplicate_name) { mutation }
-        expect(response.status).to eq(200), result.inspect
-
-        errors = result.dig('data', 'createUnitGroup', 'errors')
-        expect(errors).not_to be_empty
-        expect(errors.first['fullMessage']).to eq('Name must be unique in the project')
-      end
-    end
-
-    context 'when unit type is missing' do
-      let(:input_without_unit_type) { base_input.deep_merge(input: { unitTypeId: nil }) }
-
-      it 'returns validation error' do
-        response, result = post_graphql(input_without_unit_type) { mutation }
-        expect(response.status).to eq(200), result.inspect
-
-        errors = result.dig('data', 'createUnitGroup', 'errors')
-        expect(errors).not_to be_empty
-        expect(errors.first['attribute']).to eq('unitTypeId')
-        expect(errors.first['type']).to eq('required')
-      end
+      errors = result.dig('data', 'createUnitGroup', 'errors')
+      expect(errors).not_to be_empty
+      expect(errors.first['attribute']).to eq('unitTypeId')
+      expect(errors.first['type']).to eq('invalid')
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/create_unit_group_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_unit_group_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
             name
             workflowTemplateIdentifier
             ceEventType
+            unitType {
+              id
+              description
+            }
           }
           #{error_fields}
         }
@@ -31,6 +35,7 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
 
   let!(:access_control) { create_access_control(hmis_user, p1, with_permission: [:can_view_project, :can_manage_units, :can_view_units]) }
   let!(:workflow_template) { create(:hmis_workflow_definition_template, data_source: ds1) }
+  let!(:unit_type) { create(:hmis_unit_type, description: 'Studio Apartment') }
 
   before(:each) { hmis_login(user) }
 
@@ -41,6 +46,7 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
         name: 'New Unit Group',
         workflowTemplateIdentifier: workflow_template.identifier,
         ceEventType: 'REFERRAL_TO_PSH_PROJECT_RESOURCE_OPENING',
+        unitTypeId: unit_type.id.to_s,
       },
     }
   end
@@ -54,6 +60,8 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
     expect(created_group['name']).to eq('New Unit Group')
     expect(created_group['workflowTemplateIdentifier']).to eq(workflow_template.identifier)
     expect(created_group['ceEventType']).to eq('REFERRAL_TO_PSH_PROJECT_RESOURCE_OPENING')
+    expect(created_group['unitType']['id']).to eq(unit_type.id.to_s)
+    expect(created_group['unitType']['description']).to eq('Studio Apartment')
 
     # Verify the unit group was actually created in the database
     unit_group = Hmis::UnitGroup.find(created_group['id'])
@@ -61,6 +69,7 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
     expect(unit_group.project_id).to eq(p1.id)
     expect(unit_group.workflow_template_identifier).to eq(workflow_template.identifier)
     expect(unit_group.ce_event_type).to eq(14)
+    expect(unit_group.unit_type_id).to eq(unit_type.id)
   end
 
   context 'validation errors' do
@@ -89,6 +98,20 @@ RSpec.describe 'CreateUnitGroup Mutation', type: :request do
         errors = result.dig('data', 'createUnitGroup', 'errors')
         expect(errors).not_to be_empty
         expect(errors.first['fullMessage']).to eq('Name must be unique in the project')
+      end
+    end
+
+    context 'when unit type is missing' do
+      let(:input_without_unit_type) { base_input.deep_merge(input: { unitTypeId: nil }) }
+
+      it 'returns validation error' do
+        response, result = post_graphql(input_without_unit_type) { mutation }
+        expect(response.status).to eq(200), result.inspect
+
+        errors = result.dig('data', 'createUnitGroup', 'errors')
+        expect(errors).not_to be_empty
+        expect(errors.first['attribute']).to eq('unitTypeId')
+        expect(errors.first['type']).to eq('required')
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add Unit Type column to Unit Group
- Require Unit Type when creating a new Unit Group
- Add Rake task that:
  - Sets unit type on existing unit groups
  - Migrates units into unit groups

## Type of change
Data migration

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
