### PR TITLE
Include legacy referrals in open_referral_project_types field

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/match/expression/client_field_map.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/client_field_map.rb
@@ -97,11 +97,24 @@ module Hmis::Ce::Match::Expression
 
     def open_referral_project_types_field
       {
-        query: ->(clients) { project_types_query(clients, Hmis::Ce::Referral.active, :target_project) },
+        query: ->(clients) do
+          # Get project types from CE referrals
+          ce_referrals_result = project_types_query(clients, Hmis::Ce::Referral.active, :target_project)
+
+          # Get project types from legacy referrals
+          legacy_referrals_scope = HmisExternalApis::AcHmis::ReferralHouseholdMember.joins(:postings).
+            merge(HmisExternalApis::AcHmis::ReferralPosting.active)
+          legacy_referrals_result = project_types_query(clients, legacy_referrals_scope, postings: :project)
+
+          # Merge results from both referral types
+          ce_referrals_result.merge(legacy_referrals_result) { |_key, values1, values2| (values1 + values2).uniq }
+        end,
         format_for_display: method(:format_project_types),
       }
     end
 
+    # Returns a hash mapping client IDs to arrays of project type IDs
+    # @return [Hash{Integer => Array<Integer>}] e.g. { 123 => [1, 3, 13], 456 => [2, 4], 789 => [] }
     def project_types_query(clients, scope, project_association)
       client_ids = clients.pluck(:id)
       values = scope.joins(client: :warehouse_client_source).

--- a/drivers/hmis/app/models/hmis/ce/match/expression/client_field_map.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/client_field_map.rb
@@ -107,7 +107,7 @@ module Hmis::Ce::Match::Expression
           legacy_referrals_result = project_types_query(clients, legacy_referrals_scope, postings: :project)
 
           # Merge results from both referral types
-          ce_referrals_result.merge(legacy_referrals_result) { |_key, values1, values2| (values1 + values2).uniq }
+          ce_referrals_result.merge(legacy_referrals_result) { |_key, values1, values2| (values1 + values2).uniq.sort }
         end,
         format_for_display: method(:format_project_types),
       }

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/client_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/client_field_map_spec.rb
@@ -162,20 +162,98 @@ RSpec.describe Hmis::Ce::Match::Expression::ClientFieldMap, type: :model do
     end
 
     context 'for open_referral_project_types' do
-      before do
-        ds1 = client1.data_source
-        project1 = create(:hmis_hud_project, project_type: 3, data_source: ds1) # PSH
-        create(:hmis_ce_referral, client: client1, data_source: client1.data_source, target_project: project1, status: 'active')
+      context 'with CE referrals only' do
+        before do
+          ds1 = client1.data_source
+          project1 = create(:hmis_hud_project, project_type: 3, data_source: ds1) # PSH
+          create(:hmis_ce_referral, client: client1, data_source: client1.data_source, target_project: project1, status: 'in_progress')
 
-        ds2 = client2.data_source
-        project2 = create(:hmis_hud_project, project_type: 2, data_source: ds2) # TH
-        create(:hmis_ce_referral, client: client2, data_source: client2.data_source, target_project: project2, status: 'rejected') # not active
+          ds2 = client2.data_source
+          project2 = create(:hmis_hud_project, project_type: 2, data_source: ds2) # TH
+          create(:hmis_ce_referral, client: client2, data_source: client2.data_source, target_project: project2, status: 'rejected') # not active
+        end
+
+        it 'returns project types for active CE referrals' do
+          result = field_map.client_query(all_destination_clients, 'open_referral_project_types')
+          expect(result[destination_client1.id]).to contain_exactly(3)
+          expect(result[destination_client2.id]).to be_empty
+        end
       end
 
