### PR TITLE
Fixes for 8395 hopwa caper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -474,11 +474,12 @@ module ApplicationHelper
   #
   # @example Usage:
   #   render_paginated_list(scope: users, item_name: 'user', list_partial: 'users/card')
+  #   render_paginated_list(scope: users, item_name: 'user', list_partial: 'users/card', list_locals: { headers: headers })
   #
-  def render_paginated_list(scope:, item_name:, list_partial:)
+  def render_paginated_list(scope:, item_name:, list_partial:, list_locals: {})
     pagy_sym = scope.is_a?(Array) ? :pagy_array : :pagy
     pagy, list = controller.send(pagy_sym, scope)
-    render_paginated_list_with_explicit_pagy(pagy: pagy, list: list, item_name: item_name, list_partial: list_partial)
+    render_paginated_list_with_explicit_pagy(pagy: pagy, list: list, item_name: item_name, list_partial: list_partial, list_locals: list_locals)
   end
 
   # Renders a paginated list of the items in `list` with pagination controls at the top and bottom based
@@ -489,18 +490,20 @@ module ApplicationHelper
   # @param [Array] list The list of items to render.
   # @param [String] item_name The singular name of the item being listed, used for messages.
   # @param [String] list_partial The path to the partial used to render the list items.
+  # @param [Hash] list_locals Optional additional local variables to pass to the list partial.
   #
   # @return [String] HTML markup for the paginated list with controls.
   #
   # @example Usage:
   #   render_paginated_list_with_explicit_pagy(pagy: @pagy, scope: @user_array, item_name: 'user', list_partial: 'users/card')
+  #   render_paginated_list_with_explicit_pagy(pagy: @pagy, list: @users, item_name: 'user', list_partial: 'users/card', list_locals: { show_actions: true })
   #
-  def render_paginated_list_with_explicit_pagy(pagy:, list:, item_name:, list_partial:)
+  def render_paginated_list_with_explicit_pagy(pagy:, list:, item_name:, list_partial:, list_locals: {})
     return content_tag(:div, "No #{item_name.pluralize} found", class: 'none-found') if pagy.count.zero?
 
     capture do
       concat render('common/pagination_top', item_name: item_name, pagy: pagy)
-      concat render(list_partial, list: list)
+      concat render(list_partial, { list: list }.merge(list_locals))
       concat render('common/pagination_bottom', item_name: item_name, pagy: pagy)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -476,7 +476,7 @@ module ApplicationHelper
   #   render_paginated_list(scope: users, item_name: 'user', list_partial: 'users/card')
   #   render_paginated_list(scope: users, item_name: 'user', list_partial: 'users/card', list_locals: { headers: headers })
   #
-  def render_paginated_list(scope:, item_name:, list_partial:, list_locals: {})
+  def render_paginated_list(scope:, item_name:, list_partial:, list_locals: {}.freeze)
     pagy_sym = scope.is_a?(Array) ? :pagy_array : :pagy
     pagy, list = controller.send(pagy_sym, scope)
     render_paginated_list_with_explicit_pagy(pagy: pagy, list: list, item_name: item_name, list_partial: list_partial, list_locals: list_locals)
@@ -498,7 +498,7 @@ module ApplicationHelper
   #   render_paginated_list_with_explicit_pagy(pagy: @pagy, scope: @user_array, item_name: 'user', list_partial: 'users/card')
   #   render_paginated_list_with_explicit_pagy(pagy: @pagy, list: @users, item_name: 'user', list_partial: 'users/card', list_locals: { show_actions: true })
   #
-  def render_paginated_list_with_explicit_pagy(pagy:, list:, item_name:, list_partial:, list_locals: {})
+  def render_paginated_list_with_explicit_pagy(pagy:, list:, item_name:, list_partial:, list_locals: {}.freeze)
     return content_tag(:div, "No #{item_name.pluralize} found", class: 'none-found') if pagy.count.zero?
 
     capture do

--- a/db/warehouse/migrate/20251121213404_undo_default_service_source_on_hopwa_caper_services.rb
+++ b/db/warehouse/migrate/20251121213404_undo_default_service_source_on_hopwa_caper_services.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UndoDefaultServiceSourceOnHopwaCaperServices < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_column_default :hopwa_caper_services, :service_source, from: 'hud_service', to: nil
+    end
+  end
+end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -131,7 +131,18 @@ module HopwaCaper
     def self.detail_headers
       special = ['personal_id', 'hmis_enrollment_id', 'first_name', 'last_name']
       remove = ['id', 'created_at', 'updated_at', 'report_instance_id', 'enrollment_id', 'report_household_id']
-      cols = special + (column_names - special - remove)
+      # Move 'sex' to appear right after 'races' (which should be near gender-related columns)
+      other_cols = column_names - special - remove - ['sex']
+      cols = special + other_cols
+
+      # Insert 'sex' after 'races' if races exists, otherwise add near the front
+      races_index = cols.index('races')
+      if races_index
+        cols.insert(races_index + 1, 'sex')
+      else
+        cols.insert(special.length, 'sex')
+      end
+
       cols.map do |header|
         label = case header
         when 'destination_client_id'
@@ -145,6 +156,15 @@ module HopwaCaper
         end
         [header, label]
       end.to_h
