### PR TITLE
Add Label and AssessmentKey to custom ac cded export

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cded_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/cded_export.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisExternalApis::AcHmis::Exporters
   class CdedExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
@@ -32,6 +34,8 @@ module HmisExternalApis::AcHmis::Exporters
           cded.key,
           cded.owner_type.demodulize,
           cded.field_type,
+          cded.label,
+          cded.form_definition_identifier,
         ]
         write_row(values)
       end
@@ -41,9 +45,11 @@ module HmisExternalApis::AcHmis::Exporters
 
     def columns
       [
-        'CustomFieldKey',
-        'RecordType',
-        'FieldType',
+        'CustomFieldKey', # maps to CustomFieldKey in CustomFieldValues.csv
+        'RecordType', # eg 'Service', 'CustomAssessment', 'Client'
+        'FieldType', # eg 'string', 'integer'
+        'Label', # human-readable label for this field
+        'AssessmentKey', # maps to AssessmentKey in CustomAssessments.csv if RecordType is CustomAssessment
       ]
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/cded_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/cded_export_spec.rb
@@ -4,12 +4,14 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HmisExternalApis::AcHmis::Exporters::CdedExport, type: :model do
   let!(:ds) { create(:hmis_data_source) }
   let(:subject) { HmisExternalApis::AcHmis::Exporters::CdedExport.new }
-  let!(:cded) { create :hmis_custom_data_element_definition, label: 'A string', data_source: ds, owner_type: 'Hmis::Hud::Service', field_type: :string }
+  let!(:cded) { create :hmis_custom_data_element_definition, label: 'A string', data_source: ds, owner_type: 'Hmis::Hud::Service', field_type: :string, form_definition_identifier: 'my_form' }
   let(:output) do
     subject.output.rewind
     subject.output.read
@@ -23,9 +25,12 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CdedExport, type: :model do
   it 'makes a csv' do
     subject.run!
     result = CSV.parse(output, headers: true)
+
     expect(result.length).to eq(1)
     expect(result.first['CustomFieldKey']).to eq(cded.key)
     expect(result.first['FieldType']).to eq('string')
     expect(result.first['RecordType']).to eq('Service')
+    expect(result.first['Label']).to eq(cded.label)
+    expect(result.first['AssessmentKey']).to eq(cded.form_definition_identifier)
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue https://github.com/open-path/Green-River/issues/7813

Add `Label` and `AssessmentKey` to existing CDED export for AC to support identifying questions from assessments.

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
