### PR TITLE
Add overrides to provisional eligibility calculation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
@@ -45,7 +45,8 @@ module Mutations
 
     ALWAYS_OVERRIDE = {
       # Custom fields that should always be overridden when calculating provisional client eligibility. (#8129)
-      'housing_needs_post_referrals_to_waitlist': 'Yes',
+      'cde.custom_assessment.housing_needs_post_referrals_to_waitlist': 'Yes',
+      'custom_assessment.prevention_assessment_questions.date_created': Date.current,
     }.stringify_keys.freeze
 
     def build_overrides(values_by_link_id, form_definition_id)
@@ -63,7 +64,7 @@ module Mutations
 
         # Map to CDE field format for CE evaluation - see FieldMap
         ["cde.custom_assessment.#{custom_field_key}", value]
-      end.to_h
+      end.to_h.merge(ALWAYS_OVERRIDE)
     end
 
     def calculate_eligible_project_types(client, field_value_overrides)

--- a/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
@@ -46,7 +46,6 @@ module Mutations
     ALWAYS_OVERRIDE = {
       # Custom fields that should always be overridden when calculating provisional client eligibility. (#8129)
       'cde.custom_assessment.housing_needs_post_referrals_to_waitlist': 'Yes',
-      'custom_assessment.prevention_assessment_questions.date_created': Date.current,
     }.stringify_keys.freeze
 
     def build_overrides(values_by_link_id, form_definition_id)
@@ -54,14 +53,21 @@ module Mutations
       form_definition = Hmis::Form::Definition.find(form_definition_id)
 
       # Build overrides hash. Note that values_by_link_id does not include hidden fields.
-      values_by_link_id.filter_map do |link_id, value|
+      overrides = values_by_link_id.filter_map do |link_id, value|
         form_item = form_definition.link_id_item_hash[link_id]
         custom_field_key = form_item&.dig('mapping', 'custom_field_key')
         next unless custom_field_key
 
         # Map to CDE field format for CE evaluation - see FieldMap
         ["cde.custom_assessment.#{custom_field_key}", value]
-      end.to_h.merge(ALWAYS_OVERRIDE)
+      end.to_h
+
+      # Add assessment metadata overrides, because for the purposes of calculating what opportunities the client *would* be eligible for given the form values, we should also pretend they've had a real form submitted
+      overrides["custom_assessment.#{form_definition.identifier}.date_created"] = Time.current
+      overrides["custom_assessment.#{form_definition.identifier}.date_updated"] = Time.current
+      overrides["custom_assessment.#{form_definition.identifier}.assessment_date"] = Date.current
+
+      overrides.merge(ALWAYS_OVERRIDE)
     end
 
     def calculate_eligible_project_types(client, field_value_overrides)

--- a/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
@@ -59,9 +59,6 @@ module Mutations
         custom_field_key = form_item&.dig('mapping', 'custom_field_key')
         next unless custom_field_key
 
-        # If this field is present in the ALWAYS_OVERRIDE map, use that override value instead of whatever was submitted
-        next ["cde.custom_assessment.#{custom_field_key}", ALWAYS_OVERRIDE[custom_field_key]] if ALWAYS_OVERRIDE.key?(custom_field_key)
-
         # Map to CDE field format for CE evaluation - see FieldMap
         ["cde.custom_assessment.#{custom_field_key}", value]
       end.to_h.merge(ALWAYS_OVERRIDE)

--- a/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/calculate_client_ce_eligibility.rb
@@ -8,7 +8,9 @@
 
 module Mutations
   class Ce::CalculateClientCeEligibility < CleanBaseMutation
-    # Does not mutate data, but implemented as a mutation in order to use CleanBaseMutation's validation error pattern.
+    # Calculates provisional client eligibility, based on the form values provided.
+    # Does not result in the client actually becoming a Candidate for any opportunities.
+    # Does not mutate data. Implemented as a mutation in order to use CleanBaseMutation's validation error pattern.
 
     description 'Calculate client eligibility based on provided assessment values and return applicable project types'
 
@@ -41,6 +43,11 @@ module Mutations
 
     private
 
+    ALWAYS_OVERRIDE = {
+      # Custom fields that should always be overridden when calculating provisional client eligibility. (#8129)
+      'housing_needs_post_referrals_to_waitlist': 'Yes',
+    }.stringify_keys.freeze
+
     def build_overrides(values_by_link_id, form_definition_id)
       # Get the form definition to map from link_id to custom_field_key
       form_definition = Hmis::Form::Definition.find(form_definition_id)
