### PR TITLE
Allow adding household members to target enrollment household

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -477,8 +477,14 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
     raise 'Unit is already assigned to a different household' if occupants.where.not(household_id: household_id).present?
 
     opportunity = unit.latest_opportunity
-    if opportunity&.locked? || opportunity&.open?
-      raise 'Cannot assign directly to a unit receiving referrals' unless opportunity.active_referral&.client == client
+    raise 'Cannot assign directly to a unit receiving referrals' if opportunity&.open?
+
+    if opportunity&.locked?
+      # Check if the enrollment being assigned is for the same client that is actively referred to this unit
+      is_same_client = opportunity.active_referral&.client == client
+      # Check if the enrollment being assigned belongs to the same household as the active referral's target enrollment
+      is_same_household = opportunity.active_referral&.target_enrollment&.household_id == household_id
+      raise 'Cannot assign to a unit with locked opportunity' unless is_same_client || is_same_household
     end
 
     # include project id here since it may not be available during after_save hooks due to WIP

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -893,12 +893,44 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
       end
 
       context 'with locked opportunity' do
-        let!(:opportunity) { create(:hmis_ce_opportunity, unit: unit, status: :locked) }
+        let!(:opportunity) { create(:hmis_ce_opportunity, unit: unit, status: :locked, data_source: ds1) }
 
         it 'raises an error' do
           expect do
             process_record(record: e1, hud_values: hud_values, user: hmis_user, definition: definition)
-          end.to raise_error(RuntimeError, /Cannot assign directly to a unit receiving referrals/)
+          end.to raise_error(RuntimeError, /Cannot assign to a unit with locked opportunity/)
+        end
+
+        context 'and active referral for a different client' do
+          let(:c2) { create :hmis_hud_client_complete, data_source: ds1 }
+          let!(:referral) { create(:hmis_ce_referral, opportunity: opportunity, client: c2) }
+          it 'raises an error' do
+            expect do
+              process_record(record: e1, hud_values: hud_values, user: hmis_user, definition: definition)
+            end.to raise_error(RuntimeError, /Cannot assign to a unit with locked opportunity/)
+          end
+        end
+
+        context 'and active referral for the same client' do
+          let!(:referral) { create(:hmis_ce_referral, opportunity: opportunity, client: e1.client) }
+
+          it 'allows assignment' do
+            expect do
+              process_record(record: e1, hud_values: hud_values, user: hmis_user, definition: definition)
+            end.not_to raise_error
+          end
+        end
+
+        context 'and active referral for a client in same household' do
+          let(:c2) { create :hmis_hud_client_complete, data_source: ds1 }
+          let!(:e2) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1, household_id: e1.household_id }
+          let!(:referral) { create(:hmis_ce_referral, opportunity: opportunity, client: c2, target_enrollment: e2) }
+
+          it 'allows assignment' do
+            expect do
+              process_record(record: e1, hud_values: hud_values, user: hmis_user, definition: definition)
+            end.not_to raise_error
+          end
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8281

Bug repro:
* Create a referral
* Progress the referral such that the client gets enrolled. dont close the referral yet
* Go to the target enrollment and try to add a household member. It will fail with error `Cannot assign directly to a unit receiving referrals`. Expected behavior is that it should be allowed to enroll client


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
