### PR TITLE
Enrollment CoC from HoH

### DIFF
--- a/app/models/concerns/export/scopes.rb
+++ b/app/models/concerns/export/scopes.rb
@@ -47,11 +47,12 @@ module Export::Scopes
         end
 
         # limit enrollment coc to the cocs chosen, and any random thing that's not a valid coc
-        if @coc_codes.present?
-          e_scope = e_scope.where(EnrollmentCoC: @coc_codes).
-            or(e_scope.where(EnrollmentCoC: nil)).
-            or(e_scope.where.not(EnrollmentCoC: HudHelper.util.cocs.keys))
-        end
+        # Only include enrollments where:
+        # 1. HouseholdID is null → check enrollment's own CoC
+        # 2. HouseholdID exists and HoH exists with valid CoC → include
+        # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
+        e_scope = e_scope.where(hoh_exists_with_valid_coc_clause) if @coc_codes.present?
+        # puts "e_scope: #{e_scope.to_sql}"
         e_scope.distinct.preload(:project, :client)
       end
     end
@@ -87,23 +88,71 @@ module Export::Scopes
         # no-op
       end
       # limit enrollment coc to the cocs chosen, and any random thing that's not a valid coc
-      if @coc_codes.present?
-        e_scope = e_scope.where(EnrollmentCoC: @coc_codes).
-          or(e_scope.where(EnrollmentCoC: nil)).
-          or(e_scope.where.not(EnrollmentCoC: HudHelper.util.cocs.keys))
-      end
-      e_scope.where(
+      # Only include enrollments where:
+      # 1. HouseholdID is null → check enrollment's own CoC
+      # 2. HouseholdID exists and HoH exists with valid CoC → include
+      # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
+      e_scope = e_scope.where(hoh_exists_with_valid_coc_clause) if @coc_codes.present?
+      e_scope = e_scope.where(
         e_t[:PersonalID].eq(c_t[:PersonalID]).
           and(e_t[:data_source_id].eq(c_t[:data_source_id])),
       ).where(
         project_exists_for_enrollment,
       ).arel.exists
+      e_scope
     end
 
     def project_exists_for_enrollment
       project_scope.where(
         p_t[:ProjectID].eq(e_t[:ProjectID]).
           and(p_t[:data_source_id].eq(e_t[:data_source_id])),
+      ).arel.exists
+    end
+
+    # Only include enrollments where:
+    # 1. HouseholdID is null → check enrollment's own CoC
+    # 2. HouseholdID exists and HoH exists with valid CoC → include
+    # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
+    def hoh_exists_with_valid_coc_clause
+      e_t[:HouseholdID].eq(nil).and(enrollment_coc_query(e_t)).
+        or(
+          Arel::Nodes::Grouping.new(
+            e_t[:HouseholdID].not_eq(nil).and(
+              hoh_exists_with_valid_coc.or(
+                Arel::Nodes::Not.new(hoh_exists_at_all).and(enrollment_coc_query(e_t)),
+              ),
+            ),
+          ),
+        )
+    end
+
+    # Used for limiting enrollments that are missing HouseholdID to those where the Enrollment CoC is matching, invalid, or missing
+    def enrollment_coc_query(table)
+      table[:EnrollmentCoC].in(@coc_codes).
+        or(table[:EnrollmentCoC].eq(nil)).
+        or(table[:EnrollmentCoC].not_in(HudHelper.util.cocs.keys))
+    end
+
+    # For enrollments with a HouseholdID, check if a HoH exists with matching CoC
+    def hoh_exists_with_valid_coc
+      hoh_t = GrdaWarehouse::Hud::Enrollment.arel_table.alias('hoh_t')
+      GrdaWarehouse::Hud::Enrollment.from(hoh_t).where(
+        hoh_t[:HouseholdID].eq(e_t[:HouseholdID]).
+          and(hoh_t[:data_source_id].eq(e_t[:data_source_id])).
+          and(hoh_t[:ProjectID].eq(e_t[:ProjectID])).
+          and(hoh_t[:RelationshipToHoH].eq(1)).
+          and(enrollment_coc_query(hoh_t)),
+      ).arel.exists
+    end
+
+    # Check if ANY HoH exists for this household (regardless of CoC)
+    def hoh_exists_at_all
+      hoh_t = GrdaWarehouse::Hud::Enrollment.arel_table.alias('hoh_exists_t')
+      GrdaWarehouse::Hud::Enrollment.from(hoh_t).where(
+        hoh_t[:HouseholdID].eq(e_t[:HouseholdID]).
+          and(hoh_t[:data_source_id].eq(e_t[:data_source_id])).
+          and(hoh_t[:ProjectID].eq(e_t[:ProjectID])).
+          and(hoh_t[:RelationshipToHoH].eq(1)),
       ).arel.exists
     end
   end

--- a/app/models/concerns/export/scopes.rb
+++ b/app/models/concerns/export/scopes.rb
@@ -47,12 +47,11 @@ module Export::Scopes
         end
 
         # limit enrollment coc to the cocs chosen, and any random thing that's not a valid coc
-        # Only include enrollments where:
-        # 1. HouseholdID is null → check enrollment's own CoC
-        # 2. HouseholdID exists and HoH exists with valid CoC → include
-        # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
-        e_scope = e_scope.where(hoh_exists_with_valid_coc_clause) if @coc_codes.present?
-        # puts "e_scope: #{e_scope.to_sql}"
+        # Use LEFT JOIN to HoH + COALESCE for efficient filtering:
+        # - For HoH records: uses their own CoC
+        # - For non-HoH with HoH present: uses HoH's CoC
+        # - For non-HoH without HoH: falls back to their own CoC
+        e_scope = apply_hoh_coc_filter(e_scope) if @coc_codes.present?
         e_scope.distinct.preload(:project, :client)
       end
     end
@@ -88,18 +87,14 @@ module Export::Scopes
         # no-op
       end
       # limit enrollment coc to the cocs chosen, and any random thing that's not a valid coc
-      # Only include enrollments where:
-      # 1. HouseholdID is null → check enrollment's own CoC
-      # 2. HouseholdID exists and HoH exists with valid CoC → include
-      # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
-      e_scope = e_scope.where(hoh_exists_with_valid_coc_clause) if @coc_codes.present?
-      e_scope = e_scope.where(
+      # Use LEFT JOIN to HoH + COALESCE for efficient filtering
+      e_scope = apply_hoh_coc_filter(e_scope) if @coc_codes.present?
+      e_scope.where(
         e_t[:PersonalID].eq(c_t[:PersonalID]).
           and(e_t[:data_source_id].eq(c_t[:data_source_id])),
       ).where(
         project_exists_for_enrollment,
       ).arel.exists
-      e_scope
     end
 
     def project_exists_for_enrollment
@@ -109,51 +104,33 @@ module Export::Scopes
       ).arel.exists
     end
 
-    # Only include enrollments where:
-    # 1. HouseholdID is null → check enrollment's own CoC
-    # 2. HouseholdID exists and HoH exists with valid CoC → include
-    # 3. HouseholdID exists but no HoH exists → check enrollment's own CoC (fallback)
-    def hoh_exists_with_valid_coc_clause
-      e_t[:HouseholdID].eq(nil).and(enrollment_coc_query(e_t)).
-        or(
-          Arel::Nodes::Grouping.new(
-            e_t[:HouseholdID].not_eq(nil).and(
-              hoh_exists_with_valid_coc.or(
-                Arel::Nodes::Not.new(hoh_exists_at_all).and(enrollment_coc_query(e_t)),
-              ),
-            ),
+    # Apply LEFT JOIN to HoH enrollment and filter on coalesced CoC value
+    # This efficiently handles all three cases in a single join:
+    # 1. No HouseholdID → COALESCE(NULL, enrollment.EnrollmentCoC) = enrollment's own CoC
+    # 2. HoH exists → COALESCE(hoh.EnrollmentCoC, enrollment.EnrollmentCoC) = HoH's CoC
+    # 3. HouseholdID exists but no HoH → COALESCE(NULL, enrollment.EnrollmentCoC) = enrollment's own CoC
+    def apply_hoh_coc_filter(scope)
+      hoh_t = GrdaWarehouse::Hud::Enrollment.arel_table.alias('hoh')
+      scope.joins(
+        e_t.create_join(
+          hoh_t,
+          e_t.create_on(
+            hoh_t[:HouseholdID].eq(e_t[:HouseholdID]).
+              and(hoh_t[:data_source_id].eq(e_t[:data_source_id])).
+              and(hoh_t[:ProjectID].eq(e_t[:ProjectID])).
+              and(hoh_t[:RelationshipToHoH].eq(1)),
           ),
-        )
+          Arel::Nodes::OuterJoin,
+        ),
+      ).where(enrollment_coc_query_coalesced(cl(hoh_t[:EnrollmentCoC], e_t[:EnrollmentCoC])))
     end
 
-    # Used for limiting enrollments that are missing HouseholdID to those where the Enrollment CoC is matching, invalid, or missing
-    def enrollment_coc_query(table)
-      table[:EnrollmentCoC].in(@coc_codes).
-        or(table[:EnrollmentCoC].eq(nil)).
-        or(table[:EnrollmentCoC].not_in(HudHelper.util.cocs.keys))
-    end
-
-    # For enrollments with a HouseholdID, check if a HoH exists with matching CoC
-    def hoh_exists_with_valid_coc
-      hoh_t = GrdaWarehouse::Hud::Enrollment.arel_table.alias('hoh_t')
-      GrdaWarehouse::Hud::Enrollment.from(hoh_t).where(
-        hoh_t[:HouseholdID].eq(e_t[:HouseholdID]).
-          and(hoh_t[:data_source_id].eq(e_t[:data_source_id])).
-          and(hoh_t[:ProjectID].eq(e_t[:ProjectID])).
-          and(hoh_t[:RelationshipToHoH].eq(1)).
-          and(enrollment_coc_query(hoh_t)),
-      ).arel.exists
-    end
-
-    # Check if ANY HoH exists for this household (regardless of CoC)
-    def hoh_exists_at_all
-      hoh_t = GrdaWarehouse::Hud::Enrollment.arel_table.alias('hoh_exists_t')
-      GrdaWarehouse::Hud::Enrollment.from(hoh_t).where(
-        hoh_t[:HouseholdID].eq(e_t[:HouseholdID]).
-          and(hoh_t[:data_source_id].eq(e_t[:data_source_id])).
-          and(hoh_t[:ProjectID].eq(e_t[:ProjectID])).
-          and(hoh_t[:RelationshipToHoH].eq(1)),
-      ).arel.exists
+    # Filter on coalesced CoC value (HoH's CoC if exists, else enrollment's own CoC)
+    # Accepts in @coc_codes, is NULL, or is not a valid CoC code
+    def enrollment_coc_query_coalesced(coalesced_coc_node)
+      coalesced_coc_node.in(@coc_codes).
+        or(coalesced_coc_node.eq(nil)).
+        or(coalesced_coc_node.not_in(HudHelper.util.cocs.keys))
     end
   end
 end

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb
@@ -63,4 +63,101 @@ RSpec.describe HmisCsvTwentyTwentySix::Exporter::Base, type: :model do
       expect(csv.count).to eq 3
     end
   end
+
+  describe 'non-HoH member filtering by their HoH CoC' do
+    before(:all) do
+      cleanup_test_environment
+      ExportHelper2026.setup_data
+
+      # Set up project with one CoC
+      ExportHelper2026.project_cocs.first.update(CoCCode: 'XX-501')
+      ExportHelper2026.project_cocs.last(4).map { |m| m.update(CoCCode: 'XX-601') }
+
+      @test_project = ExportHelper2026.projects.first
+
+      # Household 1: HoH with valid CoC (XX-501), all included
+      @hoh_valid = ExportHelper2026.enrollments[0]
+      @hoh_valid.update(
+        HouseholdID: 'VALID-HH-001',
+        RelationshipToHoH: 1,
+        ProjectID: @test_project.ProjectID,
+        EnrollmentCoC: 'XX-501',
+      )
+
+      @member_valid_1 = ExportHelper2026.enrollments[1]
+      @member_valid_1.update(
+        HouseholdID: 'VALID-HH-001',
+        RelationshipToHoH: 2,
+        ProjectID: @test_project.ProjectID,
+        EnrollmentCoC: nil,
+      )
+
+      # Household 2: HoH with valid CoC (XX-502), but not included in the filter, excluded
+      @hoh_invalid = ExportHelper2026.enrollments[2]
+      @hoh_invalid.update(
+        HouseholdID: 'INVALID-HH-001',
+        RelationshipToHoH: 1,
+        ProjectID: @test_project.ProjectID,
+        EnrollmentCoC: 'XX-502', # valid CoC, but not included
+      )
+
+      @member_invalid_1 = ExportHelper2026.enrollments[3]
+      @member_invalid_1.update(
+        HouseholdID: 'INVALID-HH-001',
+        RelationshipToHoH: 2,
+        ProjectID: @test_project.ProjectID,
+        EnrollmentCoC: nil,
+      )
+
+      # Household 3: Member with no HoH (no RelationshipToHoH = 1), included, nil CoC
+      @member_no_hoh = ExportHelper2026.enrollments[4]
+      @member_no_hoh.update(
+        HouseholdID: 'NO-HOH-HH-001',
+        RelationshipToHoH: 2,
+        ProjectID: @test_project.ProjectID,
+        EnrollmentCoC: nil,
+      )
+
+      @exporter = HmisCsvTwentyTwentySix::Exporter::Base.new(
+        start_date: 1.week.ago.to_date,
+        end_date: Date.current,
+        projects: [@test_project.id],
+        coc_codes: ['XX-501'],
+        options: { 'coc_codes' => ['XX-501'] },
+        period_type: 3,
+        directive: 3,
+        user_id: ExportHelper2026.user.id,
+      )
+      ExportHelper2026.instance_variable_set(:@exporter, @exporter)
+      @exporter.export!(cleanup: false, zip: false, upload: false)
+    end
+
+    after(:all) do
+      ExportHelper2026.cleanup
+    end
+
+    it 'includes HoH with valid CoC' do
+      expect(@exporter.enrollment_scope).to include(@hoh_valid)
+    end
+
+    it 'includes household members when their HoH has valid CoC' do
+      expect(@exporter.enrollment_scope).to include(@member_valid_1)
+    end
+
+    it 'excludes HoH with invalid CoC' do
+      expect(@exporter.enrollment_scope).not_to include(@hoh_invalid)
+    end
+
+    it 'excludes household members when their HoH has invalid CoC' do
+      expect(@exporter.enrollment_scope).not_to include(@member_invalid_1)
+    end
+
+    it 'excludes household members when there is no HoH in the household' do
+      expect(@exporter.enrollment_scope).to include(@member_no_hoh)
+    end
+
+    it 'enrollment scope includes only 3 enrollments, 2 from the valid household and 1 from the no hoh household' do
+      expect(@exporter.enrollment_scope.count).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
* Uses the EnrollmentCoC from the HoH instead fo the individual client when exporting HMIS CSVs with a CoC filter
* This more closely aligns with the LSA logic which in some situations was creating households with no HoH when the HoH was excluded from the export but the remaining clients were included.
* NOTE: performance may need tuning

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
