### PR TITLE
remove PH from required move in date text

### DIFF
--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -1209,8 +1209,8 @@ module HmisDataQualityTool
           so_missed_exit_length: 365,
         },
         days_in_ph_prior_to_move_in_90_issues: {
-          title: 'Possible Missed Move In Date - PH, Time in Enrollment 90 Days or More',
-          description: 'There is an expectation that clients in PH will eventually move into housing, these clients have been in PH without a move-in date 90 days ore more, or have an invalid move-in date ',
+          title: 'Possible Missed Move In Date, Time in Enrollment 90 Days or More',
+          description: 'There is an expectation that clients will eventually move into housing, these clients have been without a move-in date 90 days ore more, or have an invalid move-in date ',
           required_for: 'HoH in PH (excluding RRH-SSO) and SSO with VA: GPD CM/HR',
           detail_columns: default_detail_columns + [
             :project_type,
@@ -1233,8 +1233,8 @@ module HmisDataQualityTool
           ph_missed_exit_length: 90,
         },
         days_in_ph_prior_to_move_in_180_issues: {
-          title: 'Possible Missed Move In Date - PH, Time in Enrollment 180 Days or More',
-          description: 'There is an expectation that clients in PH will eventually move into housing, these clients have been in PH without a move-in date 180 days ore more, or have an invalid move-in date',
+          title: 'Possible Missed Move In Date, Time in Enrollment 180 Days or More',
+          description: 'There is an expectation that clients will eventually move into housing, these clients have been without a move-in date 180 days ore more, or have an invalid move-in date',
           required_for: 'HoH in PH (excluding RRH-SSO) and SSO with VA: GPD CM/HR',
           detail_columns: default_detail_columns + [
             :project_type,
@@ -1257,8 +1257,8 @@ module HmisDataQualityTool
           ph_missed_exit_length: 180,
         },
         days_in_ph_prior_to_move_in_365_issues: {
-          title: 'Possible Missed Move In Date - PH, Time in Enrollment 365 Days or More',
-          description: 'There is an expectation that clients in PH will eventually move into housing, these clients have been in PH without a move-in date 365 days or more, or have an invalid move-in date',
+          title: 'Possible Missed Move In Date, Time in Enrollment 365 Days or More',
+          description: 'There is an expectation that clients will eventually move into housing, these clients have been without a move-in date 365 days or more, or have an invalid move-in date',
           required_for: 'HoH in PH (excluding RRH-SSO) and SSO with VA: GPD CM/HR',
           detail_columns: default_detail_columns + [
             :project_type,

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           # Verify clients are found in the report
           expect(@report.clients.count).to be > 0
 
-          expect_result(title: 'Name', invalid_count: 0)
+          expect_result(key: :name_issues, invalid_count: 0)
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags name issues' do
-          expect_result(title: 'Name', invalid_count: 1)
+          expect_result(key: :name_issues, invalid_count: 1)
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags name issues' do
-          expect_result(title: 'Name', invalid_count: 1)
+          expect_result(key: :name_issues, invalid_count: 1)
         end
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid SSNs' do
-          expect_result(title: 'Social Security Number', invalid_count: 0)
+          expect_result(key: :ssn_issues, invalid_count: 0)
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags SSN issues' do
-          expect_result(title: 'Social Security Number', invalid_count: 1)
+          expect_result(key: :ssn_issues, invalid_count: 1)
         end
       end
 
@@ -111,7 +111,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags SSN issues' do
-          expect_result(title: 'Social Security Number', invalid_count: 1)
+          expect_result(key: :ssn_issues, invalid_count: 1)
         end
       end
 
@@ -125,7 +125,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags SSN issues' do
-          expect_result(title: 'Social Security Number', invalid_count: 1)
+          expect_result(key: :ssn_issues, invalid_count: 1)
         end
       end
     end
@@ -141,7 +141,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid DOBs' do
-          expect_result(title: 'DOB', invalid_count: 0)
+          expect_result(key: :dob_issues, invalid_count: 0)
         end
       end
 
@@ -154,7 +154,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags DOB issues' do
-          expect_result(title: 'DOB', invalid_count: 1)
+          expect_result(key: :dob_issues, invalid_count: 1)
         end
       end
 
@@ -168,7 +168,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags DOB issues' do
-          expect_result(title: 'DOB', invalid_count: 1)
+          expect_result(key: :dob_issues, invalid_count: 1)
         end
       end
 
@@ -182,7 +182,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags DOB issues' do
-          expect_result(title: 'DOB', invalid_count: 1)
+          expect_result(key: :dob_issues, invalid_count: 1)
         end
       end
     end
@@ -207,7 +207,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid race data' do
-          expect_result(title: 'Race', invalid_count: 0)
+          expect_result(key: :race_issues, invalid_count: 0)
         end
       end
 
@@ -230,7 +230,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags race issues' do
-          expect_result(title: 'Race', invalid_count: 1)
+          expect_result(key: :race_issues, invalid_count: 1)
         end
       end
 
@@ -253,7 +253,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags race issues' do
-          expect_result(title: 'Race', invalid_count: 1)
+          expect_result(key: :race_issues, invalid_count: 1)
         end
       end
     end
@@ -269,7 +269,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid veteran status' do
-          expect_result(title: 'Veteran Status', invalid_count: 0)
+          expect_result(key: :veteran_issues, invalid_count: 0)
         end
       end
 
@@ -283,7 +283,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags veteran status issues' do
-          expect_result(title: 'Veteran Status', invalid_count: 1)
+          expect_result(key: :veteran_issues, invalid_count: 1)
         end
       end
 
@@ -298,7 +298,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
 
         it 'does not flag veteran status for children' do
           # Children are not in the denominator
-          expect_result(title: 'Veteran Status', total: 0, invalid_count: 0)
+          expect_result(key: :veteran_issues, total: 0, invalid_count: 0)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
 
         it 'does not flag short stays' do
           # Should not be flagged if under 90 days
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 90 Days or More', invalid_count: 0)
+          expect_result(key: :lot_es_90_issues, invalid_count: 0)
         end
       end
 
@@ -49,7 +49,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags long ES stays' do
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 90 Days or More', invalid_count: 1)
+          expect_result(key: :lot_es_90_issues, invalid_count: 1)
         end
       end
 
@@ -68,8 +68,8 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags very long ES stays' do
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 180 Days or More', invalid_count: 1)
+          expect_result(key: :lot_es_90_issues, invalid_count: 1)
+          expect_result(key: :lot_es_180_issues, invalid_count: 1)
         end
       end
 
@@ -88,9 +88,9 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags very long ES stays' do
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 180 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - ES, Time in Enrollment 365 Days or More', invalid_count: 1)
+          expect_result(key: :lot_es_90_issues, invalid_count: 1)
+          expect_result(key: :lot_es_180_issues, invalid_count: 1)
+          expect_result(key: :lot_es_365_issues, invalid_count: 1)
         end
       end
     end
@@ -113,7 +113,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag recent service' do
-          expect_result(title: 'Possible Missed Exit - ES NbN, No Service in 90 Days or More', invalid_count: 0)
+          expect_result(key: :days_since_last_service_es_90_issues, invalid_count: 0)
         end
       end
 
@@ -134,7 +134,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing service' do
-          expect_result(title: 'Possible Missed Exit - ES NbN, No Service in 90 Days or More', invalid_count: 1)
+          expect_result(key: :days_since_last_service_es_90_issues, invalid_count: 1)
         end
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags long SO stays' do
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 90 Days or More', invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_90_issues, invalid_count: 1)
         end
       end
 
@@ -174,8 +174,8 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags long SO stays' do
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 180 Days or More', invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_90_issues, invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_180_issues, invalid_count: 1)
         end
       end
 
@@ -194,9 +194,9 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags long SO stays' do
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 180 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 365 Days or More', invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_90_issues, invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_180_issues, invalid_count: 1)
+          expect_result(key: :days_since_last_service_so_365_issues, invalid_count: 1)
         end
       end
 
@@ -215,7 +215,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid move-in dates' do
-          expect_result(title: 'Possible Missed Exit - SO, Time in Enrollment 90 Days or More', invalid_count: 0)
+          expect_result(key: :days_since_last_service_so_90_issues, invalid_count: 0)
         end
       end
     end
@@ -238,7 +238,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing move-in date' do
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 90 Days or More', invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_90_issues, invalid_count: 1)
         end
       end
 
@@ -259,8 +259,8 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing move-in date' do
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 180 Days or More', invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_90_issues, invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_180_issues, invalid_count: 1)
         end
       end
 
@@ -281,9 +281,9 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing move-in date' do
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 90 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 180 Days or More', invalid_count: 1)
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 365 Days or More', invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_90_issues, invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_180_issues, invalid_count: 1)
+          expect_result(key: :days_in_ph_prior_to_move_in_365_issues, invalid_count: 1)
         end
       end
 
@@ -305,7 +305,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid move-in dates' do
-          expect_result(title: 'Possible Missed Move In Date - PH, Time in Enrollment 90 Days or More', invalid_count: 0)
+          expect_result(key: :days_in_ph_prior_to_move_in_90_issues, invalid_count: 0)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid disabling condition' do
-          expect_result(title: 'Disabling Condition', invalid_count: 0)
+          expect_result(key: :disabling_condition_issues, invalid_count: 0)
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags disabling condition issues' do
-          expect_result(title: 'Disabling Condition', invalid_count: 1)
+          expect_result(key: :disabling_condition_issues, invalid_count: 1)
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid living situation' do
-          expect_result(title: 'Prior Living Situation', invalid_count: 0)
+          expect_result(key: :living_situation_issues, invalid_count: 0)
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags living situation issues' do
-          expect_result(title: 'Prior Living Situation', invalid_count: 1)
+          expect_result(key: :living_situation_issues, invalid_count: 1)
         end
       end
     end
@@ -109,8 +109,8 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid HoH' do
-          expect_result(title: 'No Head of Household', invalid_count: 0)
-          expect_result(title: 'Multiple Heads of Household', invalid_count: 0)
+          expect_result(key: :no_hoh_issues, invalid_count: 0)
+          expect_result(key: :multiple_hoh_issues, invalid_count: 0)
         end
       end
 
@@ -129,7 +129,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags no HoH issues' do
-          expect_result(title: 'No Head of Household', invalid_count: 1)
+          expect_result(key: :no_hoh_issues, invalid_count: 1)
         end
       end
 
@@ -159,7 +159,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags multiple HoH issues' do
-          expect_result(title: 'Multiple Heads of Household', total: 2, invalid_count: 2)
+          expect_result(key: :multiple_hoh_issues, total: 2, invalid_count: 2)
         end
       end
     end
@@ -179,7 +179,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid exit dates' do
-          expect_result(title: 'Exit Before Entry', invalid_count: 0)
+          expect_result(key: :exit_date_issues, invalid_count: 0)
         end
       end
 
@@ -197,7 +197,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags exit date issues' do
-          expect_result(title: 'Exit Before Entry', invalid_count: 1)
+          expect_result(key: :exit_date_issues, invalid_count: 1)
         end
       end
     end
@@ -218,7 +218,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid destinations' do
-          expect_result(title: 'Destination', invalid_count: 0)
+          expect_result(key: :destination_issues, invalid_count: 0)
         end
       end
 
@@ -237,7 +237,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags destination issues' do
-          expect_result(title: 'Destination', invalid_count: 1)
+          expect_result(key: :destination_issues, invalid_count: 1)
         end
       end
     end
@@ -274,7 +274,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags future entry date issues' do
-          expect_result(title: 'Future Entry Date', invalid_count: 1)
+          expect_result(key: :future_entry_date_issues, invalid_count: 1)
         end
       end
 
@@ -292,7 +292,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags future exit date issues' do
-          expect_result(title: 'Future Exit Date', invalid_count: 1)
+          expect_result(key: :future_exit_date_issues, invalid_count: 1)
         end
       end
     end
@@ -314,7 +314,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags move-in date issues' do
-          expect_result(title: 'Move-In Before Entry Date', invalid_count: 1)
+          expect_result(key: :move_in_prior_to_start_issues, invalid_count: 1)
         end
       end
 
@@ -334,7 +334,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags move-in date issues' do
-          expect_result(title: 'Move-In After Exit Date', invalid_count: 1)
+          expect_result(key: :move_in_post_exit_issues, invalid_count: 1)
         end
       end
     end
@@ -358,7 +358,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid operating dates' do
-          expect_result(title: 'Enrollment Active Outside of Project Operating Dates', invalid_count: 0)
+          expect_result(key: :enrollment_outside_project_operating_dates_issues, invalid_count: 0)
         end
       end
 
@@ -380,7 +380,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags operating date issues' do
-          expect_result(title: 'Enrollment Active Outside of Project Operating Dates', invalid_count: 1)
+          expect_result(key: :enrollment_outside_project_operating_dates_issues, invalid_count: 1)
         end
       end
     end
@@ -401,7 +401,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags unaccompanied youth under 12' do
-          expect_result(title: 'Unaccompanied Youth < 12 Years Old', invalid_count: 1)
+          expect_result(key: :unaccompanied_youth_issues, invalid_count: 1)
         end
       end
 
@@ -431,7 +431,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag accompanied youth' do
-          expect_result(title: 'Unaccompanied Youth < 12 Years Old', invalid_count: 0)
+          expect_result(key: :unaccompanied_youth_issues, invalid_count: 0)
         end
       end
     end
@@ -453,7 +453,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing enrollment CoC' do
-          expect_result(title: 'Head of Household is Missing Enrollment CoC', invalid_count: 1)
+          expect_result(key: :hoh_client_location_issues, invalid_count: 1)
         end
       end
 
@@ -473,7 +473,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag matching CoC' do
-          expect_result(title: 'Head of Household is Missing Enrollment CoC', invalid_count: 0)
+          expect_result(key: :hoh_client_location_issues, invalid_count: 0)
         end
       end
     end
@@ -499,7 +499,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing DV data' do
-          expect_result(title: 'Survivor of Domestic Violence', invalid_count: 1)
+          expect_result(key: :dv_at_entry, invalid_count: 1)
         end
       end
 
@@ -523,7 +523,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid DV data' do
-          expect_result(title: 'Survivor of Domestic Violence', invalid_count: 0)
+          expect_result(key: :dv_at_entry, invalid_count: 0)
         end
       end
     end
@@ -550,7 +550,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when disabilities are collected' do
-          expect_result(title: 'Disability at entry', invalid_count: 0)
+          expect_result(key: :disability_at_entry_collected, invalid_count: 0)
         end
       end
 
@@ -575,7 +575,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when disabilities are not collected' do
-          expect_result(title: 'Disability at entry', invalid_count: 1)
+          expect_result(key: :disability_at_entry_collected, invalid_count: 1)
         end
       end
     end
@@ -604,7 +604,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid VAMC station' do
-          expect_result(title: 'VAMC Station Number is Missing', invalid_count: 0)
+          expect_result(key: :vamc_station, invalid_count: 0)
         end
       end
 
@@ -631,7 +631,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing VAMC station' do
-          expect_result(title: 'VAMC Station Number is Missing', invalid_count: 1)
+          expect_result(key: :vamc_station, invalid_count: 1)
         end
       end
     end
@@ -659,7 +659,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when veteran is in household' do
-          expect_result(title: 'No Veteran in Household', invalid_count: 0)
+          expect_result(key: :no_veteran_in_household, invalid_count: 0)
         end
       end
 
@@ -685,7 +685,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when no veteran is in household' do
-          expect_result(title: 'No Veteran in Household', invalid_count: 1)
+          expect_result(key: :no_veteran_in_household, invalid_count: 1)
         end
       end
     end
@@ -713,7 +713,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when HoH is a veteran' do
-          expect_result(title: 'Head of Household is not a Veteran', invalid_count: 0)
+          expect_result(key: :hoh_not_veteran, invalid_count: 0)
         end
       end
 
@@ -739,7 +739,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when HoH is not a veteran' do
-          expect_result(title: 'Head of Household is not a Veteran', invalid_count: 1)
+          expect_result(key: :hoh_not_veteran, invalid_count: 1)
         end
       end
     end
@@ -762,7 +762,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when date to street is present' do
-          expect_result(title: 'Approximate Date Homeless', invalid_count: 0)
+          expect_result(key: :date_to_street_issues, invalid_count: 0)
         end
       end
 
@@ -783,7 +783,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when date to street is missing' do
-          expect_result(title: 'Approximate Date Homeless', invalid_count: 1)
+          expect_result(key: :date_to_street_issues, invalid_count: 1)
         end
       end
     end
@@ -807,7 +807,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when times homeless is present' do
-          expect_result(title: 'Number Times Homeless', invalid_count: 0)
+          expect_result(key: :times_homeless_issues, invalid_count: 0)
         end
       end
 
@@ -829,7 +829,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when times homeless is missing' do
-          expect_result(title: 'Number Times Homeless', invalid_count: 1)
+          expect_result(key: :times_homeless_issues, invalid_count: 1)
         end
       end
     end
@@ -853,7 +853,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when months homeless is present' do
-          expect_result(title: 'Number of Months Homeless', invalid_count: 0)
+          expect_result(key: :months_homeless_issues, invalid_count: 0)
         end
       end
 
@@ -875,7 +875,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when months homeless is missing' do
-          expect_result(title: 'Number of Months Homeless', invalid_count: 1)
+          expect_result(key: :months_homeless_issues, invalid_count: 1)
         end
       end
     end
@@ -898,7 +898,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag timely entry date entry' do
-          expect_result(title: 'Time for Record Entry of Entry Date', invalid_count: 0)
+          expect_result(key: :entry_date_entry_issues, invalid_count: 0)
         end
       end
 
@@ -919,7 +919,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags untimely entry date entry' do
-          expect_result(title: 'Time for Record Entry of Entry Date', invalid_count: 1)
+          expect_result(key: :entry_date_entry_issues, invalid_count: 1)
         end
       end
     end
@@ -949,7 +949,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid current living situation' do
-          expect_result(title: 'Current Living Situation', invalid_count: 0)
+          expect_result(key: :current_living_situation_issues, invalid_count: 0)
         end
       end
 
@@ -977,7 +977,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags invalid current living situation' do
-          expect_result(title: 'Current Living Situation', invalid_count: 1)
+          expect_result(key: :current_living_situation_issues, invalid_count: 1)
         end
       end
     end
@@ -1001,7 +1001,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag timely exit date entry' do
-          expect_result(title: 'Time for Record Entry of Exit Date', invalid_count: 0)
+          expect_result(key: :exit_date_entry_issues, invalid_count: 0)
         end
       end
 
@@ -1023,7 +1023,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags untimely exit date entry' do
-          expect_result(title: 'Time for Record Entry of Exit Date', invalid_count: 1)
+          expect_result(key: :exit_date_entry_issues, invalid_count: 1)
         end
       end
     end
@@ -1059,7 +1059,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag when annual assessments are complete' do
-          expect_result(title: 'Incomplete Annual Assessments', invalid_count: 0)
+          expect_result(key: :annual_assessment_issues, invalid_count: 0)
         end
       end
 
@@ -1081,7 +1081,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags when annual assessments are missing' do
-          expect_result(title: 'Incomplete Annual Assessments', invalid_count: 1)
+          expect_result(key: :annual_assessment_issues, invalid_count: 1)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid income data' do
-          expect_result(title: 'Income From Any Source at Entry', invalid_count: 0)
+          expect_result(key: :income_from_any_source_at_entry, invalid_count: 0)
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing income data' do
-          expect_result(title: 'Income From Any Source at Entry', invalid_count: 1)
+          expect_result(key: :income_from_any_source_at_entry, invalid_count: 1)
         end
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid income data' do
-          expect_result(title: 'Income From Any Source at Annual Assessment', invalid_count: 0)
+          expect_result(key: :income_from_any_source_at_annual, invalid_count: 0)
         end
       end
 
@@ -129,7 +129,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing income data' do
-          expect_result(title: 'Income From Any Source at Annual Assessment', invalid_count: 1)
+          expect_result(key: :income_from_any_source_at_annual, invalid_count: 1)
         end
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid income data' do
-          expect_result(title: 'Income From Any Source at Exit', invalid_count: 0)
+          expect_result(key: :income_from_any_source_at_exit, invalid_count: 0)
         end
       end
 
@@ -185,7 +185,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing income data' do
-          expect_result(title: 'Income From Any Source at Exit', invalid_count: 1)
+          expect_result(key: :income_from_any_source_at_exit, invalid_count: 1)
         end
       end
     end
@@ -217,7 +217,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_entry, invalid_count: 1)
           end
         end
 
@@ -246,7 +246,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_entry, invalid_count: 1)
           end
         end
       end
@@ -281,7 +281,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_annual, invalid_count: 1)
           end
         end
 
@@ -314,7 +314,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_annual, invalid_count: 1)
           end
         end
       end