-      it 'returns project types for active referrals' do
-        result = field_map.client_query(all_destination_clients, 'open_referral_project_types')
-        expect(result[destination_client1.id]).to contain_exactly(3)
-        expect(result[destination_client2.id]).to be_empty
+      context 'with legacy referrals only' do
+        before do
+          ds1 = client1.data_source
+          project1 = create(:hmis_hud_project, project_type: 3, data_source: ds1) # PSH
+          project2 = create(:hmis_hud_project, project_type: 13, data_source: ds1) # RRH
+
+          # Create legacy referral for client1, with both active and inactive postings
+          referral = create(:hmis_external_api_ac_hmis_referral)
+          create(:hmis_external_api_ac_hmis_referral_household_member, referral: referral, client: client1)
+          create(:hmis_external_api_ac_hmis_referral_posting, referral: referral, project: project1, status: 'assigned_status') # active
+          create(:hmis_external_api_ac_hmis_referral_posting, referral: referral, project: project2, status: 'denied_status') # not active
+
+          ds2 = client2.data_source
+          project3 = create(:hmis_hud_project, project_type: 2, data_source: ds2) # TH
+
+          # Create legacy referral for client2 with inactive posting
+          referral2 = create(:hmis_external_api_ac_hmis_referral)
+          create(:hmis_external_api_ac_hmis_referral_household_member, referral: referral2, client: client2)
+          create(:hmis_external_api_ac_hmis_referral_posting, referral: referral2, project: project3, status: 'accepted_status') # not active
+        end
+
+        it 'returns project types for active legacy referrals' do
+          result = field_map.client_query(all_destination_clients, 'open_referral_project_types')
+          expect(result[destination_client1.id]).to contain_exactly(3) # PSH is only active posting
+          expect(result[destination_client2.id]).to be_empty
+        end
+      end
+
+      context 'with both CE and legacy referrals' do
+        before do
+          ds1 = client1.data_source
+          ce_project = create(:hmis_hud_project, project_type: 3, data_source: ds1) # PSH
+          legacy_project = create(:hmis_hud_project, project_type: 13, data_source: ds1) # RRH
+
+          # CE referral
+          create(:hmis_ce_referral, client: client1, data_source: client1.data_source, target_project: ce_project, status: 'in_progress')
+
+          # Legacy referral
+          referral = create(:hmis_external_api_ac_hmis_referral)
+          create(:hmis_external_api_ac_hmis_referral_household_member, referral: referral, client: client1)
+          create(:hmis_external_api_ac_hmis_referral_posting, referral: referral, project: legacy_project, status: 'accepted_pending_status') # active
+
+          ds2 = client2.data_source
+          project2 = create(:hmis_hud_project, project_type: 2, data_source: ds2) # TH
+
+          # Only CE referral for client2
+          create(:hmis_ce_referral, client: client2, data_source: client2.data_source, target_project: project2, status: 'in_progress')
+        end
+
+        it 'returns project types from both CE and legacy referrals, deduplicated' do
+          result = field_map.client_query(all_destination_clients, 'open_referral_project_types')
+          expect(result[destination_client1.id]).to contain_exactly(3, 13) # Both CE and legacy
+          expect(result[destination_client2.id]).to contain_exactly(2) # Only CE
+        end
+      end
+
+      context 'with duplicate project types across referral types' do
+        before do
+          ds1 = client1.data_source
+          project1 = create(:hmis_hud_project, project_type: 3, data_source: ds1) # PSH
+
+          # Both CE and legacy referrals to the same project type
+          create(:hmis_ce_referral, client: client1, data_source: client1.data_source, target_project: project1, status: 'in_progress')
+
+          referral = create(:hmis_external_api_ac_hmis_referral)
+          create(:hmis_external_api_ac_hmis_referral_household_member, referral: referral, client: client1)
+          create(:hmis_external_api_ac_hmis_referral_posting, referral: referral, project: project1, status: 'assigned_status')
+        end
+
+        it 'deduplicates project types when same type appears in both referral types' do
+          result = field_map.client_query(all_destination_clients, 'open_referral_project_types')
+          expect(result[destination_client1.id]).to contain_exactly(3) # Deduplicated
+          expect(result[destination_client2.id]).to be_empty
+        end
       end
     end
   end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_household_member.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_household_member.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisExternalApis::AcHmis
   # A member of a household that is referred for services
   class ReferralHouseholdMember < ::HmisExternalApis::HmisExternalApisBase
@@ -11,6 +13,7 @@ module HmisExternalApis::AcHmis
     has_paper_trail(meta: { client_id: :client_id })
     belongs_to :referral, class_name: 'HmisExternalApis::AcHmis::Referral'
     belongs_to :client, class_name: 'Hmis::Hud::Client'
+    has_many :postings, class_name: 'HmisExternalApis::AcHmis::ReferralPosting', through: :referral
 
     enum(
       relationship_to_hoh: ::HudHelper.util.hud_list_map_as_enumerable(:relationships_to_hoh),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8346

Update the `open_referral_project_types` CE requirement field to include Project Types where the client has an active external (legacy) `ReferralPosting`. Active scope includes Assigned, Accepted Pending, and Denied Pending postings.

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

