### PR TITLE
Update SimpleStateMachine to raise on failed transition

### DIFF
--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -39,7 +39,7 @@ module SimpleStateMachine
 
           # Find a valid transition
           transition_to = transition_map[current_state]
-          return false unless transition_to
+          raise ArgumentError, "Invalid transition: cannot perform transition '#{event_name}' from state '#{current_state}'" unless transition_to
 
           self[ssm_column] = transition_to
           save!

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     workflow_instance { association :hmis_workflow_execution_instance, template: workflow_template }
     client { association :hmis_hud_client, data_source: data_source }
     referred_by { association :hmis_user, data_source: data_source }
-    status { 'in_progress' }
+    status { 'initialized' }
     referral_origin { Hmis::Ce::Referral::WAITLIST_ORIGIN }
 
     after(:create) do |referral|

--- a/drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb
@@ -49,15 +49,21 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
       client_acceptance = engine.active_steps.sole
       engine.start_step!(client_acceptance, user: hmis_user)
       engine.complete_step!(client_acceptance, user: hmis_user, submitted_values: {})
+      # Start the next step, which will be referenced as 'current_step' in tests
+      next_step = engine.active_steps.sole
+      engine.start_step!(next_step, user: hmis_user)
     end
+
+    # step that creates an enrollment
+    let(:current_step) { engine.active_steps.sole }
 
     it 'creates an enrollment and associates it with the referral' do
       expect do
-        current_step = engine.active_steps.sole
         engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
         referral.reload
       end.to change(Hmis::Hud::Enrollment, :count).by(1).
-        and change(referral, :target_enrollment).from(nil)
+        and change(referral, :target_enrollment).from(nil).
+        and change(current_step, :status).to('completed')
 
       enrollment = referral.target_enrollment
       expect(enrollment.project).to eq(project)
@@ -70,7 +76,7 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
       let!(:auto_enter_config) { create :hmis_project_auto_enter_config, project: project }
 
       it 'creates an enrollment that is not WIP' do
-        engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: {})
+        engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
         referral.reload
         expect(referral.target_enrollment.in_progress?).to be_falsey
       end
@@ -81,7 +87,7 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
 
       it 'raises an error and does not save the enrollment' do
         expect do
-          engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: {})
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
         end.to raise_error(HmisErrors::ApiError, /Client has another enrollment in this project/).
           and not_change(Hmis::Hud::Enrollment, :count)
       end
@@ -94,7 +100,7 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
 
       it 'fails to create enrollment' do
         expect do
-          engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: {})
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
         end.to raise_error(RuntimeError, /CoC Code required/).
           and not_change(Hmis::Hud::Enrollment, :count)
       end
@@ -105,14 +111,14 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
 
       it 'requires CoC input' do
         expect do
-          engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: {})
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
         end.to raise_error(RuntimeError, /CoC Code required/).
           and not_change(Hmis::Hud::Enrollment, :count)
       end
 
       it 'succeeds when CoC input is provided' do
         expect do
-          engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: { Hmis::Ce::ReferralEnroller::COC_CODE_LINK_ID => 'CO-600' })
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: { Hmis::Ce::ReferralEnroller::COC_CODE_LINK_ID => 'CO-600' })
           referral.reload
         end.to change(Hmis::Hud::Enrollment, :count).by(1)
 
@@ -129,7 +135,7 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
 
       it 'marks the unit as occupied' do
         expect do
-          engine.complete_step!(engine.active_steps.sole, user: hmis_user, submitted_values: {})
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: {})
           referral.reload
           unit.reload
         end.to change(referral, :target_enrollment).from(nil).
@@ -189,12 +195,12 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
       it 'assigns the move-in date attribute on the enrollment' do
         move_in_date = 2.weeks.ago.to_date
         expect do
-          current_step = engine.active_steps.sole
           current_step.form_definition = move_in_date_form_def # this is set in the mutation, not the engine complete_step!
           engine.complete_step!(current_step, user: hmis_user, submitted_values: { move_in_date_link_id => move_in_date })
           referral.reload
         end.to change(Hmis::Hud::Enrollment, :count).by(1).
-          and change(referral, :target_enrollment).from(nil)
+          and change(referral, :target_enrollment).from(nil).
+          and change(current_step, :status).to('completed')
 
         expect(referral.target_enrollment.move_in_date).to eq(move_in_date)
       end
@@ -219,7 +225,6 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
         context 'if enrollment does not exist' do
           it 'raises an exception, indicating a workflow configuration issue' do
             expect do
-              current_step = engine.active_steps.sole
               current_step.form_definition = move_in_date_form_def
               engine.complete_step!(current_step, user: hmis_user, submitted_values: { move_in_date_link_id => 2.weeks.ago.to_date })
               referral.reload
@@ -231,7 +236,6 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
         context 'the move-in date value is not parseable' do
           it 'raises an exception' do
             expect do
-              current_step = engine.active_steps.sole
               current_step.form_definition = move_in_date_form_def
               engine.complete_step!(current_step, user: hmis_user, submitted_values: { move_in_date_link_id => 'bad string' })
             end.to raise_error(RuntimeError, /Failed to parse/).

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         }
       end
 
-      let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1) }
+      let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, status: :in_progress) }
       let!(:in_progress_referral) { create(:hmis_ce_referral, status: :in_progress, project: project, data_source: ds1) }
       let!(:accepted_referral) { create(:hmis_ce_referral, status: :accepted, project: project, data_source: ds1) }
       let!(:rejected_referral) { create(:hmis_ce_referral, status: :rejected, project: project, data_source: ds1) }

--- a/spec/models/simple_state_machine_spec.rb
+++ b/spec/models/simple_state_machine_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe SimpleStateMachine do
       expect { record.close! }.to change { record.status }.from('locked').to('closed')
     end
 
-    it 'returns false for invalid transitions' do
+    it 'raises an error for invalid transitions' do
       record.close!
       expect(record.closed?).to be true
-      expect(record.reserve!).to be false
-      expect(record.release!).to be false
+      expect { record.reserve! }.to raise_error(ArgumentError, /Invalid transition/)
+      expect { record.release! }.to raise_error(ArgumentError, /Invalid transition/)
     end
 
     it 'handles multiple from states and persists changes' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Propose updating SimpleStateMachine to raise on a failed transition instead of returning false. The `Hmis::WorkflowExecution::Engine` does not check for the return value when updating step states, so it's possible there are silent failures happening. I ran into this when working on a test.



Previous behavior for execution engine:
```ruby
step.enable!
step.complete! # returns false, step.start! should have been called first
```
New behavior
```ruby
step.enable!
step.complete! # raises an error instead of returning false
```

## Type of change
bug fix / feature change

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