@@ -346,7 +346,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_exit, invalid_count: 1)
           end
         end
 
@@ -376,7 +376,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags cash income mismatch' do
-            expect_result(title: 'Cash Income Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :cash_income_as_expected_at_exit, invalid_count: 1)
           end
         end
       end
@@ -407,7 +407,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_entry, invalid_count: 1)
           end
         end
 
@@ -434,7 +434,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_entry, invalid_count: 1)
           end
         end
       end
@@ -467,7 +467,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_annual, invalid_count: 1)
           end
         end
 
@@ -498,7 +498,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_annual, invalid_count: 1)
           end
         end
       end
@@ -528,7 +528,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_exit, invalid_count: 1)
           end
         end
 
@@ -556,7 +556,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags NCB mismatch' do
-            expect_result(title: 'Non-Cash Benefits Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :ncb_as_expected_at_exit, invalid_count: 1)
           end
         end
       end
@@ -591,7 +591,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags income amount mismatch' do
-            expect_result(title: 'Total Monthly Income Matches Sources at Entry', invalid_count: 1)
+            expect_result(key: :income_source_amounts_match_total_at_entry, invalid_count: 1)
           end
         end
       end
@@ -625,7 +625,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags income amount mismatch' do
-            expect_result(title: 'Total Monthly Income Matches Sources at Exit', invalid_count: 1)
+            expect_result(key: :income_source_amounts_match_total_at_exit, invalid_count: 1)
           end
         end
       end
@@ -656,7 +656,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags total monthly income mismatch' do
-          expect_result(title: 'Total Monthly Income at Exit', invalid_count: 1)
+          expect_result(key: :total_monthly_income_at_exit, invalid_count: 1)
         end
       end
 
@@ -684,7 +684,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags total monthly income mismatch' do
-          expect_result(title: 'Total Monthly Income at Exit', invalid_count: 1)
+          expect_result(key: :total_monthly_income_at_exit, invalid_count: 1)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid insurance data' do
-          expect_result(title: 'Insurance From Any Source at Entry', invalid_count: 0)
+          expect_result(key: :insurance_from_any_source_at_entry, invalid_count: 0)
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing insurance data' do
-          expect_result(title: 'Insurance From Any Source at Entry', invalid_count: 1)
+          expect_result(key: :insurance_from_any_source_at_entry, invalid_count: 1)
         end
       end
     end
@@ -94,7 +94,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid insurance data' do
-          expect_result(title: 'Insurance From Any Source at Annual Assessment', invalid_count: 0)
+          expect_result(key: :insurance_from_any_source_at_annual, invalid_count: 0)
         end
       end
 
@@ -124,7 +124,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing insurance data' do
-          expect_result(title: 'Insurance From Any Source at Annual Assessment', invalid_count: 1)
+          expect_result(key: :insurance_from_any_source_at_annual, invalid_count: 1)
         end
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag valid insurance data' do
-          expect_result(title: 'Insurance From Any Source at Exit', invalid_count: 0)
+          expect_result(key: :insurance_from_any_source_at_exit, invalid_count: 0)
         end
       end
 
@@ -180,7 +180,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags missing insurance data' do
-          expect_result(title: 'Insurance From Any Source at Exit', invalid_count: 1)
+          expect_result(key: :insurance_from_any_source_at_exit, invalid_count: 1)
         end
       end
     end
@@ -210,7 +210,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_entry, invalid_count: 1)
           end
         end
 
