### PR TITLE
Add field to AC data warehouse feed, drop newlines

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/ce_referral_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/ce_referral_export.rb
@@ -52,6 +52,7 @@ module HmisExternalApis::AcHmis::Exporters
           referral.created_at,                   # CreatedAt
           referral.updated_at,                   # UpdatedAt
           referral.referral_origin,              # Origin (direct or waitlist)
+          referral.opportunity.created_at,       # UnitMarkedAvailableAt
         ]
         write_row(values)
       end
@@ -79,6 +80,7 @@ module HmisExternalApis::AcHmis::Exporters
         'CreatedAt',                  # Timestamp when the referral was created
         'UpdatedAt',                  # Timestamp when the referral was last updated
         'Origin',                     # Origin of the referral (direct or waitlist)
+        'UnitMarkedAvailableAt',      # Timestamp when the Opportunity was created (a.k.a. when unit was marked available)
       ]
     end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/csv_exporter.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/csv_exporter.rb
@@ -53,6 +53,8 @@ module HmisExternalApis::AcHmis::Exporters::CsvExporter
             value.strftime('%Y-%m-%d')
           elsif value.respond_to?(:strftime)
             value.strftime('%Y-%m-%d %H:%M:%S')
+          elsif value.is_a?(String)
+            value.gsub(/\r?\n/, ' ') # replace newlines with spaces (matches \n or \r\n)
           else
             value
           end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/case_note_export_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CaseNoteExport, type: :model
     expect(result.first['NoteContent']).to eq(case_note_1.content)
   end
 
-  it 'quotes newlines' do
+  it 'replaces newlines with spaces' do
     case_note_1.update!(content: "first\nsecond")
 
     subject.run!
@@ -45,6 +45,17 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CaseNoteExport, type: :model
     result = CSV.parse(output, headers: true)
 
     expect(result.length).to eq(1)
-    expect(result.first['NoteContent']).to eq(case_note_1.content)
+    expect(result.first['NoteContent']).to eq('first second')
+  end
+
+  it 'replaces Windows-style newlines with spaces' do
+    case_note_1.update!(content: "first\r\nsecond")
+
+    subject.run!
+
+    result = CSV.parse(output, headers: true)
+
+    expect(result.length).to eq(1)
+    expect(result.first['NoteContent']).to eq('first second')
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/ce_referral_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/ce_referral_export_spec.rb
@@ -67,5 +67,6 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CeReferralExport, type: :mod
     expect(row['CreatedAt']).to eq(referral.created_at.strftime('%Y-%m-%d %H:%M:%S'))
     expect(row['UpdatedAt']).to eq(referral.updated_at.strftime('%Y-%m-%d %H:%M:%S'))
     expect(row['Origin']).to eq(referral.referral_origin)
+    expect(row['UnitMarkedAvailableAt']).to eq(referral.opportunity.created_at.strftime('%Y-%m-%d %H:%M:%S'))
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8657

Make 2 requested changes to custom AC feeds:

1. Add timestamp for when opportunity was created to referral export
2. Remove newlines from csv exports

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
