### PR TITLE
Allow setting empty project types for PATH report

### DIFF
--- a/app/models/filters/census_report_filter.rb
+++ b/app/models/filters/census_report_filter.rb
@@ -60,7 +60,7 @@ module Filters
     end
 
     def project_type_code_options_for_select
-      HudHelper.util.residential_type_titles.freeze.invert
+      HudHelper.util.residential_type_titles.invert.freeze
     end
 
     # These are not presented in the UI, but need to be set to nothing or all homeless projects are returned

--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -821,7 +821,7 @@ module Filters
     end
 
     def project_type_code_options_for_select
-      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(default_project_type_codes) }.freeze.invert
+      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(default_project_type_codes) }.invert.freeze
     end
 
     def project_options_for_select(user:)

--- a/app/views/hud_reports/_parameters.haml
+++ b/app/views/hud_reports/_parameters.haml
@@ -1,6 +1,7 @@
 .mb-2.reports.warehouse-reports__completed
   - # NOTE: this is not ideal, we need to figure out which filter type we're actually using
   - # but for displaying the items chosen, it's probably fine
-  - filter = Filters::FilterBase.new(user_id: report.user_id).update(report.options.with_indifferent_access)
+  - @filter_class ||= Filters::FilterBase
+  - filter = @filter_class.new(user_id: report.user_id).update(report.options.with_indifferent_access)
   = filter.describe_filter_as_html(@generator.allowed_options(report))
   = render 'filters/view_filter_details', filter_hash: filter.to_h, selected_keys: @generator.allowed_options(report)

--- a/drivers/hud_path_report/app/controllers/hud_path_report/base_controller.rb
+++ b/drivers/hud_path_report/app/controllers/hud_path_report/base_controller.rb
@@ -32,11 +32,15 @@ module HudPathReport
 
     # NOTE filter differs slightly from the base version
     private def filter
+      # Override the filter class for display in app/views/hud_reports/_parameters.haml
+      # Without this override, filter base will include project types that aren't applicable
+      @filter_class ||= filter_class
       year = if Date.current.month >= 10
         Date.current.year
       else
         Date.current.year - 1
       end
+
       # Some sane defaults, using the previous report if available
       @filter = filter_class.new(user_id: current_user.id)
       if filter_params.blank?
@@ -59,7 +63,7 @@ module HudPathReport
         end
       end
       # Override with params if set
-      @filter.set_from_params(filter_params) if filter_params.present?
+      @filter.update(filter_params) if filter_params.present?
     end
 
     def active_report_versions

--- a/drivers/hud_path_report/app/controllers/hud_path_report/base_controller.rb
+++ b/drivers/hud_path_report/app/controllers/hud_path_report/base_controller.rb
@@ -42,7 +42,7 @@ module HudPathReport
       end
 
       # Some sane defaults, using the previous report if available
-      @filter = filter_class.new(user_id: current_user.id)
+      @filter = @filter_class.new(user_id: current_user.id)
       if filter_params.blank?
         prior_report = generator.find_report(current_user)
         options = prior_report&.options

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -14,9 +14,7 @@ module HudPathReport::Filters
       []
     end
 
-    def project_type_code_options_for_select
-      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(path_project_types) }.invert.freeze
-    end
+    def project_type_code_options_for_select = path_project_types_for_select
 
     def path_project_types_for_select
       HudHelper.util.project_type_group_titles.select { |k, _| k.in?(path_project_types) }.invert.freeze

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -8,14 +8,14 @@
 
 module HudPathReport::Filters
   class PathFilter < ::Filters::HudFilterBase
-    # Don't sent any defaults for project types, they get used in a variety of places and
+    # Don't set any defaults for project types, they get used in a variety of places and
     # make it impossible to run a report that doesn't include all projects in a type
     def default_project_type_codes
       []
     end
 
     def project_type_code_options_for_select
-      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(path_project_types) }.freeze.invert
+      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(path_project_types) }.invert.freeze
     end
 
     def path_project_types_for_select

