### PR TITLE
Fix flaky test

### DIFF
--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
         end
         it 'includes clients without open referrals to PH (9) projects' do
           results = generate_candidates(pool)
-          expect(results).to contain_exactly(*clients_not_referred_to_ph.map { |c| c.destination_client.id })
+          expect(results).to eq(clients_not_referred_to_ph.map { |c| c.destination_client.id }.sort)
         end
       end
     end

--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
         end
         it 'includes clients without open referrals to PH (9) projects' do
           results = generate_candidates(pool)
-          expect(results).to eq(clients_not_referred_to_ph.map { |c| c.destination_client.id })
+          expect(results).to contain_exactly(*clients_not_referred_to_ph.map { |c| c.destination_client.id })
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes a test that failed on CI due to a list whose order is not deterministic. Example failure: https://github.com/greenriver/hmis-warehouse/actions/runs/18886680038/job/53903726360

The test functionality isn't testing prioritization, so the order doesn't matter for purposes of this test. The other tests in the file sort both the expected and actual lists, so that is the fix I made here. Another alternative would be to use `contain_exactly`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Test clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
