### PR TITLE
Change workflow engine assignment behavior

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
@@ -39,9 +39,8 @@ module Mutations
         # Remove existing participants that are not included in the input
         referral.participants.where.not(id: seen_participants.map(&:id)).each(&:destroy!)
 
-        # If the referral has any active steps, the engine should assign them out to their correct participants.
-        # (Existing assignments won't be deleted)
-        referral.workflow_engine.active_steps.each do |step|
+        # Reassign each active User Task based on updated referral participants
+        referral.workflow_engine.active_steps.joins(:user_task).each do |step|
           referral.workflow_engine.assign_task!(step)
         end
       end

--- a/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
+++ b/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
@@ -93,9 +93,16 @@ module Hmis::WorkflowExecution
     # TODO(#7080) When we add notifications, we may need to add notification from within this method,
     # even though it's called outside of process_triggers, so that users are notified of assignment.
     def assign_task!(step)
-      assignment_handler.call(step.node).each do |user|
+      # Get the new assignments from the handler
+      assigned_users = assignment_handler.call(step.node)
+
+      # Create or find assignments for new users
+      assigned_users.each do |user|
         step.assignments.find_or_create_by!(user: user)
       end
+
+      # Remove assignments for users that are no longer assigned
+      step.assignments.where.not(user: assigned_users).each(&:destroy!)
     end
 
     protected
@@ -163,7 +170,7 @@ module Hmis::WorkflowExecution
       case node
       when Hmis::WorkflowDefinition::UserTask
         step = enable_step!(node)
-        assign_task!(step)
+        assign_task!(step) # xx
         process_triggers(node: node, event_type: 'enable_step', user: user)
       when Hmis::WorkflowDefinition::ScriptTask
         step = enable_step!(node)

--- a/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
+++ b/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
@@ -46,7 +46,6 @@ module Hmis::WorkflowExecution
     end
 
     def start_step!(step, user:)
-      step.assignments.find_or_create_by!(user: user)
       step.started_at = Time.current
       step.start!
       # We don't populate the step's updated_by id here, because from the user's perspective, starting the step is just clicking a button, but not updating anything

--- a/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
+++ b/drivers/hmis/app/models/hmis/workflow_execution/engine.rb
@@ -169,7 +169,7 @@ module Hmis::WorkflowExecution
       case node
       when Hmis::WorkflowDefinition::UserTask
         step = enable_step!(node)
-        assign_task!(step) # xx
+        assign_task!(step)
         process_triggers(node: node, event_type: 'enable_step', user: user)
       when Hmis::WorkflowDefinition::ScriptTask
         step = enable_step!(node)

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -26,205 +26,231 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
 
   let!(:hmis_user2) { create(:hmis_user, data_source: ds1) }
 
