### PR TITLE
Stupidedi gem frozen string literals

### DIFF
--- a/app/models/health/eligibility_inquiry.rb
+++ b/app/models/health/eligibility_inquiry.rb
@@ -113,53 +113,66 @@ module Health
       sender_id = "#{sender.pid}#{sender.sl}"
       application_id = id&.to_s
 
-      b.ISA '00', b.blank, '00', b.blank, 'ZZ', sender_id, 'ZZ', sender.receiver_id, created_at, created_at, '^', '00501', isa_control_number, '0', interchange_usage_indicator, '>'
-      b.GS 'HS', sender_id, sender.receiver_id, created_at, created_at.strftime('%H%M'), group_control_number, 'X', '005010X279A1'
-      b.ST '270', transaction_control_number, '005010X279A1'
-      b.BHT '0022', '13', application_id, created_at, created_at.strftime('%H%M')
+      # Ensure all string values are mutable to avoid frozen string literal warnings
+      # Stupidedi builder methods are mutating the string within the gem flagging the frozen string literal warnings.
+      b.ISA(*mutable_args('00', b.blank, '00', b.blank, 'ZZ', sender_id, 'ZZ', sender.receiver_id.to_s, created_at, created_at, '^', '00501', isa_control_number.to_s, '0', interchange_usage_indicator.to_s, '>'))
+      b.GS(*mutable_args('HS', sender_id, sender.receiver_id, created_at, created_at.strftime('%H%M'), group_control_number, 'X', '005010X279A1'))
+      b.ST(*mutable_args('270', transaction_control_number, '005010X279A1'))
+      b.BHT(*mutable_args('0022', '13', application_id, created_at, created_at.strftime('%H%M')))
       # Information source
       hl += 1
-      b.HL hl, b.blank, '20', '1'
-      b.NM1 'PR', '2', sender.receiver_name, b.blank, b.blank, b.blank, b.blank, '46', sender.receiver_id
+      b.HL(*mutable_args(hl, b.blank, '20', '1'))
+      b.NM1(*mutable_args('PR', '2', sender.receiver_name, b.blank, b.blank, b.blank, b.blank, '46', sender.receiver_id))
       # Information receiver
       hl += 1
-      b.HL hl, '1', '21', '1'
-      b.NM1 '1P', '2', sender.mmis_enrollment_name, b.blank, b.blank, b.blank, b.blank, 'XX', sender.npi
+      b.HL(*mutable_args(hl, '1', '21', '1'))
+      b.NM1(*mutable_args('1P', '2', sender.mmis_enrollment_name, b.blank, b.blank, b.blank, b.blank, 'XX', sender.npi))
 
       batch.each do |patient|
         # Subscriber information
         hl += 1
-        b.HL hl, '2', '22', '0'
+        b.HL(*mutable_args(hl, '2', '22', '0'))
         # Use the patient's medicaid id as the trace record number
-        b.TRN '1', patient.medicaid_id, sender.trace_id
-        b.NM1 'IL', '1', patient.last_name, patient.first_name, patient.middle_name, b.blank, b.blank, 'MI', patient.medicaid_id
-        b.DMG 'D8', patient.birthdate&.strftime('%Y%m%d'), edi_gender(patient.gender)
-        b.DTP '291', 'D8', service_date.strftime('%Y%m%d')
-        b.EQ(b.repeated('30'))
+        b.TRN(*mutable_args('1', patient.medicaid_id, sender.trace_id))
+        b.NM1(*mutable_args('IL', '1', patient.last_name, patient.first_name, patient.middle_name, b.blank, b.blank, 'MI', patient.medicaid_id))
+        b.DMG(*mutable_args('D8', patient.birthdate&.strftime('%Y%m%d'), edi_gender(patient.gender)))
+        b.DTP(*mutable_args('291', 'D8', service_date.strftime('%Y%m%d')))
+        b.EQ(b.repeated(*mutable_args('30')))
       end
 
       m = b.machine
       st = m
       st = st.parent.fetch while st.segment.fetch.node.id != :ST
 
-      b.SE 2 + m.distance(st).fetch, transaction_control_number
-      b.GE '1', group_control_number
-      b.IEA '1', isa_control_number
+      b.SE(*mutable_args(2 + m.distance(st).fetch, transaction_control_number))
+      b.GE(*mutable_args('1', group_control_number))
+      b.IEA(*mutable_args('1', isa_control_number))
 
       @edi_builder = b
+    end
+
+    # Helper method to make strings in an argument array mutable
+    # Preserves special objects like b.blank and non-string values like dates
+    private def mutable_args(*args)
+      args.map do |arg|
+        arg.is_a?(String) ? arg.dup : arg
+      end
     end
 
     private def convert_to_text
       file = ''
       @edi_builder.machine.zipper.tap do |z|
