### PR TITLE
Add patch for continued VA disability collection

### DIFF
--- a/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
+++ b/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/psde_local_funder_rules.json
@@ -104,6 +104,18 @@
           "variable": "projectId",
           "operator": "EQUAL",
           "value": "1174"
+        },
+        {
+          "_comment": "Continue collection for HUD/VASH after requirement removed for FY26",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 20
+        },
+        {
+          "_comment": "Continue collection for VA GPD after requirement removed for FY26",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "VA: GPD"
         }
       ]
     }
@@ -128,6 +140,18 @@
           "variable": "projectId",
           "operator": "EQUAL",
           "value": "1174"
+        },
+        {
+          "_comment": "Continue collection for HUD/VASH after requirement removed for FY26",
+          "variable": "projectFunders",
+          "operator": "INCLUDE",
+          "value": 20
+        },
+        {
+          "_comment": "Continue collection for VA GPD after requirement removed for FY26",
+          "variable": "projectFunderComponents",
+          "operator": "INCLUDE",
+          "value": "VA: GPD"
         }
       ]
     }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/8234#issuecomment-3344195310
https://github.com/greenriver/hmis-warehouse/pull/5669/files

Add patches to continue collection for HUD/VASH and VA GPD. Note that CRS and Community Contract Safe Haven are intentionally excluded because collection does not need to be continued for those.


**How to test**: `CLIENT=customer rails driver:hmis:seed_definitions`. I tested this based on `7853-hmis-hud-2026-breaking-changes` to ensure the questions are collected in fy26

## Type of change
configuration

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
