### PR TITLE
Reference HudUtility2026 in hmis

### DIFF
--- a/drivers/hmis/app/graphql/types/ac_hmis/mci_clearance_input.rb
+++ b/drivers/hmis/app/graphql/types/ac_hmis/mci_clearance_input.rb
@@ -22,7 +22,8 @@ module Types
       Hmis::Hud::Client.new(
         **attributes,
         **Hmis::Hud::Processors::ClientProcessor.gender_attributes(genders),
-        **HudUtility2024.races.keys.map { |k| [k, 99] }.to_h,
+        # *confirm keys not changing
+        **HudUtility2026.races.keys.map { |k| [k, 99] }.to_h,
         name_data_quality: 1,
         dob_data_quality: 1,
         ssn_data_quality: attributes[:ssn].present? ? 1 : 99,

--- a/drivers/hmis/app/graphql/types/base_audit_event.rb
+++ b/drivers/hmis/app/graphql/types/base_audit_event.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Types
   class BaseAuditEvent < BaseObject
     def self.build(node_class, excluded_keys: nil, transform_changes: nil)
@@ -78,14 +80,14 @@ module Types
 
         'Contact Information'
       when 'Hmis::Hud::Disability'
-        HudUtility2024.disability_type(item_attributes['DisabilityType']) || 'Disability'
+        HudUtility2026.disability_type(item_attributes['DisabilityType']) || 'Disability'
       when 'Hmis::Hud::CustomDataElement'
         # Try to label Custom Data Elements based on their definition label
         definition_id = item_attributes['data_element_definition_id']
         custom_data_element_labels_by_id[definition_id] || 'Custom Data Element'
       when 'Hmis::Hud::CustomAssessment'
         # Label Assessment by name (eg "Exit Assessment")
-        HudUtility2024.assessment_name_by_data_collection_stage[item_attributes['DataCollectionStage']] ||
+        HudUtility2026.assessment_name_by_data_collection_stage[item_attributes['DataCollectionStage']] ||
           custom_assessment_title ||
           'Assessment'
       else

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -50,7 +50,7 @@ module Types
           # TODO: replace with call to HudUtility once project type groupings are moved there.
           # FIXME: internally our definition of "residential" includes 4 (SO) and 9 (OPH) which
           # are not valid for Residential project affiliations.
-          where(project_type: HudUtility2024.residential_project_type_ids).
+          where(project_type: HudUtility2026.residential_project_type_ids).
           preload(:organization).
           sort_by_option(:organization_and_name).
           map(&:to_pick_list_option)
@@ -165,7 +165,7 @@ module Types
           map(&:to_pick_list_option)
       when 'OTHER_FUNDERS'
         Hmis::Hud::Funder.where(data_source_id: user.hmis_data_source_id).
-          where(Funder: HudUtility2024.local_or_other_funding_source).where.not(OtherFunder: nil).
+          where(Funder: HudUtility2026.local_or_other_funding_source).where.not(OtherFunder: nil).
           pluck(:OtherFunder).uniq.sort.map do |other_funder|
             { code: other_funder, label: other_funder }
           end
@@ -322,9 +322,9 @@ module Types
 
     def self.coc_picklist(selected_project)
       available_codes = if selected_project.present?
-        selected_project.project_cocs.pluck(:CoCCode).uniq.map { |code| [code, ::HudUtility2024.cocs[code] || code] }
+        selected_project.project_cocs.pluck(:CoCCode).uniq.map { |code| [code, ::HudUtility2026.cocs[code] || code] }
       else
-        ::HudUtility2024.cocs_in_state(GrdaWarehouse::Config.relevant_state_codes)
+        ::HudUtility2026.cocs_in_state(GrdaWarehouse::Config.relevant_state_codes)
       end
 
       available_codes.sort.map do |code, name|
@@ -451,16 +451,16 @@ module Types
       end
 
       [
-        [HudUtility2024::SITUATION_HOMELESS_RANGE, :HOMELESS, 'Homeless Situations'],
-        [HudUtility2024::SITUATION_INSTITUTIONAL_RANGE, :INSTITUTIONAL, 'Institutional Situations'],
-        [HudUtility2024::SITUATION_TEMPORARY_RANGE, :TEMPORARY, 'Temporary Housing Situations'],
-        [HudUtility2024::SITUATION_PERMANENT_RANGE, :PERMANENT, 'Permanent Housing Situations'],
-        [HudUtility2024::SITUATION_OTHER_RANGE, :OTHER, 'Other'],
+        [HudUtility2026::SITUATION_HOMELESS_RANGE, :HOMELESS, 'Homeless Situations'],
+        [HudUtility2026::SITUATION_INSTITUTIONAL_RANGE, :INSTITUTIONAL, 'Institutional Situations'],
+        [HudUtility2026::SITUATION_TEMPORARY_RANGE, :TEMPORARY, 'Temporary Housing Situations'],
+        [HudUtility2026::SITUATION_PERMANENT_RANGE, :PERMANENT, 'Permanent Housing Situations'],
+        [HudUtility2026::SITUATION_OTHER_RANGE, :OTHER, 'Other'],
       ].map do |range, group_code, group_label|
         enum_value_definitions.select { |e| range.include? e.value }.map do |enum|
           {
             code: enum.graphql_name,
-            label: ::HudUtility2024.living_situation(enum.value),
+            label: ::HudUtility2026.living_situation(enum.value),
             group_code: group_code,
             group_label: group_label,
           }

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -255,7 +255,8 @@ module Types
     end
 
     def race
-      selected_races = ::HudUtility2024.races.except('RaceNone').keys.select { |f| object.send(f).to_i == 1 }
+      # *this would be breaking if HudUtility2026.races.keys are changing but confirm theyre not?
+      selected_races = ::HudUtility2026.races.except('RaceNone').keys.select { |f| object.send(f).to_i == 1 }
       selected_races << object.RaceNone if object.RaceNone && selected_races.empty?
       selected_races
     end
@@ -364,13 +365,13 @@ module Types
       # Check if there's an open enrollment at a residential project with a move in date that has occurred
       today = Date.current
       client_is_housed = open_enrollments.any? do |enrollment|
-        enrollment.project.project_type.in?(HudUtility2024.permanent_housing_project_types) && (enrollment.move_in_date&.<= today)
+        enrollment.project.project_type.in?(HudUtility2026.permanent_housing_project_types) && (enrollment.move_in_date&.<= today)
       end
       return false if client_is_housed
 
       # Check chronic status at open enrollments for homeless project types
       open_enrollments.any? do |enrollment|
-        enrollment.project.project_type.in?(HudUtility2024.chronic_project_types) && enrollment.ch_enrollment&.chronically_homeless?
+        enrollment.project.project_type.in?(HudUtility2026.chronic_project_types) && enrollment.ch_enrollment&.chronically_homeless?
       end
     end
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -479,7 +479,7 @@ module Types
       when Hmis::Hud::CurrentLivingSituation
         'CURRENT_LIVING_SITUATION'
       when Hmis::Hud::CustomAssessment
-        assessment_name = HudUtility2024.assessment_name_by_data_collection_stage[last_contact_entity.data_collection_stage]
+        assessment_name = HudUtility2026.assessment_name_by_data_collection_stage[last_contact_entity.data_collection_stage]
         assessment_name.present? ? Types::BaseEnum.to_enum_key(assessment_name) : 'ASSESSMENT'
       when Hmis::Hud::CustomCaseNote
         'CASE_NOTE'

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/age_range.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/age_range.rb
@@ -24,7 +24,7 @@ module Types
       { code: 'Age62Plus', description: '62+' },
       { code: 'Age65Plus', description: '65+' },
     ].map do |option|
