### PR TITLE
Make legacy referral auto-exit behavior configurable (target 191)

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
@@ -189,6 +189,9 @@ module HmisExternalApis::AcHmis
       # don't auto-exit if referral is from link
       return if from_link?
 
+      # don't auto-exit if the environment specifies not to
+      return if AppConfigProperty.where(key: 'hmis_external_apis/legacy_referrals/keep_source_enrollment_open', value: '1')
+
       # for find the origin household through the enrollment
       referral_household = referral&.enrollment&.household
       return unless referral_household

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/referral_posting.rb
@@ -190,7 +190,7 @@ module HmisExternalApis::AcHmis
       return if from_link?
 
       # don't auto-exit if the environment specifies not to
-      return if AppConfigProperty.where(key: 'hmis_external_apis/legacy_referrals/keep_source_enrollment_open', value: '1')
+      return if AppConfigProperty.where(key: 'hmis_external_apis/legacy_referrals/keep_source_enrollment_open', value: '1').exists?
 
       # for find the origin household through the enrollment
       referral_household = referral&.enrollment&.household


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
For legacy referrals, the original custom-built functionality was to exit the source enrollment when the referral completes (if there are no other active referrals.) This change allows that to be configured per installation.

How to test:
- create a local config:

```ruby
AppConfigProperty.create!(
  key: 'hmis_external_apis/legacy_referrals/keep_source_enrollment_open',
  value: '1',
)
```

- create a legacy referral for a client that has no other active legacy referrals.
- progress through the steps to either move the referral to "Denied Pending" status, or fully accept with a completed intake.
- the client's source enrollment should not be auto-exited.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
