### PR TITLE
Patch: Resolve client id on referral household members

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1234,6 +1234,7 @@ type CeReferralSourceEnrollmentsPaginated {
 
 type CeReferralSourceHouseholdMember {
   access: CeReferralSourceHouseholdMemberAccess!
+  clientId: ID!
 
   """
   The name of the client. Returns masked name if the user does not have permission to view the client name.

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_household_member.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_household_member.rb
@@ -11,14 +11,19 @@ module Types
     # object is a Hmis::Hud::Enrollment belonging to the household that is the "source" of a CE Referral
     # NOTE: this type can be resolved even if the current user does not have full enrollment details access.
 
-    field :id, ID, null: false
+    field :id, ID, null: false # enrollment id
     field :relationship_to_ho_h, Types::HmisSchema::Enums::Hud::RelationshipToHoH, null: false
+    field :client_id, ID, null: false
     field :client_name, String, null: false, description: 'The name of the client. Returns masked name if the user does not have permission to view the client name.'
 
     # Access field informs whether the frontend can display a link to the Client profile for this household member.
     # Use plural "can view clients" to match the permission name resolved elsewhere in application
     access_field do
       field :can_view_clients, Boolean, null: false
+    end
+
+    def client_id
+      client&.id
     end
 
     def client_name

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_household_member.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_source_household_member.rb
@@ -23,7 +23,7 @@ module Types
     end
 
     def client_id
-      client&.id
+      client.id
     end
 
     def client_name

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               householdSize
               householdMembers {
                 id
+                clientId
                 clientName
                 relationshipToHoH
                 access {
@@ -179,12 +180,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               'relationshipToHoH' => 'SELF_HEAD_OF_HOUSEHOLD',
               'clientName' => client.brief_name,
               'access' => { 'canViewClients' => true },
+              'clientId' => client.id.to_s,
             ),
             a_hash_including(
               'id' => household_enrollment_2.id.to_s,
               'relationshipToHoH' => 'CHILD',
               'clientName' => household_client_2.brief_name,
               'access' => { 'canViewClients' => true },
+              'clientId' => household_client_2.id.to_s,
             ),
           )
         end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/5785 to fix a mistake. We need to resolve the Client ID for each household member, not just the enrollment ID.
https://github.com/greenriver/hmis-frontend/pull/1278

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
