### PR TITLE
Add ClientPolicy and use it in mutations

### DIFF
--- a/drivers/hmis/app/graphql/mutations/bulk_merge_clients.rb
+++ b/drivers/hmis/app/graphql/mutations/bulk_merge_clients.rb
@@ -12,7 +12,7 @@ module Mutations
     field :success, Boolean, null: true
 
     def resolve(input:)
-      raise 'not allowed' unless current_user.can_merge_clients?
+      access_denied! unless policy_for(Hmis::Hud::Client, policy_type: :hmis_client).can_merge?
 
       all_client_ids = input.map(&:client_ids).flatten.uniq
       clients = Hmis::Hud::Client.viewable_by(current_user).where(id: all_client_ids)

--- a/drivers/hmis/app/graphql/mutations/create_client_alert.rb
+++ b/drivers/hmis/app/graphql/mutations/create_client_alert.rb
@@ -15,7 +15,7 @@ module Mutations
 
     def resolve(input:)
       client = Hmis::Hud::Client.find(input.client_id)
-      raise 'not allowed' unless current_permission?(permission: :can_manage_client_alerts, entity: client)
+      access_denied! unless policy_for(client, policy_type: :hmis_client).can_manage_alerts?
 
       params = input.to_params
       alert = Hmis::ClientAlert.new(params)

--- a/drivers/hmis/app/graphql/mutations/create_scan_card_code.rb
+++ b/drivers/hmis/app/graphql/mutations/create_scan_card_code.rb
@@ -15,7 +15,7 @@ module Mutations
 
     def resolve(client_id:, expiration_date: nil)
       client = Hmis::Hud::Client.viewable_by(current_user).find(client_id)
