### PR TITLE
Hotfix - add sex field to client cleanup script

### DIFF
--- a/app/models/grda_warehouse/sex_selector.rb
+++ b/app/models/grda_warehouse/sex_selector.rb
@@ -31,14 +31,20 @@ module GrdaWarehouse
   class SexSelector
     Candidate = Struct.new(:value, :tie_breakers, keyword_init: true)
 
-    def self.call(dest_attr:, source_clients:, use_oldest: false)
-      new(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest).call
+    VALID_PRIORITIZATION_METHODS = [:newest_first].freeze
+
+    def self.call(dest_attr:, source_clients:, prioritization_method: :newest_first)
+      new(dest_attr: dest_attr, source_clients: source_clients, prioritization_method: prioritization_method).call
     end
 
-    def initialize(dest_attr:, source_clients:, use_oldest: false)
+    def initialize(dest_attr:, source_clients:, prioritization_method: :newest_first)
       @dest_attr = dest_attr.with_indifferent_access
       @source_clients = Array.wrap(source_clients).map { |client| normalize_source(client) }
-      @use_oldest = use_oldest
+      @prioritization_method = prioritization_method
+
+      return if VALID_PRIORITIZATION_METHODS.include?(@prioritization_method)
+
+      raise ArgumentError, "Invalid prioritization_method: #{@prioritization_method}. Valid methods: #{VALID_PRIORITIZATION_METHODS.join(', ')}"
     end
 
     def call
@@ -63,8 +69,6 @@ module GrdaWarehouse
       return unless coerced_value
       return unless coerced_value.in?(valid_sex_values)
 
-      date_key = timestamp_for(source[:DateUpdated])
-
       # Prefer 0 or 1 (Female/Male) over 8, 9, 99
       # Lower priority number = higher preference
       priority = if coerced_value.in?([0, 1])
@@ -73,7 +77,7 @@ module GrdaWarehouse
         1
       end
 
-      tie_breakers = [priority, date_key, source_identifier_for(source)]
+      tie_breakers = [priority, priority_modifier(source), source_identifier_for(source)]
 
       Candidate.new(value: coerced_value, tie_breakers: tie_breakers)
     end
@@ -94,6 +98,27 @@ module GrdaWarehouse
       base
     end
 
+    def priority_modifier(source)
+      case @prioritization_method
+      when :newest_first
+        newest_first_priority_modifier(source)
+      else
+        raise ArgumentError, "Invalid prioritization_method: #{@prioritization_method}. Valid methods: #{VALID_PRIORITIZATION_METHODS.join(', ')}"
+      end
+    end
+
+    def newest_first_priority_modifier(source)
+      timestamp = timestamp_for(source[:DateUpdated])
+      # Negate to prefer newer (larger) timestamps when using min_by
+      # Larger timestamps become more negative, so they sort first
+      # If timestamp is nil, use +Float::INFINITY so missing dates sort last (after negation)
+      if timestamp.nil?
+        Float::INFINITY
+      else
+        -timestamp
+      end
+    end
+
     def timestamp_for(value)
       timestamp =
         case value
@@ -107,17 +132,7 @@ module GrdaWarehouse
           raise ArgumentError, "invalid timestamp #{value.inspect}"
         end
 
-      timestamp ||= default_date_key
-      timestamp *= -1 unless use_oldest?
       timestamp
-    end
-
-    def use_oldest?
-      @use_oldest
-    end
-
-    def default_date_key
-      use_oldest? ? Float::INFINITY : -Float::INFINITY
     end
 
     def source_identifier_for(source)

