### PR TITLE
Add state validation to state machine

### DIFF
--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -35,6 +35,7 @@ module SimpleStateMachine
       validates ssm_column, inclusion: {
         in: state_machine_states.map(&:to_s),
         message: "must be one of: #{state_machine_states.map(&:to_s).join(', ')}",
+        allow_nil: true,
       }
 
       # Define event methods

--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -35,7 +35,6 @@ module SimpleStateMachine
       validates ssm_column, inclusion: {
         in: state_machine_states.map(&:to_s),
         message: "must be one of: #{state_machine_states.map(&:to_s).join(', ')}",
-        allow_nil: true,
       }
 
       # Define event methods

--- a/app/models/concerns/simple_state_machine.rb
+++ b/app/models/concerns/simple_state_machine.rb
@@ -31,6 +31,12 @@ module SimpleStateMachine
         scope state_name, -> { where(ssm_column => state_name.to_s) }
       end
 
+      # Add validation for state column
+      validates ssm_column, inclusion: {
+        in: state_machine_states.map(&:to_s),
+        message: "must be one of: #{state_machine_states.map(&:to_s).join(', ')}",
+      }
+
       # Define event methods
       ssm_events.each do |event_name, transition_map|
         # Define bang method that performs the transition

--- a/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/opportunities.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     end
 
     sequence(:name) { |n| "Opportunity #{n}" }
+    status { 'open' }
     project { association :hmis_hud_project, data_source: data_source }
     workflow_template { association :hmis_workflow_definition_template, data_source: data_source }
     unit { association :hmis_unit, project: project }

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       unit { build :hmis_unit, project: project }
     end
 
-    opportunity { association :hmis_ce_opportunity, project: project, workflow_template: workflow_template, data_source: data_source, unit: unit }
+    opportunity { association :hmis_ce_opportunity, project: project, workflow_template: workflow_template, data_source: data_source, unit: unit, status: 'locked' }
     workflow_instance { association :hmis_workflow_execution_instance, template: workflow_template }
     client { association :hmis_hud_client_with_warehouse_client, data_source: data_source }
     referred_by { association :hmis_user, data_source: data_source }

--- a/drivers/hmis/spec/factories/hmis/ce/referrals.rb
+++ b/drivers/hmis/spec/factories/hmis/ce/referrals.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       unit { build :hmis_unit, project: project }
     end
 
-    opportunity { association :hmis_ce_opportunity, project: project, workflow_template: workflow_template, data_source: data_source, unit: unit, status: 'locked' }
+    opportunity { association :hmis_ce_opportunity, project: project, workflow_template: workflow_template, data_source: data_source, unit: unit }
     workflow_instance { association :hmis_workflow_execution_instance, template: workflow_template }
     client { association :hmis_hud_client_with_warehouse_client, data_source: data_source }
     referred_by { association :hmis_user, data_source: data_source }

--- a/drivers/hmis/spec/models/hmis/ce/referral_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe Hmis::Ce::Referral, type: :model do
       end.to raise_error(ActiveRecord::RecordInvalid, /must be a CE template/)
     end
 
+    it 'does not save a referral with an invalid status' do
+      referral = build(:hmis_ce_referral, status: 'not_a_status', opportunity: opportunity, data_source: data_source)
+      expect(referral.valid?).to be_falsy
+      expect do
+        referral.save!
+      end.to raise_error(ActiveRecord::RecordInvalid, /Status must be one of/)
+    end
+
     ['initialized', 'in_progress', 'accepted'].each do |status|
       context "when there is an existing #{status} referral" do
         let!(:existing) { create(:hmis_ce_referral, opportunity: opportunity, data_source: data_source, status: status) }

--- a/spec/models/simple_state_machine_spec.rb
+++ b/spec/models/simple_state_machine_spec.rb
@@ -154,11 +154,12 @@ RSpec.describe SimpleStateMachine do
       expect(record.errors[:workflow_state]).to include('must be one of: draft, review')
     end
 
-    it 'allows nil values' do
+    it 'disallows nil values' do
       record = SimpleStateMachineTestRecord.new
       record.status = nil
 
-      expect(record).to be_valid
+      expect(record).not_to be_valid
+      expect(record.errors[:status]).to include('must be one of: open, locked, closed')
     end
   end
 

--- a/spec/models/simple_state_machine_spec.rb
+++ b/spec/models/simple_state_machine_spec.rb
@@ -123,6 +123,45 @@ RSpec.describe SimpleStateMachine do
     end
   end
 
+  describe 'state validation' do
+    it 'validates state inclusion' do
+      record = SimpleStateMachineTestRecord.new
+      record.status = 'invalid_state'
+
+      expect(record).not_to be_valid
+      expect(record.errors[:status]).to include('must be one of: open, locked, closed')
+    end
+
+    it 'accepts valid states as strings' do
+      record = SimpleStateMachineTestRecord.new
+      record.status = 'locked'
+
+      expect(record).to be_valid
+    end
+
+    it 'accepts valid states as symbols' do
+      record = SimpleStateMachineTestRecord.new
+      record.status = :closed
+
+      expect(record).to be_valid
+    end
+
+    it 'works with custom column names' do
+      record = CustomColumnStateMachineRecord.new
+      record.workflow_state = 'invalid_state'
+
+      expect(record).not_to be_valid
+      expect(record.errors[:workflow_state]).to include('must be one of: draft, review')
+    end
+
+    it 'allows nil values' do
+      record = SimpleStateMachineTestRecord.new
+      record.status = nil
+
+      expect(record).to be_valid
+    end
+  end
+
   describe 'ambiguous transitions' do
     it 'raises an error when the same state appears in multiple transitions' do
       expect do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Update state machine class to add class validation on state column.

**Testing**: I tested that creating/completing a referral workflow was happy, and marking units available/unavailable.


**Classes that use SimpleStateMachine**: `Hmis::Ce::Opportunity`, `Hmis::Ce:Referral`, `Hmis::WorkflowDefinition::Template`, `Hmis::WorkflowExecution::Step`


## Type of change
Bug fix / validation

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

