### PR TITLE
Non-Manual HUD Report Priorities

### DIFF
--- a/app/jobs/reporting/hud/run_report_job.rb
+++ b/app/jobs/reporting/hud/run_report_job.rb
@@ -22,34 +22,39 @@ module Reporting::Hud
       # advisory lock to check the number of jobs running for this generator so we don't
       # all check at exactly the same time and get the same result
       @generator = class_name.constantize.new(report)
-      HudReports::ReportInstance.with_advisory_lock(@generator.class.name, timeout_seconds: 20) do
-        # We can't only count the running delayed jobs because we start a DJ every time we check
-        # So, we'll check the report class for running reports instead.
-        running_reports_count = HudReports::ReportInstance.
-          created_recently.
-          incomplete.
-          started.
-          for_report(report.report_name).
-          count
+      if report.manual
+        HudReports::ReportInstance.with_advisory_lock(@generator.class.name, timeout_seconds: 20) do
+          # We can't only count the running delayed jobs because we start a DJ every time we check
+          # So, we'll check the report class for running reports instead.
+          running_reports_count = HudReports::ReportInstance.
+            created_recently.
+            incomplete.
+            started.
+            for_report(report.report_name).
+            count
 
-        if running_reports_count > 1
-          puts "Found #{running_reports_count} running reports, for #{@generator.class.name} (#{report.report_name}), postponing run of #{report_id}"
-          requeue_job(class_name)
-          return
+          if running_reports_count > 1
+            puts "Found #{running_reports_count} running reports, for #{@generator.class.name} (#{report.report_name}), postponing run of #{report_id}"
+            requeue_job(class_name)
+            return
+          end
         end
       end
-
       # puts "Running: #{@generator.class.name} Report ID: #{report_id}"
 
+      run_report(report, @generator, email: email)
+    end
+
+    protected def run_report(report, generator, email:)
       capture_failure(report) do
-        @generator.prepare_report
-        @generator.class.questions.each do |q, klass|
-          klass.new(@generator, report).run! if report.build_for_questions.include?(q)
+        generator.prepare_report
+        generator.class.questions.each do |q, klass|
+          klass.new(generator, report).run! if report.build_for_questions.include?(q)
         end
       end
 
       report_completed = report.complete_report
-      NotifyUser.driver_hud_report_finished(@generator).deliver_now if report.user_id && email
+      NotifyUser.driver_hud_report_finished(generator).deliver_now if report.user_id && email
       report_completed
     end
 

--- a/app/jobs/reporting/hud/run_report_job.rb
+++ b/app/jobs/reporting/hud/run_report_job.rb
@@ -22,27 +22,42 @@ module Reporting::Hud
       # advisory lock to check the number of jobs running for this generator so we don't
       # all check at exactly the same time and get the same result
       @generator = class_name.constantize.new(report)
-      if report.manual
-        HudReports::ReportInstance.with_advisory_lock(@generator.class.name, timeout_seconds: 20) do
-          # We can't only count the running delayed jobs because we start a DJ every time we check
-          # So, we'll check the report class for running reports instead.
-          running_reports_count = HudReports::ReportInstance.
-            created_recently.
-            incomplete.
-            started.
-            for_report(report.report_name).
-            count
 
-          if running_reports_count > 1
-            puts "Found #{running_reports_count} running reports, for #{@generator.class.name} (#{report.report_name}), postponing run of #{report_id}"
-            requeue_job(class_name)
-            return
-          end
+      # this report was called directly as opposed to being called through an automated process (e.g. to back a different report)
+      # so we'll make sure there isn't another similar report running before we start
+      if report.manual
+        requeued = check_and_requeue_for_running(report, @generator.class.name)
+        # a similar report is already running, this report has been adding back to the queue so it will be tried again in a bit
+        return if requeued
+      end
+
+      # puts "Running: #{@generator.class.name} Report ID: #{report_id}"
+      run_report(report, @generator, email: email)
+    end
+
+    # Check if a similar report is already running and requeue this report if it is
+    #
+    # @param report [HudReports::ReportInstance] the report to check
+    # @param generator_class_name [String] the class name of the generator
+    # @return [Boolean] true if the report was requeued, false otherwise
+    protected def check_and_requeue_for_running(report, generator_class_name)
+      HudReports::ReportInstance.with_advisory_lock(generator_class_name, timeout_seconds: 20) do
+        # We can't only count the running delayed jobs because we start a DJ every time we check
+        # So, we'll check the report class for running reports instead.
+        running_reports_count = HudReports::ReportInstance.
+          created_recently.
+          incomplete.
+          started.
+          for_report(report.report_name).
+          count
+
+        if running_reports_count > 1
+          puts "Found #{running_reports_count} running reports, for #{generator_class_name} (#{report.report_name}), postponing run of #{report.id}"
+          requeue_job(class_name)
+          return true
         end
       end
-      # puts "Running: #{@generator.class.name} Report ID: #{report_id}"
-
-      run_report(report, @generator, email: email)
+      false
     end
 
     protected def run_report(report, generator, email:)

--- a/drivers/boston_project_scorecard/app/models/boston_project_scorecard/report.rb
+++ b/drivers/boston_project_scorecard/app/models/boston_project_scorecard/report.rb
@@ -316,6 +316,8 @@ module BostonProjectScorecard
       apr = HudReports::ReportInstance.from_filter(filter, generator.title, build_for_questions: questions)
       generator.new(apr).run!(email: false, manual: false)
 
+      raise 'APR not completed' unless apr.reload.completed?
+
       apr
     end
 
@@ -347,6 +349,8 @@ module BostonProjectScorecard
       generator = apr_generator
       apr = HudReports::ReportInstance.from_filter(comparison_filter, generator.title, build_for_questions: questions)
       generator.new(apr).run!(email: false, manual: false)
+
+      raise 'APR Comparison not completed' unless apr.reload.completed?
 
       apr
     end

--- a/drivers/project_scorecard/app/models/project_scorecard/report.rb
+++ b/drivers/project_scorecard/app/models/project_scorecard/report.rb
@@ -236,6 +236,8 @@ module ProjectScorecard
         apr = HudReports::ReportInstance.from_filter(filter, generator.title, build_for_questions: questions)
         generator.new(apr).run!(email: false, manual: false)
 
+        raise 'APR not completed' unless apr.reload.completed?
+
         assessment_answers.merge!(
           {
             apr_id: apr.id,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Only bump manually run hud reports for if additional similar reports ar running. This allows hud reports started as backing for additional reports to be processed without being requeued du to priority issues.

This change also adds a check to the scorecard reports to verify the apr backing them ahs been completed before moving forward.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
