### PR TITLE
Remove nested transaction from Create Direct Referral mutation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/create_direct_ce_referral.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/create_direct_ce_referral.rb
@@ -42,21 +42,19 @@ module Mutations
 
       referral = nil
 
-      Hmis::Ce::Referral.transaction do
-        opportunity.with_lock do
-          unless opportunity.open? # check inside lock for race condition
-            errors.add(:base, :invalid, full_message: unavailable_error(unit_group, target_project))
-            return { errors: errors }
-          end
-
-          instance = opportunity.workflow_template.instances.create!
-          referral = opportunity.referrals.originated_from_direct_send.create!(
-            workflow_instance: instance,
-            referred_by: current_user,
-            client: source_enrollment.client,
-            source_enrollment: source_enrollment,
-          )
+      opportunity.with_lock do
+        unless opportunity.open? # check inside lock for race condition
+          errors.add(:base, :invalid, full_message: unavailable_error(unit_group, target_project))
+          return { errors: errors }
         end
+
+        instance = opportunity.workflow_template.instances.create!
+        referral = opportunity.referrals.originated_from_direct_send.create!(
+          workflow_instance: instance,
+          referred_by: current_user,
+          client: source_enrollment.client,
+          source_enrollment: source_enrollment,
+        )
 
         engine = referral.workflow_engine
         engine.start_workflow!(user: current_user)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Remove nested transaction; perform whole mutation in transaction created by opportunity lock.

Followup to https://github.com/greenriver/hmis-warehouse/pull/5738#discussion_r2337536433

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