@@ -237,7 +237,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Entry', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_entry, invalid_count: 1)
           end
         end
       end
@@ -270,7 +270,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_annual, invalid_count: 1)
           end
         end
 
@@ -301,7 +301,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Annual Assessment', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_annual, invalid_count: 1)
           end
         end
       end
@@ -331,7 +331,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_exit, invalid_count: 1)
           end
         end
 
@@ -359,7 +359,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags insurance mismatch' do
-            expect_result(title: 'Insurance Matches Expected Value at Exit', invalid_count: 1)
+            expect_result(key: :insurance_as_expected_at_exit, invalid_count: 1)
           end
         end
       end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/inventory_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/inventory_metrics_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag matching bed counts' do
-          expect_result(title: 'Sum of Dedicated Beds does not Equal Total Beds')
+          expect_result(key: :dedicated_bed_issues)
         end
       end
 
@@ -77,7 +77,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags mismatched bed counts' do
-          expect_result(title: 'Sum of Dedicated Beds does not Equal Total Beds', invalid_count: 1)
+          expect_result(key: :dedicated_bed_issues, invalid_count: 1)
         end
       end
 
@@ -110,7 +110,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag zero beds' do
-          expect_result(title: 'Sum of Dedicated Beds does not Equal Total Beds')
+          expect_result(key: :dedicated_bed_issues)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag non-overlapping enrollments' do
-          expect_result(title: 'Overlapping Entry/Exit enrollments in ES, SH, and TH', invalid_count: 0)
+          expect_result(key: :overlapping_entry_exit_issues, invalid_count: 0)
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags overlapping enrollments' do
-          expect_result(title: 'Overlapping Entry/Exit enrollments in ES, SH, and TH', invalid_count: 1)
+          expect_result(key: :overlapping_entry_exit_issues, invalid_count: 1)
         end
       end
 
