### PR TITLE
Enable PSDE data collection for local PSH funder

### DIFF
--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/health_and_dv.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/health_and_dv.json
@@ -7,11 +7,6 @@
         {
           "variable": "projectOtherFunders",
           "operator": "NOT_INCLUDE",
-          "value": "Non-contracted Permanent Housing"
-        },
-        {
-          "variable": "projectOtherFunders",
-          "operator": "NOT_INCLUDE",
           "value": "Non-contracted Case Management"
         },
         {

--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/health_insurance.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/health_insurance.json
@@ -8,11 +8,6 @@
         {
           "variable": "projectOtherFunders",
           "operator": "NOT_INCLUDE",
-          "value": "Non-contracted Permanent Housing"
-        },
-        {
-          "variable": "projectOtherFunders",
-          "operator": "NOT_INCLUDE",
           "value": "Non-contracted Case Management"
         },
         {

--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/income_and_sources.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/income_and_sources.json
@@ -8,11 +8,6 @@
         {
           "variable": "projectOtherFunders",
           "operator": "NOT_INCLUDE",
-          "value": "Non-contracted Permanent Housing"
-        },
-        {
-          "variable": "projectOtherFunders",
-          "operator": "NOT_INCLUDE",
           "value": "Non-contracted Case Management"
         },
         {

--- a/drivers/hmis/lib/form_data/allegheny/fragments/patches/non_cash_benefits.json
+++ b/drivers/hmis/lib/form_data/allegheny/fragments/patches/non_cash_benefits.json
@@ -8,11 +8,6 @@
         {
           "variable": "projectOtherFunders",
           "operator": "NOT_INCLUDE",
-          "value": "Non-contracted Permanent Housing"
-        },
-        {
-          "variable": "projectOtherFunders",
-          "operator": "NOT_INCLUDE",
           "value": "Non-contracted Case Management"
         },
         {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
https://github.com/open-path/Green-River/issues/8758

Configuration change: stop excluding a certain local funder from PSDE collection in HUD assessments.

How to test: seed forms for this client, set up a funder with this OtherFunder string

## Type of change
Configuration

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
