### PR TITLE
8519 ssh algorithms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -195,6 +195,7 @@ gem 'dotenv-rails'
 
 gem 'net-sftp', require: false
 gem 'net-ssh', '~> 7', require: false
+gem 'x25519', require: false
 gem 'net-http'
 gem 'multipart-post'
 gem 'addressable' # normalize uris

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1089,6 +1089,7 @@ GEM
     with_advisory_lock (5.1.0)
       activerecord (>= 6.1)
       zeitwerk (>= 2.6)
+    x25519 (1.0.10)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yabeda (0.13.1)
@@ -1348,6 +1349,7 @@ DEPENDENCIES
   webmock
   whenever
   with_advisory_lock
+  x25519
   yabeda-prometheus
   yabeda-puma-plugin
   yabeda-rails
@@ -1773,6 +1775,7 @@ CHECKSUMS
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   whenever (1.0.0) sha256=d9b71417c43960f5eb125b77207174cba4691091cedae0d282a29cfc72eaa246
   with_advisory_lock (5.1.0) sha256=0692cd82013b271c59aa5e1f603b741ab94926dbce098990fbace5dd5412fed7
+  x25519 (1.0.10) sha256=ec9c446a6c601b226410a8d3812bc3eed7daef837f8a20bb0b314b2a6cabaa12
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   yabeda (0.13.1) sha256=3213025f22b7746602c8a4c41e2ed82d73a90bdc5489f6ef472142b06c1cf954
   yabeda-prometheus (0.9.1) sha256=b87d80cae8cffbeb527c25d288eafa8eed9c1fb56cf49616db5c8611768cd5fd

--- a/drivers/claims_reporting/app/models/claims_reporting/importer.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/importer.rb
@@ -53,6 +53,15 @@ module ClaimsReporting
         credentials['username'],
         password: credentials['password'] || credentials.password,
         auth_methods: ['publickey', 'password'],
+        kex: %w[
+          curve25519-sha256@libssh.org
+          ecdh-sha2-nistp521
+          ecdh-sha2-nistp384
+          ecdh-sha2-nistp256
+          diffie-hellman-group-exchange-sha256
+          diffie-hellman-group14-sha256
+          diffie-hellman-group14-sha1
+        ],
         keepalive: true,
         keepalive_interval: 60,
       ) do |connection|

--- a/drivers/claims_reporting/app/models/claims_reporting/importer.rb
+++ b/drivers/claims_reporting/app/models/claims_reporting/importer.rb
@@ -9,6 +9,10 @@
 require 'net/sftp'
 require 'zip'
 
+# support curve25519-sha256
+# verify with bundle exec ruby -r x25519  -r net/ssh -e "p Net::SSH::Transport::Algorithms::ALGORITHMS[:kex]"
+require 'x25519'
+
 module ClaimsReporting
   class Importer
     include NotifierConfig
@@ -53,15 +57,6 @@ module ClaimsReporting
         credentials['username'],
         password: credentials['password'] || credentials.password,
         auth_methods: ['publickey', 'password'],
-        kex: %w[
-          curve25519-sha256@libssh.org
-          ecdh-sha2-nistp521
-          ecdh-sha2-nistp384
-          ecdh-sha2-nistp256
-          diffie-hellman-group-exchange-sha256
-          diffie-hellman-group14-sha256
-          diffie-hellman-group14-sha1
-        ],
         keepalive: true,
         keepalive_interval: 60,
       ) do |connection|

--- a/drivers/claims_reporting/spec/models/claims_reporting/importer_spec.rb
+++ b/drivers/claims_reporting/spec/models/claims_reporting/importer_spec.rb
@@ -58,4 +58,41 @@ RSpec.describe ClaimsReporting::Importer do
     it_behaves_like 'imports data from zip', true
     it_behaves_like 'imports data from zip', false
   end
+
+  describe '#using_sftp' do
+    let(:credentials) do
+      {
+        'host' => 'sftp.example.org',
+        'username' => 'claims_user',
+        'password' => 'super-secret',
+      }
+    end
+    let(:expected_kex) do
+      %w[
+        curve25519-sha256@libssh.org
+        ecdh-sha2-nistp521
+        ecdh-sha2-nistp384
+        ecdh-sha2-nistp256
+        diffie-hellman-group-exchange-sha256
+        diffie-hellman-group14-sha256
+        diffie-hellman-group14-sha1
+      ]
+    end
+    let(:connection) { instance_double(Net::SFTP::Session) }
+
+    it 'configures Net::SFTP with the expected kex algorithms' do
+      expect(Net::SFTP).to receive(:start) do |host, username, options|
+        expect(host).to eq(credentials['host'])
+        expect(username).to eq(credentials['username'])
+        expect(options[:kex]).to eq(expected_kex)
+        expect(options[:auth_methods]).to eq(%w[publickey password])
+        expect(options[:password]).to eq(credentials['password'])
+        connection
+      end.and_yield(connection)
+
+      importer.send(:using_sftp, credentials) do |sftp|
+        expect(sftp).to eq(connection)
+      end
+    end
+  end
 end

--- a/drivers/claims_reporting/spec/models/claims_reporting/importer_spec.rb
+++ b/drivers/claims_reporting/spec/models/claims_reporting/importer_spec.rb
@@ -58,41 +58,4 @@ RSpec.describe ClaimsReporting::Importer do
     it_behaves_like 'imports data from zip', true
     it_behaves_like 'imports data from zip', false
   end
-
-  describe '#using_sftp' do
-    let(:credentials) do
-      {
-        'host' => 'sftp.example.org',
-        'username' => 'claims_user',
-        'password' => 'super-secret',
-      }
-    end
-    let(:expected_kex) do
-      %w[
-        curve25519-sha256@libssh.org
-        ecdh-sha2-nistp521
-        ecdh-sha2-nistp384
-        ecdh-sha2-nistp256
-        diffie-hellman-group-exchange-sha256
-        diffie-hellman-group14-sha256
-        diffie-hellman-group14-sha1
-      ]
-    end
-    let(:connection) { instance_double(Net::SFTP::Session) }
-
-    it 'configures Net::SFTP with the expected kex algorithms' do
-      expect(Net::SFTP).to receive(:start) do |host, username, options|
-        expect(host).to eq(credentials['host'])
-        expect(username).to eq(credentials['username'])
-        expect(options[:kex]).to eq(expected_kex)
-        expect(options[:auth_methods]).to eq(%w[publickey password])
-        expect(options[:password]).to eq(credentials['password'])
-        connection
-      end.and_yield(connection)
-
-      importer.send(:using_sftp, credentials) do |sftp|
-        expect(sftp).to eq(connection)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Adjust ssh algorithms, see issue

## Type of change
Bug fix

## QA

verify that `curve25519-sha256` is now supported:
```
bundle exec ruby -r x25519  -r net/ssh -e "p Net::SSH::Transport::Algorithms::ALGORITHMS[:kex]"
["curve25519-sha256", "curve25519-sha256@libssh.org", "ecdh-sha2-nistp521", "ecdh-sha2-nistp384", "ecdh-sha2-nistp256", "diffie-hellman-group-exchange-sha256", "diffie-hellman-group14-sha256", "diffie-hellman-group14-sha1", "diffie-hellman-group-exchange-sha1", "diffie-hellman-group1-sha1"]
```

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
