### PR TITLE
improve type validation on global auth policies

### DIFF
--- a/drivers/hmis/app/models/hmis/auth_policies/base_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/base_policy.rb
@@ -13,6 +13,10 @@ class Hmis::AuthPolicies::BasePolicy
   # used in child policy classes
   include Memery
 
+  def self.for_resource(context:, resource:)
+    new(context: context, resource: resource)
+  end
+
   def initialize(context:, resource:)
     @context = context
     validate_resource!(resource)
@@ -24,16 +28,23 @@ class Hmis::AuthPolicies::BasePolicy
   # convenience
   def user = context.user
 
-  # sanity check, is the resource what we expect
-  def validate_resource!(_arg) = raise 'override this in child class'
+  # Get global permissions for the user (across all projects)
+  def global_permissions = context.global_permissions
 
-  # validation helper
+  # sanity check, is the resource what we expect. must be implemented by child policy
+  def validate_resource!(_arg) = raise NotImplementedError, 'must implement in subclass'
+
+  # validation helper for instances
   def ensure_arg_type!(arg, klass)
     return if arg.is_a?(klass)
 
-    # For ActiveRecord models, also accept the class itself
-    return if arg.is_a?(Class) && arg < ActiveRecord::Base && arg == klass
+    raise ArgumentError, "Expected an instance of #{klass.name}, got #{arg.class.name}"
+  end
 
-    raise ArgumentError, "Expected a #{klass.name} got #{arg.class}"
+  # validation helper for classes
+  def ensure_arg_class!(arg, klass)
+    return if arg == klass
+
+    raise ArgumentError, "Expected the #{klass.name} class, got #{arg.inspect}"
   end
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/ce_opportunity_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/ce_opportunity_policy.rb
@@ -7,27 +7,43 @@
 # frozen_string_literal: true
 
 # Determines a user's permissions for CE Opportunities
-class Hmis::AuthPolicies::CeOpportunityPolicy < Hmis::AuthPolicies::BasePolicy
-  # Accepts client parameter because referral authorization requires validating
-  # the relationship between three entities: user, opportunity, and client.
-  def can_create_referral?(client:)
-    return false unless Hmis::Ce.configuration.enabled?
-
-    # Does the client record data source match the current user?
-    return false unless client.data_source_id == user.hmis_data_source_id
-
-    # Does the user have permission?
-    return false unless context.project_permissions(opportunity.unit.project_id).include?(:can_start_referrals)
-
-    true
+class Hmis::AuthPolicies::CeOpportunityPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  def can_view_candidates?
-    context.project_permissions(opportunity.unit.project_id).include?(:can_view_prioritized_client_lists)
+  class Global < Hmis::AuthPolicies::BasePolicy
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Ce::Opportunity)
   end
 
-  protected
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    # Accepts client parameter because referral authorization requires validating
+    # the relationship between three entities: user, opportunity, and client.
+    def can_create_referral?(client:)
+      return false unless Hmis::Ce.configuration.enabled?
 
-  def opportunity = resource
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Ce::Opportunity)
+      # Does the client record data source match the current user?
+      return false unless client.data_source_id == user.hmis_data_source_id
+
+      # Does the user have permission?
+      return false unless context.project_permissions(opportunity.unit.project_id).include?(:can_start_referrals)
+
+      true
+    end
+
+    def can_view_candidates?
+      context.project_permissions(opportunity.unit.project_id).include?(:can_view_prioritized_client_lists)
+    end
+
+    protected
+
+    def opportunity = resource
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Ce::Opportunity)
+  end
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/ce_referral_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/ce_referral_policy.rb
@@ -13,91 +13,107 @@
 # - A user can also view a referral if they have `:can_view_own_referrals` and are a participant in a swimlane
 #   that has a completed step in the referral.
 # - Indexing (e.g., for a dashboard) requires a combination of view and perform permissions.
-class Hmis::AuthPolicies::CeReferralPolicy < Hmis::AuthPolicies::BasePolicy
-  def can_index?
-    return false unless Hmis::Ce.configuration.enabled?
-
-    # require that a user could both view referrals and act on them
-    return false unless (context.potential_permissions & [:can_view_referrals, :can_view_own_referrals]).any?
-    return false unless (context.potential_permissions & [:can_perform_any_referral_tasks, :can_perform_own_referral_tasks]).any?
-
-    true
+class Hmis::AuthPolicies::CeReferralPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  def can_view?
-    return false unless Hmis::Ce.configuration.enabled?
+  class Global < Hmis::AuthPolicies::BasePolicy
+    def can_index?
+      return false unless Hmis::Ce.configuration.enabled?
 
