### PR TITLE
Add utility to transfer HMIS enrollment between clients

### DIFF
--- a/drivers/hmis/app/jobs/hmis/transfer_enrollment_client_job.rb
+++ b/drivers/hmis/app/jobs/hmis/transfer_enrollment_client_job.rb
@@ -66,13 +66,11 @@ module Hmis
 
       # All record types that reference PersonalID and are associated with enrollments
       record_types = [
+        # HUD Record Types
         Hmis::Hud::Assessment,
         Hmis::Hud::AssessmentQuestion,
         Hmis::Hud::AssessmentResult,
         Hmis::Hud::CurrentLivingSituation,
-        Hmis::Hud::CustomAssessment,
-        Hmis::Hud::CustomCaseNote,
-        Hmis::Hud::CustomService,
         Hmis::Hud::Disability,
         Hmis::Hud::EmploymentEducation,
         Hmis::Hud::Event,
@@ -81,7 +79,12 @@ module Hmis
         Hmis::Hud::IncomeBenefit,
         Hmis::Hud::Service,
         Hmis::Hud::YouthEducationStatus,
+        # Custom Record Types
+        Hmis::Hud::CustomAssessment,
+        Hmis::Hud::CustomCaseNote,
+        Hmis::Hud::CustomService,
       ]
+      # Note: there is no need to update other associated records like CustomDataElement which are associated with the enrollment via primary key, without a PersonalID reference.
 
       record_types.each do |record_type|
         t = record_type.arel_table

