### PR TITLE
Move data_collected_about rule in custom patch

### DIFF
--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_annual_questions.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_annual_questions.json
@@ -7,6 +7,7 @@
         "link_id": "hopwa_annual",
         "text": "HOPWA Annual Questions",
         "type": "GROUP",
+        "data_collected_about": "HOH",
         "item": [
           {
             "text": "County of Residence",
@@ -18,7 +19,6 @@
             "warn_if_empty": false,
             "disabled_display": "HIDDEN",
             "pick_list_reference": "GEOCODE",
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "county_of_residence"
             }
@@ -39,7 +39,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "housing_plan"
             }
@@ -60,7 +59,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "service_plan"
             }
@@ -97,7 +95,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "maintained_contact_with_case_manager"
             }
@@ -134,7 +131,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "primary_health_contact"
             }
@@ -157,7 +153,6 @@
                 "code": "Unknown"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "improved_viral_load_or_achieved_viral_suppression"
             }

--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_exit_questions.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_exit_questions.json
@@ -7,6 +7,7 @@
         "link_id": "hopwa_exit",
         "text": "HOPWA Exit Questions",
         "type": "GROUP",
+        "data_collected_about": "HOH",
         "item": [
           {
             "text": "County of Residence",
@@ -18,7 +19,6 @@
             "warn_if_empty": false,
             "disabled_display": "HIDDEN",
             "pick_list_reference": "GEOCODE",
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "county_of_residence"
             }
@@ -39,7 +39,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "housing_plan"
             }
@@ -60,7 +59,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "service_plan"
             }
@@ -97,7 +95,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "maintained_contact_with_case_manager"
             }
@@ -134,7 +131,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "primary_health_contact"
             }
@@ -157,7 +153,6 @@
                 "code": "Unknown"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "improved_viral_load_or_achieved_viral_suppression"
             }

--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_intake_questions.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_intake_questions.json
@@ -7,6 +7,7 @@
         "link_id": "hopwa_intake",
         "text": "HOPWA Intake Questions",
         "type": "GROUP",
+        "data_collected_about": "HOH",
         "item": [
           {
             "text": "County of Residence",
@@ -18,7 +19,6 @@
             "warn_if_empty": false,
             "disabled_display": "HIDDEN",
             "pick_list_reference": "GEOCODE",
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "county_of_residence"
             }
@@ -39,7 +39,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "housing_plan"
             }
@@ -60,7 +59,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "service_plan"
             }
@@ -97,7 +95,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "maintained_contact_with_case_manager"
             }
@@ -134,7 +131,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "primary_health_contact"
             }
@@ -149,7 +145,6 @@
                 "read_only": false,
                 "warn_if_empty": false,
                 "disabled_display": "HIDDEN",
-                "data_collected_about": "HOH",
                 "mapping": {
                   "custom_field_key": "hiv_status_verification_source"
                 }
@@ -162,7 +157,6 @@
                 "read_only": false,
                 "warn_if_empty": false,
                 "disabled_display": "HIDDEN",
-                "data_collected_about": "HOH",
                 "mapping": {
                   "custom_field_key": "hiv_status_verification_date"
                 }
@@ -191,7 +185,6 @@
                 "code": "Unknown"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "improved_viral_load_or_achieved_viral_suppression"
             }

--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_update_questions.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/hopwa_update_questions.json
@@ -7,6 +7,7 @@
         "link_id": "hopwa_update",
         "text": "HOPWA Update Questions",
         "type": "GROUP",
+        "data_collected_about": "HOH",
         "item": [
           {
             "text": "County of Residence",
@@ -18,7 +19,6 @@
             "warn_if_empty": false,
             "disabled_display": "HIDDEN",
             "pick_list_reference": "GEOCODE",
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "county_of_residence"
             }
@@ -39,7 +39,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "housing_plan"
             }
@@ -60,7 +59,6 @@
                 "code": "No"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "service_plan"
             }
@@ -97,7 +95,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "maintained_contact_with_case_manager"
             }
@@ -134,7 +131,6 @@
                 "code": "Not in Plan"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "primary_health_contact"
             }
@@ -157,7 +153,6 @@
                 "code": "Unknown"
               }
             ],
-            "data_collected_about": "HOH",
             "mapping": {
               "custom_field_key": "improved_viral_load_or_achieved_viral_suppression"
             }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/8472

Apply `data_collected_about` rule to the top-level group for customer patches that collect additional questions for the HoH.

This is a hotfix for release-186. The underlying issue is a render issue where the frontend can't handle empty groups. The linked issue 8472 includes another additional solution which is to update the frontend to gracefuilly handle cases where the group is empty. I opted to do the hotfix as the configuration change first, so we can take more time with testing and reviewing the code change.

**Locally tested:**
* Seed customer assessments
* Test intake for hoh+child household
* Test exit for hoh+child household
* Test update for hoh and child
* Test annual for hoh and child

## Type of change
Configuration

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
