### PR TITLE
Move enable-on-load and submit-on-change to generic form stimulus controller

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -73,7 +73,6 @@
 //= require_directory ./d3_charts
 //= require_directory ./clients
 
-//= require_directory ./window/clients
 //= require_directory ./users
 
 

--- a/app/assets/javascripts/window/clients/users.js.coffee
+++ b/app/assets/javascripts/window/clients/users.js.coffee
@@ -1,5 +1,0 @@
-$ ->
-
-  $(document).on 'change', '.submit-on-change', (e) ->
-    form = $(e.target).closest 'form'
-    form.submit()

--- a/app/javascript/application_esbuild.js
+++ b/app/javascript/application_esbuild.js
@@ -28,11 +28,6 @@ function waitForJQuery() {
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
 const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
 
-// TODO: This can be compartmentalized into a FormInputsController if we end up needing additional global javascript for input forms.
-document.querySelectorAll('.enable-on-load').forEach((input) => {
-  input.disabled = false
-})
-
 // Make both Bootstrap and Popper globally available for legacy scripts.
 window.bootstrap = bootstrap
 window.Popper = Popper

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -70,6 +70,17 @@ export default class extends Controller {
         this.addButtonLabels();
       }, 100);
     });
+
+    // Listen for date changes and dispatch a standard change event for submit-on-change functionality
+    this.element.addEventListener('change.td', (_event) => {
+      // Find the input field within the datepicker wrapper
+      const inputField = this.element.querySelector('input');
+      if (inputField) {
+        // Dispatch a standard change event on the input field for submit-on-change functionality
+        const changeEvent = new Event('change', { bubbles: true, cancelable: true });
+        inputField.dispatchEvent(changeEvent);
+      }
+    });
   }
 
   disconnect() {

--- a/app/javascript/controllers/forms_controller.js
+++ b/app/javascript/controllers/forms_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus"
+// Some general purpose form helpers
+// 1. enableOnLoad - enables previously disabled inputs on page load
+// 2. submitOnChange - submits forms on input change (generally these are submitted with remote: true)
+
+// Connects to data-controller="forms"
+export default class extends Controller {
+  static targets = ["enableOnLoad"]
+
+  connect() {
+    this.submissionTimeouts = new WeakMap();
+    this.enableInputsOnLoad();
+  }
+
+  enableInputsOnLoad() {
+    console.log('enableInputsOnLoad', this.enableOnLoadTargets);
+    this.enableOnLoadTargets.forEach((wrapper) => {
+      // Find the actual input element within the datepicker wrapper
+      const input = wrapper.querySelector('input');
+      if (input) {
+        input.disabled = false;
+      }
+    });
+  }
+
+  submitOnChange(event) {
+    const form = $(event.target).closest('form');
+
+    if (form.length > 0) {
+      const formElement = form[0];
+
+      // Clear any existing timeout for this form
+      if (this.submissionTimeouts.has(formElement)) {
+        clearTimeout(this.submissionTimeouts.get(formElement));
+      }
+
+      // Set a new timeout to debounce the submission
+      const timeoutId = setTimeout(() => {
+        // Trigger Rails UJS form submission to respect remote: true
+        form.trigger('submit');
+        this.submissionTimeouts.delete(formElement);
+      }, 300); // 300ms debounce
+
+      this.submissionTimeouts.set(formElement, timeoutId);
+    }
+  }
+
+  disconnect() {
+    // Clear any pending timeouts
+    if (this.submissionTimeouts) {
+      // WeakMap doesn't have a clear method, but it will be garbage collected
+      this.submissionTimeouts = null;
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("filter-projects", FilterProjectsController)
 // TODO: this is only needed on some pages
 import ChartLoaderController from "./chart_loader_controller.js"
 application.register("chart-loader", ChartLoaderController)
+
+import FormsController from "./forms_controller.js"
+application.register("forms", FormsController)

--- a/app/views/clients/files/_file_row.haml
+++ b/app/views/clients/files/_file_row.haml
@@ -1,6 +1,6 @@
 - details_visible = file.confidential == false || file.id.in?(@visible_confidential_ids)
 - if details_visible
-  .well{ class: "client-file-#{file.id}" }
+  .well{ class: "client-file-#{file.id}", data: { controller: 'forms' } }
     .row
       .col-8
         %h3.d-flex
@@ -71,18 +71,18 @@
           - if @consent_editable
             - unless GrdaWarehouse::Config.get(:release_duration) == 'Use Expiration Date'
               = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|
-                = f.input :consent_form_signed_on, as: :date_picker, label: 'Effective Date/Signed On', input_html: { disabled: true, class: 'submit-on-change enable-on-load' }
+                = f.input :consent_form_signed_on, as: :date_picker, label: 'Effective Date/Signed On', input_html: { disabled: true, data: { action: 'change->forms#submitOnChange', forms_target: 'enableOnLoad' } }
             - if can_confirm_housing_release? && ! GrdaWarehouse::Config.get(:auto_confirm_consent)
               = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|
                 .mt-2
-                  = f.input :consent_form_confirmed, as: :boolean, input_html: { class: 'submit-on-change' }, label: Translation.translate('Consent form confirmed')
+                  = f.input :consent_form_confirmed, as: :boolean, input_html: { data: { action: 'change->forms#submitOnChange' } }, label: Translation.translate('Consent form confirmed')
             = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|
-              = f.input :consent_revoked_at, as: :date_picker, label: 'Revoked or Refused On', input_html: { disabled: true, class: 'submit-on-change enable-on-load' }
+              = f.input :consent_revoked_at, as: :date_picker, label: 'Revoked or Refused On', input_html: { disabled: true, data: { action: 'change->forms#submitOnChange', forms_target: 'enableOnLoad' } }
             - if file.revoked?
               %dd Revoked or Refused By: #{file.consent_revoked_by_user&.name}
             - if GrdaWarehouse::Config.get(:release_duration) == 'Use Expiration Date'
               = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|
-                = f.input :expiration_date, as: :date_picker, label: 'Expiration Date', input_html: { disabled: true, class: 'submit-on-change enable-on-load' }
+                = f.input :expiration_date, as: :date_picker, label: 'Expiration Date', input_html: { disabled: true, data: { action: 'change->forms#submitOnChange', forms_target: 'enableOnLoad' } }
           - else
             - if file.consent_form_confirmed
               %dl

--- a/app/views/clients/files/update.js.coffee
+++ b/app/views/clients/files/update.js.coffee
@@ -1,9 +1,9 @@
 <% if @file.errors.any? %>
   alert "<%= @file.errors.full_messages.join(', ') %>"
 <% else %>
-  $(".client-file-<%= @file.id %>").addClass 'highlight'
+  $(".client-file-<%= @file.id %>").addClass 'bg-warning-subtle'
 
   setTimeout ->
-    $(".client-file-<%= @file.id %>").removeClass('highlight')
+    $(".client-file-<%= @file.id %>").removeClass('bg-warning-subtle')
   , 2000
 <% end %>

--- a/app/views/clients/users/_relationship_list.haml
+++ b/app/views/clients/users/_relationship_list.haml
@@ -1,5 +1,5 @@
 %h1= content_for :title
-.table-responsive
+.table-responsive{ data: { controller: 'forms' } }
   - if can_assign_users_to_clients?
     = simple_form_for @user, url: polymorphic_path(users_path_generator, client_id: @client) do |f|
       %table.table.table-striped
@@ -63,25 +63,25 @@
           %td
             - if can_assign_users_to_clients?
               = simple_form_for user_client, remote: true, url: polymorphic_path(user_path_generator, client_id: user_client.client, id: user_client.id) do |f|
-                = f.input :start_date, as: :date_picker, label: false, input_html: { value: user_client.start_date, class: 'submit-on-change' }
+                = f.input :start_date, as: :date_picker, label: false, input_html: { value: user_client.start_date, data: { action: 'change->forms#submitOnChange' } }
             - else
               = user_client.start_date
           %td
             - if can_assign_users_to_clients?
               = simple_form_for user_client, remote: true, url: polymorphic_path(user_path_generator, client_id: user_client.client, id: user_client.id) do |f|
-                = f.input :end_date, as: :date_picker, label: false, input_html: { value: user_client.end_date, class: 'submit-on-change' }
+                = f.input :end_date, as: :date_picker, label: false, input_html: { value: user_client.end_date, data: { action: 'change->forms#submitOnChange' } }
             - else
               = user_client.end_date
           %td.text-center
             - if can_assign_users_to_clients?
               = simple_form_for user_client, remote: true, url: polymorphic_path(user_path_generator, client_id: user_client.client, id: user_client.id) do |f|
-                = f.input :client_notifications, label: false, input_html: { value: user_client.client_notifications, class: 'submit-on-change' }
+                = f.input :client_notifications, label: false, input_html: { value: user_client.client_notifications, data: { action: 'change->forms#submitOnChange' } }
             - else
               = checkmark_or_x user_client.client_notifications
           %td.text-center
             - if can_assign_users_to_clients?
               = simple_form_for user_client, remote: true, url: polymorphic_path(user_path_generator, client_id: user_client.client, id: user_client.id) do |f|
-                = f.input :confidential, label: false, input_html: { value: user_client.confidential, class: 'submit-on-change' }
+                = f.input :confidential, label: false, input_html: { value: user_client.confidential, data: { action: 'change->forms#submitOnChange' } }
             - else
               = checkmark_or_x user_client.confidential
           %td

--- a/app/views/clients/users/update.js.coffee
+++ b/app/views/clients/users/update.js.coffee
@@ -1,9 +1,9 @@
 <% if @user.errors.any? %>
   alert "<%= @user.errors.full_messages.join(', ') %>"
 <% else %>
-  $(".user-client-<%= @user.id %>").addClass 'highlight'
+  $(".user-client-<%= @user.id %>").addClass 'bg-warning-subtle'
 
   setTimeout ->
-    $(".user-client-<%= @user.id %>").removeClass('highlight')
+    $(".user-client-<%= @user.id %>").removeClass('bg-warning-subtle')
   , 2000
 <% end %>


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Moves two JS interactions that were recently broken via a regression to a generic "forms" stimulus controller.
* Specifically, on the client files pages and client relationship pages, inputs that were tagged with `enable-on-load` and `submit-on-change` classes now use this controller.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
*  Code clean-up
*  Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
