### PR TITLE
Add capability of workflow to delete a wip enrollment

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -63,7 +63,6 @@ module Hmis::Ce
         return # in non-dev env: return, we are unable to perform the action
       end
 
-
       referral.update!(target_enrollment: nil)
       enrollment.destroy!
     end

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -51,6 +51,18 @@ module Hmis::Ce
       referral.update!(target_enrollment: enrollment)
     end
 
+    def delete_wip_enrollment(_message)
+      enrollment = referral.target_enrollment
+      return unless enrollment
+
+      raise "target enrollment #{enrollment.id} has already had intake completed" unless enrollment.in_progress?
+
+      Hmis::Hud::Enrollment.transaction do
+        referral.update!(target_enrollment: nil)
+        enrollment.destroy!
+      end
+    end
+
     # Sets the Move-In Date on the target enrollment, based on a date value collected on the step form.
     # This requires a Move-in date item to be on the step form with the following attributes:
     # { "link_id": "move_in_date", "type": "DATE", "mapping": { "custom_field_key": "" } }

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -63,10 +63,9 @@ module Hmis::Ce
         return # in non-dev env: return, we are unable to perform the action
       end
 
-      Hmis::Hud::Enrollment.transaction do
-        referral.update!(target_enrollment: nil)
-        enrollment.destroy!
-      end
+
+      referral.update!(target_enrollment: nil)
+      enrollment.destroy!
     end
 
     # Sets the Move-In Date on the target enrollment, based on a date value collected on the step form.

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -55,7 +55,13 @@ module Hmis::Ce
       enrollment = referral.target_enrollment
       return unless enrollment
 
-      raise "target enrollment #{enrollment.id} has already had intake completed" unless enrollment.in_progress?
+      unless enrollment.in_progress?
+          message = "target enrollment #{enrollment.id} has already had intake completed, unable to perform delete_wip_enrollment message"
+          raise message if Rails.env.development?
+
+          Sentry.capture_message(message)
+          return # in non-dev env: return, we are unable to perform the action
+     end
 
       Hmis::Hud::Enrollment.transaction do
         referral.update!(target_enrollment: nil)

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -56,12 +56,12 @@ module Hmis::Ce
       return unless enrollment
 
       unless enrollment.in_progress?
-          message = "target enrollment #{enrollment.id} has already had intake completed, unable to perform delete_wip_enrollment message"
-          raise message if Rails.env.development?
+        message = "target enrollment #{enrollment.id} has already had intake completed, unable to perform delete_wip_enrollment message"
+        raise message if Rails.env.development?
 
-          Sentry.capture_message(message)
-          return # in non-dev env: return, we are unable to perform the action
-     end
+        Sentry.capture_message(message)
+        return # in non-dev env: return, we are unable to perform the action
+      end
 
       Hmis::Hud::Enrollment.transaction do
         referral.update!(target_enrollment: nil)

--- a/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
@@ -45,6 +45,8 @@ module Hmis::Ce
       when 'create_enrollment'
         referral_enroller.create_enrollment(message)
         reversible = false
+      when 'delete_wip_enrollment'
+        referral_enroller.delete_wip_enrollment(message)
       when 'set_move_in_date'
         # Can be triggered on the same step as create_enrollment, or a later step
         referral_enroller.set_move_in_date(message)

--- a/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
@@ -337,6 +337,12 @@ module CeWorkflows::Ac
         form_definition_identifier: CE_STEP_FORMS.fetch(:change_provider_outcome),
         template_id: template.id,
         swimlane: project_staff_swimlane,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'delete_wip_enrollment',
+          },
+        ],
       )
       create_enrollment_task.connect_to!(change_provider_outcome_task)
 

