### PR TITLE
Add hmis url to analytics.data_sources

### DIFF
--- a/db/views/analytics_data_sources_v02.sql
+++ b/db/views/analytics_data_sources_v02.sql
@@ -1,0 +1,6 @@
+SELECT
+  id, name, short_name, last_imported_at, source_type, visible_in_window, authoritative, authoritative_type, obey_consent, hmis
+FROM
+  data_sources
+WHERE
+  deleted_at IS NULL

--- a/db/views/analytics_data_sources_v02.sql
+++ b/db/views/analytics_data_sources_v02.sql
@@ -1,5 +1,5 @@
 SELECT
-  id, name, short_name, last_imported_at, source_type, visible_in_window, authoritative, authoritative_type, obey_consent, hmis
+  id, name, short_name, last_imported_at, source_type, visible_in_window, authoritative, authoritative_type, obey_consent, hmis as hmis_url
 FROM
   data_sources
 WHERE

--- a/db/warehouse/migrate/20251014152145_update_analytics_data_sources_to_version_2.rb
+++ b/db/warehouse/migrate/20251014152145_update_analytics_data_sources_to_version_2.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class UpdateAnalyticsDataSourcesToVersion2 < ActiveRecord::Migration[7.1]
+  def change
+    update_view 'analytics.data_sources', version: 2, revert_to_version: 1
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -2526,7 +2526,7 @@ CREATE VIEW analytics.data_sources AS
     authoritative,
     authoritative_type,
     obey_consent,
-    hmis
+    hmis AS hmis_url
    FROM public.data_sources
   WHERE (deleted_at IS NULL);
 

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -2525,7 +2525,8 @@ CREATE VIEW analytics.data_sources AS
     visible_in_window,
     authoritative,
     authoritative_type,
-    obey_consent
+    obey_consent,
+    hmis
    FROM public.data_sources
   WHERE (deleted_at IS NULL);
 
@@ -75855,6 +75856,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251014152145'),
 ('20251007133153'),
 ('20251007130048'),
 ('20251003200049'),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8401

Add the URL for OP HMIS data sources to the analytics view, so they can be used to populate backlinks to OP HMIS from reports.

## Type of change
Analytics view

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