-    # Referrals that the user can view because they have can_view_referrals in the target project
-    return true if project_permissions.include?(:can_view_referrals) && project_permissions.include?(:can_view_project)
+      # require that a user could both view referrals and act on them
+      return false unless (context.potential_permissions & [:can_view_referrals, :can_view_own_referrals]).any?
+      return false unless (context.potential_permissions & [:can_perform_any_referral_tasks, :can_perform_own_referral_tasks]).any?
 
-    # Referrals that the user can view because they have can_view_outgoing_referral_details in the source project.
-    # Note that can_view_outgoing_referral_details grants full referral details,
-    # whereas can_manage_outgoing_referrals only grants summary level permission.
-    return true if source_project_permissions.include?(:can_view_outgoing_referral_details)
+      true
+    end
 
-    # Referrals that have a step assigned to this user, in projects in which the user can_view_own_referrals.
-    # Referral only becomes viewable once the assigned step becomes available.
-    # Note that the user does *not* need can_view_project in this case
-    project_permissions.include?(:can_view_own_referrals) && context.assigned_referral_instance_ids.include?(referral.workflow_instance_id)
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Ce::Referral)
   end
 
-  def can_view_summary?
-    return false unless Hmis::Ce.configuration.enabled?
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    def can_view?
+      return false unless Hmis::Ce.configuration.enabled?
 
-    return true if can_view?
+      # Referrals that the user can view because they have can_view_referrals in the target project
+      return true if project_permissions.include?(:can_view_referrals) && project_permissions.include?(:can_view_project)
 
-    # Users who can manage outgoing referrals from the source project
-    return true if source_project_permissions.include?(:can_manage_outgoing_referrals)
+      # Referrals that the user can view because they have can_view_outgoing_referral_details in the source project.
+      # Note that can_view_outgoing_referral_details grants full referral details,
+      # whereas can_manage_outgoing_referrals only grants summary level permission.
+      return true if source_project_permissions.include?(:can_view_outgoing_referral_details)
 
-    # Users who can view the target enrollment. Bakes in the assumption that the target enrollment is in the referral's project, which is validated on the referral
-    # TODO(8549) - encapsulate this check requiring both can_view_enrollment_details and can_view_project in the Enrollment Policy
-    return true if referral.target_enrollment_id.present? && project_permissions.include?(:can_view_enrollment_details) && project_permissions.include?(:can_view_project)
+      # Referrals that have a step assigned to this user, in projects in which the user can_view_own_referrals.
+      # Referral only becomes viewable once the assigned step becomes available.
+      # Note that the user does *not* need can_view_project in this case
+      project_permissions.include?(:can_view_own_referrals) && context.assigned_referral_instance_ids.include?(referral.workflow_instance_id)
+    end
 
-    false
+    def can_view_summary?
+      return false unless Hmis::Ce.configuration.enabled?
+
+      return true if can_view?
+
+      # Users who can manage outgoing referrals from the source project
+      return true if source_project_permissions.include?(:can_manage_outgoing_referrals)
+
+      # Users who can view the target enrollment. Bakes in the assumption that the target enrollment is in the referral's project, which is validated on the referral
+      # TODO(8549) - encapsulate this check requiring both can_view_enrollment_details and can_view_project in the Enrollment Policy
+      return true if referral.target_enrollment_id.present? && project_permissions.include?(:can_view_enrollment_details) && project_permissions.include?(:can_view_project)
+
+      false
+    end
+
+    def can_assign_referral_tasks?
+      return false unless Hmis::Ce.configuration.enabled?
+
+      project_permissions.include?(:can_assign_referral_tasks)
+    end
+
+    def can_perform?(step: nil)
+      return false unless Hmis::Ce.configuration.enabled?
+
+      return true if project_permissions.include?(:can_perform_any_referral_tasks)
+
+      return context.assigned_referral_step_ids.include?(step.id) if step && project_permissions.include?(:can_perform_own_referral_tasks)
+
+      false
+    end
+
+    def can_create_note?(step: nil)
+      return can_perform?(step: step) if step
+
+      # If step is not provided, this check is for creating a top-level referral note. Allowed if user can perform _any_ available steps.
+      return false unless Hmis::Ce.configuration.enabled?
+      return true if project_permissions.include?(:can_perform_any_referral_tasks)
+      return true if project_permissions.include?(:can_perform_own_referral_tasks) && context.assigned_referral_instance_ids.include?(referral.workflow_instance_id)
+
+      false
+    end
+
+    protected
+
+    # convenience
+    def referral = resource
+
+    # *target* project
+    def project_permissions
+      project_id = context.referral_project_id(referral.id)
+      context.project_permissions(project_id)
+    end
+
+    def source_project_permissions
+      project_id = context.referral_source_project_id(referral.id)
+      context.project_permissions(project_id)
+    end
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Ce::Referral)
   end
