### PR TITLE
tt/7165-file-cache

### DIFF
--- a/app/jobs/purge_unattached_blobs_job.rb
+++ b/app/jobs/purge_unattached_blobs_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Purge unattached Active Storage blobs older than a specified age.
+#
+# Active Storage creates "unattached" blobs when files are cached for form resubmissions
+# (e.g., Health::HealthFile's cached_file attachment). These blobs should be purged after
+# they're no longer needed to avoid accumulating orphaned files in storage.
+class PurgeUnattachedBlobsJob < BaseJob
+  queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+
+  # @param older_than [ActiveSupport::Duration] Purge blobs created before this duration ago (default: 2 days)
+  def perform(older_than: 2.days)
+    instrument_as_maintenance_task do |run|
+      ActiveStorage::Blob.with_advisory_lock(
+        'purge_unattached_blobs_job',
+        timeout_seconds: 0,
+      ) do
+        purged_count = 0
+        ActiveStorage::Blob.unattached.where('active_storage_blobs.created_at <= ?', older_than.ago).find_each do |blob|
+          blob.purge
+          purged_count += 1
+        end
+
+        Rails.logger.info "Purged #{purged_count} unattached Active Storage blobs"
+        run.complete!
+      end
+    end
+  end
+end

--- a/app/models/health/health_file.rb
+++ b/app/models/health/health_file.rb
@@ -9,6 +9,10 @@
 # ### HIPAA Risk Assessment
 # Risk: Indirectly relates to a patient. Binary data may contain PHI
 # Control: PHI attributes documented
+#
+# Uses Active Storage for temporary file caching during form resubmissions.
+# Cached files are stored as unattached blobs with signed_ids passed through forms.
+# Unattached blobs older than 2 days are purged daily by PurgeUnattachedBlobsJob.
 module Health
   class HealthFile < HealthBase
     include NotifierConfig
@@ -22,44 +26,47 @@ module Health
     belongs_to :user, optional: true
     belongs_to :client, class_name: 'GrdaWarehouse::Hud::Client', optional: true
 
-    # Remove CarrierWave dependency
-    # mount_uploader :file, HealthFileUploader
-
-    # Virtual attributes to receive uploaded file from form
+    # Virtual attributes to receive uploaded file or cache from form
     attr_accessor :file
     attr_accessor :file_cache
 
-    validate :validate_uploaded_file_content
+    # --- Form Submission Lifecycle ---
+    # 1. process_upload_context (before_validation): Restores from cache OR ingests new upload
+    # 2. validate_file_content_and_metadata: Validates content and extracts metadata
+    # 3. set_file_cache (side-effect of validation): Updates cache for next render if validation fails
+    # 4. set_calculated!: Final orchestration called by controllers to trigger save/persistence
 
-    # Handle file_cache to preserve uploads between form submissions
-    before_validation :process_file_cache
+    before_validation :process_upload_context
+    validate :validate_file_content_and_metadata
 
-    def validate_uploaded_file_content
-      return if content.blank? && file.blank?
+    # Orchestrates the persistence of a health file. Called by controllers (e.g., via HealthFileController concern)
+    # after assigning user/client IDs. Returns boolean success.
+    def set_calculated!(user_id, client_id)
+      self.user_id ||= user_id
+      self.client_id ||= client_id
 
-      # Skip validation if we already have content stored (e.g., on update)
-      return if content.present? && file.blank?
+      # Verify we have a file source (upload, cache, or direct content assignment)
+      if file.blank? && content.blank? && file_cache.blank?
+        Rails.logger.error("Health::HealthFile#set_calculated! called without file data. id: #{id}")
+        return false
+      end
 
-      # Validate newly uploaded file
-      return unless file.present?
+      # Trigger validations (including before_validation callbacks that populate content)
+      return false unless valid?
 
-      file_content = file.respond_to?(:read) ? file.read : file
-      file.rewind if file.respond_to?(:rewind)
+      # Final check: ensure content was successfully populated
+      if content.blank?
+        Rails.logger.error("Health::HealthFile#set_calculated! content not populated after validation. id: #{id}")
+        errors.add(:file, 'could not be processed')
+        return false
+      end
 
-      file_extension = File.extname(file.respond_to?(:original_filename) ? file.original_filename : name || '.pdf')
-      claimed_content_type = file.respond_to?(:content_type) ? file.content_type : nil
-
-      allowed_types = ['application/pdf']
-      result = self.class.validate_file_content(
-        file_content,
-        claimed_content_type,
-        allowed_types,
-        file_extension,
-      )
-
-      return if result[:valid]
-
-      errors.add(:file, 'must be a valid PDF')
+      if save
+        true
+      else
+        Rails.logger.error("Health::HealthFile#set_calculated! save failed: #{errors.full_messages.join(', ')}")
+        false
+      end
     end
 
     def title
