### PR TITLE
Restore access to entities when set via the user's private access group

### DIFF
--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -94,16 +94,14 @@ module GrdaWarehouse
         return none if ids.empty?
 
         where(id: ids)
-      else
-        if user.can_access_some_cohorts # rubocop:disable Style/IfInsideElse
-          if current_scope.present?
-            current_scope.merge(user.cohorts)
-          else
-            user.cohorts
-          end
+      elsif user.can_access_some_cohorts
+        if current_scope.present?
+          current_scope.merge(user.cohorts)
         else
-          none
+          user.cohorts
         end
+      else
+        none
       end
       # END_ACL
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,7 +224,8 @@ class User < ApplicationRecord
     @ids_for_relations[relation] = if using_acls?
       collections.flat_map(&relation)
     else
-      access_groups.flat_map(&relation)
+      # access granted via groups + access granted via the user's own access group
+      access_groups.flat_map(&relation) + [access_group.send(relation)]
     end
     # END_ACL
     @ids_for_relations[relation]

--- a/spec/models/grda_warehouse/cohort_legacy_spec.rb
+++ b/spec/models/grda_warehouse/cohort_legacy_spec.rb
@@ -87,4 +87,42 @@ RSpec.describe GrdaWarehouse::Cohort, type: :model do
       expect(GrdaWarehouse::Cohort.viewable_by(viewer).where(id: cohort.id).exists?).to be_falsey
     end
   end
+
+  describe 'when access is granted via different access group mechanisms' do
+    let(:general_access_group) { create(:access_group, name: 'General Cohort Access') }
+    let(:test_user) { create(:user) }
+
+    before do
+      # Give test_user the necessary role to view cohorts
+      test_user.legacy_roles = [cohort_viewer]
+    end
+
+    it 'user should have access via their personal access_group' do
+      test_user.access_group.add_viewable(cohort)
+      expect(GrdaWarehouse::Cohort.viewable_by(test_user).where(id: cohort.id).exists?).to be true
+    end
+
+    it 'user should have access via a general access_group they are a member of' do
+      general_access_group.add_viewable(cohort)
+      general_access_group.add(test_user)
+      expect(GrdaWarehouse::Cohort.viewable_by(test_user).where(id: cohort.id).exists?).to be true
+    end
+
+    it 'user should NOT have access to cohorts in general access_groups they are not a member of' do
+      general_access_group.add_viewable(cohort)
+      # Note: test_user is NOT added to general_access_group
+      expect(GrdaWarehouse::Cohort.viewable_by(test_user).where(id: cohort.id).exists?).to be false
+    end
+
+    it 'user.cohorts should include cohorts from their personal access_group' do
+      test_user.access_group.add_viewable(cohort)
+      expect(test_user.cohorts.pluck(:id)).to include(cohort.id)
+    end
+
+    it 'user.cohorts should include cohorts from general access_groups they belong to' do
+      general_access_group.add_viewable(cohort)
+      general_access_group.add(test_user)
+      expect(test_user.cohorts.pluck(:id)).to include(cohort.id)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Bug fix for lack of including a user's private access group for legacy role-based users when accessing project groups and cohorts

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
