### PR TITLE
pg_repack versioned binaries bug

### DIFF
--- a/app/models/dba/database_bloat.rb
+++ b/app/models/dba/database_bloat.rb
@@ -158,12 +158,14 @@ class Dba::DatabaseBloat
         options = "--no-superuser-check -U #{escaped_username} -d #{escaped_database} -h #{escaped_host} -p #{escaped_port} -t #{escaped_schema}.#{escaped_table}"
 
         # In order to support multiple versions of pg_repack, we need to use the version-specific binary
-        cmd = "#{escaped_binary} #{options}"
+        # Use bash's 'exec -a' to override argv[0] (the program name) to avoid version mismatch errors
+        # The pg_repack extension checks that argv[0] matches 'pg_repack', so we use exec -a to set it
+        # This allows us to use versioned binaries like 'pg_repack-1.5.2' while reporting as 'pg_repack'
+        bash_cmd = "exec -a pg_repack #{escaped_binary} #{options}"
+        cmd = ['bash', '-c', bash_cmd]
 
-        raise 'version of pg_repack needs to match that in the database'
-
-        Rails.logger.info("Repacking #{row['tblname']}") # rubocop:disable Lint/UnreachableCode
-        system(cmd)
+        Rails.logger.info("Repacking #{row['tblname']} with binary: #{binary}")
+        system(*cmd)
 
         raise 'running repack failed.' if $?.exitstatus != 0 # rubocop:disable Style/SpecialGlobalVars
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix issue with running pg_repack using versioned instances of the binary. The issue was that pg_repack checks both the version and the binary program name ("pg_repack") matches what is installed in the database. In our case, we have versioned isntallations on the server, so the binary "pg_repack-1.5.2" was not meeting pg_repack's requirements even though it was using the correct version.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug FIx

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