@@ -67,7 +74,7 @@ module Health
     end
 
     def signature
-      return nil
+      nil
     end
 
     def valid_for_current_enrollment
@@ -79,94 +86,78 @@ module Health
     def valid_for_contributing_enrollment
       return nil unless client.patient
 
-      client.patient.contributed_enrollment_ranges.each do |range|
-        return true if range.cover?(signature)
+      client.patient.contributed_enrollment_ranges.any? do |range|
+        range.cover?(signature)
       end
-
-      return false
-    end
-
-    def set_calculated!(user_id, client_id)
-      self.user_id ||= user_id
-      self.client_id ||= client_id
-
-      # Handle file upload without CarrierWave
-      if file.present?
-        file_content = file.respond_to?(:read) ? file.read : file
-        file.rewind if file.respond_to?(:rewind)
-
-        if file_content.present?
-          # Validate file content BEFORE setting attributes
-          file_extension = File.extname(file.respond_to?(:original_filename) ? file.original_filename : 'file.pdf')
-          allowed_types = ['application/pdf']
-          result = self.class.validate_file_content(
-            file_content,
-            file.respond_to?(:content_type) ? file.content_type : nil,
-            allowed_types,
-            file_extension,
-          )
-
-          # If validation fails, add error and return without setting content
-          unless result[:valid]
-            errors.add(:file, 'must be a valid PDF')
-            return false
-          end
-
-          # Validation passed, set attributes
-          self.content = file_content
-          self.size = file_content.bytesize
-          self.name = file.respond_to?(:original_filename) ? file.original_filename : 'uploaded_file.pdf'
-          self.content_type = result[:detected_type]
-
-          # Set file_cache for form resubmission support
-          set_file_cache
-
-          save!
-        else
-          error_message = "Health::HealthFile#set_calculated! with blank file contents. id: #{id}, user_id: #{user_id}, client_id: #{client_id}"
-          Rails.logger.error(error_message)
-          false
-        end
-      else
-        error_message = "Health::HealthFile#set_calculated! without upload. id: #{id}, user_id: #{user_id}, client_id: #{client_id}"
-        Rails.logger.error(error_message)
-        false
-      end
-    rescue ActiveRecord::RecordInvalid => e
-      # Validation failed, errors are already on the record
-      Rails.logger.error("Health::HealthFile#set_calculated! validation failed: #{e.message}")
-      false
     end
 
     private
 
-    # Process file_cache to restore file on form resubmission (this is to handle the situation where the form has errors, but a file was also included)
-    def process_file_cache
-      return if file.present? # New file takes precedence
-      return if file_cache.blank?
-      return if content.present? # Already have content stored
-
-      # Parse cached file data
-      begin
-        cache_data = JSON.parse(file_cache)
-        self.content = Base64.decode64(cache_data['content'])
-        self.name = cache_data['name']
-        self.content_type = cache_data['content_type']
-        self.size = content.bytesize
-      rescue JSON::ParserError, KeyError => e
-        Rails.logger.error("Failed to process file_cache: #{e.message}")
+    # Ingests the raw file data from either a new upload (multipart) or a cached signed_id.
+    # This ensures `content` and `name` are populated before validations run.
+    def process_upload_context
+      if file.present?
+        # New file takes precedence over cache
+        self.content = file.respond_to?(:read) ? file.read : file
+        file.rewind if file.respond_to?(:rewind)
+        self.name = file.respond_to?(:original_filename) ? file.original_filename : 'uploaded_file.pdf'
+      elsif file_cache.present? && content.blank?
+        # Restore content from Active Storage if parent form failed validation previously
+        process_file_cache
       end
     end
 
-    # Set file_cache for form resubmission support
+    # Validates that the file is a legitimate PDF (not just by extension).
+    # Side-effect: If valid, populates metadata (size, content_type) and updates the temporary cache.
+    def validate_file_content_and_metadata
+      return if content.blank?
+      # Skip re-validation if we already have content and aren't uploading a new file
+      return unless new_record? || file.present?
+
+      result = self.class.validate_file_content(
+        content,
+        file.respond_to?(:content_type) ? file.content_type : nil,
+        ['application/pdf'],
+        File.extname(name || '.pdf'),
+      )
+
+      if result[:valid]
+        self.content_type = result[:detected_type]
+        self.size = content.bytesize
+        # Update the cache so the file persists even if other form fields fail validation
+        set_file_cache if file.present?
+      else
+        errors.add(:file, 'must be a valid PDF')
+      end
+    end
+
+    # Retrieves file content from Active Storage using a signed_id.
+    # Rescues from invalid signatures or missing files gracefully.
+    def process_file_cache
+      blob = ActiveStorage::Blob.find_signed(file_cache)
+      return unless blob
+
+      self.content = blob.download
+      self.name = blob.filename.to_s
+      self.content_type = blob.content_type
+      self.size = blob.byte_size
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveStorage::FileNotFoundError => e
+      Rails.logger.error("Failed to process file_cache: #{e.message}")
+    end
+
+    # Stores a temporary copy of the file in Active Storage.
+    # This allows the signed_id to be passed back to the hidden `file_cache` field in the form.
     def set_file_cache
       return unless content.present?
 
