### PR TITLE
Fix flaky test on merge clients mutation

### DIFF
--- a/drivers/hmis/spec/requests/hmis/bulk_merge_clients_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/bulk_merge_clients_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'BulkMergeClients', type: :request do
     end
 
     it 'fails if a client is not viewable by the user' do
-      other_ds = create(:hmis_primary_data_source)
+      other_ds = create(:hmis_data_source)
       other_client = create(:hmis_hud_client, data_source: other_ds)
 
       input = { input: [{ client_ids: [c1.id, other_client.id] }] }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[Example of test flake](https://github.com/greenriver/hmis-warehouse/actions/runs/21452728232/job/61785513153)

**Bug**: This test was creating a second DS using the `:hmis_primary_data_source` factory. [`attach_data_source_id`](https://github.com/greenriver/hmis-warehouse/blob/66a9080b3fbb09a16bd62750490ac82d9ea63d72/drivers/hmis/app/controllers/hmis/base_controller.rb#L40-L50) expects data sources to be unique by domain, so this was causing non-deterministic results:
- When `ds1` is selected, the test passes because the user is authorized to merge clients in the ds, but can't view the client, so 'not found' is correctly returned
- When `other_ds` is selected, the test fails because the user is _not_ authorized to merge clients in the ds, so 'unauthorized' is returned instead of 'not found'

**Fix**: For `other_ds`, use the regular `:hmis_data_source` factory which auto-generates a distinct domain name.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix in test

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
