### PR TITLE
Increment ChangeMarker when associated record is deleted

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3469,7 +3469,6 @@ Style/FrozenStringLiteralComment:
     - 'drivers/hmis/spec/jobs/activity_log_processor_job_spec.rb'
     - 'drivers/hmis/spec/jobs/assessment_questions_job_spec.rb'
     - 'drivers/hmis/spec/jobs/merge_clients_job_perf_spec.rb'
-    - 'drivers/hmis/spec/jobs/merge_clients_job_spec.rb'
     - 'drivers/hmis/spec/models/hmis/client_alert_spec.rb'
     - 'drivers/hmis/spec/models/hmis/file_spec.rb'
     - 'drivers/hmis/spec/models/hmis/form/definition_spec.rb'

--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -59,6 +59,7 @@ module Hmis
         dedup(client_to_retain.custom_data_elements)
         client_to_retain.reload
         destroy_merged_clients
+        mark_clients_as_dirty_after_merge
       end
     end
 
@@ -320,12 +321,33 @@ module Hmis
     def destroy_merged_clients
       Rails.logger.info 'soft-deleting merged clients'
       ids = clients_needing_reference_updates.map(&:id)
-      scope = Hmis::Hud::Client.where(id: ids)
-      # preload associations to reduce n+1 when destroying a batch
-      preloads = Hmis::Hud::Client.reflect_on_all_associations.
-        filter { |a| a.options[:dependent] == :destroy }.
-        map(&:name)
-      scope.preload(*preloads).each(&:destroy!)
+
+      # Temporarily skip the mark_destination_client_dirty callback to avoid excessive queries during bulk destroy
+      Hmis::Hud::Client.skip_callback(:destroy, :after, :mark_destination_client_dirty)
+
+      begin
+        scope = Hmis::Hud::Client.where(id: ids)
+        # preload associations to reduce n+1 when destroying a batch
+        preloads = Hmis::Hud::Client.reflect_on_all_associations.
+          filter { |a| a.options[:dependent] == :destroy }.
+          map(&:name)
+        scope.preload(*preloads).each(&:destroy!)
+      ensure
+        # Restore the callback
+        Hmis::Hud::Client.set_callback(:destroy, :after, :mark_destination_client_dirty)
+      end
+    end
+
+    def mark_clients_as_dirty_after_merge
+      return unless Hmis::Ce.configuration.enabled?
+
+      # Find destination client for the retained client
+      destination_client_id = client_to_retain.destination_client&.id
+      return unless destination_client_id
+
+      # Mark the destination client as dirty
+      Hmis::Ce::ChangeMarker.upsert_or_bump_version('GrdaWarehouse::Hud::Client', trackable_ids: [destination_client_id])
+      Rails.logger.info "Marked destination client #{destination_client_id} as dirty after merge for retained client #{client_to_retain.id}"
     end
   end
 end

--- a/drivers/hmis/app/models/concerns/hmis/mark_client_as_dirty_behavior.rb
+++ b/drivers/hmis/app/models/concerns/hmis/mark_client_as_dirty_behavior.rb
@@ -11,6 +11,7 @@ module Hmis::MarkClientAsDirtyBehavior
 
   included do
     after_save :mark_destination_client_dirty
+    after_destroy :mark_destination_client_dirty
   end
 
   protected

--- a/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
+++ b/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Hmis::MergeClientsJob, type: :model do
@@ -143,6 +145,25 @@ RSpec.describe Hmis::MergeClientsJob, type: :model do
       puts "SEARCHFORME: #{ap Hmis::Hud::Client.with_deleted}" if Hmis::Hud::Client.with_deleted.count != 2
       expect(Hmis::Hud::Client.with_deleted.count).to eq(2)
       expect(client2.reload.deleted?).to be_truthy
+    end
+  end
+
+  context 'with CE enabled' do
+    let(:client1) { create(:hmis_hud_client_with_warehouse_client, data_source: data_source) }
+    let(:client2) { create(:hmis_hud_client_with_warehouse_client, data_source: data_source) }
+
+    before do
+      allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
+    end
+
+    it 'marks the merged clients as dirty' do
+      expect(Hmis::Ce::ChangeMarker.dirty.count).to eq(0)
+
+      expect do
+        Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id)
+      end.to change { Hmis::Ce::ChangeMarker.dirty.count }.by(1)
+
+      expect(Hmis::Ce::ChangeMarker.sole.trackable).to eq(client1.destination_client.as_warehouse)
     end
   end
 

--- a/drivers/hmis/spec/models/concerns/hmis/mark_client_as_dirty_behavior_spec.rb
+++ b/drivers/hmis/spec/models/concerns/hmis/mark_client_as_dirty_behavior_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Hmis::MarkClientAsDirtyBehavior do
         create model_factory, client: c1, data_source: ds1, **model_attrs
       end.to change { Hmis::Ce::ChangeMarker.where(trackable: destination_client).dirty.count }.by(1)
     end
+
+    it "marks destination client dirty when #{model_factory} is destroyed" do
+      model = create model_factory, client: c1, data_source: ds1, **model_attrs
+      Hmis::Ce::ChangeMarker.mark_processed(Hmis::Ce::ChangeMarker.all)
+
+      expect do
+        model.destroy!
+      end.to change { Hmis::Ce::ChangeMarker.where(trackable: destination_client).dirty.count }.by(1)
+    end
   end
 
   include_examples 'marks client as dirty', :hmis_custom_assessment


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Bug repro:
- Find a client on a waitlist in a Unit Group where the eligibility depends on the client's open enrollments. I.e., the unit group has a rule such as "Must not have open Enrollment at PSH/RRH/TH"
- Create a WIP enrollment for that client in one of the project types referenced by the rule. Their eligibility will update. (ChangeMarker is incremented)
- Delete the WIP enrollment. The ChangeMarker does not get incremented, so their eligibility doesn't update until the next full refresh.

Why:
- Poking into the [`paranoia` gem source](https://github.com/rubysherpas/paranoia/blob/core/lib/paranoia.rb#L115) I learned that calling `destroy!` on a paranoid model calls `update_columns` under the hood, which bypasses ActiveRecords `after_save` hook. So the `after_save` hook was getting called on create and update, but not on destroy.
- Solution: Call the same `mark_client_as_dirty` in an `after_destroy` hook.
- This issue also impacts other records like CustomAssessment and Exit. The fix is on the shared `MarkClientAsDirtyBehavior` concern, so it should fix all of them. I haven't tested them all locally, only `Enrollment` and `CustomAssessment`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
