### PR TITLE
8395 hopwa caper fixes v2

### DIFF
--- a/app/models/concerns/sql_helper.rb
+++ b/app/models/concerns/sql_helper.rb
@@ -44,7 +44,12 @@ module SqlHelper
     type ? "#{result}::#{type}[]" : result
   end
 
-  # Generates a SQL condition to check if a field is a non-empty subset of a given set.
+  # Generates a SQL condition to check if a field contains ONLY values from a given set (and is non-empty).
+  # Uses PostgreSQL's <@ (contained-by/subset) operator.
+  #
+  # IMPORTANT: This checks that ALL elements in the field are in the set. If the field has ANY elements
+  # not in the set, this will return false. For checking if the field has ANY elements from the set,
+  # use `array_overlap_condition` instead.
   #
   # @param field [String] The name of the database field to check.
   # @param set [Array] The set to compare against.
@@ -52,12 +57,42 @@ module SqlHelper
   #
   # @return [String] A SQL condition string.
   #
-  # @example
+  # @example Use this when you want EXCLUSIVE matching (field contains ONLY these values)
+  #   # Field has ['ruby', 'rails'] -> TRUE
+  #   # Field has ['ruby'] -> TRUE
+  #   # Field has ['ruby', 'python'] -> FALSE (python not in set)
   #   SqlHelper.non_empty_array_subset_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
   #   # => "tags <@ '{\"ruby\",\"rails\"}'::text[] AND tags != '{}'::text[]"
+  #
+  # @example For checking if field has ANY of these values, use array_overlap_condition instead
+  #   # Field has ['ruby', 'python'] with set ['ruby', 'rails'] -> TRUE (has ruby)
+  #   SqlHelper.array_overlap_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
   module_function def non_empty_array_subset_condition(field:, set:, type:)
     empty_q_set = SqlHelper.quote_sql_array([], type: type)
     q_set = SqlHelper.quote_sql_array(set, type: type)
     "#{field} <@ #{q_set} AND #{field} != #{empty_q_set}"
+  end
+
+  # Generates a SQL condition to check if a field has ANY overlap with a given set.
+  # Uses PostgreSQL's && (overlap) operator to check for array intersection.
+  #
+  # This checks if the field contains AT LEAST ONE element from the set. The field can also
+  # contain other elements not in the set.
+  #
+  # @param field [String] The name of the database field to check.
+  # @param set [Array] The set to compare against.
+  # @param type [String] The SQL type of the array (e.g., 'integer', 'text', 'varchar').
+  #
+  # @return [String] A SQL condition string.
+  #
+  # @example Use this when you want to find records with ANY of these values
+  #   # Field has ['ruby', 'python'] -> TRUE (has ruby)
+  #   # Field has ['rails'] -> TRUE (has rails)
+  #   # Field has ['python', 'java'] -> FALSE (no overlap)
+  #   SqlHelper.array_overlap_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
+  #   # => "tags && '{\"ruby\",\"rails\"}'::text[]"
+  module_function def array_overlap_condition(field:, set:, type:)
+    q_set = SqlHelper.quote_sql_array(set, type: type)
+    "#{field} && #{q_set}"
   end
 end

--- a/app/models/concerns/sql_helper.rb
+++ b/app/models/concerns/sql_helper.rb
@@ -44,54 +44,29 @@ module SqlHelper
     type ? "#{result}::#{type}[]" : result
   end
 
-  # Generates a SQL condition to check if a field contains ONLY values from a given set (and is non-empty).
-  # Uses PostgreSQL's <@ (contained-by/subset) operator.
-  #
-  # IMPORTANT: This checks that ALL elements in the field are in the set. If the field has ANY elements
-  # not in the set, this will return false. For checking if the field has ANY elements from the set,
-  # use `array_overlap_condition` instead.
-  #
+  # SQL condition to check if a field (a PG array) is a non-empty subset of a given set.
+  # This is an EXCLUSIVE match: all elements in `field` must be in `set`.
+  # For an INCLUSIVE match (any element in `set`), use `array_overlap_condition`.
   # @param field [String] The name of the database field to check.
   # @param set [Array] The set to compare against.
   # @param type [String] The SQL type of the array (e.g., 'integer', 'text').
   #
   # @return [String] A SQL condition string.
   #
