### PR TITLE
DQ Tool - project calculations hotfix

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3843,7 +3843,6 @@ Style/FrozenStringLiteralComment:
     - 'drivers/hmis_csv_twenty_twenty_two/app/models/hmis_csv_twenty_twenty_two/loader/youth_education_status.rb'
     - 'drivers/hmis_csv_twenty_twenty_two/config/routes.rb'
     - 'drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/goal_configs_controller.rb'
-    - 'drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb'
     - 'drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool.rb'
     - 'drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_chart_pdf_export.rb'
     - 'drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/document_exports/report_export.rb'

--- a/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
+++ b/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
@@ -218,12 +218,5 @@ module HmisDataQualityTool::WarehouseReports
       items.flat_map { |item| item.respond_to?(:project_ids) ? item.project_ids : [item.project_id] }.compact.uniq
     end
     helper_method :all_project_ids_from_items
-
-    # Returns a Set of project IDs the current user can view for reporting purposes
-    # Memoized to avoid multiple queries per request
-    def viewable_project_ids_for_user
-      @viewable_project_ids_for_user ||= GrdaWarehouse::Hud::Project.viewable_by(current_user, permission: :can_view_clients).pluck(:id).to_set
-    end
-    helper_method :viewable_project_ids_for_user
   end
 end

--- a/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
+++ b/drivers/hmis_data_quality_tool/app/controllers/hmis_data_quality_tool/warehouse_reports/reports_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module HmisDataQualityTool::WarehouseReports
   class ReportsController < ApplicationController
     include WarehouseReportAuthorization
@@ -112,6 +114,11 @@ module HmisDataQualityTool::WarehouseReports
 
       @result = @report.result_from_key(@key)
       @items = @report.items_for(@key)
+
+      # Preload project dependencies for PII policy checks
+      all_project_ids = all_project_ids_from_items(@items)
+      current_user.policy_context.preload_project_dependencies(all_project_ids)
+
       respond_to do |format|
         format.html {}
         format.xlsx do
@@ -205,5 +212,18 @@ module HmisDataQualityTool::WarehouseReports
       cell
     end
     helper_method :formatted_cell
+
+    # Collects all project_ids from items, handling both Client (with project_ids) and Enrollment (with project_id) types
+    def all_project_ids_from_items(items)
+      items.flat_map { |item| item.respond_to?(:project_ids) ? item.project_ids : [item.project_id] }.compact.uniq
+    end
+    helper_method :all_project_ids_from_items
+
+    # Returns a Set of project IDs the current user can view for reporting purposes
+    # Memoized to avoid multiple queries per request
+    def viewable_project_ids_for_user
+      @viewable_project_ids_for_user ||= GrdaWarehouse::Hud::Project.viewable_by(current_user, permission: :can_view_clients).pluck(:id).to_set
+    end
+    helper_method :viewable_project_ids_for_user
   end
 end

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
@@ -26,6 +26,19 @@ module HmisDataQualityTool
     belongs_to :client, class_name: 'GrdaWarehouse::Hud::Client', optional: true
     belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource', optional: true
 