--- a/drivers/hmis/lib/form_data/allegheny/ce_referral_steps/change_provider_outcome.json
+++ b/drivers/hmis/lib/form_data/allegheny/ce_referral_steps/change_provider_outcome.json
@@ -52,7 +52,7 @@
       ]
     },
     {
-      "text": "The client has already been enrolled in the project.",
+      "text": "The client's in-progress enrollment in this project will be deleted.",
       "type": "DISPLAY",
       "link_id": "already_enrolled_message",
       "component": "ALERT_WARNING"

--- a/drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb
@@ -322,4 +322,118 @@ RSpec.describe Hmis::Ce::ReferralEnroller, type: :model do
         and not_change(referral, :target_enrollment).from(nil)
     end
   end
+
+  describe 'workflow with side effect that deletes a WIP enrollment' do
+    let!(:provider_acceptance_task) do
+      create(
+        :hmis_workflow_definition_user_task,
+        template: workflow_template,
+        name: 'Provider Acceptance',
+        swimlane: provider_swimlane,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'create_enrollment',
+          },
+        ],
+      )
+    end
+
+    let!(:confirm_success_task) do
+      create(
+        :hmis_workflow_definition_user_task,
+        template: workflow_template,
+        name: 'Confirm Success',
+        swimlane: case_manager_swimlane,
+      )
+    end
+
+    let!(:change_provider_outcome_task) do
+      create(
+        :hmis_workflow_definition_user_task,
+        template: workflow_template,
+        name: 'Change Provider Outcome',
+        swimlane: provider_swimlane,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'delete_wip_enrollment',
+          },
+        ],
+      )
+    end
+
+    before do
+      # Set up the workflow flow: client_acceptance -> provider_acceptance -> change_provider_outcome
+      client_acceptance_task.outflows.destroy_all
+      provider_acceptance_task.outflows.destroy_all
+
+      client_acceptance_task.connect_to!(provider_acceptance_task)
+      provider_acceptance_task.connect_to!(change_provider_outcome_task)
+      provider_acceptance_task.connect_to!(confirm_success_task)
+      change_provider_outcome_task.connect_to!(reject_referral)
+      confirm_success_task.connect_to!(accept_referral)
+
+      engine.start_workflow!(user: hmis_user)
+
+      # Complete client acceptance
+      first_step = engine.active_steps.sole
+      engine.start_step!(first_step, user: hmis_user)
+      engine.complete_step!(first_step, user: hmis_user, submitted_values: {})
+
+      # Complete provider acceptance (creates enrollment)
+      second_step = engine.active_steps.sole
+      engine.start_step!(second_step, user: hmis_user)
+      engine.complete_step!(second_step, user: hmis_user, submitted_values: {})
+    end
+
+    let(:change_provider_outcome_step) do
+      # Start change provider outcome step (the one that will delete enrollment)
+      current_step = engine.active_steps.where(node: change_provider_outcome_task).sole
+      engine.start_step!(current_step, user: hmis_user)
+
+      current_step
+    end
+
+    context 'when referral has a WIP enrollment' do
+      it 'deletes the enrollment and clears the referral association' do
+        referral.reload
+        enrollment = referral.target_enrollment
+        expect(enrollment).to be_present
+        expect(enrollment.in_progress?).to be_truthy
+
+        expect do
+          engine.complete_step!(change_provider_outcome_step, user: hmis_user, submitted_values: {})
+          referral.reload
+        end.to change(Hmis::Hud::Enrollment, :count).by(-1).
+          and change(referral, :target_enrollment).from(enrollment).to(nil).
+          and change(change_provider_outcome_step, :status).to('completed')
+
+        # Verify the enrollment was deleted
+        expect(enrollment.reload.date_deleted).not_to be_nil
+      end
+    end
+
+    context 'when referral has an enrollment with a unit assignment' do
+      let!(:unit) { create :hmis_unit, project: project }
+      let!(:opportunity) { create :hmis_ce_opportunity, project: project, workflow_template: workflow_template, unit: unit }
+
+      it 'deletes the enrollment and frees up the unit' do
+        referral.reload
+        enrollment = referral.target_enrollment
+        unit.reload
+        expect(enrollment).to be_present
+        expect(enrollment.current_unit).to eq(unit)
+        expect(unit.occupied?).to be_truthy
+
+        expect do
+          engine.complete_step!(change_provider_outcome_step, user: hmis_user, submitted_values: {})
+          referral.reload
+          unit.reload
+        end.to change(Hmis::Hud::Enrollment, :count).by(-1).
+          and change(referral, :target_enrollment).from(enrollment).to(nil).
+          and change(unit, :occupied?).from(true).to(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- When the "Change Provider Outcome" step is completed, delete the WIP enrollment created by the previous "Provider Acceptance" step.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Client request

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
