### PR TITLE
Longitudinal SPM Blank Tables Fix

### DIFF
--- a/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
+++ b/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
@@ -141,8 +141,9 @@ module LongitudinalSpm
     def spm_describe(measure_or_table, cell = nil, row_col = :row)
       return spm_generator.describe_table(measure_or_table) if cell.blank?
 
-      # Don't break terribly if the SPM version has changed
-      return '' unless spms.first&.hud_spm&.report_name == 'System Performance Measures - FY 2024'
+      # Don't break terribly if loading a 2020 version.
+      # There were breaking changes moving from version 2020 to version 2023.
+      return '' if spms.first&.hud_spm&.report_name == 'System Performance Measures - FY 2020'
 
       @sample_spm ||= spms.first.hud_spm # Just find one of the SPMs so we can get metadata
       # Sometimes we get into a weird state where the SPMs didn't run, return so we don't throw errors


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix bug in Longitudinal SPM that wass only allowing the showing data generated from the 2024 SPMs. It appears this functionality was introduced after the major changes from 2020->2023. This should allow all versions other than 202 to be viewed, which appears to be the original intent of the original change.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