@@ -82,7 +82,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags overlapping TH enrollments' do
-          expect_result(title: 'Overlapping Entry/Exit enrollments in ES, SH, and TH', invalid_count: 1)
+          expect_result(key: :overlapping_entry_exit_issues, invalid_count: 1)
         end
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags overlapping NBN enrollments' do
-          expect_result(title: 'Overlapping Night-by-Night ES enrollments with other ES, SH, and TH', invalid_count: 1)
+          expect_result(key: :overlapping_nbn_issues, invalid_count: 1)
         end
       end
     end
@@ -148,7 +148,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags overlapping PH enrollments' do
-          expect_result(title: 'Overlapping Moved-in PH', invalid_count: 1)
+          expect_result(key: :overlapping_post_move_in_issues, invalid_count: 1)
         end
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags overlapping homeless service after PH move-in' do
-          expect_result(title: 'Overlapping Homeless Service After Move-in in PH', invalid_count: 1)
+          expect_result(key: :overlapping_pre_move_in_issues, invalid_count: 1)
         end
       end
     end
@@ -217,7 +217,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags missing service' do
-            expect_result(title: 'Possible Missed Exit - ES NbN, No Service in 90 Days or More', invalid_count: 1)
+            expect_result(key: :days_since_last_service_es_90_issues, invalid_count: 1)
           end
         end
       end