--- a/drivers/hmis/app/jobs/hmis/transfer_enrollment_client_job.rb
+++ b/drivers/hmis/app/jobs/hmis/transfer_enrollment_client_job.rb
@@ -1,0 +1,103 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Hmis
+  class TransferEnrollmentClientJob < BaseJob
+    # Utility class for transferring an Enrollment from one Client to another.
+    # Updates all associated records' PersonalIDs to point to the new client.
+    # Without updating timestamps on associated records or leaving a papertrail.
+    #
+    # This can be used for:
+    # - Manual enrollment transfers (admin feature)
+    # - Un-merging clients (restoring enrollments to original clients)
+    #
+    # Usage:
+    #   Hmis::TransferEnrollmentClientJob.perform_now(enrollment_id: enrollment.id, to_client_id: new_client.id, dry_run: true)
+    #
+    # NOTE: This job intentionally uses update_column/update_all so it can update PersonalID references
+    # without updating timestamps on associated records or leaving a papertrail.
+    def perform(enrollment_id:, to_client_id:, dry_run: false)
+      enrollment = Hmis::Hud::Enrollment.find_by(id: enrollment_id)
+      raise ArgumentError, 'Enrollment must be provided' unless enrollment
+
+      to_client = Hmis::Hud::Client.find_by(id: to_client_id)
+      raise ArgumentError, 'To client must be provided' unless to_client
+
+      from_client = enrollment.client
+      raise ArgumentError, 'Could not find existing client for enrollment' unless from_client
+
+      raise ArgumentError, 'Clients must be in the same data source' unless from_client.data_source_id == to_client.data_source_id
+      raise ArgumentError, 'Enrollment must be in the same data source as to_client' unless enrollment.data_source_id == to_client.data_source_id
+
+      if dry_run
+        update_personal_ids(enrollment: enrollment, from_client: from_client, to_client: to_client, dry_run: true)
+        Rails.logger.info('Dry run complete')
+        return
+      end
+
+      Hmis::Hud::Base.transaction do
+        update_personal_ids(enrollment: enrollment, from_client: from_client, to_client: to_client, dry_run: false)
+        enrollment.invalidate_processing!
+      end
+
+      # Queue service history processing (if not already queued)
+      Hmis::Hud::Enrollment.queue_service_history_processing!
+
+      Rails.logger.info 'Completed successfully'
+    end
+
+    private
+
+    def update_personal_ids(enrollment:, from_client:, to_client:, dry_run:)
+      enrollment_id = enrollment.EnrollmentID
+      data_source_id = to_client.data_source_id
+
+      if dry_run
+        Rails.logger.info "Dry run: would update Enrollment #{enrollment.id} PersonalID from #{from_client.personal_id} to #{to_client.personal_id} (EnrollmentID: #{enrollment_id})"
+      else
+        enrollment.update_column(:PersonalID, to_client.personal_id)
+        Rails.logger.info "Transferred Enrollment #{enrollment.id} from Client #{from_client.id} (PersonalID: #{from_client.personal_id}) to Client #{to_client.id} (PersonalID: #{to_client.personal_id})"
+      end
+
+      # All record types that reference PersonalID and are associated with enrollments
+      record_types = [
+        Hmis::Hud::Assessment,
+        Hmis::Hud::AssessmentQuestion,
+        Hmis::Hud::AssessmentResult,
+        Hmis::Hud::CurrentLivingSituation,
+        Hmis::Hud::CustomAssessment,
+        Hmis::Hud::CustomCaseNote,
+        Hmis::Hud::CustomService,
+        Hmis::Hud::Disability,
+        Hmis::Hud::EmploymentEducation,
+        Hmis::Hud::Event,
+        Hmis::Hud::Exit,
+        Hmis::Hud::HealthAndDv,
+        Hmis::Hud::IncomeBenefit,
+        Hmis::Hud::Service,
+        Hmis::Hud::YouthEducationStatus,
+      ]
+
+      record_types.each do |record_type|
+        t = record_type.arel_table
+        scope = record_type.
+          where(t['EnrollmentID'].eq(enrollment_id)).
+          where(t['PersonalID'].eq(from_client.personal_id)).
+          where(t['data_source_id'].eq(data_source_id))
+
+        if dry_run
+          count = scope.count
+          Rails.logger.info "Dry run: would update #{count} #{record_type.name} records for Enrollment #{enrollment_id}" if count > 0
+        else
+          count = scope.update_all(PersonalID: to_client.personal_id)
+          Rails.logger.info "Updated #{count} #{record_type.name} records for Enrollment #{enrollment_id}" if count > 0
+        end
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/jobs/hmis/transfer_enrollment_client_job_spec.rb
+++ b/drivers/hmis/spec/jobs/hmis/transfer_enrollment_client_job_spec.rb
@@ -1,0 +1,81 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hmis::TransferEnrollmentClientJob, type: :model do
+  let(:data_source) { create(:hmis_data_source) }
+  let(:from_client) { create(:hmis_hud_client_complete, data_source: data_source) }
+  let(:to_client) { create(:hmis_hud_client_complete, data_source: data_source) }
+  let(:project) { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, client: from_client, project: project, data_source: data_source) }
+  let!(:service) { create(:hmis_hud_service, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:assessment) { create(:hmis_hud_assessment, enrollment: enrollment, client: from_client, data_source: data_source) }
+
+  describe '#perform' do
+    it 'raises error if enrollment is missing' do
+      expect do
+        described_class.perform_now(enrollment_id: nil, to_client_id: to_client.id)
+      end.to raise_error(ArgumentError, 'Enrollment must be provided')
+    end
+
+    it 'raises error if to_client is missing' do
+      expect do
+        described_class.perform_now(enrollment_id: enrollment.id, to_client_id: nil)
+      end.to raise_error(ArgumentError, 'To client must be provided')
+    end
+
+    it 'raises error if clients are in different data sources' do
+      other_data_source = create(:hmis_data_source)
+      other_client = create(:hmis_hud_client_complete, data_source: other_data_source)
+
+      expect do
+        described_class.perform_now(enrollment_id: enrollment.id, to_client_id: other_client.id)
+      end.to raise_error(ArgumentError, 'Clients must be in the same data source')
+    end
+
+    it 'transfers enrollment to new client' do
+      described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id)
+
+      enrollment.reload
+      expect(enrollment.personal_id).to eq(to_client.personal_id)
+      expect(enrollment.client).to eq(to_client)
+    end
+
+    it 'updates associated records PersonalIDs' do
+      expect do
+        described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id)
+        [enrollment, service, assessment].each(&:reload)
+      end.to change(service, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(assessment, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and not_change(service, :date_updated)
+    end
+
+    it 'only updates records for the specific enrollment' do
+      other_enrollment = create(:hmis_hud_enrollment, client: from_client, project: project, data_source: data_source)
+      other_service = create(:hmis_hud_service, enrollment: other_enrollment, client: from_client, data_source: data_source)
+      expect do
+        described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id)
+        [enrollment, other_enrollment, service, other_service].each(&:reload)
+      end.to change(service, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and not_change(other_enrollment, :personal_id).
+        and not_change(other_service, :personal_id).
+        and not_change(service, :date_updated).
+        and not_change(other_service, :date_updated)
+    end
+
+    it 'handles dry run without making changes' do
+      expect do
+        described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id, dry_run: true)
+        [enrollment, service, assessment].each(&:reload)
+      end.to not_change(enrollment, :personal_id).
+        and not_change(service, :personal_id).
+        and not_change(assessment, :personal_id)
+    end
+  end
+end

--- a/drivers/hmis/spec/jobs/hmis/transfer_enrollment_client_job_spec.rb
+++ b/drivers/hmis/spec/jobs/hmis/transfer_enrollment_client_job_spec.rb
@@ -14,8 +14,16 @@ RSpec.describe Hmis::TransferEnrollmentClientJob, type: :model do
   let(:to_client) { create(:hmis_hud_client_complete, data_source: data_source) }
   let(:project) { create(:hmis_hud_project, data_source: data_source) }
   let(:enrollment) { create(:hmis_hud_enrollment, client: from_client, project: project, data_source: data_source) }
+
+  # Associated records for 'enrollment' that should have their PersonalIDs updated
   let!(:service) { create(:hmis_hud_service, enrollment: enrollment, client: from_client, data_source: data_source) }
   let!(:assessment) { create(:hmis_hud_assessment, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:income_benefit) { create(:hmis_income_benefit, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:cls) { create(:hmis_current_living_situation, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:custom_assessment) { create(:hmis_custom_assessment, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:custom_case_note) { create(:hmis_hud_custom_case_note, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let!(:custom_service) { create(:hmis_custom_service, enrollment: enrollment, client: from_client, data_source: data_source) }
+  let(:associated_records) { [service, assessment, income_benefit, cls, custom_assessment, custom_case_note, custom_service] }
 
   describe '#perform' do
     it 'raises error if enrollment is missing' do
@@ -50,21 +58,29 @@ RSpec.describe Hmis::TransferEnrollmentClientJob, type: :model do
     it 'updates associated records PersonalIDs' do
       expect do
         described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id)
-        [enrollment, service, assessment].each(&:reload)
+        associated_records.each(&:reload)
       end.to change(service, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
         and change(assessment, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(income_benefit, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(cls, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(custom_assessment, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(custom_case_note, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
+        and change(custom_service, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
         and not_change(service, :date_updated)
     end
 
     it 'only updates records for the specific enrollment' do
       other_enrollment = create(:hmis_hud_enrollment, client: from_client, project: project, data_source: data_source)
       other_service = create(:hmis_hud_service, enrollment: other_enrollment, client: from_client, data_source: data_source)
+      other_custom_assessment = create(:hmis_custom_assessment, enrollment: other_enrollment, client: from_client, data_source: data_source)
+
       expect do
         described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id)
-        [enrollment, other_enrollment, service, other_service].each(&:reload)
+        [enrollment, other_enrollment, service, other_service, custom_assessment, other_custom_assessment, custom_service].each(&:reload)
       end.to change(service, :personal_id).from(from_client.personal_id).to(to_client.personal_id).
         and not_change(other_enrollment, :personal_id).
         and not_change(other_service, :personal_id).
+        and not_change(other_custom_assessment, :personal_id).
         and not_change(service, :date_updated).
         and not_change(other_service, :date_updated)
     end
@@ -72,10 +88,15 @@ RSpec.describe Hmis::TransferEnrollmentClientJob, type: :model do
     it 'handles dry run without making changes' do
       expect do
         described_class.perform_now(enrollment_id: enrollment.id, to_client_id: to_client.id, dry_run: true)
-        [enrollment, service, assessment].each(&:reload)
+        associated_records.each(&:reload)
       end.to not_change(enrollment, :personal_id).
         and not_change(service, :personal_id).
-        and not_change(assessment, :personal_id)
+        and not_change(assessment, :personal_id).
+        and not_change(income_benefit, :personal_id).
+        and not_change(cls, :personal_id).
+        and not_change(custom_assessment, :personal_id).
+        and not_change(custom_case_note, :personal_id).
+        and not_change(custom_service, :personal_id)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8535

Introduce a utility job for transferring an Enrollment from one client to another. We are doing this manually when undoing HMIS client merges upon request. Using a shared utility will make the process faster and less error-prone.

## Type of change
Utility

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
