### PR TITLE
official-docker-pkgs

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -193,6 +193,11 @@ FROM base AS dev-build
 
 USER root
 
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+
 COPY docker/app/entrypoint.dev.sh /usr/bin/
 COPY docker/app/entrypoint.spec.sh /usr/bin/
 COPY docker/app/entrypoint.dj-eks-test.sh /usr/bin/
@@ -201,7 +206,11 @@ ENTRYPOINT ["/usr/bin/entrypoint.dev.sh"]
 RUN git config --global --add safe.directory /app \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  neovim less docker.io python3 zsh openssh-client \
+  docker-ce-cli \
+  less \
+  python3 \
+  zsh \
+  openssh-client \
   && rm -rf /var/lib/apt/lists/*
 
 USER ${USER_ID}


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
After upgrading docker desktop I could no longer use the legacy ECS deploy script due to a version incompatibility error: "Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"

Replacing the `docker.io` package with the official docker package seems to resolve the issue

Also removes neovim; probably not needed in our images anymore as we have regular vim  

## Type of change
Dependency update

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