-
-  def can_assign_referral_tasks?
-    return false unless Hmis::Ce.configuration.enabled?
-
-    project_permissions.include?(:can_assign_referral_tasks)
-  end
-
-  def can_perform?(step: nil)
-    return false unless Hmis::Ce.configuration.enabled?
-
-    return true if project_permissions.include?(:can_perform_any_referral_tasks)
-
-    return context.assigned_referral_step_ids.include?(step.id) if step && project_permissions.include?(:can_perform_own_referral_tasks)
-
-    false
-  end
-
-  def can_create_note?(step: nil)
-    return can_perform?(step: step) if step
-
-    # If step is not provided, this check is for creating a top-level referral note. Allowed if user can perform _any_ available steps.
-    return false unless Hmis::Ce.configuration.enabled?
-    return true if project_permissions.include?(:can_perform_any_referral_tasks)
-    return true if project_permissions.include?(:can_perform_own_referral_tasks) && context.assigned_referral_instance_ids.include?(referral.workflow_instance_id)
-
-    false
-  end
-
-  protected
-
-  # convenience
-  def referral = resource
-
-  # *target* project
-  def project_permissions
-    project_id = context.referral_project_id(referral.id)
-    context.project_permissions(project_id)
-  end
-
-  def source_project_permissions
-    project_id = context.referral_source_project_id(referral.id)
-    context.project_permissions(project_id)
-  end
-
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Ce::Referral)
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/form_definition_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/form_definition_policy.rb
@@ -6,75 +6,97 @@
 
 # frozen_string_literal: true
 
-class Hmis::AuthPolicies::FormDefinitionPolicy < Hmis::AuthPolicies::BasePolicy
-  # Catch-all field that is resolved to frontend.
-  # "Manage" form includes ability to create and edit drafts, duplicate, and publish forms.
-  def can_manage_form?
-    return false if form_definition.managed_in_version_control?
-
-    # Only super-admins can manage forms that are marked as 'admin_editable_only' in the database
-    return false if form_definition.admin_editable_only? && !global_permissions.include?(:can_administrate_config)
-
-    can_manage_form_by_role?
+class Hmis::AuthPolicies::FormDefinitionPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  # Whether the user can create an entirely new form definition
-  def can_create?(role:)
-    can_manage_form_by_role?(role: role)
+  class Global < Hmis::AuthPolicies::BasePolicy
+    # Whether the user can create an entirely new form definition
+    def can_create?(role:)
+      can_manage_form_by_role?(role: role)
+    end
+
+    protected
+
+    # Determines if the current user can manage forms for a given role.
+    def can_manage_form_by_role?(role:)
+      global_permissions.include?(:can_manage_forms) && manageable_form_role?(role: role)
+    end
+
+    # Determines if the form role is considered a non-super-admin form or a super-admin form
+    def manageable_form_role?(role:)
+      role.to_s.in?(Hmis::Form::Definition::NON_ADMIN_FORM_ROLES) || global_permissions.include?(:can_administrate_config)
+    end
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Form::Definition)
   end
 
-  # Whether the user can create a draft version of the form definition
-  def can_create_draft? = can_manage_form?
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    # Catch-all field that is resolved to frontend.
+    # "Manage" form includes ability to create and edit drafts, duplicate, and publish forms.
+    def can_manage_form?
+      return false if form_definition.managed_in_version_control?
 
-  # Whether the user can edit a draft version of the form definition
-  def can_edit_draft? = can_manage_form?
+      # Only super-admins can manage forms that are marked as 'admin_editable_only' in the database
+      return false if form_definition.admin_editable_only? && !global_permissions.include?(:can_administrate_config)
 
