### PR TITLE
8663 support sig term in jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -31,19 +31,18 @@ class ApplicationJob < ActiveJob::Base
   # Check for cancellation before the job starts performing.
   before_perform :check_halt_status!
 
-  protected
-
   def check_halt_status!
     return unless self.class.queue_adapter_name == 'delayed_job'
+
+    # Check for SIGTERM first
+    raise JobInterrupted, 'Job interrupted by SIGTERM' if SignalHandlerPlugin.current_worker_stopping?
+
     return unless provider_job_id.present?
 
-    # provider_job_id is the ID of the Delayed::Job record in the database.
-    # We look up the record to check its specific cancellation state.
-    job = Delayed::Job.find_by(id: provider_job_id)
-
-    # This calls the check_halt_status! method defined in the Delayed::Job monkey patch
-    # (see config/initializers/delayed_job.rb), which raises JobCancelled if
-    # cancellation_requested_at is set.
-    job&.check_halt_status!
+    # Check for manual cancellation
+    requested_at = Delayed::Job.where(id: provider_job_id).pluck(:cancellation_requested_at).first
+    raise JobCancelled, 'Job cancelled' if requested_at.present?
   end
+
+  protected
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -48,12 +48,10 @@ class ApplicationJob < ActiveJob::Base
     Delayed::Job.uncached do
       requested_at = Delayed::Job.where(id: provider_job_id).pluck(:cancellation_requested_at).first
     end
-    if requested_at
-      msg = "Job #{provider_job_id} cancelled"
-      Rails.logger.warn(msg)
-      raise JobCancelled, msg
-    end
-  end
+    return unless requested_at
 
-  protected
+    msg = "Job #{provider_job_id} cancelled"
+    Rails.logger.warn(msg)
+    raise JobCancelled, msg
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -29,11 +29,11 @@ class ApplicationJob < ActiveJob::Base
   end
 
   # Check for cancellation before the job starts performing.
-  before_perform :handle_cancellation!
+  before_perform :check_halt_status!
 
   protected
 
-  def handle_cancellation!
+  def check_halt_status!
     return unless self.class.queue_adapter_name == 'delayed_job'
     return unless provider_job_id.present?
 
@@ -41,9 +41,9 @@ class ApplicationJob < ActiveJob::Base
     # We look up the record to check its specific cancellation state.
     job = Delayed::Job.find_by(id: provider_job_id)
 
-    # This calls the handle_cancellation! method defined in the Delayed::Job monkey patch
+    # This calls the check_halt_status! method defined in the Delayed::Job monkey patch
     # (see config/initializers/delayed_job.rb), which raises JobCancelled if
     # cancellation_requested_at is set.
-    job&.handle_cancellation!
+    job&.check_halt_status!
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,12 +9,11 @@
 class ApplicationJob < ActiveJob::Base
   # Custom error to signal that a job should be stopped or terminated
   class JobCancelled < StandardError; end
-  class JobRetried < StandardError; end
+  class JobInterrupted < StandardError; end
 
   # retry_on and discard_on are standard Active Job features
   # When JobCancelled is raised, Active Job catches it and prevents any retries.
   discard_on JobCancelled
-  retry_on JobRetried
 
   # By default, jobs are not interruptible once they have started.
   # Subclasses can override this if they have implemented manual cancellation checkpoints.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,12 +7,14 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  # Custom error to signal that a job should be stopped because cancellation was requested.
+  # Custom error to signal that a job should be stopped or terminated
   class JobCancelled < StandardError; end
+  class JobRetried < StandardError; end
 
-  # discard_on is a standard Active Job feature
+  # retry_on and discard_on are standard Active Job features
   # When JobCancelled is raised, Active Job catches it and prevents any retries.
   discard_on JobCancelled
+  retry_on JobRetried
 
   # By default, jobs are not interruptible once they have started.
   # Subclasses can override this if they have implemented manual cancellation checkpoints.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,13 +7,20 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  # Custom error to signal that a job should be stopped or terminated
+  # Custom error to signal that a job should be stopped and discarded or retried
   class JobCancelled < StandardError; end
   class JobInterrupted < StandardError; end
 
-  # retry_on and discard_on are standard Active Job features
+  # discard_on is a standard Active Job feature
   # When JobCancelled is raised, Active Job catches it and prevents any retries.
   discard_on JobCancelled
+
+  rescue_from JobInterrupted do |_error|
+    # Re-enqueue on SIGTERM so work resumes after the worker shuts down.
+    # Delay to avoid immediately re-running in the same worker loop.
+    wait_time = ENV.fetch('RETRY_DELAY_ON_INTERRUPTION', 60)
+    retry_job wait: wait_time.to_i.seconds
+  end
 
   # By default, jobs are not interruptible once they have started.
   # Subclasses can override this if they have implemented manual cancellation checkpoints.

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -35,13 +35,24 @@ class ApplicationJob < ActiveJob::Base
     return unless self.class.queue_adapter_name == 'delayed_job'
 
     # Check for SIGTERM first
-    raise JobInterrupted, 'Job interrupted by SIGTERM' if SignalHandlerPlugin.current_worker_stopping?
+    if SignalHandlerPlugin.current_worker_stopping?
+      msg = 'Job interrupted by SIGTERM'
+      Rails.logger.warn(msg)
+      raise JobInterrupted, msg
+    end
 
     return unless provider_job_id.present?
 
     # Check for manual cancellation
-    requested_at = Delayed::Job.where(id: provider_job_id).pluck(:cancellation_requested_at).first
-    raise JobCancelled, 'Job cancelled' if requested_at.present?
+    requested_at = nil
+    Delayed::Job.uncached do
+      requested_at = Delayed::Job.where(id: provider_job_id).pluck(:cancellation_requested_at).first
+    end
+    if requested_at
+      msg = "Job #{provider_job_id} cancelled"
+      Rails.logger.warn(msg)
+      raise JobCancelled, msg
+    end
   end
 
   protected

