### PR TITLE
8395 hopw caper fix v3

### DIFF
--- a/docs/features/hopwa_caper.md
+++ b/docs/features/hopwa_caper.md
@@ -12,6 +12,9 @@ The report lives under the HUD Reports, use `HopwaCaper::BaseController` as an e
 - **Household eligibility tagging:** `update_hopwa_eligibility` assigns a single HOPWA-eligible member per household (preferring an HIV-positive head of household). This resolves cases where multiple members qualify.
 - **Universe links:** Both staging models inherit from `HudReports::ReportClientBase`, exposing `as_report_members` helpers that register each record as a `HudReports::UniverseMember`. This connects records to HUD report drill-downs and client detail tables.
 
+## Household Counting Methodology
+Household counts follow the HUD HMIS reporting glossary definition: "distinct count of personal IDs of all heads of households." When a household has multiple enrollments during the reporting period (e.g., enrolling at different projects), they are counted only once by deduplicating on the HoH.
+
 ## Question Sheets and Builders
 - **Sheet architecture:** The FY 2026 generator enumerates sheet classes. Each inherits from `HopwaCaper::Generators::Fy2026::Sheets::Base` or `BaseProgramSheet`, which wrap `HudReports::QuestionSheet` and provide helpers for enrollment scoping, cell creation, and household table generation.
 - **Filters:** Enrollment filters (age, gender, income, longevity, prior living situation, housing outcomes) and service filters (record type, STRMU assistance categories) are located under `app/models/hopwa_caper/generators/fy2026/enrollment_filters` and `.../service_filters`. Filters contain the business rules for grouping rows.

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -201,7 +201,7 @@ module HopwaCaper
       when 'sex'
         HudHelper.util('2026').sex(value)
       when 'percent_ami'
-        HudHelper.util('2026').percent_ami(value)
+        HudHelper.util('2026').percent_ami(value.to_i) # db has this as a float, it should be a numeric integer code
       when 'housing_assessment_at_exit'
         HudHelper.util('2026').housing_assessment_at_exit(value)
       when 'dob_quality'

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -46,6 +46,10 @@ module HopwaCaper
       distinct_on(:destination_client_id).order(destination_client_id: :desc, entry_date: :desc, id: :desc)
     }
 
+    scope :latest_by_distinct_hoh_client_id, -> {
+      distinct_on(:destination_client_id).order(destination_client_id: :desc, entry_date: :desc, id: :desc)
+    }
+
     scope :head_of_household, -> { where(relationship_to_hoh: 1) }
 
     scope :active_after, ->(date) { where('exit_date IS NULL OR exit_date > ?', date) }

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/household_scoped_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/household_scoped_filter.rb
@@ -7,32 +7,30 @@
 ###
 
 module HopwaCaper::Generators::Fy2026::EnrollmentFilters
-  # Provides helpers for filters that need to consider all household members while
-  # respecting the original scope constraints (report instance, project filters, etc.).
+  # Helpers for filtering households based on attributes across all household members.
+  # All methods preserve the original scope's constraints (report instance, date ranges, project filters).
   module HouseholdScopedFilter
     private
 
+    # Returns all members of households present in the scope, preserving all scope constraints.
+    # Example: if scope is "TBRA enrollments Jan-Dec 2024", returns all household members
+    # who are also in TBRA during Jan-Dec 2024.
     def household_members(scope)
-      HopwaCaper::Enrollment.
-        from("#{HopwaCaper::Enrollment.table_name} household_members").
-        joins("INNER JOIN (#{scoped_households(scope).to_sql}) scoped_households ON scoped_households.report_household_id = household_members.report_household_id")
+      household_ids = scope.distinct.pluck(:report_household_id)
+      scope.unscope(:select, :order, :limit, :offset).where(report_household_id: household_ids)
     end
 
-    def scoped_households(scope)
-      scope.
-        unscope(:select, :order, :limit, :offset).
-        select(:report_household_id).
-        distinct
-    end
-
-    # Filter to households where ANY member has at least one of the specified array values.
-    # Returns a scope filtered to households matching the condition.
+    # Filters to households where ANY member has at least one of the specified values.
+    # Loads records into memory for simplicity since datasets are small.
     def households_with_any_member_having(scope, field:, values:, type:)
