### PR TITLE
Alert Sentry, don't raise, for unknown CE event type

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -21,7 +21,7 @@ module Hmis::Ce
       # If the referral already has a CE event, return early and don't raise
       return if referral.ce_event.present?
 
-      # If there is no event type determined for this project/unit group, return without creating one
+      # If there is no CE event type for this project/unit group, return without creating a CE event
       event_type = determine_event_type
       return unless event_type
 
@@ -35,8 +35,8 @@ module Hmis::Ce
     end
 
     def set_ce_event_result(message) # rubocop:disable Naming/AccessorMethodName
-      # If there is no event type determined for this project/unit group, that indicates CE event creation wasn't possible
-      event_type = determine_event_type(capture_to_sentry: false)
+      # If there is no event type determined for this project/unit group, that indicates CE event wasn't created
+      event_type = determine_event_type(capture_to_sentry: false) # No need to capture to Sentry a second time
       return unless event_type
 
       # If CE Event Type can be determined, but CE Event is missing, raise.

--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -21,18 +21,26 @@ module Hmis::Ce
       # If the referral already has a CE event, return early and don't raise
       return if referral.ce_event.present?
 
-      target_project = referral.target_project
+      # If there is no event type determined for this project/unit group, return without creating one
+      event_type = determine_event_type
+      return unless event_type
 
       enrollment.events.create!(
         event_date: Date.current,
-        event: determine_event_type,
-        location_crisis_or_ph_housing: target_project.id, # TODO(#7954) add target project ID reference column to Event
+        event: event_type,
+        location_crisis_or_ph_housing: referral.target_project.id, # TODO(#7954) add target project ID reference column to Event
         user: Hmis::Hud::User.from_user(message.user),
         ce_referral: referral,
       )
     end
 
     def set_ce_event_result(message) # rubocop:disable Naming/AccessorMethodName
+      # If there is no event type determined for this project/unit group, that indicates CE event creation wasn't possible
+      event_type = determine_event_type(capture_to_sentry: false)
+      return unless event_type
+
+      # If CE Event Type can be determined, but CE Event is missing, raise.
+      # This indicates the workflow is misconfigured because CE Event Creation should have occurred already.
       event = referral.ce_event
       raise "Expected to find CE event for referral #{referral.id}" unless event
 
@@ -47,7 +55,7 @@ module Hmis::Ce
 
     private
 
-    def determine_event_type
+    def determine_event_type(capture_to_sentry: true)
       # Check if there's a configured ce_event_type on the unit group
       unit_group = referral.opportunity.unit&.unit_group
       return unit_group.ce_event_type if unit_group&.ce_event_type.present?
@@ -55,7 +63,11 @@ module Hmis::Ce
       # Fall back to determining the event type based on the referral target project
       project = referral.target_project
       event_type = HudUtility2026.project_to_ce_event_type(project)
-      raise "Unable to determine CE Event Type for project type #{project.project_type} on project #{project.id} for referral #{referral.id}" unless event_type
+
+      if capture_to_sentry && !event_type
+        # Log to Sentry without raising. This is expected for projects that reuse a workflow from another project, but don't need to generate a CE event.
+        Sentry.capture_message("Unable to determine CE Event Type for project type #{project.project_type} on project #{project.id} for referral #{referral.id}")
+      end
 
       event_type
     end

--- a/drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb
@@ -233,6 +233,20 @@ RSpec.describe Hmis::Ce::ReferralCeEventManager, type: :model do
         end.to raise_error(RuntimeError, /Referral does not have a source enrollment/)
       end
     end
+
+    context 'when no CE Event Type can be determined' do
+      let!(:project) { create :hmis_hud_project, data_source: ds1, user: u1, project_type: 4 } # 4 = SO, doesn't collect CE event
+
+      it 'reports to Sentry and returns without creating CE event' do
+        allow(Sentry).to receive(:capture_message)
+
+        submit_current_step
+
+        expect(referral.source_enrollment.events.count).to eq(0)
+        expect(referral.ce_event).to be_nil
+        expect(Sentry).to have_received(:capture_message).with(/Unable to determine CE Event Type/)
+      end
+    end
   end
 
   describe 'side effect that updates the event' do
@@ -247,39 +261,82 @@ RSpec.describe Hmis::Ce::ReferralCeEventManager, type: :model do
       end
     end
 