--- a/app/jobs/reporting/hud/run_report_job.rb
+++ b/app/jobs/reporting/hud/run_report_job.rb
@@ -26,6 +26,8 @@ module Reporting::Hud
       # Occasionally people delete the report before it actually runs
       return unless report.present?
 
+      report.active_job = self
+
       # advisory lock to check the number of jobs running for this generator so we don't
       # all check at exactly the same time and get the same result
       @generator = class_name.constantize.new(report)

--- a/app/jobs/test_job.rb
+++ b/app/jobs/test_job.rb
@@ -15,6 +15,10 @@ class TestJob < BaseJob
     end
   end
 
+  def self.interruptible?
+    true
+  end
+
   def perform(length_in_seconds: 10, memory_bloat_per_second: 10_000_000, simulate_failure: false)
     Rails.logger.info 'TestJob started and has a log message in the job'
     Rails.logger.tagged({ process_name: 'testjob' }) do
@@ -34,6 +38,7 @@ class TestJob < BaseJob
     bloater = {}
 
     while (Time.now - a) < length_in_seconds
+      check_halt_status!
       Rails.logger.info 'Simulating processing.'
       bloater[Random.rand.to_s] = Array.new(memory_bloat_per_second * SLEEP_TIME) if memory_bloat_per_second
       sleep SLEEP_TIME

--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -168,7 +168,7 @@ module HudReports
     def track_progress(checkpoint_name)
       raise unless checkpoint_name.present?
 
-      related_job&.handle_cancellation!
+      related_job&.check_halt_status!
 
       # If this step has already been successfully completed, skip it (resume)
       existing = checkpoints.find_by(name: checkpoint_name, status: 'success')

--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -23,6 +23,9 @@ module HudReports
 
     self.table_name = 'hud_report_instances'
 
+    # Reference to the ActiveJob instance currently processing this report
+    attr_accessor :active_job
+
     belongs_to :user, optional: true
     has_many :report_cells # , dependent: :destroy # for the moment, this is too slow
     has_many :universe_cells, -> do
@@ -165,10 +168,14 @@ module HudReports
       update!(state: 'Started', started_at: started_at)
     end
 
+    def check_halt_status!
+      active_job&.check_halt_status!
+    end
+
     def track_progress(checkpoint_name)
       raise unless checkpoint_name.present?
 
-      related_job&.check_halt_status!
+      check_halt_status!
 
       # If this step has already been successfully completed, skip it (resume)
       existing = checkpoints.find_by(name: checkpoint_name, status: 'success')

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -66,10 +66,6 @@ module Delayed
         end
 
         def interruptible?
-          # We use JobDetail to encapsulate the logic for inspecting the job payload.
-          # This is more robust than simple string matching on the handler.
-          return false unless defined?(JobDetail)
-
           JobDetail.new(self).interruptible?
         rescue StandardError
           false

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -55,11 +55,9 @@ module Delayed
           where(failed_at: nil).where.not(locked_at: nil)
         end
 
-        def handle_cancellation!
+        def check_halt_status!
           # check to see if we've been terminated
-          if defined?(SignalHandlerPlugin) && SignalHandlerPlugin.current_worker_stopping?
-            raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM'
-          end
+          raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM' if defined?(SignalHandlerPlugin) && SignalHandlerPlugin.current_worker_stopping?
 
           # Always check the database for fresh cancellation status
           # The job instance may have been loaded before cancellation was requested

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -55,18 +55,6 @@ module Delayed
           where(failed_at: nil).where.not(locked_at: nil)
         end
 
-        def check_halt_status!
-          # check to see if we've been terminated
-          raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM' if defined?(SignalHandlerPlugin) && SignalHandlerPlugin.current_worker_stopping?
-
-          # Always check the database for fresh cancellation status
-          # The job instance may have been loaded before cancellation was requested
-          fresh_cancellation_requested_at = self.class.where(id: id).pluck(:cancellation_requested_at).first
-          return unless fresh_cancellation_requested_at.present?
-
-          raise ApplicationJob::JobCancelled, 'Job cancelled'
-        end
-
         def cancellable?
           return false if cancellation_requested_at.present? || failed_at.present?
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -56,6 +56,9 @@ module Delayed
         end
 
         def handle_cancellation!
+          # check to see if we've been terminated
+          raise ApplicationJob::JobRetried, 'SIGTERM caught, retrying' if sigterm_received?
+
           # Always check the database for fresh cancellation status
           # The job instance may have been loaded before cancellation was requested
           fresh_cancellation_requested_at = self.class.where(id: id).pluck(:cancellation_requested_at).first
@@ -90,6 +93,11 @@ module Delayed
           return false if locked_at
 
           failed_at.present? || cancellation_requested_at.present?
+        end
+
+        # what to do when the worker receives sigterm
+        def sigterm_received?
+          id && SignalHandlerPlugin.interrupted_job_id == id
         end
       end
     end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -57,7 +57,9 @@ module Delayed
 
         def handle_cancellation!
           # check to see if we've been terminated
-          raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM' if sigterm_received?
+          if defined?(SignalHandlerPlugin) && SignalHandlerPlugin.current_worker_stopping?
+            raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM'
+          end
 
           # Always check the database for fresh cancellation status
           # The job instance may have been loaded before cancellation was requested
@@ -93,13 +95,6 @@ module Delayed
           return false if locked_at
 
           failed_at.present? || cancellation_requested_at.present?
-        end
-
-        # what to do when the worker receives sigterm
-        def sigterm_received?
-          return false unless defined?(SignalHandlerPlugin)
-
-          SignalHandlerPlugin.current_worker_stopping?
         end
       end
     end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -57,7 +57,7 @@ module Delayed
 
         def handle_cancellation!
           # check to see if we've been terminated
