### PR TITLE
Include user's own access group in PII checks

### DIFF
--- a/app/models/grda_warehouse/auth_policies/user_legacy_context.rb
+++ b/app/models/grda_warehouse/auth_policies/user_legacy_context.rb
@@ -98,7 +98,11 @@ class GrdaWarehouse::AuthPolicies::UserLegacyContext
   memoize def permissions_for_access_group_ids(access_group_ids)
     access_group_ids += system_access_group_ids(:data_sources)
     return EMPTY_SET if access_group_ids.blank?
-    return EMPTY_SET unless user.access_groups.where(id: access_group_ids).exists?
+
+    # Check if the user is a member of any of the access groups, or if the user's own access group is included
+    access_group_exists = user.access_groups.where(id: access_group_ids).exists?
+    access_group_exists ||= access_group_ids.include?(user.access_group.id) if user.access_group.present?
+    return EMPTY_SET unless access_group_exists
 
     legacy_permissions
   end

--- a/spec/models/auth_policies/user_legacy_context_spec.rb
+++ b/spec/models/auth_policies/user_legacy_context_spec.rb
@@ -102,4 +102,70 @@ RSpec.describe GrdaWarehouse::AuthPolicies::UserLegacyContext do
       end
     end
   end
+
+  describe 'user.access_group direct assignments' do
+    subject(:context) { described_class.new(legacy_user) }
+
+    before do
+      # Ensure user's access group is persisted
+      legacy_user.access_group.save! unless legacy_user.access_group.persisted?
+    end
+
+    describe '#project_role_permissions' do
+      context 'when project is directly assigned to user.access_group' do
+        before do
+          legacy_user.access_group.add_viewable(project)
+        end
+
+        it 'returns correct permissions for the project' do
+          expect(context.project_role_permissions(project.id)).to include(:can_view_projects)
+        end
+      end
+
+      context 'when project is not assigned to user.access_group' do
+        it 'returns empty set when project has no other access groups' do
+          expect(context.project_role_permissions(project.id)).to be_empty
+        end
+      end
+    end
+
+    describe '#data_source_role_permissions' do
+      context 'when data source is directly assigned to user.access_group' do
+        before do
+          legacy_user.access_group.add_viewable(data_source)
+        end
+
+        it 'returns correct permissions for the data source' do
+          expect(context.data_source_role_permissions(data_source.id)).to include(:can_view_projects)
+        end
+      end
+
+      context 'when data source is not assigned to user.access_group' do
+        it 'returns empty set when data source has no other access groups' do
+          expect(context.data_source_role_permissions(data_source.id)).to be_empty
+        end
+      end
+    end
+
+    describe '#direct_client_role_permissions' do
+      let(:client_data_source) { create(:grda_warehouse_data_source, authoritative: true) }
+      let(:client) { create(:hud_client, data_source: client_data_source) }
+
+      context 'when client data source is directly assigned to user.access_group' do
+        before do
+          legacy_user.access_group.add_viewable(client_data_source)
+        end
+
+        it 'returns correct permissions for the client' do
+          expect(context.direct_client_role_permissions(client.id)).to include(:can_view_projects)
+        end
+      end
+
+      context 'when client data source is not assigned to user.access_group' do
+        it 'returns empty set when client has no other access groups' do
+          expect(context.direct_client_role_permissions(client.id)).to be_empty
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The PII Policies were not acccounting for viewable entities assigned directly to the user (as opposed to through access groups). This update now includes those entities when building the PII permissions.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