-      household_ids = household_members(scope).
-        where(SqlHelper.array_overlap_condition(field: "household_members.#{field}", set: values, type: type)).
-        select(:report_household_id).
-        distinct
-      scope.where(report_household_id: household_ids)
+      all_members = household_members(scope).to_a
+
+      matching_household_ids = all_members.group_by(&:report_household_id).filter_map do |household_id, members|
+        has_match = members.any? { |member| (member.public_send(field) & values.map(&:to_s)).any? }
+        household_id if has_match
+      end
+
+      scope.where(report_household_id: matching_household_ids)
     end
   end
 end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
@@ -11,18 +11,20 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
     include HouseholdScopedFilter
 
     # Filter households based on income sources across all household members.
-    # - For specific income types: includes households where ANY member has those income sources
-    # - For no income (types: []): includes households where ALL members have no income sources
+    # - For specific income types: households where ANY member has those income sources
+    # - For no income (types: []): households where ALL members have no income sources
     def apply(scope)
       return households_with_any_member_having(scope, field: 'income_benefit_source_types', values: types, type: 'varchar') if types.present?
 
-      # Household has no income only if ALL members have empty income_benefit_source_types.
-      # Ensure households have at least one member to avoid matching orphaned household IDs.
-      household_ids = household_members(scope).
-        group(:report_household_id).
-        having("COUNT(*) > 0 AND BOOL_AND(household_members.income_benefit_source_types = '{}'::varchar[])").
-        select(:report_household_id)
-      scope.where(report_household_id: household_ids)
+      # "No income" requires ALL household members to have no income sources
+      all_members = household_members(scope).to_a
+
+      household_ids_with_no_income = all_members.group_by(&:report_household_id).filter_map do |household_id, members|
+        all_have_no_income = members.all? { |m| m.income_benefit_source_types.empty? }
+        household_id if all_have_no_income && members.any?
+      end
+
+      scope.where(report_household_id: household_ids_with_no_income)
     end
 
     def self.all

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_program_sheet.rb
@@ -51,7 +51,9 @@ module HopwaCaper::Generators::Fy2026::Sheets
       members = @report.
         hopwa_caper_enrollments.
         head_of_household.
-        where(report_household_id: enrollments.select(:report_household_id)).as_report_members
+        where(report_household_id: enrollments.select(:report_household_id)).
+        latest_by_distinct_hoh_client_id.
+        as_report_members
       sheet.append_row(label: label) do |row|
         row.append_cell_members(members: members)
       end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/supportive_services_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/supportive_services_sheet.rb
@@ -93,6 +93,7 @@ module HopwaCaper::Generators::Fy2026::Sheets
 
       HopwaCaper::Enrollment.head_of_household.
         where(report_instance_id: @report.id, report_household_id: services.select(:report_household_id)).
+        latest_by_distinct_hoh_client_id.
         as_report_members
     end
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/tbra_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/tbra_sheet.rb
@@ -49,12 +49,12 @@ module HopwaCaper::Generators::Fy2026::Sheets
     def health_outcomes_sheet(sheet)
       sheet.append_row(label: 'How many HOPWA-eligible individuals served with TBRA this year have ever been prescribed Anti-Retroviral Therapy?') do |row|
         cell_scope = relevant_enrollments.where(hopwa_eligible: true, ever_prescribed_anti_retroviral_therapy: true)
-        row.append_cell_members(members: cell_scope.latest_by_distinct_client_id.as_report_members)
+        row.append_cell_members(members: cell_scope.head_of_household.latest_by_distinct_hoh_client_id.as_report_members)
       end
 
       sheet.append_row(label: 'How many HOPWA-eligible persons served with TBRA have shown an improved viral load or achieved viral suppression?') do |row|
         cell_scope = relevant_enrollments.where(hopwa_eligible: true, viral_load_suppression: true)
-        row.append_cell_members(members: cell_scope.latest_by_distinct_client_id.as_report_members)
+        row.append_cell_members(members: cell_scope.head_of_household.latest_by_distinct_hoh_client_id.as_report_members)
       end
     end
 

--- a/drivers/hopwa_caper/spec/models/enrollment_spec.rb
+++ b/drivers/hopwa_caper/spec/models/enrollment_spec.rb
@@ -241,4 +241,76 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
       end
     end
   end