-          raise ApplicationJob::JobRetried, 'SIGTERM caught, retrying' if sigterm_received?
+          raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM' if sigterm_received?
 
           # Always check the database for fresh cancellation status
           # The job instance may have been loaded before cancellation was requested
@@ -97,7 +97,9 @@ module Delayed
 
         # what to do when the worker receives sigterm
         def sigterm_received?
-          id && SignalHandlerPlugin.interrupted_job_id == id
+          return false unless defined?(SignalHandlerPlugin)
+
+          SignalHandlerPlugin.current_worker_stopping?
         end
       end
     end

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -42,7 +42,7 @@ class SignalHandlerPlugin < Delayed::Plugin
   callbacks do |lifecycle|
     lifecycle.around(:perform) do |worker, _job, &block|
       SignalHandlerPlugin.register_worker(worker)
-      block.call if block
+      block&.call
     ensure
       SignalHandlerPlugin.unregister_worker
     end

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -53,9 +53,7 @@ class DelayedJobJobIdProvider < Delayed::Plugin
   callbacks do |lifecycle|
     lifecycle.before(:invoke_job) do |job|
       # job.id is the ID of the Delayed::Job record in the database
-      if job.payload_object.respond_to?(:job_data)
-        job.payload_object.job_data["provider_job_id"] = job.id
-      end
+      job.payload_object.job_data['provider_job_id'] = job.id if job.payload_object.respond_to?(:job_data)
     end
   end
 end

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -1,24 +1,64 @@
 # frozen_string_literal: true
 
 class SignalHandlerPlugin < Delayed::Plugin
-  class Registry < ActiveSupport::CurrentAttributes
-    attribute :worker
-  end
+  # While standard Delayed Job workers run in a single-threaded process,
+  # thread-safety will support future threaded worker configurations
+  # and parallelized test environments.
+  @registry_mutex = Mutex.new
+  @active_workers = {}.compare_by_identity # { thread_object => worker_instance }
 
   class << self
+    attr_reader :registry_mutex
+
+    def register_worker(worker)
+      @registry_mutex.synchronize do
+        @active_workers[Thread.current] = worker
+      end
+    end
+
+    def unregister_worker
+      @registry_mutex.synchronize do
+        @active_workers.delete(Thread.current)
+      end
+    end
+
     def current_worker_stopping?
-      Registry.worker&.stop? || false
+      worker = nil
+      @registry_mutex.synchronize do
+        worker = @active_workers[Thread.current]
+      end
+
+      worker&.stop? || false
+    end
+
+    # For testing purposes
+    def reset!
+      @registry_mutex.synchronize do
+        @active_workers = {}.compare_by_identity
+      end
     end
   end
 
   callbacks do |lifecycle|
     lifecycle.around(:perform) do |worker, _job, &block|
-      Registry.worker = worker
+      SignalHandlerPlugin.register_worker(worker)
       block&.call
     ensure
-      Registry.reset
+      SignalHandlerPlugin.unregister_worker
     end
   end
 end
 
+class DelayedJobJobIdProvider < Delayed::Plugin
+  callbacks do |lifecycle|
+    lifecycle.before(:invoke_job) do |job|
+      # job.id is the ID of the Delayed::Job record in the database
+      if job.payload_object.respond_to?(:job_data)
+        job.payload_object.job_data["provider_job_id"] = job.id
+      end
+    end
+  end
+end
+
+Delayed::Worker.plugins << DelayedJobJobIdProvider unless Delayed::Worker.plugins.include?(DelayedJobJobIdProvider)
 Delayed::Worker.plugins << SignalHandlerPlugin unless Delayed::Worker.plugins.include?(SignalHandlerPlugin)

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -1,0 +1,38 @@
+class SignalHandlerPlugin < Delayed::Plugin
+  # We use a class variable or a thread-safe flag to communicate
+  # between the trap context and the Ruby execution context.
+  @interrupted_job_id = nil
+  @previous_trap = nil
+
+  class << self
+    attr_accessor :interrupted_job_id, :previous_trap
+  end
+
+  callbacks do |lifecycle|
+    lifecycle.before(:perform) do |worker, job|
+      # Set up the trap and store the previous one
+      SignalHandlerPlugin.previous_trap = Signal.trap('TERM') do
+        SignalHandlerPlugin.interrupted_job_id = job.id
+        # Tell the worker to stop after this job is done
+        worker.stop
+
+        # Call the previous handler if it was a proc
+        if SignalHandlerPlugin.previous_trap.respond_to?(:call)
+          SignalHandlerPlugin.previous_trap.call
+        end
+      end
+    end
+
+    lifecycle.after(:perform) do |_worker, _job|
+      # Restore the previous trap
+      if SignalHandlerPlugin.previous_trap
+        Signal.trap('TERM', SignalHandlerPlugin.previous_trap)
+      end
+
+      SignalHandlerPlugin.interrupted_job_id = nil
+      SignalHandlerPlugin.previous_trap = nil
+    end
+  end
+end
+
+Delayed::Worker.plugins << SignalHandlerPlugin

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -1,50 +1,22 @@
 # frozen_string_literal: true
 
 class SignalHandlerPlugin < Delayed::Plugin
-  # While standard Delayed Job workers run in a single-threaded process,
-  # thread-safety will support future threaded worker configurations
-  # and parallelized test environments.
-  @registry_mutex = Mutex.new
-  @active_workers = {}.compare_by_identity # { thread_object => worker_instance }
+  class Registry < ActiveSupport::CurrentAttributes
+    attribute :worker
+  end
 
   class << self
