### PR TITLE
Fix ReferralEnroller for consistency

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_enroller.rb
@@ -68,7 +68,7 @@ module Hmis::Ce
       # Do this before saving the other hh member enrollments, so that assign_unit validations pass.
       hoh_target_enrollment = enrollments.find { |e| e.client == referral.client }
       enrollments.delete(hoh_target_enrollment) # Remove from list so it's not saved again below
-      hoh_target_enrollment.assign_unit(unit: unit, start_date: entry_date, user: message.user)
+      hoh_target_enrollment.assign_unit(unit: unit, start_date: entry_date, user: message.user, active_referral: referral)
 
       # Save the HoH's (referred client's) enrollment and associate it with the referral.
       hoh_target_enrollment.save_new_enrollment! # Saves as WIP or non-WIP, depending on auto-enter rules in the project


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Follow up on previous PR feedback: https://github.com/greenriver/hmis-warehouse/pull/5915#discussion_r2453397423

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