+    end
+
+    private
+
+    def transform_value(column, value, pii_policy)
+      return HudHelper.util('2026').sex(value) if column == 'sex'
+      return HudHelper.util('2026').percent_ami(value) if column == 'percent_ami'
+
+      super
     end
   end
 end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -48,6 +48,8 @@ module HopwaCaper
 
     scope :head_of_household, -> { where(relationship_to_hoh: 1) }
 
+    scope :active_after, ->(date) { where('exit_date IS NULL OR exit_date > ?', date) }
+
     INSURANCE_FIELDS = [
       :Medicaid,
       :Medicare,
@@ -69,6 +71,7 @@ module HopwaCaper
       :Unemployment,
       :OtherIncomeSource
     ].freeze
+
     def self.from_hud_record(enrollment:, report:, client:)
       project = enrollment.project
       # get deterministic order
@@ -128,22 +131,41 @@ module HopwaCaper
       enrollment.enrollment_id
     end
 
+    DETAIL_HEADER_ORDER = [
+      'personal_id',
+      'hmis_enrollment_id',
+      'first_name',
+      'last_name',
+      'destination_client_id',
+      'age',
+      'dob',
+      'dob_quality',
+      'genders',
+      'races',
+      'sex',
+      'veteran',
+      'entry_date',
+      'exit_date',
+      'relationship_to_hoh',
+      'project_funders',
+      'project_type',
+      'income_benefit_source_types',
+      'medical_insurance_types',
+      'hiv_positive',
+      'hopwa_eligible',
+      'chronically_homeless',
+      'prior_living_situation',
+      'rental_subsidy_type',
+      'exit_destination',
+      'housing_assessment_at_exit',
+      'subsidy_information',
+      'ever_prescribed_anti_retroviral_therapy',
+      'viral_load_suppression',
+      'percent_ami',
+    ].freeze
+
     def self.detail_headers
-      special = ['personal_id', 'hmis_enrollment_id', 'first_name', 'last_name']
-      remove = ['id', 'created_at', 'updated_at', 'report_instance_id', 'enrollment_id', 'report_household_id']
-      # Move 'sex' to appear right after 'races' (which should be near gender-related columns)
-      other_cols = column_names - special - remove - ['sex']
-      cols = special + other_cols
-
-      # Insert 'sex' after 'races' if races exists, otherwise add near the front
-      races_index = cols.index('races')
-      if races_index
-        cols.insert(races_index + 1, 'sex')
-      else
-        cols.insert(special.length, 'sex')
-      end
-
-      cols.map do |header|
+      DETAIL_HEADER_ORDER.map do |header|
         label = case header
         when 'destination_client_id'
           'Warehouse Client ID'
@@ -151,6 +173,10 @@ module HopwaCaper
           'HMIS Personal ID'
         when 'hmis_enrollment_id'
           'HMIS Enrollment ID'
+        when 'hiv_positive'
+          'HIV positive'
+        when 'percent_ami'
+          'Percent AMI'
         else
           header.humanize
         end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/age_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/age_filter.rb
@@ -13,10 +13,9 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
     end
 
     def apply(scope)
-      scope.where(age: range, dob_quality: [1, 2])
+      scope.where(age: range)
     end
 
-    # there's no bucket in the spec to count individuals with missing dobs
     def self.all
       [
         new(label: 'Younger than 18', range: 0...18),

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
@@ -84,7 +84,7 @@ module HopwaCaper::Generators::Fy2026::Sheets
       add_household_enrollments_row(
         sheet,
         label: 'How many households continued receiving this type of HOPWA assistance into the next year?',
-        enrollments: scope.where(exit_date: nil),
+        enrollments: scope.where('exit_date IS NULL OR exit_date > ?', @report.end_date),
       )
 
       filters = HopwaCaper::Generators::Fy2026::EnrollmentFilters::ExitDestinationFilter.all_destinations

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
@@ -84,7 +84,7 @@ module HopwaCaper::Generators::Fy2026::Sheets
       add_household_enrollments_row(
         sheet,
         label: 'How many households continued receiving this type of HOPWA assistance into the next year?',
-        enrollments: scope.where('exit_date IS NULL OR exit_date > ?', @report.end_date),
+        enrollments: scope.active_after(@report.end_date),
       )
 
       filters = HopwaCaper::Generators::Fy2026::EnrollmentFilters::ExitDestinationFilter.all_destinations

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -57,15 +57,19 @@ module HopwaCaper::Generators::Fy2026::Sheets
         )
       end
 
+      # Only include households that have services in the reporting period
+      households_with_services = relevant_services.select(:report_household_id).distinct.pluck(:report_household_id)
+      multi_type_household_ids = households_with_services - seen_household_ids.uniq
+
       add_household_enrollments_row(
         sheet,
         label: 'How many households received more than one type of STRMU assistance?',
-        enrollments: relevant_enrollments.where.not(report_household_id: seen_household_ids.uniq.sort),
+        enrollments: relevant_enrollments.where(report_household_id: multi_type_household_ids),
       )
       add_household_enrollments_row(
         sheet,
         label: 'STRMU Households Total',
-        enrollments: relevant_enrollments,
+        enrollments: relevant_enrollments.where(report_household_id: households_with_services),
       )
     end
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -58,8 +58,8 @@ module HopwaCaper::Generators::Fy2026::Sheets
       end
 
       # Only include households that have services in the reporting period
