### PR TITLE
8191-ce-prioritization-order-2

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
@@ -22,6 +22,24 @@ module Hmis::Ce::Match::Expression
         :string,
         ->(identifier) { HudUtility2026.hmis_project_type_key(identifier, true) },
       )
+      calculator.add_function(
+        :EPOCH_SECONDS,
+        :numeric,
+        ->(value) {
+          return nil if value.nil?
+
+          case value
+          when Time
+            value.to_i
+          when Date
+            value.to_time(:utc).to_i
+          when String
+            Time.zone.parse(value).to_i
+          else
+            raise ArgumentError, "Cannot cast #{value.inspect} to seconds"
+          end
+        },
+      )
 
       return calculator
     end

--- a/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
@@ -32,7 +32,7 @@ module Hmis::Ce::Match::Expression
           when Time
             value.to_i
           when Date
-            value.to_i
+            value.to_time.to_i
           when String
             DateTime.parse(value).to_i
           else

--- a/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
@@ -32,9 +32,9 @@ module Hmis::Ce::Match::Expression
           when Time
             value.to_i
           when Date
-            value.to_time(:utc).to_i
+            value.to_i
           when String
-            Time.zone.parse(value).to_i
+            DateTime.parse(value).to_i
           else
             raise ArgumentError, "Cannot cast #{value.inspect} to seconds"
           end

--- a/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/calculator_factory.rb
@@ -29,12 +29,15 @@ module Hmis::Ce::Match::Expression
           return nil if value.nil?
 
           case value
-          when Time
-            value.to_i
+          when ActiveSupport::TimeWithZone, Time
+            value.in_time_zone.to_i
           when Date
-            value.to_time.to_i
+            Time.zone.local(value.year, value.month, value.day).to_i
           when String
-            DateTime.parse(value).to_i
+            parsed = Time.zone.parse(value)
+            raise ArgumentError, "Cannot cast #{value.inspect} to seconds" unless parsed
+
+            parsed.to_i
           else
             raise ArgumentError, "Cannot cast #{value.inspect} to seconds"
           end

--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -154,6 +154,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
           UserID: 'fake',
         )
       end
+      return assessment
     end
   end
 
@@ -677,6 +678,51 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       senior_veteran_dest_client = destination_clients.find { |c| c.id == client_senior_veteran.destination_client.id }
       senior_veteran_candidate = senior_veteran_dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool_with_comma_expr)
       expect(senior_veteran_candidate.priority_scores).to eq([100, 68, 1])
+    end
+  end
+
+  describe 'priority expression functions' do
+    include_context 'with CDE assessment setup'
+
+    let(:cde_key) { 'test' }
+    it 'supports EPOCH_SECONDS on custom assessment date fields' do
+      client = create(:hmis_hud_client, data_source: data_source)
+      assessment = create_assessment_with_cde(client, 'yes')
+      timestamp = Time.zone.parse('2025-01-01 12:00:00')
+      assessment.update!(DateUpdated: timestamp)
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+
+      pool = create(
+        :hmis_ce_match_candidate_pool,
+        requirement_expression: '1=1',
+        priority_expression: "{EPOCH_SECONDS(`custom_assessment.#{fd.identifier}.date_updated`)}",
+      )
+
+      generate_candidates(pool, clients: destination_clients_for([client]))
+
+      dest_client = destination_clients_for([client]).sole
+      candidate = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool)
+      expect(candidate.priority_scores).to eq([timestamp.to_i])
+    end
+
+    it 'supports EPOCH_SECONDS with string literal timestamps' do
+      client = create(:hmis_hud_client, data_source: data_source)
+      create_assessment_with_cde(client, 'yes')
+
+      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+
+      pool = create(
+        :hmis_ce_match_candidate_pool,
+        requirement_expression: '1=1',
+        priority_expression: "{EPOCH_SECONDS('2025-02-03 15:04:05')}",
+      )
+
+      generate_candidates(pool, clients: destination_clients_for([client]))
+
+      dest_client = destination_clients_for([client]).sole
+      candidate = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool)
+      expected = Time.zone.parse('2025-02-03 15:04:05').to_i
+      expect(candidate.priority_scores).to eq([expected])
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -689,40 +689,59 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
       client = create(:hmis_hud_client, data_source: data_source)
       assessment = create_assessment_with_cde(client, 'yes')
       timestamp = Time.zone.parse('2025-01-01 12:00:00')
