### PR TITLE
8290-null-date-fix-on-export

### DIFF
--- a/drivers/client_documents_report/app/models/client_documents_report/report.rb
+++ b/drivers/client_documents_report/app/models/client_documents_report/report.rb
@@ -160,7 +160,7 @@ module ClientDocumentsReport
           if enrollment.entry_date == client_data[enrollment.client_id]['Newest Entry Date']
             income_record = enrollment.enrollment&.income_benefits&.
               to_a&.
-              filter { |ib| ib.information_date }.
+              filter(&:information_date)&.
               max_by(&:information_date)
 
             client_data[enrollment.client_id]['Newest Income from Any Source'] = HudHelper.util.no_yes_reasons_for_missing_data(income_record&.income_from_any_source)

--- a/drivers/client_documents_report/app/models/client_documents_report/report.rb
+++ b/drivers/client_documents_report/app/models/client_documents_report/report.rb
@@ -158,7 +158,10 @@ module ClientDocumentsReport
           end
           # For the most-recently started enrollment, get the most-recent Income Benefit record
           if enrollment.entry_date == client_data[enrollment.client_id]['Newest Entry Date']
-            income_record = enrollment.enrollment&.income_benefits&.max_by(&:information_date)
+            income_record = enrollment.enrollment&.income_benefits&.
+              to_a&.
+              filter { |ib| ib.information_date }.
+              max_by(&:information_date)
 
             client_data[enrollment.client_id]['Newest Income from Any Source'] = HudHelper.util.no_yes_reasons_for_missing_data(income_record&.income_from_any_source)
             client_data[enrollment.client_id]['Newest Total Monthly Income'] = income_record&.total_monthly_income

--- a/drivers/client_documents_report/spec/models/client_documents_report/report_spec.rb
+++ b/drivers/client_documents_report/spec/models/client_documents_report/report_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClientDocumentsReport::Report, type: :model do
+  let(:filter_double) do
+    double(
+      'ReportFilter',
+      required_files: [],
+      optional_files: [],
+      chosen_secondary_cohorts: [],
+      apply: ->(scope, _) { scope },
+    )
+  end
+
+  subject(:report) { described_class.new(filter_double) }
+
+  describe '#additional_client_data' do
+    it 'handles nil information_date' do
+      client = instance_double('GrdaWarehouse::Hud::Client', id: 1)
+
+      income_with_nil_date = instance_double('IncomeBenefit', information_date: nil, income_from_any_source: 1, total_monthly_income: 100)
+      income_with_date = instance_double('IncomeBenefit', information_date: Date.new(2024, 1, 1), income_from_any_source: 1, total_monthly_income: 200)
+
+      enrollment_record = instance_double('GrdaWarehouse::Hud::Enrollment', income_benefits: [income_with_nil_date, income_with_date])
+
+      enrollment = instance_double(
+        'GrdaWarehouse::ServiceHistoryEnrollment',
+        client_id: client.id,
+        client: client,
+        entry_date: Date.new(2024, 1, 1),
+        enrollment: enrollment_record,
+      )
+
+      relation_double = double('Relation')
+      allow(relation_double).to receive(:preload).and_return(relation_double)
+      allow(relation_double).to receive(:find_each).and_yield(enrollment)
+      allow(report).to receive(:enrollments).and_return(relation_double)
+
+      expect do
+        data = report.additional_client_data(client)
+        expect(data).to be_a(Hash)
+      end.not_to raise_error
+    end
+  end
+end

--- a/drivers/client_documents_report/spec/models/client_documents_report/report_spec.rb
+++ b/drivers/client_documents_report/spec/models/client_documents_report/report_spec.rb
@@ -3,44 +3,63 @@
 require 'rails_helper'
 
 RSpec.describe ClientDocumentsReport::Report, type: :model do
-  let(:filter_double) do
-    double(
-      'ReportFilter',
+  let(:user) { create(:user) }
+  let(:start_date) { Date.new(2024, 1, 1) }
+  let(:end_date) { Date.new(2024, 12, 31) }
+  let(:filter) do
+    ::Filters::FilterBase.new(
+      user_id: user.id,
+      start: start_date,
+      end: end_date,
+      # keep reports simple for this spec
       required_files: [],
       optional_files: [],
-      chosen_secondary_cohorts: [],
-      apply: ->(scope, _) { scope },
     )
   end
 
-  subject(:report) { described_class.new(filter_double) }
+  subject(:report) { described_class.new(filter) }
 
   describe '#additional_client_data' do
     it 'handles nil information_date' do
-      client = instance_double('GrdaWarehouse::Hud::Client', id: 1)
+      client = create(:grda_warehouse_hud_client)
 
-      income_with_nil_date = instance_double('IncomeBenefit', information_date: nil, income_from_any_source: 1, total_monthly_income: 100)
-      income_with_date = instance_double('IncomeBenefit', information_date: Date.new(2024, 1, 1), income_from_any_source: 1, total_monthly_income: 200)
-
-      enrollment_record = instance_double('GrdaWarehouse::Hud::Enrollment', income_benefits: [income_with_nil_date, income_with_date])
-
-      enrollment = instance_double(
-        'GrdaWarehouse::ServiceHistoryEnrollment',
-        client_id: client.id,
-        client: client,
-        entry_date: Date.new(2024, 1, 1),
-        enrollment: enrollment_record,
+      entry_date = Date.new(2024, 1, 1)
+      hud_enrollment = create(
+        :grda_warehouse_hud_enrollment,
+        PersonalID: client.PersonalID,
+        data_source_id: client.data_source_id,
+        EntryDate: entry_date,
       )
 
-      relation_double = double('Relation')
-      allow(relation_double).to receive(:preload).and_return(relation_double)
-      allow(relation_double).to receive(:find_each).and_yield(enrollment)
-      allow(report).to receive(:enrollments).and_return(relation_double)
+      create(
+        :grda_warehouse_service_history,
+        client: client,
+        enrollment: hud_enrollment,
+        first_date_in_program: entry_date,
+        record_type: 'entry',
+      )
 
-      expect do
-        data = report.additional_client_data(client)
-        expect(data).to be_a(Hash)
-      end.not_to raise_error
+      create(
+        :hud_income_benefit,
+        EnrollmentID: hud_enrollment.EnrollmentID,
+        PersonalID: client.PersonalID,
+        data_source: client.data_source,
+        InformationDate: nil,
+        IncomeFromAnySource: 1,
+        TotalMonthlyIncome: 100,
+      )
+
+      create(
+        :hud_income_benefit,
+        EnrollmentID: hud_enrollment.EnrollmentID,
+        PersonalID: client.PersonalID,
+        data_source: client.data_source,
+        InformationDate: entry_date,
+        IncomeFromAnySource: 1,
+        TotalMonthlyIncome: 200,
+      )
+
+      expect { report.additional_client_data(client) }.not_to raise_error
     end
   end
 end

--- a/spec/factories/grda_warehouse/data_quality_report.rb
+++ b/spec/factories/grda_warehouse/data_quality_report.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   end
 
   trait :single_project do
-    project { GrdaWarehouse::Hud::Project.first }
+    project { GrdaWarehouse::Hud::Project.order(:id).first }
   end
 
   factory :dq_project_group, class: 'GrdaWarehouse::ProjectGroup' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

* Fix crash in DocumentExportJob (ClientDocumentsReport) by handling nil `information_date` when computing additional client data
* fix possible fragility in test due to missing `order`

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

