### PR TITLE
8109 Prevent duplicate PaperTrail version creation,  cleanup task

### DIFF
--- a/app/models/grda_warehouse_base.rb
+++ b/app/models/grda_warehouse_base.rb
@@ -26,6 +26,25 @@ class GrdaWarehouseBase < ActiveRecord::Base
 
   # default colocated versions table for warehouse records
   def self.has_paper_trail(options = {}) # rubocop:disable Naming/PredicateName
+    # Detect duplicate has_paper_trail calls to prevent double version creation
+    # Check if paper_trail callbacks are already defined
+    if respond_to?(:paper_trail_options) && paper_trail_options.present?
+      message = "PaperTrail already enabled on #{name}. This will cause duplicate version records."
+      backtrace = caller.select { |line| line.include?(Rails.root.to_s) }.first(5)
+
+      raise StandardError, "#{message}\nCalled from:\n#{backtrace.join("\n")}" unless Rails.env.production?
+
+      # In production, log to Sentry but allow it to continue
+      Sentry.capture_message(
+        message,
+        level: :warning,
+        extra: {
+          model: name,
+          backtrace: backtrace,
+        },
+      )
+    end
+
     versions = options.fetch(:versions, {}).merge(class_name: 'GrdaWarehouse::Version')
     skip = options.fetch(:skip, [:lock_version])
     super(options.merge(versions: versions, skip: skip))

--- a/drivers/hmis/spec/models/hmis/hud/assessment_question_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/assessment_question_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::AssessmentQuestion, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_assessment_question) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(assessment_question_order: 999) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/assessment_result_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/assessment_result_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::AssessmentResult, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_assessment_result) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(assessment_result: 'Updated result') }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/assessment_spec.rb
@@ -6,6 +6,7 @@
 
 require 'rails_helper'
 require_relative '../../../support/hmis_base_setup'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
 
 RSpec.describe Hmis::Hud::Assessment, type: :model do
   before(:all) do
@@ -13,6 +14,16 @@ RSpec.describe Hmis::Hud::Assessment, type: :model do
   end
   after(:all) do
     cleanup_test_environment
+  end
+
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_hud_assessment) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(assessment_date: 1.week.ago) }
+    end
   end
 
   describe 'saved assessments' do

--- a/drivers/hmis/spec/models/hmis/hud/current_living_situation_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/current_living_situation_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::CurrentLivingSituation, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_current_living_situation) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb
@@ -6,6 +6,7 @@
 
 require 'rails_helper'
 require_relative '../../../support/hmis_base_setup'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
 
 RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
   before(:all) do
@@ -16,6 +17,16 @@ RSpec.describe Hmis::Hud::CustomAssessment, type: :model do
   end
 
   include_context 'hmis base setup'
+
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_custom_assessment) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(assessment_date: 1.week.ago) }
+    end
+  end
 
   describe 'destroying WIP assessment' do
     let!(:assessment) { create(:hmis_wip_custom_assessment) }

