### PR TITLE
Fix bug in over-requesting referrals fix

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/mark_units_available.rb
@@ -75,10 +75,9 @@ module Mutations
         next if unit_type_id.nil? # Skip units without unit type
 
         # Count total vacant units for this unit type in this project
-        vacant_units_count = project.units.
-          unoccupied_on.
-          where(unit_type_id: unit_type_id).
-          count
+        vacant_units_count = project.units.unoccupied_on.with_unit_type(unit_type_id).count
+        # Units that are already receiving referrals
+        accepting_referrals_count = project.units.receiving_referrals.with_unit_type(unit_type_id).count
 
         # Count 'assigned' and 'denied pending' ReferralPostings for this unit type in this project.
         # Note: 'accepted pending' is not counted because accepted pending postings have an associated enrollment that is already placed in a unit.
@@ -87,7 +86,7 @@ module Mutations
           count
 
         # Calculate how many units can be marked available: vacant units - assigned postings
-        max_available_units = vacant_units_count - assigned_postings_count
+        max_available_units = vacant_units_count - assigned_postings_count - accepting_referrals_count
         max_available_units = [max_available_units, 0].max # if already over-requested, max is 0
 
         # Skip if we're not trying to mark more units available than allowed

--- a/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb
@@ -246,6 +246,34 @@ RSpec.describe Mutations::Ce::MarkUnitsAvailable, type: :request do
             expect(response.status).to eq(200), result.inspect
           end.to change(Hmis::Ce::Opportunity, :count).by(2)
         end
+
+        context 'and other unit already has opportunity' do
+          let!(:opportunity) { create(:hmis_ce_opportunity, unit: unit, project: project, data_source: ds1, status: :open) }
+          # 3 vacant units - 1 already marked available (has open opportunity) - 2 assigned postings = 0 units can be marked available
+
+          it 'raises an error when trying to mark too many units' do
+            variables = { unitIds: [one_br_unit2.id] }
+            expect do
+              expect_gql_error(
+                post_graphql(**variables) { mutation },
+                message: /Cannot mark 1 1 Bedroom Apartment units as available because of overlapping legacy Referral Postings. At most 0 1 Bedroom Apartment units can be marked available at this time./,
+              )
+            end.to not_change(Hmis::Ce::Opportunity, :count)
+          end
+        end
+
+        context 'and other unit is occupied' do
+          let!(:occupancy) { create(:hmis_unit_occupancy, unit: unit) }
+          it 'raises an error when trying to mark too many units' do
+            variables = { unitIds: [one_br_unit2.id] }
+            expect do
+              expect_gql_error(
+                post_graphql(**variables) { mutation },
+                message: /Cannot mark 1 1 Bedroom Apartment units as available because of overlapping legacy Referral Postings. At most 0 1 Bedroom Apartment units can be marked available at this time./,
+              )
+            end.to not_change(Hmis::Ce::Opportunity, :count)
+          end
+        end
       end
 
       context 'when referral postings have other statuses' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8359

Fix bug found in QA for https://github.com/greenriver/hmis-warehouse/pull/5881

The logic needed to take into account units that had already been marked available.

Testing example:
- 10 units
- 5 occupied, 5 vacant
- 2 assigned postings
- 1 unit marked available
- max **2** additional units can be marked available, even though there are 4 more vacant ones, because 2 need to be "held" for the postings

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