+
+  describe '#transform_value' do
+    let(:enrollment) do
+      described_class.new(
+        report_instance_id: report.id,
+        destination_client_id: client.id,
+        enrollment_id: hud_enrollment.id,
+      )
+    end
+    let(:pii_policy) { double('pii_policy') }
+
+    context 'when transforming percent_ami' do
+      it 'converts float value 1.0 to "30% or less"' do
+        enrollment.percent_ami = 1.0
+        result = enrollment.transform_value('percent_ami', 1.0, pii_policy)
+        expect(result).to eq('30% or less')
+      end
+
+      it 'converts float value 2.0 to "31% to 50%"' do
+        enrollment.percent_ami = 2.0
+        result = enrollment.transform_value('percent_ami', 2.0, pii_policy)
+        expect(result).to eq('31% to 50%')
+      end
+
+      it 'converts float value 3.0 to "51% to 80%"' do
+        enrollment.percent_ami = 3.0
+        result = enrollment.transform_value('percent_ami', 3.0, pii_policy)
+        expect(result).to eq('51% to 80%')
+      end
+
+      it 'converts float value 4.0 to "81% or greater"' do
+        enrollment.percent_ami = 4.0
+        result = enrollment.transform_value('percent_ami', 4.0, pii_policy)
+        expect(result).to eq('81% or greater')
+      end
+
+      it 'converts float value 99.0 to "Data not collected"' do
+        enrollment.percent_ami = 99.0
+        result = enrollment.transform_value('percent_ami', 99.0, pii_policy)
+        expect(result).to eq('Data not collected')
+      end
+
+      it 'converts nil value to "Data not collected"' do
+        enrollment.percent_ami = nil
+        result = enrollment.transform_value('percent_ami', nil, pii_policy)
+        expect(result).to eq('Data not collected')
+      end
+
+      it 'handles integer values correctly' do
+        enrollment.percent_ami = 1
+        result = enrollment.transform_value('percent_ami', 1, pii_policy)
+        expect(result).to eq('30% or less')
+      end
+    end
+
+    context 'when transforming other fields with data not collected support' do
+      it 'converts nil sex to "Data not collected"' do
+        result = enrollment.transform_value('sex', nil, pii_policy)
+        expect(result).to eq('Data not collected')
+      end
+
+      it 'converts nil housing_assessment_at_exit to "Data not collected"' do
+        result = enrollment.transform_value('housing_assessment_at_exit', nil, pii_policy)
+        expect(result).to eq('Data not collected')
+      end
+
+      it 'does not convert nil for fields without data not collected support' do
+        result = enrollment.transform_value('hiv_positive', nil, pii_policy)
+        expect(result).to be_nil
+      end
+    end
+  end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb
@@ -155,6 +155,39 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::TbraSheet, type: :model d
     end
   end
 
