### PR TITLE
Support passing scope to fix_incorrect_personal_id_references

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -28,7 +28,9 @@ module Hmis::Hud::Concerns::Shared
       warehouse_class.find(id)
     end
 
-    def self.enrollment_related_hud_class_names
+    # Classes that use EnrollmentID + PersonalID composite keys to associate with enrollments.
+    # Includes both HUD-defined and custom record types that follow this association pattern.
+    def self.enrollment_personal_id_keyed_class_names
       [
         'Disability',
         'EmploymentEducation',
@@ -42,7 +44,6 @@ module Hmis::Hud::Concerns::Shared
         'AssessmentResult',
         'Event',
         'YouthEducationStatus',
-        # custom but use EnrollmentID and PersonalID like other enrollment-related records
         'CustomAssessment',
         'CustomCaseNote',
         'CustomService',
@@ -51,7 +52,7 @@ module Hmis::Hud::Concerns::Shared
 
     def self.hud_class_names
       [
-        *enrollment_related_hud_class_names,
+        *enrollment_personal_id_keyed_class_names,
         'Export',
         'Organization',
         'Project',
@@ -68,7 +69,7 @@ module Hmis::Hud::Concerns::Shared
     end
 
     def self.hmis_enrollment_related_classes
-      enrollment_related_hud_class_names.map do |name|
+      enrollment_personal_id_keyed_class_names.map do |name|
         "Hmis::Hud::#{name}".constantize
       end
     end

--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -42,6 +42,10 @@ module Hmis::Hud::Concerns::Shared
         'AssessmentResult',
         'Event',
         'YouthEducationStatus',
+        # custom but use EnrollmentID and PersonalID like other enrollment-related records
+        'CustomAssessment',
+        'CustomCaseNote',
+        'CustomService',
       ].freeze
     end
 

--- a/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
+++ b/drivers/hmis/app/models/hmis/hud/concerns/shared.rb
@@ -52,7 +52,7 @@ module Hmis::Hud::Concerns::Shared
 
     def self.hud_class_names
       [
-        *enrollment_personal_id_keyed_class_names,
+        *enrollment_personal_id_keyed_class_names.filter { |name| !name.start_with?('Custom') },
         'Export',
         'Organization',
         'Project',

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -178,25 +178,24 @@ module HmisDataCleanup
 
       Hmis::Hud::Base.transaction do
         classes.each do |klass|
-          Rails.logger.info "[#{klass.name}] Processing"
-
           # Build the base scope for records
           base_scope = klass.where(data_source_id: data_source_id)
           base_scope = base_scope.where(EnrollmentID: enrollment_ids) if enrollment_ids
 
-          if dry_run
-            records_needing_update = base_scope.
-              left_outer_joins(:enrollment).
-              where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
-              count
+          # Outer join to enrollment and select records where the enrollment is null,
+          # indicating the record's PersonalID may be incorrect (the EnrollmentID and
+          # PersonalID columns don't point to the same enrollment).
+          records_needing_update = base_scope.
+            left_outer_joins(:enrollment).
+            where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil))
 
-            Rails.logger.info "[#{klass.name}] #{records_needing_update} records with bad PersonalID"
-            next
-          end
+          ids = records_needing_update.limit(15).pluck(:id)
+          num_records = records_needing_update.count
+          Rails.logger.info "[#{klass.name}] Found #{num_records} records with potentially bad PersonalID: #{ids.inspect}#{'...' if num_records > 15}"
 
-          base_scope.left_outer_joins(:enrollment).
-            where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
-            find_in_batches do |batch|
+          next if dry_run
+
+          records_needing_update.find_in_batches do |batch|
             Rails.logger.info "[#{klass.name}] Processing batch"
 
             # map {EnrollmentID=>PersonalID} for each enrollment referenced by this batch of records

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -157,7 +157,11 @@ module HmisDataCleanup
     end
 
     # Fix any instances of enrollment-related records where the PersonalID does not match the Enrollment's PersonalIDs