-    attr_reader :registry_mutex
-
-    def register_worker(worker)
-      @registry_mutex.synchronize do
-        @active_workers[Thread.current] = worker
-      end
-    end
-
-    def unregister_worker
-      @registry_mutex.synchronize do
-        @active_workers.delete(Thread.current)
-      end
-    end
-
     def current_worker_stopping?
-      worker = nil
-      @registry_mutex.synchronize do
-        worker = @active_workers[Thread.current]
-      end
-
-      worker&.stop? || false
-    end
-
-    # For testing purposes
-    def reset!
-      @registry_mutex.synchronize do
-        @active_workers = {}.compare_by_identity
-      end
+      Registry.worker&.stop? || false
     end
   end
 
   callbacks do |lifecycle|
     lifecycle.around(:perform) do |worker, _job, &block|
-      SignalHandlerPlugin.register_worker(worker)
+      Registry.worker = worker
       block&.call
     ensure
-      SignalHandlerPlugin.unregister_worker
+      Registry.reset
     end
   end
 end

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -1,36 +1,55 @@
+# frozen_string_literal: true
+
 class SignalHandlerPlugin < Delayed::Plugin
-  # We use a class variable or a thread-safe flag to communicate
-  # between the trap context and the Ruby execution context.
-  @interrupted_job_id = nil
-  @previous_trap = nil
+  # We use a thread-safe registry to track which worker is running in which thread.
+  # This allows us to check if the specific worker has been signaled to stop (SIGTERM)
+  # without interfering with Delayed Job's internal signal handling.
+  @registry_mutex = Mutex.new
+  @active_workers = {} # { thread_object_id => worker_instance }
 
   class << self
-    attr_accessor :interrupted_job_id, :previous_trap
-  end
+    attr_reader :registry_mutex
 
-  callbacks do |lifecycle|
-    lifecycle.before(:perform) do |worker, job|
-      # Set up the trap and store the previous one
-      SignalHandlerPlugin.previous_trap = Signal.trap('TERM') do
-        SignalHandlerPlugin.interrupted_job_id = job.id
-        # Tell the worker to stop after this job is done
-        worker.stop
-
-        # Call the previous handler if it was a proc
-        if SignalHandlerPlugin.previous_trap.respond_to?(:call)
-          SignalHandlerPlugin.previous_trap.call
-        end
+    def register_worker(worker)
+      @registry_mutex.synchronize do
+        # rubocop:disable Lint/HashCompareByIdentity
+        @active_workers[Thread.current.object_id] = worker
+        # rubocop:enable Lint/HashCompareByIdentity
       end
     end
 
-    lifecycle.after(:perform) do |_worker, _job|
-      # Restore the previous trap
-      if SignalHandlerPlugin.previous_trap
-        Signal.trap('TERM', SignalHandlerPlugin.previous_trap)
+    def unregister_worker
+      @registry_mutex.synchronize do
+        @active_workers.delete(Thread.current.object_id)
       end
+    end
 
-      SignalHandlerPlugin.interrupted_job_id = nil
-      SignalHandlerPlugin.previous_trap = nil
+    def current_worker_stopping?
+      worker = nil
+      @registry_mutex.synchronize do
+        # rubocop:disable Lint/HashCompareByIdentity
+        worker = @active_workers[Thread.current.object_id]
+        # rubocop:enable Lint/HashCompareByIdentity
+      end
+      # Delayed::Worker uses @exit to signal shutdown when it receives SIGTERM
+      worker&.instance_variable_get(:@exit) || false
+    end
+
+    # For testing purposes
+    def reset!
+      @registry_mutex.synchronize do
+        @active_workers = {}
+      end
+    end
+  end
+
+  callbacks do |lifecycle|
+    lifecycle.before(:perform) do |worker, _job|
+      SignalHandlerPlugin.register_worker(worker)
+    end
+
+    lifecycle.after(:perform) do |_worker, _job|
+      SignalHandlerPlugin.unregister_worker
     end
   end
 end

--- a/config/initializers/delayed_job_plugins.rb
+++ b/config/initializers/delayed_job_plugins.rb
@@ -1,57 +1,52 @@
 # frozen_string_literal: true
 
 class SignalHandlerPlugin < Delayed::Plugin
-  # We use a thread-safe registry to track which worker is running in which thread.
-  # This allows us to check if the specific worker has been signaled to stop (SIGTERM)
-  # without interfering with Delayed Job's internal signal handling.
+  # While standard Delayed Job workers run in a single-threaded process,
+  # thread-safety will support future threaded worker configurations
+  # and parallelized test environments.
   @registry_mutex = Mutex.new
-  @active_workers = {} # { thread_object_id => worker_instance }
+  @active_workers = {}.compare_by_identity # { thread_object => worker_instance }
 
   class << self
     attr_reader :registry_mutex
 
     def register_worker(worker)
       @registry_mutex.synchronize do
-        # rubocop:disable Lint/HashCompareByIdentity
-        @active_workers[Thread.current.object_id] = worker
-        # rubocop:enable Lint/HashCompareByIdentity
+        @active_workers[Thread.current] = worker
       end
     end
 
     def unregister_worker
       @registry_mutex.synchronize do
-        @active_workers.delete(Thread.current.object_id)
+        @active_workers.delete(Thread.current)
       end
     end
 
     def current_worker_stopping?
       worker = nil
       @registry_mutex.synchronize do
-        # rubocop:disable Lint/HashCompareByIdentity
-        worker = @active_workers[Thread.current.object_id]
-        # rubocop:enable Lint/HashCompareByIdentity
+        worker = @active_workers[Thread.current]
       end
-      # Delayed::Worker uses @exit to signal shutdown when it receives SIGTERM
-      worker&.instance_variable_get(:@exit) || false
+
+      worker&.stop? || false
     end
 
     # For testing purposes
     def reset!
       @registry_mutex.synchronize do
