### PR TITLE
Add dependent: :destroy relation for all CE rule owners

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/organization.rb
+++ b/drivers/hmis/app/models/hmis/hud/organization.rb
@@ -21,6 +21,8 @@ class Hmis::Hud::Organization < Hmis::Hud::Base
   has_many :group_viewable_entity_projects
   has_many :group_viewable_entities, through: :group_viewable_entity_projects, source: :group_viewable_entity
 
+  has_many :ce_match_rules, class_name: 'Hmis::Ce::Match::Rule', as: :owner, dependent: :destroy
+
   validates_with Hmis::Hud::Validators::OrganizationValidator
 
   # hide previous declaration of :viewable_by, we'll use this one

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -59,6 +59,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   has_many :project_staff_assignment_configs, class_name: 'Hmis::ProjectStaffAssignmentConfig'
   has_many :ce_opportunities, class_name: 'Hmis::Ce::Opportunity', foreign_key: :project_id, dependent: :destroy, inverse_of: :project
   has_many :ce_referrals, class_name: 'Hmis::Ce::Referral', through: :ce_opportunities, source: :referrals
+  has_many :ce_match_rules, class_name: 'Hmis::Ce::Match::Rule', as: :owner, dependent: :destroy
 
   # All referrals where the source enrollment is in this project. NOT only 'direct' referrals
   has_many :outgoing_ce_referrals, class_name: 'Hmis::Ce::Referral', through: :enrollments, source: :outgoing_ce_referrals

--- a/drivers/hmis/extensions/grda_warehouse/data_source_extension.rb
+++ b/drivers/hmis/extensions/grda_warehouse/data_source_extension.rb
@@ -14,6 +14,7 @@ module Hmis::GrdaWarehouse
       has_many :custom_data_element_definitions, class_name: 'Hmis::Hud::CustomDataElementDefinition'
       has_many :custom_service_types, class_name: 'Hmis::Hud::CustomServiceType'
       has_many :hmis_project_groups, class_name: 'Hmis::ProjectGroup'
+      has_many :ce_match_rules, class_name: 'Hmis::Ce::Match::Rule', as: :owner, dependent: :destroy
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
For all entities that can own CE Match Rules -- Data Source, Organization, Project, and Unit Group -- there should be a `dependent: :destroy` directive so that if the entity is deleted, its associated match rules are deleted too. Directive was already added on Unit Group in #6041.

Tested For each of Data Source, Organization, and Project:
- Associate a Match Rule with an instance of this entity
- Delete the entity
- Confirm the unit group page still loads (no exception is raised [here](https://github.com/greenriver/hmis-warehouse/blob/87c0fb6e52a5fbe6bbe522bd4fd32bd309a5a0c6/drivers/hmis/app/models/hmis/ce/match/match_applicability.rb#L48))

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