-  describe 'assign participants mutation' do
-    let(:mutation) do
-      <<~GRAPHQL
-        mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
-          assignReferralParticipants(referralId: $referralId, participants: $participants) {
-            referral {
+  let(:mutation) do
+    <<~GRAPHQL
+      mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
+        assignReferralParticipants(referralId: $referralId, participants: $participants) {
+          referral {
+            id
+            swimlanes {
               id
-              swimlanes {
+              name
+              participants {
                 id
                 name
-                participants {
-                  id
-                  name
-                }
               }
-              steps {
+            }
+            steps {
+              id
+              stepId
+              name
+              status
+              swimlane
+              assignees {
                 id
-                stepId
                 name
-                status
-                swimlane
-                assignees {
-                  id
-                  name
-                }
               }
             }
           }
         }
-      GRAPHQL
+      }
+    GRAPHQL
+  end
+
+  let(:variables) do
+    {
+      referralId: referral.id,
+      participants: [
+        {
+          userId: hmis_user.id,
+          swimlaneId: case_manager_swimlane.id,
+        },
+        {
+          userId: hmis_user2.id,
+          swimlaneId: provider_swimlane.id,
+        },
+      ],
+    }
+  end
+
+  before do
+    referral.workflow_engine.start_workflow!(user: hmis_user)
+  end
+  let(:step) { referral.workflow_engine.active_steps.sole }
+
+  it 'creates referral participants' do
+    expect do
+      response, result = post_graphql(**variables) { mutation }
+      expect(response.status).to eq(200), result.inspect
+
+      referral_swimlanes = result.dig('data', 'assignReferralParticipants', 'referral', 'swimlanes')
+      expect(referral_swimlanes).to contain_exactly(
+        a_hash_including(
+          'id' => case_manager_swimlane.id.to_s,
+          'name' => case_manager_swimlane.name,
+          'participants' => [
+            a_hash_including(
+              'id' => hmis_user.id.to_s,
+              'name' => hmis_user.name,
+            ),
+          ],
+        ),
+        a_hash_including(
+          'id' => provider_swimlane.id.to_s,
+          'name' => provider_swimlane.name,
+          'participants' => [
+            a_hash_including(
+              'id' => hmis_user2.id.to_s,
+              'name' => hmis_user2.name,
+            ),
+          ],
+        ),
+      )
+    end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+  end
+
+  # describe 'referral with available task' do
+  it 'creates step assignments on active steps' do
+    expect do
+      response, result = post_graphql(**variables) { mutation }
+      expect(response.status).to eq(200), result.inspect
+      step.reload
+    end.to change(step.assignments, :count).from(0).to(1).
+      and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
+    expect(step.assignments.sole.user).to eq(hmis_user)
+  end
+
+  context 'when active step is already assigned' do
+    let!(:assignment) { step.assignments.create(user: hmis_user) }
+
+    it 'does not try to create duplicate assignees' do
+      expect do
+        response, result = post_graphql(**variables) { mutation }
+        expect(response.status).to eq(200), result.inspect
+        step.reload
+      end.to not_change(step.assignments, :count).from(1)
+      expect(step.assignments.sole.user).to eq(hmis_user)
+    end
+  end
+
+  context 'when active step is already assigned to a different user' do
+    let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
+
+    it 'removes old assignee and assigns new user' do
+      expect do
+        response, result = post_graphql(**variables) { mutation }
+        expect(response.status).to eq(200), result.inspect
+        step.reload
+      end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
+
+      expect(other_user_assignment.reload).to be_deleted
+    end
+    context 'when step is completed' do
+      before(:each) do
+        step.start!
+        step.complete!
+      end
+      it 'does not remove old assignee' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+          step.reload
+        end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
+
+        expect(other_user_assignment.reload).not_to be_deleted
+      end
+    end
+  end
+
+  describe 'referral with existing participant' do
+    let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
+
+    it 'does not create duplicate participants' do
+      expect do
+        response, result = post_graphql(**variables) { mutation }
+        expect(response.status).to eq(200), result.inspect
+        existing_participant.reload
+      end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
+        and not_change(existing_participant, :updated_at)
     end
 
+    context 'with input that indicates deletion of a participant' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [],
+        }
+      end
+
+      it 'deletes removed participants' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
+      end
+    end
+  end
+
+  context 'with invalid user' do
+    let(:variables) do
+      {
+        referralId: referral.id,
+        participants: [
+          {
+            userId: 'abc',
+            swimlaneId: case_manager_swimlane.id,
+          },
+        ],
+      }
+    end
+
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+    end
+  end
+
+  context 'with invalid swimlane' do
     let(:variables) do
       {
         referralId: referral.id,
         participants: [
           {
             userId: hmis_user.id,
-            swimlaneId: case_manager_swimlane.id,
-          },
-          {
-            userId: hmis_user2.id,
-            swimlaneId: provider_swimlane.id,
+            swimlaneId: 'xyz',
           },
         ],
       }
     end
 
-    it 'creates referral participants' do
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+    end
+  end
+
+  context 'with no permission' do
+    let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
+    end
+  end
+
+  context 'when the assigned user does not have permission' do
+    let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+    end
+  end
+
+  context 'when the assigned user has permission to do their own tasks' do
+    let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
+
+    it 'successfully creates participants' do
       expect do
         response, result = post_graphql(**variables) { mutation }
         expect(response.status).to eq(200), result.inspect
-
-        referral_swimlanes = result.dig('data', 'assignReferralParticipants', 'referral', 'swimlanes')
-        expect(referral_swimlanes).to contain_exactly(
-          a_hash_including(
-            'id' => case_manager_swimlane.id.to_s,
-            'name' => case_manager_swimlane.name,
-            'participants' => [
-              a_hash_including(
-                'id' => hmis_user.id.to_s,
-                'name' => hmis_user.name,
-              ),
-            ],
-          ),
-          a_hash_including(
-            'id' => provider_swimlane.id.to_s,
-            'name' => provider_swimlane.name,
-            'participants' => [
-              a_hash_including(
-                'id' => hmis_user2.id.to_s,
-                'name' => hmis_user2.name,
-              ),
-            ],
-          ),
-        )
       end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-    end
-
-    describe 'referral with available task' do
-      before do
-        referral.workflow_engine.start_workflow!(user: hmis_user)
-      end
-
-      it 'creates assignees as well as participants' do
-        step = referral.workflow_engine.active_steps.sole
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          step.reload
-        end.to change(step.assignments, :count).from(0).to(1)
-        expect(step.assignments.sole.user).to eq(hmis_user)
-      end
-
-      context 'with existing assignee' do
-        let!(:assignment) { referral.workflow_engine.active_steps.sole.assignments.create(user: hmis_user) }
-
-        it 'does not try to create duplicate assignees' do
-          step = referral.workflow_engine.active_steps.sole
-          expect do
-            response, result = post_graphql(**variables) { mutation }
-            expect(response.status).to eq(200), result.inspect
-            step.reload
-          end.to not_change(step.assignments, :count).from(1)
-          expect(step.assignments.sole.user).to eq(hmis_user)
-        end
-      end
-    end
-
-    describe 'referral with existing participant' do
-      let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
-
-      it 'does not create duplicate participants' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          existing_participant.reload
-        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
-          and not_change(existing_participant, :updated_at)
-      end
-
-      context 'with input that indicates deletion of a participant' do
-        let(:variables) do
-          {
-            referralId: referral.id,
-            participants: [],
-          }
-        end
-
-        it 'deletes removed participants' do
-          expect do
-            response, result = post_graphql(**variables) { mutation }
-            expect(response.status).to eq(200), result.inspect
-          end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
-        end
-      end
-    end
-
-    context 'with invalid user' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [
-            {
-              userId: 'abc',
-              swimlaneId: case_manager_swimlane.id,
-            },
-          ],
-        }
-      end
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'with invalid swimlane' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [
-            {
-              userId: hmis_user.id,
-              swimlaneId: 'xyz',
-            },
-          ],
-        }
-      end
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'with no permission' do
-      let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
-      end
-    end
-
-    context 'when the assigned user does not have permission' do
-      let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'when the assigned user has permission to do their own tasks' do
-      let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
-
-      it 'successfully creates participants' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-        end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-      end
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
       end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
     end
 
