### PR TITLE
Fix table config bug: return nil if no config found

### DIFF
--- a/drivers/hmis/app/graphql/types/table_config_lookup.rb
+++ b/drivers/hmis/app/graphql/types/table_config_lookup.rb
@@ -39,6 +39,8 @@ module Types
           find_by(owner: owner)
         return config if config
       end
+
+      nil # return nil if no applicable config was found
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/table_config_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/table_config_lookup_spec.rb
@@ -1,0 +1,191 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let!(:access_control) { create_access_control(hmis_user, ds1) }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  describe 'TableConfigLookup' do
+    describe 'ceClientsGlobalConfig' do
+      let(:query) do
+        <<~GRAPHQL
+          query TableConfigLookup {
+            tableConfigLookup {
+              ceClientsGlobalConfig {
+                columns {
+                  key
+                  label
+                  type
+                }
+                filters {
+                  key
+                  label
+                  options {
+                    code
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      context 'when no global config exists' do
+        it 'returns null' do
+          response, result = post_graphql({}) { query }
+
+          aggregate_failures 'checking response' do
+            expect(response.status).to eq(200), result.inspect
+            config = result.dig('data', 'tableConfigLookup', 'ceClientsGlobalConfig')
+            expect(config).to be_nil
+          end
+        end
+      end
+
+      context 'when global config exists' do
+        let!(:global_config) do
+          create(
+            :hmis_table_configuration_ce_clients,
+            :with_columns,
+            :with_filters,
+            data_source: ds1,
+            owner: nil,
+          )
+        end
+
+        it 'returns the global configuration' do
+          response, result = post_graphql({}) { query }
+
+          aggregate_failures 'checking response' do
+            expect(response.status).to eq(200), result.inspect
+            config = result.dig('data', 'tableConfigLookup', 'ceClientsGlobalConfig')
+            expect(config).to be_present
+
+            # Check columns
+            expect(config['columns']).to be_present
+            column = config['columns'].first
+            expect(column).to include(
+              'key' => 'cde.custom_assessment.my_household_type',
+              'type' => 'STRING',
+              'label' => 'Household Type',
+            )
+
+            # Check filters
+            expect(config['filters']).to be_present
+            filter = config['filters'].first
+            expect(filter).to include(
+              'key' => 'cde.custom_assessment.my_household_type',
+              'label' => 'Household Type',
+            )
+            expect(filter['options']).to contain_exactly(
+              { 'code' => 'Household with children' },
+              { 'code' => 'Household without children' },
+            )
+          end
+        end
+      end
+    end
+
+    describe 'ceClientsUnitGroupConfig' do
+      let!(:organization) { create :hmis_hud_organization, data_source: ds1 }
+      let!(:project) { create :hmis_hud_project, data_source: ds1, organization: organization }
+      let!(:unit_group) { create :hmis_unit_group, project: project, name: 'Test Unit Group' }
+
+      let(:query) do
+        <<~GRAPHQL
+          query TableConfigLookup($unitGroupId: ID!) {
+            tableConfigLookup {
+              ceClientsUnitGroupConfig(unitGroupId: $unitGroupId) {
+                columns {
+                  key
+                  label
+                  type
+                }
+                filters {
+                  key
+                  label
+                  options {
+                    code
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      end
+
+      context 'when unit group has no applicable config' do
+        it 'returns null' do
+          response, result = post_graphql({ unit_group_id: unit_group.id }) { query }
+
+          aggregate_failures 'checking response' do
+            expect(response.status).to eq(200), result.inspect
+            config = result.dig('data', 'tableConfigLookup', 'ceClientsUnitGroupConfig')
+            expect(config).to be_nil
+          end
+        end
+      end
+
+      context 'when unit group has config' do
+        let!(:unit_group_config) do
+          create(
+            :hmis_table_configuration_ce_clients,
+            :with_columns,
+            :with_filters,
+            data_source: ds1,
+            owner: unit_group,
+          )
+        end
+
+        it 'returns the unit group configuration' do
+          response, result = post_graphql({ unit_group_id: unit_group.id }) { query }
+
+          aggregate_failures 'checking response' do
+            expect(response.status).to eq(200), result.inspect
+            config = result.dig('data', 'tableConfigLookup', 'ceClientsUnitGroupConfig')
+            expect(config).to be_present
+
+            # Check columns
+            expect(config['columns']).to be_present
+            column = config['columns'].first
+            expect(column).to include(
+              'key' => 'cde.custom_assessment.my_household_type',
+              'type' => 'STRING',
+              'label' => 'Household Type',
+            )
+
+            # Check filters
+            expect(config['filters']).to be_present
+            filter = config['filters'].first
+            expect(filter).to include(
+              'key' => 'cde.custom_assessment.my_household_type',
+              'label' => 'Household Type',
+            )
+            expect(filter['options']).to contain_exactly(
+              { 'code' => 'Household with children' },
+              { 'code' => 'Household without children' },
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- See linked ticket which includes repro instructions & sentry link

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
