### PR TITLE
DRAFT - WIP household members importer

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
@@ -5,7 +5,7 @@ require 'rubyXL'
 class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
   def self.call(...) = new.call(...)
 
-  def call(filename, ce_project_id:, form_definition_identifier:, dry_run: true)
+  def call(filename, ce_project_id:, form_definition_identifier:, dry_run: true, raise_on_missing_hoh: true)
     raise 'Missing AC HMIS MCI credentials' unless mci_creds
     raise 'Missing AC HMIS MCI Unique ID credentials' unless mci_uniq_creds
 
@@ -27,14 +27,13 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
 
         # Find the HoH Enrollment in the CE project. It should exist because it should have been created
         # by the HousingAssessmentImporter on 10/1 import.
-        # TODO: have the job accept a flag for whether to raise or skip if not found. We may want to skip these (after investigating)
-        hoh_enrollment = find_hoh_enrollment(hoh_row, raise_on_missing: true)
+        hoh_enrollment = find_hoh_enrollment(hoh_row, raise_on_missing: raise_on_missing_hoh)
         next unless hoh_enrollment
 
         # Skip if the household already has multiple members. This indicates that a user has already manually updated the household,
         # so we shouldn't mess with the household composition at all.
         if hoh_enrollment.household_members.size > 1
-          log_info("Household #{household_id} (HouseholdID: #{hoh_enrollment.household_id}) already has multiple members. Skipping to avoid creating duplicate enrollments, since a user has already manually updated the household.")
+          log_info("[Row #{hoh_row.row_number}] Household #{household_id} (HouseholdID: #{hoh_enrollment.household_id}) already has multiple members. Skipping to avoid creating duplicate enrollments, since a user has already manually updated the household.")
           next
         end
 
@@ -42,8 +41,10 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
         # This process will look for existing clients, and create them if needed.
         household_members.reject(&:hoh?).each do |row|
           enrollment = create_ce_enrollment(row, hoh_enrollment: hoh_enrollment)
+          next unless enrollment
+
           ensure_intake_assessment!(row, enrollment)
-          log_info("Processed row #{row.row_number}. HUD ID: #{row.hud_id}, enrollment_id: #{enrollment.id}")
+          log_info("Processed row #{row.row_number}. HUD ID: #{row.hud_id}, enrollment_id: #{enrollment.id} added to household '#{hoh_enrollment.household_id}' (HoH Enrollment##{hoh_enrollment.id} Client##{hoh_enrollment.client.id})")
         end
       end
       raise ActiveRecord::Rollback if dry_run
@@ -84,17 +85,23 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
 
   # NEW
   def find_hoh_enrollment(waitlist, raise_on_missing: true)
-    # Try to find corresponding enrollment in the CE project.
-    # Look up by PersonalID because the HousingAssessmentImporter set a deterministic value for PersonalID. (See "hud_id" method and "create_hmis_client" method.)
+    # First, try to find the client (by MCI Unique ID or MCI ID)
+    found_client = find_hmis_client(waitlist)
+    # If found, use that clients PersonalID to look up the enrollment. Otherwise, use the waitlist's HUD ID.
+    # (because the HousingAssessmentImporter set a deterministic value for PersonalID. (See "hud_id" method and "create_hmis_client" method.)
+
+    hoh_personal_id = found_client&.personal_id || waitlist.hud_id
+
     found_enrollment = hmis_ce_project.enrollments.
       heads_of_households.
-      where(personal_id: waitlist.hud_id). # hud_id = Digest::MD5.hexdigest(raw_values.client_id.to_s)
+      where(personal_id: hoh_personal_id).
       max_by(&:entry_date)
 
     return found_enrollment if found_enrollment
 
-    log_info("No enrollment found for HoH on row #{waitlist.row_number}, client_id: #{waitlist.client_id}. Skipping.")
-    raise "No enrollment found for HoH on row #{waitlist.row_number}" if raise_on_missing
+    msg = "[Row #{waitlist.row_number}] No HoH enrollment found for client_id: #{waitlist.client_id}. Skipping."
+    log_info(msg)
+    raise msg if raise_on_missing
   end
 
   # NEW
@@ -105,7 +112,11 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     # Check if client is already enrolled in the CE project. We don't want to create duplicate enrollments
     already_enrolled = hmis_ce_project.enrollments.open_on_date.
       where(client: hmis_client).exists?
-    raise "Client #{hmis_client.id} already has an open enrollment in the project" if already_enrolled
+
+    if already_enrolled
+      log_info("[Row #{waitlist.row_number}] Client #{hmis_client.id} already has an open enrollment in the project in a different household. Not adding to household '#{hoh_enrollment.household_id}' (HoH Enrollment##{hoh_enrollment.id} Client##{hoh_enrollment.client.id})")
+      return
+    end
 
     enrollment = hmis_ce_project.enrollments.new(
       client: hmis_client,
@@ -120,7 +131,7 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
       source_hash: 'WAITLIST_HOUSEHOLD_MEMBERS_IMPORTER', # to help identify these if we need to clean them up. maybe unset after import is done and validated
     )
     without_record_timestamps do
-      enrollment.save!
+      enrollment.save! # this makes papertrail versions with null created_at which causes issues in audit UI, had to clean up manually
     end
     enrollment
   end
@@ -132,7 +143,7 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     intake.date_created = waitlist.date_created
     intake.date_updated = waitlist.date_updated
     without_record_timestamps do
-      intake.save!
+      intake.save! # this makes papertrail versions with null created_at which causes issues in audit UI, had to clean up manually
     end
   end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
@@ -14,15 +14,16 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
       @form_definition_identifier = form_definition_identifier
       raw_rows = read_file_rows(filename)
       column_names = raw_rows.shift.map { |col| col.to_s.downcase.strip }
