### PR TITLE
Patch R13 to allow resolving additional values for FY26

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -3996,7 +3996,7 @@ HUD Enrollment
 """
 type Enrollment {
   access: EnrollmentAccess!
-  alcoholDrugUseDisorderFam: NoYesMissing
+  alcoholDrugUseDisorderFam: NoYesReasonsForMissingData
   annualPercentAmi: AnnualPercentAMI
   assessmentEligibilities: [AssessmentEligibility!]!
   assessments(filters: AssessmentsForEnrollmentFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
@@ -4061,9 +4061,9 @@ type Enrollment {
   id: ID!
   inProgress: Boolean!
   incarceratedAdult: IncarceratedAdult
-  incarceratedParent: NoYesMissing
+  incarceratedParent: NoYesReasonsForMissingData
   incomeBenefits(limit: Int, offset: Int): IncomeBenefitsPaginated!
-  insufficientIncome: NoYesMissing
+  insufficientIncome: NoYesReasonsForMissingData
   intakeAssessment: Assessment
   juvenileJusticeMonths: Int
   juvenileJusticeYears: RHYNumberofYears
@@ -4077,7 +4077,7 @@ type Enrollment {
   lockVersion: Int!
   losUnderThreshold: NoYesMissing
   mentalHealthConsultation: MentalHealthConsultation
-  mentalHealthDisorderFam: NoYesMissing
+  mentalHealthDisorderFam: NoYesReasonsForMissingData
   monthsHomelessPastThreeYears: MonthsHomelessPastThreeYears
   moveInAddresses: [ClientAddress!]!
   moveInDate: ISO8601Date
@@ -4090,7 +4090,7 @@ type Enrollment {
   openEnrollmentSummary: [EnrollmentSummary!]!
   organizationName: String!
   percentAmi: PercentAMI
-  physicalDisabilityFam: NoYesMissing
+  physicalDisabilityFam: NoYesReasonsForMissingData
   preferredLanguage: PreferredLanguage
   preferredLanguageDifferent: String
   previousStreetEssh: NoYesMissing
@@ -4123,7 +4123,7 @@ type Enrollment {
   timeToHousingLoss: TimeToHousingLoss
   timesHomelessPastThreeYears: TimesHomelessPastThreeYears
   translationNeeded: NoYesReasonsForMissingData
-  unemploymentFam: NoYesMissing
+  unemploymentFam: NoYesReasonsForMissingData
   user: ApplicationUser
   vamcStation: VamcStationNumber
   youthEducationStatuses(limit: Int, offset: Int): YouthEducationStatusesPaginated!

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -180,12 +180,12 @@ module Types
     field :juvenile_justice_years, HmisSchema::Enums::Hud::RHYNumberofYears, null: true
     field :juvenile_justice_months, Integer, null: true
     # R13
-    field :unemployment_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    field :mental_health_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    field :physical_disability_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    field :alcohol_drug_use_disorder_fam, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    field :insufficient_income, HmisSchema::Enums::Hud::NoYesMissing, null: true
-    field :incarcerated_parent, HmisSchema::Enums::Hud::NoYesMissing, null: true
+    field :unemployment_fam, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :mental_health_disorder_fam, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :physical_disability_fam, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :alcohol_drug_use_disorder_fam, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :insufficient_income, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
+    field :incarcerated_parent, HmisSchema::Enums::Hud::NoYesReasonsForMissingData, null: true
     # V6
     field :vamc_station, HmisSchema::Enums::Hud::VamcStationNumber, null: true
     # V7


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix issue where new enum values for R13 fields could not be resolved. R13 fields were expanded in FY26 to include 8/9/99 values. The form was updated to collect these, but the graphql API was not updated to be able to resolve them.

Issue: https://github.com/open-path/Green-River/issues/8382
Frontend PR: https://github.com/greenriver/hmis-frontend/pull/1293 (codegen)



Screenshots from testing to ensure fields are stored and resolved:

<img width="565" height="585" alt="Screenshot 2025-10-09 at 9 30 25 AM" src="https://github.com/user-attachments/assets/ea810ef3-f426-4029-a60e-04eb9f5c0cd9" />

<img width="421" height="476" alt="Screenshot 2025-10-09 at 9 31 01 AM" src="https://github.com/user-attachments/assets/bbd13e94-60b6-47c4-b239-a6773bcb66b1" />


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