--- a/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/filters/path_filter.rb
@@ -8,8 +8,14 @@
 
 module HudPathReport::Filters
   class PathFilter < ::Filters::HudFilterBase
+    # Don't sent any defaults for project types, they get used in a variety of places and
+    # make it impossible to run a report that doesn't include all projects in a type
     def default_project_type_codes
-      path_project_types
+      []
+    end
+
+    def project_type_code_options_for_select
+      HudHelper.util.project_type_group_titles.select { |k, _| k.in?(path_project_types) }.freeze.invert
     end
 
     def path_project_types_for_select

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/base.rb
@@ -163,7 +163,7 @@ module HudPathReport::Generators::Fy2026
     def initialize(generator = nil, report = nil, options: {})
       super
       options = report.options.with_indifferent_access.merge(user_id: report.user_id) if options.blank?
-      @filter = HudPathReport::Filters::PathFilter.new(user_id: report.user_id).set_from_params(options)
+      @filter = HudPathReport::Filters::PathFilter.new(user_id: report.user_id).update(options)
     end
 
     private def universe

--- a/drivers/hud_path_report/spec/controllers/hud_path_report/base_controller_spec.rb
+++ b/drivers/hud_path_report/spec/controllers/hud_path_report/base_controller_spec.rb
@@ -1,0 +1,130 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudPathReport::BaseController, type: :controller do
+  # Test through PathsController since BaseController is abstract
+  controller(HudPathReport::PathsController) do
+  end
+
+  let(:user) { create :acl_user }
+  let(:role) { create :role, can_view_assigned_reports: true, can_view_all_hud_reports: true }
+  let(:data_source) { create :data_source_fixed_id }
+  let(:organization) { create :grda_warehouse_hud_organization }
+  let(:config) { create :config }
+  let(:site_coc_codes) { ['XX-500'] }
+  # We don't actually need the HMIS reports collection as we don't check that for HUD reports yet, but we need A collection.
+  let(:all_reports_collection) { Collection.system_collection(:hmis_reports) }
+
+  before do
+    Collection.maintain_system_groups
+    setup_access_control(user, role, all_reports_collection)
+    sign_in user
+  end
+
+  describe '#filter' do
+    describe 'setting @filter_class' do
+      it 'sets @filter_class to PathFilter' do
+        get :index
+        expect(assigns(:filter_class)).to eq(HudPathReport::Filters::PathFilter)
+      end
+
+      it 'creates a filter instance using filter_class' do
+        get :index
+        expect(assigns(:filter)).to be_a(HudPathReport::Filters::PathFilter)
+      end
+
+      it 'sets @filter_class before creating filter instance' do
+        get :index
+        # @filter_class should be set so views can use it
+        expect(assigns(:filter_class)).to be_present
+        expect(assigns(:filter)).to be_a(assigns(:filter_class))
+      end
+    end
+
+    describe 'filter parameter handling' do
+      let(:base_filter_params) do
+        {
+          start: '2023-10-01',
+          end: '2024-09-30',
+          coc_codes: site_coc_codes,
+        }
+      end
+
+      context 'when no project_type_codes are provided' do
+        it 'accepts empty project_type_codes' do
+          filter_params = base_filter_params.merge(project_type_codes: [])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to eq([])
+        end
+
+        it 'accepts missing project_type_codes parameter' do
+          post :create, params: { filter: base_filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to eq([])
+        end
+      end
+
+      context 'when a valid PATH project_type_code is provided' do
+        it 'accepts "so" as a valid project type code' do
+          filter_params = base_filter_params.merge(project_type_codes: ['so'])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to include('so')
+        end
+
+        it 'accepts "services_only" as a valid project type code' do
+          filter_params = base_filter_params.merge(project_type_codes: ['services_only'])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to include('services_only')
+        end
+      end
+
+      # The following indicate that the filter accepts a variety of project type codes.
+      # In the future, we may want to limit these to valid PATH types, for now these are limited by the form.
+      context 'when an invalid project_type_code is provided' do
+        it 'accepts non-PATH project type codes but they are not in PATH types' do
+          filter_params = base_filter_params.merge(project_type_codes: ['es'])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          # The filter will accept it, but it's not a valid PATH type
+          expect(filter.project_type_codes).to include('es')
+          expect(filter.path_project_types).not_to include('es')
+        end
+
+        it 'accepts "th" as a project type code but it is not a PATH type' do
+          filter_params = base_filter_params.merge(project_type_codes: ['th'])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to include('th')
+          expect(filter.path_project_types).not_to include('th')
+        end
+
+        it 'accepts "ph" as a project type code but it is not a PATH type' do
+          filter_params = base_filter_params.merge(project_type_codes: ['ph'])
+          post :create, params: { filter: filter_params }
+          filter = assigns(:filter)
+          expect(filter.project_type_codes).to include('ph')
+          expect(filter.path_project_types).not_to include('ph')
+        end
+      end
+
+      it 'uses update method when filter_params are present' do
+        filter_params = base_filter_params.merge(project_type_codes: ['so'])
+        post :create, params: { filter: filter_params }
+        filter = assigns(:filter)
+        expect(filter.start).to eq(Date.parse('2023-10-01'))
+        expect(filter.end).to eq(Date.parse('2024-09-30'))
+        expect(filter.project_type_codes).to include('so')
+      end
+    end
+  end
+end

--- a/drivers/hud_path_report/spec/models/hud_path_report/filters/path_filter_spec.rb
+++ b/drivers/hud_path_report/spec/models/hud_path_report/filters/path_filter_spec.rb
@@ -1,0 +1,72 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudPathReport::Filters::PathFilter, type: :model do
+  let(:user) { create :acl_user }
+  let(:filter) { described_class.new(user_id: user.id) }
+
+  describe '#default_project_type_codes' do
+    it 'returns an empty array' do
+      expect(filter.default_project_type_codes).to eq([])
+    end
+
+    it 'does not include any project types by default' do
+      expect(filter.default_project_type_codes).to be_empty
+    end
+  end
+
+  describe '#project_type_code_options_for_select' do
+    let(:path_project_types) { filter.path_project_types }
+
+    it 'returns only PATH project types' do
+      options = filter.project_type_code_options_for_select
+      expect(options.values.map(&:to_sym)).to all(be_in(path_project_types))
+    end
+
+    it 'excludes non-PATH project types' do
+      all_project_types = HudHelper.util.project_type_group_titles.keys
+      non_path_types = all_project_types - path_project_types
+      options = filter.project_type_code_options_for_select
+      expect(options.keys).not_to include(*non_path_types)
+    end
+
+    it 'returns an inverted hash with titles as keys' do
+      options = filter.project_type_code_options_for_select
+      expect(options).to be_a(Hash)
+      # The hash should be inverted (titles as keys, codes as values)
+      path_project_types.each do |code|
+        matching_title = HudHelper.util.project_type_group_titles[code]
+        expect(options).to have_key(matching_title) if matching_title
+      end
+    end
+  end
+
+  describe 'filter behavior with empty default_project_type_codes' do
+    it 'does not include any projects when project_type_codes is empty' do
+      filter_params = { project_type_codes: [] }
+      filter.update(filter_params)
+      # This should not include projects based on default project types
+      expect(filter.project_type_codes).to eq([])
+    end
+
+    it 'requires explicit project type selection' do
+      filter_params = {}
+      filter.update(filter_params)
+      expect(filter.project_type_codes).to eq([])
+    end
+  end
+
+  describe '#path_project_types' do
+    it 'returns the PATH project type codes from HudHelper' do
+      expected_types = HudHelper.util.path_project_type_codes
+      expect(filter.path_project_types).to eq(expected_types)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* The PATH report was insisting that it only be run for ALL SO and SSO projects.  This adjusts the defaults so that it will allow you to pick your project types, or leave it blank to enable running for a single project.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