-      households_with_services = relevant_services.select(:report_household_id).distinct.pluck(:report_household_id)
-      multi_type_household_ids = households_with_services - seen_household_ids.uniq
+      households_with_services = relevant_services.distinct.pluck(:report_household_id).sort
+      multi_type_household_ids = (households_with_services - seen_household_ids.uniq).sort
 
       add_household_enrollments_row(
         sheet,

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
@@ -1,0 +1,16 @@
+.card
+  .overflow-x-scroll
+    %table.table.table-sm.table-bordered
+      %thead.table-dark
+        %tr
+          %th
+          - headers.each_value do |header|
+            %th= header
+      %tbody
+        - list.each.with_index do |record, i|
+          - pii_policy = current_user.reporting_policy_for_project(project_id: record.project_id)
+          %tr
+            %th= i + 1
+            - headers.each_key do |field|
+              %td{style: 'max-width: 600px;'}
+                = record.display_value(field, pii_policy: pii_policy, include_content_tag: true)

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
@@ -1,16 +1,16 @@
+- project_ids = list.map(&:project_id).uniq
+- current_user.policy_context.preload_project_dependencies(project_ids)
 .card
   .overflow-x-scroll
     %table.table.table-sm.table-bordered
       %thead.table-dark
         %tr
-          %th
           - headers.each_value do |header|
             %th= header
       %tbody
-        - list.each.with_index do |record, i|
+        - list.each do |record|
           - pii_policy = current_user.reporting_policy_for_project(project_id: record.project_id)
           %tr
-            %th= i + 1
             - headers.each_key do |field|
               %td{style: 'max-width: 600px;'}
                 = record.display_value(field, pii_policy: pii_policy, include_content_tag: true)

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
@@ -5,47 +5,19 @@
   = "#{report_short_name} #{@question} #{@cell}"
 
 .d-flex.mb-4
-  .mr-4
-    .input-group
-      %input#table_search.form-control{autofocus: true, type: :text, placeholder: 'Search...'}
-      %button.btn.btn-secondary Search
-  - unless @pdf
-    .ml-auto
-      = link_to({format: :xlsx}.merge(link_params),{class: 'btn btn-secondary'}) do
-        %i.icon.icon-download2
-        Download Excel
+  .ml-auto
+    = link_to({format: :xlsx}.merge(link_params),{class: 'btn btn-secondary'}) do
+      %i.icon.icon-download2
+      Download Excel
 
 - project_ids = @enrollments.map(&:project_id).uniq + @services.map(&:project_id).uniq
 - current_user.policy_context.preload_project_dependencies(project_ids)
-- seen = false
-- [[HopwaCaper::Enrollment.detail_headers, @enrollments], [HopwaCaper::Service.detail_headers, @services]].each do |headers, records|
-  - next if records.to_a.empty?
-  - seen = true
-  .card
-    .overflow-x-scroll{style: "height: 800px"}
-      %table.table.table-sm.table-bordered.table-fixed
-        %thead.table-dark
-          %tr
-            %th
-            - headers.each_value do |header|
-              %th= header
-        %tbody
-          - records.each.with_index do |record, i|
-            - pii_policy = current_user.reporting_policy_for_project(project_id: record.project_id)
-            %tr
-              %th= i + 1
-              - headers.each_key do |field|
-                %td{style: 'max-width: 600px;'}
-                  = record.display_value(field, pii_policy: pii_policy, include_content_tag: true)
-- if !seen
-  .none-found No records found.
 
-= content_for :page_js do
-  :javascript
-    table = $('.datatable').DataTable({
-      paging: false,
-      "dom": 'lrtip'
-    });
-    $('#table_search').keyup(function(){
-      table.search($(this).val()).draw();
-    });
+- if @enrollments.any?
+  = render_paginated_list(scope: @enrollments, item_name: 'enrollment', list_partial: 'list', list_locals: { headers: HopwaCaper::Enrollment.detail_headers })
+
+- if @services.any?
+  = render_paginated_list(scope: @services, item_name: 'service', list_partial: 'list', list_locals: { headers: HopwaCaper::Service.detail_headers })
+
+- if @enrollments.empty? && @services.empty?
+  .none-found No records found.

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
@@ -10,13 +10,12 @@
       %i.icon.icon-download2
       Download Excel
 
-- project_ids = @enrollments.map(&:project_id).uniq + @services.map(&:project_id).uniq
-- current_user.policy_context.preload_project_dependencies(project_ids)
-
 - if @enrollments.any?
+  %h3 Enrollments
   = render_paginated_list(scope: @enrollments, item_name: 'enrollment', list_partial: 'list', list_locals: { headers: HopwaCaper::Enrollment.detail_headers })
 
 - if @services.any?
+  %h3 Services
   = render_paginated_list(scope: @services, item_name: 'service', list_partial: 'list', list_locals: { headers: HopwaCaper::Service.detail_headers })
 
 - if @enrollments.empty? && @services.empty?

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
@@ -1,10 +1,10 @@
 wb = xlsx_package.workbook
 wb.add_worksheet(name: @name.slice(0,30).gsub(':', ' ')) do |sheet|
   title = sheet.styles.add_style(sz: 12, b: true, alignment: {horizontal: :center})
-  
+
   project_ids = @enrollments.map(&:project_id).uniq + @services.map(&:project_id).uniq
   current_user.policy_context.preload_project_dependencies(project_ids)
-  
+
   [[HopwaCaper::Enrollment.detail_headers, @enrollments], [HopwaCaper::Service.detail_headers, @services]].each do |headers, records|
     next if records.to_a.empty?
     sheet.add_row(headers.values, style: title)
@@ -16,4 +16,5 @@ wb.add_worksheet(name: @name.slice(0,30).gsub(':', ' ')) do |sheet|
       end
       sheet.add_row(row)
     end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
@@ -281,4 +281,58 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
       expect(all_rows.size).to be > 25 # Should have full report structure
     end
   end
+
+  context 'with poor DOB quality but valid age (Issue 4)' do
+    let(:household_id) { Hmis::Hud::Base.generate_uuid }
+    let(:poor_dob_quality_client) do
+      create(
+        :hud_client,
+        DOB: today - 35.years,
+        DOBDataQuality: 8, # Client doesn't know
+        White: 1,
+        Sex: 1,
+        data_source: data_source,
+      )
+    end
+
+    let!(:hoh_enrollment) do
+      create_hiv_positive_enrollment(
+        client: poor_dob_quality_client,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: household_id,
+      )
+    end
+
+    before do
+      create(
+        :hud_service,
+        enrollment: hoh_enrollment,
+        record_type: hopwa_financial_assistance,
+        type_provided: rental_assistance,
+        fa_amount: 100,
+        date_provided: hoh_enrollment.entry_date,
+        data_source: data_source,
+      )
+    end
+
+    it 'includes client in age/sex/race breakdown despite poor DOB quality' do
+      report = create_report([project])
+      run_report(report)
+
+      expect(report.hopwa_caper_enrollments.size).to eq(1)
+      enrollment = report.hopwa_caper_enrollments.first
+      expect(enrollment.hiv_positive).to be(true)
+      expect(enrollment.dob_quality).to eq(8)
+      expect(enrollment.age).to eq(34)
+      expect(enrollment.sex).to eq(1)
+
+      all_rows = question_as_rows(question_number: 'Q1', report: report)
+
+      # Client should appear in the age/sex/race breakdown table (Male 31-50 & White)
+      rows_to_table(all_rows.slice(2, 11)).yield_self do |table|
+        expect(table['White']['Male 31-50']).to eq(1)
+      end
+    end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
@@ -177,37 +177,17 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
   end
 
   context 'with Hispanic ethnicity demographics' do
-    let(:household_id) { Hmis::Hud::Base.generate_uuid }
-    let(:hispanic_client) do
-      create(
-        :hud_client,
-        DOB: today - 25.years,
-        DOBDataQuality: 1,
-        HispanicLatinaeo: 1,
-        AmIndAKNative: 1,
-        Sex: 1,
-        data_source: data_source,
-      )
-    end
-
-    let!(:hoh_enrollment) do
-      create_hiv_positive_enrollment(
-        client: hispanic_client,
+    let!(:setup) do
+      create_enrolled_client_with_service(
+        client_attrs: {
+          DOB: today - 25.years,
+          DOBDataQuality: 1,
+          HispanicLatinaeo: 1,
+          AmIndAKNative: 1,
+          Sex: 1,
+        },
         project: project,
         entry_date: report_start_date + 1.day,
-        household_id: household_id,
-      )
-    end
-
-    before do
-      create(
-        :hud_service,
-        enrollment: hoh_enrollment,
-        record_type: hopwa_financial_assistance,
-        type_provided: rental_assistance,
-        fa_amount: 100,
-        date_provided: hoh_enrollment.entry_date,
-        data_source: data_source,
       )
     end
 
@@ -230,36 +210,16 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
   end
 
   context 'with unknown or missing demographic data' do
-    let(:household_id) { Hmis::Hud::Base.generate_uuid }
-    let(:unknown_demographics_client) do
-      create(
-        :hud_client,
-        DOB: nil,
-        DOBDataQuality: 99,
-        RaceNone: 9,
-        Sex: 99,
-        data_source: data_source,
-      )
-    end
-
-    let!(:hoh_enrollment) do
-      create_hiv_positive_enrollment(
-        client: unknown_demographics_client,
+    let!(:setup) do
+      create_enrolled_client_with_service(
+        client_attrs: {
+          DOB: nil,
+          DOBDataQuality: 99,
+          RaceNone: 9,
+          Sex: 99,
+        },
         project: project,
         entry_date: report_start_date + 1.day,
-        household_id: household_id,
-      )
-    end
-
-    before do
-      create(
-        :hud_service,
-        enrollment: hoh_enrollment,
-        record_type: hopwa_financial_assistance,
-        type_provided: rental_assistance,
-        fa_amount: 100,
-        date_provided: hoh_enrollment.entry_date,
-        data_source: data_source,
       )
     end
 
@@ -273,46 +233,26 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
       expect(enrollment.hiv_positive).to be(true)
       expect(enrollment.dob_quality).to eq(99)
       expect(enrollment.sex).to eq(99)
-      expect(enrollment.races).to include(unknown_demographics_client.RaceNone) # Preserve RaceNone response for reporting
+      expect(enrollment.races).to include(setup[:client].RaceNone)
 
       # Verify the report generates without errors
       all_rows = question_as_rows(question_number: 'Q1', report: report)
       expect(all_rows).to be_present
-      expect(all_rows.size).to be > 25 # Should have full report structure
+      expect(all_rows.size).to be > 25
     end
   end
 
-  context 'with poor DOB quality but valid age (Issue 4)' do
-    let(:household_id) { Hmis::Hud::Base.generate_uuid }
-    let(:poor_dob_quality_client) do
-      create(
-        :hud_client,
-        DOB: today - 35.years,
-        DOBDataQuality: 8, # Client doesn't know
-        White: 1,
-        Sex: 1,
-        data_source: data_source,
-      )
-    end
-
-    let!(:hoh_enrollment) do
-      create_hiv_positive_enrollment(
-        client: poor_dob_quality_client,
+  context 'with poor DOB quality but valid age' do
+    let!(:setup) do
+      create_enrolled_client_with_service(
+        client_attrs: {
+          DOB: today - 35.years,
+          DOBDataQuality: 8,
+          White: 1,
+          Sex: 1,
+        },
         project: project,
         entry_date: report_start_date + 1.day,
-        household_id: household_id,
-      )
-    end
-
-    before do
-      create(
-        :hud_service,
-        enrollment: hoh_enrollment,
-        record_type: hopwa_financial_assistance,
-        type_provided: rental_assistance,
-        fa_amount: 100,
-        date_provided: hoh_enrollment.entry_date,
-        data_source: data_source,
       )
     end
 
@@ -336,7 +276,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
     end
   end
 
-  context 'with HIV+ beneficiaries (Issue 5)' do
+  context 'with HIV+ beneficiaries' do
     let(:household_id) { Hmis::Hud::Base.generate_uuid }
     let(:hoh_client) do
       create(

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb
@@ -335,4 +335,122 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivin
       end
     end
   end
+
+  context 'with HIV+ beneficiaries (Issue 5)' do
+    let(:household_id) { Hmis::Hud::Base.generate_uuid }
+    let(:hoh_client) do
+      create(
+        :hud_client,
+        DOB: today - 45.years,
+        DOBDataQuality: 1,
+        White: 1,
+        Sex: 1,
+        data_source: data_source,
+      )
+    end
+    let(:hiv_positive_beneficiary) do
+      create(
+        :hud_client,
+        DOB: today - 12.years,
+        DOBDataQuality: 1,
+        White: 1,
+        Sex: 0,
+        data_source: data_source,
+      )
+    end
+    let(:hiv_negative_beneficiary) do
+      create(
+        :hud_client,
+        DOB: today - 8.years,
+        DOBDataQuality: 1,
+        White: 1,
+        Sex: 0,
+        data_source: data_source,
+      )
+    end
+
+    let!(:hoh_enrollment) do
+      create_hiv_positive_enrollment(
+        client: hoh_client,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: household_id,
+      )
+    end
+
+    let!(:hiv_pos_beneficiary_enrollment) do
+      enrollment = create_enrollment(
+        client: hiv_positive_beneficiary,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: household_id,
+        relationship_to_ho_h: 3,
+      )
+      # Create HIV disability for this beneficiary
+      create(
+        :hud_disability,
+        data_source: data_source,
+        enrollment: enrollment,
+        information_date: enrollment.entry_date,
+        disability_type: hiv_positive,
+        disability_response: 1,
+      )
+      enrollment
+    end
+
+    let!(:hiv_neg_beneficiary_enrollment) do
+      create_enrollment(
+        client: hiv_negative_beneficiary,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: household_id,
+        relationship_to_ho_h: 3,
+      )
+    end
+
+    before do
+      [hoh_enrollment, hiv_pos_beneficiary_enrollment, hiv_neg_beneficiary_enrollment].each do |enrollment|
+        create(
+          :hud_service,
+          enrollment: enrollment,
+          record_type: hopwa_financial_assistance,
+          type_provided: rental_assistance,
+          fa_amount: 100,
+          date_provided: enrollment.entry_date,
+          data_source: data_source,
+        )
+      end
+    end
+
+    it 'correctly counts HIV+ status for beneficiaries vs HOPWA-eligible individuals' do
+      report = create_report([project])
+      run_report(report)
+
+      expect(report.hopwa_caper_enrollments.size).to eq(3)
+
+      # HOPWA-eligible individual (HoH) should be HIV+
+      hoh = report.hopwa_caper_enrollments.find_by(personal_id: hoh_client.PersonalID)
+      expect(hoh.hopwa_eligible).to be(true)
+      expect(hoh.hiv_positive).to be(true)
+
+      # HIV+ beneficiary should be marked as HIV+
+      hiv_pos_ben = report.hopwa_caper_enrollments.find_by(personal_id: hiv_positive_beneficiary.PersonalID)
+      expect(hiv_pos_ben.hopwa_eligible).to be(false)
+      expect(hiv_pos_ben.hiv_positive).to be(true)
+
+      # HIV- beneficiary should be marked as HIV-
+      hiv_neg_ben = report.hopwa_caper_enrollments.find_by(personal_id: hiv_negative_beneficiary.PersonalID)
+      expect(hiv_neg_ben.hopwa_eligible).to be(false)
+      expect(hiv_neg_ben.hiv_positive).to be(false)
+
+      # Verify counts in the report output
+      all_rows = question_as_rows(question_number: 'Q1', report: report)
+      lookup = all_rows.to_h { |row| [row[0], row[1]] }.compact_blank
+
+      expect(lookup.fetch('Total number of HOPWA-eligible individuals served with HOPWA assistance:')).to eq(1)
+      expect(lookup.fetch('Total number of other household members (beneficiaries) served with HOPWA assistance:')).to eq(2)
+      expect(lookup.fetch('How many other household members (beneficiaries) are HIV+?')).to eq(1)
+      expect(lookup.fetch('How many other household members (beneficiaries) are HIV negative or have an unknown HIV status?')).to eq(1)
+    end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
@@ -77,6 +77,45 @@ module HopwaCaperHelpers
     end
   end
 
+  # Create client with enrollment and service in one call
+  def create_enrolled_client_with_service(
+    client_attrs:,
+    project:,
+    entry_date:,
+    household_id: nil,
+    relationship_to_ho_h: 1,
+    service_type: nil,
+    type_provided: nil,
+    service_date: nil,
+    fa_amount: 100
+  )
+    household_id ||= Hmis::Hud::Base.generate_uuid
+    service_date ||= entry_date
+    service_type ||= hopwa_financial_assistance
+    type_provided ||= rental_assistance
+
+    client = create(:hud_client, **client_attrs.merge(data_source: data_source))
+    enrollment = create_hiv_positive_enrollment(
+      client: client,
+      project: project,
+      entry_date: entry_date,
+      household_id: household_id,
+      relationship_to_ho_h: relationship_to_ho_h,
+    )
+
+    service = create(
+      :hud_service,
+      enrollment: enrollment,
+      record_type: service_type,
+      type_provided: type_provided,
+      fa_amount: fa_amount,
+      date_provided: service_date,
+      data_source: data_source,
+    )
+
+    { client: client, enrollment: enrollment, service: service, household_id: household_id }
+  end
+
   # Create standard income benefits (Medicaid + Earned income)
   def create_standard_income_benefits(enrollment, date: report_start_date)
     enrollment.income_benefits.create!(

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
@@ -47,7 +47,7 @@ module HopwaCaperHelpers
   end
 
   # Create an HIV+ enrollment with standard disability attributes
-  def create_hiv_positive_enrollment(client:, project:, entry_date:, household_id:, relationship_to_ho_h: 1)
+  def create_hiv_positive_enrollment(client:, project:, entry_date:, household_id:, relationship_to_ho_h: 1, exit_date: nil, destination: nil)
     create_enrollment(
       client: client,
       project: project,
@@ -55,7 +55,7 @@ module HopwaCaperHelpers
       household_id: household_id,
       relationship_to_ho_h: relationship_to_ho_h,
     ).tap do |enrollment|
-      create(
+      enrolment = create(
         :hud_disability,
         disability_type: hiv_positive,
         enrollment: enrollment,
@@ -64,6 +64,18 @@ module HopwaCaperHelpers
         viral_load: 100,
         data_source: data_source,
       )
+      if exit_date.present?
+        create(
+          :hud_exit,
+          enrollment: enrollment,
+          exit_date: exit_date,
+          data_source: data_source,
+          personal_id: client.personal_id,
+          destination: destination,
+        )
+      end
+
+      enrollment
     end
   end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
@@ -55,7 +55,7 @@ module HopwaCaperHelpers
       household_id: household_id,
       relationship_to_ho_h: relationship_to_ho_h,
     ).tap do |enrollment|
-      enrolment = create(
+      create(
         :hud_disability,
         disability_type: hiv_positive,
         enrollment: enrollment,
@@ -74,8 +74,6 @@ module HopwaCaperHelpers
           destination: destination,
         )
       end
-
-      enrollment
     end
   end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -179,4 +179,65 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
       expect(rows.fetch('How many households received more than one type of STRMU assistance?')).to eq(1)
     end
   end
+
+  context 'with household overlapping report but no services in period (Issue 1)' do
+    let(:household_with_services_id) { Hmis::Hud::Base.generate_uuid }
+    let(:household_no_services_id) { Hmis::Hud::Base.generate_uuid }
+
+    let!(:enrollment_with_services) do
+      create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date + 1.day,
+        exit_date: nil,
+        household_id: household_with_services_id,
+      )
+    end
+
+    let!(:enrollment_no_services) do
+      create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date - 30.days, # Overlaps report period
+        exit_date: report_end_date + 30.days,     # Exits after report period
+        household_id: household_no_services_id,
+      )
+    end
+
+    before do
+      # Household 1: Has a service during the reporting period
+      create(
+        :hud_service,
+        enrollment: enrollment_with_services,
+        record_type: hopwa_financial_assistance,
+        type_provided: rental_assistance,
+        fa_amount: 500,
+        date_provided: report_start_date + 5.days,
+        data_source: data_source,
+      )
+
+      # Household 2: Has NO services during the reporting period
+      # (Service is BEFORE the report period)
+      create(
+        :hud_service,
+        enrollment: enrollment_no_services,
+        record_type: hopwa_financial_assistance,
+        type_provided: rental_assistance,
+        fa_amount: 500,
+        date_provided: report_start_date - 10.days, # Before report period
+        data_source: data_source,
+      )
+    end
+
+    it 'only counts households with services in the reporting period' do
+      _, rows = run_and_extract_rows([project], 'Q3')
+
+      # Only the household with services in the period should be counted
+      expect(rows.fetch('STRMU Households Total')).to eq(1)
+      expect(rows.fetch('How many households were served with STRMU rental assistance only?')).to eq(1)
+
+      # The household without services should NOT be in "more than one type"
+      expect(rows.fetch('How many households received more than one type of STRMU assistance?')).to eq(0)
+    end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
     end
   end
 
-  context 'with household overlapping report but no services in period (Issue 1)' do
+  context 'with household overlapping report but no services in period' do
     let(:household_with_services_id) { Hmis::Hud::Base.generate_uuid }
     let(:household_no_services_id) { Hmis::Hud::Base.generate_uuid }
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
         client: create(:hud_client, data_source: data_source),
         project: project,
         entry_date: report_start_date - 30.days, # Overlaps report period
-        exit_date: report_end_date + 30.days,     # Exits after report period
+        exit_date: report_end_date + 30.days, # Exits after report period
         household_id: household_no_services_id,
       )
     end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
@@ -134,4 +134,69 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet, 
       end
     end
   end
+
+  context 'with percent AMI values for drilldown display (Issue 8)' do
+    let(:client_with_ami) do
+      create(
+        :hud_client,
+        DOB: today - 40.years,
+        DOBDataQuality: 1,
+        White: 1,
+        Sex: 1,
+        data_source: data_source,
+      )
+    end
+
+    let(:enrollment_with_ami) do
+      create_hiv_positive_enrollment(
+        client: client_with_ami,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+    end
+
+    let!(:income_benefit) do
+      create(
+        :hud_income_benefit,
+        enrollment: enrollment_with_ami,
+        InformationDate: report_start_date + 5.days,
+        IncomeFromAnySource: 1,
+        TotalMonthlyIncome: 1500,
+        PercentAMI: 1, # Less than 30%
+        data_source: data_source,
+      )
+    end
+
+    before do
+      create(
+        :hud_service,
+        enrollment: enrollment_with_ami,
+        record_type: hopwa_supportive_service,
+        type_provided: case_management_code,
+        fa_amount: 100,
+        date_provided: enrollment_with_ami.entry_date,
+        data_source: data_source,
+      )
+    end
+
+    it 'transforms percent_ami to human-readable strings in drilldowns' do
+      report = create_report([project])
+      run_report(report)
+
+      expect(report.hopwa_caper_enrollments.size).to eq(1)
+      enrollment = report.hopwa_caper_enrollments.first
+      expect(enrollment.percent_ami).to eq(1)
+
+      # Verify transform_value converts the code to a string
+      transformed = enrollment.send(:transform_value, 'percent_ami', 1, nil)
+      expect(transformed).to eq('Less than 30%')
+
+      # Test other percent_ami codes
+      expect(enrollment.send(:transform_value, 'percent_ami', 2, nil)).to eq('30% to 50%')
+      expect(enrollment.send(:transform_value, 'percent_ami', 3, nil)).to eq('Greater than 50%')
+      expect(enrollment.send(:transform_value, 'percent_ami', 4, nil)).to eq('Greater than 80%')
+      expect(enrollment.send(:transform_value, 'percent_ami', 99, nil)).to eq('Data not collected')
+    end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
@@ -156,18 +156,6 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet, 
       )
     end
 
-    let!(:income_benefit) do
-      create(
-        :hud_income_benefit,
-        enrollment: enrollment_with_ami,
-        InformationDate: report_start_date + 5.days,
-        IncomeFromAnySource: 1,
-        TotalMonthlyIncome: 1500,
-        PercentAMI: 1, # Less than 30%
-        data_source: data_source,
-      )
-    end
-
     before do
       create(
         :hud_service,
@@ -186,16 +174,12 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet, 
 
       expect(report.hopwa_caper_enrollments.size).to eq(1)
       enrollment = report.hopwa_caper_enrollments.first
-      expect(enrollment.percent_ami).to eq(1)
 
-      # Verify transform_value converts the code to a string
-      transformed = enrollment.send(:transform_value, 'percent_ami', 1, nil)
-      expect(transformed).to eq('Less than 30%')
-
-      # Test other percent_ami codes
-      expect(enrollment.send(:transform_value, 'percent_ami', 2, nil)).to eq('30% to 50%')
-      expect(enrollment.send(:transform_value, 'percent_ami', 3, nil)).to eq('Greater than 50%')
-      expect(enrollment.send(:transform_value, 'percent_ami', 4, nil)).to eq('Greater than 80%')
+      # Test transform_value for all percent_ami codes
+      expect(enrollment.send(:transform_value, 'percent_ami', 1, nil)).to eq('30% or less')
+      expect(enrollment.send(:transform_value, 'percent_ami', 2, nil)).to eq('31% to 50%')
+      expect(enrollment.send(:transform_value, 'percent_ami', 3, nil)).to eq('51% to 80%')
+      expect(enrollment.send(:transform_value, 'percent_ami', 4, nil)).to eq('81% or greater')
       expect(enrollment.send(:transform_value, 'percent_ami', 99, nil)).to eq('Data not collected')
     end
   end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
@@ -135,52 +135,44 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet, 
     end
   end
 
-  context 'with percent AMI values for drilldown display (Issue 8)' do
-    let(:client_with_ami) do
-      create(
-        :hud_client,
-        DOB: today - 40.years,
-        DOBDataQuality: 1,
-        White: 1,
-        Sex: 1,
-        data_source: data_source,
-      )
-    end
-
-    let(:enrollment_with_ami) do
-      create_hiv_positive_enrollment(
-        client: client_with_ami,
+  context 'with percent AMI values for drilldown display' do
+    let!(:setup) do
+      create_enrolled_client_with_service(
+        client_attrs: {
+          DOB: today - 40.years,
+          DOBDataQuality: 1,
+          White: 1,
+          Sex: 1,
+        },
         project: project,
         entry_date: report_start_date + 1.day,
-        household_id: Hmis::Hud::Base.generate_uuid,
-      )
-    end
-
-    before do
-      create(
-        :hud_service,
-        enrollment: enrollment_with_ami,
-        record_type: hopwa_supportive_service,
+        service_type: hopwa_supportive_service,
         type_provided: case_management_code,
-        fa_amount: 100,
-        date_provided: enrollment_with_ami.entry_date,
-        data_source: data_source,
       )
     end
 
-    it 'transforms percent_ami to human-readable strings in drilldowns' do
+    it 'transforms percent_ami and sex to human-readable strings in drilldowns' do
       report = create_report([project])
       run_report(report)
 
       expect(report.hopwa_caper_enrollments.size).to eq(1)
       enrollment = report.hopwa_caper_enrollments.first
 
-      # Test transform_value for all percent_ami codes
-      expect(enrollment.send(:transform_value, 'percent_ami', 1, nil)).to eq('30% or less')
-      expect(enrollment.send(:transform_value, 'percent_ami', 2, nil)).to eq('31% to 50%')
-      expect(enrollment.send(:transform_value, 'percent_ami', 3, nil)).to eq('51% to 80%')
-      expect(enrollment.send(:transform_value, 'percent_ami', 4, nil)).to eq('81% or greater')
-      expect(enrollment.send(:transform_value, 'percent_ami', 99, nil)).to eq('Data not collected')
+      # Test display_value transforms percent_ami codes correctly
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: 1, calculate_cell: false)).to eq('30% or less')
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: 2, calculate_cell: false)).to eq('31% to 50%')
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: 3, calculate_cell: false)).to eq('51% to 80%')
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: 4, calculate_cell: false)).to eq('81% or greater')
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: 99, calculate_cell: false)).to eq('Data not collected')
+
+      # Test display_value transforms sex codes correctly
+      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: 0, calculate_cell: false)).to eq('Female')
+      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: 1, calculate_cell: false)).to eq('Male')
+      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: 99, calculate_cell: false)).to eq('Data not collected')
+
+      # Test nil handling
+      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
     end
   end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::TbraSheet, type: :model d
     end
   end
 
