### PR TITLE
Prevent page crash for CE Referrals when source enrollment is deleted 8539

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -216,6 +216,7 @@ module Types
 
       # Resolve source Enrollment without checking viewable_by.This resolves as type CeReferralSourceEnrollment, so it only exposes limited data from the Enrollment
       enrollment = load_ar_association(object, :source_enrollment)
+      return unless enrollment # May be missing if source enrollment was deleted and reference was not cleaned up
 
       # Not passing definition_identifiers because we don't need to resolve assessment data in this context (for now)
       OpenStruct.new(enrollment: enrollment, definition_identifiers: [])

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -236,6 +236,19 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         end
       end
 
+      context 'with dangling source enrollment reference (regression #8539)' do
+        let!(:deleted_source_enrollment) { create(:hmis_hud_enrollment, date_deleted: Time.current, client: client, data_source: ds1) }
+        before do
+          referral.update!(source_enrollment: deleted_source_enrollment)
+        end
+
+        it 'returns the referral with a null source enrollment' do
+          response, result = post_graphql(**variables) { query }
+          expect(response.status).to eq(200), result.inspect
+          expect(result.dig('data', 'ceReferral', 'sourceEnrollment')).to be_nil
+        end
+      end
+
       it 'returns no referral when user lacks permission' do
         # see additional permission logic testing in the model spec referral_permission_spec
         remove_permissions(ds_access_control, :can_view_referrals)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8539

Minimal patch for the Sentry crash linked in the issue. The issue occurs when the Source Enrollment for a Referral is deleted. The `source_enrollment_id` value remains (foreign key doesn't restrict due to soft-deletion) but the Enrollment does not resolve.

We most likely want a more comprehensive solution to prevent dangling referrals (https://github.com/greenriver/hmis-warehouse/pull/6000 is in draft), but opening this immediate fix separately to prevent users from continuing to get a crashed page in this scenario.


**How to test**:
- create a referral (direct or waitlist)
- delete the source enrollment
- view the referral
  - **before:** page crashes
  - **now:** referral page renders, detail panel shows no source enrollment
## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