-    def self.fix_incorrect_personal_id_references!(classes: nil, dry_run: false)
+    # @param classes [Array<Class>, nil] Optional array of classes to process. If nil, processes all enrollment-related classes.
+    # @param enrollment_scope [ActiveRecord::Relation, nil] Optional scope of enrollments to limit the fix to.
+    #   When provided, only records associated with enrollments in this scope will be fixed.
+    # @param dry_run [Boolean] If true, only reports what would be fixed without making changes.
+    def self.fix_incorrect_personal_id_references!(classes: nil, enrollment_scope: nil, dry_run: false)
       classes&.each do |klass|
         raise "Invalid class: #{klass.name}" unless Hmis::Hud::Enrollment.hmis_enrollment_related_classes.include?(klass)
       end
@@ -165,12 +169,23 @@ module HmisDataCleanup
       classes ||= Hmis::Hud::Enrollment.hmis_enrollment_related_classes
       data_source_id = GrdaWarehouse::DataSource.hmis.first.id
 
+      # Extract EnrollmentIDs from the scope if provided, otherwise use all enrollments
+      enrollment_ids = enrollment_scope.pluck(:EnrollmentID) if enrollment_scope
+
+      # Base scope for looking up enrollments (always use GrdaWarehouse for consistency)
+      enrollment_lookup_scope = GrdaWarehouse::Hud::Enrollment.where(data_source_id: data_source_id)
+      enrollment_lookup_scope = enrollment_lookup_scope.where(EnrollmentID: enrollment_ids) if enrollment_ids
+
       Hmis::Hud::Base.transaction do
         classes.each do |klass|
           Rails.logger.info "[#{klass.name}] Processing"
 
+          # Build the base scope for records
+          base_scope = klass.where(data_source_id: data_source_id)
+          base_scope = base_scope.where(EnrollmentID: enrollment_ids) if enrollment_ids
+
           if dry_run
-            records_needing_update = klass.where(data_source_id: data_source_id).
+            records_needing_update = base_scope.
               left_outer_joins(:enrollment).
               where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
               count
@@ -179,16 +194,14 @@ module HmisDataCleanup
             next
           end
 
-          klass.where(data_source_id: data_source_id).left_outer_joins(:enrollment).
+          base_scope.left_outer_joins(:enrollment).
             where(GrdaWarehouse::Hud::Enrollment.arel_table[:id].eq(nil)).
             find_in_batches do |batch|
             Rails.logger.info "[#{klass.name}] Processing batch"
 
             # map {EnrollmentID=>PersonalID} for each enrollment referenced by this batch of records
-            eid_to_pid = GrdaWarehouse::Hud::Enrollment.where(
-              data_source_id: data_source_id,
-              EnrollmentID: batch.map(&:EnrollmentID),
-            ).pluck(:EnrollmentID, :PersonalID).to_h
+            eid_to_pid = enrollment_lookup_scope.where(EnrollmentID: batch.map(&:EnrollmentID)).
+              pluck(:EnrollmentID, :PersonalID).to_h
 
             values = []
             batch.each do |record|

--- a/drivers/hmis/lib/hmis_data_cleanup/util.rb
+++ b/drivers/hmis/lib/hmis_data_cleanup/util.rb
@@ -229,6 +229,12 @@ module HmisDataCleanup
           end
         end
       end
+
+      if dry_run
+        Rails.logger.info 'Dry run complete'
+      else
+        Rails.logger.info 'Finished fixing incorrect PersonalID references'
+      end
     end
 
     def self.delete_duplicate_bed_nights!

--- a/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_assessments.rb
@@ -11,11 +11,12 @@ FactoryBot.define do
     definition { association :hmis_form_definition }
   end
 
-  factory :hmis_custom_assessment, class: 'Hmis::Hud::CustomAssessment' do
+  factory :hmis_custom_assessment, class: 'Hmis::Hud::CustomAssessment', parent: :hmis_base_factory do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
+    sequence(:CustomAssessmentID, 100)
     wip { false }
     AssessmentDate { Date.yesterday }
     DataCollectionStage { 1 }
@@ -37,7 +38,7 @@ FactoryBot.define do
       assessment.build_form_processor(values: evaluator.values, hud_values: evaluator.hud_values, definition: evaluator.definition)
       assessment.form_processor.definition ||= build(:hmis_form_definition)
       assessment.data_collection_stage = Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES[evaluator.definition.role.to_sym] if evaluator.definition
