### PR TITLE
FY26 label change (non-breaking change)

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -10181,7 +10181,7 @@ enum Race {
   DATA_NOT_COLLECTED
 
   """
-  (HispanicLatinaeo) Hispanic/Latina/e/o
+  (HispanicLatinaeo) Hispanic/Latina/o
   """
   HISPANIC_LATINAEO
 

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -317,10 +317,10 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   # fix these so they use DATA_NOT_COLLECTED And the other standard names
-  use_enum(:gender_enum_map, ::HudUtility2024.genders) do |hash|
+  use_enum(:gender_enum_map, ::HudUtility2026.genders) do |hash|
     hash.map do |value, desc|
       {
-        key: [8, 9, 99].include?(value) ? desc : ::HudUtility2024.gender_id_to_field_name[value],
+        key: [8, 9, 99].include?(value) ? desc : ::HudUtility2026.gender_id_to_field_name[value],
         value: value,
         desc: desc,
         null: [8, 9, 99].include?(value),
@@ -328,7 +328,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     end
   end
 
-  use_enum(:race_enum_map, ::HudUtility2024.races.except('RaceNone'), include_base_null: true) do |hash|
+  use_enum(:race_enum_map, ::HudUtility2026.races.except('RaceNone'), include_base_null: true) do |hash|
     hash.map do |value, desc|
       {
         key: value,

--- a/lib/data/2026_hud_lists.json
+++ b/lib/data/2026_hud_lists.json
@@ -5533,7 +5533,7 @@
       },
       {
         "key": "HispanicLatinaeo",
-        "description": "Hispanic/Latina/e/o"
+        "description": "Hispanic/Latina/o"
       },
       {
         "key": "MidEastNAfrican",

--- a/lib/util/concerns/hud_lists_2026.rb
+++ b/lib/util/concerns/hud_lists_2026.rb
@@ -2595,7 +2595,7 @@ module Concerns::HudLists2026
         'AmIndAKNative' => 'American Indian, Alaska Native, or Indigenous',
         'Asian' => 'Asian or Asian American',
         'BlackAfAmerican' => 'Black, African American, or African',
-        'HispanicLatinaeo' => 'Hispanic/Latina/e/o',
+        'HispanicLatinaeo' => 'Hispanic/Latina/o',
         'MidEastNAfrican' => 'Middle Eastern or North African',
         'NativeHIPacific' => 'Native Hawaiian or Pacific Islander',
         'White' => 'White',


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Can be re-targeted to 179

Update label for race/ethnicity value, HUD HMIS 2026 spec change

Frontend PR that picks up the change: https://github.com/greenriver/hmis-frontend/pull/1250

## Type of change
hud compliance

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