--- a/app/models/grda_warehouse/sex_selector.rb
+++ b/app/models/grda_warehouse/sex_selector.rb
@@ -1,0 +1,143 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module GrdaWarehouse
+  # Determines the preferred Sex value from a set of source client records.
+  # This service object encapsulates the business rules for selecting the best
+  # available Sex value based on a multi-level sorting algorithm.
+  #
+  # The selection process prioritizes candidates based on the following criteria
+  # in order:
+  #   1. Sex value preference (0 or 1 preferred over 8, 9, 99)
+  #   2. Record timestamp (DateUpdated), preferring most recent
+  #   3. Record ID (lower is better)
+  #
+  # Valid Sex values:
+  #   0 => Female
+  #   1 => Male
+  #   8 => Client doesn't know
+  #   9 => Client prefers not to answer
+  #   99 => Data not collected
+  #
+  # This class handles data normalization for various source data formats
+  # (e.g., Hashes, ActiveRecord objects). The goal is to provide a consistent
+  # and reliable way to determine the most trustworthy Sex value from potentially
+  # conflicting source data.
+  class SexSelector
+    Candidate = Struct.new(:value, :tie_breakers, keyword_init: true)
+
+    def self.call(dest_attr:, source_clients:, use_oldest: false)
+      new(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest).call
+    end
+
+    def initialize(dest_attr:, source_clients:, use_oldest: false)
+      @dest_attr = dest_attr.with_indifferent_access
+      @source_clients = Array.wrap(source_clients).map { |client| normalize_source(client) }
+      @use_oldest = use_oldest
+    end
+
+    def call
+      best = select_best_candidate
+      @dest_attr[:Sex] = best.value if best
+      @dest_attr
+    end
+
+    private
+
+    def select_best_candidate
+      @source_clients.
+        filter_map { |source| build_candidate_from_source(source) }.
+        min_by(&:tie_breakers)
+    end
+
+    def build_candidate_from_source(source)
+      value = source[:Sex]
+      return unless value.present?
+
+      coerced_value = coerce_value(value)
+      return unless coerced_value
+      return unless coerced_value.in?(valid_sex_values)
+
+      date_key = timestamp_for(source[:DateUpdated])
+
+      # Prefer 0 or 1 (Female/Male) over 8, 9, 99
+      # Lower priority number = higher preference
+      priority = if coerced_value.in?([0, 1])
+        0
+      else
+        1
+      end
+
+      tie_breakers = [priority, date_key, source_identifier_for(source)]
+
+      Candidate.new(value: coerced_value, tie_breakers: tie_breakers)
+    end
+
+    def normalize_source(client)
+      base =
+        case client
+        when ActiveSupport::HashWithIndifferentAccess
+          client
+        when Hash
+          client.with_indifferent_access
+        when ActiveRecord::Base
+          client.attributes.with_indifferent_access
+        else
+          raise ArgumentError, "Unsupported source client: #{client.class.name}"
+        end
+
+      base
+    end
+
+    def timestamp_for(value)
+      timestamp =
+        case value
+        when nil, ''
+          nil
+        when Time, DateTime, ActiveSupport::TimeWithZone
+          value.to_i
+        when Date
+          value.to_time.to_i
+        else
+          raise ArgumentError, "invalid timestamp #{value.inspect}"
+        end
+
+      timestamp ||= default_date_key
+      timestamp *= -1 unless use_oldest?
+      timestamp
+    end
+
+    def use_oldest?
+      @use_oldest
+    end
+
+    def default_date_key
+      use_oldest? ? Float::INFINITY : -Float::INFINITY
+    end
+
+    def source_identifier_for(source)
+      raw = source[:id]
+      return Float::INFINITY if raw.blank?
+
+      coerced = Integer(raw, exception: false)
+      coerced || Float::INFINITY
+    end
+
+    def valid_sex_values
+      @valid_sex_values ||= HudHelper.util('2026').sexes.keys.sort
+    end
+
+    def coerce_value(value)
+      return if value.blank?
+
+      return value if value.is_a?(Integer)
+
+      Integer(value, exception: false)
+    end
+  end
+end

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -608,7 +608,7 @@ module GrdaWarehouse::Tasks
       GrdaWarehouse::SexSelector.call(
         dest_attr: dest_attr,
         source_clients: source_clients,
-        use_oldest: false,
+        prioritization_method: :newest_first,
       )
     end
 

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -391,6 +391,7 @@ module GrdaWarehouse::Tasks
       # DifferentIdentity
       # GenderNone
       # DifferentIdentityText
+      # Sex
       # VeteranStatus
       #
       # YearEnteredService
@@ -412,6 +413,7 @@ module GrdaWarehouse::Tasks
       dest_attr = choose_best_veteran_status(dest_attr, source_clients)
       dest_attr = choose_best_gender(dest_attr, source_clients)
       dest_attr = choose_best_race(dest_attr, source_clients)
+      dest_attr = choose_best_sex(dest_attr, source_clients)
 
       dest_attr
     end
@@ -600,6 +602,14 @@ module GrdaWarehouse::Tasks
 
     private def gender_columns
       @gender_columns ||= ::HudHelper.util.gender_fields - [:GenderNone]
+    end
+
+    def choose_best_sex dest_attr, source_clients
+      GrdaWarehouse::SexSelector.call(
+        dest_attr: dest_attr,
+        source_clients: source_clients,
+        use_oldest: false,
+      )
     end
 
     def choose_best_race dest_attr, source_clients
