### PR TITLE
Update HUD Dependant Reports for FY2026 APR gender removal

### DIFF
--- a/app/controllers/hud_reports/base_controller.rb
+++ b/app/controllers/hud_reports/base_controller.rb
@@ -124,10 +124,7 @@ module HudReports
     # @return [Symbol] The default report version (:fy2024 or :fy2026)
     # Override as necessary in subclasses
     def default_report_version
-      return :fy2024 if Rails.env.production? && Date.current <= '2025-10-01'.to_date
-      return :fy2024 if (Rails.env.staging? || Rails.env.test? && Date.current <= '2025-09-01'.to_date) && ENV['CLIENT'] != 'qa'
-
-      :fy2026
+      "fy#{::GrdaWarehouse::Hud::Export.hud_csv_version}".to_sym
     end
 
     protected def filter_class

--- a/drivers/boston_project_scorecard/app/models/boston_project_scorecard/report.rb
+++ b/drivers/boston_project_scorecard/app/models/boston_project_scorecard/report.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module BostonProjectScorecard
   class Report < GrdaWarehouseBase
     include Rails.application.routes.url_helpers
@@ -229,9 +231,10 @@ module BostonProjectScorecard
         denominator = [3, 6, 15, 17].map { |row| answer_client_ids(apr, 'Q5a', 'B' + row.to_s) }.flatten.uniq.count
         total_income_and_housing_errors = (2..5).map { |row| answer_client_ids(apr, 'Q6c', 'B' + row.to_s) }.flatten.uniq.count
         percent_income_and_housing_errors = percentage(total_income_and_housing_errors / denominator.to_f)
+
         assessment_answers.merge!(
           {
-            pii_error_rate: percentage(answer(apr, 'Q6a', 'F7')),
+            pii_error_rate: percentage(answer(apr, 'Q6a', pii_error_cell)),
             ude_error_rate: percent_ude_errors,
             income_and_housing_error_rate: percent_income_and_housing_errors,
           },
@@ -264,6 +267,24 @@ module BostonProjectScorecard
       BostonProjectScorecard::ScorecardMailer.scorecard_complete(self).deliver_later
     end
 
+    def include_gender_data?
+      [
+        HudApr::Generators::Apr::Fy2020::Generator,
+        HudApr::Generators::Apr::Fy2021::Generator,
+        HudApr::Generators::Apr::Fy2023::Generator,
+        HudApr::Generators::Apr::Fy2024::Generator,
+      ].include?(apr_generator)
+    end
+
+    def pii_error_cell
+      # Gender data was removed from the APR in FY 2026, causing the total pii error percentage cell to shift in the APR.
+      include_gender_data? ? 'F7' : 'F6'
+    end
+
+    private def apr_generator
+      HudApr.current_generator(report: :apr)
+    end
+
     private def apr_report
       filter = ::Filters::HudFilterBase.new(user_id: user_id)
       if project_id.present?
@@ -291,7 +312,7 @@ module BostonProjectScorecard
         'Question 22',
         'Question 23',
       ]
-      generator = HudApr.current_generator(report: :apr)
+      generator = apr_generator
       apr = HudReports::ReportInstance.from_filter(filter, generator.title, build_for_questions: questions)
       generator.new(apr).run!(email: false, manual: false)
 
@@ -323,7 +344,7 @@ module BostonProjectScorecard
       questions = [
         'Question 22',
       ]
-      generator = HudApr.current_generator(report: :apr)
+      generator = apr_generator
       apr = HudReports::ReportInstance.from_filter(comparison_filter, generator.title, build_for_questions: questions)
       generator.new(apr).run!(email: false, manual: false)
 

--- a/drivers/boston_project_scorecard/app/views/boston_project_scorecard/warehouse_reports/scorecards/_data_quality.haml
+++ b/drivers/boston_project_scorecard/app/views/boston_project_scorecard/warehouse_reports/scorecards/_data_quality.haml
@@ -18,7 +18,7 @@
         = link_to_apr('Q6a:', 'Question 6')
         Data Quality: Personally Identifiable Information
         %hr
-        %small Q6a F7 * 100
+        %small= "Q6a #{@report.pii_error_cell} * 100"
       %td
         5 pts: 20%-0
         %br

--- a/drivers/hud_apr/app/models/hud_apr.rb
+++ b/drivers/hud_apr/app/models/hud_apr.rb
@@ -7,6 +7,8 @@
 # frozen_string_literal: true
 
 module HudApr