-    # describe 'referral with available task' do
     it 'creates step assignments on active steps' do
       expect do
         response, result = post_graphql(**variables) { mutation }

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -26,231 +26,233 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
 
   let!(:hmis_user2) { create(:hmis_user, data_source: ds1) }
 
-  let(:mutation) do
-    <<~GRAPHQL
-      mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
-        assignReferralParticipants(referralId: $referralId, participants: $participants) {
-          referral {
-            id
-            swimlanes {
+  describe 'assign participants mutation' do
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
+          assignReferralParticipants(referralId: $referralId, participants: $participants) {
+            referral {
               id
-              name
-              participants {
+              swimlanes {
                 id
                 name
+                participants {
+                  id
+                  name
+                }
               }
-            }
-            steps {
-              id
-              stepId
-              name
-              status
-              swimlane
-              assignees {
+              steps {
                 id
+                stepId
                 name
+                status
+                swimlane
+                assignees {
+                  id
+                  name
+                }
               }
             }
           }
         }
-      }
-    GRAPHQL
-  end
-
-  let(:variables) do
-    {
-      referralId: referral.id,
-      participants: [
-        {
-          userId: hmis_user.id,
-          swimlaneId: case_manager_swimlane.id,
-        },
-        {
-          userId: hmis_user2.id,
-          swimlaneId: provider_swimlane.id,
-        },
-      ],
-    }
-  end
-
-  before do
-    referral.workflow_engine.start_workflow!(user: hmis_user)
-  end
-  let(:step) { referral.workflow_engine.active_steps.sole }
-
-  it 'creates referral participants' do
-    expect do
-      response, result = post_graphql(**variables) { mutation }
-      expect(response.status).to eq(200), result.inspect
-
-      referral_swimlanes = result.dig('data', 'assignReferralParticipants', 'referral', 'swimlanes')
-      expect(referral_swimlanes).to contain_exactly(
-        a_hash_including(
-          'id' => case_manager_swimlane.id.to_s,
-          'name' => case_manager_swimlane.name,
-          'participants' => [
-            a_hash_including(
-              'id' => hmis_user.id.to_s,
-              'name' => hmis_user.name,
-            ),
-          ],
-        ),
-        a_hash_including(
-          'id' => provider_swimlane.id.to_s,
-          'name' => provider_swimlane.name,
-          'participants' => [
-            a_hash_including(
-              'id' => hmis_user2.id.to_s,
-              'name' => hmis_user2.name,
-            ),
-          ],
-        ),
-      )
-    end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-  end
-
-  # describe 'referral with available task' do
-  it 'creates step assignments on active steps' do
-    expect do
-      response, result = post_graphql(**variables) { mutation }
-      expect(response.status).to eq(200), result.inspect
-      step.reload
-    end.to change(step.assignments, :count).from(0).to(1).
-      and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
-    expect(step.assignments.sole.user).to eq(hmis_user)
-  end
-
-  context 'when active step is already assigned' do
-    let!(:assignment) { step.assignments.create(user: hmis_user) }
-
-    it 'does not try to create duplicate assignees' do
-      expect do
-        response, result = post_graphql(**variables) { mutation }
-        expect(response.status).to eq(200), result.inspect
-        step.reload
-      end.to not_change(step.assignments, :count).from(1)
-      expect(step.assignments.sole.user).to eq(hmis_user)
-    end
-  end
-
-  context 'when active step is already assigned to a different user' do
-    let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
-
-    it 'removes old assignee and assigns new user' do
-      expect do
-        response, result = post_graphql(**variables) { mutation }
-        expect(response.status).to eq(200), result.inspect
-        step.reload
-      end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
-
-      expect(other_user_assignment.reload).to be_deleted
-    end
-    context 'when step is completed' do
-      before(:each) do
-        step.start!
-        step.complete!
-      end
-      it 'does not remove old assignee' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          step.reload
-        end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
-
-        expect(other_user_assignment.reload).not_to be_deleted
-      end
-    end
-  end
-
-  describe 'referral with existing participant' do
-    let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
-
-    it 'does not create duplicate participants' do
-      expect do
-        response, result = post_graphql(**variables) { mutation }
-        expect(response.status).to eq(200), result.inspect
-        existing_participant.reload
-      end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
-        and not_change(existing_participant, :updated_at)
+      GRAPHQL
     end
 
-    context 'with input that indicates deletion of a participant' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [],
-        }
-      end
-
-      it 'deletes removed participants' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
-      end
-    end
-  end
-
-  context 'with invalid user' do
-    let(:variables) do
-      {
-        referralId: referral.id,
-        participants: [
-          {
-            userId: 'abc',
-            swimlaneId: case_manager_swimlane.id,
-          },
-        ],
-      }
-    end
-
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-    end
-  end
-
-  context 'with invalid swimlane' do
     let(:variables) do
       {
         referralId: referral.id,
         participants: [
           {
             userId: hmis_user.id,
-            swimlaneId: 'xyz',
+            swimlaneId: case_manager_swimlane.id,
+          },
+          {
+            userId: hmis_user2.id,
+            swimlaneId: provider_swimlane.id,
           },
         ],
       }
     end
 
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+    before do
+      referral.workflow_engine.start_workflow!(user: hmis_user)
     end
-  end
+    let(:step) { referral.workflow_engine.active_steps.sole }
 
-  context 'with no permission' do
-    let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
-    end
-  end
-
-  context 'when the assigned user does not have permission' do
-    let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-    end
-  end
-
-  context 'when the assigned user has permission to do their own tasks' do
-    let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
-
-    it 'successfully creates participants' do
+    it 'creates referral participants' do
       expect do
         response, result = post_graphql(**variables) { mutation }
         expect(response.status).to eq(200), result.inspect
+
+        referral_swimlanes = result.dig('data', 'assignReferralParticipants', 'referral', 'swimlanes')
+        expect(referral_swimlanes).to contain_exactly(
+          a_hash_including(
+            'id' => case_manager_swimlane.id.to_s,
+            'name' => case_manager_swimlane.name,
+            'participants' => [
+              a_hash_including(
+                'id' => hmis_user.id.to_s,
+                'name' => hmis_user.name,
+              ),
+            ],
+          ),
+          a_hash_including(
+            'id' => provider_swimlane.id.to_s,
+            'name' => provider_swimlane.name,
+            'participants' => [
+              a_hash_including(
+                'id' => hmis_user2.id.to_s,
+                'name' => hmis_user2.name,
+              ),
+            ],
+          ),
+        )
       end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+    end
+
+    # describe 'referral with available task' do
+    it 'creates step assignments on active steps' do
+      expect do
+        response, result = post_graphql(**variables) { mutation }
+        expect(response.status).to eq(200), result.inspect
+        step.reload
+      end.to change(step.assignments, :count).from(0).to(1).
+        and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
+      expect(step.assignments.sole.user).to eq(hmis_user)
+    end
+
+    context 'when active step is already assigned' do
+      let!(:assignment) { step.assignments.create(user: hmis_user) }
+
+      it 'does not try to create duplicate assignees' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+          step.reload
+        end.to not_change(step.assignments, :count).from(1)
+        expect(step.assignments.sole.user).to eq(hmis_user)
+      end
+    end
+
+    context 'when active step is already assigned to a different user' do
+      let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
+
+      it 'removes old assignee and assigns new user' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+          step.reload
+        end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
+
+        expect(other_user_assignment.reload).to be_deleted
+      end
+      context 'when step is completed' do
+        before(:each) do
+          step.start!
+          step.complete!
+        end
+        it 'does not remove old assignee' do
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+            step.reload
+          end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
+
+          expect(other_user_assignment.reload).not_to be_deleted
+        end
+      end
+    end
+
+    describe 'referral with existing participant' do
+      let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
+
+      it 'does not create duplicate participants' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+          existing_participant.reload
+        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
+          and not_change(existing_participant, :updated_at)
+      end
+
+      context 'with input that indicates deletion of a participant' do
+        let(:variables) do
+          {
+            referralId: referral.id,
+            participants: [],
+          }
+        end
+
+        it 'deletes removed participants' do
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+          end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
+        end
+      end
+    end
+
+    context 'with invalid user' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [
+            {
+              userId: 'abc',
+              swimlaneId: case_manager_swimlane.id,
+            },
+          ],
+        }
+      end
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+      end
+    end
+
+    context 'with invalid swimlane' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [
+            {
+              userId: hmis_user.id,
+              swimlaneId: 'xyz',
+            },
+          ],
+        }
+      end
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+      end
+    end
+
+    context 'with no permission' do
+      let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
+      end
+    end
+
+    context 'when the assigned user does not have permission' do
+      let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
+      end
+    end
+
+    context 'when the assigned user has permission to do their own tasks' do
+      let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
+
+      it 'successfully creates participants' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+        end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+      end
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb
@@ -126,16 +126,14 @@ RSpec.describe Mutations::Ce::StartCeReferralStep, type: :request do
           expect(step_data['status']).to eq('in_progress')
           expect(step_data['name']).to eq('Client Acceptance')
           expect(step_data.dig('swimlane')).to eq(swimlane.name)