-  # @example Use this when you want EXCLUSIVE matching (field contains ONLY these values)
-  #   # Field has ['ruby', 'rails'] -> TRUE
-  #   # Field has ['ruby'] -> TRUE
-  #   # Field has ['ruby', 'python'] -> FALSE (python not in set)
-  #   SqlHelper.non_empty_array_subset_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
-  #   # => "tags <@ '{\"ruby\",\"rails\"}'::text[] AND tags != '{}'::text[]"
-  #
-  # @example For checking if field has ANY of these values, use array_overlap_condition instead
-  #   # Field has ['ruby', 'python'] with set ['ruby', 'rails'] -> TRUE (has ruby)
-  #   SqlHelper.array_overlap_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
   module_function def non_empty_array_subset_condition(field:, set:, type:)
     empty_q_set = SqlHelper.quote_sql_array([], type: type)
     q_set = SqlHelper.quote_sql_array(set, type: type)
     "#{field} <@ #{q_set} AND #{field} != #{empty_q_set}"
   end
 
-  # Generates a SQL condition to check if a field has ANY overlap with a given set.
-  # Uses PostgreSQL's && (overlap) operator to check for array intersection.
-  #
-  # This checks if the field contains AT LEAST ONE element from the set. The field can also
-  # contain other elements not in the set.
-  #
-  # @param field [String] The name of the database field to check.
-  # @param set [Array] The set to compare against.
-  # @param type [String] The SQL type of the array (e.g., 'integer', 'text', 'varchar').
-  #
-  # @return [String] A SQL condition string.
-  #
-  # @example Use this when you want to find records with ANY of these values
-  #   # Field has ['ruby', 'python'] -> TRUE (has ruby)
-  #   # Field has ['rails'] -> TRUE (has rails)
-  #   # Field has ['python', 'java'] -> FALSE (no overlap)
-  #   SqlHelper.array_overlap_condition(field: 'tags', set: ['ruby', 'rails'], type: 'text')
-  #   # => "tags && '{\"ruby\",\"rails\"}'::text[]"
+  # SQL condition to check if a field (a PG array) has ANY overlap with a given set.
+  # This is an INCLUSIVE match: at least one element in `field` must be in `set`.
+  # For an EXCLUSIVE match (all elements in `set`), use `non_empty_array_subset_condition`.
+  # Uses PostgreSQL's && (overlap) operator.
+  # The `set` cannot be empty, as this would always return false in SQL.
   module_function def array_overlap_condition(field:, set:, type:)
+    raise ArgumentError, 'Set cannot be empty - array overlap with empty set always returns false' if set.empty?
+
     q_set = SqlHelper.quote_sql_array(set, type: type)
     "#{field} && #{q_set}"
   end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -183,18 +183,19 @@ module HopwaCaper
 
     private
 
-    # HUD data elements that support "Data not collected (99)"
-    HUD_FIELDS_WITH_99 = [
-      'sex',
-      'dob_quality',
-      'percent_ami',
-      'exit_destination',
-      'housing_assessment_at_exit',
-    ].freeze
+    def fields_supporting_data_not_collected
+      @fields_supporting_data_not_collected ||= [
+        'sex',
+        'dob_quality',
+        'percent_ami',
+        'exit_destination',
+        'housing_assessment_at_exit',
+      ].to_set.freeze
+    end
 
     def transform_value(column, value, pii_policy)
       # Treat nil as 99 (Data not collected) for HUD fields that support it
-      value = 99 if value.nil? && HUD_FIELDS_WITH_99.include?(column)
+      value = 99 if value.nil? && fields_supporting_data_not_collected.include?(column)
 
       case column
       when 'sex'

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -184,12 +184,12 @@ module HopwaCaper
     private
 
     # HUD data elements that support "Data not collected (99)"
