### PR TITLE
Raise error if attempting to over-request Units

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -87,7 +87,8 @@ module Mutations
           count
 
         # Calculate how many units can be marked available: vacant units - assigned postings
-        max_available_units = vacant_units_count - assigned_postings_count # TODO- dont allow to be negative, just say 0 if thats the case
+        max_available_units = vacant_units_count - assigned_postings_count
+        max_available_units = [max_available_units, 0].max # if already over-requested, max is 0
 
         # Skip if we're not trying to mark more units available than allowed
         next unless num_units_being_marked > max_available_units

--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -24,6 +24,9 @@ module Mutations
       project = Hmis::Hud::Project.find_by(id: project_ids.first)
       access_denied! unless policy_for(project, policy_type: :hmis_project).can_update_unit_availability?
 
+      # Validate that units being marked available don't exceed assigned legacy ReferralPostings
+      validate_unit_availability_against_referral_postings(units, project)
+
       opportunities = units.map { |unit| build_opportunity_for_unit(unit) }
       Hmis::Ce::Opportunity.import!(opportunities)
 
@@ -56,6 +59,45 @@ module Mutations
 
     def rule_resolver
       @rule_resolver ||= Hmis::Ce::Match::UnitGroupRuleResolver.new
+    end
+
+    # Validate that the units being marked available don't exceed assigned legacy ReferralPostings.
+    # This is a temporary fix for issue #8359.
+    # This is in place for systems where legacy ReferralPostings and CE Referrals coexist during a transition period,
+    # and can be removed once referral postings are removed from the system.
+    def validate_unit_availability_against_referral_postings(units, project)
+      return unless project.external_referral_postings.active.exists? # early return if no active legacy ReferralPostings
+
+      # Count units being marked available by unit type
+      num_units_by_type = units.map(&:unit_type_id).tally
+
+      num_units_by_type.each do |unit_type_id, num_units_being_marked|
+        next if unit_type_id.nil? # Skip units without unit type
+
+        # Count total vacant units for this unit type in this project
+        vacant_units_count = project.units.
+          unoccupied_on.
+          where(unit_type_id: unit_type_id).
+          count
+
+        # Count 'assigned' and 'denied pending' ReferralPostings for this unit type in this project.
+        # Note: 'accepted pending' is not counted because accepted pending postings have an associated enrollment that is already placed in a unit.
+        assigned_postings_count = project.external_referral_postings.
+          where(unit_type_id: unit_type_id, status: ['assigned_status', 'denied_pending_status']).
+          count
+
+        # Calculate how many units can be marked available: vacant units - assigned postings
+        max_available_units = vacant_units_count - assigned_postings_count # TODO- dont allow to be negative, just say 0 if thats the case
+
+        # Skip if we're not trying to mark more units available than allowed
+        next unless num_units_being_marked > max_available_units
+
+        # Raise user-facing error if we're trying to mark more units available than allowed.
+        # (Raising instead of returning a validation error because validation errors not supported by the frontend in this UI, and this is a temporary fix.)
+        unit_type = Hmis::UnitType.find(unit_type_id)
+        msg = "Cannot mark #{num_units_being_marked} #{unit_type.description} units as available because of overlapping legacy Referral Postings. At most #{max_available_units} #{unit_type.description} units can be marked available at this time."
+        raise HmisErrors::ApiError.new(msg, display_message: msg)
+      end
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
           expect do
             response, result = post_graphql(**variables) { mutation }
             expect(response.status).to eq(200), result.inspect
-          end.to change(Hmis::Ce::Opportunity, :count).by(2)
+          end.to change(Hmis::Ce::Opportunity, :count).by(1)
         end
 
         it 'rejects above threshold' do

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -204,5 +204,69 @@ RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
         end.to not_change(Hmis::Ce::Opportunity, :count)
       end
     end