-          expect(step_data['assignees']).to contain_exactly(
-            a_hash_including('id' => hmis_user.id.to_s, 'name' => hmis_user.name),
-          )
+          expect(step_data['assignees']).to be_empty
           expect(step_data['formDefinition']['id']).to eq(client_acceptance_task.form_definitions.sole.id.to_s)
 
           step.reload
         end.to change(step, :status).to('in_progress').
           and change(step, :started_at).from(nil).
           and change(Hmis::WorkflowExecution::AuditEvent, :count).by(1).
-          and change(step.assignments, :count).by(1)
+          and change(step.assignments, :count).by(0)
 
         audit_event = Hmis::WorkflowExecution::AuditEvent.last
         expect(audit_event.event_type).to eq('start_step')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Issue: https://github.com/open-path/Green-River/issues/8153


Two changes:
1. **Clean Assignment Updates**: When changing step assignments, previous assignments are now removed from active steps instead of accumulating (old behavior left assignments with no removal mechanism). Note, this does not affect completed steps.
2. **Remove Auto-Assignment**: Steps no longer auto-assign to the user who starts them.


Why/notes:
- Assignments = notifications: Admins don't need to notify themselves when they start/complete tasks
- Audit trail preserved: User who started the step is still recorded in Hmis::WorkflowExecution::AuditEvent start_step events

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