-    before(:each) do
-      submit_current_step # Submit the ce creation step
-      expect(referral.source_enrollment.events.count).to eq(1)
-    end
-
-    context 'when the client rejects the referral' do
-      include_examples 'updates the event with referral result', { client_accepted: 0 }, 2
-    end
-
-    context 'when the provider rejects the referral' do
-      before do
-        submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+    context 'when event exists' do
+      before(:each) do
+        submit_current_step # Submit the ce creation step
+        expect(referral.source_enrollment.events.count).to eq(1)
       end
 
-      include_examples 'updates the event with referral result', { provider_accepted: 0 }, 3
-    end
-
-    context 'when everybody accepts' do
-      before do
-        submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+      context 'when the client rejects the referral' do
+        include_examples 'updates the event with referral result', { client_accepted: 0 }, 2
       end
 
-      include_examples 'updates the event with referral result', { provider_accepted: 1 }, 1
-    end
+      context 'when the provider rejects the referral' do
+        before do
+          submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+        end
 
-    context 'with unit group ce_event_type configuration' do
-      let!(:unit_group) { create(:hmis_unit_group, project: project, ce_event_type: 18) }
-
-      before do
-        submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+        include_examples 'updates the event with referral result', { provider_accepted: 0 }, 3
       end
 
-      include_examples 'updates the event with referral result', { provider_accepted: 1 }, 1
+      context 'when everybody accepts' do
+        before do
+          submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+        end
+
+        include_examples 'updates the event with referral result', { provider_accepted: 1 }, 1
+      end
+
+      context 'with unit group ce_event_type configuration' do
+        let!(:unit_group) { create(:hmis_unit_group, project: project, ce_event_type: 18) }
+
+        before do
+          submit_current_step({ client_accepted: 1 }) # Client accepts the referral
+        end
+
+        include_examples 'updates the event with referral result', { provider_accepted: 1 }, 1
+      end
+    end
+
+    context 'when no CE Event Type can be determined' do
+      let!(:project) { create :hmis_hud_project, data_source: ds1, user: u1, project_type: 4 }
+
+      it 'returns early without error when setting CE event result' do
+        # First step will not create CE event because event type cannot be determined
+        allow(Sentry).to receive(:capture_message)
+        submit_current_step
+
+        # Go to the next step that normally would update the CE event
+        current_step = engine.active_steps.sole
+        engine.start_step!(current_step, user: hmis_user)
+        # This returns early and does not raise an error because CE Event Type could not be determined
+        engine.complete_step!(current_step, user: hmis_user, submitted_values: { client_accepted: 0 })
+
+        expect(referral.source_enrollment.events.count).to eq(0)
+
+        # Sentry should only be called once (from create_ce_event, not set_ce_event_result)
+        expect(Sentry).to have_received(:capture_message).once.with(/Unable to determine CE Event Type/)
+      end
+    end
+
+    context 'when CE Event Type can be determined but CE Event is missing' do
+      let!(:project) { create :hmis_hud_project, data_source: ds1, user: u1, project_type: 0 } # Project that should create event
+
+      before(:each) do
+        submit_current_step # Submit the CE creation step - should create an event
+        expect(referral.source_enrollment.events.count).to eq(1)
+        # Manually delete the CE event to simulate misconfigured workflow
+        referral.source_enrollment.events.destroy_all
+        referral.reload
+      end
+
+      it 'raises an error when setting CE event result' do
+        expect do
+          current_step = engine.active_steps.sole
+          engine.start_step!(current_step, user: hmis_user)
+          engine.complete_step!(current_step, user: hmis_user, submitted_values: { client_accepted: 0 })
+        end.to raise_error(RuntimeError, /Expected to find CE event for referral/)
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Enable projects that don't correspond to a CE event type to reuse the same CE workflow.
* On `create_ce_event` message, report to Sentry instead of raising if unable to determine the CE Event Type.
* On `set_ce_event_result`,
  * If CE event type can't be determined, return without reporting to Sentry or raising
  * If CE Event Type _can_ be determined, but CE Event is missing, raise

Testing instructions
- Set up a project whose project type doesn't map to a CE Event (such as 4, Street Outreach) so that it accepts referrals using a workflow that does create ce events (such as Housing Referral Workflow V1).
- Step through the workflow for a client. The referral should be able to be completed successfully and nothing should raise. On the source enrollment, no CE event should be created.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