-        @active_workers = {}
+        @active_workers = {}.compare_by_identity
       end
     end
   end
 
   callbacks do |lifecycle|
-    lifecycle.before(:perform) do |worker, _job|
+    lifecycle.around(:perform) do |worker, _job, &block|
       SignalHandlerPlugin.register_worker(worker)
-    end
-
-    lifecycle.after(:perform) do |_worker, _job|
+      block.call if block
+    ensure
       SignalHandlerPlugin.unregister_worker
     end
   end
 end
 
-Delayed::Worker.plugins << SignalHandlerPlugin
+Delayed::Worker.plugins << SignalHandlerPlugin unless Delayed::Worker.plugins.include?(SignalHandlerPlugin)

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
@@ -141,7 +141,7 @@ module HudSpmReport::Fy2026
       enrollments = HudSpmReport::Adapters::ServiceHistoryEnrollmentFilter.new(report_instance).enrollments
       household_infos = household(enrollments)
       enrollments.preload(:client, :destination_client, :exit, :income_benefits_at_exit, :income_benefits_at_entry, :income_benefits, project: :funders).find_in_batches(batch_size: 500) do |batch|
-        report_instance.related_job&.handle_cancellation!
+        report_instance.related_job&.check_halt_status!
         members = []
         batch.each do |enrollment|
           client = enrollment.client

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
@@ -141,7 +141,7 @@ module HudSpmReport::Fy2026
       enrollments = HudSpmReport::Adapters::ServiceHistoryEnrollmentFilter.new(report_instance).enrollments
       household_infos = household(enrollments)
       enrollments.preload(:client, :destination_client, :exit, :income_benefits_at_exit, :income_benefits_at_entry, :income_benefits, project: :funders).find_in_batches(batch_size: 500) do |batch|
-        report_instance.related_job&.check_halt_status!
+        report_instance.check_halt_status!
         members = []
         batch.each do |enrollment|
           client = enrollment.client

--- a/drivers/hud_spm_report/spec/models/fy2026/retry_behavior_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/retry_behavior_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'HUD SPM FY2026 retry behavior', type: :model do
       expect(report.related_job).to eq(job)
 
       # We need to trick ApplicationJob into thinking it's running under delayed_job
-      # so it doesn't skip handle_cancellation!.
+      # so it doesn't skip check_halt_status!.
       allow(Reporting::Hud::RunReportJob).to receive(:queue_adapter_name).and_return('delayed_job')
 
       # Mock a point in the process to request cancellation.

--- a/drivers/hud_spm_report/spec/models/fy2026/retry_behavior_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/retry_behavior_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'HUD SPM FY2026 retry behavior', type: :model do
       # We need to trick ApplicationJob into thinking it's running under delayed_job
       # so it doesn't skip check_halt_status!.
       allow(Reporting::Hud::RunReportJob).to receive(:queue_adapter_name).and_return('delayed_job')
+      allow_any_instance_of(Reporting::Hud::RunReportJob).to receive(:provider_job_id).and_return(job.id)
 
       # Mock a point in the process to request cancellation.
       # create_enrollment_set is called early in the report process.

--- a/spec/config/initializers/delayed_job_plugins_spec.rb
+++ b/spec/config/initializers/delayed_job_plugins_spec.rb
@@ -3,69 +3,57 @@
 require 'rails_helper'
 
 RSpec.describe SignalHandlerPlugin do
-  let(:worker) { double('Delayed::Worker', stop: nil) }
+  let(:worker) { double('Delayed::Worker') }
   let(:job) { double('Delayed::Job', id: 123) }
   let(:lifecycle) { Delayed::Lifecycle.new }
 
   before do
-    # Clear state before each test
-    SignalHandlerPlugin.interrupted_job_id = nil
-    SignalHandlerPlugin.previous_trap = nil
-
+    SignalHandlerPlugin.reset!
     # Apply the plugin callbacks to our test lifecycle
     SignalHandlerPlugin.callback_block.call(lifecycle)
   end
 
   describe 'callbacks' do
-    it 'registers before and after perform callbacks' do
-      # This is a bit internal to Delayed Job, but we want to ensure our plugin is active
+    it 'registers the plugin' do
       expect(Delayed::Worker.plugins).to include(SignalHandlerPlugin)
     end
 
-    describe 'TERM signal trapping' do
-      let(:trap_block) { [] }
-
-      before do
-        # Mock Signal.trap to capture the block being registered
-        # and support returning a value. Allow any arguments.
-        allow(Signal).to receive(:trap).with('TERM', any_args) do |*args, &block|
-          trap_block << block if block
-          'PREVIOUS_HANDLER'
+    it 'registers the worker in the registry during performance' do
+      lifecycle.run_callbacks(:perform, worker, job) do
+        # Within the perform block, the worker should be registered
+        SignalHandlerPlugin.registry_mutex.synchronize do
+          active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+          # rubocop:disable Lint/HashCompareByIdentity
+          expect(active_workers[Thread.current.object_id]).to eq(worker)
+          # rubocop:enable Lint/HashCompareByIdentity
         end
       end
 
-      it 'sets up a trap before perform and restores it after' do
-        # 1. Trigger before_perform
-        lifecycle.run_callbacks(:perform, worker, job) do
-          expect(Signal).to have_received(:trap).with('TERM')
-          expect(SignalHandlerPlugin.previous_trap).to eq('PREVIOUS_HANDLER')
-
-          # 2. Simulate the signal being received
-          trap_block.first.call
-
-          expect(SignalHandlerPlugin.interrupted_job_id).to eq(job.id)
-          expect(worker).to have_received(:stop)
-        end
-
-        # 3. Trigger after_perform cleanup
-        expect(Signal).to have_received(:trap).with('TERM', 'PREVIOUS_HANDLER')
-        expect(SignalHandlerPlugin.interrupted_job_id).to be_nil
-        expect(SignalHandlerPlugin.previous_trap).to be_nil
+      # After performance, it should be unregistered
+      SignalHandlerPlugin.registry_mutex.synchronize do
+        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+        expect(active_workers).not_to have_key(Thread.current.object_id)
       end
