### PR TITLE
Bug fix on external forms household ID

### DIFF
--- a/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
+++ b/drivers/hmis_external_apis/app/assets/javascripts/external_forms.js
@@ -148,8 +148,9 @@ window.addHouseholdTypeListener = function (individualOrFamilySelector) {
   // Generates a "household id" that is unlikely to have collisions among form submissions,
   // without using external library (uuid) or modern browser features (crypto)
   var generateHouseholdId = function () {
-    var current = (new Date()).getTime().toString()
-    var rand = Math.random().toString(16).substring(2)
+    // Keep the ID a constant length: "HH" + 13 (ms timestamp) + 13 (random hex-ish)
+    var current = (new Date()).getTime().toString().slice(-13).padStart(13, '0')
+    var rand = Math.random().toString(16).substring(2).padStart(13, '0').slice(-13)
     return String('HH' + current + rand).toUpperCase();
   }
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Generated household ID is expected to be 28 chars (expectation is a ~20 lines below ), but it wasn't consistently 28 characters. Fixed in least intrusive way I could find, since this seems like a risky time to be making larger changes.
(AI suggested to use Uint8Array for generating the key but I wasn't sure about browser compatibility so opted not to)

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
