### PR TITLE
fix test timing issues

### DIFF
--- a/drivers/hmis/spec/system/hmis/ac_hmis/ac_ce_referral_workflows_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ac_hmis/ac_ce_referral_workflows_spec.rb
@@ -40,6 +40,10 @@ RSpec.feature 'AC CE Referral Workflows', type: :system do
     HmisUtil::JsonForms.new.seed_record_form_definitions(roles: [:ENROLLMENT])
   end
 
+  # consistent time for avoid failures when run across day boundaries
+  before(:each)  { freeze_time }
+  after(:each) { travel_back }
+
   let!(:ds1) { GrdaWarehouse::DataSource.hmis.find_by(hmis: 'localhost') } # created already
   let!(:client1) { create(:hmis_hud_client_with_warehouse_client, data_source: ds1, first_name: 'Alice', last_name: 'A') }
 

--- a/drivers/hmis/spec/system/hmis/bulk_services_spec.rb
+++ b/drivers/hmis/spec/system/hmis/bulk_services_spec.rb
@@ -12,6 +12,10 @@ RSpec.feature 'Bulk Services behavior', type: :system do
   include_context 'hmis base setup'
   include_context 'hmis service setup'
 
+  # consistent time for avoid failures when run across day boundaries
+  before(:each)  { freeze_time }
+  after(:each) { travel_back }
+
   let!(:ds1) { create(:hmis_data_source, hmis: 'localhost') }
 
   let!(:access_control) { create_access_control(hmis_user, p1) }

--- a/drivers/hmis/spec/system/hmis/join_households_workflow_spec.rb
+++ b/drivers/hmis/spec/system/hmis/join_households_workflow_spec.rb
@@ -12,6 +12,11 @@ require_relative '../../support/hmis_base_setup'
 
 RSpec.feature 'Join Households', type: :system do
   include_context 'hmis base setup'
+
+  # consistent time for avoid failures when run across day boundaries
+  before(:each)  { freeze_time }
+  after(:each) { travel_back }
+
   let!(:ds1) { create(:hmis_data_source, hmis: 'localhost') }
 
   let!(:c1) { create :hmis_hud_client, data_source: ds1, first_name: 'Apple', last_name: 'Orange' }

--- a/spec/models/filters/filter_base_spec.rb
+++ b/spec/models/filters/filter_base_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Filters::FilterBase, type: :model do
   describe 'date parsing for :on param' do
     before { freeze_time }
     after { travel_back }
-    let!(:today) { Date.current }
+    let(:today) { Date.current }
     let(:base) { Filters::FilterBase.new(user_id: user.id) }
     let(:test_date) { Date.new(2025, 4, 27) }
 

--- a/spec/support/e2e_setup.rb
+++ b/spec/support/e2e_setup.rb
@@ -109,13 +109,15 @@ RSpec.shared_context 'SystemSpecHelper' do
   end
 
   def mui_table_expect(expected, row_index:, column_header:, from:)
+    # Wait for table to have rows before proceeding
+    expect(from).to have_css('tbody tr', minimum: row_index + 1)
+
     header_cells = from.all('thead th')
     column_index = header_cells.find_index { |cell| !!cell.text.match(column_header) }
     expect(column_index).not_to be_nil
 
     rows = from.all('tbody tr')
-    row = rows[row_index]
-    cell = row.all('td')[column_index]
+    cell = rows[row_index].all('td')[column_index]
     expect(cell.text).to match(expected)
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Improves the reliability of system tests by mitigating timing-related failures.

- **System Tests**: Adds `freeze_time` to  some system tests to ensure consistent time across test runs when run across day boundaries.
- **E2E Test Helper**: Enhances the `mui_table_expect` helper to explicitly wait for table rows to load before making assertions, preventing race conditions during UI rendering.
- **Filter Spec**: Changes a `let!` to `let` in `filter_base_spec.rb` to ensure a test date is consistent

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail



