### PR TITLE
Return false from "project can accept referral" if client already referred

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -527,8 +527,11 @@ module Types
       # Can't accept the referral if any client in the household has an existing open enrollment in the project.
       personal_ids = source_enrollment.household_members.pluck(:PersonalID)
 
-      # This doesn't check viewable_by either, see comment above
-      !project.enrollments.open_including_wip.where(personal_id: personal_ids).exists?
+      # These don't check viewable_by either, see comment above
+      return false if project.enrollments.open_including_wip.where(personal_id: personal_ids).exists?
+      return false if project.ce_referrals.active.joins(:client).where(client: { personal_id: personal_ids }).exists?
+
+      true
     end
 
     field :client_detail_forms, [Types::HmisSchema::OccurrencePointForm], null: false, description: 'Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form)'

--- a/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:destination_project) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1 }
   let!(:referral_instance) { create :hmis_form_instance, role: :REFERRAL, entity: destination_project }
 
+  shared_examples 'returns true for project can accept referral' do
+    it 'returns true' do
+      response, result = post_graphql(**variables) { query }
+      expect(response.status).to eq 200
+      expect(result.dig('data', 'projectCanAcceptReferral')).to eq(true)
+    end
+  end
+
+  shared_examples 'returns false for project can accept referral' do
+    it 'returns false' do
+      response, result = post_graphql(**variables) { query }
+      expect(response.status).to eq 200
+      expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
+    end
+  end
+
   describe 'projectCanAcceptReferral query' do
     let(:query) do
       <<~GRAPHQL
@@ -57,24 +73,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_access_denied post_graphql(**variables) { query }
     end
 
-    it 'returns true when the client does not have an open enrollment at the destination project' do
-      response, result = post_graphql(**variables) { query }
-      expect(response.status).to eq 200
-      expect(result.dig('data', 'projectCanAcceptReferral')).to eq(true)
+    context 'when the referral can be accepted (no conflicting enrollment)' do
+      it_behaves_like 'returns true for project can accept referral'
     end
 
-    it 'returns false when the client has an open enrollment at the destination project' do
-      create :hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1
-      response, result = post_graphql(**variables) { query }
-      expect(response.status).to eq 200
-      expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
+    context 'when the client has a conflicting open enrollment at the destination project' do
+      let!(:conflicting_enrollment) { create(:hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1) }
+
+      it_behaves_like 'returns false for project can accept referral'
     end
 
-    it 'returns true when the client has an exited enrollment at the destination project' do
-      create :hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1, entry_date: 2.weeks.ago, exit_date: 1.week.ago
-      response, result = post_graphql(**variables) { query }
-      expect(response.status).to eq 200
-      expect(result.dig('data', 'projectCanAcceptReferral')).to eq(true)
+    context 'when the client has an exited enrollment at the destination project' do
+      let!(:exited_enrollment) { create(:hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1, entry_date: 2.weeks.ago, exit_date: 1.week.ago) }
+
+      it_behaves_like 'returns true for project can accept referral'
     end
 
     context 'when the referral mode is CE' do
@@ -88,30 +100,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         }
       end
 
-      it 'returns true when the destination project can accept the referral' do
-        response, result = post_graphql(**variables) { query }
-        expect(response.status).to eq(200), result.inspect
-        expect(result.dig('data', 'projectCanAcceptReferral')).to eq(true)
+      context 'when the referral can be accepted' do
+        it_behaves_like 'returns true for project can accept referral'
       end
 
-      context 'when the client has an open enrollment in the destination project' do
-        let!(:existing_enrollment) { create(:hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1) }
+      context 'when the client has a conflicting open enrollment at the destination project' do
+        let!(:conflicting_enrollment) { create(:hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1) }
 
-        it 'returns false' do
-          response, result = post_graphql(**variables) { query }
-          expect(response.status).to eq 200
-          expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
-        end
+        it_behaves_like 'returns false for project can accept referral'
       end
 
       context 'when client already has an in-progress referral at the destination project' do
-        let!(:existing_referral) { create(:hmis_ce_referral, client: c1, project: destination_project, data_source: ds1, status: :in_progress) }
+        let!(:conflicting_referral) { create(:hmis_ce_referral, client: c1, project: destination_project, data_source: ds1, status: :in_progress) }
 
-        it 'returns false' do
-          response, result = post_graphql(**variables) { query }
-          expect(response.status).to eq 200
-          expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
-        end
+        it_behaves_like 'returns false for project can accept referral'
       end
 
       context 'when dest project does not accept ce referrals' do

--- a/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb
@@ -88,20 +88,30 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         }
       end
 
-      it 'returns true when the destination project accepts CE referrals and the client does not have an open enrollment' do
+      it 'returns true when the destination project can accept the referral' do
         response, result = post_graphql(**variables) { query }
-
         expect(response.status).to eq(200), result.inspect
         expect(result.dig('data', 'projectCanAcceptReferral')).to eq(true)
       end
 
-      it 'returns false when the destination project accepts CE referrals but the client has an open enrollment' do
-        create :hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1
+      context 'when the client has an open enrollment in the destination project' do
+        let!(:existing_enrollment) { create(:hmis_hud_enrollment, client: c1, project: destination_project, data_source: ds1) }
 
-        response, result = post_graphql(**variables) { query }
+        it 'returns false' do
+          response, result = post_graphql(**variables) { query }
+          expect(response.status).to eq 200
+          expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
+        end
+      end
 
-        expect(response.status).to eq 200
-        expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
+      context 'when client already has an in-progress referral at the destination project' do
+        let!(:existing_referral) { create(:hmis_ce_referral, client: c1, project: destination_project, data_source: ds1, status: :in_progress) }
+
+        it 'returns false' do
+          response, result = post_graphql(**variables) { query }
+          expect(response.status).to eq 200
+          expect(result.dig('data', 'projectCanAcceptReferral')).to eq(false)
+        end
       end
 
       context 'when dest project does not accept ce referrals' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add a check in the `projectCanAcceptReferral` endpoint, to see if any household member already has a referral in progress at this project
- Refactor spec to use shared examples

How to test: Try to Direct Refer someone twice. Previously, you would only see the soft-warning message if they already had a conflicting enrollment. With this change, you should also see that message if they already have another open referral.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [na] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [na] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