+    end
+  end
 
-      it 'calls the previous handler if it was a proc' do
-        previous_proc = double('proc', call: nil)
-        # Override the return value but keep the block capture
-        allow(Signal).to receive(:trap).with('TERM', any_args) do |*args, &block|
-          trap_block << block if block
-          previous_proc
-        end
-
-        lifecycle.run_callbacks(:perform, worker, job) do
-          trap_block.first.call
-          expect(previous_proc).to have_received(:call)
-        end
+  describe '.current_worker_stopping?' do
+    it 'returns true if the registered worker has @exit set to true' do
+      lifecycle.run_callbacks(:perform, worker, job) do
+        worker.instance_variable_set(:@exit, true)
+        expect(SignalHandlerPlugin.current_worker_stopping?).to be true
       end
+    end
+
+    it 'returns false if the registered worker has @exit set to false' do
+      lifecycle.run_callbacks(:perform, worker, job) do
+        worker.instance_variable_set(:@exit, false)
+        expect(SignalHandlerPlugin.current_worker_stopping?).to be false
+      end
+    end
+
+    it 'returns false if no worker is registered' do
+      expect(SignalHandlerPlugin.current_worker_stopping?).to be false
     end
   end
 end

--- a/spec/config/initializers/delayed_job_plugins_spec.rb
+++ b/spec/config/initializers/delayed_job_plugins_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SignalHandlerPlugin do
   let(:lifecycle) { Delayed::Lifecycle.new }
 
   before do
-    SignalHandlerPlugin::Registry.reset
+    SignalHandlerPlugin.reset!
     # Apply the plugin callbacks to our test lifecycle
     SignalHandlerPlugin.callback_block.call(lifecycle)
   end
@@ -21,19 +21,28 @@ RSpec.describe SignalHandlerPlugin do
     it 'registers the worker in the registry during performance' do
       lifecycle.run_callbacks(:perform, worker, job) do
         # Within the perform block, the worker should be registered
-        expect(SignalHandlerPlugin::Registry.worker).to eq(worker)
+        SignalHandlerPlugin.registry_mutex.synchronize do
+          active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+          expect(active_workers[Thread.current]).to eq(worker)
+        end
       end
 
-      # After performance, it should be reset
-      expect(SignalHandlerPlugin::Registry.worker).to be_nil
+      # After performance, it should be unregistered
+      SignalHandlerPlugin.registry_mutex.synchronize do
+        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+        expect(active_workers).not_to have_key(Thread.current)
+      end
     end
 
-    it 'resets the registry even if perform raises' do
+    it 'unregisters the worker even if perform raises' do
       expect do
         lifecycle.run_callbacks(:perform, worker, job) { raise 'boom' }
       end.to raise_error('boom')
 
-      expect(SignalHandlerPlugin::Registry.worker).to be_nil
+      SignalHandlerPlugin.registry_mutex.synchronize do
+        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+        expect(active_workers).not_to have_key(Thread.current)
+      end
     end
   end
 

--- a/spec/config/initializers/delayed_job_plugins_spec.rb
+++ b/spec/config/initializers/delayed_job_plugins_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SignalHandlerPlugin do
+  let(:worker) { double('Delayed::Worker', stop: nil) }
+  let(:job) { double('Delayed::Job', id: 123) }
+  let(:lifecycle) { Delayed::Lifecycle.new }
+
+  before do
+    # Clear state before each test
+    SignalHandlerPlugin.interrupted_job_id = nil
+    SignalHandlerPlugin.previous_trap = nil
+
+    # Apply the plugin callbacks to our test lifecycle
+    SignalHandlerPlugin.callback_block.call(lifecycle)
+  end
+
+  describe 'callbacks' do
+    it 'registers before and after perform callbacks' do
+      # This is a bit internal to Delayed Job, but we want to ensure our plugin is active
+      expect(Delayed::Worker.plugins).to include(SignalHandlerPlugin)
+    end
+
+    describe 'TERM signal trapping' do
+      let(:trap_block) { [] }
+
+      before do
+        # Mock Signal.trap to capture the block being registered
+        # and support returning a value. Allow any arguments.
+        allow(Signal).to receive(:trap).with('TERM', any_args) do |*args, &block|
+          trap_block << block if block
+          'PREVIOUS_HANDLER'
+        end
+      end
+
+      it 'sets up a trap before perform and restores it after' do
+        # 1. Trigger before_perform
+        lifecycle.run_callbacks(:perform, worker, job) do
+          expect(Signal).to have_received(:trap).with('TERM')
+          expect(SignalHandlerPlugin.previous_trap).to eq('PREVIOUS_HANDLER')
+
+          # 2. Simulate the signal being received
+          trap_block.first.call
+
+          expect(SignalHandlerPlugin.interrupted_job_id).to eq(job.id)
+          expect(worker).to have_received(:stop)
+        end
+
+        # 3. Trigger after_perform cleanup
+        expect(Signal).to have_received(:trap).with('TERM', 'PREVIOUS_HANDLER')
+        expect(SignalHandlerPlugin.interrupted_job_id).to be_nil
+        expect(SignalHandlerPlugin.previous_trap).to be_nil
+      end
+
+      it 'calls the previous handler if it was a proc' do
+        previous_proc = double('proc', call: nil)
+        # Override the return value but keep the block capture
+        allow(Signal).to receive(:trap).with('TERM', any_args) do |*args, &block|
+          trap_block << block if block
+          previous_proc
+        end
+
+        lifecycle.run_callbacks(:perform, worker, job) do
+          trap_block.first.call
+          expect(previous_proc).to have_received(:call)
+        end
+      end
+    end
+  end
+end