+  TodoOrDie('Set APR Default Generator on Staging to FY 2026 version', by: '2025-09-01')
+  TodoOrDie('Set APR Default Generator to the FY 2026 version', by: '2025-10-01')
   def self.current_generator(report:)
     case report
     when :caper

--- a/drivers/hud_apr/app/models/hud_apr.rb
+++ b/drivers/hud_apr/app/models/hud_apr.rb
@@ -7,16 +7,15 @@
 # frozen_string_literal: true
 
 module HudApr
-  TodoOrDie('Set APR Default Generator on Staging to FY 2026 version', by: '2025-09-01')
-  TodoOrDie('Set APR Default Generator to the FY 2026 version', by: '2025-10-01')
   def self.current_generator(report:)
+    version = ::HudReports::BaseController.new.default_report_version
     case report
     when :caper
-      HudApr::Generators::Caper::Fy2024::Generator
+      "HudApr::Generators::Caper::#{version.to_s.capitalize}::Generator".constantize
     when :apr
-      HudApr::Generators::Apr::Fy2024::Generator
+      "HudApr::Generators::Apr::#{version.to_s.capitalize}::Generator".constantize
     when :ce_apr
-      HudApr::Generators::CeApr::Fy2024::Generator
+      "HudApr::Generators::CeApr::#{version.to_s.capitalize}::Generator".constantize
     else
       raise
     end

--- a/drivers/project_pass_fail/app/models/project_pass_fail/client.rb
+++ b/drivers/project_pass_fail/app/models/project_pass_fail/client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module ProjectPassFail
   class Client < GrdaWarehouseBase
     self.table_name = :project_pass_fails_clients
@@ -23,7 +25,7 @@ module ProjectPassFail
     end
 
     def calculate_universal_data_elements(apr_client)
-      assign_attributes(
+      attributes = {
         client_id: apr_client.client_id,
         first_name: apr_client.first_name,
         last_name: apr_client.last_name,
@@ -43,7 +45,9 @@ module ProjectPassFail
         enrollment_created: apr_client.enrollment_created,
         enrollment_coc: apr_client.enrollment_coc,
         income_at_entry: apr_client.income_from_any_source_at_start,
-      )
+      }
+      attributes.delete('Gender') unless project_pass_fail.include_gender_data?
+      assign_attributes(attributes)
     end
 
     def calculate_time_to_enter
@@ -53,7 +57,7 @@ module ProjectPassFail
     end
 
     def self.detail_headers
-      {
+      headers = {
         first_name: 'First Name',
         last_name: 'Last Name',
         name_quality: 'Name Quality',
@@ -75,6 +79,8 @@ module ProjectPassFail
         days_served: 'Days Served',
         income_at_entry: 'Income at Entry',
       }
+      headers.delete('Gender') unless project_pass_fail.include_gender_data?
+      headers
     end
 
     def self.detail_headers_for_export

--- a/drivers/project_pass_fail/app/models/project_pass_fail/project.rb
+++ b/drivers/project_pass_fail/app/models/project_pass_fail/project.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module ProjectPassFail
   class Project < GrdaWarehouseBase
     self.table_name = :project_pass_fails_projects
@@ -64,24 +66,29 @@ module ProjectPassFail
         'Location' => location_error_rate,
         'Disabling Condition' => disabling_condition_error_rate,
       }
+      ude.delete('Gender') unless project_pass_fail.include_gender_data?
       ude['Income at Entry'] = income_at_entry_error_rate if GrdaWarehouse::Config.get(:pf_show_income)
       ude
     end
 
     def universal_data_element_table_cell(label)
