### PR TITLE
Add system test for CE Referrals page tabs

### DIFF
--- a/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
@@ -1,0 +1,144 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: false
+
+require 'rails_helper'
+
+# Tests what tabs are available on the CE referrals page, depending on a combo of user permissions + project config.
+# In the future, coverage could be expanded to test actual referral fields shown.
+RSpec.feature 'CE Project Referrals Page', type: :system do
+  # Use find_or_create_by since some tests create the data source in a before(:all) block for performance reasons.
+  let!(:ds1) { GrdaWarehouse::DataSource.find_or_create_by!(hmis: 'localhost', name: 'HMIS', short_name: 'HMIS', authoritative: true) }
+  let!(:project) { create(:hmis_hud_project, data_source: ds1, ProjectType: 3, with_coc: true) }
+
+  let!(:admin) { create(:hmis_user, data_source: ds1, first_name: 'Alexandra', last_name: 'Admin') }
+  let!(:access_control) { create_access_control(admin, ds1) }
+
+  before(:each) do
+    allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
+    sign_in(admin)
+  end
+
+  def expect_tabs(tabs_names)
+    tabs = page.all('[aria-label="Project CE Tabs"] a')
+    expect(tabs.map(&:text)).to eq(tabs_names)
+  end
+
+  context 'project has no CE config' do
+    context 'legacy referrals are enabled via permissions' do
+      it 'shows the Referrals page with legacy referrals only' do
+        visit "/projects/#{project.id}"
+        expect(page).to have_content('Referrals')
+        visit "/projects/#{project.id}/referrals"
+        expect(page).to have_content('Incoming Referrals')
+        expect(page).to have_content('Outgoing Referrals')
+        # Tabs are not rendered because only one tab (legacy referrals) is shown
+        expect(page).not_to have_selector('[aria-label="Project CE Tabs"]')
+      end
+    end
+
+    context 'legacy referrals are not enabled via permissions' do
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_manage_incoming_referrals, :can_manage_outgoing_referrals]) }
+
+      it 'does not show the CE referrals page' do
+        visit "/projects/#{project.id}"
+        expect(page).not_to have_content('Referrals')
+        visit "/projects/#{project.id}/referrals"
+        expect(page).to have_content('Page not found')
+      end
+    end
+  end
+
+  context 'project receives direct referrals' do
+    let!(:project_ce_config) { create(:hmis_project_ce_config, project: project, receives_direct_referrals: true, supports_waitlist_referrals: false) }
+
+    it 'shows the CE referrals page' do
+      visit "/projects/#{project.id}/referrals"
+
+      # Since legacy referrals are also shown, 2 tabs are rendered
+      expect_tabs(['Referrals', 'Legacy Referrals'])
+    end
+
+    context 'user can view their own referrals, not all referrals in the project' do
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_view_referrals]) }
+
+      it 'still shows the CE referrals page' do
+        visit "/projects/#{project.id}/referrals"
+        expect_tabs(['Referrals', 'Legacy Referrals'])
+      end
+    end
+  end
+
+  context 'project supports waitlist referrals' do
+    let!(:project_ce_config) { create(:hmis_project_ce_config, project: project, supports_waitlist_referrals: true, receives_direct_referrals: false) }
+
+    it 'shows the CE referrals page' do
+      visit "/projects/#{project.id}/referrals"
+
+      expect_tabs(['Referrals', 'Available Units', 'Legacy Referrals'])
+    end
+
+    context 'but user does not have permission to view units' do
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_view_units]) }
+
+      it 'shows the CE referrals page with legacy referrals only' do
+        visit "/projects/#{project.id}/referrals"
+
+        expect_tabs(['Referrals', 'Legacy Referrals'])
+      end
+    end
+  end
+
+  context 'project sends direct referrals' do
+    let!(:project_ce_config) { create(:hmis_project_sends_direct_ce_referrals_config, project: project) }
+
+    it 'shows the CE referrals page and allows sending direct referrals' do
+      visit "/projects/#{project.id}/referrals"
+
+      expect_tabs(['Outgoing Referrals', 'Legacy Referrals'])
+      expect(page).to have_link('Send Referral')
+      click_link 'Send Referral'
+      expect(page).to have_content('HoH Enrollment (Required)')
+      expect(page).to have_content('Project (Required)')
+    end
+
+    context 'user can manage outgoing referrals, but not view referrals in the target project' do
+      let!(:access_control) { create_access_control(admin, ds1, with_permission: [:can_view_project, :can_manage_outgoing_referrals]) }
+
+      it 'shows the CE referrals page and allows sending direct referrals' do
+        visit "/projects/#{project.id}/referrals"
+
+        expect_tabs(['Outgoing Referrals', 'Legacy Referrals'])
+        expect(page).to have_link('Send Referral')
+      end
+    end
+
+    context 'user can view but not manage outgoing referrals' do
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_manage_outgoing_referrals]) }
+
+      it 'shows the CE referrals page but does not allow sending direct referrals' do
+        visit "/projects/#{project.id}/referrals"
+
+        expect_tabs(['Outgoing Referrals', 'Legacy Referrals'])
+        expect(page).not_to have_link('Send Referral')
+      end
+    end
+
+    context 'user cannot view or manage outgoing referrals' do
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_manage_outgoing_referrals, :can_view_outgoing_referral_details, :can_manage_incoming_referrals]) }
+      let!(:project_ce_config) { create(:hmis_project_ce_config, project: project, supports_waitlist_referrals: true) } # Project also accepts referrals
+
+      it 'does not show the Outgoing Referrals tab' do
+        visit "/projects/#{project.id}/referrals"
+
+        expect_tabs(['Referrals', 'Available Units'])
+        expect(page).not_to have_content('Outgoing Referrals')
+        expect(page).not_to have_link('Send Referral')
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
@@ -11,8 +11,7 @@ require 'rails_helper'
 # Tests what tabs are available on the CE referrals page, depending on a combo of user permissions + project config.
 # In the future, coverage could be expanded to test actual referral fields shown.
 RSpec.feature 'CE Project Referrals Page', type: :system do
-  # Use find_or_create_by since some tests create the data source in a before(:all) block for performance reasons.
-  let!(:ds1) { GrdaWarehouse::DataSource.find_or_create_by!(hmis: 'localhost', name: 'HMIS', short_name: 'HMIS', authoritative: true) }
+  let!(:ds1) { create :hmis_primary_data_source, hmis: 'localhost' }
   let!(:project) { create(:hmis_hud_project, data_source: ds1, ProjectType: 3, with_coc: true) }
 
   let!(:admin) { create(:hmis_user, data_source: ds1, first_name: 'Alexandra', last_name: 'Admin') }

--- a/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ce/project_referrals_page_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'CE Project Referrals Page', type: :system do
     end
 
     context 'user can manage outgoing referrals, but not view referrals in the target project' do
-      let!(:access_control) { create_access_control(admin, ds1, with_permission: [:can_view_project, :can_manage_outgoing_referrals]) }
+      let!(:access_control) { create_access_control(admin, ds1, without_permission: [:can_view_referrals]) }
 
       it 'shows the CE referrals page and allows sending direct referrals' do
         visit "/projects/#{project.id}/referrals"


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Adds a system test for which tabs are shown on the Referrals page. See related frontend logic: https://github.com/greenriver/hmis-frontend/blob/f650ef20ba9551cccb15f6e3c940464e715dfc93/src/modules/ce/components/project/ProjectReferralsPage.tsx#L29-L61

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New test

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