+  context 'with same household re-enrolling in different projects' do
+    let(:hoh_client) { create(:hud_client, data_source: data_source) }
+    let(:project_a) do
+      create_hopwa_project(funder: funder)
+    end
+    let(:project_b) do
+      create_hopwa_project(funder: funder)
+    end
+
+    let!(:first_enrollment) do
+      create_hiv_positive_enrollment(
+        client: hoh_client,
+        project: project_a,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+    end
+
+    let!(:second_enrollment) do
+      create_hiv_positive_enrollment(
+        client: hoh_client,
+        project: project_b,
+        entry_date: report_start_date + 6.months,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+    end
+
+    it 'counts the household only once by HoH destination_client_id' do
+      _, rows = run_and_extract_rows([project_a, project_b], 'Q2')
+      expect(rows.fetch('How many households were served with HOPWA TBRA assistance?')).to eq(1)
+    end
+  end
+
   context 'with various exit scenarios for continued assistance' do
     let!(:no_exit_enrollment) do
       create_hiv_positive_enrollment(

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/household_scoped_filter_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/household_scoped_filter_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+require_relative 'hopwa_caper_shared_context'
+
+RSpec.describe HopwaCaper::Generators::Fy2026::EnrollmentFilters::IncomeBenefitSourceFilter, type: :model do
+  include_context('HOPWA CAPER shared context')
+
+  let(:hopwa_funder) do
+    HudHelper.util('2026').funding_sources.invert.fetch('HUD: HOPWA - Permanent Housing (facility based or TBRA)')
+  end
+
+  let(:non_hopwa_funder) do
+    HudHelper.util('2026').funding_sources.invert.fetch('HUD: CoC - Permanent Supportive Housing')
+  end
+
+  let(:hopwa_project) { create_hopwa_project(funder: hopwa_funder) }
+  let(:non_hopwa_project) do
+    project = create(:hud_project, data_source: data_source, organization: organization)
+    create(:hud_project_coc, project: project, data_source_id: data_source.id, CoCCode: coc_code)
+    create(:hud_funder, project: project, funder: non_hopwa_funder, data_source: data_source)
+    project
+  end
+
+  # This test reproduces the bug where household_scoped_filter includes historical enrollments
+  # that should be filtered out by date range. Due to the 15-year lookback for longevity,
+  # a single report snapshot includes both current and historical enrollments.
+  context 'when household has historical enrollments in the same report snapshot' do
+    let(:household_id) { Hmis::Hud::Base.generate_uuid }
+    let(:hoh_client) { create(:hud_client, data_source: data_source) }
+    let(:beneficiary_client) { create(:hud_client, data_source: data_source) }
+
+    # Current enrollments (within report period)
+    let!(:hoh_enrollment_current) do
+      create_enrollment(
+        client: hoh_client,
+        project: hopwa_project,
+        entry_date: report_start_date + 10.days,
+        household_id: household_id,
+        relationship_to_ho_h: 1,
+      )
+    end
+
+    let!(:beneficiary_enrollment_current) do
+      create_enrollment(
+        client: beneficiary_client,
+        project: hopwa_project,
+        entry_date: report_start_date + 10.days,
+        household_id: household_id,
+        relationship_to_ho_h: 2,
+      )
+    end
+
+    # Historical enrollments (outside report period but within 15-year lookback)
+    # These get included in the snapshot for longevity calculations
+    let!(:hoh_enrollment_historical) do
+      enrollment = create_enrollment(
+        client: hoh_client,
+        project: hopwa_project,
+        entry_date: report_start_date - 2.years,
+        household_id: household_id,
+        relationship_to_ho_h: 1,
+      )
+      create(
+        :hud_exit,
+        enrollment: enrollment,
+        exit_date: report_start_date - 1.year,
+        data_source: data_source,
+      )
+      enrollment
+    end
+
+    let!(:beneficiary_enrollment_historical) do
+      enrollment = create_enrollment(
+        client: beneficiary_client,
+        project: hopwa_project,
+        entry_date: report_start_date - 2.years,
+        household_id: household_id,
+        relationship_to_ho_h: 2,
+      )
+      create(
+        :hud_exit,
+        enrollment: enrollment,
+        exit_date: report_start_date - 1.year,
+        data_source: data_source,
+      )
+      enrollment
+    end
+
+    before do
+      # Mark HoH as HIV+ in both enrollments
+      [hoh_enrollment_current, hoh_enrollment_historical].each do |enrollment|
+        create(
+          :hud_disability,
+          disability_type: hiv_positive,
+          enrollment: enrollment,
+          data_source: data_source,
+          disability_response: 1,
+        )
+      end
+
+      # Current period: HoH has earned income, beneficiary has no income
+      create(
+        :hud_income_benefit,
+        enrollment: hoh_enrollment_current,
+        Earned: 1,
+        information_date: report_start_date + 15.days,
+        data_source: data_source,
+        personal_id: hoh_client.PersonalID,
+      )
+      create(
+        :hud_income_benefit,
+        enrollment: beneficiary_enrollment_current,
+        information_date: report_start_date + 15.days,
+        data_source: data_source,
+        personal_id: beneficiary_client.PersonalID,
+      )
+
+      # Historical period: HoH had no income, beneficiary had SNAP
+      create(
+        :hud_income_benefit,
+        enrollment: hoh_enrollment_historical,
+        information_date: report_start_date - 18.months,
+        data_source: data_source,
+        personal_id: hoh_client.PersonalID,
+      )
+      create(
+        :hud_income_benefit,
+        enrollment: beneficiary_enrollment_historical,
+        SNAP: 1, # This should NOT affect current period income calculations
+        information_date: report_start_date - 18.months,
+        data_source: data_source,
+        personal_id: beneficiary_client.PersonalID,
+      )
+    end
+
+    it 'excludes historical enrollments when filtering household income by date range' do
+      report = create_report([hopwa_project])
+      run_report(report)
+
+      # The report snapshot includes both current and historical enrollments (due to 15-year lookback)
+      expect(report.hopwa_caper_enrollments.count).to eq(4) # 2 current + 2 historical
+
+      # Apply date filter to get only current period enrollments
+      program_filter = HopwaCaper::Generators::Fy2026::EnrollmentFilters::ProjectFunderFilter.tbra_hopwa
+      relevant_enrollments = report.hopwa_caper_enrollments.
+        overlapping_range(start_date: report.start_date, end_date: report.end_date).
+        merge(program_filter.apply(report.hopwa_caper_enrollments))
+
+      expect(relevant_enrollments.count).to eq(2) # Only current enrollments
+
+      # Apply SNAP filter (which only exists in historical enrollments)
+      snap_filter = HopwaCaper::Generators::Fy2026::EnrollmentFilters::IncomeBenefitSourceFilter.new(
+        label: 'SNAP',
+        types: [:SNAP],
+      )
+
+      filtered = snap_filter.apply(relevant_enrollments)
+
+      # Should be 0 because SNAP only exists in historical enrollments
+      # If household_members() lost the date filter, it would incorrectly
+      # include the historical beneficiary enrollment and find SNAP income
+      expect(filtered.count).to eq(0),
+        "Expected no enrollments with SNAP income in current period, but household_scoped_filter may be including historical enrollments"
+    end
+  end
+
+  # This context tests that project filters are also preserved
+  context 'when client has enrollments in different projects in the same snapshot' do
+    let(:household_id) { Hmis::Hud::Base.generate_uuid }
+    let(:household_id_2) { Hmis::Hud::Base.generate_uuid }
+
+    let(:hoh_client) { create(:hud_client, data_source: data_source) }
+    let(:beneficiary_client) { create(:hud_client, data_source: data_source) }
+
+    # HoH in HOPWA project within report period
+    let!(:hoh_hopwa_enrollment) do
+      create_enrollment(
+        client: hoh_client,
+        project: hopwa_project,
+        entry_date: report_start_date + 10.days,
+        household_id: household_id,
+        relationship_to_ho_h: 1,
+      )
+    end
+
+    # Beneficiary in HOPWA project within report period
+    let!(:beneficiary_hopwa_enrollment) do
+      create_enrollment(
+        client: beneficiary_client,
+        project: hopwa_project,
+        entry_date: report_start_date + 10.days,
+        household_id: household_id,
+        relationship_to_ho_h: 2,
+      )
+    end
+
+    # Same beneficiary in a NON-HOPWA project (should NOT affect HOPWA household income)
+    let!(:beneficiary_non_hopwa_enrollment) do
+      create_enrollment(
+        client: beneficiary_client,
+        project: non_hopwa_project,
+        entry_date: report_start_date + 10.days,
+        household_id: household_id_2,
+        relationship_to_ho_h: 1,
+      )
+    end
+
+    before do
+      # Mark HoH as HIV+
+      create(
+        :hud_disability,
+        disability_type: hiv_positive,
+        enrollment: hoh_hopwa_enrollment,
+        data_source: data_source,
+        disability_response: 1,
+      )
+
+      # HoH in HOPWA project has earned income
+      create(
+        :hud_income_benefit,
+        enrollment: hoh_hopwa_enrollment,
+        Earned: 1,
+        information_date: report_start_date + 15.days,
+        data_source: data_source,
+        personal_id: hoh_client.PersonalID,
+      )
+
+      # Beneficiary in HOPWA project has no income
+      create(
+        :hud_income_benefit,
+        enrollment: beneficiary_hopwa_enrollment,
+        information_date: report_start_date + 15.days,
+        data_source: data_source,
+        personal_id: beneficiary_client.PersonalID,
+      )
+
+      # Beneficiary in NON-HOPWA project has SNAP income
+      # This should NOT affect the HOPWA household income calculation
+      create(
+        :hud_income_benefit,
+        enrollment: beneficiary_non_hopwa_enrollment,
+        SNAP: 1,
+        information_date: report_start_date + 15.days,
+        data_source: data_source,
+        personal_id: beneficiary_client.PersonalID,
+      )
+    end
+
+    it 'excludes income from enrollments in other projects' do
+      report = create_report([hopwa_project])
+      run_report(report)
+      _, rows = run_and_extract_rows([hopwa_project], 'Q2')
+
+      # Household should be counted as having earned income (from HoH in HOPWA project)
+      expect(rows.fetch('Earned Income from Employment')).to eq(1)
+
+      # count SNAP income from the beneficiary's non-HOPWA enrollment
+      expect(rows.fetch('Other Welfare Assistance (Supplemental Nutrition Assistance Program, WIC, TANF, etc.)')).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

Corrects household deduplication in HOPWA CAPER reports to prevent double-counting households with multiple enrollments.

second attempt at fixing percent ami formatting in drilldown

## Type of Change

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