@@ -806,6 +816,7 @@ module GrdaWarehouse::Tasks
         DifferentIdentity: c_t[:DifferentIdentity].to_sql,
         GenderNone: c_t[:GenderNone].to_sql,
         DifferentIdentityText: c_t[:DifferentIdentityText].to_sql,
+        Sex: c_t[:Sex].to_sql,
         VeteranStatus: c_t[:VeteranStatus].to_sql,
         YearEnteredService: c_t[:YearEnteredService].to_sql,
         YearSeparated: c_t[:YearSeparated].to_sql,

--- a/spec/models/grda_warehouse/sex_selector_spec.rb
+++ b/spec/models/grda_warehouse/sex_selector_spec.rb
@@ -1,0 +1,465 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::SexSelector do
+  subject(:selected) do
+    described_class.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest)
+  end
+
+  let(:dest_attr) { {} }
+  let(:source_clients) { [] }
+  let(:use_oldest) { false }
+  let(:hud_util) { instance_double('HudUtil') }
+
+  before do
+    allow(hud_util).to receive(:sexes).and_return(
+      {
+        0 => 'Female',
+        1 => 'Male',
+        8 => "Client doesn't know",
+        9 => 'Client prefers not to answer',
+        99 => 'Data not collected',
+      },
+    )
+    allow(HudHelper).to receive(:util).with('2026').and_return(hud_util)
+  end
+
+  describe '.call' do
+    context 'when no source client has a Sex value' do
+      it 'returns the destination without setting Sex' do
+        expect(selected[:Sex]).to be_nil
+      end
+    end
+
+    context 'when a source client has Sex value 0 (Female)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'sets Sex to 0' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when a source client has Sex value 1 (Male)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'sets Sex to 1' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when a source client has Sex value 8 (Client doesn\'t know)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 8,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'sets Sex to 8' do
+        expect(selected[:Sex]).to eq(8)
+      end
+    end
+
+    context 'when a source client has Sex value 9 (Client prefers not to answer)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 9,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'sets Sex to 9' do
+        expect(selected[:Sex]).to eq(9)
+      end
+    end
+
+    context 'when a source client has Sex value 99 (Data not collected)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 99,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'sets Sex to 99' do
+        expect(selected[:Sex]).to eq(99)
+      end
+    end
+
+    context 'when multiple sources exist with different values' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 8,
+            DateUpdated: Time.zone.local(2021, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'prefers 0 or 1 over 8, 9, 99' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when sources share preference level with mixed-type values' do
+      let(:source_clients) do
+        [
+          {
+            Sex: '1',
+            DateUpdated: Time.zone.local(2021, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'normalizes values and selects the most recent preferred value' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when multiple sources have equivalent preference (0 or 1)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2021, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'selects the most recent record when configured to prefer newest' do
+        expect(selected[:Sex]).to eq(1)
+      end
+
+      context 'when configured to use the oldest record' do
+        let(:use_oldest) { true }
+
+        it 'selects the oldest record' do
+          expect(selected[:Sex]).to eq(0)
+        end
+      end
+    end
+
+    context 'when multiple sources have equivalent preference (8, 9, 99)' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 8,
+            DateUpdated: Time.zone.local(2021, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: 9,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'selects the most recent record' do
+        expect(selected[:Sex]).to eq(9)
+      end
+    end
+
+    context 'when sources share preference but one record has no DateUpdated' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: nil,
+            id: 1,
+          },
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'prefers the record with a timestamped DateUpdated' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when preferring newest records but one DateUpdated is missing' do
+      let(:use_oldest) { false }
+
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: nil,
+            id: 1,
+          },
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2025, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'still prefers the record with a real DateUpdated timestamp' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when a source client lacks an id' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2024, 1, 1),
+            id: nil,
+          },
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2024, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'selects the candidate with a real id when tie-breakers match' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when a preferred value (0 or 1) exists alongside non-preferred values' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 8,
+            DateUpdated: Time.zone.local(2025, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2001, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'selects the preferred value even if it is older' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when all candidates are removed due to invalid data' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 999,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+          {
+            Sex: nil,
+            DateUpdated: Time.zone.local(2022, 1, 1),
+            id: 2,
+          },
+        ]
+      end
+
+      it 'returns nil Sex' do
+        expect(selected[:Sex]).to be_nil
+      end
+    end
+
+    context 'when a candidate has an invalid string value' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 'invalid',
+            DateUpdated: Time.zone.local(2023, 1, 2),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'ignores invalid values and returns nil' do
+        expect(selected[:Sex]).to be_nil
+      end
+    end
+
+    context 'when source clients are ActiveRecord objects' do
+      let(:client1) do
+        create(:hud_client, Sex: 0, DateUpdated: Time.zone.local(2023, 1, 1))
+      end
+      let(:client2) do
+        create(:hud_client, Sex: 1, DateUpdated: Time.zone.local(2024, 1, 1))
+      end
+      let(:source_clients) { [client1, client2] }
+
+      it 'normalizes ActiveRecord objects and selects the most recent' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when source clients are plain Hashes' do
+      let(:source_clients) do
+        [
+          {
+            'Sex' => 0,
+            'DateUpdated' => Time.zone.local(2023, 1, 1),
+            'id' => 1,
+          },
+          {
+            'Sex' => 1,
+            'DateUpdated' => Time.zone.local(2024, 1, 1),
+            'id' => 2,
+          },
+        ]
+      end
+
+      it 'normalizes Hashes and selects the most recent' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when destination already has a Sex value' do
+      let(:dest_attr) { { Sex: 1 } }
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'overwrites with the selected value from source clients' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when DateUpdated is a Date object' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Date.new(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'handles Date objects correctly' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when DateUpdated is a DateTime object' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: DateTime.new(2023, 1, 1, 12, 0, 0),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'handles DateTime objects correctly' do
+        expect(selected[:Sex]).to eq(0)
+      end
+    end
+
+    context 'when multiple sources have same DateUpdated but different ids' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 2,
+          },
+          {
+            Sex: 1,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'selects the candidate with the lower id' do
+        expect(selected[:Sex]).to eq(1)
+      end
+    end
+
+    context 'when an unsupported source client type is provided' do
+      let(:source_clients) { ['invalid'] }
+
+      it 'raises an ArgumentError' do
+        expect { selected }.to raise_error(ArgumentError, /Unsupported source client/)
+      end
+    end
+
+    context 'when DateUpdated has an invalid type' do
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: 'invalid',
+            id: 1,
+          },
+        ]
+      end
+
+      it 'raises an ArgumentError' do
+        expect { selected }.to raise_error(ArgumentError, /invalid timestamp/)
+      end
+    end
+  end
+end

