### PR TITLE
Fix for missing `has_rdoc` method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1122,7 +1122,6 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-24
-  ruby
 
 DEPENDENCIES
   abbrev

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -168,6 +168,10 @@ RUN chmod +x /usr/local/bin/install_pg_repack.sh \
 
 WORKDIR /app
 
+# Shim legacy gemspecs that still call the removed Gem::Specification#has_rdoc=
+COPY docker/app/has_rdoc_patch.rb /usr/local/lib/ruby/has_rdoc_patch.rb
+ENV RUBYOPT="-r/usr/local/lib/ruby/has_rdoc_patch.rb ${RUBYOPT}"
+
 # CVE-2025-58767, note rexml is bundled with ruby, and must be explicitly pinned
 RUN gem update --system \
   && gem update rexml \

--- a/docker/app/has_rdoc_patch.rb
+++ b/docker/app/has_rdoc_patch.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Support legacy gemspecs (e.g., stupidedi) that still call the removed
+# Gem::Specification#has_rdoc= writer. The method disappeared in RubyGems 4 /
+# Ruby 3.4, so we provide a no-op shim until the upstream gem is updated.
+unless Gem::Specification.method_defined?(:has_rdoc=)
+  Gem::Specification.class_eval do
+    attr_accessor :has_rdoc
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Works around errors during image build related to the old `stupidedi` gem

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