--- a/drivers/hmis/spec/models/hmis/hud/custom_service_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/custom_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::CustomService, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_custom_service) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(date_provided: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/disability_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/disability_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::Disability, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_disability) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/employment_education_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/employment_education_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::EmploymentEducation, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_employment_education) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/event_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/event_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::Event, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_hud_event) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(event_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/exit_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/exit_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::Exit, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_hud_exit) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(destination: 99) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/health_and_dv_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/health_and_dv_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::HealthAndDv, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_health_and_dv) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/income_benefit_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/income_benefit_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::IncomeBenefit, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_income_benefit) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/service_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::Service, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_hud_service) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(date_provided: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/hud/youth_education_status_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/youth_education_status_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe Hmis::Hud::YouthEducationStatus, type: :model do
+  it_behaves_like 'enrollment related versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_youth_education_status) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(information_date: 1.week.ago) }
+    end
+  end
+end

--- a/drivers/hmis/spec/support/shared_examples/versioning_and_paranoia.rb
+++ b/drivers/hmis/spec/support/shared_examples/versioning_and_paranoia.rb
@@ -33,3 +33,23 @@ RSpec.shared_examples 'versioned model' do
     expect { record.destroy }.to change { record.versions.size }.by(1)
   end
 end
+
+RSpec.shared_examples 'enrollment related versioned model' do
+  # Include the base versioned model behavior
+  it_behaves_like 'versioned model'
+
+  describe 'version metadata' do
+    include_context 'with paper trail'
+
+    it 'stores enrollment_id, client_id, and project_id in version metadata' do
+      raise('define let(:build_record) to use enrollment related versioned model shared examples') unless defined?(build_record)
+
+      record = instance_exec(&build_record)
+
+      version = record.versions.order(:id).last
+      expect(version.enrollment_id).to eq(record.enrollment.id)
+      expect(version.client_id).to eq(record.client.id)
+      expect(version.project_id).to eq(record.project.id)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/unit_availability_sync.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/unit_availability_sync.rb
@@ -8,6 +8,8 @@ module HmisExternalApis::AcHmis
   # Track local and synced changes
   class UnitAvailabilitySync < ::HmisExternalApis::HmisExternalApisBase
     self.table_name = 'hmis_external_unit_availability_syncs'
+    has_paper_trail
+
     belongs_to :project, class_name: 'Hmis::Hud::Project'
     belongs_to :unit_type, class_name: 'Hmis::UnitType'
     belongs_to :user, class_name: 'Hmis::User'

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_publication.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_publication.rb
@@ -8,6 +8,8 @@
 module HmisExternalApis::ExternalForms
   class FormPublication < ::HmisExternalApis::HmisExternalApisBase
     self.table_name = 'hmis_external_form_publications'
+    has_paper_trail
+
     belongs_to :definition, class_name: 'Hmis::Form::Definition'
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_submission.rb
@@ -8,6 +8,7 @@ module HmisExternalApis::ExternalForms
   class FormSubmission < ::HmisExternalApis::HmisExternalApisBase
     include ::Hmis::Hud::Concerns::FormSubmittable
     self.table_name = 'hmis_external_form_submissions'
+    has_paper_trail
 
     belongs_to :definition, class_name: 'Hmis::Form::Definition'
     # Enrollment that was generated as a result of processing this form submission. Only applicable for certain external forms, like the PIT.

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/hmis_external_apis_base.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/hmis_external_apis_base.rb
@@ -7,7 +7,5 @@
 module HmisExternalApis
   class HmisExternalApisBase < ::GrdaWarehouseBase
     self.abstract_class = true
-
-    has_paper_trail
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_household_member_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_household_member_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../../../hmis/spec/support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe HmisExternalApis::AcHmis::ReferralHouseholdMember, type: :model do
+  it_behaves_like 'versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_external_api_ac_hmis_referral_household_member) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(relationship_to_hoh: 'child') }
+    end
+  end
+
+  describe 'version metadata' do
+    include_context 'with paper trail'
+
+    it 'stores client_id in version metadata' do
+      member = create(:hmis_external_api_ac_hmis_referral_household_member)
+
+      version = member.versions.last
+      expect(version.client_id).to eq(member.client.id)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_posting_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_posting_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../../../hmis/spec/support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe HmisExternalApis::AcHmis::ReferralPosting, type: :model do
+  it_behaves_like 'versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_external_api_ac_hmis_referral_posting) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(status: 'accepted_pending_status') }
+    end
+  end
+
+  describe 'version metadata' do
+    include_context 'with paper trail'
+
+    it 'stores project_id in version metadata' do
+      posting = create(:hmis_external_api_ac_hmis_referral_posting)
+
+      version = posting.versions.last
+      expect(version.project_id).to eq(posting.project.id)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_request_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_request_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../../../hmis/spec/support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe HmisExternalApis::AcHmis::ReferralRequest, type: :model do
+  it_behaves_like 'versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_external_api_ac_hmis_referral_request) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(voided_at: Time.current) }
+    end
+  end
+
+  describe 'version metadata' do
+    include_context 'with paper trail'
+
+    it 'stores project_id in version metadata' do
+      request = create(:hmis_external_api_ac_hmis_referral_request)
+
+      version = request.versions.last
+      expect(version.project_id).to eq(request.project.id)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/referral_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative '../../../../../hmis/spec/support/shared_examples/versioning_and_paranoia'
+
+RSpec.describe HmisExternalApis::AcHmis::Referral, type: :model do
+  let(:enrollment) { create(:hmis_hud_enrollment) }
+
+  it_behaves_like 'versioned model' do
+    let(:build_record) do
+      -> { create(:hmis_external_api_ac_hmis_referral, enrollment: enrollment) }
+    end
+
+    let(:update_attributes_for_versioning) do
+      ->(record) { record.update!(referral_notes: 'Updated notes') }
+    end
+  end
+
+  describe 'version metadata' do
+    include_context 'with paper trail'
+
+    it 'stores enrollment_id, client_id, and project_id in version metadata' do
+      referral = create(:hmis_external_api_ac_hmis_referral, enrollment: enrollment)
+
+      version = referral.versions.last
+      expect(version.enrollment_id).to eq(enrollment.id)
+      expect(version.client_id).to eq(enrollment.client.id)
+      expect(version.project_id).to eq(enrollment.project.id)
+    end
+  end
+end

--- a/lib/tasks/deduplicate_paper_trail_versions.rake
+++ b/lib/tasks/deduplicate_paper_trail_versions.rake
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+namespace :paper_trail do
+  desc 'De-duplicate paper trail version records for models affected by double has_paper_trail bug'
+  task :deduplicate_versions, [:dry_run] => :environment do |_task, args|
+    # A dry run is the default. To do a live run, pass `false`.
+    # Example: railse "paper_trail:deduplicate_versions[false]"
+    dry_run = args[:dry_run] != 'false'
+
+    puts '=' * 80
+    puts 'Paper Trail Version De-duplication Script'
+    puts "Mode: #{dry_run ? 'DRY RUN' : 'LIVE'}"
+    puts '=' * 80
+    puts
+
+    # Models that were affected by the double paper trail bug
+    affected_models = [
+      'HmisExternalApis::AcHmis::ReferralPosting',
+      'HmisExternalApis::AcHmis::ReferralRequest',
+      'HmisExternalApis::AcHmis::Referral',
+      'HmisExternalApis::AcHmis::ReferralHouseholdMember',
+    ]
+
+    total_duplicates_found = 0
+    total_duplicates_removed = 0
+
+    affected_models.each do |model_name|
+      puts "Processing #{model_name}..."
+
+      # Find groups of versions with identical attributes (including created_at timestamp).
+      # True duplicates from the double has_paper_trail bug will have the exact same created_at.
+      duplicate_groups = GrdaWarehouse::Version.where(item_type: model_name).
+        group(:item_id, :event, :whodunnit, :object_changes, :created_at).
+        having('COUNT(*) > 1').
+        pluck(:item_id, :event, :whodunnit, :object_changes, :created_at)
+
+      if duplicate_groups.empty?
+        puts '  No duplicates found'
+        puts
+        next
+      end
+
+      puts "  Found #{duplicate_groups.size} groups of duplicates"
+
+      duplicate_groups.each do |item_id, event, whodunnit, object_changes, created_at|
+        group = GrdaWarehouse::Version.where(
+          item_type: model_name,
+          item_id: item_id,
+          event: event,
+          whodunnit: whodunnit,
+          object_changes: object_changes,
+          created_at: created_at,
+        ).order(:id).to_a
+
+        total_duplicates_found += group.size - 1
+
+        # Keep the version with metadata (enrollment_id, client_id, or project_id) if available,
+        # otherwise keep the first one (lowest ID)
+        version_to_keep = group.min_by do |v|
+          has_metadata = [v.enrollment_id, v.client_id, v.project_id].any?(&:present?)
+          [has_metadata ? 0 : 1, v.id]
+        end
+
+        versions_to_delete = group - [version_to_keep]
+
+        puts "    Item #{item_id}, #{event}: keeping version #{version_to_keep.id}, removing #{versions_to_delete.size} duplicate(s)"
+
+        if dry_run
+          puts "      Would delete versions: #{versions_to_delete.map(&:id).join(', ')}"
+        else
+          deleted_count = GrdaWarehouse::Version.where(id: versions_to_delete.map(&:id)).delete_all
+          total_duplicates_removed += deleted_count
+          puts "      Deleted #{deleted_count} version(s)"
+        end
+      end
+
+      puts
+    end
+
+    puts '=' * 80
+    puts 'Summary:'
+    puts "  Total duplicate versions found: #{total_duplicates_found}"
+    if dry_run
+      puts "  Total duplicate versions that would be removed: #{total_duplicates_found}"
+      puts
+      puts 'To actually remove duplicates, run with `false` as an argument:'
+      puts '  rake "paper_trail:deduplicate_versions[false]"'
+    else
+      puts "  Total duplicate versions removed: #{total_duplicates_removed}"
+    end
+    puts '=' * 80
+  end
+end

--- a/spec/lib/tasks/deduplicate_paper_trail_versions_spec.rb
+++ b/spec/lib/tasks/deduplicate_paper_trail_versions_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require 'rake'
+
+describe 'paper_trail:deduplicate_versions' do
+  let(:rake) { Rake::Application.new }
+  let(:task_name) { 'paper_trail:deduplicate_versions' }
+  let(:task_path) { 'lib/tasks/deduplicate_paper_trail_versions' }
+
+  before do
+    Rake.application = rake
+    Rake::Task.define_task(:environment)
+    Rake.load_rakefile(Rails.root.join("#{task_path}.rake"))
+  end
+
+  after do
+    rake[task_name].reenable
+  end
+
+  context 'when there are duplicate versions' do
+    let!(:referral) { create(:hmis_external_api_ac_hmis_referral, referral_notes: 'initial notes') }
+    let(:item_type) { 'HmisExternalApis::AcHmis::Referral' }
+    let(:object_changes) { { referral_notes: ['updated notes', 'final notes'] }.to_yaml }
+    let(:version_scope) { GrdaWarehouse::Version.where(item_type: item_type, item_id: referral.id) }
+
+    # Helper to create duplicate versions with the same timestamp
+    def create_duplicate_versions(attributes = {})
+      timestamp = Time.current
+      base_attrs = { item_type: item_type, item_id: referral.id, event: 'update', object_changes: object_changes, created_at: timestamp }
+      2.times { GrdaWarehouse::Version.create!(base_attrs.merge(attributes)) }
+    end
+
+    before do
+      referral.update!(referral_notes: 'updated notes')
+      version_scope.delete_all
+      GrdaWarehouse::Version.create!(
+        item_id: referral.id,
+        item_type: item_type,
+        event: 'update',
+        object_changes: { referral_notes: ['initial notes', 'updated notes'] }.to_yaml,
+      )
+    end
+
+    context 'with a dry run' do
+      it 'identifies and reports duplicates without deleting them' do
+        create_duplicate_versions
+
+        expect { Rake::Task[task_name].invoke }.to output(/Total duplicate versions that would be removed: 1/).to_stdout
+        expect(version_scope.count).to eq(3)
+      end
+    end
+
+    context 'with a live run' do
+      it 'deletes the duplicate versions' do
+        create_duplicate_versions
+
+        expect { Rake::Task[task_name].invoke('false') }.to output(/Total duplicate versions removed: 1/).to_stdout
+        expect(version_scope.count).to eq(2)
+      end
+
+      it 'keeps the version with metadata' do
+        timestamp = Time.current
+        base_attrs = { item_type: item_type, item_id: referral.id, event: 'update', object_changes: object_changes, created_at: timestamp }
+        version_without_metadata = GrdaWarehouse::Version.create!(base_attrs)
+        version_with_metadata = GrdaWarehouse::Version.create!(base_attrs.merge(enrollment_id: 123))
+
+        Rake::Task[task_name].invoke('false')
+
+        remaining_ids = version_scope.pluck(:id)
+        expect(remaining_ids).to include(version_with_metadata.id)
+        expect(remaining_ids).not_to include(version_without_metadata.id)
+      end
+    end
+  end
+
+  context 'when there are no duplicate versions' do
+    it 'reports that no duplicates were found' do
+      expect { Rake::Task[task_name].invoke }.to output(/No duplicates found/).to_stdout
+    end
+  end
+
+  context 'when there are similar but non-duplicate versions' do
+    let!(:referral) { create(:hmis_external_api_ac_hmis_referral, referral_notes: 'initial notes') }
+    let(:item_type) { 'HmisExternalApis::AcHmis::Referral' }
+    let(:version_scope) { GrdaWarehouse::Version.where(item_type: item_type, item_id: referral.id) }
+
+    before do
+      version_scope.delete_all
+      timestamp = Time.current
+
+      # Create versions that are similar but differ in key grouping criteria
+      GrdaWarehouse::Version.create!(
+        item_type: item_type,
+        item_id: referral.id,
+        event: 'update',
+        object_changes: { referral_notes: ['v1', 'v2'] }.to_yaml,
+        created_at: timestamp,
+      )
+      # Different timestamp
+      GrdaWarehouse::Version.create!(
+        item_type: item_type,
+        item_id: referral.id,
+        event: 'update',
+        object_changes: { referral_notes: ['v1', 'v2'] }.to_yaml,
+        created_at: timestamp + 1.second,
+      )
+      # Different object_changes
+      GrdaWarehouse::Version.create!(
+        item_type: item_type,
+        item_id: referral.id,
+        event: 'update',
+        object_changes: { referral_notes: ['v2', 'v3'] }.to_yaml,
+        created_at: timestamp,
+      )
+      # Different event
+      GrdaWarehouse::Version.create!(
+        item_type: item_type,
+        item_id: referral.id,
+        event: 'create',
+        object_changes: { referral_notes: ['v1', 'v2'] }.to_yaml,
+        created_at: timestamp,
+      )
+      # Different whodunnit
+      GrdaWarehouse::Version.create!(
+        item_type: item_type,
+        item_id: referral.id,
+        event: 'update',
+        object_changes: { referral_notes: ['v1', 'v2'] }.to_yaml,
+        whodunnit: '123',
+        created_at: timestamp,
+      )
+    end
+
+    it 'does not delete any versions' do
+      initial_count = version_scope.count
+
+      Rake::Task[task_name].invoke('false')
+
+      expect(version_scope.count).to eq(initial_count)
+    end
+
+    it 'reports no duplicates found' do
+      expect { Rake::Task[task_name].invoke }.to output(/No duplicates found/).to_stdout
+    end
+  end
+end

--- a/spec/models/concerns/paper_trail_duplicate_prevention_spec.rb
+++ b/spec/models/concerns/paper_trail_duplicate_prevention_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe 'Paper Trail Duplicate Prevention', type: :model do
+  # Create a temporary table and model for testing
+  before(:all) do
+    # Use the warehouse database connection
+    GrdaWarehouseBase.connection.execute(<<~SQL)
+      CREATE TABLE IF NOT EXISTS test_paper_trail_models (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255),
+        description TEXT,
+        created_at TIMESTAMP,
+        updated_at TIMESTAMP
+      )
+    SQL
+
+    # Define a test model class
+    class TestPaperTrailModel < GrdaWarehouseBase
+      self.table_name = 'test_paper_trail_models'
+      has_paper_trail
+    end
+  end
+
+  after(:all) do
+    # Clean up: remove the test table and class
+    GrdaWarehouseBase.connection.execute('DROP TABLE IF EXISTS test_paper_trail_models CASCADE')
+    Object.send(:remove_const, :TestPaperTrailModel) if defined?(TestPaperTrailModel)
+  end
+
+  describe 'single version creation' do
+    include_context 'with paper trail'
+    it 'creates only 1 version on create' do
+      expect do
+        TestPaperTrailModel.create!(name: 'Test', description: 'Test Description')
+      end.to change(GrdaWarehouse::Version, :count).by(1)
+    end
+
+    it 'creates only 1 version on update' do
+      record = TestPaperTrailModel.create!(name: 'Test', description: 'Original')
+
+      expect do
+        record.update!(description: 'Updated')
+      end.to change(GrdaWarehouse::Version, :count).by(1)
+    end
+
+    it 'creates only 1 version on destroy' do
+      record = TestPaperTrailModel.create!(name: 'Test', description: 'To Delete')
+
+      expect do
+        record.destroy
+      end.to change(GrdaWarehouse::Version, :count).by(1)
+    end
+
+    it 'stores version with correct model type' do
+      record = TestPaperTrailModel.create!(name: 'Test', description: 'Check Version')
+
+      version = GrdaWarehouse::Version.where(
+        item_type: 'TestPaperTrailModel',
+        item_id: record.id,
+      ).last
+
+      expect(version).to be_present
+      expect(version.item_type).to eq('TestPaperTrailModel')
+      expect(version.event).to eq('create')
+    end
+  end
+
+  describe 'safeguard against duplicate has_paper_trail calls' do
+    it 'raises an error in non-production environments when has_paper_trail is called twice' do
+      expect do
+        Class.new(GrdaWarehouseBase) do
+          self.table_name = 'test_paper_trail_models'
+          has_paper_trail
+          has_paper_trail # This should raise an error
+        end
+      end.to raise_error(StandardError, /PaperTrail already enabled/)
+    end
+
+    it 'includes helpful backtrace information in the error message' do
+      Class.new(GrdaWarehouseBase) do
+        self.table_name = 'test_paper_trail_models'
+        has_paper_trail
+        has_paper_trail
+      end
+    rescue StandardError => e
+      expect(e.message).to include('PaperTrail already enabled')
+      expect(e.message).to include('Called from:')
+    end
+
+    it 'raises when a subclass mixes in has_paper_trail after the parent already enabled it' do
+      parent_class = Class.new(GrdaWarehouseBase) do
+        self.table_name = 'test_paper_trail_models'
+        has_paper_trail
+      end
+
+      mixin = Module.new do
+        def self.included(base)
+          base.has_paper_trail
+        end
+      end
+
+      expect do
+        Class.new(parent_class) do
+          include mixin
+        end
+      end.to raise_error(StandardError, /PaperTrail already enabled/)
+    end
+  end
+  it 'logs to Sentry in production instead of raising' do
+    # Stub Rails.env to return production
+    allow(Rails.env).to receive(:production?).and_return(true)
+
+    # Expect Sentry to receive the warning message
+    expect(Sentry).to receive(:capture_message).with(
+      /PaperTrail already enabled/,
+      hash_including(level: :warning),
+    )
+
+    # Should not raise an error in production
+    expect do
+      Class.new(GrdaWarehouseBase) do
+        self.table_name = 'test_paper_trail_models'
+        has_paper_trail
+        has_paper_trail
+      end
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

*   **Prevent Duplicate PaperTrail Versions**: Resolves an issue where models including certain concerns would generate duplicate version records. `has_paper_trail` was removed from `HmisExternalApisBase` to prevent double inclusion.
*   **Add Duplicate Declaration Guard**: A check has been added to `GrdaWarehouseBase` that raises an exception in development/test environments if `has_paper_trail` is called more than once on a model, preventing this issue from recurring. In production, a warning is logged to Sentry.
*   **Expand Versioning Test Coverage**: Add versioning tests to all 14 models that use the `EnrollmentRelated` concern
*   **Add De-duplication Rake Task**: A new task, `paper_trail:deduplicate_versions`, is included to identify and remove existing duplicate version records from the database. The task defaults to a dry run for safety.
## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)


After deploy:
run `rails paper_trail:deduplicate_versions[false]`

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