-      raise 'unauthorized' unless current_permission?(permission: :can_manage_scan_cards, entity: client)
+      access_denied! unless policy_for(client, policy_type: :hmis_client).can_manage_scan_cards?
 
       scan_card_code = Hmis::ScanCardCode.new(
         client: client,

--- a/drivers/hmis/app/graphql/mutations/delete_client.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client.rb
@@ -24,24 +24,27 @@ module Mutations
 
       # While this is redundant with the viewable_by() scope above, this check caches the authorization result so that
       # the client object-level authorization check will succeed even after the client has been deleted
+      # TODO - remove when the authorization check in HmisSchema::Client is updated to use the policy
       access_denied! unless current_permission?(permission: :can_view_clients, entity: client)
 
       warnings, resolvable_enrollments = check_enrollments(client, ignore_warnings: confirmed)
 
       return { client: nil, errors: warnings } if warnings.any?
 
+      access_denied! unless policy_for(client, policy_type: :hmis_client).can_destroy?
+
       client.transaction do
-        default_delete_record(
-          record: client,
-          field_name: :client,
-          permissions: :can_delete_clients,
-          after_delete: -> do
-            resolvable_enrollments.each do |enrollment|
-              enrollment.update!(relationship_to_ho_h: 1)
-            end
-          end,
-        )
+        client.destroy!
+
+        resolvable_enrollments.each do |enrollment|
+          enrollment.update!(relationship_to_ho_h: 1)
+        end
       end
+
+      {
+        client: client,
+        errors: [],
+      }
     end
 
     def check_enrollments(client, ignore_warnings: false)

--- a/drivers/hmis/app/graphql/mutations/delete_client_alert.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client_alert.rb
@@ -15,7 +15,7 @@ module Mutations
 
     def resolve(id:)
       record = Hmis::ClientAlert.find(id)
-      raise 'Access denied' unless current_permission?(permission: :can_manage_client_alerts, entity: record.client)
+      access_denied! unless policy_for(record.client, policy_type: :hmis_client).can_manage_alerts?
 
       record.destroy!
 

--- a/drivers/hmis/app/graphql/mutations/delete_client_file.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client_file.rb
@@ -13,13 +13,18 @@ module Mutations
     field :file, Types::HmisSchema::File, null: true
 
     def resolve(file_id:)
-      file = Hmis::File.find_by(id: file_id)
-      default_delete_record(
-        record: file,
-        field_name: :file,
-        permissions: :can_manage_any_client_files,
-        authorize: Hmis::File.authorize_proc,
-      )
+      file = Hmis::File.find_by(id: file_id) # TODO - only include files that the user can view.
+      # Can't use viewable_by scope since it includes confidential files even if the user can only view nonconfidential
+
+      raise HmisErrors::ApiError, 'Record not found' unless file.present?
+      raise HmisErrors::ApiError, 'Access denied' unless policy_for(file.client, policy_type: :hmis_client).can_edit_client_file?(file: file)
+
+      file.destroy!
+
+      {
+        file: file,
+        errors: [],
+      }
     end
   end
 end

--- a/drivers/hmis/app/graphql/mutations/delete_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_client_image.rb
@@ -15,7 +15,7 @@ module Mutations
     def resolve(client_id:)
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
       raise HmisErrors::ApiError, 'Record not found' unless client.present?
-      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
+      raise HmisErrors::ApiError, 'Access denied' unless policy_for(client, policy_type: :hmis_client).can_edit?
 
       client.delete_image
       client = client.reload

--- a/drivers/hmis/app/graphql/mutations/delete_scan_card_code.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_scan_card_code.rb
@@ -14,7 +14,7 @@ module Mutations
 
     def resolve(id:)
       code = Hmis::ScanCardCode.find(id)
-      raise 'unauthorized' unless current_permission?(permission: :can_manage_scan_cards, entity: code.client)
+      access_denied! unless policy_for(code.client, policy_type: :hmis_client).can_manage_scan_cards?
 
       code.deleted_at = Time.current
       code.deleted_by = current_user

--- a/drivers/hmis/app/graphql/mutations/merge_clients.rb
+++ b/drivers/hmis/app/graphql/mutations/merge_clients.rb
@@ -13,7 +13,7 @@ module Mutations
     field :client, Types::HmisSchema::Client, null: true
 
     def resolve(client_ids:)
-      raise 'not allowed' unless current_user.can_merge_clients?
+      access_denied! unless policy_for(Hmis::Hud::Client, policy_type: :hmis_client).can_merge?
 
       clients = Hmis::Hud::Client.viewable_by(current_user).where(id: client_ids)
       raise 'not found' unless clients.size == client_ids.uniq.length

--- a/drivers/hmis/app/graphql/mutations/restore_scan_card_code.rb
+++ b/drivers/hmis/app/graphql/mutations/restore_scan_card_code.rb
@@ -14,7 +14,7 @@ module Mutations
 
     def resolve(id:)
       code = Hmis::ScanCardCode.only_deleted.find(id)
-      raise 'unauthorized' unless current_permission?(permission: :can_manage_scan_cards, entity: code.client)
+      access_denied! unless policy_for(code.client, policy_type: :hmis_client).can_manage_scan_cards?
 
       code.deleted_at = nil
       code.deleted_by = nil

--- a/drivers/hmis/app/graphql/mutations/update_client_image.rb
+++ b/drivers/hmis/app/graphql/mutations/update_client_image.rb
@@ -17,7 +17,7 @@ module Mutations
       client = Hmis::Hud::Client.visible_to(current_user).find_by(id: client_id)
 
       raise HmisErrors::ApiError, 'Record not found' unless client.present?
-      raise HmisErrors::ApiError, 'Access denied' unless current_user.permissions_for?(client, :can_edit_clients)
+      raise HmisErrors::ApiError, 'Access denied' unless policy_for(client, policy_type: :hmis_client).can_edit?
 
       errors = HmisErrors::Errors.new
 

--- a/drivers/hmis/app/models/hmis/auth_policies/context_loaders/client_project_loader.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/context_loaders/client_project_loader.rb
@@ -1,0 +1,40 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Loads project IDs for client enrollments in bulk
+module Hmis::AuthPolicies::ContextLoaders
+  class ClientProjectLoader
+    include ArelHelper
+
+    def initialize
+      # { client_id => [project_id, ...] }
+      @cache = {}
+    end
+
+    # Get project IDs for a single client
+    def get(client_id)
+      preload([client_id]) unless @cache.key?(client_id)
+      @cache[client_id] || Set.new
+    end
+
+    # Preload project IDs for multiple clients at once
+    def preload(client_ids)
+      return if client_ids.empty?
+
+      # Load all enrollments for these clients and group by client_id
+      enrollments = Hmis::Hud::Enrollment.joins(:client).
+        merge(Hmis::Hud::Client.where(id: client_ids)).
+        pluck(c_t[:id], e_t[:project_pk])
+
+      enrollments.each do |client_id, project_id|
+        @cache[client_id] ||= Set.new
+        @cache[client_id] << project_id
+      end
+    end
+  end
+end

--- a/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
@@ -38,7 +38,7 @@ module Hmis::AuthPolicies::ContextLoaders
 
     protected
 
-    # Recursively checks that a permission and all its transitive requirements are satisfied
+    # Recursively checks that a permission and its transitive requirements are satisfied
     def requirements_met?(permission, permissions, visited)
       raise 'cycle detected' if visited.include?(permission) # This shouldn't occur
 
@@ -46,9 +46,13 @@ module Hmis::AuthPolicies::ContextLoaders
 
       return true if required.blank? # No requirements, keep it
 
-      # check that all requirements are satisfied
+      mode = role_config[permission][:requirements_mode] || :all?
+      raise "unknown mode #{mode}" unless mode.in?([:all?, :any?])
+
+      # check that all / any requirements are satisfied, depending on the mode
       visited.add(permission)
-      result = required.all? do |req|
+
+      result = required.send(mode) do |req|
         permissions.include?(req) && requirements_met?(req, permissions, visited)
       end
       visited.delete(permission)

--- a/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
@@ -27,8 +27,6 @@ module Hmis::AuthPolicies::ContextLoaders
       apply_permission_requirements(raw_permissions).freeze
     end
 
-    protected
-
     def apply_permission_requirements(permissions)
       # support cycle detection for requirement chains
       visited = Set.new
@@ -37,6 +35,8 @@ module Hmis::AuthPolicies::ContextLoaders
         !requirements_met?(permission, permissions, visited)
       end
     end
+
+    protected
 
     # Recursively checks that a permission and all its transitive requirements are satisfied
     def requirements_met?(permission, permissions, visited)

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
@@ -1,0 +1,59 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class Hmis::AuthPolicies::HmisClientPolicy < Hmis::AuthPolicies::BasePolicy
+  def can_view?
+    client_permissions.include?(:can_view_clients)
+  end
+
+  def can_edit?
+    client_permissions.include?(:can_edit_clients)
+  end
+
+  def can_destroy?
+    client_permissions.include?(:can_delete_clients)
+  end
+
+  def can_view_name?
+    client_permissions.include?(:can_view_client_name)
+  end
+
+  def can_manage_alerts?
+    client_permissions.include?(:can_manage_client_alerts)
+  end
+
+  def can_manage_scan_cards?
+    client_permissions.include?(:can_manage_scan_cards)
+  end
+
+  def can_manage_client_files? # todo @martha
+    client_permissions.include?(:can_manage_any_client_files) || client_permissions.include?(:can_manage_own_client_files)
+  end
+
+  def can_manage_any_client_files?
+    client_permissions.include?(:can_manage_any_client_files)
+  end
+
+  def can_merge?
+    client_permissions.include?(:can_merge_clients)
+  end
+
+  protected
+
+  memoize def client_permissions
+    if resource.is_a?(Class)
+      # Class-level policy (e.g., for merge operations)
+      context.potential_permissions
+    else
+      # Instance-level policy (for a specific client)
+      context.client_permissions(resource.id)
+    end
+  end
+
+  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Client)
+end

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
@@ -31,12 +31,22 @@ class Hmis::AuthPolicies::HmisClientPolicy < Hmis::AuthPolicies::BasePolicy
     client_permissions.include?(:can_manage_scan_cards)
   end
 
