### PR TITLE
When importing units, make sure they have unit groups

### DIFF
--- a/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
+++ b/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
@@ -17,32 +17,71 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
   scope :active, -> { where(active: true) }
 
   def self.freshen_project_units(user:, today: Date.current)
+    scope = preload(:project, :unit_type).order(:id).to_a
+    create_new_units(scope, user: user)
+    destroy_inactive_units(scope, today: today)
+  end
+
+  def self.create_new_units(scope, user:)
     # { [project_id, unit_type_id] => unit_count }
     unit_counts_by_project_and_unit_type_id = Hmis::Unit.group(:project_id, :unit_type_id).count
 
-    scope = preload(:project, :unit_type).order(:id).to_a
-    unit_attrs = scope.filter(&:active?).flat_map do |record|
-      unit_type = record.unit_type
+    records_to_import = scope.
+      filter(&:active?).
+      filter { |record| record.project.present? }. # could happen if project was deleted but ProjectUnitTypeMapping wasn't properly cleaned up
+      filter do |record|
+        # If this ProjectID is already mapped to this UnitTypeID in our system, and it is marked as Active=Y, do nothing (don't import).
+        key = [record.project.id, record.unit_type.id]
+        !unit_counts_by_project_and_unit_type_id[key]
+      end
+
+    return unless records_to_import.any?
+
+    # Batch import unit groups
+    unit_groups_to_create = records_to_import.map do |record|
+      {
+        project_id: record.project.id,
+        unit_type_id: record.unit_type.id,
+        name: record.unit_type.description,
+      }
+    end
+    # We can probably assume these don't already exist, since there were no existing units with this type in this project.
+    # But just in case, ignore duplicates.
+    Hmis::UnitGroup.import!(unit_groups_to_create, on_duplicate_key_ignore: true)
+
+    # Get unit group IDs and put them in a hash key by [project_id, unit_type_id] for lookup when creating units
+    unit_groups_by_key = Hmis::UnitGroup.where(project: records_to_import.map(&:project), unit_type: records_to_import.map(&:unit_type)).
+      pluck(:project_id, :unit_type_id, :id).
+      to_h { |project_id, unit_type_id, id| [[project_id, unit_type_id], id] }
+
+    # Create units with proper unit_group_id references
+    # Using flat_map because each record can generate multiple units (based on unit_capacity),
+    # so we need to flatten the nested arrays of unit attributes
+    units_to_create = records_to_import.flat_map do |record|
       project = record.project
-      next if project.nil? # could happen if project was deleted but ProjectUnitTypeMapping wasn't properly cleaned up
+      unit_type = record.unit_type
 
-      # If this ProjectID is already mapped to this UnitTypeID in our system, and it is marked as Active=Y, do nothing.
-      key = [project.id, unit_type.id]
-      next if unit_counts_by_project_and_unit_type_id[key]
+      unit_group_id = unit_groups_by_key[[project.id, unit_type.id]]
+      raise "Failed to create unit group for project  #{project.id}, unit_type #{unit_type.id}" unless unit_group_id
 
-      # If this ProjectID is not already mapped to this UnitTypeID, add it and add the number of units specified in the UnitCapacity column.
+      # Create the number of units specified in the UnitCapacity column
       record.unit_capacity.to_i.times.map do
         {
           project_id: project.id,
           unit_type_id: unit_type.id,
+          hmis_unit_group_id: unit_group_id,
           unit_size: unit_type.unit_size,
           user_id: user.id,
         }
       end
     end
-    Hmis::Unit.import!(unit_attrs.compact, validate: false)
 
-    # If this ProjectID is already mapped to this UnitTypeID in our system, but it is marked as Active=N, then remove the mapping. At this point also remove any Units for this unit type. Raise if any of those Units are occupied
+    Hmis::Unit.import!(units_to_create, validate: false)
+  end
+
+  def self.destroy_inactive_units(scope, today: Date.current)
+    # If this ProjectID is already mapped to this UnitTypeID in our system, but it is marked as Active=N, then remove the mapping.
+    # At this point also remove any Units for this unit type. Raise if any of those Units are occupied
     scope.filter(&:inactive?).each do |record|
       existing_units = record.project.units.where(unit_type: record.unit_type)
       raise "Can't remove active units: #{record.inspect}" if existing_units.occupied_on(today).any?

--- a/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
+++ b/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
@@ -26,7 +26,7 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
     # { [project_id, unit_type_id] => unit_count }
     unit_counts_by_project_and_unit_type_id = Hmis::Unit.group(:project_id, :unit_type_id).count
 
-    records_to_import = scope.
+    records_needing_new_units = scope.
       filter(&:active?).
       filter { |record| record.project.present? }. # could happen if project was deleted but ProjectUnitTypeMapping wasn't properly cleaned up
       filter do |record|
@@ -35,29 +35,29 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
         !unit_counts_by_project_and_unit_type_id[key]
       end
 
-    return unless records_to_import.any?
+    return unless records_needing_new_units.any?
 
-    # Batch import unit groups
-    unit_groups_to_create = records_to_import.map do |record|
+    # Collect unit groups to create
+    unit_groups_to_create = records_needing_new_units.map do |record|
       {
         project_id: record.project.id,
         unit_type_id: record.unit_type.id,
         name: record.unit_type.description,
       }
     end
