### PR TITLE
Return one source enrollment assessment per identifier

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_enrollment.rb
@@ -131,7 +131,7 @@ module Types
       # We don't expect there to be a lot, so calculate in-memory the latest assessment per definition
       assessments.group_by { |assessment| assessment.definition.identifier }.map do |_, group|
         group.max_by { |assessment| [assessment.assessment_date, assessment.id] }
-      end.sort { |a, b| b.assessment_date <=> a.assessment_date } # sort by assessment date, descending
+      end.sort_by(&:assessment_date).reverse # sort by assessment date, descending
     end
 
     def access

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_enrollment.rb
@@ -129,9 +129,9 @@ module Types
         joins(:definition).where(definition: { identifier: object.definition_identifiers })
 
       # We don't expect there to be a lot, so calculate in-memory the latest assessment per definition
-      assessments.group_by(&:definition).map do |_, group|
+      assessments.group_by { |assessment| assessment.definition.identifier }.map do |_, group|
         group.max_by { |assessment| [assessment.assessment_date, assessment.id] }
-      end
+      end.sort { |a, b| b.assessment_date <=> a.assessment_date } # sort by assessment date, descending
     end
 
     def access

--- a/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
@@ -131,26 +131,30 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let!(:cded_field_one) { create :hmis_custom_data_element_definition, owner_type: 'Hmis::Hud::CustomAssessment', key: 'fieldOne', form_definition: fd1 }
 
       let!(:assmt_fd1_new) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd1, assessment_date: 2.weeks.ago) }
+      # Cruft: Old assessment taken with this form doesn't get returned
       let!(:assmt_fd1_old) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd1, assessment_date: 3.weeks.ago) }
 
       let!(:fd2) { create(:custom_assessment_with_custom_fields, role: :CUSTOM_ASSESSMENT, status: :published, version: 1) }
       # custom_assessment_with_custom_fields factory generates cded "custom_question_1"
       let!(:cded_custom_question_1) { create :hmis_custom_data_element_definition, owner_type: 'Hmis::Hud::CustomAssessment', key: 'custom_question_1', form_definition: fd2 }
 
-      let!(:assmt_fd2_new) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd2, assessment_date: 2.weeks.ago) }
-      let!(:assmt_fd2_old) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd2, assessment_date: 3.weeks.ago) }
+      let!(:assmt_fd2_new) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd2, assessment_date: 1.week.ago) }
+      # Cruft: Old assessment taken on old version of the same form doesn't get returned (regression #8145)
+      let!(:fd2_old) { create(:custom_assessment_with_custom_fields, identifier: fd2.identifier, role: :CUSTOM_ASSESSMENT, status: :retired, version: 0) }
+      let!(:assmt_fd2_old) { create(:hmis_custom_assessment, data_source: ds1, enrollment: enrollment, definition: fd2_old, assessment_date: 3.weeks.ago) }
 
       # Update the candidate pool to refer to those cdeds
       let!(:pool) { create :hmis_ce_match_candidate_pool, requirement_expression: "`cde.custom_assessment.fieldOne` = '1'", priority_expression: 'cde.custom_assessment.custom_question_1' }
 
-      it 'returns the latest assessment per definition' do
+      it 'returns the latest assessment per definition, ordered by date' do
         response, result = post_graphql(**variables) { query }
         expect(response.status).to eq(200), result.inspect
         enrollments = result.dig('data', 'ceOpportunity', 'candidateLookup', 'enrollments', 'nodes')
-        expect(enrollments.sole['assessments']).to contain_exactly(
-          { 'id' => assmt_fd1_new.id.to_s, 'assessmentName' => fd1.title, 'assessmentDate' => assmt_fd1_new.assessment_date.iso8601 },
-          { 'id' => assmt_fd2_new.id.to_s, 'assessmentName' => fd2.title, 'assessmentDate' => assmt_fd2_new.assessment_date.iso8601 },
-        )
+        assessments = enrollments.sole['assessments']
+        expect(assessments.count).to eq(2)
+        # assessment 2 is returned 1st because it was completed more recently
+        expect(assessments.first).to eq({ 'id' => assmt_fd2_new.id.to_s, 'assessmentName' => fd2.title, 'assessmentDate' => assmt_fd2_new.assessment_date.iso8601 })
+        expect(assessments.second).to eq({ 'id' => assmt_fd1_new.id.to_s, 'assessmentName' => fd1.title, 'assessmentDate' => assmt_fd1_new.assessment_date.iso8601 })
       end
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Fix bug that was causing old assessments to be returned. Now, only one assessment should be returned per form identifier.
- Ensure that if multiple assessments are returned (because the candidate pool has rules referring to custom data elements on more than one form), they are ordered by assessment date with the most recent appearing first.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [na] If adding a new endpoint / exposing data in a new way, I have:
  - [na] ensured the API can't leak data from other data sources
  - [na] ensured this does not introduce N+1s
  - [na] ensured permissions and visibility checks are performed in the right places
- [na] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [na] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
