### PR TITLE
Apply active_for_current_eligibility on waitlist export

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export.rb
@@ -86,6 +86,7 @@ module HmisExternalApis::AcHmis::Exporters
 
     def candidate_pool_ids_for_data_source
       @candidate_pool_ids_for_data_source ||= Hmis::Ce::Match::CandidatePool.
+        active_for_current_eligibility. # matches logic of ce_clients fields, which backs the global eligible clients list on the admin screen
         joins(unit_groups: :project).
         where(Hmis::Hud::Project.arel_table[:data_source_id].eq(data_source.id)).
         distinct.

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export.rb
@@ -84,9 +84,12 @@ module HmisExternalApis::AcHmis::Exporters
         group_by(&:candidate_pool_id)
     end
 
+    # Only include candidate pools that are referenced by unit groups with CE waitlists enabled ('active_for_current_eligibility' scope).
+    # Note: This almost matches the ceClients query that backs the global eligible clients list, but not exactly.
+    # The difference is here we only include candidate pools that are referenced by unit groups, and not those referenced by stale opportunities.
     def candidate_pool_ids_for_data_source
       @candidate_pool_ids_for_data_source ||= Hmis::Ce::Match::CandidatePool.
-        active_for_current_eligibility. # matches logic of ce_clients fields, which backs the global eligible clients list on the admin screen
+        active_for_current_eligibility.
         joins(unit_groups: :project).
         where(Hmis::Hud::Project.arel_table[:data_source_id].eq(data_source.id)).
         distinct.

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CurrentWaitlistsExport, type
   let!(:ds) { create(:hmis_data_source) }
   let!(:project) { create(:hmis_hud_project, data_source: ds) }
   let!(:unit_group) { create(:hmis_unit_group, project: project) }
+  let!(:ce_project_config) { create(:hmis_project_ce_config, supports_waitlist_referrals: true, project: project) }
 
   let!(:destination_client) { create(:grda_warehouse_hud_client) }
   let!(:client_proxy) { create(:hmis_ce_client_proxy, client: destination_client) }
@@ -54,5 +55,12 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CurrentWaitlistsExport, type
     expect(row['PriorityScore1']).to eq('5')
     expect(row['PriorityScore2']).to eq('4')
     expect(row['PriorityScore3']).to eq('3')
+  end
+
+  it 'excludes candidates from inactive candidate pools' do
+    unit_group.update!(candidate_pool: nil) # remove candidate pool association, rendering the pool inactive
+    subject.run!
+    result = CSV.parse(output, headers: true)
+    expect(result.length).to eq(0)
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Fix bug in waitlist export. It was erroneously exporting clients who were only belonged to old candidate pools that are no longer in use.

Issue: https://github.com/open-path/Green-River/issues/8714

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have added spec tests (or not applicable)