-      value option[:code], option[:description], value: HudUtility2024.age_range[option[:description]]
+      value option[:code], option[:description], value: HudUtility2026.age_range[option[:description]]
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/last_contact_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/last_contact_type.rb
@@ -16,7 +16,7 @@ module Types
       'Current Living Situation',
       'Case Note',
       'Assessment',
-      *HudUtility2024.assessment_name_by_data_collection_stage.values,
+      *HudUtility2026.assessment_name_by_data_collection_stage.values,
     ].map do |contact_type|
       value to_enum_key(contact_type), description: contact_type
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_gender.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_gender.rb
@@ -30,7 +30,7 @@ module Types
           define_method(:resolve_gender) do
             client = client_association ? object.send(client_association) : object
 
-            selected_genders = ::HudUtility2024.gender_field_name_to_id.except(:GenderNone).select { |f| client.send(f).to_i == 1 }.values
+            selected_genders = ::HudUtility2026.gender_field_name_to_id.except(:GenderNone).select { |f| client.send(f).to_i == 1 }.values
             selected_genders << client.GenderNone if client.GenderNone && selected_genders.empty?
             selected_genders
           end

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -105,7 +105,7 @@ module Hmis
         data_source_id: enrollment.data_source_id,
         user_id: user.user_id,
         exit_date: exit_date,