-  # Whether the user can publish the form definition
-  def can_publish? = can_manage_form?
+      can_manage_form_by_role?
+    end
 
-  # Whether the user can duplicate the form definition
-  def can_duplicate?
-    # Users can duplicate forms even if they are managed in version control or admin-editable-only
-    can_manage_form_by_role?
+    # Whether the user can create a draft version of the form definition
+    def can_create_draft? = can_manage_form?
+
+    # Whether the user can edit a draft version of the form definition
+    def can_edit_draft? = can_manage_form?
+
+    # Whether the user can publish the form definition
+    def can_publish? = can_manage_form?
+
+    # Whether the user can duplicate the form definition
+    def can_duplicate?
+      # Users can duplicate forms even if they are managed in version control or admin-editable-only
+      can_manage_form_by_role?
+    end
+
+    # Whether the user can delete the form definition (only draft forms can be deleted)
+    def can_delete?
+      form_definition.draft? && can_manage_form?
+    end
+
+    # Whether the user can add a new Hmis::Form::Instance to the form definition
+    def can_add_form_rule?
+      global_permissions.include?(:can_configure_data_collection) && manageable_form_role?
+    end
+
+    # Whether the user can delete a Hmis::Form::Instance rule from the form definition
+    def can_delete_form_rule? = can_add_form_rule?
+
+    protected
+
+    # Determines if the current user can manage forms for a given role.
+    # can_manage_forms permission grants access to edit certain form roles (SERVICE, CUSTOM_ASSESSMENT),
+    # while "super-admin" permission can_administrate_config grants access to edit all form roles.
+    def can_manage_form_by_role?(role: nil)
+      global_permissions.include?(:can_manage_forms) && manageable_form_role?(role: role)
+    end
+
+    # Determines if the form role is considered a non-super-admin form or a super-admin form
+    def manageable_form_role?(role: nil)
+      role_to_check = role || form_definition.role
+      return false if role_to_check.nil?
+
+      role_to_check.to_s.in?(Hmis::Form::Definition::NON_ADMIN_FORM_ROLES) || global_permissions.include?(:can_administrate_config)
+    end
+
+    # Form management permissions are currently global. In the future they should be tied to data source (#6612, #6691),
+    # to support multi-CoC HMIS installations where each CoC manages their own set of forms.
+    def form_definition = resource
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Form::Definition)
   end
-
-  # Whether the user can delete the form definition (only draft forms can be deleted)
-  def can_delete?
-    form_definition.draft? && can_manage_form?
-  end
-
-  # Whether the user can add a new Hmis::Form::Instance to the form definition
-  def can_add_form_rule?
-    global_permissions.include?(:can_configure_data_collection) && manageable_form_role?
-  end
-
-  # Whether the user can delete a Hmis::Form::Instance rule from the form definition
-  def can_delete_form_rule? = can_add_form_rule?
-
-  protected
-
-  # Determines if the current user can manage forms for a given role.
-  # can_manage_forms permission grants access to edit certain form roles (SERVICE, CUSTOM_ASSESSMENT),
-  # while "super-admin" permission can_administrate_config grants access to edit all form roles.
-  def can_manage_form_by_role?(role: nil)
-    global_permissions.include?(:can_manage_forms) && manageable_form_role?(role: role)
-  end
-
-  # Determines if the form role is considered a non-super-admin form or a super-admin form
-  def manageable_form_role?(role: nil)
-    role_to_check = role || form_definition.role
-    return false if role_to_check.nil?
-
-    role_to_check.to_s.in?(Hmis::Form::Definition::NON_ADMIN_FORM_ROLES) || global_permissions.include?(:can_administrate_config)
-  end
-
-  # Form management permissions are currently global. In the future they should be tied to data source (#6612, #6691),
-  # to support multi-CoC HMIS installations where each CoC manages their own set of forms.
-  def global_permissions
-    context.global_permissions
-  end
-
-  def form_definition = resource
-
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Form::Definition)
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_client_policy.rb
@@ -6,54 +6,59 @@
 
 # frozen_string_literal: true
 