--- a/spec/models/grda_warehouse/sex_selector_spec.rb
+++ b/spec/models/grda_warehouse/sex_selector_spec.rb
@@ -10,12 +10,12 @@ require 'rails_helper'
 
 RSpec.describe GrdaWarehouse::SexSelector do
   subject(:selected) do
-    described_class.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest)
+    described_class.call(dest_attr: dest_attr, source_clients: source_clients, prioritization_method: prioritization_method)
   end
 
   let(:dest_attr) { {} }
   let(:source_clients) { [] }
-  let(:use_oldest) { false }
+  let(:prioritization_method) { :newest_first }
   let(:hud_util) { instance_double('HudUtil') }
 
   before do
@@ -180,11 +180,11 @@ RSpec.describe GrdaWarehouse::SexSelector do
         expect(selected[:Sex]).to eq(1)
       end
 
-      context 'when configured to use the oldest record' do
-        let(:use_oldest) { true }
+      context 'when configured with an unsupported prioritization method' do
+        let(:prioritization_method) { :oldest_first }
 
-        it 'selects the oldest record' do
-          expect(selected[:Sex]).to eq(0)
+        it 'raises an error for unsupported prioritization method' do
+          expect { selected }.to raise_error(ArgumentError, /Invalid prioritization_method: oldest_first/)
         end
       end
     end
@@ -232,8 +232,6 @@ RSpec.describe GrdaWarehouse::SexSelector do
     end
 
     context 'when preferring newest records but one DateUpdated is missing' do
-      let(:use_oldest) { false }
-
       let(:source_clients) do
         [
           {
@@ -459,6 +457,23 @@ RSpec.describe GrdaWarehouse::SexSelector do
 
       it 'raises an ArgumentError' do
         expect { selected }.to raise_error(ArgumentError, /invalid timestamp/)
+      end
+    end
+
+    context 'when an invalid prioritization_method is provided' do
+      let(:prioritization_method) { :invalid_method }
+      let(:source_clients) do
+        [
+          {
+            Sex: 0,
+            DateUpdated: Time.zone.local(2023, 1, 1),
+            id: 1,
+          },
+        ]
+      end
+
+      it 'raises an ArgumentError' do
+        expect { selected }.to raise_error(ArgumentError, /Invalid prioritization_method: invalid_method/)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds the Sex field to the client cleanup script. 

The Sex field is prioritized by (in order)
1. Sex value preference (0 or 1 preferred over 8, 9, 99)
2. Record timestamp (DateUpdated), preferring most recent
3. Record ID (lower is better)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