-        destination: HudUtility2024.destination_no_exit_interview_completed,
+        destination: HudUtility2026.destination_no_exit_interview_completed,
         auto_exited: DateTime.current,
       )
 

--- a/drivers/hmis/app/jobs/hmis/create_fake_enrollments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/create_fake_enrollments_job.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'csv' # needed by FakeData
 
 # == Hmis::CreateFakeEnrollmentsJob
@@ -195,13 +197,13 @@ module Hmis
         DisablingCondition: rand_boolean ? 1 : 0,
         DateCreated: to_datetime(entry_date),
         DateUpdated: to_datetime(entry_date),
-        LivingSituation: HudUtility2024.prior_living_situations.keys.sample,
+        LivingSituation: HudUtility2026.prior_living_situations.keys.sample,
       )
       # rubocop:disable Style/IfUnlessModifier
-      if is_hoh && HudUtility2024.doe_project_types.include?(project.ProjectType) && rand_boolean(10)
+      if is_hoh && HudUtility2026.doe_project_types.include?(project.ProjectType) && rand_boolean(10)
         enrollment.DateOfEngagement = [enrollment.EntryDate + rand(30), today].min
       end
-      if is_hoh && HudUtility2024.permanent_housing_project_types.include?(project.ProjectType) && rand_boolean(10)
+      if is_hoh && HudUtility2026.permanent_housing_project_types.include?(project.ProjectType) && rand_boolean(10)
         enrollment.MoveInDate = [enrollment.EntryDate + rand(30), today].min
       end
       # rubocop:enable Style/IfUnlessModifier