@@ -240,7 +240,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags missing service' do
-            expect_result(title: 'Possible Missed Exit - ES NbN, No Service in 180 Days or More', invalid_count: 1)
+            expect_result(key: :days_since_last_service_es_180_issues, invalid_count: 1)
           end
         end
       end
@@ -263,7 +263,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
           end
 
           it 'flags missing service' do
-            expect_result(title: 'Possible Missed Exit - ES NbN, No Service in 365 Days or More', invalid_count: 1)
+            expect_result(key: :days_since_last_service_es_365_issues, invalid_count: 1)
           end
         end
       end
@@ -285,7 +285,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags homeless living situation' do
-          expect_result(title: 'HP - Homeless Prior Living Situation', invalid_count: 1)
+          expect_result(key: :homeless_living_situation_issues, invalid_count: 1)
         end
       end
 
@@ -304,7 +304,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag non-homeless living situation' do
-          expect_result(title: 'HP - Homeless Prior Living Situation', invalid_count: 0)
+          expect_result(key: :homeless_living_situation_issues, invalid_count: 0)
         end
       end
     end
@@ -325,7 +325,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'flags non-homeless living situation' do
-          expect_result(title: 'RRH - Non-Homeless Prior Living Situation', invalid_count: 1)
+          expect_result(key: :non_homeless_living_situation_issues, invalid_count: 1)
         end
       end
 
@@ -344,7 +344,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
 
         it 'does not flag homeless living situation' do
-          expect_result(title: 'RRH - Non-Homeless Prior Living Situation', invalid_count: 0)
+          expect_result(key: :non_homeless_living_situation_issues, invalid_count: 0)
         end
       end
     end

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/shared_context.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/shared_context.rb
@@ -111,9 +111,9 @@ RSpec.shared_context 'DQ Tool test setup', shared_context: :metadata do
   end
 
   # Helper method to DRY up result checking
-  def expect_result(title:, total: 1, invalid_count: 0, report: nil)
+  def expect_result(key:, total: 1, invalid_count: 0, report: nil)
     report ||= @report
-    result = report.results.find { |r| r.title == title }
+    result = report.results.find { |r| r.slug.to_s == key.to_s }
     expect(result).to be_present
     expect(result.total).to eq(total)
     expect(result.invalid_count).to eq(invalid_count)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Clean up text describing PH required move in dates now that its not only PH. The text removed the project type from the section and description but the `required for` text outlines specifically which types of projects require the move in date.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
