### PR TITLE
8395-hopwa-caper-feedback

### DIFF
--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -75,19 +75,17 @@ module HopwaCaper
     def self.from_hud_record(enrollment:, report:, client:)
       project = enrollment.project
       # get deterministic order
-      hiv_disabilities = enrollment.disabilities.filter(&:hiv?).sort_by(&:id)
+      hiv_disabilities = enrollment.disabilities.
+        filter { |r| r.hiv? && r.disability_response == 1 }.
+        sort_by(&:id)
 
-      report_date_range = report.start_date..report.end_date
-      income_benefit_source_types = enrollment.income_benefits.flat_map do |record|
-        next unless record.InformationDate.in?(report_date_range)
+      # Determines current income/insurance status using most recent assessment as of report end date
+      latest_income_benefit = enrollment.income_benefits.
+        select { |r| r.InformationDate && r.InformationDate <= report.end_date }.
+        max_by { |r| [r.InformationDate, r.id] }
 
-        INCOME_SOURCE_FIELDS.filter { |field| record[field] == 1 }
-      end
-      medical_insurance_types = enrollment.income_benefits.flat_map do |record|
-        next unless record.InformationDate.in?(report_date_range)
-
-        INSURANCE_FIELDS.filter { |field| record[field] == 1 }
-      end
+      income_benefit_source_types = INCOME_SOURCE_FIELDS.filter { |field| latest_income_benefit&.[](field) == 1 }
+      medical_insurance_types = INSURANCE_FIELDS.filter { |field| latest_income_benefit&.[](field) == 1 }
 
       exit = enrollment.exit if enrollment.exit&.exit_date&.<= report.end_date
       new(
@@ -140,7 +138,6 @@ module HopwaCaper
       'age',
       'dob',
       'dob_quality',
-      'genders',
       'races',
       'sex',
       'veteran',

--- a/drivers/hopwa_caper/spec/models/enrollment_spec.rb
+++ b/drivers/hopwa_caper/spec/models/enrollment_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'generators/fy2026/hopwa_caper_shared_context'
+
+RSpec.describe HopwaCaper::Enrollment, type: :model do
+  include_context('HOPWA CAPER shared context')
+
+  let(:project) { create(:hud_project, data_source: data_source, organization: organization) }
+  let(:client) { create(:hud_client, data_source: data_source) }
+  let(:hud_enrollment) do
+    create(:hud_enrollment, client: client, project: project, data_source: data_source, entry_date: report_start_date + 1.day)
+  end
+  let(:report) { create_report([project]) }
+
+  describe '.from_hud_record' do
+    context 'with income_benefits records' do
+      context 'with multiple income_benefit records' do
+        let!(:older_income_benefit) do
+          create(
+            :hud_income_benefit,
+            enrollment: hud_enrollment,
+            information_date: report_start_date + 5.days,
+            Medicaid: 1,
+            Earned: 0,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        let!(:latest_income_benefit) do
+          create(
+            :hud_income_benefit,
+            enrollment: hud_enrollment,
+            information_date: report_start_date + 15.days,
+            Medicaid: 0,
+            Medicare: 1,
+            Earned: 1,
+            SSDI: 1,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        let!(:middle_income_benefit) do
+          create(
+            :hud_income_benefit,
+            enrollment: hud_enrollment,
+            information_date: report_start_date + 10.days,
+            Medicaid: 1,
+            Medicare: 1,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        it 'uses only the latest income_benefit record as of report end date' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          # Should use latest_income_benefit values only
+          expect(enrollment.medical_insurance_types).to contain_exactly('Medicare')
+          expect(enrollment.income_benefit_source_types).to contain_exactly('Earned', 'SSDI')
+          expect(enrollment.medical_insurance_types).not_to include('Medicaid')
+        end
+      end
+
+      context 'with income_benefit dated after report end_date' do
+        let!(:within_range_benefit) do
+          create(
+            :hud_income_benefit,
+            enrollment: hud_enrollment,
+            information_date: report_end_date - 1.day,
+            Medicaid: 1,
+            Earned: 1,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        let!(:after_report_benefit) do
+          create(
+            :hud_income_benefit,
+            enrollment: hud_enrollment,
+            information_date: report_end_date + 10.days,
+            Medicare: 1,
+            SSDI: 1,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        it 'ignores income_benefit records dated after report end_date' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          # Should only use within_range_benefit
+          expect(enrollment.medical_insurance_types).to contain_exactly('Medicaid')
+          expect(enrollment.income_benefit_source_types).to contain_exactly('Earned')
+          expect(enrollment.medical_insurance_types).not_to include('Medicare')
+          expect(enrollment.income_benefit_source_types).not_to include('SSDI')
+        end
+      end
+
+      context 'with no income_benefit records' do
+        it 'handles missing income_benefits gracefully' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          expect(enrollment.medical_insurance_types).to be_empty
+          expect(enrollment.income_benefit_source_types).to be_empty
+        end
+      end
+    end
+
+    context 'with HIV disability records' do
+      context 'with disability_response set to 1' do
+        let!(:confirmed_hiv_disability) do
+          create(
+            :hud_disability,
+            enrollment: hud_enrollment,
+            disability_type: hiv_positive,
+            disability_response: 1,
+            anti_retroviral: 1,
+            viral_load_available: 1,
+            viral_load: 150,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        it 'marks enrollment as hiv_positive when disability_response is 1' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          expect(enrollment.hiv_positive).to be(true)
+          expect(enrollment.viral_load_suppression).to be(true)
+          expect(enrollment.ever_prescribed_anti_retroviral_therapy).to be(true)
+        end
+      end
+
+      context 'with disability_response not set to 1' do
+        let!(:unconfirmed_hiv_disability) do
+          create(
+            :hud_disability,
+            enrollment: hud_enrollment,
+            disability_type: hiv_positive,
+            disability_response: 0,
+            anti_retroviral: 1,
+            viral_load_available: 1,
+            viral_load: 150,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        it 'does not mark enrollment as hiv_positive when disability_response is not 1' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          expect(enrollment.hiv_positive).to be(false)
+          expect(enrollment.viral_load_suppression).to be(false)
+          expect(enrollment.ever_prescribed_anti_retroviral_therapy).to be(false)
+        end
+      end
+
+      context 'with mixed disability_response values' do
+        let!(:confirmed_hiv) do
+          create(
+            :hud_disability,
+            enrollment: hud_enrollment,
+            disability_type: hiv_positive,
+            disability_response: 1,
+            anti_retroviral: 1,
+            viral_load_available: 1,
+            viral_load: 150,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        let!(:unconfirmed_hiv) do
+          create(
+            :hud_disability,
+            enrollment: hud_enrollment,
+            disability_type: hiv_positive,
+            disability_response: 0,
+            viral_load_available: 1,
+            viral_load: 50,
+            data_source: data_source,
+            personal_id: client.PersonalID,
+          )
+        end
+
+        it 'considers only confirmed disabilities for hiv_positive status' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          expect(enrollment.hiv_positive).to be(true)
+          # Should use confirmed_hiv viral load (150), not unconfirmed (50)
+          expect(enrollment.viral_load_suppression).to be(true)
+        end
+      end
+
+      context 'with no HIV disabilities' do
+        it 'marks enrollment as not hiv_positive' do
+          enrollment = described_class.from_hud_record(
+            enrollment: hud_enrollment,
+            report: report,
+            client: client,
+          )
+
+          expect(enrollment.hiv_positive).to be(false)
+          expect(enrollment.viral_load_suppression).to be(false)
+          expect(enrollment.ever_prescribed_anti_retroviral_therapy).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_helpers.rb
@@ -63,6 +63,7 @@ module HopwaCaperHelpers
         viral_load_available: 1,
         viral_load: 100,
         data_source: data_source,
+        disability_response: 1,
       )
       if exit_date.present?
         create(

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
         viral_load_available: 1,
         viral_load: 100,
         data_source: data_source,
+        disability_response: 1,
       )
     end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::TbraSheet, type: :model d
         viral_load_available: 1,
         viral_load: 100,
         data_source: data_source,
+        disability_response: 1,
       )
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Fixes HOPWA CAPER enrollment logic around income benefit records and require confirmed HIV disability responses.

- **Enrollment Income/Insurance Calculation**: consider only the most recent assessment as of the report end date
- **HIV Status Determination**: filter to only records where `disability_response == 1` (confirmed positive)
- **Test Coverage**: Added unit tests covering edge cases 

## Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