+
+    context 'when project has assigned legacy Referral Postings' do
+      let!(:unit_type_2) { create :hmis_unit_type, description: '2 Bedroom Apartment' }
+      let!(:unit_group_2) { create :hmis_unit_group, project: project, workflow_template: template }
+      let!(:two_br_unit1) { create :hmis_unit, project: project, unit_type: unit_type_2, unit_group: unit_group_2 }
+      let!(:two_br_unit2) { create :hmis_unit, project: project, unit_type: unit_type_2, unit_group: unit_group_2 }
+      let!(:one_br_unit2) { create :hmis_unit, project: project, unit_type: unit_type, unit_group: unit_group }
+      let!(:one_br_unit3) { create :hmis_unit, project: project, unit_type: unit_type, unit_group: unit_group }
+
+      context 'with 2 assigned postings to 1 Bedroom Apartment' do
+        let!(:assigned_posting_1) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :assigned_status) }
+        let!(:assigned_posting_2) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :assigned_status) }
+
+        it 'allows marking 1 unit when within the limit' do
+          variables = { unitIds: [one_br_unit2.id] }
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+          end.to change(Hmis::Ce::Opportunity, :count).by(1)
+        end
+
+        it 'raises an error when trying to mark too many units' do
+          # There are 2 assigned postings for 3 vacant units = 1 1BR unit can be marked available
+          # But trying to mark 2 units
+
+          variables = { unitIds: [one_br_unit2.id, one_br_unit3.id] }
+
+          expect do
+            expect_gql_error(
+              post_graphql(**variables) { mutation },
+              message: /Cannot mark 2 1 Bedroom Apartment units as available because of overlapping legacy Referral Postings. At most 1 1 Bedroom Apartment units can be marked available at this time./,
+            )
+          end.to not_change(Hmis::Ce::Opportunity, :count)
+        end
+
+        it 'allows marking units available for other unit types' do
+          variables = { unitIds: [two_br_unit1.id, two_br_unit2.id] }
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+          end.to change(Hmis::Ce::Opportunity, :count).by(2)
+        end
+      end
+
+      context 'when referral postings have other statuses' do
+        let!(:posting1) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :assigned_status) }
+        let!(:posting2) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :denied_pending_status) }
+        let!(:posting3) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :accepted_pending_status) }
+        let!(:posting4) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :accepted_status) }
+        let!(:posting5) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :denied_status) }
+
+        it 'counts only assigned and denied_pending statuses' do
+          # Create postings with different statuses
+
+          # 3 vacant units - 2 counted postings (assigned + denied_pending) = 1 units can be marked available
+          variables = { unitIds: [two_br_unit1.id, two_br_unit2.id] }
+
+          expect do
+            response, result = post_graphql(**variables) { mutation }
+            expect(response.status).to eq(200), result.inspect
+          end.to change(Hmis::Ce::Opportunity, :count).by(2)
+        end
+      end
+    end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -256,15 +256,21 @@ RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
         let!(:posting5) { create(:hmis_external_api_ac_hmis_referral_posting, project: project, unit_type: unit_type, status: :denied_status) }
 
         it 'counts only assigned and denied_pending statuses' do
-          # Create postings with different statuses
-
           # 3 vacant units - 2 counted postings (assigned + denied_pending) = 1 units can be marked available
-          variables = { unitIds: [two_br_unit1.id, two_br_unit2.id] }
+          variables = { unitIds: [one_br_unit2.id] }
 
           expect do
             response, result = post_graphql(**variables) { mutation }
             expect(response.status).to eq(200), result.inspect
           end.to change(Hmis::Ce::Opportunity, :count).by(2)
+        end
+
+        it 'rejects above threshold' do
+          variables = { unitIds: [one_br_unit2.id, one_br_unit3.id] }
+
+          expect do
+            expect_gql_error post_graphql(**variables) { mutation }
+          end.to not_change(Hmis::Ce::Opportunity, :count)
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8359

Fix: Prevent over-requesting units with legacy ReferralPostings
* **Problem**: Providers could "over-request" units when legacy ReferralPostings exist, potentially assigning new referrals to units already slated for legacy referrals.
* **Solution**: Added validation to MarkUnitsAvailable mutation that prevents marking more units available than can be safely assigned. Calculates max available units as vacant_units - assigned_legacy_postings and rejects requests that exceed this limit.

This is a temporary fix for the transition period until legacy ReferralPostings are phased out. 


**How to test:** go to a project that has any assigned or accepted pendings. set it up for CE referrals. try to mark all units available such that it could max out the capacity, making it impossible for the postings to be accepted

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s **note** has some N+1 on number of unit types but thats minimal so I think not worth optimizing)
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
