### PR TITLE
Update workflow to ensure enrollment exists

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -18,6 +18,8 @@ module Hmis::Ce
     end
 
     def create_enrollment(message)
+      raise "Referral #{referral.id} already has an enrollment. This indicates a misconfigured workflow" if referral.target_enrollment
+
       project = referral.target_project
 
       # Step form may specify CoC code. This is required if the Project serves multiple CoCs.

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -69,6 +69,10 @@ module Hmis::Ce
       enrollment.destroy!
     end
 
+    def raise_if_no_enrollment(_message)
+      raise "Referral #{referral.id} has no enrollment. This may indicate user error or a misconfigured workflow." if referral.target_enrollment.nil?
+    end
+
     # Sets the Move-In Date on the target enrollment, based on a date value collected on the step form.
     # This requires a Move-in date item to be on the step form with the following attributes:
     # { "link_id": "move_in_date", "type": "DATE", "mapping": { "custom_field_key": "" } }

--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -69,10 +69,6 @@ module Hmis::Ce
       enrollment.destroy!
     end
 
-    def raise_if_no_enrollment(_message)
-      raise "Referral #{referral.id} has no enrollment. This may indicate user error or a misconfigured workflow." if referral.target_enrollment.nil?
-    end
-
     # Sets the Move-In Date on the target enrollment, based on a date value collected on the step form.
     # This requires a Move-in date item to be on the step form with the following attributes:
     # { "link_id": "move_in_date", "type": "DATE", "mapping": { "custom_field_key": "" } }

--- a/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
@@ -47,8 +47,6 @@ module Hmis::Ce
         reversible = false
       when 'delete_wip_enrollment'
         referral_enroller.delete_wip_enrollment(message)
-      when 'raise_if_no_enrollment'
-        referral_enroller.raise_if_no_enrollment(message)
       when 'set_move_in_date'
         # Can be triggered on the same step as create_enrollment, or a later step
         referral_enroller.set_move_in_date(message)

--- a/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_message_handler.rb
@@ -47,6 +47,8 @@ module Hmis::Ce
         reversible = false
       when 'delete_wip_enrollment'
         referral_enroller.delete_wip_enrollment(message)
+      when 'raise_if_no_enrollment'
+        referral_enroller.raise_if_no_enrollment(message)
       when 'set_move_in_date'
         # Can be triggered on the same step as create_enrollment, or a later step
         referral_enroller.set_move_in_date(message)

--- a/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
@@ -238,7 +238,17 @@ module CeWorkflows::Ac
       )
       denied_pending_trigger_config = [{ event: 'enable_step', message: 'set_custom_referral_status', params: { 'custom_status_key': denied_pending_status.key } }]
       assigned_status_trigger_config = [{ event: 'enable_step', message: 'set_custom_referral_status', params: { 'custom_status_key': assigned_status.key } }]
-      enrolled_status_trigger_config = [{ event: 'enable_step', message: 'set_custom_referral_status', params: { 'custom_status_key': enrolled_status.key } }]
+      enrolled_status_trigger_config = [
+        {
+          event: 'enable_step',
+          message: 'set_custom_referral_status',
+          params: { 'custom_status_key': enrolled_status.key },
+        },
+        {
+          event: 'complete_step',
+          message: 'raise_if_no_enrollment',
+        },
+      ]
 
       # Provider Outcome Task 1 - defined outside the loop since it's only available once
       provider_outcome_task_1 = Hmis::WorkflowDefinition::UserTask.create!(
@@ -314,7 +324,7 @@ module CeWorkflows::Ac
 
       # The denial loop with 3 opportunities to send back. Built in a subroutine for reusability
       denial_loop_tasks = build_provider_outcome_denial_review_loop(
-        next_task_after_success: create_enrollment_task,
+        next_task_after_success: confirm_success_task,
         next_task_after_denial: admin_decline_gateway,
         denied_pending_trigger_config: denied_pending_trigger_config,
         assigned_status_trigger_config: assigned_status_trigger_config,
@@ -348,7 +358,7 @@ module CeWorkflows::Ac
 
       # Second denial loop kicked off by the optional Change Provider Outcome task
       second_denial_loop_tasks = build_provider_outcome_denial_review_loop(
-        next_task_after_success: confirm_success_task, # create enrollment task was already completed, so go straight to confirm success
+        next_task_after_success: confirm_success_task,
         next_task_after_denial: admin_decline_gateway,
         denied_pending_trigger_config: denied_pending_trigger_config,
         assigned_status_trigger_config: assigned_status_trigger_config,
@@ -383,12 +393,32 @@ module CeWorkflows::Ac
         swimlane: project_staff_swimlane,
         trigger_config: assigned_status_trigger_config,
       )
+      create_enrollment_task_2 = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Create Enrollment (Second)',
+        template_id: template.id,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'create_enrollment',
+          },
+        ],
+      )
       provider_outcome_task_3 = Hmis::WorkflowDefinition::UserTask.create!(
         name: 'Provider Outcome (Third Attempt)',
         form_definition_identifier: CE_STEP_FORMS.fetch(:provider_outcome_3),
         template_id: template.id,
         swimlane: project_staff_swimlane,
         trigger_config: assigned_status_trigger_config,
+      )
+      create_enrollment_task_3 = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Create Enrollment (Third)',
+        template_id: template.id,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'create_enrollment',
+          },
+        ],
       )
 
       # Denial Review User Tasks
@@ -418,13 +448,15 @@ module CeWorkflows::Ac
       provider_outcome_gateway_2 = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'provider_outcome_2')
       provider_outcome_task_2.connect_to!(provider_outcome_gateway_2)
       provider_outcome_gateway_2.connect_to!(denial_review_task_2, condition: 'move_forward = 0')
-      provider_outcome_gateway_2.connect_to!(next_task_after_success)
+      provider_outcome_gateway_2.connect_to!(create_enrollment_task_2)
+      create_enrollment_task_2.connect_to!(next_task_after_success)
 
       # Provider Outcome 3 => Gateway => Denial Review 3 OR Create Enrollment (Script)
       provider_outcome_gateway_3 = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'provider_outcome_3')
       provider_outcome_task_3.connect_to!(provider_outcome_gateway_3)
       provider_outcome_gateway_3.connect_to!(denial_review_task_3, condition: 'move_forward = 0')
-      provider_outcome_gateway_3.connect_to!(next_task_after_success)
+      provider_outcome_gateway_3.connect_to!(create_enrollment_task_3)
+      create_enrollment_task_3.connect_to!(next_task_after_success)
 
       # Denial Review 1 => Gateway => Decline OR send back to Provider Outcome
       denial_review_gateway_1 = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'denial_review_1')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- targets `release-180`, should be re-deployed after PR is merged

## Description
- Update the Workflow with 3 separate Enrollment steps. See ticket and comments for rationale
- Propose a new referral step side effect, "raise_if_no_enrollment", that prevents users from "Confirm Success" on a referral whose enrollment has been deleted, either manually or by the workflow. (Not discussed, can revert https://github.com/greenriver/hmis-warehouse/pull/5757/commits/67905fc987981dcbb83c5c9d399268ce3726bcc5) 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
