### PR TITLE
Add patch for hud service note

### DIFF
--- a/drivers/hmis/lib/form_data/springfield/fragments/patches/append_hud_service_note.json
+++ b/drivers/hmis/lib/form_data/springfield/fragments/patches/append_hud_service_note.json
@@ -1,0 +1,23 @@
+[
+  {
+    "form_identifier": "service",
+    "append_items": [
+      {
+        "text": "Note",
+        "type": "TEXT",
+        "link_id": "hud_service_note",
+        "mapping": {
+          "custom_field_key": "hud_service_note"
+        },
+        "enable_behavior": "ANY",
+        "enable_when": [
+          {
+            "local_constant": "$hudRecordType",
+            "operator": "EQUAL",
+            "answer_code": "RHY_SERVICE_CONNECTIONS"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Issue: https://github.com/open-path/Green-River/issues/8630

Add patch for collecting note alongside HUD service. Named generically `hud_service_note` in case note is wanted for other HUD service types later. For now it is only RHY Connection services.

See [similar patch](https://github.com/greenriver/hmis-warehouse/blob/release-193/drivers/hmis/lib/form_data/tarrant_county/fragments/patches/append_hud_service_note.json)

**How to test**: seed form definitions with client specified, collect service with note for RHY (and without note for other HUD services)

## Type of change
Configuration

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
