### PR TITLE
Enable v10 in qa

### DIFF
--- a/drivers/hmis/lib/form_data/qa_hmis/fragments/patches/enable_everything_patch.json
+++ b/drivers/hmis/lib/form_data/qa_hmis/fragments/patches/enable_everything_patch.json
@@ -264,6 +264,14 @@
     }
   },
   {
+    "link_id": "V10",
+    "custom_rule": {
+      "variable": "projectId",
+      "operator": "NOT_EQUAL",
+      "value": "non-existent-project-id"
+    }
+  },
+  {
     "link_id": "medical_assistance",
     "custom_rule": {
       "variable": "projectId",


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Add V10 to this patch for `qa_hmis` environment to enable all questions in HUD assessments

## Type of change
qa configuration

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
