### PR TITLE
Suppress sentry noise for expected non-ce event projects

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -63,9 +63,12 @@ module Hmis::Ce
       # Fall back to determining the event type based on the referral target project
       project = referral.target_project
       event_type = HudHelper.util('2026').project_to_ce_event_type(project)
-      if capture_to_sentry && !event_type
-        # Log to Sentry without raising. This is expected for projects that reuse a workflow from another project, but don't need to generate a CE event.
-        Sentry.capture_message("Unable to determine CE Event Type for project type #{project.project_type} on project #{project.id} for referral #{referral.id}")
+
+      expected_project_types = [12] # If the project is one of these expected types, don't log to sentry
+      if capture_to_sentry && !event_type && !expected_project_types.include?(project.project_type)
+        # Log to Sentry without raising.
+        # This may indicate a misconfigured workflow, but may just indicate a project that's reusing a workflow template but doesn't need to generate CE events.
+        Sentry.capture_message("Unable to determine CE Event Type for project type #{project.project_type} on project #{project.id} for referral #{referral.id}. Not a user-facing error.")
       end
       event_type
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Suppresses https://green-river.sentry.io/issues/6920753137/?alert_rule_id=12523843&alert_type=issue&notification_uuid=fdb505d0-9289-47d8-8127-fd66d046bb1b&project=4503977346662400&referrer=slack

To discuss: Is this suppression generic enough across installations?

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Sentry tuning

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
