### PR TITLE
TK & HispanicLatina(e)o imports

### DIFF
--- a/app/models/concerns/hmis_structure/base.rb
+++ b/app/models/concerns/hmis_structure/base.rb
@@ -43,7 +43,7 @@ module HmisStructure::Base
       # Move to 2026 in staging after 2025-09-01
       cutoff_date = if Rails.env.production?
         Date.new(2025, 10, 1)
-      elsif (Rails.env.staging? || Rails.env.test?) && ENV['CLIENT'] != 'qa' # Test remains pinned to 2024 until test kits are out
+      elsif Rails.env.staging? && ENV['CLIENT'] != 'qa' # Test remains pinned to 2024 until test kits are out
         Date.new(2025, 9, 1)
       else
         Date.current

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/importer/client.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/importer/client.rb
@@ -17,6 +17,20 @@ module HmisCsvTwentyTwentySix::Importer
 
     has_one :destination_record, **hud_assoc(:PersonalID, 'Client')
 
+    # Override to return column names to match the loader's column_name_for_import
+    def self.create_columns
+      # Reimplement the base method but with our column name mapping
+      base_columns = (hmis_structure.keys + [:data_source_id]).map(&:to_s)
+
+      # Map HispanicLatinao -> HispanicLatinaeo
+      base_columns.map do |col|
+        case col
+        when 'HispanicLatinao' then 'HispanicLatinaeo'
+        else col
+        end
+      end.freeze
+    end
+
     def self.clean_row_for_import(row, deidentified:)
       row = deidentify_client_name(row) if deidentified
       row['SSN'] = row['SSN'].to_s[0..8] # limit SSNs to 9 characters

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_m_rrh.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_m_rrh.rb
@@ -134,12 +134,6 @@ RSpec.shared_context 'datalab organization m rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q12',
-        skip: [
-          'B8', # expected '35.0000' (35), got '36.0000' (36)
-          'C8', # expected '5.0000' (5), got '6.0000' (6)
-          'B26', # expected '1.0000' (1), got '0.0000' (0)
-          'C26', # expected '1.0000' (1), got '0.0000' (0)
-        ],
       )
     end
 
@@ -301,13 +295,6 @@ RSpec.shared_context 'datalab organization m rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q22f',
-        skip: [
-          'H2', # expected '35.0000' (35), got '36.0000' (36)
-          'I2', # expected '1.0000' (1), got '0.0000' (0)
-          'H4', # expected '37.4900' (37.4857), got '36.8300' (36.8333)
-          'I4', # expected '14.0000' (14.0000), got '0.0000' ()
-          'I5', # expected '14.0000' (14.0000), got '0.0000' ()
-        ],
       )
     end
 
@@ -316,12 +303,7 @@ RSpec.shared_context 'datalab organization m rrh apr', shared_context: :metadata
         file_path: result_file_prefix + results_dir,
         question: 'Q22g',
         skip: [
-          'H2', # expected '34.0000' (34), got '35.0000' (35)
-          'I2', # expected '1.0000' (1), got '0.0000' (0)
           'D3', # expected '0.0000' (0), got '2.0000' (2)
-          'H4', # expected '110.8200' (110.8235), got '108.8600' (108.8571)
-          'I4', # expected '42.0000' (42.0000), got '0.0000' ()
-          'I5', # expected '42.0000' (42.0000), got '0.0000' ()
         ],
       )
     end
@@ -344,12 +326,6 @@ RSpec.shared_context 'datalab organization m rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q23e',
-        skip: [
-          'I5', # expected '7.0000' (7), got '8.0000' (8)
-          'J5', # expected '1.0000' (1), got '0.0000' (0)
-          'I7', # expected '7.0000' (7), got '8.0000' (8)
-          'J7', # expected '1.0000' (1), got '0.0000' (0)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_s_rrh.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_s_rrh.rb
@@ -35,13 +35,6 @@ RSpec.shared_context 'datalab organization s rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6a',
-        skip: [
-          'C5', # expected '0.0000' (0), got '7.0000' (7)
-          'E5', # expected '0.0000' (0), got '7.0000' (7)
-          'F5', # expected '0.0000' (0.0000), got '0.1500' (0.1458)
-          'E6', # expected '3.0000' (3), got '9.0000' (9)
-          'F6', # expected '0.0600' (0.0625), got '0.1900' (0.1875)
-        ],
       )
     end
 