-class Hmis::AuthPolicies::HmisClientPolicy < Hmis::AuthPolicies::BasePolicy
-  def can_view?
-    client_permissions.include?(:can_view_clients)
+class Hmis::AuthPolicies::HmisClientPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  def can_edit?
-    client_permissions.include?(:can_edit_clients)
+  class Global < Hmis::AuthPolicies::BasePolicy
+    # Check if user has global permission to merge clients across any project.
+    # Note: In the future, this may be need to be restricted by data source/CoC in multi-CoC installations.
+    def can_merge_any_clients?
+      global_permissions.include?(:can_merge_clients)
+    end
+
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Hud::Client)
   end
 
-  def can_destroy?
-    client_permissions.include?(:can_delete_clients)
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    def can_view?
+      client_permissions.include?(:can_view_clients)
+    end
+
+    def can_edit?
+      client_permissions.include?(:can_edit_clients)
+    end
+
+    def can_destroy?
+      client_permissions.include?(:can_delete_clients)
+    end
+
+    def can_view_name?
+      client_permissions.include?(:can_view_client_name)
+    end
+
+    def can_manage_alerts?
+      client_permissions.include?(:can_manage_client_alerts)
+    end
+
+    def can_manage_scan_cards?
+      client_permissions.include?(:can_manage_scan_cards)
+    end
+
+    protected
+
+    # Get permissions for the specific client instance, based on the projects they are enrolled in
+    memoize def client_permissions
+      context.client_permissions(resource.id)
+    end
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Client)
   end
-
-  def can_view_name?
-    client_permissions.include?(:can_view_client_name)
-  end
-
-  def can_manage_alerts?
-    client_permissions.include?(:can_manage_client_alerts)
-  end
-
-  def can_manage_scan_cards?
-    client_permissions.include?(:can_manage_scan_cards)
-  end
-
-  # Check if user has global permission to merge clients across any project.
-  # Note: In the future, this may be need to be restricted by data source/CoC in multi-CoC installations.
-  def can_merge_any_clients?
-    global_permissions.include?(:can_merge_clients)
-  end
-
-  protected
-
-  # Get permissions for the specific client instance, based on the projects they are enrolled in
-  memoize def client_permissions
-    # SAFETY: Require client instance to prevent accidental global permission checks.
-    #   Wrong: policy_for(Hmis::Hud::Client, :hmis_client).can_destroy? (uses global permissions)
-    #   Right: policy_for(client_instance, :hmis_client).can_destroy? (uses instance permissions)
-    #   For global checks: add separate methods like can_destroy_any_clients?
-    raise ArgumentError, 'Must provide a client instance' unless resource.is_a?(Hmis::Hud::Client)
-
-    context.client_permissions(resource.id)
-  end
-
-  # Get global permissions for the user (across all projects)
-  def global_permissions
-    context.global_permissions
-  end
-
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Client)
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
@@ -6,42 +6,58 @@
 
 # frozen_string_literal: true
 
-class Hmis::AuthPolicies::HmisProjectPolicy < Hmis::AuthPolicies::BasePolicy
-  def can_view?
-    project_permissions.include?(:can_view_project)
+class Hmis::AuthPolicies::HmisProjectPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  # not used yet
-  def can_edit?
-    project_permissions.include?(:can_edit_project_details)
+  class Global < Hmis::AuthPolicies::BasePolicy
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Hud::Project)
   end
 
-  # not used yet
-  def can_destroy?
-    project_permissions.include?(:can_delete_project)
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    def can_view?
+      project_permissions.include?(:can_view_project)
+    end
+
+    # not used yet
+    def can_edit?
+      project_permissions.include?(:can_edit_project_details)
+    end
+
+    # not used yet
+    def can_destroy?
+      project_permissions.include?(:can_delete_project)
+    end
+
+    def can_manage_units?
+      project_permissions.include?(:can_manage_units)
+    end
+
+    def can_update_unit_availability?
+      project_permissions.include?(:can_update_unit_availability)
+    end
+
+    def can_send_out_direct_referral?
+      project_permissions.include?(:can_manage_outgoing_referrals)
+    end
+
+    def can_view_outgoing_referral_summaries?
+      project_permissions.include?(:can_view_outgoing_referral_details) || project_permissions.include?(:can_manage_outgoing_referrals)
+    end
+
+    protected
+
+    memoize def project_permissions
+      context.project_permissions(resource.id)
+    end
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Project)
   end