-    HUD_FIELDS_WITH_99 = %w[
-      sex
-      dob_quality
-      percent_ami
-      exit_destination
-      housing_assessment_at_exit
+    HUD_FIELDS_WITH_99 = [
+      'sex',
+      'dob_quality',
+      'percent_ami',
+      'exit_destination',
+      'housing_assessment_at_exit',
     ].freeze
 
     def transform_value(column, value, pii_policy)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -183,11 +183,31 @@ module HopwaCaper
 
     private
 
-    def transform_value(column, value, pii_policy)
-      return HudHelper.util('2026').sex(value) if column == 'sex'
-      return HudHelper.util('2026').percent_ami(value) if column == 'percent_ami'
+    # HUD data elements that support "Data not collected (99)"
+    HUD_FIELDS_WITH_99 = %w[
+      sex
+      dob_quality
+      percent_ami
+      exit_destination
+      housing_assessment_at_exit
+    ].freeze
 
-      super
+    def transform_value(column, value, pii_policy)
+      # Treat nil as 99 (Data not collected) for HUD fields that support it
+      value = 99 if value.nil? && HUD_FIELDS_WITH_99.include?(column)
+
+      case column
+      when 'sex'
+        HudHelper.util('2026').sex(value)
+      when 'percent_ami'
+        HudHelper.util('2026').percent_ami(value)
+      when 'housing_assessment_at_exit'
+        HudHelper.util('2026').housing_assessment_at_exit(value)
+      when 'dob_quality'
+        HudHelper.util('2026').dob_data_quality(value)
+      else
+        super
+      end
     end
   end
 end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/household_scoped_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/household_scoped_filter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module HopwaCaper::Generators::Fy2026::EnrollmentFilters
+  # Provides helpers for filters that need to consider all household members while
+  # respecting the original scope constraints (report instance, project filters, etc.).
+  module HouseholdScopedFilter
+    private
+
+    def household_members(scope)
+      HopwaCaper::Enrollment.
+        from("#{HopwaCaper::Enrollment.table_name} household_members").
+        joins("INNER JOIN (#{scoped_households(scope).to_sql}) scoped_households ON scoped_households.report_household_id = household_members.report_household_id")
+    end
+
+    def scoped_households(scope)
+      scope.
+        unscope(:select, :order, :limit, :offset).
+        select(:report_household_id).
+        distinct
+    end
+
+    # Filter to households where ANY member has at least one of the specified array values.
+    # Returns a scope filtered to households matching the condition.
+    def households_with_any_member_having(scope, field:, values:, type:)
+      household_ids = household_members(scope).
+        where(SqlHelper.array_overlap_condition(field: "household_members.#{field}", set: values, type: type)).
+        select(:report_household_id).
+        distinct
+      scope.where(report_household_id: household_ids)
+    end
+  end
+end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
@@ -8,14 +8,33 @@
 
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   IncomeBenefitSourceFilter = Struct.new(:label, :types, keyword_init: true) do
+    # Filter households based on income sources across all household members.
+    # - For specific income types: includes households where ANY member has those income sources
+    # - For no income (types: []): includes households where ALL members have no income sources
     def apply(scope)
-      cond = if types.present?
-        SqlHelper.non_empty_array_subset_condition(field: 'income_benefit_source_types', type: :varchar, set: types)
+      # Get unique household IDs from the current scope to constrain household lookups
+      household_ids = scope.select(:report_household_id).distinct
+
+      if types.present?
+        # Household has income if ANY member has the specified income types
+        # Look at ALL members of households in scope, not just the scoped members
+        # Use && operator to check for array overlap (ANY element in common)
+        q_set = SqlHelper.quote_sql_array(types, type: :varchar)
+        cond = HopwaCaper::Enrollment.
+          where(report_household_id: household_ids).
+          where("income_benefit_source_types && #{q_set}").
+          select(:report_household_id).
+          distinct
+        scope.where(report_household_id: cond)
       else
-        # no benefits
-        "income_benefit_source_types = '{}'::varchar[]"
+        # Household has no income only if ALL members have empty income_benefit_source_types
+        cond = HopwaCaper::Enrollment.
+          where(report_household_id: household_ids).
+          group(:report_household_id).
+          having("BOOL_AND(income_benefit_source_types = '{}'::varchar[])").
+          select(:report_household_id)
+        scope.where(report_household_id: cond)
       end
-      scope.where(cond)
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
@@ -18,14 +18,11 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
       if types.present?
         # Household has income if ANY member has the specified income types
         # Look at ALL members of households in scope, not just the scoped members
-        # Use && operator to check for array overlap (ANY element in common)
-        q_set = SqlHelper.quote_sql_array(types, type: :varchar)
         cond = HopwaCaper::Enrollment.
           where(report_household_id: household_ids).
-          where("income_benefit_source_types && #{q_set}").
+          where(SqlHelper.array_overlap_condition(field: 'income_benefit_source_types', set: types, type: :varchar)).
           select(:report_household_id).
           distinct
-        scope.where(report_household_id: cond)
       else
         # Household has no income only if ALL members have empty income_benefit_source_types
         cond = HopwaCaper::Enrollment.
@@ -33,8 +30,8 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
           group(:report_household_id).
           having("BOOL_AND(income_benefit_source_types = '{}'::varchar[])").
           select(:report_household_id)
-        scope.where(report_household_id: cond)
       end
+      scope.where(report_household_id: cond)
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
@@ -8,30 +8,21 @@
 
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   IncomeBenefitSourceFilter = Struct.new(:label, :types, keyword_init: true) do
+    include HouseholdScopedFilter
+
     # Filter households based on income sources across all household members.
     # - For specific income types: includes households where ANY member has those income sources
     # - For no income (types: []): includes households where ALL members have no income sources
     def apply(scope)
-      # Get unique household IDs from the current scope to constrain household lookups
-      household_ids = scope.select(:report_household_id).distinct
+      return households_with_any_member_having(scope, field: 'income_benefit_source_types', values: types, type: 'varchar') if types.present?
 
-      if types.present?
-        # Household has income if ANY member has the specified income types
-        # Look at ALL members of households in scope, not just the scoped members
-        cond = HopwaCaper::Enrollment.
-          where(report_household_id: household_ids).
-          where(SqlHelper.array_overlap_condition(field: 'income_benefit_source_types', set: types, type: :varchar)).
-          select(:report_household_id).
-          distinct
-      else
-        # Household has no income only if ALL members have empty income_benefit_source_types
-        cond = HopwaCaper::Enrollment.
-          where(report_household_id: household_ids).
-          group(:report_household_id).
-          having("BOOL_AND(income_benefit_source_types = '{}'::varchar[])").
-          select(:report_household_id)
-      end
-      scope.where(report_household_id: cond)
+      # Household has no income only if ALL members have empty income_benefit_source_types.
+      # Ensure households have at least one member to avoid matching orphaned household IDs.
+      household_ids = household_members(scope).
+        group(:report_household_id).
+        having("COUNT(*) > 0 AND BOOL_AND(household_members.income_benefit_source_types = '{}'::varchar[])").
+        select(:report_household_id)
+      scope.where(report_household_id: household_ids)
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
@@ -8,10 +8,21 @@
 
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   MedicalInsuranceFilter = Struct.new(:label, :types, keyword_init: true) do
+    # Filter households based on medical insurance across all household members.
+    # Includes households where ANY member has the specified medical insurance types.
     def apply(scope)
-      scope.where(
-        SqlHelper.non_empty_array_subset_condition(field: 'medical_insurance_types', type: 'varchar', set: types),
-      )
+      # Get unique household IDs from the current scope to constrain household lookups
+      household_ids = scope.select(:report_household_id).distinct
+
+      # Look at ALL members of households in scope, not just the scoped members
+      # Use && operator to check for array overlap (ANY element in common)
+      q_set = SqlHelper.quote_sql_array(types, type: 'varchar')
+      cond = HopwaCaper::Enrollment.
+        where(report_household_id: household_ids).
+        where("medical_insurance_types && #{q_set}").
+        select(:report_household_id).
+        distinct
+      scope.where(report_household_id: cond)
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
@@ -8,19 +8,12 @@
 
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   MedicalInsuranceFilter = Struct.new(:label, :types, keyword_init: true) do
+    include HouseholdScopedFilter
+
     # Filter households based on medical insurance across all household members.
     # Includes households where ANY member has the specified medical insurance types.
     def apply(scope)
-      # Get unique household IDs from the current scope to constrain household lookups
-      household_ids = scope.select(:report_household_id).distinct
-
-      # Look at ALL members of households in scope, not just the scoped members
-      cond = HopwaCaper::Enrollment.
-        where(report_household_id: household_ids).
-        where(SqlHelper.array_overlap_condition(field: 'medical_insurance_types', set: types, type: 'varchar')).
-        select(:report_household_id).
-        distinct
-      scope.where(report_household_id: cond)
+      households_with_any_member_having(scope, field: 'medical_insurance_types', values: types, type: 'varchar')
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/medical_insurance_filter.rb
@@ -15,11 +15,9 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
       household_ids = scope.select(:report_household_id).distinct
 
       # Look at ALL members of households in scope, not just the scoped members
-      # Use && operator to check for array overlap (ANY element in common)
-      q_set = SqlHelper.quote_sql_array(types, type: 'varchar')
       cond = HopwaCaper::Enrollment.
         where(report_household_id: household_ids).
-        where("medical_insurance_types && #{q_set}").
+        where(SqlHelper.array_overlap_condition(field: 'medical_insurance_types', set: types, type: 'varchar')).
         select(:report_household_id).
         distinct
       scope.where(report_household_id: cond)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/project_funder_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/project_funder_filter.rb
@@ -9,8 +9,10 @@
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   ProjectFunderFilter = Struct.new(:label, :types, keyword_init: true) do
     def apply(scope)
-      cond = SqlHelper.non_empty_array_subset_condition(field: 'project_funders', type: 'integer', set: funders)
-      scope.where(cond)
+      # Use overlap operator to find projects with ANY of the specified funders
+      # (not subset, since projects can have multiple funding sources)
+      q_set = SqlHelper.quote_sql_array(funders, type: 'integer')
+      scope.where("project_funders && #{q_set}")
     end
 
     def funders

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/project_funder_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/project_funder_filter.rb
@@ -9,10 +9,8 @@
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
   ProjectFunderFilter = Struct.new(:label, :types, keyword_init: true) do
     def apply(scope)
-      # Use overlap operator to find projects with ANY of the specified funders
-      # (not subset, since projects can have multiple funding sources)
-      q_set = SqlHelper.quote_sql_array(funders, type: 'integer')
-      scope.where("project_funders && #{q_set}")
+      # Find projects with ANY of the specified funders (not subset, since projects can have multiple funding sources)
+      scope.where(SqlHelper.array_overlap_condition(field: 'project_funders', set: funders, type: 'integer'))
     end
 
     def funders

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb
@@ -170,9 +170,16 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet, 
       expect(enrollment.display_value('sex', pii_policy: nil, cell_val: 1, calculate_cell: false)).to eq('Male')
       expect(enrollment.display_value('sex', pii_policy: nil, cell_val: 99, calculate_cell: false)).to eq('Data not collected')
 
-      # Test nil handling
-      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
-      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
+      # Test nil handling - nil should be treated as 99 (Data not collected)
+      expect(enrollment.display_value('sex', pii_policy: nil, cell_val: nil, calculate_cell: false)).to eq('Data not collected')
+      expect(enrollment.display_value('percent_ami', pii_policy: nil, cell_val: nil, calculate_cell: false)).to eq('Data not collected')
+      expect(enrollment.display_value('dob_quality', pii_policy: nil, cell_val: nil, calculate_cell: false)).to eq('Data not collected')
+      expect(enrollment.display_value('exit_destination', pii_policy: nil, cell_val: nil, calculate_cell: false)).to eq('Data not collected')
+      expect(enrollment.display_value('housing_assessment_at_exit', pii_policy: nil, cell_val: nil, calculate_cell: false)).to eq('Data not collected')
+
+      # Verify that fields without 99 option still return nil
+      expect(enrollment.display_value('rental_subsidy_type', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
+      expect(enrollment.display_value('subsidy_information', pii_policy: nil, cell_val: nil, calculate_cell: false)).to be_nil
     end
   end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
@@ -85,6 +85,51 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::TbraSheet, type: :model d
       expect(rows.fetch('How many households have been served with TBRA for less than one year?')).to eq(1)
     end
 
+    context 'with income sources on non-HoH member' do
+      it 'counts household income based on any household member' do
+        # Only the beneficiary (non-HoH) has income sources
+        create(
+          :hud_income_benefit,
+          enrollment: beneficiary_enrollment,
+          SNAP: 1,
+          Unemployment: 1,
+          information_date: report_start_date + 5.days,
+          data_source: data_source,
+          personal_id: beneficiary_client.PersonalID,
+        )
+
+        _, rows = run_and_extract_rows([project], 'Q2')
+
+        # Household should be counted as having income sources
+        expect(rows.fetch('Other Welfare Assistance (Supplemental Nutrition Assistance Program, WIC, TANF, etc.)')).to eq(1)
+        expect(rows.fetch('Unemployment Insurance')).to eq(1)
+        # Household should NOT be counted as having no income
+        expect(rows.fetch('How many households maintained no sources of income?')).to eq(0)
+      end
+
+      it 'counts as no income only when all household members have no income' do
+        # Neither HoH nor beneficiary has income sources
+        # Create income_benefit records with no income sources (all fields = 0)
+        [hoh_enrollment, beneficiary_enrollment].each do |enrollment|
+          create(
+            :hud_income_benefit,
+            enrollment: enrollment,
+            information_date: report_start_date + 5.days,
+            data_source: data_source,
+            personal_id: enrollment.personal_id,
+          )
+        end
+
+        _, rows = run_and_extract_rows([project], 'Q2')
+
+        # Household should be counted as having no income
+        expect(rows.fetch('How many households maintained no sources of income?')).to eq(1)
+        # Household should NOT be counted as having any specific income sources
+        expect(rows.fetch('Earned Income from Employment')).to eq(0)
+        expect(rows.fetch('Unemployment Insurance')).to eq(0)
+      end
+    end
+
     context 'with a prior enrollments' do
       before do
         previous_enrollment = create_enrollment(

--- a/spec/models/sql_helper_spec.rb
+++ b/spec/models/sql_helper_spec.rb
@@ -120,14 +120,14 @@ RSpec.describe SqlHelper do
       expect(result).to eq(expected)
     end
 
-    it 'handles empty set correctly' do
-      result = described_class.array_overlap_condition(
-        field: 'tags',
-        set: [],
-        type: 'text',
-      )
-      expected = "tags && '{}'::text[]"
-      expect(result).to eq(expected)
+    it 'raises error for empty set' do
+      expect do
+        described_class.array_overlap_condition(
+          field: 'tags',
+          set: [],
+          type: 'text',
+        )
+      end.to raise_error(ArgumentError, /Set cannot be empty/)
     end
   end
 end

--- a/spec/models/sql_helper_spec.rb
+++ b/spec/models/sql_helper_spec.rb
@@ -88,4 +88,46 @@ RSpec.describe SqlHelper do
       expect(result).to eq(expected)
     end
   end
+
+  describe '.array_overlap_condition' do
+    it 'generates correct SQL condition for string arrays' do
+      result = described_class.array_overlap_condition(
+        field: 'tags',
+        set: ['ruby', 'rails'],
+        type: 'text',
+      )
+      expected = "tags && '{\"ruby\",\"rails\"}'::text[]"
+      expect(result).to eq(expected)
+    end
+
+    it 'generates correct SQL condition for integer arrays' do
+      result = described_class.array_overlap_condition(
+        field: 'funders',
+        set: [1, 2, 3],
+        type: 'integer',
+      )
+      expected = "funders && '{1,2,3}'::integer[]"
+      expect(result).to eq(expected)
+    end
+
+    it 'generates correct SQL condition for varchar arrays' do
+      result = described_class.array_overlap_condition(
+        field: 'income_types',
+        set: ['SNAP', 'SSI'],
+        type: 'varchar',
+      )
+      expected = "income_types && '{\"SNAP\",\"SSI\"}'::varchar[]"
+      expect(result).to eq(expected)
+    end
+
+    it 'handles empty set correctly' do
+      result = described_class.array_overlap_condition(
+        field: 'tags',
+        set: [],
+        type: 'text',
+      )
+      expected = "tags && '{}'::text[]"
+      expect(result).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Refactors HOPWA CAPER household-level filters to correctly apply criteria across all household members.

-   **HOPWA CAPER Filters**: Introduces a `HouseholdScopedFilter` to ensure income and medical insurance criteria are evaluated for the entire household, not just individual members. The logic is now non-exclusive:
    -   Households are now included if *any* member has at least one of the specified income or medical insurance types (using an array overlap check).
    -   Previously, an individual's benefits had to be a strict subset of the filter's types, which could incorrectly exclude households with mixed benefit sources.
    -   "No income" is now counted only when *all* household members lack income.
-   **Project Funder Filter**: Updated to check for an overlap of funding sources rather than a strict subset, correctly including projects with multiple funders.
-   **Data Transformation**: `HopwaCaper::Enrollment` now correctly treats `nil` values as `99` (Data not collected) for several HUD fields


### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

