### PR TITLE
Add validation for External forms (PIT) config setup

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -4834,6 +4834,11 @@ type FormDefinition {
   dateCreated: ISO8601DateTime!
   dateUpdated: ISO8601DateTime!
   definition: FormDefinitionJson!
+
+  """
+  External object key, only present for External Form role
+  """
+  externalFormObjectKey: String
   formRules(filters: FormRuleFilterOptions, limit: Int, offset: Int, sortOrder: FormRuleSortOption): FormRulesPaginated!
   id: ID!
   identifier: String!

--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -30,6 +30,7 @@ module Types
     field :role, Types::Forms::Enums::FormRole, null: false
     field :title, String, null: false
     field :version, ID, null: false
+    field :external_form_object_key, String, null: true, description: 'External object key, only present for External Form role'
     field :supports_save_in_progress, Boolean, null: false
     field :definition, Forms::FormDefinitionJson, null: false
     field :raw_definition, JsonObject, null: false

--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/external_forms_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/external_forms_controller.rb
@@ -12,6 +12,7 @@ class HmisExternalApis::ExternalFormsController < ActionController::Base
 
   before_action do
     # Only allow calling the controller directly in development. See PublishExternalFormsJob for production usage
+    # Dev usage: https://hmis-warehouse.dev.test/hmis_external_api/external_forms/<external_form_object_key>
     raise unless Rails.env.development?
   end
 
@@ -28,7 +29,8 @@ class HmisExternalApis::ExternalFormsController < ActionController::Base
   def show
     # to refresh form content
     object_key = params[:object_key]
-    definition = Hmis::Form::Definition.published.where(external_form_object_key: object_key).first!
+    definition = Hmis::Form::Definition.where(role: :EXTERNAL_FORM).published.find_by(external_form_object_key: object_key)
+    raise "Form with external_form_object_key '#{object_key}' not found. Form must be published and have role EXTERNAL_FORM." unless definition
 
     HmisExternalApis::PublishExternalFormsJob.new.perform(definition.id)
     definition.reload

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
@@ -20,7 +20,7 @@ class HmisExternalApis::PublishExternalFormsJob
     validate_form!(definition)
     # Validate the external forms setup
     missing_config = HmisExternalApis::ExternalForms::Config.validate_external_forms_setup
-    raise "external forms feature is not not properly configured: #{missing_config.join(', ')}" if missing_config.any? && (Rails.env.production? || Rails.env.staging?)
+    raise "external forms feature is not properly configured: #{missing_config.join(', ')}" if missing_config.any? && (Rails.env.production? || Rails.env.staging?)
 
     publication = definition.external_form_publications.new
 

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
@@ -12,15 +12,15 @@ require 'nokogiri'
 #
 # currently this needs to be run manually
 class HmisExternalApis::PublishExternalFormsJob
-  # queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
   include SafeInspectable
 
   def perform(definition_id)
-    definition = Hmis::Form::Definition.find(definition_id)
-    raise unless definition.external_form_object_key.present?
-
-    # In order to publish to S3, the form should already be published in HMIS (ideally via Form Builder)
-    raise "cannot publish form with status #{definition.status}" unless definition.published?
+    definition = Hmis::Form::Definition.where(role: :EXTERNAL_FORM).published.find(definition_id)
+    # Validate the form structure and CDEDs
+    validate_form!(definition)
+    # Validate the external forms setup
+    missing_config = HmisExternalApis::ExternalForms::Config.validate_external_forms_setup
+    raise "external forms feature is not not properly configured: #{missing_config.join(', ')}" if missing_config.any? && (Rails.env.production? || Rails.env.staging?)
 
     publication = definition.external_form_publications.new
 
@@ -32,10 +32,6 @@ class HmisExternalApis::PublishExternalFormsJob
     publication.content = process_content(raw_content, digest: digest, definition_id: definition.id)
     publication.content_definition = definition.definition
 
-    # Note: Most likely, the form was already published using the Form Builder, so the CDEDs have already been created.
-    # Future improvement would be to invoke this job from publish mutation so that External Forms can be published to S3 from the config tool.
-    update_cdeds(definition)
-
     upload_to_s3(publication)
 
     publication.save!
@@ -44,26 +40,21 @@ class HmisExternalApis::PublishExternalFormsJob
 
   protected
 
+  def validate_form!(definition)
+    raise 'form must have external_form_object_key' unless definition.external_form_object_key.present?
+    raise 'form must be published' unless definition.published? # must publish in Form Builder first
+
+    # Validate the form structure and CDEDs
+    errors = Hmis::Form::DefinitionValidator.perform(definition.definition)
+    raise "cannot publish form with errors: #{errors.full_messages.join(', ')}" if errors.any?
+  end
+
   def user_id
     @user_id ||= Hmis::Hud::User.system_user(data_source_id: data_source_id).user_id
   end
 
   def data_source_id
     @data_source_id ||= GrdaWarehouse::DataSource.hmis.first.id
-  end
-
-  # construct custom data element definitions from the nodes in the form definition
-  def update_cdeds(definition)
-    Hmis::Hud::CustomDataElementDefinition.transaction do
-      generator = Hmis::Form::CustomDataElementGenerator.new(
-        definition: definition,
-        data_source: GrdaWarehouse::DataSource.find(data_source_id),
-        create_missing_mappings: false,
-        set_form_definition_identifier: true,
-      )
-      cdeds = generator.run
-      cdeds.each(&:save!)
-    end
   end
 
   # prepare form content for publication

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/publish_external_forms_job.rb
@@ -42,7 +42,7 @@ class HmisExternalApis::PublishExternalFormsJob
 
   def validate_form!(definition)
     raise 'form must have external_form_object_key' unless definition.external_form_object_key.present?
-    raise 'form must be published' unless definition.published? # must publish in Form Builder first
+    raise 'form must be published in Form Builder first' unless definition.published? # must publish in Form Builder first
 
     # Validate the form structure and CDEDs
     errors = Hmis::Form::DefinitionValidator.perform(definition.definition)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/config.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/config.rb
@@ -32,6 +32,66 @@ module HmisExternalApis::ExternalForms
       }
     end
 
