### PR TITLE
Patch AHA bug from #5953

### DIFF
--- a/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
+++ b/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
@@ -1,0 +1,159 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../hmis/login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let(:stub_aha) { double }
+  let!(:aha_credential) do
+    GrdaWarehouse::RemoteCredentials::ApiKey.first_or_create!(
+      slug: 'ac_hmis_aha',
+      active: true,
+      endpoint: 'https://example.com',
+      password: 'test-token',
+      username: '',
+    )
+  end
+  let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: c1) }
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients]) }
+
+  before(:each) do
+    hmis_login(user)
+    allow(HmisExternalApis::AcHmis::Aha).to receive(:new).and_return(stub_aha)
+  end
+
+  let(:mutation) do
+    <<~GRAPHQL
+      mutation FetchAhaScore($clientId: ID!) {
+        fetchAhaScore(clientId: $clientId) {
+          score
+          mciQualityIndicator
+          dwClientId
+          generator
+          ahaFailedReason
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  def perform_mutation(client_id:)
+    response, result = post_graphql(client_id: client_id) { mutation }
+
+    aggregate_failures 'checking response' do
+      expect(response.status).to eq 200
+      data = result.dig('data', 'fetchAhaScore')
+      errors = result.dig('data', 'fetchAhaScore', 'errors')
+      yield data, errors
+    end
+  end
+
+  context 'when AHA is enabled' do
+    before do
+      allow(HmisExternalApis::AcHmis::Aha).to receive(:enabled?).and_return(true)
+    end
+
+    context 'when client has MCI unique ID' do
+      let(:aha_result) do
+        OpenStruct.new(
+          score: 8,
+          mci_quality_indicator: 0,
+          dw_client_id: mci_unique_id.value,
+          generator: 'AHA',
+        )
+      end
+
+      it 'returns AHA score successfully' do
+        allow(stub_aha).to receive(:fetch_score).with(c1).and_return(aha_result)
+
+        perform_mutation(client_id: c1.id) do |data, errors|
+          expect(errors).to be_empty
+          expect(data['score']).to eq(8)
+          expect(data['mciQualityIndicator']).to eq(0)
+          expect(data['dwClientId']).to eq(mci_unique_id.value)
+          expect(data['generator']).to eq('AHA')
+          expect(data['ahaFailedReason']).to be_nil
+        end
+      end
+
+      it 'handles AHA score of -1' do
+        aha_result_neg_one = OpenStruct.new(
+          score: -1,
+          mci_quality_indicator: 1,
+          dw_client_id: mci_unique_id.value,
+          generator: 'AHA',
+        )
+        allow(stub_aha).to receive(:fetch_score).with(c1).and_return(aha_result_neg_one)
+
+        perform_mutation(client_id: c1.id) do |data, errors|
+          expect(errors).to be_empty
+          expect(data['score']).to eq(-1)
+          expect(data['mciQualityIndicator']).to eq(1)
+          expect(data['ahaFailedReason']).to be_nil
+        end
+      end
+    end
+
+    context 'when client has no MCI unique ID' do
+      let!(:client_without_mci) { create(:hmis_hud_client, data_source: ds1, user: u1) }
+
+      it 'returns score -1 with NO_MCI_UNIQUE_ID reason' do
+        allow(stub_aha).to receive(:fetch_score).with(client_without_mci).
+          and_raise(HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError)
+
+        perform_mutation(client_id: client_without_mci.id) do |data, errors|
+          expect(errors).to be_empty
+          expect(data['score']).to eq(-1)
+          expect(data['ahaFailedReason']).to eq('NO_MCI_UNIQUE_ID')
+          expect(data['mciQualityIndicator']).to be_nil
+          expect(data['dwClientId']).to be_nil
+          expect(data['generator']).to be_nil
+        end
+      end
+    end
+
+    context 'when client is not viewable' do
+      let!(:access_control) { create_access_control(hmis_user, ds1, without_permission: [:can_view_clients]) }
+      it 'returns access denied error' do
+        expect_access_denied(post_graphql(client_id: c1.id) { mutation })
+      end
+    end
+
+    context 'when client does not exist' do
+      it 'returns access denied error' do
+        expect_access_denied(post_graphql(client_id: '999999') { mutation })
+      end
+    end
+  end
+
+  context 'when AHA is not enabled' do
+    before do
+      allow(HmisExternalApis::AcHmis::Aha).to receive(:enabled?).and_return(false)
+    end
+
+    it 'returns server error' do
+      perform_mutation(client_id: c1.id) do |data, errors|
+        expect(data['score']).to be_nil
+        expect(errors).to contain_exactly(
+          include(
+            'type' => 'server_error',
+            'fullMessage' => 'AHA connection is not configured',
+          ),
+        )
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -39,7 +39,8 @@ module HmisExternalApis::AcHmis
     CONNECTION_TIMEOUT_SECONDS = Rails.env.staging? ? 10 : 5
 
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to AHA')
-    NoMciUniqueIdError = HmisErrors::ApiError.new(display_message: 'Client does not have an MCI unique ID')
+    # Custom error class for MciUniqueId so the mutation can catch it
+    class NoMciUniqueIdError < HmisErrors::ApiError; end
 
     def fetch_score(client)
       # Collect MCI unique IDs for this client and all source clients with the same destination client


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Patch bug introduced into release-188 (not yet released) with https://github.com/greenriver/hmis-warehouse/pull/5953.
Issue: https://github.com/open-path/Green-River/issues/8441

* Fix bug where error wasn't being rescued properly. When "testing" locally I had stubbed out the responses / API behavior separately so I didn't full test it.
* Add test suite for FetchAhaScore mutation

**Local testing procedure:**
* setup: comment-out the credential check in FetchAhaScore
* perform AHA lookup assessment for client without MCI Unique ID, ensure message is shown
  * Save, reopen, ensure AHA score appears as -1
  * (Add MCI Unique ID to client, mock successful response in the Aha api class)
  * Unlock form, re-fetch AHA score, resubmit assessment


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
