### PR TITLE
Resolve project name instead of project obj on form rule

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3527,7 +3527,6 @@ Style/FrozenStringLiteralComment:
     - 'drivers/hmis/spec/requests/hmis/form_definition_lookup_spec.rb'
     - 'drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb'
     - 'drivers/hmis/spec/requests/hmis/form_identifier_spec.rb'
-    - 'drivers/hmis/spec/requests/hmis/form_rules_spec.rb'
     - 'drivers/hmis/spec/requests/hmis/get_project_spec.rb'
     - 'drivers/hmis/spec/requests/hmis/get_projects_spec.rb'
     - 'drivers/hmis/spec/requests/hmis/graphql_controller_spec.rb'

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5243,8 +5243,9 @@ type FormRule {
   organization: Organization
   organizationId: ID
   otherFunder: String
-  project: Project
+  project: Project @deprecated(reason: "Use projectName instead")
   projectId: ID
+  projectName: String
   projectType: ProjectType
   serviceCategory: ServiceCategory
   serviceType: ServiceType

--- a/drivers/hmis/app/graphql/types/admin/form_rule.rb
+++ b/drivers/hmis/app/graphql/types/admin/form_rule.rb
@@ -74,7 +74,7 @@ module Types
     def project_name
       return unless object.entity_type == Hmis::Hud::Project.sti_name
 
-      object.entity.project_name
+      load_ar_association(object, :entity)&.project_name
     end
 
     def organization_id
@@ -86,7 +86,7 @@ module Types
     def organization
       return unless object.entity_type == Hmis::Hud::Organization.sti_name
 
-      object.entity
+      load_ar_association(object, :entity)
     end
 
     def active_status

--- a/drivers/hmis/app/graphql/types/admin/form_rule.rb
+++ b/drivers/hmis/app/graphql/types/admin/form_rule.rb
@@ -33,7 +33,8 @@ module Types
     field :organization_id, ID, null: true
     field :organization, HmisSchema::Organization, null: true
     field :project_id, ID, null: true
-    field :project, HmisSchema::Project, null: true
+    field :project_name, String, null: true # Resolve project name, regardless of whether the current user has permission to view the project
+    field :project, HmisSchema::Project, null: true, deprecation_reason: 'Use projectName instead'
     field :service_category, HmisSchema::ServiceCategory, null: true, method: :custom_service_category
     field :service_type, HmisSchema::ServiceType, null: true, method: :custom_service_type
     field :data_collected_about, Types::Forms::Enums::DataCollectedAbout, null: true
@@ -68,6 +69,12 @@ module Types
       return unless object.entity_type == Hmis::Hud::Project.sti_name
 
       object.entity
+    end
+
+    def project_name
+      return unless object.entity_type == Hmis::Hud::Project.sti_name
+
+      object.entity.project_name
     end
 
     def organization_id

--- a/drivers/hmis/spec/requests/hmis/form_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_rules_spec.rb
@@ -4,11 +4,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-###
-# Copyright 2016 - 2023 Green River Data Analysis, LLC
-#
-# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
-###
+# frozen_string_literal: true
 
 require 'rails_helper'
 require_relative 'login_and_permissions'
@@ -34,22 +30,33 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       <<~GRAPHQL
         query GetFormRules(
           $filters: FormRuleFilterOptions
+          $limit: Int
         ) {
           formRules(
             filters: $filters
+            limit: $limit
           ) {
             nodesCount
             nodes {
               id
+              definitionId
               definitionRole
+              definitionTitle
+              projectId
+              projectName
+              organizationId
+              organization {
+                id
+                organizationName
+              }
             }
           }
         }
       GRAPHQL
     end
 
-    def query_form_rules(filters: nil)
-      response, result = post_graphql(filters: filters) { query }
+    def query_form_rules(filters: nil, limit: 25)
+      response, result = post_graphql(filters: filters, limit: limit) { query }
       expect(response.status).to eq(200), result.inspect
       result.dig('data', 'formRules', 'nodes')
     end
@@ -73,6 +80,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       rules = query_form_rules(filters: { form_type: [:INTAKE] })
       expect(rules.count).to eq(0)
+    end
+
+    context 'when there are many form rules' do
+      before do
+        Hmis::Form::Instance.destroy_all # clear existing rules
+        50.times do
+          project = create(:hmis_hud_project, data_source: ds1, organization: o1)
+          create(:hmis_form_instance, definition_identifier: 'test-custom-assessment', entity: project, active: true)
+        end
+        50.times do
+          organization = create(:hmis_hud_organization, data_source: ds1)
+          create(:hmis_form_instance, definition_identifier: 'test-custom-assessment', entity: organization, active: true)
+        end
+      end
+
+      it 'avoids n+1' do
+        expect do
+          rules = query_form_rules(limit: 100)
+          expect(rules.count).to eq(100)
+        end.to make_database_queries(count: 5..10)
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Repro instructions:
- Create a form rule that refers to a specific project.
- Impersonate a user who has "can configure data collection" and "can administrate config", but NOT "can view project" on that specific project
- View the form page. Raises UnauthorizedError

Fix description:
- Resolve `projectName` on the form rule, even if the current user doesn't have permission to view that project, on the premise that they can only resolve the form rule object if they have permission to configure data collection.
- Deprecate the `project` field of the form rule object, as it's no longer used.

Corresponding frontend PR: https://github.com/greenriver/hmis-frontend/pull/1285

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
