### PR TITLE
Support initial_selected on external forms

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -247,7 +247,7 @@ module HmisExternalApis::ExternalForms
           {
             value: option['code'],
             label: option['label'] || option['code'],
-            initial_selected: option['initial_selected'],
+            initial_selected: option['initial_selected'] == true,
           }
         end
       end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -244,7 +244,11 @@ module HmisExternalApis::ExternalForms
         end
       elsif pick_list_options
         pick_list_options.map do |option|
-          { value: option['code'], label: option['label'] || option['code'] }
+          {
+            value: option['code'],
+            label: option['label'] || option['code'],
+            initial_selected: option['initial_selected'],
+          }
         end
       end
     end

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_radio_group_options.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_radio_group_options.haml
@@ -1,8 +1,8 @@
 - options.each_with_index do |option, idx|
-  - label, value = option.values_at(:label, :value)
+  - label, value, initial_selected = option.values_at(:label, :value, :initial_selected)
   - input_id = "#{html_id}-#{idx}"
   .form-check
-    %input.form-check-input{type: "radio", name: name, id: input_id, value: value, required: required}
+    %input.form-check-input{type: "radio", name: name, id: input_id, value: value, checked: initial_selected, required: required}
     %label.form-check-label{for: input_id}= label
     - if option == options.last
       .invalid-feedback This is required

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_select.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_select.haml
@@ -2,5 +2,5 @@
 %select.form-control{id: html_id, name: name, required: required, autocomplete: "off"}
   %option{value: ""}= "-- Select"
   - options.each do |option|
-    %option{value: option[:value]}= option[:label]
+    %option{value: option[:value], selected: option[:initial_selected]}= option[:label]
 .invalid-feedback This is required


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Add support for existing `initial_selected` field on pick list options. 

Issue: https://github.com/open-path/Green-River/issues/8730

## Type of change
New feature


#### radio button example

https://github.com/user-attachments/assets/ccc18ffb-5b23-47a5-8bb3-e5a6fa808813




#### select example

https://github.com/user-attachments/assets/222c6c0a-24f8-457f-bae0-bf3f5a719225


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
