### PR TITLE
Prevent API from trying to resolve script tasks

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -168,12 +168,15 @@ module Types
     end
 
     def current_steps
-      load_ar_association(object, :current_steps).sort_by { |step| [step.available_at, step.id] }
+      # Filter to only UserTasks, because CeReferralStep type is only able to resolve those
+      load_ar_association(object, :current_steps).
+        filter { |step| step.node.user_task? }. # node is preloaded
+        sort_by { |step| [step.available_at, step.id] }
     end
 
     def days_on_current_steps
       # If there are multiple open steps, use the one that has been available longest
-      oldest_open_step = load_ar_association(object, :current_steps).to_a.min_by(&:available_at)
+      oldest_open_step = current_steps.min_by(&:available_at)
       return nil if oldest_open_step.nil?
 
       # How many days ago this step was made available
@@ -182,7 +185,7 @@ module Types
 
     def updated_by
       # TODO(#7678): Add updated_by as a field to the referral table, and use that directly here
-      most_recently_updated_step = load_ar_association(object, :current_steps).to_a.max_by(&:updated_at)
+      most_recently_updated_step = current_steps.max_by(&:updated_at)
 
       # If a step was updated more recently than the referral record itself, return the user who updated that step
       if most_recently_updated_step.present? && most_recently_updated_step.updated_at > object.updated_at

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_step.rb
@@ -81,7 +81,11 @@ module Types
 
     # the Hmis::WorkflowDefinition::UserTask that configures this referral step
     def workflow_task
-      load_ar_association(object, :user_task)
+      node = load_ar_association(object, :node)
+      # Raise legible error if we mistakenly try to resolve a step that is not a UserTask
+      raise "Unable to resolve step #{object.id}. Expected node to be a UserTask, but it is a #{node&.type&.demodulize}" unless node&.user_task?
+
+      node
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
                 id
               }
               createdAt
-              currentSteps {
-                id
-                name
-              }
               referredBy {
                 id
                 name
@@ -205,6 +201,34 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         referrals = result.dig('data', 'ceReferrals', 'nodes')
         expect(referrals.size).to eq(1)
         expect(referrals.first['id']).to eq(referral2.id.to_s)
+      end
+    end
+
+    context 'when referral has available script task' do
+      # Regression test: Ensures ScriptTasks don't appear in currentSteps (only User tasks should be resolved).
+      # This came up after a manual support fix left a dangling available script task. Also future-proofing for other task types.
+      let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_1) }
+      let!(:script_task) { create(:hmis_workflow_definition_script_task, template: workflow_template_1, name: 'Script Task') }
+      let!(:start_event) { create(:hmis_workflow_definition_start_event, template: workflow_template_1) }
+      let!(:script_step) do
+        # Manually create an available script task step to simulate a dangling step from a manual support fix
+        referral.workflow_instance.steps.create!(
+          node: script_task,
+          status: 'available',
+          available_at: Time.current,
+        )
+      end
+
+      before do
+        referral.workflow_engine.start_workflow!(user: hmis_user) # start workflow to make user task available
+      end
+
+      it 'does not include ScriptTask in currentSteps, only UserTask' do
+        response, result = post_graphql { query }
+        expect(response.status).to eq(200), result.inspect
+
+        referrals = result.dig('data', 'ceReferrals', 'nodes')
+        expect(referrals).to contain_exactly(a_hash_including('currentSteps' => [a_hash_including('name' => 'Client Acceptance')]))
       end
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Bug-fix for disruptive error that occurred as a result of an incomplete manual rollback of a step. A referral ended up with a ScriptTask in "Available" state, and it caused the whole admin Referrals page to go down, as well as the project Referrals page for the associated project.

This updates the `currentSteps` field on referral to ensure it only resolves UserTasks, since the associated graphql resolver crashes if the step has a different type.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
