### PR TITLE
MCI clearance patch

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/client_processor.rb
@@ -240,10 +240,11 @@ module Hmis::Hud::Processors
       raise 'Invalid MCI ID' unless Float(value)
 
       # Initialize an ExternalID with this MCI ID
+      mci_cred = HmisExternalApis::AcHmis::Mci.new.creds
       client.update_mci_attributes = true
       client.external_ids << HmisExternalApis::ExternalId.new(
         value: value,
-        remote_credential: HmisExternalApis::AcHmis::Mci.new.creds,
+        remote_credential: mci_cred,
         namespace: HmisExternalApis::AcHmis::Mci::SYSTEM_ID,
       )
 
@@ -253,7 +254,7 @@ module Hmis::Hud::Processors
       if mci_unique_id.present? && !client.ac_hmis_mci_unique_id.present? # rubocop:disable Style/GuardClause
         client.external_ids << HmisExternalApis::ExternalId.new(
           value: mci_unique_id,
-          remote_credential: HmisExternalApis::AcHmis::DataWarehouseApi.new.send(:creds),
+          remote_credential: mci_cred, # MCI cred was used in this case, even though typically MCI Unique ID is associated with the DataWarehouseApi credential
           namespace: HmisExternalApis::AcHmis::WarehouseChangesJob::NAMESPACE,
         )
       end

--- a/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature 'Assessment definition selection', type: :system do
   let!(:ds1) { create(:hmis_data_source, hmis: 'localhost') }
   let!(:access_control) { create_access_control(hmis_user, p1) }
   let!(:mci_cred) { create(:ac_hmis_mci_credential) }
-  let!(:mci_warehouse_cred) { create(:ac_hmis_warehouse_credential) }
 
   # PH project (requires MCI clearance)
   let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, project_type: 9, with_coc: true }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix bug where client processing would fail if mci cred exists but data warehouse api cred doesn't. This is the case in staging and training.
Follow-up to https://github.com/greenriver/hmis-warehouse/pull/6093

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
