### PR TITLE
Log external request paylod as json

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -26,6 +26,10 @@
 #   }
 # }
 # aha_cred.save!
+#
+#
+# Investigating logs:
+#  HmisExternalApis::ExternalRequestLog.outgoing.url_like("scores").failed.where(requested_at: 3.days.ago..).count
 ###
 module HmisExternalApis::AcHmis
   class Aha

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_api_logger.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_api_logger.rb
@@ -13,7 +13,7 @@ module HmisExternalApis
         initiator: creds,
         url: url,
         http_method: method,
-        request: payload || {},
+        request: payload&.to_json || {},
         request_headers: headers,
         requested_at: Time.current,
         response: 'pending', # can't be null

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/oauth_credential_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/oauth_credential_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'webmock/rspec'
 
@@ -24,16 +26,16 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
       "refresh_token": fake_token,
       "scope": subject.scope,
     }.to_json
-    stub_request(:post, creds.token_url)
-      .to_return(status: 200, body: body,
-                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, creds.token_url).
+      to_return(status: 200, body: body,
+                headers: { 'Content-Type' => 'application/json' })
   end
 
   it 'supports a get' do
     path = '/test/resources/1'
-    stub_request(:get, "#{subject.base_url}#{path}")
-      .to_return(status: 200, body: { helloWorld: 1 }.to_json,
-                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "#{subject.base_url}#{path}").
+      to_return(status: 200, body: { helloWorld: 1 }.to_json,
+                headers: { 'Content-Type' => 'application/json' })
 
     result = subject.get(path)
     expect(result.http_status).to eq(200)
@@ -43,8 +45,8 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
 
   it 'handles errors' do
     path = '/test/resources/2'
-    stub_request(:get, "#{subject.base_url}#{path}")
-      .to_return(status: 404, body: nil, headers: {})
+    stub_request(:get, "#{subject.base_url}#{path}").
+      to_return(status: 404, body: nil, headers: {})
 
     result = subject.get(path)
     expect(result.http_status).to eq(404)
@@ -57,18 +59,21 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
   it 'supports a post' do
     path = '/test/resources'
     expected_status = 200
-    stub_request(:post, "#{subject.base_url}#{path}")
-      .to_return(status: expected_status, body: nil, headers: {})
+    stub_request(:post, "#{subject.base_url}#{path}").
+      to_return(status: expected_status, body: nil, headers: {})
     result = subject.post(path, { 'hello' => 'world' })
-    expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
+
     expect(result.http_status).to eq(expected_status)
+    request_logs = HmisExternalApis::ExternalRequestLog.where(initiator: creds)
+    expect(request_logs.count).to eq(1)
+    expect(request_logs.first.request).to eq({ 'hello' => 'world' }.to_json)
   end
 
   it 'supports a patch' do
     path = '/test/resources/1'
     expected_status = 200
-    stub_request(:patch, "#{subject.base_url}#{path}")
-      .to_return(status: expected_status, body: nil, headers: {})
+    stub_request(:patch, "#{subject.base_url}#{path}").
+      to_return(status: expected_status, body: nil, headers: {})
     result = subject.patch(path, { 'hello' => 'world' })
     expect(HmisExternalApis::ExternalRequestLog.where(initiator: creds).count).to eq(1)
     expect(result.http_status).to eq(expected_status)
@@ -83,9 +88,9 @@ RSpec.describe HmisExternalApis::OauthClientConnection, type: :model do
 
     it 'defers saving log records' do
       path = '/test/resources/1'
-      stub_request(:get, "#{subject.base_url}#{path}")
-        .to_return(status: 200, body: { helloWorld: 1 }.to_json,
-                   headers: { 'Content-Type' => 'application/json' })
+      stub_request(:get, "#{subject.base_url}#{path}").
+        to_return(status: 200, body: { helloWorld: 1 }.to_json,
+                  headers: { 'Content-Type' => 'application/json' })
 
       result = subject.get(path)
       expect(result.http_status).to eq(200)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Update External API Logger to log request body as json instead of stringified hash (`{:foo=>\"bar\"}`) to make it easier to parse for debugging (currently can parse with `eval` which is not ideal).


## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
