### PR TITLE
Dont require units when enrolling in Other project type

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/require_units_on_enrollments.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/require_units_on_enrollments.json
@@ -78,12 +78,17 @@
         ],
         "custom_rule": {
           "operator": "ALL",
-          "_comment": "Hide for the internal CE project, which doesnt have units. Hide for special projects that support multi-unit households",
+          "_comment": "Hide for project types Coordinated Entry (14) and Other (7), because the CE and Link projects do not use Units. Also hide for special projects that support multi-unit households, those will use the above item instead.",
           "parts": [
             {
               "variable": "projectType",
               "operator": "NOT_EQUAL",
               "value": 14
+            },
+            {
+              "variable": "projectType",
+              "operator": "NOT_EQUAL",
+              "value": 7
             },
             {
               "variable": "projectId",


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Add an additional rule for project type `Other (7)` to hide unit selection when enrolling. Using project type rather than project ID for the Link project so that this change applies to Link projects across all environments.

## Type of change
configuration changes

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

