### PR TITLE
Exclude some ClientFieldMap fields from Referral Details

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -78,7 +78,7 @@ module Types
     field :audit_events, HmisSchema::CeReferralAuditEvent.page_type, null: true
     field :notes, HmisSchema::CeReferralNote.page_type, null: true
     # generically resolve current values for any fields referenced by Match Rule expressions
-    field :current_match_values, [HmisSchema::CeMatchValue], null: true, description: 'Eligibility-related field values. May expose data beyond normal permissions.', method: :resolve_match_rule_fields
+    field :current_match_values, [HmisSchema::CeMatchValue], null: true, description: 'Eligibility-related field values. May expose data beyond normal permissions.'
 
     available_filter_options do
       arg :referral_status, [String]
@@ -88,6 +88,19 @@ module Types
       arg :organization, [ID]
       arg :on_current_task_since, GraphQL::Types::ISO8601Date # TODO - we will discuss this with design and probably make updates
       arg :origin, [HmisSchema::Enums::CeReferralOrigin]
+    end
+
+    def current_match_values
+      # Exclude certain fields from the "Referral Details" section because they are duplicative or unnecessary.
+      # We may want to add configuration later on to specify whether fields should display.
+      excluded_fields = [
+        :current_age, # Already shown
+        :days_since_last_exit,
+        :open_enrollment_project_types,
+        :open_enrollment_project_types_excluding_incomplete,
+        :open_referral_project_types,
+      ]
+      object.resolve_match_rule_fields(excluded_fields: excluded_fields)
     end
 
     def custom_status

--- a/drivers/hmis/app/models/hmis/ce/referral.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral.rb
@@ -171,7 +171,7 @@ module Hmis::Ce
     #
     # NOTE: This field intentionally does not check viewable_by scopes on the associated data;
     # it is resolved in the GraphQL API to expose pertinent data that the current user may not otherwise have permission to view.
-    def resolve_match_rule_fields
+    def resolve_match_rule_fields(excluded_fields: [])
       destination_client = client.destination_client&.as_warehouse
       return [] unless destination_client # if for whatever reason the client doesn't have a destination client, we cannot resolve the fields
 
@@ -185,6 +185,7 @@ module Hmis::Ce
       match_rules = opportunity.assignment_rules.map { |attrs| Hmis::Ce::Match::Rule.new(attrs).freeze }
       match_rules.sort_by(&:id).map do |rule|
         calculator.dependencies(rule.expression).map do |field|
+          next if excluded_fields.map(&:to_s).include?(field.to_s)
           # Skip if Field has already been processed, for example expression "household_size = 1 OR household_size = 2"
           next if seen_field_names.include?(field)
 

--- a/drivers/hmis/spec/models/hmis/ce/referral_resolved_match_rule_fields_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_resolved_match_rule_fields_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe Hmis::Ce::Referral, type: :model do
           ),
         )
       end
+
+      it 'excludes fields when specified' do
+        resolved_fields = referral.resolve_match_rule_fields(excluded_fields: [:current_age])
+        expect(resolved_fields).not_to include(
+          have_attributes(field_name: 'Current age'),
+        )
+        expect(resolved_fields).to contain_exactly(
+          have_attributes(field_name: 'Veteran status'),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Exclude some fields from referral details which are not helpful/necessary or duplicative (like client age).
These values are displayed on the "Client Details" accordion inside the Referral Details panel to referral viewers.

**Why**:
* age is duplicative, we already show it
* open enrollment/referral fields can be confusing, especially since the client does have an active referral to the current project type, and they become enrolled, these values could be misleading. confirmed customer OK with removing

## Type of change
feature update

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