-      @universal_data_element_table_cell ||= {
-        'Name' => ['Q6a', 'F2'],
-        'SSN' => ['Q6a', 'F3'],
-        'DOB' => ['Q6a', 'F4'],
-        'Race' => ['Q6a', 'F5'],
-        'Gender' => ['Q6a', 'F7'],
-        'Veteran' => ['Q6b', 'C2'],
-        'Entry Date' => ['Q6b', 'C3'],
-        'Relationship to HoH' => ['Q6b', 'C4'],
-        'Location' => ['Q6b', 'C5'],
-        'Disabling Condition' => ['Q6b', 'C6'],
-        'Income at Entry' => ['Q6c', 'C3'],
-      }
+      @universal_data_element_table_cell ||= begin
+        cells = {
+          'Name' => ['Q6a', 'F2'],
+          'SSN' => ['Q6a', 'F3'],
+          'DOB' => ['Q6a', 'F4'],
+          'Race' => ['Q6a', 'F5'],
+          'Gender' => ['Q6a', 'F7'],
+          'Veteran' => ['Q6b', 'C2'],
+          'Entry Date' => ['Q6b', 'C3'],
+          'Relationship to HoH' => ['Q6b', 'C4'],
+          'Location' => ['Q6b', 'C5'],
+          'Disabling Condition' => ['Q6b', 'C6'],
+          'Income at Entry' => ['Q6c', 'C3'],
+        }
+        cells.delete('Gender') unless project_pass_fail.include_gender_data?
+        cells
+      end
       @universal_data_element_table_cell[label]
     end
 
@@ -125,7 +132,7 @@ module ProjectPassFail
       self.ssn_error_rate = apr.answer(question: 'Q6a', cell: 'F3').summary.to_f
       self.dob_error_rate = apr.answer(question: 'Q6a', cell: 'F4').summary.to_f
       self.race_error_rate = apr.answer(question: 'Q6a', cell: 'F5').summary.to_f
-      self.gender_error_rate = apr.answer(question: 'Q6a', cell: 'F7').summary.to_f
+      self.gender_error_rate = apr.answer(question: 'Q6a', cell: 'F7').summary.to_f if project_pass_fail.include_gender_data?
       self.veteran_status_error_rate = apr.answer(question: 'Q6b', cell: 'C2').summary.to_f
       self.start_date_error_rate = apr.answer(question: 'Q6b', cell: 'C3').summary.to_f
       self.relationship_to_hoh_error_rate = apr.answer(question: 'Q6b', cell: 'C4').summary.to_f
@@ -137,7 +144,7 @@ module ProjectPassFail
       self.ssn_error_count = apr.answer(question: 'Q6a', cell: 'E3').summary.to_f
       self.dob_error_count = apr.answer(question: 'Q6a', cell: 'E4').summary.to_f
       self.race_error_count = apr.answer(question: 'Q6a', cell: 'E5').summary.to_f
-      self.gender_error_count = apr.answer(question: 'Q6a', cell: 'E7').summary.to_f
+      self.gender_error_count = apr.answer(question: 'Q6a', cell: 'E7').summary.to_f if project_pass_fail.include_gender_data?
       self.veteran_status_error_count = apr.answer(question: 'Q6b', cell: 'B2').summary.to_f
       self.start_date_error_count = apr.answer(question: 'Q6b', cell: 'B3').summary.to_f
       self.relationship_to_hoh_error_count = apr.answer(question: 'Q6b', cell: 'B4').summary.to_f

--- a/drivers/project_pass_fail/app/models/project_pass_fail/project_pass_fail.rb
+++ b/drivers/project_pass_fail/app/models/project_pass_fail/project_pass_fail.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module ProjectPassFail
   class ProjectPassFail < GrdaWarehouseBase
     self.table_name = :project_pass_fails
@@ -96,7 +98,7 @@ module ProjectPassFail
 
     # Data quality acceptable error rates
     def universal_data_element_threshold
-      value = (thresholds['universal_data_element_threshold'] || GrdaWarehouse::Config.get(:pf_universal_data_element_threshold))
+      value = thresholds['universal_data_element_threshold'] || GrdaWarehouse::Config.get(:pf_universal_data_element_threshold)
       value / 100.0
     end
 
@@ -110,6 +112,20 @@ module ProjectPassFail
     # Days allowed for entering entry assessments
     def timeliness_threshold
       thresholds['timeliness_threshold'] || GrdaWarehouse::Config.get(:pf_timeliness_threshold)
+    end
+
+    def include_gender_data?
+      # Gender data was removed from the APR in FY 2026
+      [
+        HudApr::Generators::Apr::Fy2020::Generator,
+        HudApr::Generators::Apr::Fy2021::Generator,
+        HudApr::Generators::Apr::Fy2023::Generator,
+        HudApr::Generators::Apr::Fy2024::Generator,
+      ].include?(apr_generator)
+    end
+
+    private def apr_generator
+      HudApr.current_generator(report: :apr)
     end
 
     private def calculate_utilization_rates
@@ -226,7 +242,7 @@ module ProjectPassFail
       questions = [
         'Question 6',
       ]
