### PR TITLE
pinentry-tty for gpg for git signed commits

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -131,6 +131,7 @@ RUN apt-get update && apt-get upgrade -y \
   poppler-utils \
   postgresql-client \
   postgresql-server-dev-all \
+  pinentry-tty \
   shared-mime-info \
   software-properties-common \
   tar \


### PR DESCRIPTION
somehow we need another package to support entering a passphrase with gpg