+        # Stupidedi to mutate the strings within the gem flagging the frozen string literal warnings. The strings are duped to avoid the warnings.
         separators = Stupidedi::Reader::Separators.build(
-          segment: "~\n",
-          element: '*',
-          component: '>',
-          repetition: '^',
+          segment: "~\n".dup,
+          element: '*'.dup,
+          component: '>'.dup,
+          repetition: '^'.dup,
         )
         w = Stupidedi::Writer::Default.new(z.root, separators)
-        file = w.write.upcase
+        # Pass a mutable string buffer to avoid frozen string literal warnings
+        # The gem's write method has a default parameter "" which is frozen in Ruby 3.4
+        file = w.write(String.new).upcase
       end
       file
     end

--- a/spec/models/health/eligibility_inquiry_spec.rb
+++ b/spec/models/health/eligibility_inquiry_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Health::EligibilityInquiry, type: :model do
+  before(:all) do
+    Health::Cp.destroy_all
+  end
+
+  let!(:sender) { create :sender }
+  let!(:patient_1) { create :patient, medicaid_id: '123456789', first_name: 'John', last_name: 'Doe', middle_name: 'M', birthdate: Date.new(1990, 1, 1), gender: 'M' }
+  let!(:patient_2) { create :patient, medicaid_id: '987654321', first_name: 'Jane', last_name: 'Smith', middle_name: nil, birthdate: Date.new(1985, 5, 15), gender: 'F' }
+  let(:inquiry) { create :eligibility_inquiry, service_date: Date.current }
+
+  before(:each) do
+    inquiry.batch = [patient_1, patient_2]
+    inquiry.save!
+  end
+
+  describe '#build_inquiry_file' do
+    it 'generates inquiry text without errors' do
+      expect { inquiry.build_inquiry_file }.not_to raise_error
+    end
+
+    it 'generates non-empty inquiry text' do
+      inquiry.build_inquiry_file
+      expect(inquiry.inquiry).to be_present
+      expect(inquiry.inquiry.length).to be > 0
+    end
+
+    it 'generates EDI format with required segments' do
+      inquiry.build_inquiry_file
+      edi_text = inquiry.inquiry
+
+      expect(edi_text).to include('ISA')
+      expect(edi_text).to include('GS')
+      expect(edi_text).to include('ST')
+      expect(edi_text).to include('BHT')
+      expect(edi_text).to include('HL')
+      expect(edi_text).to include('NM1')
+      expect(edi_text).to include('DMG')
+      expect(edi_text).to include('DTP')
+      expect(edi_text).to include('EQ')
+      expect(edi_text).to include('SE')
+      expect(edi_text).to include('GE')
+      expect(edi_text).to include('IEA')
+    end
+
+    it 'includes patient medicaid IDs in the EDI file' do
+      inquiry.build_inquiry_file
+      edi_text = inquiry.inquiry
+
+      expect(edi_text).to include(patient_1.medicaid_id)
+      expect(edi_text).to include(patient_2.medicaid_id)
+    end
+
+    it 'includes patient names in the EDI file' do
+      inquiry.build_inquiry_file
+      edi_text = inquiry.inquiry
+
+      expect(edi_text).to include(patient_1.last_name.upcase)
+      expect(edi_text).to include(patient_1.first_name.upcase)
+      expect(edi_text).to include(patient_2.last_name.upcase)
+      expect(edi_text).to include(patient_2.first_name.upcase)
+    end
+
+    it 'does not raise frozen string literal warnings' do
+      expect { inquiry.build_inquiry_file }.not_to raise_error
+    end
+
+    it 'sets control numbers when saved' do
+      expect(inquiry.isa_control_number).to be_present
+      expect(inquiry.group_control_number).to be_present
+      expect(inquiry.transaction_control_number).to be_present
+    end
+  end
+
+  describe '#build_inquiry_edi' do
+    it 'builds EDI structure without errors' do
+      expect { inquiry.send(:build_inquiry_edi) }.not_to raise_error
+    end
+
+    it 'sets @edi_builder instance variable' do
+      inquiry.send(:build_inquiry_edi)
+      expect(inquiry.instance_variable_get(:@edi_builder)).to be_present
+    end
+  end
+
+  describe '#convert_to_text' do
+    before do
+      inquiry.send(:build_inquiry_edi)
+    end
+
+    it 'converts EDI builder to text without errors' do
+      expect { inquiry.send(:convert_to_text) }.not_to raise_error
+    end
+
+    it 'returns a string' do
+      result = inquiry.send(:convert_to_text)
+      expect(result).to be_a(String)
+      expect(result.length).to be > 0
+    end
+
+    it 'generates uppercase EDI text' do
+      result = inquiry.send(:convert_to_text)
+      expect(result).to eq(result.upcase)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Clean up the frozen strings being used within the Stupidedi gem by passing mutable versions into the gem's method calls.

Note: I was running this succcessfully within a script calling the `build_inquiry_edi` method

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