-      assessment.update!(DateUpdated: timestamp)
+      assessment_date = Date.new(2025, 2, 3)
+      assessment.update!(DateUpdated: timestamp, AssessmentDate: assessment_date)
       GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
 
       pool = create(
         :hmis_ce_match_candidate_pool,
         requirement_expression: '1=1',
-        priority_expression: "{EPOCH_SECONDS(`custom_assessment.#{fd.identifier}.date_updated`)}",
+        priority_expression: "{EPOCH_SECONDS(`custom_assessment.#{fd.identifier}.date_updated`), EPOCH_SECONDS(`custom_assessment.#{fd.identifier}.assessment_date`)}",
       )
 
       generate_candidates(pool, clients: destination_clients_for([client]))
 
       dest_client = destination_clients_for([client]).sole
       candidate = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool)
-      expect(candidate.priority_scores).to eq([timestamp.to_i])
+      expect(candidate.priority_scores).to eq([timestamp.to_i, Time.zone.local(2025, 2, 3).to_i])
     end
 
-    it 'supports EPOCH_SECONDS with string literal timestamps' do
-      client = create(:hmis_hud_client, data_source: data_source)
-      create_assessment_with_cde(client, 'yes')
+    it 'interprets naive and date-only strings in the application Time.zone' do
+      Time.use_zone('America/Chicago') do
+        client = create(:hmis_hud_client, data_source: data_source)
+        create_assessment_with_cde(client, 'yes')
 
-      GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
+        GrdaWarehouse::Tasks::IdentifyDuplicates.new.run!
 
-      pool = create(
-        :hmis_ce_match_candidate_pool,
-        requirement_expression: '1=1',
-        priority_expression: "{EPOCH_SECONDS('2025-02-03 15:04:05')}",
-      )
+        naive = '2025-02-03 15:04:05'
+        pool_naive = create(
+          :hmis_ce_match_candidate_pool,
+          requirement_expression: '1=1',
+          priority_expression: "{EPOCH_SECONDS('#{naive}')}",
+        )
 
-      generate_candidates(pool, clients: destination_clients_for([client]))
+        date_only = '2025-02-03'
+        pool_date = create(
+          :hmis_ce_match_candidate_pool,
+          requirement_expression: '1=1',
+          priority_expression: "{EPOCH_SECONDS('#{date_only}')}",
+        )
 
-      dest_client = destination_clients_for([client]).sole
-      candidate = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool)
-      expected = Time.zone.parse('2025-02-03 15:04:05').to_i
-      expect(candidate.priority_scores).to eq([expected])
+        generate_candidates(pool_naive, clients: destination_clients_for([client]))
+        generate_candidates(pool_date, clients: destination_clients_for([client]))
+
+        dest_client = destination_clients_for([client]).sole
+        cand_naive = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool_naive)
+        cand_date = dest_client.ce_client_proxy.ce_match_candidates.find_by(candidate_pool: pool_date)
+
+        expected_local = Time.zone.parse(naive).to_i
+        expected_utc = ActiveSupport::TimeZone['UTC'].parse(naive).to_i
+        expected_local_midnight = Time.zone.local(2025, 2, 3).to_i
+
+        expect(cand_naive.priority_scores).to eq([expected_local])
+        expect(cand_naive.priority_scores.first).not_to eq(expected_utc)
+        expect(cand_date.priority_scores).to eq([expected_local_midnight])
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Adds a new EPOCH_SECONDS function to the CE match expression calculator, enabling expressions to convert dates/times to Unix epoch seconds. Allows expressions to sort asc/desc:
```
{EPOCH_SECONDS(`custom_assessment.housing_assessment.date_updated`) * -1}
```

## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