-  def can_manage_client_files? # todo @martha
-    client_permissions.include?(:can_manage_any_client_files) || client_permissions.include?(:can_manage_own_client_files)
+  def can_create_client_file?
+    can_manage_any_client_files? || can_manage_own_client_files?
+  end
+
+  def can_edit_client_file?(file:)
+    return true if can_manage_any_client_files?
+
+    can_manage_own_client_files? && file.user_id == user.id
   end
 
   def can_manage_any_client_files?
     client_permissions.include?(:can_manage_any_client_files)
+  end
+
+  def can_manage_own_client_files?
+    client_permissions.include?(:can_manage_own_client_files)
   end
 
   def can_merge?

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
@@ -48,7 +48,7 @@ class Hmis::AuthPolicies::HmisClientPolicy < Hmis::AuthPolicies::BasePolicy
   memoize def client_permissions
     if resource.is_a?(Class)
       # Class-level policy (e.g., for merge operations)
-      context.potential_permissions
+      context.global_permissions
     else
       # Instance-level policy (for a specific client)
       context.client_permissions(resource.id)

--- a/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
@@ -40,6 +40,21 @@ class Hmis::AuthPolicies::UserContext
     project_access_group_loader.preload(project_ids)
   end
 
+  # Client permissions are based on the user's permissions at projects they are enrolled in.
+  # If they have no enrollments, it's based on the user's global permissions.
+  def client_permissions(client_id)
+    project_ids = client_project_loader.get(client_id)
+
+    if project_ids.empty?
+      # Client has no enrollments - use global permissions
+      potential_permissions
+    else
+      # Client has enrollments - union permissions from all enrolled projects
+      project_access_group_loader.preload(project_ids)
+      project_ids.flat_map { |id| project_permissions(id).to_a }.to_set.freeze
+    end
+  end
+
   def preload_referral_dependencies(referral_ids)
     ce_referral_project_loader.preload(referral_ids)
     ce_referral_source_project_loader.preload(referral_ids)
