### PR TITLE
Add Sex field to the DQ Tool Report

### DIFF
--- a/db/warehouse/migrate/20260115084918_add_sex_to_hmis_dqt_clients.rb
+++ b/db/warehouse/migrate/20260115084918_add_sex_to_hmis_dqt_clients.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddSexToHmisDqtClients < ActiveRecord::Migration[7.1]
+  def change
+    add_column :hmis_dqt_clients, :sex, :integer
+  end
+end

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
@@ -57,6 +57,7 @@ module HmisDataQualityTool
         hispanic_latinaeo: { title: 'Hispanic/Latina/e/o', translator: ->(v) { "#{HudHelper.util.no_yes(v&.to_i)} (#{v})" } },
         race_none: { title: 'Race None', translator: ->(v) { "#{HudHelper.util.race_none(v)} (#{v})" } },
         veteran_status: { title: 'Veteran Status', translator: ->(v) { "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
+        sex: { title: 'Sex', translator: ->(v) { v.blank? ? '' : "#{HudHelper.util.sex(v)} (#{v})" } },
         ssn: { title: 'SSN', translator: ->(v) { masked_ssn(v) } },
         ssn_data_quality: { title: 'SSN Data Quality', translator: ->(v) { "#{HudHelper.util.ssn_data_quality(v)} (#{v})" } },
         overlapping_entry_exit: { title: 'Overlapping Entry/Exit enrollments in ES, SH, and TH' },
@@ -193,6 +194,7 @@ module HmisDataQualityTool
       report_item.hispanic_latinaeo = source_client.HispanicLatinaeo
       report_item.race_none = source_client.RaceNone
       report_item.veteran_status = source_client.VeteranStatus
+      report_item.sex = source_client.Sex
       report_item.ssn = source_client.SSN
       report_item.ssn_data_quality = source_client.SSNDataQuality
       # we need these for calculations, but don't want to store them permanently,
@@ -359,6 +361,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :am_ind_ak_native,
             :asian,
             :black_af_american,
@@ -393,6 +396,31 @@ module HmisDataQualityTool
             false
           },
         },
+        sex_issues: {
+          title: 'Sex',
+          description: 'Sex is blank, has an invalid value, or is "Data not collected" (99)',
+          required_for: 'All',
+          detail_columns: [
+            :destination_client_id,
+            :personal_id,
+            :first_name,
+            :last_name,
+            :reporting_age,
+            :sex,
+          ],
+          denominator: ->(_item) { true },
+          limiter: ->(item) {
+            valid_sex_values = HudHelper.util.sexes.keys
+            # Sex is blank
+            return true if item.sex.blank?
+            # Sex has an invalid value (not in valid set)
+            return true unless item.sex.in?(valid_sex_values)
+            # Sex is "Data not collected" (99) - flag as issue since field is required
+            return true if item.sex == 99
+
+            false
+          },
+        },
         dob_issues: {
           title: 'DOB',
           description: 'DOB is blank, before Oct. 10 1910, DOB is after an entry date, or DOB Data Quality is not collected, but DOB is present',
@@ -403,6 +431,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :dob,
             :dob_data_quality,
           ],
@@ -432,6 +461,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :ssn,
             :ssn_data_quality,
           ],
@@ -459,6 +489,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :name_data_quality,
           ],
           denominator: ->(_item) { true },
@@ -483,6 +514,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :veteran_status,
           ],
           denominator: ->(item) { item.reporting_age.present? && item.reporting_age > 18 },
@@ -504,6 +536,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :overlapping_entry_exit,
             :overlapping_entry_exit_details,
           ],
@@ -523,6 +556,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :overlapping_nbn,
             :overlapping_nbn_details,
           ],
@@ -543,6 +577,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :overlapping_pre_move_in,
             :overlapping_pre_move_in_details,
           ],
@@ -564,6 +599,7 @@ module HmisDataQualityTool
             :first_name,
             :last_name,
             :reporting_age,
+            :sex,
             :overlapping_post_move_in,
             :overlapping_post_move_in_details,
           ],

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/client.rb
@@ -410,11 +410,10 @@ module HmisDataQualityTool
           ],
           denominator: ->(_item) { true },
           limiter: ->(item) {
-            valid_sex_values = HudHelper.util.sexes.keys
             # Sex is blank
             return true if item.sex.blank?
             # Sex has an invalid value (not in valid set)
-            return true unless item.sex.in?(valid_sex_values)
+            return true unless HudHelper.util.sexes.key?(item.sex)
             # Sex is "Data not collected" (99) - flag as issue since field is required
             return true if item.sex == 99
 

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/report.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/report.rb
@@ -555,6 +555,7 @@ module HmisDataQualityTool
           ssn_issues: Client,
           dob_issues: Client,
           race_issues: Client,
+          sex_issues: Client,
           veteran_issues: Client,
           afghanistan_oef: Enrollment,
           iraq_oif: Enrollment,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds the Sex field to the DQ Tool report. This flags Clients who have sex fields that are blank, has an invalid value, or "Data not collected" (99).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