-      assessment.save!
+      assessment.save!(validate: false)
     end
   end
 

--- a/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_case_note.rb
@@ -7,11 +7,12 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :hmis_hud_custom_case_note, class: 'Hmis::Hud::CustomCaseNote' do
+  factory :hmis_hud_custom_case_note, class: 'Hmis::Hud::CustomCaseNote', parent: :hmis_base_factory do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }
     enrollment { association :hmis_hud_enrollment, data_source: data_source, client: client }
+    sequence(:CustomCaseNoteID, 100)
     information_date { Date.current }
     date_created { Time.current }
     date_updated { Time.current }

--- a/drivers/hmis/spec/factories/hmis/hud/custom_services.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/custom_services.rb
@@ -7,7 +7,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :hmis_custom_service, class: 'Hmis::Hud::CustomService' do
+  factory :hmis_custom_service, class: 'Hmis::Hud::CustomService', parent: :hmis_base_factory do
     data_source { association :hmis_data_source }
     user { association :hmis_hud_user, data_source: data_source }
     client { association :hmis_hud_client, data_source: data_source }

--- a/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
       )
   end
 
-  context 'enrollment with export ids' do
+  describe '#clear_enrollment_export_ids!' do
     before(:each)  { GrdaWarehouse::Hud::Enrollment.update_all(ExportID: 'XYZ') }
 
     it 'clears the exports' do
@@ -88,7 +88,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
-  context 'enrollments without HouseholdIDs' do
+  describe '#assign_missing_household_ids!' do
     before(:each) { GrdaWarehouse::Hud::Enrollment.update_all(HouseholdID: nil) }
     it 'assigns HouseholdIDs to HMIS records' do
       HmisDataCleanup::Util.assign_missing_household_ids!
@@ -106,7 +106,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
-  context 'single-person households with no HoH' do
+  describe '#make_sole_member_hoh!' do
     before(:each) do
       e1.update!(relationship_to_hoh: 99, household_id: 'multi-member-household')
       e2.update!(relationship_to_hoh: 99, household_id: 'multi-member-household')
@@ -131,7 +131,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
-  context 'enrollments without DisablingCondition' do
+  describe '#fix_disabling_condition_nils!' do
     before(:each) do
       # use update_columns to bypass before_save hook
       e1.update_columns(disabling_condition: nil)
@@ -158,7 +158,7 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
-  context 'clients with badly formatted race/gender data' do
+  describe '#fix_race_gender_99s!' do
     let!(:race_fields) { HudHelper.util.races.keys.excluding('RaceNone') }
     let!(:gender_fields) { HudHelper.util.gender_fields.excluding(:GenderNone) }
 
@@ -314,7 +314,26 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
     end
   end
 
-  context 'records with incorrect PersonalID references' do
+  describe '#fix_incorrect_personal_id_references!' do
+    let(:related_record_factories) do
+      [
+        :hmis_hud_service,
+        :hmis_income_benefit,
+        :hmis_health_and_dv,
+        :hmis_youth_education_status,
+        :hmis_employment_education,
+        :hmis_disability,
+        :hmis_hud_exit,
+        :hmis_current_living_situation,
+        :hmis_hud_assessment,
+        :hmis_assessment_question,
+        :hmis_assessment_result,
+        :hmis_hud_event,
+        :hmis_custom_service, # custom HUD-style table, uses PersonalID+EnrollmentID association
+        :hmis_custom_assessment, # custom HUD-style table, uses PersonalID+EnrollmentID association
+        :hmis_hud_custom_case_note, # custom HUD-style table, uses PersonalID+EnrollmentID association
+      ]
+    end
     let!(:records_with_bad_references) do
       records = []
       shared_attributes = {
@@ -324,18 +343,9 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
         DateCreated: last_year,
         DateUpdated: last_year,
       }