@@ -89,5 +104,9 @@ class Hmis::AuthPolicies::UserContext
 
   memoize def ce_referral_source_project_loader
     Hmis::AuthPolicies::ContextLoaders::CeReferralSourceProjectLoader.new
+  end
+
+  memoize def client_project_loader
+    Hmis::AuthPolicies::ContextLoaders::ClientProjectLoader.new
   end
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
@@ -30,6 +30,11 @@ class Hmis::AuthPolicies::UserContext
     user.roles.flat_map(&:granted_permissions).to_set.freeze
   end
 
+  memoize def global_permissions
+    permissions = user.roles.flat_map(&:granted_permissions).to_set
+    permission_loader.apply_permission_requirements(permissions).freeze
+  end
+
   # Project-specific permissions
   def project_permissions(project_id)
     access_group_ids = project_access_group_loader.get(project_id)

--- a/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/user_context.rb
@@ -52,7 +52,7 @@ class Hmis::AuthPolicies::UserContext
 
     if project_ids.empty?
       # Client has no enrollments - use global permissions
-      potential_permissions
+      global_permissions
     else
       # Client has enrollments - union permissions from all enrolled projects
       project_access_group_loader.preload(project_ids)

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -518,6 +518,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_manage_scan_cards: {
         description: 'Ability to create and deactivate Scan Cards',
+        requirements: [:can_view_clients],
         administrative: true,
         access: [:editable],
         category: 'Administration',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -330,6 +330,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_delete_clients: {
         administrative: true,
+        requirements: [:can_view_clients],
         access: [:editable],
         category: 'Client Access',
         sub_category: 'Access',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -532,6 +532,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_manage_client_alerts: {
         description: 'Ability to create, edit, and delete Client Alerts',
+        requirements: [:can_view_client_alerts],
         administrative: false,
         access: [:editable],
         category: 'Client Access',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -450,6 +450,8 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_manage_own_client_files: {
         description: 'Access to upload, edit, and delete client files that I uploaded',
+        requirements: [:can_view_any_nonconfidential_client_files, :can_view_any_confidential_client_files],
+        requirements_mode: :any?, # User can manage any files they can view. Must be able to view some files, through either of the required permissions.
         administrative: false,
         access: [:editable],
         category: 'Client Files',
@@ -457,6 +459,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_view_any_nonconfidential_client_files: {
         description: 'Access to view non-confidential client files uploaded by anyone',
+        requirements: [:can_view_clients],
         administrative: false,
         access: [:viewable],
         category: 'Client Files',
@@ -464,6 +467,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_view_any_confidential_client_files: {
         description: 'Access to view confidential client files uploaded by anyone',
+        requirements: [:can_view_clients],
         administrative: false,
         access: [:viewable],
         category: 'Client Files',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -441,6 +441,8 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_manage_any_client_files: {
         description: 'Access to upload, edit, and delete any client files that I can see',
+        requirements: [:can_view_any_nonconfidential_client_files, :can_view_any_confidential_client_files],
+        requirements_mode: :any?, # User can manage any files they can view. Must be able to view some files, through either of the required permissions.
         administrative: false,
         access: [:editable],
         category: 'Client Files',

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -475,6 +475,7 @@ class Hmis::Role < ::ApplicationRecord
       },
       can_merge_clients: {
         description: 'Ability to merge and split client records',
+        requirements: [:can_view_clients],
         administrative: true,
         access: [:editable],
         category: 'Administration',

--- a/drivers/hmis/spec/models/hmis/auth_policies/context_loaders/hmis_permission_loader_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/context_loaders/hmis_permission_loader_spec.rb
@@ -30,5 +30,23 @@ RSpec.describe Hmis::AuthPolicies::ContextLoaders::HmisPermissionLoader, type: :
         expect(result.to_a).to eq([:can_view_project]) # can_start_referrals filtered out due to unmet requirements
       end
     end
+
+    context 'with permission requirements mode any' do
+      it 'includes permissions when any requirement is met' do
+        access_control = create_access_control(user, project, with_permission: [:can_manage_any_client_files, :can_view_any_nonconfidential_client_files])
+
+        result = loader.for_access_group_ids([access_control.access_group.id])
+
+        expect(result).to include(:can_manage_any_client_files, :can_view_any_nonconfidential_client_files)
+      end
+
+      it 'excludes permissions when no requirements are met' do
+        access_control = create_access_control(user, project, with_permission: [:can_manage_any_client_files])
+
+        result = loader.for_access_group_ids([access_control.access_group.id])
+
+        expect(result.to_a).not_to include(:can_manage_any_client_files)
+      end
+    end
   end
 end

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_client_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_client_policy_spec.rb
@@ -1,0 +1,92 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hmis::AuthPolicies::HmisClientPolicy, type: :model do
+  let(:data_source) { create(:hmis_data_source) }
+  let(:organization) { create(:hmis_hud_organization, data_source: data_source) }
+  let(:project) { create(:hmis_hud_project, organization: organization, data_source: data_source) }
+  let(:client) { create(:hmis_hud_client, data_source: data_source) }
+  let(:user) { create(:hmis_user, hmis_data_source_id: data_source.id) }
+  let(:policy) { user.policy_for(client, policy_type: :hmis_client) }
+
+  let(:granted_permissions) { [:can_view_clients, :can_edit_clients, :can_view_client_name] }
+
+  shared_examples 'permission checks with access' do
+    it 'grants configured permissions' do
+      expect(policy.can_view?).to be true
+      expect(policy.can_edit?).to be true
+      expect(policy.can_view_name?).to be true
+    end
+
+    it 'denies unconfigured permissions' do
+      expect(policy.can_destroy?).to be false
+      expect(policy.can_manage_alerts?).to be false
+    end
+  end
+
+  shared_examples 'permission checks without access' do
+    it 'denies all permissions when user lacks access' do
+      expect(policy.can_view?).to be false
+      expect(policy.can_edit?).to be false
+      expect(policy.can_destroy?).to be false
+      expect(policy.can_view_name?).to be false
+      expect(policy.can_manage_alerts?).to be false
+    end
+  end
+
+  context 'when client is enrolled in a project' do
+    let!(:enrollment) { create(:hmis_hud_enrollment, client: client, project: project) }
+
+    context 'with project access' do
+      let!(:access_control) { create_access_control(user, project, with_permission: granted_permissions) }
+
+      include_examples 'permission checks with access'
+    end
+
+    context 'with organization access' do
+      let!(:access_control) { create_access_control(user, organization, with_permission: granted_permissions) }
+
+      include_examples 'permission checks with access'
+    end
+
+    context 'without any access' do
+      let!(:other_project) { create(:hmis_hud_project, data_source: data_source) }
+      let!(:access_control) { create_access_control(user, other_project, with_permission: granted_permissions) }
+
+      include_examples 'permission checks without access'
+    end
+  end
+
+  context 'when client has no enrollments' do
+    context 'with global permissions (granted via any access control)' do
+      let!(:access_control) { create_access_control(user, project, with_permission: granted_permissions) }
+
+      include_examples 'permission checks with access'
+    end
+
+    context 'without any permissions' do
+      include_examples 'permission checks without access'
+    end
+  end
+
+  context 'class-level policy' do
+    let(:policy) { user.policy_for(Hmis::Hud::Client, policy_type: :hmis_client) }
+
+    it 'grants permissions if user has them anywhere' do
+      create_access_control(user, project, with_permission: [:can_merge_clients])
+      expect(policy.can_merge?).to be true
+    end
+
+    it 'denies permissions if user lacks them everywhere' do
+      create_access_control(user, project, with_permission: [:can_view_clients])
+      expect(policy.can_merge?).to be false
+    end
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/bulk_merge_clients_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_merge_clients_spec.rb
@@ -1,0 +1,94 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'BulkMergeClients', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation BulkMergeClients($input: BulkMergeClientsInput!) {
+        bulkMergeClients(input: $input) {
+          success
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_merge_clients]) }
+  let!(:c1) { create :hmis_hud_client, data_source: ds1 }
+  let!(:c2) { create :hmis_hud_client, data_source: ds1 }
+  let!(:c3) { create :hmis_hud_client, data_source: ds1 }
+  let!(:c4) { create :hmis_hud_client, data_source: ds1 }
+
+  before(:each) do
+    hmis_login(user)
+    allow(Hmis::MergeClientsJob).to receive(:perform_now) # mock the job's internals, they are tested elsewhere
+  end
+
+  it 'returns success for multiple merge operations' do
+    input = {
+      input: [
+        { client_ids: [c1.id, c2.id] },
+        { client_ids: [c3.id, c4.id] },
+      ],
+    }
+
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200)
+    expect(result.dig('data', 'bulkMergeClients', 'success')).to eq(true)
+    expect(result.dig('data', 'bulkMergeClients', 'errors')).to be_empty
+
+    expect(Hmis::MergeClientsJob).to have_received(:perform_now).twice
+  end
+
+  describe 'permissions' do
+    it 'fails if user lacks can_merge_clients permission' do
+      remove_permissions(access_control, :can_merge_clients)
+      input = { input: [{ client_ids: [c1.id, c2.id] }] }
+
+      expect_access_denied post_graphql(input: input) { mutation }
+      expect(Hmis::MergeClientsJob).not_to have_received(:perform_now)
+    end
+
+    it 'fails if user lacks prerequisite can_view_clients permission' do
+      remove_permissions(access_control, :can_view_clients)
+      input = { input: [{ client_ids: [c1.id, c2.id] }] }
+
+      expect_access_denied post_graphql(input: input) { mutation }
+      expect(Hmis::MergeClientsJob).not_to have_received(:perform_now)
+    end
+  end
+
+  describe 'error handling' do
+    it 'fails if a client is not found' do
+      input = { input: [{ client_ids: [c1.id, '999999'] }] }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'not found'
+      expect(Hmis::MergeClientsJob).not_to have_received(:perform_now)
+    end
+
+    it 'fails if a client is not viewable by the user' do
+      other_ds = create(:hmis_primary_data_source)
+      other_client = create(:hmis_hud_client, data_source: other_ds)
+
+      input = { input: [{ client_ids: [c1.id, other_client.id] }] }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'not found'
+      expect(Hmis::MergeClientsJob).not_to have_received(:perform_now)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis/spec/requests/hmis/client_alert_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_alert_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       alert = Hmis::ClientAlert.find(alert_id)
       expect(alert.note).to eq('raspberries')
       expect(alert.priority).to eq(Hmis::ClientAlert::HIGH)
-      expect(alert.expiration_date).to eq((Date.current + 2.months))
+      expect(alert.expiration_date).to eq(Date.current + 2.months)
       expect(alert.created_by.id).to eq(hmis_user.id)
     end
 
@@ -170,6 +170,33 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_gql_error post_graphql(id: a1.id) { delete_alert }
       c1.reload
       expect(c1.alerts.size).to eq(2), 'no alert should have been deleted'
+    end
+  end
+
+  describe 'when the user can view, but not manage' do
+    let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_client_alerts]) }
+
+    it 'should return a client with alerts' do
+      response, result = post_graphql(id: c1.id) { query }
+      expect(response.status).to eq(200), result.inspect
+      alerts = result.dig('data', 'client', 'alerts')
+      expect(alerts.size).to eq 2
+    end
+
+    it 'should not be able to create alerts' do
+      mutation_input = { clientId: c1.id.to_s, note: 'err' }
+      expect_access_denied post_graphql(input: mutation_input) { create_alert }
+      expect(c1.alerts.size).to eq(2), 'a third alert should not have been created'
+    end
+  end
+
+  describe 'when the user can manage, but not view (missing prerequisite permission)' do
+    let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_manage_client_alerts]) }
+
+    it 'should not be able to create alerts' do
+      mutation_input = { clientId: c1.id.to_s, note: 'err' }
+      expect_access_denied post_graphql(input: mutation_input) { create_alert }
+      expect(c1.alerts.size).to eq(2), 'a third alert should not have been created'
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/client_alert_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_alert_spec.rb
@@ -188,6 +188,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect_access_denied post_graphql(input: mutation_input) { create_alert }
       expect(c1.alerts.size).to eq(2), 'a third alert should not have been created'
     end