@@ -141,20 +134,6 @@ RSpec.shared_context 'datalab organization s rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q12',
-        skip: [
-          'B5', # expected '7.0000' (7), got '0.0000' (0)
-          'C5', # expected '3.0000' (3), got '0.0000' (0)
-          'D5', # expected '4.0000' (4), got '0.0000' (0)
-          'B8', # expected '30.0000' (30), got '34.0000' (34)
-          'C8', # expected '25.0000' (25), got '26.0000' (26)
-          'D8', # expected '5.0000' (5), got '8.0000' (8)
-          'B26', # expected '4.0000' (4), got '0.0000' (0)
-          'C26', # expected '1.0000' (1), got '0.0000' (0)
-          'D26', # expected '3.0000' (3), got '0.0000' (0)
-          'B33', # expected '0.0000' (0), got '7.0000' (7)
-          'C33', # expected '0.0000' (0), got '3.0000' (3)
-          'D33', # expected '0.0000' (0), got '4.0000' (4)
-        ],
       )
     end
 
@@ -316,14 +295,6 @@ RSpec.shared_context 'datalab organization s rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q22f',
-        skip: [
-          'E2', # expected '2.0000' (2), got '0.0000' (0)
-          'K2', # expected '0.0000' (0), got '2.0000' (2)
-          'E4', # expected '42.0000' (42.0000), got '0.0000' ()
-          'K4', # expected '0.0000' (0.0000), got '42.0000' (42.0)
-          'E5', # expected '42.0000' (42.0000), got '0.0000' ()
-          'K5', # expected '0.0000' (0.0000), got '42.0000' (42.0)
-        ],
       )
     end
 
@@ -332,16 +303,11 @@ RSpec.shared_context 'datalab organization s rrh apr', shared_context: :metadata
         file_path: result_file_prefix + results_dir,
         question: 'Q22g',
         skip: [
-          'E2', # expected '2.0000' (2), got '0.0000' (0)
-          'K2', # expected '0.0000' (0), got '2.0000' (2)
           'B3', # expected '0.0000' (0), got '1.0000' (1)
           'D3', # expected '0.0000' (0), got '5.0000' (5)
-          'H3', # expected '0.0000' (0), got '26.0000' (26)
-          'K3', # expected '0.0000' (0), got '5.0000' (5)
-          'E4', # expected '131.0000' (131.0000), got '0.0000' ()
-          'K4', # expected '0.0000' (0.0000), got '131.0000' (131.0)
-          'E5', # expected '131.0000' (131.0000), got '0.0000' ()
-          'K5', # expected '0.0000' (0.0000), got '131.0000' (131.0)
+          'E3', # expected '0.0000' (0), got '5.0000' (5)
+          'H3', # expected '0.0000' (0), got '22.0000' (22)
+          'I3', # expected '0.0000' (0), got '4.0000' (4)
         ],
       )
     end
@@ -480,6 +446,10 @@ RSpec.shared_context 'datalab organization s rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q27b',
+        skip: [
+          'C2', # expected '2.0000' (2), got '1.0000' (1)
+          'D2', # expected '3.0000' (3), got '2.0000' (2)
+        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
@@ -35,13 +35,6 @@ RSpec.shared_context 'datalab organization y sso apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6a',
-        skip: [
-          'C5', # expected '0.0000' (0), got '1.0000' (1)
-          'E5', # expected '0.0000' (0), got '1.0000' (1)
-          'F5', # expected '0.0000' (0.0000), got '0.0400' (0.0400)
-          'E6', # expected '4.0000' (4), got '5.0000' (5)
-          'F6', # expected '0.1600' (0.1600), got '0.2000' (0.2000)
-        ],
       )
     end
 
@@ -141,16 +134,6 @@ RSpec.shared_context 'datalab organization y sso apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q12',
-        skip: [
-          'B5', # expected '1.0000' (1), got '0.0000' (0)
-          'E5', # expected '1.0000' (1), got '0.0000' (0)
-          'B8', # expected '3.0000' (3), got '5.0000' (5)
-          'C8', # expected '3.0000' (3), got '5.0000' (5)
-          'B26', # expected '2.0000' (2), got '0.0000' (0)
-          'C26', # expected '2.0000' (2), got '0.0000' (0)
-          'B33', # expected '0.0000' (0), got '1.0000' (1)
-          'E33', # expected '0.0000' (0), got '1.0000' (1)
-        ],
       )
     end
 
@@ -340,16 +323,6 @@ RSpec.shared_context 'datalab organization y sso apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q23e',
-        skip: [
-          'F4', # expected '1.0000' (1), got '0.0000' (0)
-          'I4', # expected '1.0000' (1), got '3.0000' (3)
-          'J4', # expected '2.0000' (2), got '0.0000' (0)
-          'L4', # expected '0.0000' (0), got '1.0000' (1)
-          'F7', # expected '1.0000' (1), got '0.0000' (0)
-          'I7', # expected '1.0000' (1), got '3.0000' (3)
-          'J7', # expected '2.0000' (2), got '0.0000' (0)
-          'L7', # expected '0.0000' (0), got '1.0000' (1)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_hp.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_hp.rb
@@ -39,11 +39,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6a',
-        skip: [
-          'C5', # expected '0.0000' (0), got '2.0000' (2)
-          'E5', # expected '0.0000' (0), got '2.0000' (2)
-          'F5', # expected '0.0000' (0.0000), got '0.0100' (0.0148)
-        ],
       )
     end
 
