### PR TITLE
Handle New RRH Assessment Name

### DIFF
--- a/app/models/grda_warehouse/hud/assessment_question.rb
+++ b/app/models/grda_warehouse/hud/assessment_question.rb
@@ -90,6 +90,7 @@ module GrdaWarehouse::Hud
       [
         'RRH-PSH Transfer',
         'RRH-PSH Transfer 2024',
+        'RRH Transfer 2024',
       ]
     end
 
@@ -108,6 +109,7 @@ module GrdaWarehouse::Hud
       return 'Pathways 2021' if pathways_2021?
       return 'RRH-PSH Transfer' if transfer_2021?
       return 'RRH-PSH Transfer 2024' if transfer_2024?
+      return 'RRH Transfer 2024' if transfer_2024_v2?
       return 'Family Pathways 2024' if family_pathways_2024?
 
       # unknown from assessment questions
@@ -140,6 +142,12 @@ module GrdaWarehouse::Hud
       return nil unless pathways_question?
 
       lookup&.response_text == 'RRH-PSH Transfer 2024'
+    end
+
+    def transfer_2024_v2?
+      return nil unless pathways_question?
+
+      lookup&.response_text == 'RRH Transfer 2024'
     end
   end
 end

--- a/app/models/grda_warehouse/hud/assessment_question.rb
+++ b/app/models/grda_warehouse/hud/assessment_question.rb
@@ -105,16 +105,21 @@ module GrdaWarehouse::Hud
     end
 
     def assessment_name
+      # Assessment names are all based on the lookup response text,
+      # return early if this doesn't exist to avoid unnecessary checks.
+      return nil unless lookup&.response_text
+
       return 'Pathways 2024' if pathways_2024?
       return 'Pathways 2021' if pathways_2021?
       return 'RRH-PSH Transfer' if transfer_2021?
-      return 'RRH-PSH Transfer 2024' if transfer_2024?
-      return 'RRH Transfer 2024' if transfer_2024_v2?
+      return lookup.response_text if transfer_2024?
       return 'Family Pathways 2024' if family_pathways_2024?
 
       # unknown from assessment questions
       nil
     end
+
+    private
 
     def family_pathways_2024?
       lookup&.response_text == 'Family Pathways 2024'
@@ -141,13 +146,7 @@ module GrdaWarehouse::Hud
     def transfer_2024?
       return nil unless pathways_question?
 
-      lookup&.response_text == 'RRH-PSH Transfer 2024'
-    end
-
-    def transfer_2024_v2?
-      return nil unless pathways_question?
-
-      lookup&.response_text == 'RRH Transfer 2024'
+      lookup&.response_text.in?(['RRH-PSH Transfer 2024', 'RRH Transfer 2024'])
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Add logic for handling an updated name for the RRH Transfer 2024 Assessment. This will now come through using the transfer name instead of the assessment default where applicable.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
