### PR TITLE
Try adding referral validation for target enrollment

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral.rb
@@ -106,6 +106,7 @@ module Hmis::Ce
     validate :unique_referral_per_opportunity
     validate :ce_template
     validate :consistent_data_source
+    validate :consistent_project
 
     # When referral status changes, its CustomReferralStatus (user-facing status) should also be updated.
     # See ReferralMessageHandler for example.
@@ -236,6 +237,12 @@ module Hmis::Ce
       # Source enrollment doesn't necessarily need to be in the same data source as the opportunity
 
       errors.add(:custom_status, msg) if custom_status && data_source != custom_status.data_source
+    end
+
+    def consistent_project
+      return unless target_enrollment
+
+      errors.add(:target_enrollment, 'must be in same project as referral') unless target_enrollment.project == target_project
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/ce/referral_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Hmis::Ce::Referral, type: :model do
       end.to raise_error(ActiveRecord::RecordInvalid, /Status must be one of/)
     end
 
+    it 'does not save a referral with an invalid target enrollment in the wrong project' do
+      referral = create(:hmis_ce_referral, opportunity: opportunity, data_source: data_source)
+      other_enrollment = create(:hmis_hud_enrollment, data_source: data_source, client: referral.client)
+      referral.target_enrollment = other_enrollment
+
+      expect(referral.valid?).to be_falsy
+      expect do
+        referral.save!
+      end.to raise_error(ActiveRecord::RecordInvalid, /must be in same project/)
+    end
+
     ['initialized', 'in_progress', 'accepted'].each do |status|
       context "when there is an existing #{status} referral" do
         let!(:existing) { create(:hmis_ce_referral, opportunity: opportunity, data_source: data_source, status: status) }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Add a validation to the Referral model, making explicit our assumption that the target enrollment is always in the referral's target project.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