@@ -234,7 +236,7 @@ module Hmis
       Hmis::Hud::Exit.new(
         enrollment: enrollment,
         exit_date: exit_date,
-        destination: HudUtility2024.destinations.keys.excluding(17).sample,
+        destination: HudUtility2026.destinations.keys.excluding(17).sample,
         DateCreated: to_datetime(exit_date),
         DateUpdated: to_datetime(exit_date),
         **hud_attributes,
@@ -242,7 +244,7 @@ module Hmis
     end
 
     def build_fake_disabilities(enrollment)
-      HudUtility2024.disability_types.keys.map.each do |type|
+      HudUtility2026.disability_types.keys.map.each do |type|
         # if enrollment's overall DisablingCondition is No, then none of the disabilities should be indefinite and impairing
         indefinite_and_impairs = enrollment.DisablingCondition == 0 ? 0 : [0, 1, 1].sample
         Hmis::Hud::Disability.new(
@@ -286,14 +288,14 @@ module Hmis
 
     # rubocop:disable Lint/EachWithObjectArgument
     def random_race_attributes
-      race_attributes = HudUtility2024.races.keys.excluding('RaceNone').each_with_object(0).to_h
+      race_attributes = HudUtility2026.races.keys.excluding('RaceNone').each_with_object(0).to_h
       race_attributes[race_attributes.keys.sample] = 1
       race_attributes[race_attributes.keys.sample] = 1 if rand_boolean # set another race
       race_attributes
     end
 
     def random_gender_attributes
-      gender_attributes = HudUtility2024.gender_fields.map(&:to_s).excluding('GenderNone').each_with_object(0).to_h
+      gender_attributes = HudUtility2026.gender_fields.map(&:to_s).excluding('GenderNone').each_with_object(0).to_h
       gender_attributes[gender_attributes.keys.sample] = 1
       gender_attributes[gender_attributes.keys.sample] = 1 if rand_boolean # set another gender
       gender_attributes

--- a/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
+++ b/drivers/hmis/app/jobs/hmis/migrate_assessments_job.rb
@@ -79,7 +79,7 @@ module Hmis
       if clobber
         Hmis::Hud::CustomAssessment.
           joins(:project).merge(project_scope).
-          where(data_collection_stage: HudUtility2024.data_collection_stages.keys). # Only clobber HUD assessments, not fully custom assessments
+          where(data_collection_stage: HudUtility2026.data_collection_stages.keys). # Only clobber HUD assessments, not fully custom assessments
           each(&:really_destroy!)
       end
 

--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -37,7 +37,7 @@ module Hmis::Ce
       raise "Expected to find CE event for referral #{referral.id}" unless event
 
       referral_result = message.params['referral_result']&.to_i
-      raise "Invalid referral result #{referral_result} submitted for referral #{referral.id} probably indicates misconfigured workflow or form definition" unless HudUtility2024.referral_results.keys.include?(referral_result)
+      raise "Invalid referral result #{referral_result} submitted for referral #{referral.id} probably indicates misconfigured workflow or form definition" unless HudUtility2026.referral_results.keys.include?(referral_result)
 
       event.update!(
         result_date: Date.current,

--- a/drivers/hmis/app/models/hmis/form/definition_item_filter.rb
+++ b/drivers/hmis/app/models/hmis/form/definition_item_filter.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Dynamic filter form definition items based on item.rule.
 class Hmis::Form::DefinitionItemFilter
   def self.perform(...)
@@ -118,7 +120,7 @@ class Hmis::Form::DefinitionItemFilter
     when 'projectFunders'
       project_funders.map { |f| f.funder&.to_i }.compact_blank
     when 'projectFunderComponents'
-      project_funders.map { |f| HudUtility2024.funder_component(f.funder&.to_i) }.compact_blank
+      project_funders.map { |f| HudUtility2026.funder_component(f.funder&.to_i) }.compact_blank
     when 'projectOtherFunders'
       # ignore case for Funder.OtherFunder value which is a free text field
       project_funders.map(&:other_funder).compact.map(&:strip).map(&:downcase).compact_blank

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Specifies which polymorphic entity (and/or service type) that a given form is applicable to.
 class Hmis::Form::Instance < ::GrdaWarehouseBase
   include Hmis::Concerns::HmisArelHelper
@@ -24,8 +26,8 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   belongs_to :custom_service_type, optional: true, class_name: 'Hmis::Hud::CustomServiceType'
 
   validates :data_collected_about, inclusion: { in: Types::Forms::Enums::DataCollectedAbout.values.keys }, allow_blank: true
-  validates :funder, inclusion: { in: HudUtility2024.funding_sources.keys }, allow_blank: true
-  validates :project_type, inclusion: { in: HudUtility2024.project_types.keys }, allow_blank: true
+  validates :funder, inclusion: { in: HudUtility2026.funding_sources.keys }, allow_blank: true
+  validates :project_type, inclusion: { in: HudUtility2026.project_types.keys }, allow_blank: true
   validate :validate_external_form_restrictions
 
   # 'system' instances can't be deleted

--- a/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_assessment.rb
@@ -122,7 +122,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   end
 
   def hud_assessment?
-    HudUtility2024.data_collection_stages.keys.include?(data_collection_stage)
+    HudUtility2026.data_collection_stages.keys.include?(data_collection_stage)
   end
 
   def intake?
@@ -146,7 +146,7 @@ class Hmis::Hud::CustomAssessment < Hmis::Hud::Base
   end
 
   def title
-    title = HudUtility2024.assessment_name_by_data_collection_stage[data_collection_stage]
+    title = HudUtility2026.assessment_name_by_data_collection_stage[data_collection_stage]
     # TODO(#187248703): replace with `definition.title` via definition_identifier column once that relationship exists
     title ||= form_processor&.definition&.title
     title ||= 'Custom Assessment'

--- a/drivers/hmis/app/models/hmis/hud/exit.rb
+++ b/drivers/hmis/app/models/hmis/hud/exit.rb
@@ -28,11 +28,11 @@ class Hmis::Hud::Exit < Hmis::Hud::Base
   scope :auto_exited, -> { where.not(auto_exited: nil) }
 
   def aftercare_methods
-    HudUtility2024.aftercare_method_fields.select { |k| send(k) == 1 }.values
+    HudUtility2026.aftercare_method_fields.select { |k| send(k) == 1 }.values
   end
 
   def counseling_methods
-    HudUtility2024.counseling_method_fields.select { |k| send(k) == 1 }.values
+    HudUtility2026.counseling_method_fields.select { |k| send(k) == 1 }.values
   end
 
   private def warehouse_trigger_processing

--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -179,12 +179,12 @@ module Hmis::Hud::Processors
 
     private def process_age_range(value)
       case value
-      when *HudUtility2024.age_range.keys
+      when *HudUtility2026.age_range.keys
         # value matches a known age range, so process it onto dob with low DQ
         { dob: approximate_dob(value), dob_data_quality: 2 }
-      when *HudUtility2024.dob_data_quality_options.values_at(8, 9, 99)
+      when *HudUtility2026.dob_data_quality_options.values_at(8, 9, 99)
         # value matches a known missing data reason, so store that. (not currently expected but future-proofing for desired pick lists)
-        { dob_data_quality: HudUtility2024.dob_data_quality(value, true, raise_on_missing: true) }
+        { dob_data_quality: HudUtility2026.dob_data_quality(value, true, raise_on_missing: true) }
       when /doesn't know|prefers not to answer|not collected/i
         # value string-matches a missing data reason (PIT form is an example), so don't raise and store 99
         { dob_data_quality: 99 }
@@ -195,7 +195,7 @@ module Hmis::Hud::Processors
     end
 
     private def approximate_dob(value)
-      dob_range = HudUtility2024.age_range[value]
+      dob_range = HudUtility2026.age_range[value]
 
       years_ago = if dob_range.end.infinite?
         # For an infinite range like 65+, just use the beginning of the range

--- a/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Hmis::Hud::Processors
   class ExitProcessor < Base
     def process(field, value)
@@ -12,9 +14,9 @@ module Hmis::Hud::Processors
 
       attributes = case attribute_name
       when 'aftercare_methods'
-        multi_select_attributes(value, attribute_value, enum_map: HudUtility2024.aftercare_method_fields)
+        multi_select_attributes(value, attribute_value, enum_map: HudUtility2026.aftercare_method_fields)
       when 'counseling_methods'
-        multi_select_attributes(value, attribute_value, enum_map: HudUtility2024.counseling_method_fields)
+        multi_select_attributes(value, attribute_value, enum_map: HudUtility2026.counseling_method_fields)
       else
         { attribute_name => attribute_value }
       end

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -167,7 +167,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     name: 'Name',
   }.freeze
 
-  HudUtility2024.residential_project_type_numbers_by_code.each do |k, v|
+  HudUtility2026.residential_project_type_numbers_by_code.each do |k, v|
     scope k, -> { where(project_type: v) }
     define_method "#{k}?" do
       v.include? project_type
@@ -219,7 +219,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   def allows_same_day_exit?
     if services_only_rrh?
       true # RRH-Services-Only projects allow same-day exit
-    elsif HudUtility2024.residential_project_type_ids.include?(project_type)
+    elsif HudUtility2026.residential_project_type_ids.include?(project_type)
       false # Residential projects do not allow same-day exit
     else
       true # Non-residential projects allow same-day exit
@@ -245,7 +245,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     {
       code: id,
       label: project_name,
-      secondary_label: HudUtility2024.project_type_brief(project_type),
+      secondary_label: HudUtility2026.project_type_brief(project_type),
       group_label: organization.organization_name,
       group_code: organization.id,
     }

--- a/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/client_validator.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValidator
   IGNORED = [
     :ExportID,
@@ -27,8 +29,8 @@ class Hmis::Hud::Validators::ClientValidator < Hmis::Hud::Validators::BaseValida
 
   def validate(record)
     super(record) do
-      record.errors.add :gender, :required if !skipped_attributes(record).include?(:gender) && ::HudUtility2024.gender_id_to_field_name.except(8, 9, 99).values.any? { |field| record.send(field).nil? }
-      record.errors.add :race, :required if !skipped_attributes(record).include?(:race) && ::HudUtility2024.races.except('RaceNone').keys.any? { |field| record.send(field).nil? }
+      record.errors.add :gender, :required if !skipped_attributes(record).include?(:gender) && ::HudUtility2026.gender_id_to_field_name.except(8, 9, 99).values.any? { |field| record.send(field).nil? }
+      record.errors.add :race, :required if !skipped_attributes(record).include?(:race) && ::HudUtility2026.races.except('RaceNone').keys.any? { |field| record.send(field).nil? }
 
       if record.dob.present?
         record.errors.add :dob, :out_of_range, message: self.class.future_message if record.dob.future?

--- a/drivers/hmis/app/models/hmis/hud/validators/inventory_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/inventory_validator.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class Hmis::Hud::Validators::InventoryValidator < Hmis::Hud::Validators::BaseValidator
   IGNORED = [
     :ExportID,
@@ -18,7 +20,7 @@ class Hmis::Hud::Validators::InventoryValidator < Hmis::Hud::Validators::BaseVal
   def validate(record)
     super(record) do
       # CoC code must be valid for project
-      record.errors.add :coc_code, :invalid, message: 'is invalid' if record.coc_code.present? && (!HudUtility2024.valid_coc?(record.coc_code) || !Hmis::Hud::ProjectCoc.where(coc_code: record.coc_code, project_id: record.project_id).exists?)
+      record.errors.add :coc_code, :invalid, message: 'is invalid' if record.coc_code.present? && (!HudUtility2026.valid_coc?(record.coc_code) || !Hmis::Hud::ProjectCoc.where(coc_code: record.coc_code, project_id: record.project_id).exists?)
 
       # Unit and bed counts must be non-negative
       [

--- a/drivers/hmis/app/models/hmis/hud/validators/service_validator.rb
+++ b/drivers/hmis/app/models/hmis/hud/validators/service_validator.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class Hmis::Hud::Validators::ServiceValidator < Hmis::Hud::Validators::BaseValidator
   IGNORED = [
     :ExportID,
@@ -13,9 +15,9 @@ class Hmis::Hud::Validators::ServiceValidator < Hmis::Hud::Validators::BaseValid
     :RecordType,
   ].freeze
 
-  TYPE_PROVIDED_MAP = ::HudUtility2024.service_types_provided_map.map { |k, v| [k, v[:list]] }.to_h.freeze
+  TYPE_PROVIDED_MAP = ::HudUtility2026.service_types_provided_map.map { |k, v| [k, v[:list]] }.to_h.freeze
 
-  SUB_TYPE_PROVIDED_MAP = ::HudUtility2024.service_sub_types_provided_map.map { |k, v| [k, v[:list]] }.to_h.freeze
+  SUB_TYPE_PROVIDED_MAP = ::HudUtility2026.service_sub_types_provided_map.map { |k, v| [k, v[:list]] }.to_h.freeze
 
   def configuration
     Hmis::Hud::Service.hmis_configuration(version: '2024').except(*IGNORED)
@@ -35,7 +37,7 @@ class Hmis::Hud::Validators::ServiceValidator < Hmis::Hud::Validators::BaseValid
     record.errors.add type_provided_field, :required unless record_type.present? && type_provided.present?
     return unless record_type.present? && type_provided.present?
 
-    unless HudUtility2024.record_types.any? { |k, _v| record_type == k }
+    unless HudUtility2026.record_types.any? { |k, _v| record_type == k }
       record.errors.add type_provided_field, :invalid, full_message: "Service type category '#{record_type}' is not a valid category"
       return
     end

--- a/drivers/hmis/app/models/hmis/project_group_criteria.rb
+++ b/drivers/hmis/app/models/hmis/project_group_criteria.rb
@@ -114,7 +114,7 @@ module Hmis
 
       # Add Project Types
       if project_type_numbers.any?
-        project_type_names = project_type_numbers.uniq.map { |pt| HudUtility2024.project_type(pt.to_i) }
+        project_type_names = project_type_numbers.uniq.map { |pt| HudUtility2026.project_type(pt.to_i) }
         criteria << { label: 'Project Types', values: project_type_names }
       end
 
@@ -142,7 +142,7 @@ module Hmis
     end
 
     def self.available_project_type_numbers
-      ::HudUtility2024.project_types.invert
+      ::HudUtility2026.project_types.invert
     end
 
     private

--- a/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
+++ b/drivers/hmis/app/models/hmis/reminders/reminder_generator.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Hmis
   module Reminders
     class ReminderGenerator
@@ -57,7 +59,7 @@ module Hmis
       end
 
       def data_stages(keys)
-        @mapped ||= HudUtility2024.hud_list_map_as_enumerable(:data_collection_stages).symbolize_keys
+        @mapped ||= HudUtility2026.hud_list_map_as_enumerable(:data_collection_stages).symbolize_keys
         @mapped.fetch_values(*keys.map(&:to_sym))
       end
 

--- a/drivers/hmis/app/views/hmis_client/assessments/show.haml
+++ b/drivers/hmis/app/views/hmis_client/assessments/show.haml
@@ -16,11 +16,11 @@
         %dd= @assessment.AssessmentDate
         - if related_ce_assessment.present?
           %dt Assessment Level
-          %dd= HudUtility2024.assessment_level related_ce_assessment.AssessmentLevel
+          %dd= HudUtility2026.assessment_level related_ce_assessment.AssessmentLevel
           %dt Assessment Type
-          %dd= HudUtility2024.assessment_type related_ce_assessment.AssessmentType
+          %dd= HudUtility2026.assessment_type related_ce_assessment.AssessmentType
           %dt Prioritization Status
-          %dd= HudUtility2024.prioritization_status related_ce_assessment.PrioritizationStatus
+          %dd= HudUtility2026.prioritization_status related_ce_assessment.PrioritizationStatus
         %dt Created
         %dd= @assessment.DateCreated
         %dt Updated

--- a/drivers/hmis/spec/factories/hmis/hud/clients.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/clients.rb
@@ -47,11 +47,11 @@ FactoryBot.define do
       with_custom_client_name { false }
     end
     after(:build) do |client, evaluator|
-      race_attributes = HudUtility2024.races.except('RaceNone').keys.map { |r| [r, [1, 0].sample] }.to_h
+      race_attributes = HudUtility2026.races.except('RaceNone').keys.map { |r| [r, [1, 0].sample] }.to_h
       race_attributes['RaceNone'] = [8, 9, 99].sample if race_attributes.values.sum.zero?
       client.assign_attributes(race_attributes)
 
-      gender_attributes = HudUtility2024.gender_fields.excluding(:GenderNone).map { |r| [r, [1, 0].sample] }.to_h
+      gender_attributes = HudUtility2026.gender_fields.excluding(:GenderNone).map { |r| [r, [1, 0].sample] }.to_h
       gender_attributes['GenderNone'] = [8, 9, 99].sample if gender_attributes.values.sum.zero?
       client.assign_attributes(gender_attributes)
 

--- a/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
+++ b/drivers/hmis/spec/jobs/migrate_assessments_job_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hmis::MigrateAssessmentsJob, type: :model do
         records << create(:hmis_employment_education, **shared_attributes, date_updated: date - 7.days)
 
         # create 1 record per disability type
-        HudUtility2024.disability_types.keys.each do |typ|
+        HudUtility2026.disability_types.keys.each do |typ|
           records << create(:hmis_disability, disability_type: typ, **shared_attributes)
         end
 

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -980,13 +980,13 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         expect(client.race_fields).to contain_exactly('White', 'Asian')
         expect(client.RaceNone).to be nil
         # All other races set to No
-        HudUtility2024.races.keys.excluding('White', 'Asian', 'RaceNone').each do |f|
+        HudUtility2026.races.keys.excluding('White', 'Asian', 'RaceNone').each do |f|
           expect(client.send(f)).to eq(0)
         end
         expect(client.gender_fields).to contain_exactly(:Woman, :Transgender)
         expect(client.GenderNone).to be nil
         # All other genders set to No
-        HudUtility2024.gender_fields.excluding(:Woman, :Transgender, :GenderNone).each do |f|
+        HudUtility2026.gender_fields.excluding(:Woman, :Transgender, :GenderNone).each do |f|
           expect(client.send(f)).to eq(0)
         end
       end
@@ -1013,12 +1013,12 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         expect(client.veteran_status).to eq(99)
         expect(client.race_fields).to eq([])
         expect(client.RaceNone).to eq(99)
-        HudUtility2024.races.keys.excluding('RaceNone').each do |f|
+        HudUtility2026.races.keys.excluding('RaceNone').each do |f|
           expect(client.send(f)).to eq(0)
         end
         expect(client.gender_fields).to eq([])
         expect(client.GenderNone).to eq(99)
-        HudUtility2024.gender_fields.excluding(:GenderNone).each do |f|
+        HudUtility2026.gender_fields.excluding(:GenderNone).each do |f|
           expect(client.send(f)).to eq(0)
         end
       end
@@ -1048,12 +1048,12 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
 
         expect(client.race_fields).to eq([])
         expect(client.RaceNone).to eq(99)
-        HudUtility2024.races.keys.excluding('RaceNone').each do |f|
+        HudUtility2026.races.keys.excluding('RaceNone').each do |f|
           expect(client.send(f)).to eq(0)
         end
         expect(client.gender_fields).to eq([])
         expect(client.GenderNone).to eq(99)
-        HudUtility2024.gender_fields.excluding(:GenderNone).each do |f|
+        HudUtility2026.gender_fields.excluding(:GenderNone).each do |f|
           expect(client.send(f)).to eq(0)
         end
         expect(client.pronouns).to be nil
@@ -1076,12 +1076,12 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
         expect(client.dob_data_quality).to eq(9)
         expect(client.race_fields).to eq([])
         expect(client.RaceNone).to eq(9)
-        HudUtility2024.races.keys.excluding('RaceNone').each do |f|
+        HudUtility2026.races.keys.excluding('RaceNone').each do |f|
           expect(client.send(f)).to eq(0)
         end
         expect(client.gender_fields).to eq([])
         expect(client.GenderNone).to eq(8)
-        HudUtility2024.gender_fields.excluding(:GenderNone).each do |f|
+        HudUtility2026.gender_fields.excluding(:GenderNone).each do |f|
           expect(client.send(f)).to eq(0)
         end
       end

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
   end
 
   context 'clients with badly formatted race/gender data' do
-    let!(:race_fields) { HudUtility2024.races.keys.excluding('RaceNone') }
-    let!(:gender_fields) { HudUtility2024.gender_fields.excluding(:GenderNone) }
+    let!(:race_fields) { HudUtility2026.races.keys.excluding('RaceNone') }
+    let!(:gender_fields) { HudUtility2026.gender_fields.excluding(:GenderNone) }
 
     context 'when the client has some race/gender fields specified' do
       let!(:c1_with_race_and_gender) do

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(response.status).to eq 200
       options = result.dig('data', 'pickList')
       expect(options[0]['code']).to eq(Types::HmisSchema::Enums::Hud::PriorLivingSituation.all_enum_value_definitions.find { |v| v.value == 101 }.graphql_name)
-      expect(options[0]['label']).to eq(::HudUtility2024.living_situation(101))
+      expect(options[0]['label']).to eq(::HudUtility2026.living_situation(101))
       expect(options[0]['groupCode']).to eq('HOMELESS')
       expect(options[0]['groupLabel']).to eq('Homeless Situations')
     end
@@ -129,7 +129,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     options = result.dig('data', 'pickList')
     expect(options.length).to eq(1)
     expect(options[0]['code']).to eq(pc1.coc_code)
-    expect(options[0]['label']).to include(::HudUtility2024.cocs[pc1.coc_code])
+    expect(options[0]['label']).to include(::HudUtility2026.cocs[pc1.coc_code])
     expect(options[0]['initialSelected']).to eq(true)
   end
 

--- a/lib/util/hud_utility_2026.rb
+++ b/lib/util/hud_utility_2026.rb
@@ -760,7 +760,7 @@ module HudUtility2026
   # These are used by assessment Form Definition to specify funder applicability rules.
   def funder_components
     {
-      'HUD: CoC' => [1, 2, 3, 4, 5, 6, 7, 43, 44, 49, 56], # Includes YHDP
+      'HUD: CoC' => [1, 2, 3, 4, 5, 6, 7, 43, 44, 49, 56], # Includes YHDP and CoC Builds
       'HUD: ESG' => [8, 9, 10, 11, 47], # Excludes ESG RUSH
       'HUD: ESG RUSH' => [53], # Even though it has the same "HUD ESG" prefix, HUD Data Dictionary treats it as a separate component
       'HUD: HOPWA' => [13, 14, 15, 16, 17, 18, 19, 48],


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Update HMIS driver to reference HudUtility2026 instead of HudUtility 2024. There should be no impact of this change.

## Type of change
fy2026

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
