### PR TITLE
add properly escaped table quotes to pg_repack

### DIFF
--- a/app/models/dba/database_bloat.rb
+++ b/app/models/dba/database_bloat.rb
@@ -152,10 +152,16 @@ class Dba::DatabaseBloat
         escaped_database = Shellwords.escape(database)
         escaped_host = Shellwords.escape(host)
         escaped_port = Shellwords.escape(port)
-        escaped_schema = Shellwords.escape(row['schemaname'])
-        escaped_table = Shellwords.escape(row['tblname'])
 
-        options = "--no-superuser-check -U #{escaped_username} -d #{escaped_database} -h #{escaped_host} -p #{escaped_port} -t #{escaped_schema}.#{escaped_table}"
+        # Quote PostgreSQL identifiers properly (double quotes for mixed case)
+        quoted_schema = quote_pg_identifier(row['schemaname'])
+        quoted_table = quote_pg_identifier(row['tblname'])
+
+        # Shell escape the quoted identifiers
+        escaped_quoted_schema = Shellwords.escape(quoted_schema)
+        escaped_quoted_table = Shellwords.escape(quoted_table)
+
+        options = "--no-superuser-check -U #{escaped_username} -d #{escaped_database} -h #{escaped_host} -p #{escaped_port} -t #{escaped_quoted_schema}.#{escaped_quoted_table}"
 
         # In order to support multiple versions of pg_repack, we need to use the version-specific binary
         # Use bash's 'exec -a' to override argv[0] (the program name) to avoid version mismatch errors
@@ -231,6 +237,20 @@ class Dba::DatabaseBloat
     result = always_run(sql)
     row = result.first
     row && row['extversion']
+  end
+
+  # Quote PostgreSQL identifiers that need it (mixed case, special characters, etc.)
+  # @param identifier [String] The identifier to quote
+  # @return [String] The properly quoted identifier
+  def quote_pg_identifier(identifier)
+    # PostgreSQL identifiers need quoting if they contain uppercase letters,
+    # start with a digit, or contain special characters
+    if identifier =~ /[^a-z_]/ || identifier =~ /^[0-9]/
+      # Double any existing double quotes and wrap in double quotes
+      '"' + identifier.gsub('"', '""') + '"'
+    else
+      identifier
+    end
   end
 
   # for finding bloat, etc. Harmless things only


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

building out tables for pg_repack requires properly escaping the quoted schema and table names.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