+
+    it 'should not be allowed to delete alerts' do
+      expect_access_denied post_graphql(id: a1.id) { delete_alert }
+      c1.reload
+      expect(c1.alerts.size).to eq(2), 'no alert should have been deleted'
+    end
   end
 
   describe 'when the user can manage, but not view (missing prerequisite permission)' do
@@ -197,6 +203,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       mutation_input = { clientId: c1.id.to_s, note: 'err' }
       expect_access_denied post_graphql(input: mutation_input) { create_alert }
       expect(c1.alerts.size).to eq(2), 'a third alert should not have been created'
+    end
+
+    it 'should not be allowed to delete alerts' do
+      expect_access_denied post_graphql(id: a1.id) { delete_alert }
+      c1.reload
+      expect(c1.alerts.size).to eq(2), 'no alert should have been deleted'
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/delete_client_image_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_client_image_spec.rb
@@ -1,0 +1,86 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'DeleteClientImage', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation DeleteClientImage($input: DeleteClientImageInput!) {
+        deleteClientImage(input: $input) {
+          client {
+            id
+          }
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_edit_clients]) }
+  let!(:client) { create :hmis_hud_client, data_source: ds1 }
+  let!(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open('drivers/hmis/spec/fixtures/files/client_photo_00001.jpg'),
+      filename: 'client_photo_00001.jpg',
+      content_type: 'image/jpeg',
+    )
+  end
+
+  before(:each) do
+    hmis_login(user)
+    client.build_client_headshot_file(blob.signed_id, u1)
+    client.save!
+  end
+
+  it 'deletes client image successfully' do
+    expect(client.client_files.count).to eq(1)
+
+    input = { client_id: client.id }
+
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200)
+    expect(result.dig('data', 'deleteClientImage', 'client', 'id')).to eq(client.id.to_s)
+    expect(result.dig('data', 'deleteClientImage', 'errors')).to be_empty
+
+    client.reload
+    expect(client.client_files.count).to eq(0)
+  end
+
+  describe 'permissions' do
+    it 'fails if user lacks can_edit_clients permission' do
+      remove_permissions(access_control, :can_edit_clients)
+      input = { client_id: client.id }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Access denied'
+    end
+
+    it 'fails if user lacks can_view_clients permission' do
+      remove_permissions(access_control, :can_view_clients)
+      input = { client_id: client.id }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Record not found'
+    end
+  end
+
+  describe 'error handling' do
+    it 'fails if client is not found' do
+      input = { client_id: '999999' }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Record not found'
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end

