### PR TITLE
Mark clients dirty when legacy referrals change

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3905,7 +3905,6 @@ Style/FrozenStringLiteralComment:
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/program_involvement.rb'
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral.rb'
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_household_member.rb'
-    - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb'
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_request.rb'
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/unit_availability_sync.rb'
     - 'drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms.rb'

--- a/drivers/hmis/spec/requests/hmis/update_referral_posting_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_referral_posting_spec.rb
@@ -20,16 +20,23 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     create(:ac_hmis_link_credential)
   end
   let!(:coc) { create :hud_project_coc, data_source: ds1, project_id: destination_project.project_id, state: 'MA' }
+  let!(:c1) { create :hmis_hud_client_with_warehouse_client, data_source: ds1, user: u1 }
+  let!(:c2) { create :hmis_hud_client_with_warehouse_client, data_source: ds1, user: u1 }
   let!(:source_enrollment) do
     create :hmis_hud_enrollment, data_source: ds1, project: source_project, client: c1, user: u1
+  end
+  let!(:source_enrollment2) do
+    create :hmis_hud_enrollment, data_source: ds1, project: source_project, client: c2, user: u1, relationship_to_hoh: 2
   end
   let!(:referral) do
     create(:hmis_external_api_ac_hmis_referral, enrollment: source_enrollment)
   end
   let!(:household_member) { create :hmis_external_api_ac_hmis_referral_household_member, client: c1, referral: referral }
+  let!(:household_member2) { create :hmis_external_api_ac_hmis_referral_household_member, client: c2, referral: referral }
 
   before(:each) do
     hmis_login(user)
+    allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
   end
 
   let(:mutation) do
@@ -57,12 +64,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         statusNote: 'test',
         referralResult: 'UNSUCCESSFUL_REFERRAL_PROVIDER_REJECTED',
       }
+      Hmis::Ce::ChangeMarker.mark_processed(Hmis::Ce::ChangeMarker.all)
       expect do
         response, result = post_graphql(id: posting.id, input: input) { mutation }
         expect(response.status).to eq 200
         errors = result.dig('data', 'updateReferralPosting', 'errors')
         expect(errors).to be_empty
-      end.to change(Hmis::Hud::Enrollment.where(id: source_enrollment.id).exited, :count).by(1)
+      end.to change(Hmis::Hud::Enrollment.where(id: source_enrollment.id).exited, :count).by(1).
+        and change(Hmis::Ce::ChangeMarker.dirty, :count).from(0).to(2) # 1 for the hoh, 1 for the other household member
     end
   end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisExternalApis::AcHmis
   # A proposed fulfillment of a referral request
   class ReferralPosting < ::HmisExternalApis::HmisExternalApisBase
@@ -162,6 +164,23 @@ module HmisExternalApis::AcHmis
         self.status_updated_at = Time.current unless status_updated_at_changed?
         self.status_updated_by_id = user.id unless status_updated_by_id_changed?
       end
+    end
+
+    after_save :mark_household_members_dirty
+    def mark_household_members_dirty
+      return unless Hmis::Ce.configuration.enabled?
+
+      source_client_ids = referral.household_members.pluck(:client_id)
+      source_client_scope = Hmis::Hud::Client.where(id: source_client_ids)
+
+      # Join to destination clients
+      client_ids = GrdaWarehouse::WarehouseClient.
+        joins(:source).
+        merge(source_client_scope).
+        pluck(:destination_id)
+
+      # enqueue
+      Hmis::Ce::ChangeMarker.upsert_or_bump_version('GrdaWarehouse::Hud::Client', trackable_ids: client_ids)
     end
 
     # If a household has been referred out from a project (e.g. the HMIS Coordinated Entry Project) and the referral has


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- targets release-182 as a hotfix

## Description
Steps taken to verify locally:
- Create a waitlist that has an eligibility rule stating clients are only eligible if they don't have open referrals to specific project types.
- Create a legacy referral for a client who is on that waitlist.
- Confirm they fall off the waitlist. (after running `ProcessClientsJob`)
- Deny the referral
- Confirm they are back on the waitlist.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