@@ -50,6 +57,9 @@ module Mutations
         form_item = form_definition.link_id_item_hash[link_id]
         custom_field_key = form_item&.dig('mapping', 'custom_field_key')
         next unless custom_field_key
+
+        # If this field is present in the ALWAYS_OVERRIDE map, use that override value instead of whatever was submitted
+        next ["cde.custom_assessment.#{custom_field_key}", ALWAYS_OVERRIDE[custom_field_key]] if ALWAYS_OVERRIDE.key?(custom_field_key)
 
         # Map to CDE field format for CE evaluation - see FieldMap
         ["cde.custom_assessment.#{custom_field_key}", value]

--- a/drivers/hmis/app/models/hmis/ce/match/unit_group_rule_resolver.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/unit_group_rule_resolver.rb
@@ -57,7 +57,9 @@ module Hmis::Ce::Match
     def compose_requirement_expression(rules)
       # All applicable eligibility requirements are combined with AND.
       rules.filter(&:eligibility_requirement?).
-        map(&:expression).
+        map do |rule|
+          "(#{rule.expression})" # Wrap rule in parens in case it internally has an OR condition
+        end.
         join(' AND ').presence
     end
   end

--- a/drivers/hmis/app/models/hmis/ce/match/unit_group_rule_resolver.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/unit_group_rule_resolver.rb
@@ -56,10 +56,9 @@ module Hmis::Ce::Match
 
     def compose_requirement_expression(rules)
       # All applicable eligibility requirements are combined with AND.
+      # Parenthesize rules that contain "OR" conditions.
       rules.filter(&:eligibility_requirement?).
-        map do |rule|
-          "(#{rule.expression})" # Wrap rule in parens in case it internally has an OR condition
-        end.
+        map { |rule| rule.expression.include?(' OR ') ? "(#{rule.expression})" : rule.expression }.
         join(' AND ').presence
     end
   end

--- a/drivers/hmis/app/models/hmis/hud/funder.rb
+++ b/drivers/hmis/app/models/hmis/hud/funder.rb
@@ -30,7 +30,7 @@ class Hmis::Hud::Funder < Hmis::Hud::Base
 
   # Convert funder string to int #183572073, #1017
   # casting as an integer because the spec lists the Funder column as an integer and we incorrectly store it as a string. Probably better to write a migration to fix the data type in the DB.
-  attribute :Funder, :integer
+  # attribute :Funder, :integer
 
   def self.sort_by_option(option)
     raise NotImplementedError unless SORT_OPTIONS.include?(option)

--- a/drivers/hmis/app/models/hmis/hud/funder.rb
+++ b/drivers/hmis/app/models/hmis/hud/funder.rb
@@ -30,7 +30,7 @@ class Hmis::Hud::Funder < Hmis::Hud::Base
 
   # Convert funder string to int #183572073, #1017
   # casting as an integer because the spec lists the Funder column as an integer and we incorrectly store it as a string. Probably better to write a migration to fix the data type in the DB.
-  # attribute :Funder, :integer
+  attribute :Funder, :integer
 
   def self.sort_by_option(option)
     raise NotImplementedError unless SORT_OPTIONS.include?(option)

--- a/drivers/hmis/spec/models/hmis/ce/match/unit_group_rule_resolver_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/unit_group_rule_resolver_spec.rb
@@ -98,4 +98,16 @@ RSpec.describe Hmis::Ce::Match::UnitGroupRuleResolver do
       expect(rules.map(&:id)).to eq([ug_priority.id, proj_req.id, org_req.id])
     end
   end
+
+  describe '#compose_requirement_expression' do
+    it 'parenthesizes expressions containing OR before ANDing' do
+      rule1 = double('Rule', expression: 'current_age > 18 OR score > 8', eligibility_requirement?: true)
+      rule2 = double('Rule', expression: 'current_age < 65', eligibility_requirement?: true)
+      rules = [rule1, rule2]
+
+      result = resolver.send(:compose_requirement_expression, rules)
+
+      expect(result).to eq('(current_age > 18 OR score > 8) AND current_age < 65')
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
See issue comments: https://github.com/open-path/Green-River/issues/8129#issuecomment-3285612104

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