@@ -165,20 +160,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q12',
-        skip: [
-          'B5', # expected '2.0000' (2), got '0.0000' (0)
-          'C5', # expected '1.0000' (1), got '0.0000' (0)
-          'D5', # expected '1.0000' (1), got '0.0000' (0)
-          'B8', # expected '84.0000' (84), got '101.0000' (101)
-          'C8', # expected '37.0000' (37), got '42.0000' (42)
-          'D8', # expected '47.0000' (47), got '59.0000' (59)
-          'B26', # expected '17.0000' (17), got '0.0000' (0)
-          'C26', # expected '5.0000' (5), got '0.0000' (0)
-          'D26', # expected '12.0000' (12), got '0.0000' (0)
-          'B33', # expected '0.0000' (0), got '2.0000' (2)
-          'C33', # expected '0.0000' (0), got '1.0000' (1)
-          'D33', # expected '0.0000' (0), got '1.0000' (1)
-        ],
       )
     end
 
@@ -333,12 +314,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q23e',
-        skip: [
-          'I5', # expected '20.0000' (20), got '34.0000' (34)
-          'J5', # expected '14.0000' (14), got '0.0000' (0)
-          'I7', # expected '22.0000' (22), got '36.0000' (36)
-          'J7', # expected '14.0000' (14), got '0.0000' (0)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_v_es.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_v_es.rb
@@ -79,10 +79,6 @@ RSpec.shared_context 'datalab organization v es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6f',
-        skip: [
-          'C2', # expected '1.0000' (1), got '4.0000' (4)
-          'D2', # expected '0.2500' (0.25), got '1.0000' (1.0000)
-        ],
       )
     end
 
@@ -159,18 +155,6 @@ RSpec.shared_context 'datalab organization v es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q12',
-        skip: [
-          'B4', # expected '42.0000' (42), got '45.0000' (45)
-          'D4', # expected '8.0000' (8), got '11.0000' (11)
-          'B8', # expected '117.0000' (117), got '122.0000' (122)
-          'C8', # expected '98.0000' (98), got '101.0000' (101)
-          'D8', # expected '18.0000' (18), got '20.0000' (20)
-          'B20', # expected '3.0000' (3), got '0.0000' (0)
-          'D20', # expected '3.0000' (3), got '0.0000' (0)
-          'B26', # expected '5.0000' (5), got '0.0000' (0)
-          'C26', # expected '3.0000' (3), got '0.0000' (0)
-          'D26', # expected '2.0000' (2), got '0.0000' (0)
-        ],
       )
     end
 
@@ -298,8 +282,7 @@ RSpec.shared_context 'datalab organization v es caper', shared_context: :metadat
         question: 'Q22g',
         skip: [
           'D3', # expected '29.0000' (29), got '31.0000' (31)
-          'H3', # expected '71.0000' (71), got '74.0000' (74)
-          'I3', # expected '2.0000' (2), got '0.0000' (0)
+          'H3', # expected '71.0000' (71), got '72.0000' (72)
         ],
       )
     end
@@ -322,18 +305,6 @@ RSpec.shared_context 'datalab organization v es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q23e',
-        skip: [
-          'I4', # expected '16.0000' (16), got '17.0000' (17)
-          'J4', # expected '1.0000' (1), got '0.0000' (0)
-          'E5', # expected '12.0000' (12), got '15.0000' (15)
-          'I5', # expected '30.0000' (30), got '31.0000' (31)
-          'J5', # expected '4.0000' (4), got '0.0000' (0)
-          'I6', # expected '49.0000' (49), got '50.0000' (50)
-          'J6', # expected '1.0000' (1), got '0.0000' (0)
-          'E7', # expected '37.0000' (37), got '40.0000' (40)
-          'I7', # expected '104.0000' (104), got '107.0000' (107)
-          'J7', # expected '6.0000' (6), got '0.0000' (0)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_ce_apr/systemwide.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_ce_apr/systemwide.rb
@@ -12,7 +12,7 @@ RSpec.shared_context 'datalab systemwide ce apr', shared_context: :metadata do
     before(:all) do
       puts
       puts 'Running CE APR SystemWide'
-      generator = HudApr::Generators::CeApr::Fy2024::Generator
+      generator = HudApr::Generators::CeApr::Fy2026::Generator
       project_ids = GrdaWarehouse::Hud::Project.all.pluck(:id)
       run(generator, project_ids_filter(project_ids))
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The 2026 importer was not fully importing the HispanicLatina(e)o column for the clients, causing TK errors. This should allow the imports using 2026 to correctly pull in HispanicLatinao records from the HMIS files and stroe them in the HispanicLatinaeo column for the client.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
