### PR TITLE
8462-date-picker

### DIFF
--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -96,21 +96,55 @@ export default class extends Controller {
       return originalParseInput(value);
     }
 
-    const stringValue = value.toString().trim();
+    const rawValue = value.toString().trim();
+
+    // Preserve any localization details supplied via data attributes so the picker
+    // respects backend configuration (locale, formatting, etc.) during parsing.
+    let optionsData = {};
+    try {
+      optionsData = this.element.dataset.dateOptions ? JSON.parse(this.element.dataset.dateOptions) : {};
+    } catch (_) {
+      optionsData = {};
+    }
+
+    const locale = optionsData.localization?.locale || 'en-US';
+    const normalizedValue = this.normalizeMonthAliases(rawValue, locale);
+    const localizationForFormat = (format) => {
+      if (optionsData.localization) {
+        return { ...optionsData.localization, locale, format };
+      }
+
+      return { locale, format };
+    };
 
     // Try the original parsing first (handles the expected format)
-    try {
-      const originalResult = originalParseInput(value);
-      if (originalResult && originalResult.isValid) {
-        return originalResult;
+    const tryOriginalParse = (candidate) => {
+      try {
+        const result = originalParseInput(candidate);
+        if (result && result.isValid) {
+          return result;
+        }
+      } catch (_) {
+        // Continue to flexible parsing if original fails
       }
-    } catch (error) {
-      // Continue to flexible parsing if original fails
+
+      return undefined;
+    };
+
+    let parsed = tryOriginalParse(rawValue);
+    if (parsed) return parsed;
+
+    if (normalizedValue !== rawValue) {
+      parsed = tryOriginalParse(normalizedValue);
+      if (parsed) return parsed;
     }
 
     // Use Tempus Dominus DateTime to parse common date formats
+    // Allow both abbreviated and fully spelled-out months along with several
+    // common numeric permutations so we accept the majority of user input cases.
     const formats = [
       'MMM d, yyyy',
+      'MMMM d, yyyy',
       'MM/dd/yyyy',
       'M/d/yyyy',
       'MM-dd-yyyy',
@@ -123,26 +157,48 @@ export default class extends Controller {
       'M-d-yy',
     ];
 
-    let locale = 'en-US';
-    try {
-      const optionsData = this.element.dataset.dateOptions ? JSON.parse(this.element.dataset.dateOptions) : {};
-      if (optionsData.localization && optionsData.localization.locale) {
-        locale = optionsData.localization.locale;
+    const parseCandidates = normalizedValue === rawValue ? [normalizedValue] : [normalizedValue, rawValue];
+    for (const candidate of parseCandidates) {
+      for (const fmt of formats) {
+        try {
+          const dt = DateTime.fromString(candidate, localizationForFormat(fmt));
+          if (dt && DateTime.isValid(dt)) {
+            return dt;
+          }
+        } catch (_) { }
       }
-    } catch (_) { }
+    }
 
-    for (const fmt of formats) {
-      try {
-        const dt = DateTime.fromString(stringValue, { locale, format: fmt });
-        if (dt && DateTime.isValid(dt)) {
-          return dt;
-        }
-      } catch (_) { }
+    // Fallback to the browser's parser for inputs Tempus Dominus cannot handle
+    // (e.g., informal month names like "Sept" that sit between MMM and MMMM).
+    for (const candidate of parseCandidates) {
+      const nativeDate = new Date(candidate);
+      if (!Number.isNaN(nativeDate.getTime())) {
+        try {
+          const localization = optionsData.localization ? { ...optionsData.localization, locale } : { locale };
+          return DateTime.convert(nativeDate, locale, localization);
+        } catch (_) { }
+      }
     }
 
     // If flexible parsing fails, return the original parsing result
     // This will let TempusDominus handle the error appropriately
     return originalParseInput(value);
+  }
+
+  normalizeMonthAliases(value, locale) {
+    const normalizedLocale = (locale || '').toLowerCase();
+    if (!normalizedLocale.startsWith('en')) {
+      return value;
+    }
+
+    return value.replace(/\bsept\.?\b/gi, (match) => this.applyMatchCase(match.replace(/\./g, ''), 'Sep'));
+  }
+
+  applyMatchCase(source, target) {
+    if (source === source.toUpperCase()) return target.toUpperCase();
+    if (source === source.toLowerCase()) return target.toLowerCase();
+    return target[0].toUpperCase() + target.slice(1);
   }
 
   addButtonLabels() {

--- a/spec/system/rails/datepicker_spec.rb
+++ b/spec/system/rails/datepicker_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'JavaScript Functionality Test', type: :rails_system do
     setup_access_control(user, role, collection)
   end
 
-  describe 'Date Picker', js: true do
+  describe DatePickerInput, js: true do
     before { sign_in_user(user) }
 
     it 'Correctly adjusts dates' do
@@ -50,6 +50,21 @@ RSpec.feature 'JavaScript Functionality Test', type: :rails_system do
         picker.trigger(:blur)
         # Ensure the date was set correctly
         expect(picker.value).to eq(expected_date)
+      end
+
+      # check the four-letter month
+      sept_expected_date = 'Sep 1, 2025'
+      ['Sept 1, 2025'].each do |date|
+        fill_in picker[:id], with: date
+        picker.trigger(:blur)
+        expect(picker.value).to eq(sept_expected_date)
+      end
+
+      # check the full month too
+      ['September 1, 2025'].each do |date|
+        fill_in picker[:id], with: date
+        picker.trigger(:blur)
+        expect(picker.value).to eq(sept_expected_date)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Fixes date parsing in date picker to handle four letter month abbreviations like “Sept” and full month names like "September"

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
