### PR TITLE
Lowercase cluster tag in ssh script

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -428,7 +428,6 @@ Layout/LeadingCommentSpace:
     - 'app/models/reports/ahar/fy2016/base.rb'
     - 'app/models/reports/ahar/fy2017/base.rb'
     - 'bin/containers/list'
-    - 'bin/containers/ssh'
 
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).

--- a/bin/containers/ssh
+++ b/bin/containers/ssh
@@ -114,7 +114,7 @@ class ContainerList
     results = ec2.describe_instances(
       filters: [
         {
-          name: 'tag:Cluster',
+          name: 'tag:cluster',
           values: ['openpath'],
         },
         {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Update our `ssh` script to look for instances with a lowercase tag `cluster` instead of uppercase `Cluster`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Helper script bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