-      generator = HudApr.current_generator(report: :apr)
+      generator = apr_generator
       apr = HudReports::ReportInstance.from_filter(apr_filter, generator.title, build_for_questions: questions)
       generator.new(apr).run!(email: false, manual: false)
       apr

--- a/drivers/project_scorecard/app/models/project_scorecard/report.rb
+++ b/drivers/project_scorecard/app/models/project_scorecard/report.rb
@@ -232,20 +232,9 @@ module ProjectScorecard
           'Question 23',
           'Question 26',
         ]
-        generator = HudApr.current_generator(report: :apr)
+        generator = apr_generator
         apr = HudReports::ReportInstance.from_filter(filter, generator.title, build_for_questions: questions)
         generator.new(apr).run!(email: false, manual: false)
-
-        generators_using_gender_data = [
-          HudApr::Generators::Apr::Fy2020::Generator,
-          HudApr::Generators::Apr::Fy2021::Generator,
-          HudApr::Generators::Apr::Fy2023::Generator,
-          HudApr::Generators::Apr::Fy2024::Generator,
-        ]
-        include_gender_data = generators_using_gender_data.include?(generator)
-
-        # Gender data was removed from the APR in FY 2026, causing the total pii error percentage cell to shift in the APR.
-        percent_pii_errors_cell = include_gender_data ? 'F7' : 'F6'
 
         assessment_answers.merge!(
           {
@@ -266,7 +255,7 @@ module ProjectScorecard
 
             average_los_leavers: answer(apr, 'Q22b', 'B2'),
 
-            percent_pii_errors: answer(apr, 'Q6a', percent_pii_errors_cell).to_f * 100,
+            percent_pii_errors: answer(apr, 'Q6a', pii_error_cell).to_f * 100,
 
             days_to_lease_up: answer(apr, 'Q22c', 'B12'),
           },
@@ -337,6 +326,24 @@ module ProjectScorecard
 
     def send_email_to_owner
       ProjectScorecard::ScorecardMailer.scorecard_complete(self).deliver_later
+    end
+
+    def include_gender_data?
+      [
+        HudApr::Generators::Apr::Fy2020::Generator,
+        HudApr::Generators::Apr::Fy2021::Generator,
+        HudApr::Generators::Apr::Fy2023::Generator,
+        HudApr::Generators::Apr::Fy2024::Generator,
+      ].include?(apr_generator)
+    end
+
+    def pii_error_cell
+      # Gender data was removed from the APR in FY 2026, causing the total pii error percentage cell to shift in the APR.
+      include_gender_data? ? 'F7' : 'F6'
+    end
+
+    private def apr_generator
+      HudApr.current_generator(report: :apr)
     end
 
     private def spm_report(project_ids)

--- a/drivers/project_scorecard/app/models/project_scorecard/report.rb
+++ b/drivers/project_scorecard/app/models/project_scorecard/report.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module ProjectScorecard
   class Report < GrdaWarehouseBase
     include Rails.application.routes.url_helpers
@@ -234,6 +236,17 @@ module ProjectScorecard
         apr = HudReports::ReportInstance.from_filter(filter, generator.title, build_for_questions: questions)
         generator.new(apr).run!(email: false, manual: false)
 
+        generators_using_gender_data = [
+          HudApr::Generators::Apr::Fy2020::Generator,
+          HudApr::Generators::Apr::Fy2021::Generator,
+          HudApr::Generators::Apr::Fy2023::Generator,
+          HudApr::Generators::Apr::Fy2024::Generator,
+        ]
+        include_gender_data = generators_using_gender_data.include?(generator)
+
+        # Gender data was removed from the APR in FY 2026, causing the total pii error percentage cell to shift in the APR.
+        percent_pii_errors_cell = include_gender_data ? 'F7' : 'F6'
+
         assessment_answers.merge!(
           {
             apr_id: apr.id,
@@ -253,7 +266,7 @@ module ProjectScorecard
 
             average_los_leavers: answer(apr, 'Q22b', 'B2'),
 
-            percent_pii_errors: answer(apr, 'Q6a', 'F7').to_f * 100,
+            percent_pii_errors: answer(apr, 'Q6a', percent_pii_errors_cell).to_f * 100,
 
             days_to_lease_up: answer(apr, 'Q22c', 'B12'),
           },


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Update the HUD Dependant Reports (Boston Project Scorecard, Project Scorecard, & Project Pass/Fail) to account for the removal of gender data in the FY2026 APR report (Q6a). 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
