### PR TITLE
[Hotfix] Hud Report Parameter Display Filter

### DIFF
--- a/app/views/hud_reports/_parameters.haml
+++ b/app/views/hud_reports/_parameters.haml
@@ -1,7 +1,7 @@
 .mb-2.reports.warehouse-reports__completed
   - # NOTE: this is not ideal, we need to figure out which filter type we're actually using
   - # but for displaying the items chosen, it's probably fine
-  - @filter_class ||= Filters::FilterBase
+  - @filter_class ||= Filters::HudFilterBase
   - filter = @filter_class.new(user_id: report.user_id).update(report.options.with_indifferent_access)
   = filter.describe_filter_as_html(@generator.allowed_options(report))
   = render 'filters/view_filter_details', filter_hash: filter.to_h, selected_keys: @generator.allowed_options(report)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Use the HudFilterBase instead of the FilterBase when building out the display for the hud report parameters. This allows us to pull the correct project type codes instead of using the lazy loaded default codes. This partial appears to only be being used by HUD reports, all of which use a filter inheriting from the HudFilterBase.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