-      raise unless column_names.sort == COLUMN_NAMES.sort # allow any order
+      missing_columns = COLUMN_NAMES - column_names
+      raise "Missing required columns: #{missing_columns.join(', ')}" if missing_columns.present?
 
       waitlists = build_waitlists(raw_rows, column_names)
 
       waitlists.group_by(&:household_id).each do |household_id, household_members|
-        next if waitlists.size == 1 # skip single-member households, they should already have been processed
+        next if household_members.size == 1 # skip single-member households, they should already have been processed
 
         hoh_row = household_members.find(&:hoh?)
-        raise "No HoH found for household #{household_id}" unless hoh
+        raise "No HoH found for household #{household_id}" unless hoh_row
 
         # Find the HoH Enrollment in the CE project. It should exist because it should have been created
         # by the HousingAssessmentImporter on 10/1 import.
@@ -61,11 +62,12 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
 
       raise "Row #{row_number} has #{row_values.size} columns; expected #{header_row.size}" if row_values.size != header_row.size
 
-      attrs = header_row.zip(row_values).to_h.symbolize_keys
+      attrs = header_row.zip(row_values).to_h.symbolize_keys.slice(*COLUMN_SYMBOLS)
       waitlist = Waitlist.new(attrs, row_number: row_number)
       raise "Row #{row_number} is invalid" unless waitlist.valid?
 
       client_id = waitlist.client_id
+
       existing = by_client_id[client_id]
       if existing.nil?
         by_client_id[client_id] = waitlist
@@ -117,7 +119,10 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
       project_id: hmis_ce_project.project_id,
       source_hash: 'WAITLIST_HOUSEHOLD_MEMBERS_IMPORTER', # to help identify these if we need to clean them up. maybe unset after import is done and validated
     )
-    enrollment.save!
+    without_record_timestamps do
+      enrollment.save!
+    end
+    enrollment
   end
 
   def ensure_intake_assessment!(waitlist, enrollment)
@@ -126,7 +131,9 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     intake = enrollment.build_synthetic_intake_assessment
     intake.date_created = waitlist.date_created
     intake.date_updated = waitlist.date_updated
-    intake.save!
+    without_record_timestamps do
+      intake.save!
+    end
   end
 
   # COPIED FROM HousingAssessmentImporter, no changes needed!
@@ -215,10 +222,6 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     @hmis_data_source ||= GrdaWarehouse::DataSource.hmis.sole
   end
 
-  def form_definition
-    @form_definition ||= Hmis::Form::Definition.published.where(identifier: @form_definition_identifier).first!
-  end
-
   def system_hud_user
     @system_hud_user ||= Hmis::Hud::User.system_user(data_source_id: hmis_data_source.id)
   end
@@ -239,6 +242,14 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     end
   end
 
+  def without_record_timestamps
+    previous = ActiveRecord::Base.record_timestamps
+    ActiveRecord::Base.record_timestamps = false
+    yield
+  ensure
+    ActiveRecord::Base.record_timestamps = previous
+  end
+
   # Note: cred does not have to be active, to support running in lower environments where these integrations may be turned off
   def mci_creds
     @mci_creds ||= GrdaWarehouse::RemoteCredential.where(slug: HmisExternalApis::AcHmis::Mci::SYSTEM_ID).sole
@@ -246,10 +257,6 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
 
   def mci_uniq_creds
     @mci_uniq_creds ||= GrdaWarehouse::RemoteCredential.where(slug: HmisExternalApis::AcHmis::DataWarehouseApi::SYSTEM_ID).sole