-
-  def can_manage_units?
-    project_permissions.include?(:can_manage_units)
-  end
-
-  def can_update_unit_availability?
-    project_permissions.include?(:can_update_unit_availability)
-  end
-
-  def can_send_out_direct_referral?
-    project_permissions.include?(:can_manage_outgoing_referrals)
-  end
-
-  def can_view_outgoing_referral_summaries?
-    project_permissions.include?(:can_view_outgoing_referral_details) || project_permissions.include?(:can_manage_outgoing_referrals)
-  end
-
-  protected
-
-  memoize def project_permissions
-    context.project_permissions(resource.id)
-  end
-
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Project)
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/staff_assignment_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/staff_assignment_policy.rb
@@ -6,15 +6,31 @@
 
 # frozen_string_literal: true
 
-class Hmis::AuthPolicies::StaffAssignmentPolicy < Hmis::AuthPolicies::BasePolicy
-  memoize def can_index?
-    return false unless Hmis::ProjectStaffAssignmentConfig.exists?
-
-    project_scope = Hmis::Hud::Project.with_access(user, :can_edit_enrollments).preload(:organization)
-    Hmis::ProjectStaffAssignmentConfig.for_projects(project_scope).exists?
+class Hmis::AuthPolicies::StaffAssignmentPolicy
+  def self.for_resource(context:, resource:)
+    if resource.is_a?(Class)
+      Global.new(context: context, resource: resource)
+    else
+      Instance.new(context: context, resource: resource)
+    end
   end
 
-  protected
+  class Global < Hmis::AuthPolicies::BasePolicy
+    memoize def can_index?
+      return false unless Hmis::ProjectStaffAssignmentConfig.exists?
 
-  def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::StaffAssignment)
+      project_scope = Hmis::Hud::Project.with_access(user, :can_edit_enrollments).preload(:organization)
+      Hmis::ProjectStaffAssignmentConfig.for_projects(project_scope).exists?
+    end
+
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::StaffAssignment)
+  end
+
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    protected
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::StaffAssignment)
+  end
 end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -274,7 +274,7 @@ class Hmis::User < ApplicationRecord
     policy_class = "Hmis::AuthPolicies::#{policy_name}".safe_constantize
     raise ArgumentError, "policy not found: #{policy_name}" unless policy_class
 
-    policy_class.new(resource: resource, context: policy_context)
+    policy_class.for_resource(resource: resource, context: policy_context)
   end
 
   memoize def policy_context

--- a/drivers/hmis/spec/models/hmis/auth_policies/ce_referral_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/ce_referral_policy_spec.rb
@@ -28,25 +28,26 @@ RSpec.describe Hmis::AuthPolicies::CeReferralPolicy, type: :model do
     )
   end
   let(:policy) { user.policy_for(referral, policy_type: :ce_referral) }
+  let(:global_policy) { user.policy_for(Hmis::Ce::Referral, policy_type: :ce_referral) }
 
   describe '#can_index?' do
     it 'returns true if user has both view and perform permissions' do
       create_access_control(user, project, with_permission: [:can_view_referrals, :can_perform_any_referral_tasks])
-      expect(policy.can_index?).to be true
+      expect(global_policy.can_index?).to be true
     end
 
     it 'returns false if user only has view permission' do
       create_access_control(user, project, with_permission: [:can_view_referrals])
-      expect(policy.can_index?).to be false
+      expect(global_policy.can_index?).to be false
     end
 
     it 'returns false if user only has perform permission' do
       create_access_control(user, project, with_permission: [:can_perform_any_referral_tasks])
-      expect(policy.can_index?).to be false
+      expect(global_policy.can_index?).to be false
     end
 
     it 'returns false if user has no permissions' do
-      expect(policy.can_index?).to be false
+      expect(global_policy.can_index?).to be false
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_client_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_client_policy_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Hmis::AuthPolicies::HmisClientPolicy, type: :model do
     end
 
     it 'raises an error if instance-specific method is called' do
-      expect { policy.can_view_name? }.to raise_error(ArgumentError, 'Must provide a client instance')
+      expect { policy.can_view_name? }.to raise_error(NoMethodError)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

# Description
Implements a factory-based authorization policy system to strictly separate global and instance-level permission checks.

- **Auth System**: Adds a `for_resource` factory that dispatches to `Global` or `Instance` policy subclasses, ensuring type-safe access to resource-specific logic.
- **User Integration**: Updates the main policy entry point in `Hmis::User` to support the new factory-based instantiation.

### Type of Change
Refactor

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


