### PR TITLE
fix expired gpg key in CI?

### DIFF
--- a/.github/workflows/container_setup/action.yml
+++ b/.github/workflows/container_setup/action.yml
@@ -54,10 +54,8 @@ runs:
         . /etc/os-release
         sh -c "echo 'deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
 
-        # Install NodeJS and Yarn repositories
+        # Install NodeJS repository
         retry curl -fsSL https://deb.nodesource.com/setup_18.x | bash -s -- -y
-        retry curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/yarn.gpg
-        echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
         retry apt-get update
 


### PR DESCRIPTION
The CI failure was caused by an expired GPG key for the legacy Yarn Debian repository. Since the workflow uses yarn via npm, the Debian repository was redundant and should be safe to remove


```
Err:5 https://dl.yarnpkg.com/debian stable InRelease
  The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
Reading package lists...
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
Command failed (attempt 3/3). Retrying in 20 seconds...
```