### PR TITLE
Add permission to update unit availability

### DIFF
--- a/db/migrate/20250909182836_add_can_update_unit_availability_permission.rb
+++ b/db/migrate/20250909182836_add_can_update_unit_availability_permission.rb
@@ -1,0 +1,18 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddCanUpdateUnitAvailabilityPermission < ActiveRecord::Migration[7.1]
+  def up
+    ::Hmis::Role.ensure_permissions_exist
+    ::Hmis::Role.reset_column_information
+  end
+
+  def down
+    remove_column :hmis_roles, :can_update_unit_availability
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -978,7 +978,8 @@ CREATE TABLE public.hmis_roles (
     can_view_client_eligible_opportunities boolean DEFAULT false,
     can_administrate_coordinated_entry boolean DEFAULT false,
     can_assign_referral_tasks boolean DEFAULT false,
-    can_print_client_case_notes boolean DEFAULT false
+    can_print_client_case_notes boolean DEFAULT false,
+    can_update_unit_availability boolean DEFAULT false
 );
 
 
@@ -4193,6 +4194,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250909182836'),
 ('20250727131402'),
 ('20250618150200'),
 ('20250523175114'),
@@ -4528,4 +4530,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20160628182622'),
 ('20160616140826'),
 ('20160615125048');
-

--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -22,7 +22,7 @@ module Mutations
       raise 'Cannot manage units across projects' if project_ids.size > 1
 
       project = Hmis::Hud::Project.find_by(id: project_ids.first)
-      access_denied! unless policy_for(project, policy_type: :hmis_project).can_manage_units?
+      access_denied! unless policy_for(project, policy_type: :hmis_project).can_update_unit_availability?
 
       opportunities = units.map { |unit| build_opportunity_for_unit(unit) }
       Hmis::Ce::Opportunity.import!(opportunities)

--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_unavailable.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_unavailable.rb
@@ -20,7 +20,7 @@ module Mutations
       raise 'Cannot manage units across projects' if project_ids.size > 1
 
       project = Hmis::Hud::Project.find_by(id: project_ids.first)
-      access_denied! unless policy_for(project, policy_type: :hmis_project).can_manage_units?
+      access_denied! unless policy_for(project, policy_type: :hmis_project).can_update_unit_availability?
 
       opportunities = Hmis::Ce::Opportunity.active.
         where(unit_id: unit_ids).

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -9622,6 +9622,7 @@ type ProjectAccess {
   canPerformOwnReferralTasks: Boolean!
   canSplitHouseholds: Boolean!
   canStartReferrals: Boolean!
+  canUpdateUnitAvailability: Boolean!
   canViewDob: Boolean!
   canViewEnrollmentDetails: Boolean!
   canViewFullSsn: Boolean!
@@ -10176,6 +10177,7 @@ type QueryAccess {
   canSplitHouseholds: Boolean!
   canStartReferrals: Boolean!
   canTransferEnrollments: Boolean!
+  canUpdateUnitAvailability: Boolean!
   canViewAnyConfidentialClientFiles: Boolean!
   canViewAnyNonconfidentialClientFiles: Boolean!
   canViewClientAlerts: Boolean!

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -119,6 +119,7 @@ module Types
       can :perform_any_referral_tasks
       can :perform_own_referral_tasks
       can :assign_referral_tasks
+      can :update_unit_availability
       can :view_prioritized_client_lists
     end
     field :unit_types, [Types::HmisSchema::UnitTypeCapacity], null: false

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
@@ -25,6 +25,10 @@ class Hmis::AuthPolicies::HmisProjectPolicy < Hmis::AuthPolicies::BasePolicy
     project_permissions.include?(:can_manage_units)
   end
 
+  def can_update_unit_availability?
+    project_permissions.include?(:can_update_unit_availability)
+  end
+
   def can_send_out_direct_referral?
     project_permissions.include?(:can_manage_outgoing_referrals)
   end

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -167,7 +167,7 @@ class Hmis::Role < ::ApplicationRecord
         sub_category: 'Management',
       },
       can_manage_units: {
-        description: 'Ability to manage bed and unit capacity in the project. If Coordinated Entry is enabled in the project, users can also mark units as available for receiving referrals.',
+        description: 'Ability to manage bed and unit capacity in the project.',
         administrative: false,
         access: [:editable],
         category: 'Project Access',
@@ -242,6 +242,14 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_assign_referral_tasks: {
         description: 'Ability to assign contacts for any referral to the project that the user can view',
+        administrative: false,
+        access: [:editable],
+        category: 'Referrals',
+        sub_category: 'Management',
+        proc: -> { Hmis::Ce.configuration.enabled? },
+      },
+      can_update_unit_availability: {
+        description: 'Ability to mark units as available or unavailable for receiving referrals.',
         administrative: false,
         access: [:editable],
         category: 'Referrals',

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -13,7 +13,7 @@ require_relative '../../../support/hmis_base_setup'
 RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
   include_context 'hmis base setup'
 
-  let!(:access_control) { create_access_control(hmis_user, ds1) }
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_units, :can_update_unit_availability]) }
   let!(:project) { create :hmis_hud_project, data_source: ds1 }
   let!(:template) { create :hmis_workflow_definition_template, status: 'published', data_source: ds1 }
   let!(:unit_type) { create :hmis_unit_type, description: '1 Bedroom Apartment' }

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb
@@ -13,7 +13,7 @@ require_relative '../../../support/hmis_base_setup'
 RSpec.describe Mutations::Ce::MarkUnitsUnavailable, type: :request do
   include_context 'hmis base setup'
 
-  let!(:access_control) { create_access_control(hmis_user, ds1) }
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_units, :can_update_unit_availability]) }
   let!(:project) { create :hmis_hud_project, data_source: ds1 }
   let!(:unit_group) { create(:hmis_unit_group, project: project) }
   let!(:unit) { create :hmis_unit, project: project, unit_group: unit_group }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add migration to add a new permission, `can_update_unit_availability`
- Use this permission instead of `can_manage_units` in the `MarkUnitsAvailable` and `MarkUnitsUnavailable` mutations

Frontend PR: https://github.com/greenriver/hmis-frontend/pull/1264

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) see ticket

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