--- a/spec/config/initializers/delayed_job_plugins_spec.rb
+++ b/spec/config/initializers/delayed_job_plugins_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SignalHandlerPlugin do
   let(:lifecycle) { Delayed::Lifecycle.new }
 
   before do
-    SignalHandlerPlugin.reset!
+    SignalHandlerPlugin::Registry.reset
     # Apply the plugin callbacks to our test lifecycle
     SignalHandlerPlugin.callback_block.call(lifecycle)
   end
@@ -21,28 +21,19 @@ RSpec.describe SignalHandlerPlugin do
     it 'registers the worker in the registry during performance' do
       lifecycle.run_callbacks(:perform, worker, job) do
         # Within the perform block, the worker should be registered
-        SignalHandlerPlugin.registry_mutex.synchronize do
-          active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
-          expect(active_workers[Thread.current]).to eq(worker)
-        end
+        expect(SignalHandlerPlugin::Registry.worker).to eq(worker)
       end
 
-      # After performance, it should be unregistered
-      SignalHandlerPlugin.registry_mutex.synchronize do
-        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
-        expect(active_workers).not_to have_key(Thread.current)
-      end
+      # After performance, it should be reset
+      expect(SignalHandlerPlugin::Registry.worker).to be_nil
     end
 
-    it 'unregisters the worker even if perform raises' do
+    it 'resets the registry even if perform raises' do
       expect do
         lifecycle.run_callbacks(:perform, worker, job) { raise 'boom' }
       end.to raise_error('boom')
 
-      SignalHandlerPlugin.registry_mutex.synchronize do
-        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
-        expect(active_workers).not_to have_key(Thread.current)
-      end
+      expect(SignalHandlerPlugin::Registry.worker).to be_nil
     end
   end
 

--- a/spec/config/initializers/delayed_job_plugins_spec.rb
+++ b/spec/config/initializers/delayed_job_plugins_spec.rb
@@ -23,31 +23,40 @@ RSpec.describe SignalHandlerPlugin do
         # Within the perform block, the worker should be registered
         SignalHandlerPlugin.registry_mutex.synchronize do
           active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
-          # rubocop:disable Lint/HashCompareByIdentity
-          expect(active_workers[Thread.current.object_id]).to eq(worker)
-          # rubocop:enable Lint/HashCompareByIdentity
+          expect(active_workers[Thread.current]).to eq(worker)
         end
       end
 
       # After performance, it should be unregistered
       SignalHandlerPlugin.registry_mutex.synchronize do
         active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
-        expect(active_workers).not_to have_key(Thread.current.object_id)
+        expect(active_workers).not_to have_key(Thread.current)
+      end
+    end
+
+    it 'unregisters the worker even if perform raises' do
+      expect do
+        lifecycle.run_callbacks(:perform, worker, job) { raise 'boom' }
+      end.to raise_error('boom')
+
+      SignalHandlerPlugin.registry_mutex.synchronize do
+        active_workers = SignalHandlerPlugin.instance_variable_get(:@active_workers)
+        expect(active_workers).not_to have_key(Thread.current)
       end
     end
   end
 
   describe '.current_worker_stopping?' do
-    it 'returns true if the registered worker has @exit set to true' do
+    it 'returns true if the registered worker is stopping' do
       lifecycle.run_callbacks(:perform, worker, job) do
-        worker.instance_variable_set(:@exit, true)
+        allow(worker).to receive(:stop?).and_return(true)
         expect(SignalHandlerPlugin.current_worker_stopping?).to be true
       end
     end
 
-    it 'returns false if the registered worker has @exit set to false' do
+    it 'returns false if the registered worker is not stopping' do
       lifecycle.run_callbacks(:perform, worker, job) do
-        worker.instance_variable_set(:@exit, false)
+        allow(worker).to receive(:stop?).and_return(false)
         expect(SignalHandlerPlugin.current_worker_stopping?).to be false
       end
     end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationJob do
+  let(:job_class) do
+    stub_const('InterruptTestJob', Class.new(described_class) do
+      queue_as :__sigterm_test__
+
+      def perform
+        raise ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM'
+      end
+    end)
+  end
+
+  around do |example|
+    previous_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :delayed_job
+    example.run
+  ensure
+    ActiveJob::Base.queue_adapter = previous_adapter
+  end
+
+  it 're-enqueues interrupted jobs without marking failure' do
+    Delayed::Job.delete_all
+    job = job_class.perform_later
+
+    worker = Delayed::Worker.new(queues: ['__sigterm_test__'])
+    successes, failures = worker.work_off
+
+    expect(successes).to eq(1)
+    expect(failures).to eq(0)
+    expect(Delayed::Job.exists?(job.provider_job_id)).to be false
+
+    # A new job should have been enqueued by retry_job and scheduled for later
+    new_job = Delayed::Job.where(queue: '__sigterm_test__').first
+    expect(new_job).to be_present
+    expect(new_job.run_at).to be > 10.seconds.from_now
+  end
+end

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Job halting logic' do
   let(:job_class) do
     stub_const('HaltTestJob', Class.new(ApplicationJob) do
-      def perform; end
+      def perform
+      end
     end)
   end
   let(:job_instance) { job_class.new }

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -21,28 +21,20 @@ RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
         allow(job).to receive(:sigterm_received?).and_return(true)
       end
 
-      it 'raises a JobRetried exception' do
-        expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobRetried, 'SIGTERM caught, retrying')
+      it 'raises a JobInterrupted exception' do
+        expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
       end
     end
   end
 
   describe '#sigterm_received?' do
