### PR TITLE
Update Housing Needs Importer to lookup client by MCI ID if not found by MCI Unique ID

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/housing_assessment_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/housing_assessment_importer.rb
@@ -198,7 +198,7 @@ class HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter
   end
 
   def create_ce_enrollment(waitlist)
-    hmis_client = find_and_update_hmis_client(waitlist) || create_hmis_client(waitlist)
+    hmis_client = find_hmis_client(waitlist) || create_hmis_client(waitlist)
     deterministic_id = waitlist.hud_id
 
     # remove existing enrollment if it exists
@@ -236,7 +236,7 @@ class HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter
     ActiveRecord::Base.record_timestamps = true
   end
 
-  def find_and_update_hmis_client(waitlist)
+  def find_hmis_client(waitlist)
     # client_id is the MCI Unique ID
     mci_scope = HmisExternalApis::ExternalId.
       where(namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE).
@@ -253,7 +253,7 @@ class HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter
     # "posting" for a new client, we generate a new Client record with an MCI ID. We don't create an MCI Unique ID at that time,
     # and the MCI Unique ID won't get created until/unless the client has any enrollments. (Unenrolled clients
     # are not exported in HMIS export, so Data Warehouse API won't provide MCI Unique IDs for those clients.)
-    found_mci_ids = HmisExternalApis::ExternalId.mci_ids.where(value: waitlist.client_mci_id)
+    found_mci_ids = HmisExternalApis::ExternalId.mci_ids.where(value: waitlist.client_mci_id).to_a
     return nil unless found_mci_ids.size == 1 # if multiple, can't be sure which one to update, don't use
 
     client = found_mci_ids.first.source

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/housing_assessment_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/housing_assessment_importer.rb
@@ -236,7 +236,6 @@ class HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter
     ActiveRecord::Base.record_timestamps = true
   end
 
-  # TODO: if not found by MCI Unique ID, should we try to look up by MCI ID?
   def find_and_update_hmis_client(waitlist)
     # client_id is the MCI Unique ID
     mci_scope = HmisExternalApis::ExternalId.
@@ -244,9 +243,23 @@ class HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter
       where(value: waitlist.client_id)
 
     client = Hmis::Hud::Client.joins(:ac_hmis_mci_unique_id).merge(mci_scope).first
-    return nil unless client
+    if client
+      log_info("Found client with MCI Unique ID #{waitlist.client_id}: #{client.id}")
+      return client
+    end
 
-    log_info("Found client with MCI Unique ID #{waitlist.client_id}: #{client.id}")
+    # If not found by MCI Unique ID, look up by MCI ID. This would be needed if the client exists in HMIS
+    # because they were referred from LINK, but they don't have an MCI Unique ID. When Link sends a referral
+    # "posting" for a new client, we generate a new Client record with an MCI ID. We don't create an MCI Unique ID at that time,
+    # and the MCI Unique ID won't get created until/unless the client has any enrollments. (Unenrolled clients
+    # are not exported in HMIS export, so Data Warehouse API won't provide MCI Unique IDs for those clients.)
+    found_mci_ids = HmisExternalApis::ExternalId.mci_ids.where(value: waitlist.client_mci_id)
+    return nil unless found_mci_ids.size == 1 # if multiple, can't be sure which one to update, don't use
+
+    client = found_mci_ids.first.source
+    return nil unless client.ac_hmis_mci_unique_id.nil? # if they already have an MCI Unique ID, don't use, something is off
+
+    log_info("Found client with MCI ID #{waitlist.client_mci_id}: #{client.id}")
     client
   end
 

--- a/drivers/hmis_external_apis/spec/models/importers/housing_assessment_importer_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/importers/housing_assessment_importer_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter do
       project = instance_double('Hmis::Hud::Project', enrollments: enrollments, project_id: 'mocked_project_id')
 
       allow(importer).to receive(:hmis_ce_project).and_return(project)
-      allow(importer).to receive(:find_and_update_hmis_client).with(waitlist).and_return(existing_client)
+      allow(importer).to receive(:find_hmis_client).with(waitlist).and_return(existing_client)
       expect(importer).not_to receive(:create_hmis_client)
 
       enrollment = importer.send(:create_ce_enrollment, waitlist)
@@ -318,7 +318,7 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter do
       project = instance_double('Hmis::Hud::Project', enrollments: enrollments, project_id: 'mocked_project_id')
 
       allow(importer).to receive(:hmis_ce_project).and_return(project)
-      allow(importer).to receive(:find_and_update_hmis_client).with(waitlist).and_return(nil)
+      allow(importer).to receive(:find_hmis_client).with(waitlist).and_return(nil)
       expect(importer).to receive(:create_hmis_client).with(waitlist).and_return(new_client)
 
       importer.send(:create_ce_enrollment, waitlist)
@@ -334,7 +334,7 @@ RSpec.describe HmisExternalApis::AcHmis::Importers::HousingAssessmentImporter do
       project = instance_double('Hmis::Hud::Project', enrollments: enrollments, project_id: 'mocked_project_id')
 
       allow(importer).to receive(:hmis_ce_project).and_return(project)
-      allow(importer).to receive(:find_and_update_hmis_client).with(waitlist).and_return(existing_client)
+      allow(importer).to receive(:find_hmis_client).with(waitlist).and_return(existing_client)
 
       importer.send(:create_ce_enrollment, waitlist)
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Update Housing Needs Importer to lookup client by MCI ID if not found by MCI Unique ID

Issue:
https://github.com/open-path/Green-River/issues/7985
https://github.com/open-path/Green-River/issues/8163

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
