### PR TITLE
Disallow direct referral to closed project, do not maintain candidate pool for closed project

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -611,6 +611,7 @@ module Types
 
       # Load all projects in the data source into memory and iterate through them to call detect_best_config_for_project.
       project_scope = Hmis::Hud::Project.where(data_source: from_project.data_source).
+        open_on_date.
         where.not(id: from_project.id).
         preload(:organization).
         sort_by_option(:organization_and_name)

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -160,6 +160,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     where(id: referral_project_ids)
   end
 
+  # Projects that are open and have CE waitlist referrals enabled
   scope :with_ce_waitlists_enabled, -> do
     configs = Hmis::ProjectCeConfig.active.filter(&:supports_waitlist_referrals?)
 
@@ -168,7 +169,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
       arel_table[:id].in(configs.map(&:project_id)),
       Hmis::Hud::Organization.arel_table[:id].in(configs.map(&:organization_id)),
     ]
-    joins(:organization).where(conditions.inject(&:or))
+    open_on_date.joins(:organization).where(conditions.inject(&:or))
   end
 
   SORT_OPTIONS = [:organization_and_name, :name].freeze

--- a/drivers/hmis/spec/models/hmis/ce/match/candidate_pool_builder_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/candidate_pool_builder_spec.rb
@@ -157,6 +157,54 @@ RSpec.describe Hmis::Ce::Match::CandidatePoolBuilder do
         expect(Hmis::Ce::Match::CandidatePool.exists?(active_pool.id)).to be_truthy
       end
     end
+
+    context 'with closed projects' do
+      let!(:closed_project) { create(:hmis_hud_project, organization: organization, operating_end_date: 1.day.ago) }
+      let!(:ce_project_config) { create(:hmis_project_ce_config, supports_waitlist_referrals: true, project: closed_project) }
+      let!(:unit_group) { create(:hmis_unit_group, project: closed_project) }
+      let!(:opportunity) { create(:hmis_ce_opportunity, unit: create(:hmis_unit, unit_group: unit_group), candidate_pool: nil) }
+
+      before do
+        # Add rules to the closed project's unit group
+        create(:hmis_ce_eligibility_requirement, owner: unit_group, expression: 'closed_project_eligible = 1')
+        create(:hmis_ce_priority_scheme, owner: unit_group, expression: 'closed_project_score')
+      end
+
+      it 'does not create candidate pools for closed projects' do
+        expect { described_class.call }.not_to change(Hmis::Ce::Match::CandidatePool, :count)
+      end
+
+      it 'does not associate unit groups from closed projects with candidate pools' do
+        described_class.call
+        expect(unit_group.reload.candidate_pool_id).to be_nil
+      end
+
+      it 'does not backfill opportunities from closed projects' do
+        described_class.call
+        opportunity.reload
+        expect(opportunity.candidate_pool_id).to be_nil
+      end
+
+      it 'excludes closed projects even when scoped to specific unit groups' do
+        expect { described_class.call(unit_group_ids: [unit_group.id]) }.
+          not_to change(Hmis::Ce::Match::CandidatePool, :count)
+        expect(unit_group.reload.candidate_pool_id).to be_nil
+      end
+
+      it 'only processes open projects when both open and closed projects exist' do
+        # Create unit group in open project for comparison
+        open_unit_group = create(:hmis_unit_group, project: project)
+        create(:hmis_project_ce_config, supports_waitlist_referrals: true, project: project)
+        create(:hmis_ce_eligibility_requirement, owner: open_unit_group, expression: 'open_project_eligible = 1')
+        create(:hmis_ce_priority_scheme, owner: open_unit_group, expression: 'open_project_score')
+
+        expect { described_class.call }.to change(Hmis::Ce::Match::CandidatePool, :count).from(0).to(1)
+
+        # Only the open project's unit group should be associated with a pool
+        expect(open_unit_group.reload.candidate_pool).to be_present
+        expect(unit_group.reload.candidate_pool_id).to be_nil
+      end
+    end
   end
 
   describe 'locking behavior' do

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -532,6 +532,16 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(options.first['label']).to eq(receiving_project.project_name)
     end
 
+    context 'when project is closed' do
+      let!(:receiving_project) { create(:hmis_hud_project, data_source: ds1, user: u1, operating_end_date: 1.week.ago) }
+
+      it 'excludes closed project' do
+        response, result = post_graphql(pick_list_type: 'PROJECTS_RECEIVING_DIRECT_CE_REFERRALS', project_id: sending_project.id.to_s) { query }
+        expect(response.status).to eq 200
+        options = result.dig('data', 'pickList')
+        expect(options.size).to eq(0)
+      end
+    end
     context 'when the sending project also receives' do
       let!(:sending_config) { create(:hmis_project_ce_config, project: sending_project, receives_direct_referrals: true) }
       let!(:sending_unit_group) { create(:hmis_unit_group, project: sending_project, name: 'Another Group') }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
1. Remove closed projects from the list of projects when you are sending a direct ce referral. There is no need to support referring to closed projects. (This caused issues if you enable direct referrals at the project-type or org-level)
2. Do not create or maintain candidate pools for unit groups at closed projects

https://github.com/open-path/Green-River/issues/8256

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
