### PR TITLE
Role-Based Report Viewable

### DIFF
--- a/app/models/grda_warehouse/warehouse_reports/report_definition.rb
+++ b/app/models/grda_warehouse/warehouse_reports/report_definition.rb
@@ -36,16 +36,14 @@ module GrdaWarehouse::WarehouseReports
               entity_type: 'GrdaWarehouse::WarehouseReports::ReportDefinition',
             ),
           )
+      # Users with role-based access fall into the scenarios below
+      elsif user.can_view_all_reports? || user.can_view_assigned_reports?
+        # Both permissions allow access to report definitions the user has access to
+        # (via collections/access groups). can_view_all_reports additionally allows
+        # seeing report runs by other users (handled elsewhere, not in this method).
+        where(id: user.reports.pluck(:id))
       else
-        if user.can_view_all_reports? # rubocop:disable Style/IfInsideElse
-          # If you can view all reports, regardless of who ran the report, for reports you have access to
-          where(id: user.reports.pluck(:id))
-        elsif user.can_view_assigned_reports?
-          joins(:group_viewable_entities).
-            merge(GrdaWarehouse::GroupViewableEntity.viewable_by(user))
-        else
-          none
-        end
+        none
       end
     end
     # END_ACL


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Users with role-based access were unable to access reports assigned directly to their account. They were able to access reports assigned to them through groups.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
