### PR TITLE
Stupidedi Frozen Strings

### DIFF
--- a/app/models/health/claim.rb
+++ b/app/models/health/claim.rb
@@ -183,13 +183,16 @@ module Health
     def convert_claims_to_text
       file = ''
       @edi_builder.machine.zipper.tap do |z|
+        # Stupidedi mutates the strings within the gem flagging the frozen string literal warnings. The strings are duped to avoid the warnings.
         separators = Stupidedi::Reader::Separators.build(
-          segment: "~\n",
-          element: '*',
-          component: component_element_separator,
-          repetition: repetition_separator,
+          segment: "~\n".dup,
+          element: '*'.dup,
+          component: component_element_separator.dup,
+          repetition: repetition_separator.dup,
         )
         w = Stupidedi::Writer::Default.new(z.root, separators)
+        # Pass a mutable string buffer to avoid frozen string literal warnings
+        # The gem's write method has a default parameter "" which is frozen in Ruby 3.4
         file = w.write(String.new).upcase
       end
       return file

--- a/drivers/medicaid_hmis_interchange/app/models/medicaid_hmis_interchange/health/medicaid_id_inquiry.rb
+++ b/drivers/medicaid_hmis_interchange/app/models/medicaid_hmis_interchange/health/medicaid_id_inquiry.rb
@@ -104,13 +104,16 @@ module MedicaidHmisInterchange::Health
     private def convert_to_text
       file = ''
       @edi_builder.machine.zipper.tap do |z|
+        # Stupidedi mutates the strings within the gem flagging the frozen string literal warnings. The strings are duped to avoid the warnings.
         separators = Stupidedi::Reader::Separators.build(
-          segment: "~\n",
-          element: '*',
-          component: '>',
-          repetition: '^',
+          segment: "~\n".dup,
+          element: '*'.dup,
+          component: '>'.dup,
+          repetition: '^'.dup,
         )
         w = Stupidedi::Writer::Default.new(z.root, separators)
+        # Pass a mutable string buffer to avoid frozen string literal warnings
+        # The gem's write method has a default parameter "" which is frozen in Ruby 3.4
         file = w.write(String.new).upcase
       end
       file

--- a/spec/models/health/claim_spec.rb
+++ b/spec/models/health/claim_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Health::Claim, type: :model do
   let!(:sender) { create(:sender) }
-  let!(:patient) { create(:patient) }
+  let!(:patient) { create :patient, medicaid_id: '123456789' }
   let!(:patient_referral) { create :current_referral, patient_id: patient.id }
   let!(:ssm) { create(:ssm, patient_id: patient.id, housing_score: 1) }
   let!(:qa1) { create(:qualifying_activity, patient_id: patient.id, date_of_activity: Date.current, force_payable: true) }
@@ -34,5 +34,59 @@ RSpec.describe Health::Claim, type: :model do
     # binding.pry # 'puts claim.convert_claims_to_text' to bench check
   end
 
-  # TODO: automate the claims file introspection rather than bench checks
+  describe '#convert_claims_to_text' do
+    before do
+      claim.build_claims_file
+    end
+
+    it 'converts claims to text without errors' do
+      expect { claim.convert_claims_to_text }.not_to raise_error
+    end
+
+    it 'returns a non-empty string' do
+      result = claim.convert_claims_to_text
+      expect(result).to be_a(String)
+      expect(result.length).to be > 0
+    end
+
+    it 'generates uppercase EDI text' do
+      result = claim.convert_claims_to_text
+      expect(result).to eq(result.upcase)
+    end
+
+    it 'generates EDI format with required segments' do
+      edi_text = claim.convert_claims_to_text
+
+      expect(edi_text).to include('ISA')
+      expect(edi_text).to include('GS')
+      expect(edi_text).to include('ST')
+      expect(edi_text).to include('BHT')
+      expect(edi_text).to include('NM1')
+      expect(edi_text).to include('PER')
+      expect(edi_text).to include('HL')
+      expect(edi_text).to include('N3')
+      expect(edi_text).to include('N4')
+      expect(edi_text).to include('REF')
+      expect(edi_text).to include('SBR')
+      expect(edi_text).to include('DMG')
+      expect(edi_text).to include('CLM')
+      expect(edi_text).to include('HI')
+      expect(edi_text).to include('LX')
+      expect(edi_text).to include('SV1')
+      expect(edi_text).to include('DTP')
+      expect(edi_text).to include('SE')
+      expect(edi_text).to include('GE')
+      expect(edi_text).to include('IEA')
+    end
+
+    it 'includes patient medicaid IDs in the EDI file' do
+      edi_text = claim.convert_claims_to_text
+
+      expect(edi_text).to include(patient.medicaid_id)
+    end
+
+    it 'does not raise frozen string literal errors' do
+      expect { claim.convert_claims_to_text }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Clean up the frozen strings being used within the Stupidedi gem. This addresses [this sentry issue](https://green-river.sentry.io/issues/7028768360/?alert_rule_id=12523843&alert_type=issue&notification_uuid=874bbb5d-ed98-403d-9d68-edd104100783&project=4503977346662400&referrer=slack).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency 
update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
