### PR TITLE
Fix bug with direct referral creation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/create_direct_ce_referral.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/create_direct_ce_referral.rb
@@ -74,7 +74,7 @@ module Mutations
         errors.push(*validations)
         errors.drop_warnings! if confirmed
         errors.deduplicate!
-        return { errors: errors } if errors.any?
+        raise ActiveRecord::Rollback if errors.any?
 
         engine.start_step!(step, user: current_user)
 
@@ -84,6 +84,8 @@ module Mutations
 
         engine.complete_step!(step, user: current_user, submitted_values: values_by_link_id)
       end
+
+      return { errors: errors } if errors.any?
 
       { referral: referral }
     end

--- a/drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb
@@ -144,6 +144,29 @@ RSpec.describe Mutations::Ce::CreateDirectCeReferral, type: :request do
       end
     end
 
+    context 'when form validation fails' do
+      before do
+        fake_errors = HmisErrors::Errors.new
+        fake_errors.add(:base, :invalid, full_message: 'fake error')
+        allow_any_instance_of(Hmis::WorkflowExecution::Engine).to receive(:validate_step).and_return(fake_errors.errors)
+      end
+
+      it 'does not create a referral and returns errors' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+
+          errors = result.dig('data', 'createDirectCeReferral', 'errors')
+          expect(errors).to be_present
+          expect(errors.first['fullMessage']).to include('fake error')
+
+          referral_data = result.dig('data', 'createDirectCeReferral', 'referral')
+          expect(referral_data).to be_nil
+        end.to not_change(Hmis::Ce::Referral, :count).
+          and not_change(Hmis::WorkflowExecution::Instance, :count)
+      end
+    end
+
     context 'when the unit group has a direct referral workflow template' do
       let!(:direct_referral_workflow_template) { create(:hmis_workflow_definition_template, :with_basic_tasks, data_source: ds1) }
       let!(:unit_group) { create(:hmis_unit_group, project: project, workflow_template: workflow_template, direct_referral_workflow_template: direct_referral_workflow_template) }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Bug: Set up a direct referral workflow where the first step form includes some form validations, such as "warn on empty". Submit the form.
  - Expected: You see a warning box asking you to confirm the empty fields (or error telling you to fix the errors). Only after you have confirmed (or fixed and successfully submitted) is a referral created.
  - Observed instead: A referral is created when you first hit Submit, before confirming warnings and/or fixing errors. (If it's a confirm warnings situation, a second referral is created when you confirm.)
- I believe this bug isn't currently manifesting anywhere in prod, because the only existing prod direct referral form doesn't have any required or warn-if-empty fields.
- Discovered while working on #8521, but I'm opening a separate PR, since the fix touches unrelated code

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