-      self.file_cache = {
-        content: Base64.encode64(content),
-        name: name,
+      # Create an unattached blob directly. These are purged daily by PurgeUnattachedBlobsJob.
+      # Note: We don't use has_one_attached for the final record to avoid redundant storage.
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new(content),
+        filename: name,
         content_type: content_type,
-      }.to_json
+      )
+      self.file_cache = blob.signed_id
     end
   end
 end

--- a/app/views/health/health_files/_display.haml
+++ b/app/views/health/health_files/_display.haml
@@ -32,7 +32,9 @@
           $('.j-existing-file-form-group').fadeOut('slow', function() {
             $(this).remove();
             $('.j-existing-file__form').show()
-            $('.j-existing-file__form').find('input[name="form[health_file_attributes][file_cache]"]').val('');
+            // Use name$= (ends with) selector to match file_cache field across different parent form names
+            // (form[health_file_attributes][file_cache], careplan[health_file_attributes][file_cache], etc.)
+            $('.j-existing-file__form').find('input[name$="[file_cache]"]').val('');
           });
         });
       });

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -408,6 +408,11 @@ namespace :grda_warehouse do
       PurgeSoftDeletedRecordsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later(dry_run: false) if DateTime.current.hour == 5 && enabled
     end
 
+    # Purge unattached Active Storage blobs older than 2 days
+    safely_execute do
+      PurgeUnattachedBlobsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later if DateTime.current.hour == 5
+    end
+
     # Run CSG Engage export if ready
     MaReports::CsgEngage::Report.run_if_ready if RailsDrivers.loaded.include?(:ma_reports)
 

--- a/spec/jobs/purge_unattached_blobs_job_spec.rb
+++ b/spec/jobs/purge_unattached_blobs_job_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PurgeUnattachedBlobsJob, type: :job do
+  describe '#perform' do
+    let!(:old_unattached_blob) do
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new('old test content'),
+        filename: 'old_test.pdf',
+        content_type: 'application/pdf',
+      ).tap { |blob| blob.update_column(:created_at, 3.days.ago) }
+    end
+
+    let!(:recent_unattached_blob) do
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new('recent test content'),
+        filename: 'recent_test.pdf',
+        content_type: 'application/pdf',
+      )
+    end
+
+    let!(:old_attached_blob) do
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new('attached content'),
+        filename: 'attached_test.pdf',
+        content_type: 'application/pdf',
+      )
+      blob.update_column(:created_at, 3.days.ago)
+
+      # Attach to a test record to make it "attached"
+      ActiveStorage::Attachment.create!(
+        name: 'test_attachment',
+        record_type: 'User',
+        record_id: create(:user).id,
+        blob: blob,
+      )
+
+      blob
+    end
+
+    it 'purges old unattached blobs' do
+      expect { described_class.new.perform }.
+        to change { ActiveStorage::Blob.exists?(old_unattached_blob.id) }.from(true).to(false)
+    end
+
+    it 'preserves recent unattached blobs' do
+      expect { described_class.new.perform }.
+        not_to(change { ActiveStorage::Blob.exists?(recent_unattached_blob.id) })
+    end
+
+    it 'preserves old attached blobs' do
+      expect { described_class.new.perform }.
+        not_to(change { ActiveStorage::Blob.exists?(old_attached_blob.id) })
+    end
+
+    it 'respects custom older_than parameter' do
+      described_class.new.perform(older_than: 4.days)
+
+      expect(ActiveStorage::Blob.exists?(old_unattached_blob.id)).to be true
+      expect(ActiveStorage::Blob.exists?(recent_unattached_blob.id)).to be true
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
**AI GENERATED DRAFT PR, not tested**
Replaces base64-based file caching with Active Storage signed blobs

- **Health Files**: switch to temporary file caching during form resubmissions using Active Storage
- **Maintenance Infrastructure**: Added `PurgeUnattachedBlobsJob` and a scheduled daily task to clean up unattached blobs older than 2 days.
- **Health File UI**: Updated jQuery selectors in the file display partial to correctly clear the `file_cache` field when removing files.


### Rationale
This refactor addresses the following issues:
- **Performance**: Eliminates the overhead of Base64 encoding files in forms, moves large file data out of the request/response cycle into dedicated storage.
- **Standardization**: somewhat similar to existing Active Storage patterns in HMIS (drivers/hmis/app/models/hmis/hud/processors/base.rb:350`)


### Type of Change
Refactor
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