+    def project_id
+      project_ids.first
+    end
+
+    def project_ids
+      # Projects are preloaded in client_scope (source_enrollments: [:exit, :project]) which is used to build enrollments
+      @project_ids ||= if enrollments.blank?
+        []
+      else
+        enrollments.map { |en| en.project&.id }.compact.uniq
+      end
+    end
+
     def self.detail_headers
       {
         destination_client_id: { title: 'Warehouse Client ID' },

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/dq_concern.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/dq_concern.rb
@@ -82,7 +82,7 @@ module HmisDataQualityTool::DqConcern
     # Falls back to the first project_id if none are accessible
     def project_id_for_policy(viewable_project_ids:)
       if respond_to?(:project_ids) && project_ids.present?
-        project_ids.find { |pid| viewable_project_ids.include?(pid) } || project_ids.first
+        (project_ids & viewable_project_ids)&.first || project_ids.first
       else
         project_id
       end

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/dq_concern.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/dq_concern.rb
@@ -77,6 +77,17 @@ module HmisDataQualityTool::DqConcern
       value
     end
 
+    # Returns the project_id to use for PII policy checks
+    # For items with multiple projects (like Client), finds the first one the user has access to
+    # Falls back to the first project_id if none are accessible
+    def project_id_for_policy(viewable_project_ids:)
+      if respond_to?(:project_ids) && project_ids.present?
+        project_ids.find { |pid| viewable_project_ids.include?(pid) } || project_ids.first
+      else
+        project_id
+      end
+    end
+
     # returns [stay_length_category, stay_length_limit]
     def self.stay_length_limit(key, report)
       section = sections(report)[key]

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.haml
@@ -29,6 +29,7 @@
             - headers.each_value do |header|
               %th= header[:title]
         %tbody
+          - viewable_project_ids_for_user = current_user.viewable_project_ids(:can_view_clients)
           - @items.each.with_index do |item, i|
             - project_id_for_policy = item.project_id_for_policy(viewable_project_ids: viewable_project_ids_for_user)
             - pii_policy = current_user.reporting_policy_for_project(project_id: project_id_for_policy)

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.haml
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.haml
@@ -29,9 +29,9 @@
             - headers.each_value do |header|
               %th= header[:title]
         %tbody
-          - current_user.policy_context.preload_project_dependencies(@items.pluck(:project_id).uniq)
           - @items.each.with_index do |item, i|
-            - pii_policy = current_user.reporting_policy_for_project(project_id: item.project_id)
+            - project_id_for_policy = item.project_id_for_policy(viewable_project_ids: viewable_project_ids_for_user)
+            - pii_policy = current_user.reporting_policy_for_project(project_id: project_id_for_policy)
             %tr
               %th.table-dark= i + 1
               - data_source_link_available = item.data_source.present? && item.data_source.hmis_link_available?
@@ -41,8 +41,7 @@
                 - formatted_value = formatted_cell(value)
                 %td
                   - if k.to_s == 'destination_client_id'
-                    = link_to_if @report.can_see_client_details?(current_user), appropriate_client_path(item[k]) do
-                      = value
+                    = link_to_if @report.can_see_client_details?(current_user), value, appropriate_client_path(item[k])
                     %a{href: '#', class: ['btn', 'btn-sm'], data: { 'bs-toggle' => :popover, title: 'Client Information', url: api_client_path(item.client_id), html: 'true' }}
                       %i.icon-info
                   - elsif k.to_s == 'hmis_enrollment_id'

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.xlsx.axlsx
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.xlsx.axlsx
@@ -5,9 +5,9 @@ wb.add_worksheet(name: ws_title.slice(0, 30).gsub(':', ' ').gsub('/', '-')) do |
   title = sheet.styles.add_style(sz: 12, b: true, alignment: { horizontal: :center })
   headers = if @result.slug.present? then @result.item_class.constantize.detail_headers_for(@result.slug, @report, export: true) else @result.detail_columns end
   sheet.add_row(headers.values.map { |h| h[:title] }, style: title)
-  current_user.policy_context.preload_project_dependencies(@items.pluck(:project_id).uniq)
   @items.each do |item|
-    pii_policy = current_user.reporting_policy_for_project(project_id: item.project_id, mode: :download)
+    project_id_for_policy = item.project_id_for_policy(viewable_project_ids: viewable_project_ids_for_user)
+    pii_policy = current_user.reporting_policy_for_project(project_id: project_id_for_policy, mode: :download)
     row = []
     headers.each_key do |k|
       row << item.download_value(k, pii_policy: pii_policy)

--- a/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.xlsx.axlsx
+++ b/drivers/hmis_data_quality_tool/app/views/hmis_data_quality_tool/warehouse_reports/reports/items.xlsx.axlsx
@@ -5,6 +5,7 @@ wb.add_worksheet(name: ws_title.slice(0, 30).gsub(':', ' ').gsub('/', '-')) do |
   title = sheet.styles.add_style(sz: 12, b: true, alignment: { horizontal: :center })
   headers = if @result.slug.present? then @result.item_class.constantize.detail_headers_for(@result.slug, @report, export: true) else @result.detail_columns end
   sheet.add_row(headers.values.map { |h| h[:title] }, style: title)
+  viewable_project_ids_for_user = current_user.viewable_project_ids(:can_view_clients)
   @items.each do |item|
     project_id_for_policy = item.project_id_for_policy(viewable_project_ids: viewable_project_ids_for_user)
     pii_policy = current_user.reporting_policy_for_project(project_id: project_id_for_policy, mode: :download)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Hotfix for items page (Enrollments/Clients/etc... breakdowns page) running into 500 errors for a mehtod_missing project_id. This was being used to prepopulate the pii policies for the data breakdowns. 

This also updates the DQ Clients to look for a project id that is viewable to the user when showing the client data instead of defaulting to the first project from the clients enrollments.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