-  context 'with various exit scenarios for continued assistance (Issue 2)' do
+  context 'with various exit scenarios for continued assistance' do
     let!(:no_exit_enrollment) do
       create_hiv_positive_enrollment(
         client: create(:hud_client, data_source: data_source),

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
@@ -108,4 +108,76 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::TbraSheet, type: :model d
       end
     end
   end
+
+  context 'with various exit scenarios for continued assistance (Issue 2)' do
+    let!(:no_exit_enrollment) do
+      create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date + 1.day,
+        exit_date: nil,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+    end
+
+    let!(:exit_after_report_enrollment) do
+      enrollment = create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+      create(
+        :hud_exit,
+        enrollment: enrollment,
+        exit_date: report_end_date + 30.days, # Exits AFTER report period
+        data_source: data_source,
+      )
+      enrollment
+    end
+
+    let!(:exit_on_last_day_enrollment) do
+      enrollment = create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+      create(
+        :hud_exit,
+        enrollment: enrollment,
+        exit_date: report_end_date, # Exits ON last day of report
+        data_source: data_source,
+      )
+      enrollment
+    end
+
+    let!(:exit_before_end_enrollment) do
+      enrollment = create_hiv_positive_enrollment(
+        client: create(:hud_client, data_source: data_source),
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+      create(
+        :hud_exit,
+        enrollment: enrollment,
+        exit_date: report_end_date - 10.days, # Exits BEFORE end of report
+        data_source: data_source,
+      )
+      enrollment
+    end
+
+    it 'counts households with no exit or exit after report period as continuing' do
+      _, rows = run_and_extract_rows([project], 'Q2')
+
+      # Should count:
+      # - no_exit_enrollment (exit_date IS NULL)
+      # - exit_after_report_enrollment (exit_date > report.end_date)
+      # Should NOT count:
+      # - exit_on_last_day_enrollment (exit_date = report.end_date)
+      # - exit_before_end_enrollment (exit_date < report.end_date)
+      expect(rows.fetch('How many households continued receiving this type of HOPWA assistance into the next year?')).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fixes multiple HOPWA CAPER report calculation and display issues, refactors drilldown views to use pagination, and reverts a database default.

- **STRMU Sheet**: Changed household counting logic to only include households with services in the reporting period when calculating "more than one type" and total STRMU households, fixing false positives from enrollments that overlapped the report period but had no actual services
- **All Program Sheets (TBRA, STRMU, PHP)**: Updated "continued receiving assistance" logic to include households that exited after the reporting period
- **Age/Sex/Race Demographics**: Removed DOB quality filter, correcting discrepancy between totals and demographic cells
- **Drilldown Display**: Improved display of `sex` and `percent_ami` columns to reordered `detail_headers` to position sex column after races near other gender columns
- **Cell Drilldown View**: Refactored from custom table rendering  to use pagination helper
- **Drilldown Excel Export**: Added missing `end` statement to fix runtime error
- **Pagination Helpers**: Added optional `list_locals` parameter to to support passing custom local variables (like headers) to list partials
- Removed default value `'hud_service'` from `hopwa_caper_services.service_source` column
- Improved test coverage

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

