### PR TITLE
Fix bug with custom referral status pick list

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -197,7 +197,7 @@ module Types
       when 'PROJECT_CONFIG_TYPES'
         project_config_types_picklist
       when 'CE_REFERRAL_STATUSES'
-        ce_referral_statuses_picklist
+        ce_referral_statuses_picklist(user: user)
       end
     end
 
@@ -214,7 +214,7 @@ module Types
       end.compact
     end
 
-    def self.ce_referral_statuses_picklist
+    def self.ce_referral_statuses_picklist(user:)
       # To avoid key collisions, we display only custom statuses in the picklist.
       # In order to achieve the desired behavior, where both custom and default (state machine) statuses appear in the picklist,
       # we need to also duplicate state machine statuses as custom statuses during workflow setup (ce_define_workflows.rake)

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -735,6 +735,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       it_behaves_like 'returns empty pick list'
     end
   end
+
+  describe 'CE_REFERRAL_STATUSES' do
+    before(:each) do
+      allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
+      CeWorkflows::Shared::CeBuilderUtils.create_state_machine_custom_statuses(ds1)
+    end
+    let!(:custom_status) { create(:hmis_ce_custom_referral_status, data_source: ds1, name: 'Assigned Pending Review', key: 'assigned_pending_review') }
+
+    it 'returns all custom referral statuses' do
+      response, result = post_graphql(pick_list_type: 'CE_REFERRAL_STATUSES') { query }
+      expect(response.status).to eq 200
+      options = result.dig('data', 'pickList')
+      expect(options.count).to eq(4)
+      expect(options).to contain_exactly(
+        a_hash_including('code' => 'accepted', 'label' => 'Accepted'),
+        a_hash_including('code' => 'rejected', 'label' => 'Declined'),
+        a_hash_including('code' => 'in_progress', 'label' => 'In Progress'),
+        a_hash_including('code' => 'assigned_pending_review', 'label' => 'Assigned Pending Review'),
+      )
+    end
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Fixes bug introduced to release-192 (not yet on QA). Bug was introduced here: https://github.com/greenriver/hmis-warehouse/pull/6042/files#r2593105618
- Adds spec

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
