### PR TITLE
Gracefully return CE referral Step if already started

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/start_ce_referral_step.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/start_ce_referral_step.rb
@@ -22,7 +22,8 @@ module Mutations
         step = engine.active_steps.find(step_id)
         access_denied! unless policy_for(referral, policy_type: :ce_referral).can_perform?(step: step)
 
-        engine.start_step!(step, user: current_user)
+        # Start step. Skip if step is in progress, which indicates that someone has already started this step.
+        engine.start_step!(step, user: current_user) unless step.in_progress?
       end
 
       {

--- a/drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb
@@ -140,6 +140,26 @@ RSpec.describe Mutations::Ce::StartCeReferralStep, type: :request do
         expect(audit_event.user).to eq(hmis_user)
         expect(audit_event.step).to eq(step)
       end
+
+      context 'and the step has already been started' do
+        before(:each) do
+          referral.workflow_engine.start_step!(step, user: hmis_user)
+        end
+
+        it 'returns the started step' do
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+
+            step_data = result.dig('data', 'startCeReferralStep', 'step')
+            expect(step_data['status']).to eq('in_progress')
+            expect(step_data['name']).to eq('Client Acceptance')
+
+            step.reload
+          end.to not_change(step, :status).from('in_progress').
+            and not_change(Hmis::WorkflowExecution::AuditEvent, :count)
+        end
+      end
     end
 
     context 'when the user does not have access' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
**Old behavior**: mutation raises error if step has already been started. This could occur if a different user started it since the user loaded the page, or the same user started it in another tab.

**New behavior**: mutation gracefully returns the step if it has already been started.


https://green-river.sentry.io/issues/6858284403/?environment=staging&project=4503977346662400&query=is%3Aunresolved&referrer=issue-stream


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