--- a/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_file_spec.rb
@@ -11,13 +11,6 @@ require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
 RSpec.describe Hmis::GraphqlController, type: :request do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   include_context 'hmis base setup'
   include_context 'file upload setup'
 
@@ -45,7 +38,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   def call_mutation(file_id)
     response, result = post_graphql(file_id: file_id) { mutation }
-    expect(response.status).to eq 200
+    expect(response.status).to eq(200), result.inspect
     file = result.dig('data', 'deleteClientFile', 'file')
     errors = result.dig('data', 'deleteClientFile', 'errors')
     [file, errors]
@@ -67,12 +60,25 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(Hmis::File.all).to include(have_attributes(id: file_id))
     end
 
-    it 'should throw error if only allowed to manage own files and trying to delete file that is not their own' do
-      remove_permissions(access_control, :can_manage_any_client_files)
-      file_id = f1.id
-      f1.update!(user_id: u2.id)
-      expect_gql_error post_graphql(file_id: file_id) { mutation }
-      expect(Hmis::File.all).to include(have_attributes(id: file_id))
+    context 'only allowed to manage own files' do
+      before(:each) do
+        remove_permissions(access_control, :can_manage_any_client_files)
+      end
+
+      it 'should delete the file if it is their own' do
+        file_id = f1.id
+        file, errors = call_mutation(file_id)
+        expect(errors).to be_empty
+        expect(file).to be_present
+        expect(Hmis::File.all).not_to include(have_attributes(id: file_id))
+      end
+
+      it 'should throw error if trying to delete file that is not their own' do
+        file_id = f1.id
+        f1.update!(user_id: u2.id)
+        expect_gql_error post_graphql(file_id: file_id) { mutation }
+        expect(Hmis::File.all).to include(have_attributes(id: file_id))
+      end
     end
 
     it 'tracks metadata on versions' do

