### PR TITLE
CI Build Fix

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -193,6 +193,8 @@ FROM base AS dev-build
 
 USER root
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN install -m 0755 -d /etc/apt/keyrings \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
   && chmod a+r /etc/apt/keyrings/docker.gpg \


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The CI Build was failing with the following:

```
Run docker run -v $(pwd)/.hadolint.yaml:/.hadolint.yaml \
Unable to find image 'ghcr.io/hadolint/hadolint:latest-alpine' locally
latest-alpine: Pulling from hadolint/hadolint
9824c27679d3: Pulling fs layer
c8f581594091: Pulling fs layer
9824c27679d3: Verifying Checksum
9824c27679d3: Download complete
9824c27679d3: Pull complete
c8f581594091: Verifying Checksum
c8f581594091: Download complete
c8f581594091: Pull complete
Digest: sha256:7aba693c1442eb31c0b015c129697cb3b6cb7da589d85c7562f9deb435a6657c
Status: Downloaded newer image for ghcr.io/hadolint/hadolint:latest-alpine
/Dockerfile:196 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
Error: Process completed with exit code 1.
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