+    # Validate that all necessary creds and config are present to support publishing
+    # external forms and consuming external form submissions.
+    # See https://docs.google.com/document/d/1gV_naB47tUd0xB57EZFyWPjybbOMj2TKm2T1UDC2FU4/edit?tab=t.0#heading=h.58f9u5u7aj7f for more details on setup.
+    def self.validate_external_forms_setup
+      logger = Rails.logger
+      missing = []
+
+      logger.info('Validating External Forms setup...')
+
+      # validate: public bucket credential (for serving published HTML forms)
+      public_bucket = GrdaWarehouse::RemoteCredentials::S3.where(slug: 'public_bucket').first
+      if public_bucket.nil?
+        missing << 'remote_credential:S3 slug=public_bucket (for published HTML forms)'
+        logger.warn('missing RemoteCredentials::S3 with slug=public_bucket  ')
+      else
+        logger.info("public_bucket credential found: active=#{public_bucket.active?} bucket=#{public_bucket.bucket.inspect}")
+        logger.warn('public_bucket credential is inactive') unless public_bucket.active?
+      end
+
+      # validate: hmis_external_form_submissions credential (for storing incoming submissions)
+      submissions_bucket = GrdaWarehouse::RemoteCredentials::S3.where(slug: 'hmis_external_form_submissions').first
+      if submissions_bucket.nil?
+        missing << 'remote_credential:S3 slug=hmis_external_form_submissions (for incoming submissions)'
+        logger.warn('missing RemoteCredentials::S3 with slug=hmis_external_form_submissions')
+      else
+        logger.info("hmis_external_form_submissions credential found: active=#{submissions_bucket.active?} bucket=#{submissions_bucket.bucket.inspect}")
+        logger.warn('hmis_external_form_submissions credential is inactive') unless submissions_bucket.active?
+      end
+
+      # validate: hmis_external_forms_shared_key (for encrypting submission data)
+      encryption_key = GrdaWarehouse::RemoteCredentials::SymmetricEncryptionKey.where(slug: 'hmis_external_forms_shared_key').first
+      if encryption_key.nil?
+        missing << 'remote_credential:SymmetricEncryptionKey slug=hmis_external_forms_shared_key (for captcha score / submission data)'
+        logger.warn('missing RemoteCredentials::SymmetricEncryptionKey with slug=hmis_external_forms_shared_key')
+      else
+        logger.info("hmis_external_forms_shared_key found: active=#{encryption_key.active?}")
+        logger.warn('hmis_external_forms_shared_key credential is inactive') unless encryption_key.active?
+      end
+
+      # validate: required app config properties (for configuring the external form)
+      [:presign_url, :recaptcha_key, :sentry_sdk_url].each do |key|
+        key = "external_forms/#{key}"
+        value = AppConfigProperty.find_by(key: key)&.value
+        if value.blank?
+          missing << "AppConfigProperty key=#{key}"
+          logger.warn("missing AppConfigProperty key=#{key}")
+        else
+          logger.info("AppConfigProperty #{key} present (value=#{value.inspect})")
+        end
+      end
+
+      if missing.any?
+        logger.warn("❌ External Forms setup validation complete: missing/misconfigured=#{missing.join(' | ')}")
+      else
+        logger.info('✅ External Forms setup validation complete: no missing items detected')
+      end
+
+      missing
+    end
+
     protected
 
     # remove the path of a url (for inclusion in CSP)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
A few changes to make it easier (as a developer) to set up External Forms:
* Resolve `external_form_object_key` in graphql API, to display in the form detail page
* Add more helpful error message to dev controller for external forms
* Add additional validation to `PublishExternalFormsJob`
  * And remove unnecessary redundant CDED generation code, now that config tool handles that properly. Add validation check to ensure CDEDs exist pre-publish.
* Add utility method `HmisExternalApis::ExternalForms::Config.validate_external_forms_setup` to help with external forms setup. This logs if anything is missing.

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