-      records << create(:hmis_hud_service, :skip_validate, **shared_attributes)
-      records << create(:hmis_income_benefit, :skip_validate, **shared_attributes)
-      records << create(:hmis_health_and_dv, :skip_validate, **shared_attributes)
-      records << create(:hmis_youth_education_status, :skip_validate, **shared_attributes)
-      records << create(:hmis_employment_education, :skip_validate, **shared_attributes)
-      records << create(:hmis_disability, :skip_validate, **shared_attributes)
-      records << create(:hmis_hud_exit, :skip_validate, **shared_attributes)
-      records << create(:hmis_current_living_situation, :skip_validate, **shared_attributes)
-      records << create(:hmis_hud_assessment, :skip_validate, **shared_attributes)
-      records << create(:hmis_assessment_question, :skip_validate, **shared_attributes)
-      records << create(:hmis_assessment_result, :skip_validate, **shared_attributes)
-      records << create(:hmis_hud_event, :skip_validate, **shared_attributes)
+      related_record_factories.each do |factory|
+        records << create(factory, :skip_validate, **shared_attributes)
+      end
       records
     end
 
@@ -348,19 +358,9 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
         DateCreated: last_year,
         DateUpdated: last_year,
       }
-      records << create(:hmis_hud_service, **shared_attributes)
-      records << create(:hmis_income_benefit, **shared_attributes)
-      records << create(:hmis_health_and_dv, **shared_attributes)
-      records << create(:hmis_youth_education_status, **shared_attributes)
-      records << create(:hmis_employment_education, **shared_attributes)
-      records << create(:hmis_disability, **shared_attributes)
-      records << create(:hmis_hud_exit, **shared_attributes)
-      records << create(:hmis_current_living_situation, **shared_attributes)
-      records << create(:hmis_hud_assessment, **shared_attributes)
-      records << create(:hmis_assessment_question, **shared_attributes)
-      records << create(:hmis_assessment_result, **shared_attributes)
-      records << create(:hmis_hud_event, **shared_attributes)
-      records
+      related_record_factories.each do |factory|
+        records << create(factory, **shared_attributes)
+      end
     end
 
     it 'works for services' do
@@ -394,6 +394,27 @@ RSpec.describe HmisDataCleanup::Util, type: :model do
 
       records_with_bad_references.each(&:reload)
       expect(records_with_bad_references.map(&:PersonalID).uniq).to contain_exactly('not-real')
+    end
+
+    context 'with enrollment scope' do
+      let!(:bad_service_e1) { create(:hmis_hud_service, :skip_validate, enrollment: e1, PersonalID: 'wrong-id-1', data_source: hmis_ds) }
+      let!(:bad_service_e2) { create(:hmis_hud_service, :skip_validate, enrollment: e2, PersonalID: 'wrong-id-2', data_source: hmis_ds) }
+      let!(:bad_income_e1) { create(:hmis_income_benefit, :skip_validate, enrollment: e1, PersonalID: 'wrong-id-1', data_source: hmis_ds) }
+      let!(:bad_income_e2) { create(:hmis_income_benefit, :skip_validate, enrollment: e2, PersonalID: 'wrong-id-2', data_source: hmis_ds) }
+
+      it 'only fixes records for enrollments in the scope' do
+        enrollment_scope = Hmis::Hud::Enrollment.where(id: e1.id)
+
+        HmisDataCleanup::Util.fix_incorrect_personal_id_references!(enrollment_scope: enrollment_scope)
+
+        [bad_service_e1, bad_service_e2, bad_income_e1, bad_income_e2].each(&:reload)
+        # Records for e1 should be fixed
+        expect(bad_service_e1.personal_id).to eq(e1.personal_id)
+        expect(bad_income_e1.personal_id).to eq(e1.personal_id)
+        # Records for e2 should NOT be fixed
+        expect(bad_service_e2.personal_id).to eq('wrong-id-2')
+        expect(bad_income_e2.personal_id).to eq('wrong-id-2')
+      end
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Support passing an enrollment scope to `fix_incorrect_personal_id_references`, so it can be used to assist when needing to manually transfer enrollments from one client to another (as dev support work, currently). Instead of manually updating each associated records PersonalID, this existing cleanup method can be used for the particular enrollment(s) after the `Enrollment.PersonalID` is changed.

Also updates `fix_incorrect_personal_id_references` so that it fixes PersonalID references on custom HUD-like tables (CustomAssessment, CustomService, and CustomCaseNote)

## Type of change
New dev feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
