### PR TITLE
Call new params on external API

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -43,9 +43,11 @@ module HmisExternalApis::AcHmis
 
       return nil if mci_uniq_ids.empty?
 
-      payload = {
-        'dw_client_id': mci_uniq_ids.join(','),
-      }
+      payload = if mci_uniq_ids.size > 1
+        { 'dw_client_id__dw_client_id__overlap': mci_uniq_ids.join(',') }
+      else
+        { 'dw_client_id__dw_client_id__includes': mci_uniq_ids.first }
+      end
 
       result = conn.post('api/v1/clients/scores/search/', payload).
         then { |r| handle_error(r) }
@@ -63,7 +65,7 @@ module HmisExternalApis::AcHmis
           OpenStruct.new(
             score: score_value.to_i,
             mci_quality_indicator: score_obj.dig('metadata', 'alt_aha_flag')&.to_i,
-            dw_client_id: response_client.dig('dw_client_id'),
+            dw_client_id: Array.wrap(response_client.dig('dw_client_id') || response_client.dig('dw_client_id_dw_client_id'))&.first,
             generator: score_obj.dig('generator'),
           )
         end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         },
       )
 
-      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id': mci_unique_id.value }).and_return(mock_response)
+      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id__dw_client_id__includes': mci_unique_id.value }).and_return(mock_response)
     end
 
     it 'calls API with single MCI ID' do
@@ -109,7 +109,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         },
       )
 
-      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id': "#{mci_unique_id1.value},#{mci_unique_id2.value}" }).and_return(mock_response)
+      expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { 'dw_client_id__dw_client_id__overlap': "#{mci_unique_id1.value},#{mci_unique_id2.value}" }).and_return(mock_response)
     end
 
     it 'calls API with comma-separated list of all sibling MCI IDs' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Update client to call new params on API which recently changed. Tested updated api in postman

Issue:  https://github.com/open-path/Green-River/issues/7766

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

