### PR TITLE
8181-block-auto-exit-if-open-referrals

### DIFF
--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -8,6 +8,26 @@
 
 module Hmis
   class AutoExitJob < BaseJob
+    # Automatically exits inactive HMIS enrollments based on project-specific Auto-Exit configuration.
+    #
+    # Behavior
+    # - Runs against all HMIS projects by default; can be scoped by data_source or project_ids.
+    # - Operates on households: if ANY member has a recent contact within the configured window,
+    #   the entire household is skipped. Otherwise, ALL household members are exited together using
+    #   a shared exit_date equal to the most recent contact across the household.
+    # - Prevents auto-exit when any household member has an ACTIVE CE referral referencing that
+    #   member's enrollment via source_enrollment_id OR target_enrollment_id.
+    # - For ES Night-by-Night projects, the most recent contact is the latest bed night with a
+    #   non-nil date_provided; if missing/invalid, falls back to the enrollment entry.
+    # - For other project types, the most recent contact is the latest of:
+    #   Service.date_provided (present), CustomService.date_provided, CurrentLivingSituation.information_date,
+    #   CustomAssessment.assessment_date, or the Enrollment (entry).
+    #
+    # Exit Creation
+    # - Creates Hmis::Hud::Exit with destination "No exit interview completed" and timestamps auto_exited.
+    # - Creates a CustomAssessment at data collection stage 3 on the exit_date.
+    # - Releases any assigned unit and closes any external referral via enrollment hooks.
+    # - Skips enrollments that already have an exit record.
     include NotifierConfig
 
     def self.enabled?
@@ -46,6 +66,10 @@ module Hmis
         raise "Auto-exit config unusually low: #{config.length_of_absence_days}" if config.length_of_absence_days < 30
 
         project.households.active.not_in_progress.preload(:enrollments).each do |household|
+          # Skip auto-exit if any household member has an active CE referral that references
+          # one of the household enrollments as either the source or target enrollment.
+          next if household_has_active_ce_referral?(household)
+
           # Get the most recent contact date for the whole household
           most_recent_contact = household.enrollments.
             map { |hhm| get_most_recent_contact(hhm, project) }.
@@ -71,6 +95,19 @@ module Hmis
     end
 
     private
+
+    def household_has_active_ce_referral?(household)
+      enrollment_ids = household.enrollments.map(&:id)
+      return false if enrollment_ids.blank?
+
+      rf_t = Hmis::Ce::Referral.arel_table
+      cond = [
+        rf_t[:source_enrollment_id].in(enrollment_ids),
+        rf_t[:target_enrollment_id].in(enrollment_ids),
+      ].reduce(:or)
+
+      Hmis::Ce::Referral.active.where(cond).exists?
+    end
 
     def get_most_recent_contact(enrollment, project)
       if project.es_nbn? # Night-by-night Emergency Shelter

--- a/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
+++ b/drivers/hmis/app/jobs/hmis/auto_exit_job.rb
@@ -97,6 +97,8 @@ module Hmis
     private
 
     def household_has_active_ce_referral?(household)
+      return false unless Hmis::Ce.configuration.enabled?
+
       enrollment_ids = household.enrollments.map(&:id)
       return false if enrollment_ids.blank?
 

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -225,6 +225,8 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
   end
 
   describe 'auto-exit is blocked by active CE referral' do
+    before { allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true) }
+
     let(:project_type) { 1 }
     let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1, project_type: project_type }
     let!(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }

--- a/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
+++ b/drivers/hmis/spec/jobs/auto_exit_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -219,6 +221,44 @@ RSpec.describe Hmis::AutoExitJob, type: :model do
 
       Hmis::AutoExitJob.perform_now
       expect(e1.exit).to have_attributes(auto_exited: be_present, exit_date: e1.entry_date, destination: 30)
+    end
+  end
+
+  describe 'auto-exit is blocked by active CE referral' do
+    let(:project_type) { 1 }
+    let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1, project_type: project_type }
+    let!(:c1) { create :hmis_hud_client, data_source: ds1, user: u1 }
+    let!(:aec) { create :hmis_project_auto_exit_config, length_of_absence_days: 30, project: p1 }
+    let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, user: u1, entry_date: Date.current - 2.months }
+
+    def expect_no_auto_exit_for(enrollment)
+      expect do
+        Hmis::AutoExitJob.perform_now
+        enrollment.reload
+      end.not_to(change { enrollment.exit })
+    end
+
+    context 'when referral references source_enrollment' do
+      it 'does not auto-exit enrollment' do
+        # Active referral (status initialized) tied to source_enrollment blocks auto-exit
+        create :hmis_ce_referral, data_source: ds1, project: p1, client: c1, source_enrollment: e1
+        expect_no_auto_exit_for(e1)
+      end
+    end
+
+    context 'when referral references target_enrollment' do
+      let(:project_type) { 6 }
+
+      before do
+        # Make enrollment eligible for auto-exit by having an old service/contact
+        create :hmis_hud_service, data_source: ds1, client: c1, enrollment: e1, user: u1, record_type: 141, type_provided: 1, date_provided: Date.current - 31.days
+        # Active referral (status initialized) tied to target_enrollment blocks auto-exit
+        create :hmis_ce_referral, data_source: ds1, project: p1, client: c1, target_enrollment: e1
+      end
+
+      it 'does not auto-exit enrollment' do
+        expect_no_auto_exit_for(e1)
+      end
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

* Block auto-exit when any active CE referral references an enrollment via `source_enrollment_id` or `target_enrollment_id`.
* Added class-level docs in `Hmis::AutoExitJob` detailing household logic and contact sources.
* Note, this incurs a small n+1 cost in auto exit job

## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

