### PR TITLE
Update logo path

### DIFF
--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -13,9 +13,11 @@ class Hmis::AppSettingsController < Hmis::BaseController
   def show
     okta_enabled = ENV['HMIS_OKTA_CLIENT_ID'].present? && ENV['OKTA_DOMAIN'].present?
 
-    logo = ENV['HMIS_LOGO']&.presence || ENV['LOGO']&.presence # prefer HMIS_LOGO if provided, otherwise LOGO
+    logo = GrdaWarehouse::Theme.logo
+    logo_path = nil
     if logo.present?
-      logo_path = SerializedAsset.exists?(logo) ? SerializedAsset.get_src(logo) : "theme/logo/#{logo}"
+      content_type = logo.blob.content_type
+      logo_path = "data:#{content_type};base64,#{GrdaWarehouse::Theme.encoded_logo}"
     end
 
     hostname = ENV['FQDN']
@@ -27,7 +29,7 @@ class Hmis::AppSettingsController < Hmis::BaseController
 
     render json: {
       oktaPath: okta_enabled ? '/hmis/users/auth/okta' : nil,
-      logoPath: logo_path.present? ? ActionController::Base.helpers.asset_path(logo_path) : nil,
+      logoPath: logo_path.present? ? logo_path : nil,
       warehouseUrl: "https://#{hostname}",
       warehouseName: Translation.translate('Open Path HMIS Warehouse'),
       appName: Translation.translate('Open Path HMIS'), # TODO: app name should be configurable per data source


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Should solve: https://green-river.sentry.io/issues/6934589975/?referrer=slack&notification_uuid=4bf8afb8-7558-465e-97dd-1ca4ff8c1ea6&alert_rule_id=14733065&alert_type=issue

Here's my understanding, @eanders please chime in with corrections if I haven't gotten it quite right:
- In this [PR that went into 184,](https://github.com/greenriver/hmis-warehouse/pull/5864) we made some changes to asset compilation. That impacted the path where the logos and other assets are stored
- This PR updates the asset controller that serves the logo path to the HMIS, so it now points at the logo stored in `GrdaWarehouse::Theme`. It now ignores the `ENV['HMIS_LOGO']` variable
- @eanders will open another PR shortly to update `GrdaWarehouse::Theme` to include an `.hmis_logo` alongside `.logo`, and preferentially use `.hmis_logo` if found. **Question:** In the meantime, client envs that have a different HMIS vs. warehouse logo (only 1 currently) will display WH logo for both for a few hours. Is that acceptable? We can also hold off on deploying release-184 to those envs until Elliot's upcoming PR is in place.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
