### PR TITLE
Patch mci build route

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/mci.rb
@@ -186,9 +186,9 @@ module HmisExternalApis::AcHmis
     def build_route(endpoint)
       base_url = creds.base_url.chomp('/') + '/' # ensure trailing slash is present
       if base_url.match?(/\/api\//) # expectation is that if base_url contains /api/ then the endpoint is relative to the base url
-        URI.join(base_url, endpoint).to_s
+        endpoint
       else
-        URI.join(base_url, 'clients/v1/api/clients/', endpoint).to_s
+        "clients/v1/api/clients/#{endpoint}"
       end
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/mci_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/mci_spec.rb
@@ -54,22 +54,24 @@ RSpec.describe 'MCI API', type: :model do
 
     it 'builds route when cred has full base url' do
       create(:ac_hmis_mci_credential, base_url: 'https://example.com/clients-custom/api/clients/')
-      expect(mci.send(:build_route, 'clearance')).to eq('https://example.com/clients-custom/api/clients/clearance')
+      expect(mci.send(:build_route, 'clearance')).to eq('clearance')
+      expect(mci.send(:conn).send(:url_for, 'clearance')).to eq('https://example.com/clients-custom/api/clients/clearance')
     end
 
     it 'builds route when cred has full base url without trailing slash' do
       create(:ac_hmis_mci_credential, base_url: 'https://example.com/clients-custom/api/clients')
-      expect(mci.send(:build_route, 'clearance')).to eq('https://example.com/clients-custom/api/clients/clearance')
+      expect(mci.send(:build_route, 'clearance')).to eq('clearance')
     end
 
     it 'builds default route when cred has partial base url' do
       create(:ac_hmis_mci_credential, base_url: 'https://example.com/')
-      expect(mci.send(:build_route, 'clearance')).to eq('https://example.com/clients/v1/api/clients/clearance')
+      expect(mci.send(:build_route, 'clearance')).to eq('clients/v1/api/clients/clearance')
+      expect(mci.send(:conn).send(:url_for, 'clients/v1/api/clients/clearance')).to eq('https://example.com/clients/v1/api/clients/clearance')
     end
 
     it 'builds default route when cred has partial base url without trailing slash' do
       create(:ac_hmis_mci_credential, base_url: 'https://example.com')
-      expect(mci.send(:build_route, 'clearance')).to eq('https://example.com/clients/v1/api/clients/clearance')
+      expect(mci.send(:build_route, 'clearance')).to eq('clients/v1/api/clients/clearance')
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix mistake in https://github.com/greenriver/hmis-warehouse/pull/5287/files

`ExternalApiConnection` expects to receive a route that is relative to the base_url. In PR 5287 I mistakenly started passing the full URL including the base, so it's incorreclty making requests to `"https://www.example.com/clients/v1/api/clients/https://www.example.com/clients/v1/api/clients/clearance"

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