--- a/drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'Manage Scan Card Mutations', type: :request do
 
     let!(:client) { create(:hmis_hud_client, data_source: ds1) }
     let!(:code1) { create(:hmis_scan_card_code, client: client) }
+    let!(:code2) { create(:hmis_scan_card_code, client: client, deleted_at: Time.current) }
 
     before(:each) do
       add_permissions(access_control, :can_manage_scan_cards)
@@ -99,9 +100,9 @@ RSpec.describe 'Manage Scan Card Mutations', type: :request do
     it 'requires permission for all mutations' do
       remove_permissions(access_control, :can_manage_scan_cards)
 
-      expect_gql_error post_graphql(id: client.id) { create_code }
-      expect_gql_error post_graphql(id: code1.id) { delete_code }
-      expect_gql_error post_graphql(id: code1.id) { restore_code }
+      expect_access_denied post_graphql(id: client.id) { create_code }
+      expect_access_denied post_graphql(id: code1.id) { delete_code }
+      expect_access_denied post_graphql(id: code2.id) { restore_code }
     end
 
     it 'creates codes' do

--- a/drivers/hmis/spec/requests/hmis/merge_clients_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/merge_clients_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(result.dig('data', 'mergeClients', 'client', 'id')).to eq(remaining_clients.first.id.to_s)
     end
 