-    # We can probably assume these don't already exist, since there were no existing units with this type in this project.
-    # But just in case, ignore duplicates.
+
+    # Batch import unit groups. These probably don't already exist,
+    # since we checked that no units exist for this project and unit type.
+    # But, it could exist and be empty, so just in case, ignore on conflict.
     Hmis::UnitGroup.import!(unit_groups_to_create, on_duplicate_key_ignore: true)
 
-    # Get unit group IDs and put them in a hash key by [project_id, unit_type_id] for lookup when creating units
-    unit_groups_by_key = Hmis::UnitGroup.where(project: records_to_import.map(&:project), unit_type: records_to_import.map(&:unit_type)).
+    # Get unit group IDs and put them in a hash keyed by [project_id, unit_type_id] for lookup when creating units
+    unit_groups_by_key = Hmis::UnitGroup.where(project: records_needing_new_units.map(&:project), unit_type: records_needing_new_units.map(&:unit_type)).
       pluck(:project_id, :unit_type_id, :id).
       to_h { |project_id, unit_type_id, id| [[project_id, unit_type_id], id] }
 
-    # Create units with proper unit_group_id references
-    # Using flat_map because each record can generate multiple units (based on unit_capacity),
-    # so we need to flatten the nested arrays of unit attributes
-    units_to_create = records_to_import.flat_map do |record|
+    # Collect units to create
+    units_to_create = records_needing_new_units.flat_map do |record|
       project = record.project
       unit_type = record.unit_type
 
@@ -76,6 +76,7 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
       end
     end
 
+    # Batch import units
     Hmis::Unit.import!(units_to_create, validate: false)
   end
 

--- a/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
+++ b/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
@@ -15,6 +15,7 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
   belongs_to :unit_type, class_name: 'Hmis::UnitType'
 
   scope :active, -> { where(active: true) }
+  scope :inactive, -> { where(active: false) }
 
   def self.freshen_project_units(user:, today: Date.current)
     scope = preload(:project, :unit_type).order(:id)
@@ -29,7 +30,6 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
     unit_counts_by_project_and_unit_type_id = Hmis::Unit.group(:project_id, :unit_type_id).count
 
     records_needing_new_units = scope.
-      filter(&:active?).
       filter { |record| record.project.present? }. # could happen if project was deleted but ProjectUnitTypeMapping wasn't properly cleaned up
       filter do |record|
         # If this ProjectID is already mapped to this UnitTypeID in our system, and it is marked as Active=Y, do nothing (don't import).
@@ -85,7 +85,9 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
   def self.destroy_inactive_units(scope, today: Date.current)
     # If this ProjectID is already mapped to this UnitTypeID in our system, but it is marked as Active=N, then remove the mapping.
     # At this point also remove any Units for this unit type. Raise if any of those Units are occupied
-    scope.filter(&:inactive?).each do |record|
+    # TODO(#8157) Update to look up by unit-group/unit-type relationship, something like:
+    #  record.project.unit_groups.where(unit_type: record.unit_type).each(&:destroy!)
+    scope.each do |record|
       existing_units = record.project.units.where(unit_type: record.unit_type)
       raise "Can't remove active units: #{record.inspect}" if existing_units.occupied_on(today).any?
 

--- a/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
+++ b/drivers/hmis/app/models/hmis/project_unit_type_mapping.rb
@@ -17,9 +17,11 @@ class Hmis::ProjectUnitTypeMapping < Hmis::HmisBase
   scope :active, -> { where(active: true) }
 
   def self.freshen_project_units(user:, today: Date.current)
-    scope = preload(:project, :unit_type).order(:id).to_a
-    create_new_units(scope, user: user)
-    destroy_inactive_units(scope, today: today)
+    scope = preload(:project, :unit_type).order(:id)
+    # Create initial Units for new Active Project Unit Type Mappings
+    create_new_units(scope.active, user: user)
+    # Destroy Units for Project Unit Type Mappings that are Inactive
+    destroy_inactive_units(scope.inactive, today: today)
   end
 
   def self.create_new_units(scope, user:)

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/importers/projects_importer_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HmisExternalApis::AcHmis::Importers::ProjectsImporter, type: :model do
@@ -41,8 +43,10 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::ProjectsImporter, type: :mod
     expect(Hmis::Hud::CustomDataElement.count).to eq(1)
     expect(Hmis::Hud::CustomDataElement.first.value_boolean).to be(false)
     expect(Hmis::ProjectUnitTypeMapping.count).to eq(2)
+    expect(Hmis::UnitGroup.count).to eq(1)
     expect(Hmis::Unit.count).to eq(10)
     expect(Hmis::Unit.where(unit_type: active_unit_type).count).to eq(10)
+    expect(Hmis::Unit.where.missing(:unit_group)).to be_empty
 
     # fixes incorrect hmis format
     expect(GrdaWarehouse::Hud::ProjectCoc.first.zip).to eq('11111')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- targets 179, since this is fixes an ongoing issue

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
When importing Units, they should be created with Unit Groups.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