-  end
-
-  def cded_lookup
-    @cded_lookup ||= form_definition.custom_data_element_definitions.index_by(&:key)
   end
 
   COLUMN_NAMES = [
@@ -260,8 +267,10 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     'client_mci_id', # non-unique mci id
     'date_created',
     'date_updated',
+    'household_id',
+    'relationship_type_desc',
+    'assessment_date', # use for tie-breaker on duplicate rows
     # Assessment-related columns are ignored in this importer, we are only adding household member Clients/Enrollments
-    # 'assessment_date',
     # 'chronically_homeless',
     # 'aha_score',
     # 'alt_aha_score',
@@ -294,7 +303,8 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
     Rails.logger.info(msg)
   end
 
-  Row = Struct.new(*COLUMN_NAMES.map(&:to_sym))
+  COLUMN_SYMBOLS = COLUMN_NAMES.map(&:to_sym).freeze
+  Row = Struct.new(*COLUMN_SYMBOLS, keyword_init: true)
   class Waitlist
     attr_accessor :row_number, :raw_values
 
@@ -378,6 +388,7 @@ class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
       :client_last_name,
       :chronically_homeless,
       :client_mci_id,
+      :household_id,
       # :anyone_in_household_service_in_military,
       # :anyone_in_household_megans_law,
       # :anyone_in_household_disability,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/importers/waitlist_household_members_importer.rb
@@ -1,0 +1,438 @@
+# frozen_string_literal: true
+
+require 'rubyXL'
+
+class HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter
+  def self.call(...) = new.call(...)
+
+  def call(filename, ce_project_id:, form_definition_identifier:, dry_run: true)
+    raise 'Missing AC HMIS MCI credentials' unless mci_creds
+    raise 'Missing AC HMIS MCI Unique ID credentials' unless mci_uniq_creds
+
+    with_tx_lock do
+      @ce_project_id = ce_project_id
+      @form_definition_identifier = form_definition_identifier
+      raw_rows = read_file_rows(filename)
+      column_names = raw_rows.shift.map { |col| col.to_s.downcase.strip }
+      raise unless column_names.sort == COLUMN_NAMES.sort # allow any order
+
+      waitlists = build_waitlists(raw_rows, column_names)
+
+      waitlists.group_by(&:household_id).each do |household_id, household_members|
+        next if waitlists.size == 1 # skip single-member households, they should already have been processed
+
+        hoh_row = household_members.find(&:hoh?)
+        raise "No HoH found for household #{household_id}" unless hoh
+
+        # Find the HoH Enrollment in the CE project. It should exist because it should have been created
+        # by the HousingAssessmentImporter on 10/1 import.
+        # TODO: have the job accept a flag for whether to raise or skip if not found. We may want to skip these (after investigating)
+        hoh_enrollment = find_hoh_enrollment(hoh_row, raise_on_missing: true)
+        next unless hoh_enrollment
+
+        # Skip if the household already has multiple members. This indicates that a user has already manually updated the household,
+        # so we shouldn't mess with the household composition at all.
+        if hoh_enrollment.household_members.size > 1
+          log_info("Household #{household_id} (HouseholdID: #{hoh_enrollment.household_id}) already has multiple members. Skipping to avoid creating duplicate enrollments, since a user has already manually updated the household.")
+          next
+        end
+
+        # Create enrollments for each household member (Excluding HoH).
+        # This process will look for existing clients, and create them if needed.
+        household_members.reject(&:hoh?).each do |row|
+          enrollment = create_ce_enrollment(row, hoh_enrollment: hoh_enrollment)
+          ensure_intake_assessment!(row, enrollment)
+          log_info("Processed row #{row.row_number}. HUD ID: #{row.hud_id}, enrollment_id: #{enrollment.id}")
+        end
+      end
+      raise ActiveRecord::Rollback if dry_run
+    end
+    log_info 'Import complete'
+  end
+
+  protected
+
+  def build_waitlists(rows, header_row)
+    by_client_id = {}
+
+    rows.each_with_index do |row_values, idx|
+      row_number = idx + 2
+      next if row_values.compact.blank?
+
+      raise "Row #{row_number} has #{row_values.size} columns; expected #{header_row.size}" if row_values.size != header_row.size
+
+      attrs = header_row.zip(row_values).to_h.symbolize_keys
+      waitlist = Waitlist.new(attrs, row_number: row_number)
+      raise "Row #{row_number} is invalid" unless waitlist.valid?
+
+      client_id = waitlist.client_id
+      existing = by_client_id[client_id]
+      if existing.nil?
+        by_client_id[client_id] = waitlist
+      else
+        # Keep the waitlist with the most recent assessment_date
+        existing_date = existing.assessment_date
+        new_date = waitlist.assessment_date
+        by_client_id[client_id] = waitlist if new_date && (!existing_date || new_date > existing_date)
+      end
+    end
+
+    by_client_id.values
+  end
+
+  # NEW
+  def find_hoh_enrollment(waitlist, raise_on_missing: true)
+    # Try to find corresponding enrollment in the CE project.
+    # Look up by PersonalID because the HousingAssessmentImporter set a deterministic value for PersonalID. (See "hud_id" method and "create_hmis_client" method.)
+    found_enrollment = hmis_ce_project.enrollments.
+      heads_of_households.
+      where(personal_id: waitlist.hud_id). # hud_id = Digest::MD5.hexdigest(raw_values.client_id.to_s)
+      max_by(&:entry_date)
+
+    return found_enrollment if found_enrollment
+
+    log_info("No enrollment found for HoH on row #{waitlist.row_number}, client_id: #{waitlist.client_id}. Skipping.")
+    raise "No enrollment found for HoH on row #{waitlist.row_number}" if raise_on_missing
+  end
+
+  # NEW
+  def create_ce_enrollment(waitlist, hoh_enrollment:)
+    hmis_client = find_hmis_client(waitlist) || create_hmis_client(waitlist)
+    deterministic_id = waitlist.hud_id # based on client_id
+
+    # Check if client is already enrolled in the CE project. We don't want to create duplicate enrollments
+    already_enrolled = hmis_ce_project.enrollments.open_on_date.
+      where(client: hmis_client).exists?
+    raise "Client #{hmis_client.id} already has an open enrollment in the project" if already_enrolled
+
+    enrollment = hmis_ce_project.enrollments.new(
+      client: hmis_client,
+      entry_date: waitlist.assessment_date,
+      user_id: system_hud_user.user_id,
+      household_id: hoh_enrollment.household_id,
+      relationship_to_hoh: waitlist.relationship_to_hoh,
+      enrollment_id: deterministic_id,
+      date_created: waitlist.date_created,
+      date_updated: waitlist.date_updated,
+      project_id: hmis_ce_project.project_id,
+      source_hash: 'WAITLIST_HOUSEHOLD_MEMBERS_IMPORTER', # to help identify these if we need to clean them up. maybe unset after import is done and validated
+    )
+    enrollment.save!
+  end
+
+  def ensure_intake_assessment!(waitlist, enrollment)
+    return if enrollment.intake_assessment.present?
+
+    intake = enrollment.build_synthetic_intake_assessment
+    intake.date_created = waitlist.date_created
+    intake.date_updated = waitlist.date_updated
+    intake.save!
+  end
+
+  # COPIED FROM HousingAssessmentImporter, no changes needed!
+  def find_hmis_client(waitlist)
+    # client_id is the MCI Unique ID
+    mci_scope = HmisExternalApis::ExternalId.
+      where(namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE).
+      where(value: waitlist.client_id)
+
+    client = Hmis::Hud::Client.joins(:ac_hmis_mci_unique_id).merge(mci_scope).first
+    if client
+      log_info("Found client with MCI Unique ID #{waitlist.client_id}: #{client.id}")
+      return client
+    end
+
+    # If not found by MCI Unique ID, look up by MCI ID. This would be needed if the client exists in HMIS
+    # because they were referred from LINK, but they don't have an MCI Unique ID. When Link sends a referral
+    # "posting" for a new client, we generate a new Client record with an MCI ID. We don't create an MCI Unique ID at that time,
+    # and the MCI Unique ID won't get created until/unless the client has any enrollments. (Unenrolled clients
+    # are not exported in HMIS export, so Data Warehouse API won't provide MCI Unique IDs for those clients.)
+    found_mci_ids = HmisExternalApis::ExternalId.mci_ids.where(value: waitlist.client_mci_id).to_a
+    return nil unless found_mci_ids.size == 1 # if multiple, can't be sure which one to update, don't use
+
+    client = found_mci_ids.first.source
+    return nil unless client.ac_hmis_mci_unique_id.nil? # if they already have an MCI Unique ID, don't use, something is off
+
+    log_info("Found client with MCI ID #{waitlist.client_mci_id}: #{client.id}")
+    client
+  end
+
+  # COPIED FROM HousingAssessmentImporter, no changes needed!
+  def client_attrs(waitlist)
+    {
+      user: system_hud_user,
+      first_name: waitlist.client_first_name,
+      last_name: waitlist.client_last_name,
+      ssn: waitlist.client_ssn,
+      ssn_data_quality: waitlist.client_ssn_data_quality,
+      dob: waitlist.client_dob,
+      dob_data_quality: waitlist.client_dob_data_quality,
+      veteran_status: waitlist.client_veteran_status,
+      **waitlist.client_gender_fields,
+      **waitlist.client_race_fields,
+      **waitlist.client_ethnicity_fields,
+    }
+  end
+
+  # COPIED FROM HousingAssessmentImporter, no changes needed!
+  def create_hmis_client(waitlist)
+    client = Hmis::Hud::Client.create!(
+      personal_id: waitlist.hud_id,
+      data_source: hmis_data_source,
+      **client_attrs(waitlist),
+    )
+
+    # Create MCI Unique ID
+    HmisExternalApis::AcHmis::Mci.external_ids.create!(
+      namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE,
+      value: waitlist.client_id,
+      source: client,
+      remote_credential: mci_uniq_creds,
+    )
+    # Create MCI ID
+    HmisExternalApis::AcHmis::Mci.external_ids.create!(
+      namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID,
+      value: waitlist.client_mci_id,
+      source: client,
+      remote_credential: mci_creds,
+    )
+
+    log_info "Created client for MCI Unique ID #{waitlist.client_id}: #{client.id}"
+    client
+  end
+
+  # COPIED FROM HousingAssessmentImporter, no changes needed!
+  def hmis_ce_project
+    raise 'CE project ID is required' if @ce_project_id.blank?
+
+    @hmis_ce_project ||= Hmis::Hud::Project.
+      where(id: @ce_project_id).
+      where(data_source: hmis_data_source).
+      sole
+  end
+
+  def hmis_data_source
+    @hmis_data_source ||= GrdaWarehouse::DataSource.hmis.sole
+  end
+
+  def form_definition
+    @form_definition ||= Hmis::Form::Definition.published.where(identifier: @form_definition_identifier).first!
+  end
+
+  def system_hud_user
+    @system_hud_user ||= Hmis::Hud::User.system_user(data_source_id: hmis_data_source.id)
+  end
+
+  def read_file_rows(filename)
+    workbook = ::RubyXL::Parser.parse(filename)
+    workbook.worksheets[0].map do |row|
+      row.cells.map { |cell| cell&.value }
+    end
+  end
+
+  def with_tx_lock
+    lock_name = self.class.name
+    Hmis::HmisBase.with_advisory_lock(lock_name, timeout_seconds: 0) do
+      Hmis::HmisBase.transaction do
+        yield
+      end
+    end
+  end
+
+  # Note: cred does not have to be active, to support running in lower environments where these integrations may be turned off
+  def mci_creds
+    @mci_creds ||= GrdaWarehouse::RemoteCredential.where(slug: HmisExternalApis::AcHmis::Mci::SYSTEM_ID).sole
+  end
+
+  def mci_uniq_creds
+    @mci_uniq_creds ||= GrdaWarehouse::RemoteCredential.where(slug: HmisExternalApis::AcHmis::DataWarehouseApi::SYSTEM_ID).sole
+  end
+
+  def cded_lookup
+    @cded_lookup ||= form_definition.custom_data_element_definitions.index_by(&:key)
+  end
+
+  COLUMN_NAMES = [
+    'client_id', # unique mci id
+    'client_dob',
+    'client_first_name',
+    'client_last_name',
+    'client_mci_id', # non-unique mci id
+    'date_created',
+    'date_updated',
+    # Assessment-related columns are ignored in this importer, we are only adding household member Clients/Enrollments
+    # 'assessment_date',
+    # 'chronically_homeless',
+    # 'aha_score',
+    # 'alt_aha_score',
+    # 'anyone_in_household_service_in_military',
+    # 'anyone_in_household_megans_law',
+    # 'anyone_in_household_disability',
+    # 'anyone_in_household_hiv_aids',
+    # 'anyone_in_household_mental_health',
+    # 'anyone_in_household_substance_use',
+    # 'anyone_in_household_needs_wheelchair_accessible_unit',
+    # 'anyone_in_household_pregnant',
+    # 'income_percentage_ami',
+    # 'income_percentage_fpl',
+    # 'referred_bedroom_sizes',
+    # 'household_composition',
+    # 'tay',
+    # 'household_size',
+    'dob_data_quality',
+    'ssn',
+    'ssn_data_quality',
+    'race_common_desc',
+    'ethnic_common_desc',
+    'gender_common_desc',
+    'vetern_flag', # note, this is misspelled in the export
+  ].freeze
+
+  def log_info(msg)
+    return puts msg if Rails.env.development?
+
+    Rails.logger.info(msg)
+  end
+
+  Row = Struct.new(*COLUMN_NAMES.map(&:to_sym))
+  class Waitlist
+    attr_accessor :row_number, :raw_values
+
+    def initialize(raw_values, row_number:)
+      @raw_values = Row.new(**raw_values)
+      @row_number = row_number
+    end
+
+    def valid?
+      # basic sanity check
+      raw_values.client_id.to_s.match?(/\A\d{5,}\z/) && raw_values.client_dob.to_s.match?(/\A[1-2]\d{3}-\d{2}-\d{2}\z/)
+    end
+
+    # repeatable personal id
+    def hud_id = Digest::MD5.hexdigest(raw_values.client_id.to_s)
+
+    def client_ssn
+      value = raw_values.ssn
+      return if value.blank?
+
+      raise ArgumentError, "Integer too long for SSN (#{value.inspect})" if value.to_s.length > 9
+
+      value.is_a?(String) ? value : format('%09d', value)
+    end
+
+    def client_veteran_status
+      raw_values.vetern_flag&.strip&.downcase == 'yes' ? 1 : 0
+    end
+
+    def client_race_fields
+      code = parse_common_desc(raw_values.race_common_desc)
+      field = HmisExternalApis::AcHmis::MciMapping::MCI_RACE_TO_HUD_RACE[code]
+      field ||= 'race_none'
+      return { field => 1 } if field
+    end
+
+    def client_ethnicity_fields
+      code = parse_common_desc(raw_values.ethnic_common_desc)
+      {
+        'hispanic_latinaeo' => code == '2' ? 0 : 1,
+      }
+    end
+
+    def client_gender_fields
+      value = raw_values.gender_common_desc
+      code = parse_common_desc(value)
+      if code == '2'
+        { 'woman' => 1, 'man' => 0 }
+      elsif code == '1'
+        { 'man' => 1, 'woman' => 0 }
+      else
+        raise ArgumentError, "gender #{value} not supported"
+      end
+    end
+
+    def hoh?
+      relationship_to_hoh == 1
+    end
+
+    # Translate provided relationship type description into HUD RelationshipToHoH
+    def relationship_to_hoh
+      case raw_values.relationship_type_desc
+      when 'Self'
+        1 # Self (head of household)
+      when 'Son', 'Daughter'
+        2 # Child
+      when 'Spouse/Partner'
+        3 # Spouse or partner
+      when 'Parent', 'Sister', 'Niece', 'Nephew', 'Grandchild'
+        4 # Other relative
+      when 'Friend'
+        5 # Unrelated household member
+      else
+        raise "unexpected relationship type #{raw_values.relationship_type_desc}"
+      end
+    end
+
+    delegate(
+      :client_id,
+      :client_first_name,
+      :client_last_name,
+      :chronically_homeless,
+      :client_mci_id,
+      # :anyone_in_household_service_in_military,
+      # :anyone_in_household_megans_law,
+      # :anyone_in_household_disability,
+      # :anyone_in_household_hiv_aids,
+      # :anyone_in_household_mental_health,
+      # :anyone_in_household_substance_use,
+      # :anyone_in_household_needs_wheelchair_accessible_unit,
+      # :anyone_in_household_pregnant,
+      # :income_percentage_ami,
+      # :income_percentage_fpl,
+      # :tay,
+      to: :raw_values,
+    )
+
+    def date_created = parse_date_time(raw_values.date_created)
+    def date_updated = parse_date_time(raw_values.date_updated)
+    def assessment_date = parse_date(raw_values.assessment_date)
+    def client_dob = parse_date(raw_values.client_dob)
+    def client_ssn_data_quality = data_quality(raw_values.ssn_data_quality)
+    def client_dob_data_quality = data_quality(raw_values.dob_data_quality)
+
+    protected
+
+    def data_quality(value)
+      value = value&.to_i || 99
+
+      raise "bad data quality #{value}" unless value.in?([1, 2, 8, 9, 99])
+
+      value
+    end
+
+    def parse_date(value)
+      case value
+      when String
+        Date.iso8601(value)
+      when Date
+        value
+      else
+        raise ArgumentError, "unknown date type #{value.inspect}"
+      end
+    end
+
+    def parse_date_time(value)
+      case value
+      when String
+        DateTime.parse(value)
+      when DateTime
+        value
+      else
+        raise ArgumentError, "unknown date type #{value.inspect}"
+      end
+    end
+
+    def parse_common_desc(value)
+      value ? value.split('~', 2)[0] : nil
+    end
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/importers/waitlist_household_members_importer_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/importers/waitlist_household_members_importer_spec.rb
@@ -1,0 +1,490 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisExternalApis::AcHmis::Importers::WaitlistHouseholdMembersImporter do
+  describe '#call' do
+    let(:data_source) { create(:hmis_data_source) }
+    let(:project) { create(:hmis_hud_project, data_source: data_source) }
+    let(:importer) { described_class.new }
+    let!(:mci_creds) { create(:ac_hmis_mci_credential) }
+    let!(:mci_uniq_creds) { create(:ac_hmis_warehouse_credential) }
+
+    def mock_file_data(rows)
+      # Add header row
+      all_rows = [described_class::COLUMN_NAMES] + rows
+      allow(importer).to receive(:read_file_rows).and_return(all_rows)
+    end
+
+    def build_row(overrides = {})
+      defaults = {
+        client_id: '12345',
+        client_dob: '1980-01-01',
+        client_first_name: 'FIRST',
+        client_last_name: 'LAST',
+        client_mci_id: '12345',
+        date_created: '2023-10-01 10:00:00',
+        date_updated: '2023-10-02 12:30:00',
+        household_id: 'HH001',
+        relationship_type_desc: 'Self',
+        assessment_date: '2023-10-02',
+        dob_data_quality: 1,
+        ssn: '111111111',
+        ssn_data_quality: 1,
+        race_common_desc: '1~White',
+        ethnic_common_desc: '2~Not Hispanic/Latinx',
+        gender_common_desc: '2~Female',
+        vetern_flag: 'Yes',
+      }
+      attrs = defaults.merge(overrides)
+      described_class::COLUMN_NAMES.map { |col| attrs[col.to_sym] }
+    end
+
+    it 'successfully processes multi-member household' do
+      # Setup: Create HoH with existing CE enrollment
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      hoh_enrollment = create(:hmis_hud_enrollment,
+                              data_source: data_source,
+                              project: project,
+                              client: hoh_client,
+                              relationship_to_hoh: 1,
+                              entry_date: Date.parse('2023-10-01'))
+
+      # Mock file data with HoH + 2 children
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, client_mci_id: 'MCI001', household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(client_id: '10002', client_mci_id: 'MCI002', client_first_name: 'Child1', household_id: 'HH001', relationship_type_desc: 'Daughter'),
+                       build_row(client_id: '10003', client_mci_id: 'MCI003', client_first_name: 'Child2', household_id: 'HH001', relationship_type_desc: 'Son'),
+                     ])
+
+      initial_enrollment_count = Hmis::Hud::Enrollment.count
+
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+
+      # Verify: 2 new enrollments created
+      expect(Hmis::Hud::Enrollment.count).to eq(initial_enrollment_count + 2)
+
+      new_enrollments = Hmis::Hud::Enrollment.where.not(id: hoh_enrollment.id).where(project: project)
+      expect(new_enrollments.count).to eq(2)
+
+      # Verify: All linked to same household_id
+      expect(new_enrollments.pluck(:household_id).uniq).to eq([hoh_enrollment.household_id])
+
+      # Verify: Correct relationships
+      expect(new_enrollments.pluck(:relationship_to_hoh)).to match_array([2, 2]) # Both children
+
+      # Verify: Intake assessments created
+      new_enrollments.each do |enrollment|
+        expect(enrollment.intake_assessment).to be_present
+      end
+
+      # Verify: Historical timestamps preserved
+      expected_created = Time.zone.parse('2023-10-01 06:00:00')
+      expected_updated = Time.zone.parse('2023-10-02 08:30:00')
+      expect(new_enrollments.map(&:date_created).uniq).to eq([expected_created])
+      expect(new_enrollments.map(&:date_updated).uniq).to eq([expected_updated])
+      expect(new_enrollments.map { |enrollment| enrollment.intake_assessment.date_created }.uniq).to eq([expected_created])
+      expect(new_enrollments.map { |enrollment| enrollment.intake_assessment.date_updated }.uniq).to eq([expected_updated])
+
+      # Verify: New clients created
+      expect(Hmis::Hud::Client.where(first_name: ['Child1', 'Child2']).count).to eq(2)
+    end
+
+    it 'skips single-member households' do
+      # Setup: File with single HoH row
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: hoh_client,
+             relationship_to_hoh: 1,
+             entry_date: Date.parse('2023-10-01'))
+
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                     ])
+
+      initial_enrollment_count = Hmis::Hud::Enrollment.count
+
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+
+      # Verify: No new enrollments created
+      expect(Hmis::Hud::Enrollment.count).to eq(initial_enrollment_count)
+    end
+
+    it 'skips households already modified by users' do
+      # Setup: HoH enrollment that already has 2+ members
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      hoh_enrollment = create(:hmis_hud_enrollment,
+                              data_source: data_source,
+                              project: project,
+                              client: hoh_client,
+                              relationship_to_hoh: 1,
+                              entry_date: Date.parse('2023-10-01'))
+
+      # Add another member to the household
+      other_client = create(:hmis_hud_client, data_source: data_source)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: other_client,
+             relationship_to_hoh: 2,
+             household_id: hoh_enrollment.household_id,
+             entry_date: Date.parse('2023-10-01'))
+
+      # Mock file trying to add another member
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(client_id: '10002', client_first_name: 'NewChild', household_id: 'HH001', relationship_type_desc: 'Son'),
+                     ])
+
+      initial_enrollment_count = Hmis::Hud::Enrollment.count
+
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+
+      # Verify: No new enrollments created
+      expect(Hmis::Hud::Enrollment.count).to eq(initial_enrollment_count)
+    end
+
+    it 'creates new clients when not found' do
+      # Setup: HoH exists but household members don't
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: hoh_client,
+             relationship_to_hoh: 1,
+             entry_date: Date.parse('2023-10-01'))
+
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(
+                         client_id: '10002',
+                         client_mci_id: 'MCI002',
+                         client_first_name: 'Jane',
+                         client_last_name: 'Doe',
+                         client_dob: '1990-05-15',
+                         ssn: '987654321',
+                         household_id: 'HH001',
+                         relationship_type_desc: 'Daughter',
+                       ),
+                     ])
+
+      initial_client_count = Hmis::Hud::Client.count
+
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+
+      # Verify: New client created with correct attributes
+      expect(Hmis::Hud::Client.count).to eq(initial_client_count + 1)
+
+      new_client = Hmis::Hud::Client.find_by(first_name: 'Jane', last_name: 'Doe')
+      expect(new_client).to be_present
+      expect(new_client.dob).to eq(Date.parse('1990-05-15'))
+      expect(new_client.ssn).to eq('987654321')
+      expect(new_client.personal_id).to eq(Digest::MD5.hexdigest('10002'))
+    end
+
+    it 'finds existing clients by MCI Unique ID' do
+      # Setup: Pre-create client with matching MCI Unique ID external_id
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: hoh_client,
+             relationship_to_hoh: 1,
+             entry_date: Date.parse('2023-10-01'))
+
+      # Create an existing client with MCI Unique ID
+      existing_client = create(:hmis_hud_client, data_source: data_source, first_name: 'Existing', last_name: 'Client')
+      HmisExternalApis::ExternalId.create!(
+        namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE,
+        value: '10002',
+        source: existing_client,
+        remote_credential: mci_uniq_creds,
+      )
+
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(client_id: '10002', client_mci_id: 'MCI002', client_first_name: 'Jane', household_id: 'HH001', relationship_type_desc: 'Daughter'),
+                     ])
+
+      initial_client_count = Hmis::Hud::Client.count
+
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+
+      # Verify: Existing client reused, no duplicate created
+      expect(Hmis::Hud::Client.count).to eq(initial_client_count)
+
+      new_enrollment = Hmis::Hud::Enrollment.where(project: project).where.not(client: hoh_client).first
+      expect(new_enrollment.client).to eq(existing_client)
+    end
+
+    it 'raises when HoH enrollment not found' do
+      # Setup: File references HoH that doesn't have CE enrollment
+      mock_file_data([
+                       build_row(client_id: '99999', household_id: 'HH999', relationship_type_desc: 'Self'),
+                       build_row(client_id: '99998', household_id: 'HH999', relationship_type_desc: 'Son'),
+                     ])
+
+      # Verify: Raises error with descriptive message
+      expect do
+        importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+      end.to raise_error(/No enrollment found for HoH/)
+    end
+
+    it 'prevents duplicate enrollments' do
+      # Setup: Client already has open enrollment in project
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: hoh_client,
+             relationship_to_hoh: 1,
+             entry_date: Date.parse('2023-10-01'))
+
+      # Create a client that already has an open enrollment
+      existing_client = create(:hmis_hud_client, data_source: data_source)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: existing_client,
+             entry_date: Date.current)
+
+      # Add external ID so the client will be found
+      HmisExternalApis::ExternalId.create!(
+        namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE,
+        value: '10002',
+        source: existing_client,
+        remote_credential: mci_uniq_creds,
+      )
+
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(client_id: '10002', household_id: 'HH001', relationship_type_desc: 'Son'),
+                     ])
+
+      # Verify: Raises error about duplicate enrollment
+      expect do
+        importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: false)
+      end.to raise_error(/already has an open enrollment/)
+    end
+
+    it 'respects dry_run flag' do
+      # Setup: HoH with existing CE enrollment
+      hoh_client_id = '10001'
+      hoh_hud_id = Digest::MD5.hexdigest(hoh_client_id)
+      hoh_client = create(:hmis_hud_client, data_source: data_source, personal_id: hoh_hud_id)
+      create(:hmis_hud_enrollment,
+             data_source: data_source,
+             project: project,
+             client: hoh_client,
+             relationship_to_hoh: 1,
+             entry_date: Date.parse('2023-10-01'))
+
+      mock_file_data([
+                       build_row(client_id: hoh_client_id, household_id: 'HH001', relationship_type_desc: 'Self'),
+                       build_row(client_id: '10002', client_first_name: 'Child', household_id: 'HH001', relationship_type_desc: 'Son'),
+                     ])
+
+      initial_enrollment_count = Hmis::Hud::Enrollment.count
+      initial_client_count = Hmis::Hud::Client.count
+
+      # Call with dry_run: true
+      importer.call('dummy_file.xlsx', ce_project_id: project.id, form_definition_identifier: 'housing_assessment', dry_run: true)
+
+      # Verify: Changes rolled back, no persisted records
+      expect(Hmis::Hud::Enrollment.count).to eq(initial_enrollment_count)
+      expect(Hmis::Hud::Client.count).to eq(initial_client_count)
+    end
+  end
+
+  describe '#build_waitlists' do
+    let(:importer) { described_class.new }
+
+    it 'creates waitlist objects from valid rows' do
+      header = described_class::COLUMN_NAMES
+      rows = [
+        [
+          '12345',               # client_id
+          '1980-01-01',          # client_dob
+          'FIRST',               # client_first_name
+          'LAST',                # client_last_name
+          '12345',               # client_mci_id
+          '2023-10-01 10:00:00', # date_created
+          '2023-10-02 12:30:00', # date_updated
+          'HH001',               # household_id
+          'Self',                # relationship_type_desc
+          '2023-10-02',          # assessment_date
+          1,                     # dob_data_quality
+          '111111111',           # ssn
+          1,                     # ssn_data_quality
+          '1~White',             # race_common_desc
+          '2~Not Hispanic/Latinx', # ethnic_common_desc
+          '2~Female',            # gender_common_desc
+          'Yes',                 # vetern_flag
+        ],
+      ]
+
+      waitlists = importer.send(:build_waitlists, rows, header)
+
+      expect(waitlists.length).to eq(1)
+      waitlist = waitlists.first
+      expect(waitlist.client_id).to eq('12345')
+      expect(waitlist.client_first_name).to eq('FIRST')
+      expect(waitlist.household_id).to eq('HH001')
+      expect(waitlist.hoh?).to be(true)
+    end
+
+    it 'deduplicates rows by client_id, keeping most recent assessment_date' do
+      header = described_class::COLUMN_NAMES
+      rows = [
+        [
+          '12345', '1980-01-01', 'FIRST', 'LAST', '12345', '2023-10-01 10:00:00', '2023-10-02 12:30:00',
+          'HH001', 'Self', '2023-10-01', 1, '111111111', 1, '1~White', '2~Not Hispanic/Latinx', '2~Female', 'Yes'
+        ],
+        [
+          '12345', '1980-01-01', 'FIRST', 'LAST', '12345', '2023-10-03 10:00:00', '2023-10-04 12:30:00',
+          'HH001', 'Self', '2023-10-03', 1, '111111111', 1, '1~White', '2~Not Hispanic/Latinx', '2~Female', 'Yes'
+        ],
+      ]
+
+      waitlists = importer.send(:build_waitlists, rows, header)
+
+      expect(waitlists.length).to eq(1)
+      expect(waitlists.first.assessment_date).to eq(Date.parse('2023-10-03'))
+    end
+
+    it 'skips blank rows' do
+      header = described_class::COLUMN_NAMES
+      rows = [
+        [
+          '12345', '1980-01-01', 'FIRST', 'LAST', '12345', '2023-10-01 10:00:00', '2023-10-02 12:30:00',
+          'HH001', 'Self', '2023-10-02', 1, '111111111', 1, '1~White', '2~Not Hispanic/Latinx', '2~Female', 'Yes'
+        ],
+        [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil],
+      ]
+
+      waitlists = importer.send(:build_waitlists, rows, header)
+
+      expect(waitlists.length).to eq(1)
+    end
+  end
+
+  describe 'Waitlist#relationship_to_hoh' do
+    def build_waitlist(relationship_desc)
+      attrs = {
+        client_id: '12345', client_dob: '1980-01-01', client_first_name: 'FIRST', client_last_name: 'LAST',
+        client_mci_id: '12345', date_created: '2023-10-01 10:00:00', date_updated: '2023-10-02 12:30:00',
+        household_id: 'HH001', relationship_type_desc: relationship_desc, assessment_date: '2023-10-02',
+        dob_data_quality: 1, ssn: '111111111', ssn_data_quality: 1,
+        race_common_desc: '1~White', ethnic_common_desc: '2~Not Hispanic/Latinx',
+        gender_common_desc: '2~Female', vetern_flag: 'Yes'
+      }
+      described_class::Waitlist.new(attrs, row_number: 2)
+    end
+
+    it 'translates Self to HUD RelationshipToHoH 1' do
+      expect(build_waitlist('Self').relationship_to_hoh).to eq(1)
+    end
+
+    it 'translates Son/Daughter to HUD RelationshipToHoH 2 (Child)' do
+      expect(build_waitlist('Son').relationship_to_hoh).to eq(2)
+      expect(build_waitlist('Daughter').relationship_to_hoh).to eq(2)
+    end
+
+    it 'translates Spouse/Partner to HUD RelationshipToHoH 3' do
+      expect(build_waitlist('Spouse/Partner').relationship_to_hoh).to eq(3)
+    end
+
+    it 'translates relatives to HUD RelationshipToHoH 4 (Other relative)' do
+      expect(build_waitlist('Parent').relationship_to_hoh).to eq(4)
+      expect(build_waitlist('Sister').relationship_to_hoh).to eq(4)
+      expect(build_waitlist('Niece').relationship_to_hoh).to eq(4)
+      expect(build_waitlist('Nephew').relationship_to_hoh).to eq(4)
+      expect(build_waitlist('Grandchild').relationship_to_hoh).to eq(4)
+    end
+
+    it 'translates Friend to HUD RelationshipToHoH 5 (Unrelated household member)' do
+      expect(build_waitlist('Friend').relationship_to_hoh).to eq(5)
+    end
+  end
+
+  describe 'Waitlist value parsing' do
+    def build_waitlist(overrides = {})
+      attrs = {
+        client_id: '12345', client_dob: '1980-01-01', client_first_name: 'FIRST', client_last_name: 'LAST',
+        client_mci_id: '12345', date_created: '2023-10-01 10:00:00', date_updated: '2023-10-02 12:30:00',
+        household_id: 'HH001', relationship_type_desc: 'Self', assessment_date: '2023-10-02',
+        dob_data_quality: 1, ssn: '111111111', ssn_data_quality: 1,
+        race_common_desc: '1~White', ethnic_common_desc: '2~Not Hispanic/Latinx',
+        gender_common_desc: '2~Female', vetern_flag: 'Yes'
+      }.merge(overrides)
+      described_class::Waitlist.new(attrs, row_number: 2)
+    end
+
+    it 'parses dates correctly' do
+      waitlist = build_waitlist
+      expect(waitlist.assessment_date).to be_a(Date)
+      expect(waitlist.date_created).to be_a(DateTime)
+      expect(waitlist.client_dob).to be_a(Date)
+    end
+
+    it 'generates deterministic HUD ID from client_id' do
+      waitlist = build_waitlist(client_id: '12345')
+      expect(waitlist.hud_id).to eq(Digest::MD5.hexdigest('12345'))
+    end
+
+    it 'parses veteran status correctly' do
+      expect(build_waitlist(vetern_flag: 'yes').client_veteran_status).to eq(1)
+      expect(build_waitlist(vetern_flag: 'Yes').client_veteran_status).to eq(1)
+      expect(build_waitlist(vetern_flag: 'no').client_veteran_status).to eq(0)
+      expect(build_waitlist(vetern_flag: 'No').client_veteran_status).to eq(0)
+      expect(build_waitlist(vetern_flag: nil).client_veteran_status).to eq(0)
+    end
+
+    it 'formats SSN correctly' do
+      waitlist = build_waitlist(ssn: 123_456_789)
+      expect(waitlist.client_ssn).to eq('123456789')
+
+      waitlist = build_waitlist(ssn: '987654321')
+      expect(waitlist.client_ssn).to eq('987654321')
+
+      waitlist = build_waitlist(ssn: 1234567)
+      expect(waitlist.client_ssn).to eq('001234567')
+    end
+
+    it 'parses gender fields correctly' do
+      male = build_waitlist(gender_common_desc: '1~Male')
+      expect(male.client_gender_fields).to eq({ 'man' => 1, 'woman' => 0 })
+
+      female = build_waitlist(gender_common_desc: '2~Female')
+      expect(female.client_gender_fields).to eq({ 'woman' => 1, 'man' => 0 })
+    end
+
+    it 'parses ethnicity fields correctly' do
+      hispanic = build_waitlist(ethnic_common_desc: '1~Hispanic/Latinx')
+      expect(hispanic.client_ethnicity_fields).to eq({ 'hispanic_latinaeo' => 1 })
+
+      not_hispanic = build_waitlist(ethnic_common_desc: '2~Not Hispanic/Latinx')
+      expect(not_hispanic.client_ethnicity_fields).to eq({ 'hispanic_latinaeo' => 0 })
+    end
+
+    it 'parses data quality values' do
+      waitlist = build_waitlist(dob_data_quality: 1, ssn_data_quality: 2)
+      expect(waitlist.client_dob_data_quality).to eq(1)
+      expect(waitlist.client_ssn_data_quality).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

https://github.com/open-path/Green-River/issues/8398

Adds WaitlistHouseholdMembersImporter
* Processes Excel files containing household member data, finds existing Head of Household (HoH) enrollments in CE projects, and creates enrollments for additional household members
* Skips single-member households (already processed), skips households with >1 member (indicates user modifications), avoids duplicate enrollments, validates HoH enrollment exists before processing members
* HUD compliance: Maps HUD RelationshipToHoH codes, preserves historical timestamps, creates required intake assessments

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
