### PR TITLE
Gender cleanup in 2026 project pass fail

### DIFF
--- a/drivers/project_pass_fail/app/models/project_pass_fail/client.rb
+++ b/drivers/project_pass_fail/app/models/project_pass_fail/client.rb
@@ -46,7 +46,7 @@ module ProjectPassFail
         enrollment_coc: apr_client.enrollment_coc,
         income_at_entry: apr_client.income_from_any_source_at_start,
       }
-      attributes.delete('Gender') unless project_pass_fail.include_gender_data?
+      attributes.delete(:gender_multi) unless project_pass_fail.include_gender_data?
       assign_attributes(attributes)
     end
 
@@ -56,7 +56,7 @@ module ProjectPassFail
       )
     end
 
-    def self.detail_headers
+    def self.detail_headers(include_gender_data: true)
       headers = {
         first_name: 'First Name',
         last_name: 'Last Name',
@@ -79,14 +79,14 @@ module ProjectPassFail
         days_served: 'Days Served',
         income_at_entry: 'Income at Entry',
       }
-      headers.delete('Gender') unless project_pass_fail.include_gender_data?
+      headers.delete(:gender_multi) unless include_gender_data
       headers
     end
 
-    def self.detail_headers_for_export
-      return detail_headers if GrdaWarehouse::Config.get(:include_pii_in_detail_downloads)
+    def self.detail_headers_for_export(include_gender_data: true)
+      return detail_headers(include_gender_data: include_gender_data) if GrdaWarehouse::Config.get(:include_pii_in_detail_downloads)
 
-      detail_headers.except(:first_name, :last_name, :dob, :ssn)
+      detail_headers(include_gender_data: include_gender_data).except(:first_name, :last_name, :dob, :ssn)
     end
   end
 end

--- a/drivers/project_pass_fail/app/views/project_pass_fail/warehouse_reports/project/show.haml
+++ b/drivers/project_pass_fail/app/views/project_pass_fail/warehouse_reports/project/show.haml
@@ -11,13 +11,13 @@
       %thead.table-dark
         %tr
           %th
-          - ProjectPassFail::Client.detail_headers.each_value do |header|
+          - ProjectPassFail::Client.detail_headers(include_gender_data: @report.include_gender_data?).each_value do |header|
             %th= header
       %tbody
         - @clients.each.with_index do |client, i|
           %tr
             %th= i + 1
-            - ProjectPassFail::Client.detail_headers.each_key do |k|
+            - ProjectPassFail::Client.detail_headers(include_gender_data: @report.include_gender_data?).each_key do |k|
               %td{style: 'max-width: 600px;'}
                 - if k.in?([:first_name, :last_name]) && client.client&.destination_client.present?
                   = link_to client[k], appropriate_client_path(client.client.destination_client)

--- a/drivers/project_pass_fail/app/views/project_pass_fail/warehouse_reports/project/show.xlsx.axlsx
+++ b/drivers/project_pass_fail/app/views/project_pass_fail/warehouse_reports/project/show.xlsx.axlsx
@@ -1,10 +1,10 @@
 wb = xlsx_package.workbook
 wb.add_worksheet(name: @project.project&.name.slice(0,30)) do |sheet|
   title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
-  sheet.add_row(['Warehouse Client ID'] + ProjectPassFail::Client.detail_headers_for_export.values, :style => title)
+  sheet.add_row(['Warehouse Client ID'] + ProjectPassFail::Client.detail_headers_for_export(include_gender_data: @report.include_gender_data?).values, :style => title)
   @clients.each.with_index do |client, i|
     row = [client.client.destination_client&.id]
-    ProjectPassFail::Client.detail_headers_for_export.each_key do |k|
+    ProjectPassFail::Client.detail_headers_for_export(include_gender_data: @report.include_gender_data?).each_key do |k|
       row << client[k]
     end
     sheet.add_row(row)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixed a `NameError` in `detail_headers`: it referenced `project_pass_fail.include_gender_data?`, but `project_pass_fail` is an instance method and isn't available in the class method. Added a boolean `include_gender_data` parameter (defaults to `true`) and updated the views to pass `@report.include_gender_data?`. Also fixed `calculate_universal_data_elements` to delete `:gender_multi` instead of `'Gender'` to match the symbol-keyed hash.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
