### PR TITLE
Pass additional fields when requesting AHA score

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/fetch_aha_score.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/fetch_aha_score.rb
@@ -15,6 +15,8 @@ module Mutations
     end
 
     argument :client_id, ID, required: true
+    argument :lookup_catalyst, String, required: false
+    argument :lookup_reason, [String], required: false
 
     field :score, Integer, null: true
     field :mci_quality_indicator, Integer, null: true
@@ -22,7 +24,7 @@ module Mutations
     field :generator, String, null: true
     field :aha_failed_reason, AhaFailedReason, null: true
 
-    def resolve(client_id:)
+    def resolve(client_id:, lookup_catalyst: nil, lookup_reason: nil)
       errors = HmisErrors::Errors.new
       errors.add :base, :server_error, full_message: 'AHA connection is not configured' unless HmisExternalApis::AcHmis::Aha.enabled?
       return { errors: errors } if errors.any?
@@ -33,7 +35,7 @@ module Mutations
 
       aha = HmisExternalApis::AcHmis::Aha.new
       begin
-        result = aha.fetch_score(client)
+        result = aha.fetch_score(client, lookup_catalyst: lookup_catalyst, lookup_reason: lookup_reason)
       rescue HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError => _e
         return { score: -1, aha_failed_reason: 'NO_MCI_UNIQUE_ID' }
       end

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -7193,7 +7193,7 @@ type Mutation {
   """
   Return AHA score for client
   """
-  fetchAhaScore(clientId: ID!): FetchAhaScorePayload
+  fetchAhaScore(clientId: ID!, lookupCatalyst: String, lookupReason: [String!]): FetchAhaScorePayload
   joinHousehold(joiningEnrollmentInputs: [EnrollmentRelationshipInput!]!, receivingHouseholdId: ID!): JoinHouseholdPayload
   markUnitsAvailable(unitIds: [ID!]!): MarkUnitsAvailablePayload
   markUnitsUnavailable(unitIds: [ID!]!): MarkUnitsUnavailablePayload

--- a/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
+++ b/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   let(:mutation) do
     <<~GRAPHQL
-      mutation FetchAhaScore($clientId: ID!) {
-        fetchAhaScore(clientId: $clientId) {
+      mutation FetchAhaScore($clientId: ID!, $lookupCatalyst: String, $lookupReason: [String!]) {
+        fetchAhaScore(clientId: $clientId, lookupCatalyst: $lookupCatalyst, lookupReason: $lookupReason) {
           score
           mciQualityIndicator
           dwClientId
@@ -46,8 +46,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     GRAPHQL
   end
 
-  def perform_mutation(client_id:)
-    response, result = post_graphql(client_id: client_id) { mutation }
+  def perform_mutation(client_id:, lookup_catalyst: nil, lookup_reason: nil)
+    response, result = post_graphql(client_id: client_id, lookup_catalyst: lookup_catalyst, lookup_reason: lookup_reason) { mutation }
 
     aggregate_failures 'checking response' do
       expect(response.status).to eq 200
@@ -73,9 +73,9 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
 
       it 'returns AHA score successfully' do
-        allow(stub_aha).to receive(:fetch_score).with(c1).and_return(aha_result)
+        allow(stub_aha).to receive(:fetch_score).with(c1, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other']).and_return(aha_result)
 
-        perform_mutation(client_id: c1.id) do |data, errors|
+        perform_mutation(client_id: c1.id, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other']) do |data, errors|
           expect(errors).to be_empty
           expect(data['score']).to eq(8)
           expect(data['mciQualityIndicator']).to eq(0)
@@ -92,7 +92,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           dw_client_id: mci_unique_id.value,
           generator: 'AHA',
         )
-        allow(stub_aha).to receive(:fetch_score).with(c1).and_return(aha_result_neg_one)
+        allow(stub_aha).to receive(:fetch_score).with(c1, lookup_catalyst: nil, lookup_reason: nil).and_return(aha_result_neg_one)
 
         perform_mutation(client_id: c1.id) do |data, errors|
           expect(errors).to be_empty
@@ -107,7 +107,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let!(:client_without_mci) { create(:hmis_hud_client, data_source: ds1, user: u1) }
 
       it 'returns score -1 with NO_MCI_UNIQUE_ID reason' do
-        allow(stub_aha).to receive(:fetch_score).with(client_without_mci).
+        allow(stub_aha).to receive(:fetch_score).with(client_without_mci, lookup_catalyst: nil, lookup_reason: nil).
           and_raise(HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError)
 
         perform_mutation(client_id: client_without_mci.id) do |data, errors|

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -133,10 +133,23 @@ module HmisExternalApis::AcHmis
         payload[:dw_client_id__dw_client_id__includes] = mci_uniq_ids.first
       end
 
-      payload[:lookup_catalyst] = lookup_catalyst if lookup_catalyst && LOOKUP_CATALYST_ALLOWED_VALUES.include?(lookup_catalyst)
+      # For lookup catalyst and lookup reasons, don't send unknown values to the external API,
+      # but log to Sentry if we receive unexpected values so we don't silently skip them.
+      if lookup_catalyst.present?
+        if LOOKUP_CATALYST_ALLOWED_VALUES.include?(lookup_catalyst)
+          payload[:lookup_catalyst] = lookup_catalyst
+        else
+          Sentry.capture_message("AHA received unexpected lookup catalyst: #{lookup_catalyst}")
+        end
+      end
 
-      valid_reasons = lookup_reason&.filter { |r| LOOKUP_REASON_ALLOWED_VALUES.include?(r) }
-      payload[:lookup_reason] = valid_reasons if valid_reasons&.any?
+      if lookup_reason.present?
+        valid_reasons, unknown_reasons = lookup_reason.partition { |r| LOOKUP_REASON_ALLOWED_VALUES.include?(r) }
+
+        payload[:lookup_reason] = valid_reasons if valid_reasons.any?
+
+        Sentry.capture_message("AHA received unexpected lookup reason(s): #{unknown_reasons.join(', ')}") if unknown_reasons.any?
+      end
 
       payload
     end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -42,7 +42,7 @@ module HmisExternalApis::AcHmis
     # Custom error class for MciUniqueId so the mutation can catch it
     class NoMciUniqueIdError < HmisErrors::ApiError; end
 
-    def fetch_score(client)
+    def fetch_score(client, lookup_catalyst: nil, lookup_reason: nil)
       # Collect MCI unique IDs for this client and all source clients with the same destination client
       clients = [client, *client.destination_client&.source_clients&.to_a]
       mci_uniq_ids = clients.compact.uniq.filter_map do |c|
@@ -51,10 +51,15 @@ module HmisExternalApis::AcHmis
 
       raise NoMciUniqueIdError if mci_uniq_ids.empty?
 
+      base_payload = { # todo @martha - probably this should be a backend enum that validates the frontend input. or it should be validated in the graphql model
+        **(lookup_catalyst ? { "lookup_catalyst": lookup_catalyst } : {}),
+        **(lookup_reason&.any? ? { "lookup_reason": lookup_reason } : {}),
+      }
+
       payload = if mci_uniq_ids.size > 1
-        { 'dw_client_id__dw_client_id__overlap': mci_uniq_ids.join(',') }
+        { 'dw_client_id__dw_client_id__overlap': mci_uniq_ids.join(','), **base_payload }
       else
-        { 'dw_client_id__dw_client_id__includes': mci_uniq_ids.first }
+        { 'dw_client_id__dw_client_id__includes': mci_uniq_ids.first, **base_payload }
       end
 
       result = conn.post('api/v1/clients/scores/search/', payload).

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -63,7 +63,7 @@ module HmisExternalApis::AcHmis
       clients = [client, *client.destination_client&.source_clients&.to_a]
       mci_uniq_ids = clients.compact.uniq.filter_map do |c|
         c.ac_hmis_mci_unique_id&.value
-      end.uniq
+      end.uniq.sort
 
       raise NoMciUniqueIdError if mci_uniq_ids.empty?
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -33,6 +33,22 @@
 ###
 module HmisExternalApis::AcHmis
   class Aha
+    # Lookup catalyst and reason are optional values; if present on the form, they should be submitted when we make the fetch call.
+    # Before submitting, validate against the list of allowed values.
+    # (Validate here, instead of in the graphql schema, so we have flexibility to ignore instead of raise when receiving invalid values)
+    LOOKUP_CATALYST_ALLOWED_VALUES = [
+      'OCS Staff',
+      'OCS Admin',
+      'Non-OCS Program Admin',
+      'DHS Admin',
+    ].freeze
+    LOOKUP_REASON_ALLOWED_VALUES = [
+      'Other',
+      'Vacancy Management',
+      'Prioritization Request',
+      'DHS Housing Integration',
+    ].freeze
+
     SYSTEM_ID = 'ac_hmis_aha'
     AHA_GENERATOR = 'AHA'
     VALID_AHA_SCORES = [-1, *(1..10)].freeze # AHA can be -1 or 1..10, but not zero. (Note that 'MH-AHA' generator appears to support zero as a score.)
@@ -51,16 +67,7 @@ module HmisExternalApis::AcHmis
 
       raise NoMciUniqueIdError if mci_uniq_ids.empty?
 
-      base_payload = { # todo @martha - probably this should be a backend enum that validates the frontend input. or it should be validated in the graphql model
-        **(lookup_catalyst ? { "lookup_catalyst": lookup_catalyst } : {}),
-        **(lookup_reason&.any? ? { "lookup_reason": lookup_reason } : {}),
-      }
-
-      payload = if mci_uniq_ids.size > 1
-        { 'dw_client_id__dw_client_id__overlap': mci_uniq_ids.join(','), **base_payload }
-      else
-        { 'dw_client_id__dw_client_id__includes': mci_uniq_ids.first, **base_payload }
-      end
+      payload = create_payload(mci_uniq_ids, lookup_catalyst, lookup_reason)
 
       result = conn.post('api/v1/clients/scores/search/', payload).
         then { |r| handle_error(r) }
@@ -115,6 +122,23 @@ module HmisExternalApis::AcHmis
 
     def conn
       @conn ||= HmisExternalApis::ApiKeyConnection.new(creds, connection_timeout: CONNECTION_TIMEOUT_SECONDS)
+    end
+
+    def create_payload(mci_uniq_ids, lookup_catalyst, lookup_reason)
+      payload = {}
+
+      if mci_uniq_ids.size > 1
+        payload[:dw_client_id__dw_client_id__overlap] = mci_uniq_ids.join(',')
+      else
+        payload[:dw_client_id__dw_client_id__includes] = mci_uniq_ids.first
+      end
+
+      payload[:lookup_catalyst] = lookup_catalyst if lookup_catalyst && LOOKUP_CATALYST_ALLOWED_VALUES.include?(lookup_catalyst)
+
+      valid_reasons = lookup_reason&.filter { |r| LOOKUP_REASON_ALLOWED_VALUES.include?(r) }
+      payload[:lookup_reason] = valid_reasons if valid_reasons&.any?
+
+      payload
     end
 
     def handle_error(result)

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -114,10 +114,14 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
 
     it 'ignores invalid values for lookup catalyst and reason' do
+      allow(Sentry).to receive(:capture_message)
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
       result = aha.fetch_score(client, lookup_catalyst: 'random text', lookup_reason: ['not a good reason'])
       expect(result.score).to eq(8)
+
+      expect(Sentry).to have_received(:capture_message).with('AHA received unexpected lookup catalyst: random text')
+      expect(Sentry).to have_received(:capture_message).with('AHA received unexpected lookup reason(s): not a good reason')
     end
   end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
   context 'when client has MCI unique ID' do
     let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
 
-    before do
-      response = mock_api_response(
+    let!(:response) do
+      mock_api_response(
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
@@ -96,33 +96,27 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
           ],
         ),
       )
-      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
     end
 
     it 'calls API and returns the highest AHA score, disregarding other generators' do
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
       result = aha.fetch_score(client)
       expect(result.score).to eq(8)
       expect(result.dw_client_id).to eq(mci_unique_id.value)
     end
-  end
 
-  context 'when lookup catalyst and reason are also provided' do
-    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
-
-    before do
-      response = mock_api_response(
-        client_data(
-          dw_client_id: mci_unique_id.value,
-          scores: [
-            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
-          ],
-        ),
-      )
+    it 'calls API with lookup catalyst and reason when provided' do
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+
+      result = aha.fetch_score(client, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+      expect(result.score).to eq(8)
     end
 
-    it 'calls API with lookup catalyst and reason' do
-      result = aha.fetch_score(client, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+    it 'ignores invalid values for lookup catalyst and reason' do
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, lookup_catalyst: 'random text', lookup_reason: ['not a good reason'])
       expect(result.score).to eq(8)
     end
   end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -46,10 +46,17 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     )
   end
 
-  def setup_api_expectation(mci_unique_ids:, response:)
-    payload_key = mci_unique_ids.is_a?(Array) ? :dw_client_id__dw_client_id__overlap : :dw_client_id__dw_client_id__includes
-    payload_value = mci_unique_ids.is_a?(Array) ? mci_unique_ids.join(',') : mci_unique_ids
-    expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', { payload_key => payload_value }).and_return(response)
+  def setup_api_expectation(mci_unique_ids:, response:, lookup_catalyst: nil, lookup_reason: nil)
+    mci_key = mci_unique_ids.is_a?(Array) ? :dw_client_id__dw_client_id__overlap : :dw_client_id__dw_client_id__includes
+    mci_value = mci_unique_ids.is_a?(Array) ? mci_unique_ids.join(',') : mci_unique_ids
+
+    expected_payload = {
+      mci_key => mci_value,
+    }
+    expected_payload[:lookup_catalyst] = lookup_catalyst if lookup_catalyst.present?
+    expected_payload[:lookup_reason] = lookup_reason if lookup_reason&.any?
+
+    expect(mock_connection).to receive(:post).with('api/v1/clients/scores/search/', expected_payload).and_return(response)
   end
 
   context 'when client has no MCI unique ID' do
@@ -96,6 +103,27 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       result = aha.fetch_score(client)
       expect(result.score).to eq(8)
       expect(result.dw_client_id).to eq(mci_unique_id.value)
+    end
+  end
+
+  context 'when lookup catalyst and reason are also provided' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    before do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+    end
+
+    it 'calls API with lookup catalyst and reason' do
+      result = aha.fetch_score(client, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+      expect(result.score).to eq(8)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- add lookup catalyst and reason to the graphql schema as optional arguments for the `FetchAhaScore` mutation
- when they are provided, pass them to the external API when requesting AHA score

Related frontend PR: https://github.com/greenriver/hmis-frontend/pull/1354

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
