### PR TITLE
Hide client name on referral if user cannot see any names

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -145,7 +145,12 @@ module Types
 
       # This is a summary field. If the current user can view the referral, always return the client name
       # (even if the current user can't otherwise view that client)
-      return c.brief_name.presence || c.masked_name if current_user.policy_for(object, policy_type: :ce_referral).can_view?
+      if current_user.policy_for(object, policy_type: :ce_referral).can_view?
+        # Check that the user has *any* permission to view client names. TODO - this should be a global policy check
+        return c.brief_name if c.brief_name.present? && current_user.can_view_client_name?
+
+        return c.masked_name
+      end
 
       # Otherwise if the current user can only view the referral summary, only return the client name if permissioned
       viewable_client = load_ar_scope(scope: Hmis::Hud::Client.viewable_by(current_user), id: c.id)


### PR DESCRIPTION
## _Merging this PR_
Currently, a user with _no_ permission to see any Client Names still sees names on referrals that they have permission to view. I know our intention was to have the client name visible to anyone who can view the referral, even if they can't view the client. But if you can't see any names in the data source, it seems weird to make an exception here.

This PR is in draft because it relates to our in-progress work about the `HmisClientPolicy` and global policies in general; see inline todo.

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