-    let(:job_id) { 123 }
-    before { allow(job).to receive(:id).and_return(job_id) }
-
-    it 'is true if SignalHandlerPlugin.interrupted_job_id matches job id' do
-      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(job_id)
+    it 'is true if SignalHandlerPlugin.current_worker_stopping? is true' do
+      allow(SignalHandlerPlugin).to receive(:current_worker_stopping?).and_return(true)
       expect(job.sigterm_received?).to be true
     end
 
-    it 'is false if SignalHandlerPlugin.interrupted_job_id does not match job id' do
-      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(456)
-      expect(job.sigterm_received?).to be false
-    end
-
-    it 'is false if SignalHandlerPlugin.interrupted_job_id is nil' do
-      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(nil)
+    it 'is false if SignalHandlerPlugin.current_worker_stopping? is false' do
+      allow(SignalHandlerPlugin).to receive(:current_worker_stopping?).and_return(false)
       expect(job.sigterm_received?).to be false
     end
   end

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
   let(:job) { described_class.create!(handler: 'some_handler') }
 
-  describe '#handle_cancellation!' do
+  describe '#check_halt_status!' do
     context 'when cancellation has been requested' do
       before do
         job.update!(cancellation_requested_at: Time.current)
       end
 
       it 'raises a JobCancelled exception' do
-        expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobCancelled, 'Job cancelled')
+        expect { job.check_halt_status! }.to raise_error(ApplicationJob::JobCancelled, 'Job cancelled')
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
       end
 
       it 'raises a JobInterrupted exception' do
-        expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
+        expect { job.check_halt_status! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
       end
     end
   end

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -15,6 +15,36 @@ RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
         expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobCancelled, 'Job cancelled')
       end
     end
+
+    context 'when sigterm has been received' do
+      before do
+        allow(job).to receive(:sigterm_received?).and_return(true)
+      end
+
+      it 'raises a JobRetried exception' do
+        expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobRetried, 'SIGTERM caught, retrying')
+      end
+    end
+  end
+
+  describe '#sigterm_received?' do
+    let(:job_id) { 123 }
+    before { allow(job).to receive(:id).and_return(job_id) }
+
+    it 'is true if SignalHandlerPlugin.interrupted_job_id matches job id' do
+      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(job_id)
+      expect(job.sigterm_received?).to be true
+    end
+
+    it 'is false if SignalHandlerPlugin.interrupted_job_id does not match job id' do
+      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(456)
+      expect(job.sigterm_received?).to be false
+    end
+
+    it 'is false if SignalHandlerPlugin.interrupted_job_id is nil' do
+      allow(SignalHandlerPlugin).to receive(:interrupted_job_id).and_return(nil)
+      expect(job.sigterm_received?).to be false
+    end
   end
 
   describe '#cancellable?' do

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -18,24 +18,12 @@ RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
 
     context 'when sigterm has been received' do
       before do
-        allow(job).to receive(:sigterm_received?).and_return(true)
+        allow(SignalHandlerPlugin).to receive(:current_worker_stopping?).and_return(true)
       end
 
       it 'raises a JobInterrupted exception' do
         expect { job.handle_cancellation! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
       end
-    end
-  end
-
-  describe '#sigterm_received?' do
-    it 'is true if SignalHandlerPlugin.current_worker_stopping? is true' do
-      allow(SignalHandlerPlugin).to receive(:current_worker_stopping?).and_return(true)
-      expect(job.sigterm_received?).to be true
-    end
-
-    it 'is false if SignalHandlerPlugin.current_worker_stopping? is false' do
-      allow(SignalHandlerPlugin).to receive(:current_worker_stopping?).and_return(false)
-      expect(job.sigterm_received?).to be false
     end
   end
 

--- a/spec/models/delayed_job_cancellation_spec.rb
+++ b/spec/models/delayed_job_cancellation_spec.rb
@@ -2,17 +2,28 @@
 
 require 'rails_helper'
 
-RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
-  let(:job) { described_class.create!(handler: 'some_handler') }
+RSpec.describe 'Job halting logic' do
+  let(:job_class) do
+    stub_const('HaltTestJob', Class.new(ApplicationJob) do
+      def perform; end
+    end)
+  end
+  let(:job_instance) { job_class.new }
+  let(:dj_record) { Delayed::Job.create!(handler: job_instance.to_yaml) }
+
+  before do
+    allow(job_instance).to receive(:provider_job_id).and_return(dj_record.id)
+    allow(job_class).to receive(:queue_adapter_name).and_return('delayed_job')
+  end
 
   describe '#check_halt_status!' do
     context 'when cancellation has been requested' do
       before do
-        job.update!(cancellation_requested_at: Time.current)
+        dj_record.update!(cancellation_requested_at: Time.current)
       end
 
       it 'raises a JobCancelled exception' do
-        expect { job.check_halt_status! }.to raise_error(ApplicationJob::JobCancelled, 'Job cancelled')
+        expect { job_instance.check_halt_status! }.to raise_error(ApplicationJob::JobCancelled, 'Job cancelled')
       end
     end
 
@@ -22,10 +33,14 @@ RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
       end
 
       it 'raises a JobInterrupted exception' do
-        expect { job.check_halt_status! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
+        expect { job_instance.check_halt_status! }.to raise_error(ApplicationJob::JobInterrupted, 'Job interrupted by SIGTERM')
       end
     end
   end
+end
+
+RSpec.describe Delayed::Backend::ActiveRecord::Job, type: :model do
+  let(:job) { described_class.create!(handler: 'some_handler') }
 
   describe '#cancellable?' do
     it 'is true if the job has not started' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Adds SIGTERM-aware delayed job handling to requeue interrupted jobs and ensures worker registry cleanup during job execution.

- interruptible jobs check for stopping workers and raise to exit and reschedule themselves
- Adds a worker dj plugin to track and unregister workers, enabling detection of stopping workers.

### Type of Change
Enhancement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