-    it 'should fail if user lacks permission' do
+    it 'should fail if user lacks merge permission' do
+      remove_permissions(access_control, :can_merge_clients)
+      expect_access_denied post_graphql(input: { client_ids: [c1.id, c2.id] }) { mutation }
+    end
+
+    it 'should fail if user lacks view permission' do
       remove_permissions(access_control, :can_view_clients)
-      expect_gql_error post_graphql(input: { client_ids: [c1.id, c2.id] }) { mutation }
+      expect_access_denied post_graphql(input: { client_ids: [c1.id, c2.id] }) { mutation }
     end
 
     it 'should fail if any clients are not viewable' do

--- a/drivers/hmis/spec/requests/hmis/update_client_image_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_client_image_spec.rb
@@ -1,0 +1,91 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'UpdateClientImage', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation UpdateClientImage($input: UpdateClientImageInput!) {
+        updateClientImage(input: $input) {
+          client {
+            id
+          }
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_edit_clients]) }
+  let!(:client) { create :hmis_hud_client, data_source: ds1 }
+  let!(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open('drivers/hmis/spec/fixtures/files/client_photo_00001.jpg'),
+      filename: 'client_photo_00001.jpg',
+      content_type: 'image/jpeg',
+    )
+  end
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  it 'updates client image successfully' do
+    input = { client_id: client.id, image_blob_id: blob.signed_id }
+
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200)
+    expect(result.dig('data', 'updateClientImage', 'client', 'id')).to eq(client.id.to_s)
+    expect(result.dig('data', 'updateClientImage', 'errors')).to be_empty
+
+    client.reload
+    expect(client.client_files.count).to eq(1)
+  end
+
+  describe 'permissions' do
+    it 'fails if user lacks can_edit_clients permission' do
+      remove_permissions(access_control, :can_edit_clients)
+      input = { client_id: client.id, image_blob_id: blob.signed_id }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Access denied'
+    end
+
+    it 'fails if user lacks can_view_clients permission' do
+      remove_permissions(access_control, :can_view_clients)
+      input = { client_id: client.id, image_blob_id: blob.signed_id }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Record not found'
+    end
+  end
+
+  describe 'error handling' do
+    it 'fails if client is not found' do
+      input = { client_id: '999999', image_blob_id: blob.signed_id }
+
+      expect_gql_error post_graphql(input: input) { mutation }, message: 'Record not found'
+    end
+
+    it 'fails if blob is not found' do
+      input = { client_id: client.id, image_blob_id: 'invalid_blob_id' }
+
+      response, result = post_graphql(input: input) { mutation }
+      expect(response.status).to eq(200)
+      expect(result.dig('data', 'updateClientImage', 'errors')).not_to be_empty
+      expect(result.dig('data', 'updateClientImage', 'errors', 0, 'fullMessage')).to match(/No uploaded file found/)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add ClientPolicy
- Introduce it in mutations that were previously checking client permissions directly
- Not yet included: `SubmitForm` mutation

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Non-functional code improvement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
