### PR TITLE
Support resolving assignment perm on referral

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1081,6 +1081,7 @@ type CeReferral {
 }
 
 type CeReferralAccess {
+  canAssignReferralTasks: Boolean!
   canViewReferralDetails: Boolean!
   canViewSourceEnrollmentDetails: Boolean!
   canViewTargetProject: Boolean!

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -60,6 +60,7 @@ module Types
       field :can_view_referral_details, Boolean, null: false
       field :can_view_target_project, Boolean, null: false
       field :can_view_source_enrollment_details, Boolean, null: false
+      field :can_assign_referral_tasks, Boolean, null: false
     end
 
     # Detailed fields that only those with full view access should see. Must be nullable
@@ -241,6 +242,7 @@ module Types
       {
         can_view_referral_details: policy_for(object, policy_type: :ce_referral).can_view?,
         can_view_target_project: project.present? && policy_for(project, policy_type: :hmis_project).can_view?,
+        can_assign_referral_tasks: policy_for(object, policy_type: :ce_referral).can_assign_referral_tasks?,
         can_view_source_enrollment_details: source_enrollment.present?,
       }
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Resolve this permission on the Referral so that you don't need to load the whole project to see whether a user can assign referral tasks. This is logical because task assignment lives on the referral.

This particularly makes things easier if you are rendering a Referral outside of a project context-- "floating" or in the admin dashboard-- where the project access object is not already loaded. Associated frontend PR for that: https://github.com/greenriver/hmis-frontend/pull/1261

## Type of change
code clean up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
