### PR TITLE
Refactor SPM 2026 episode model, fix logic bugs

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      testkit_check_all_table_results:
+        description: 'Ignore skip option in table comparisons'
+        required: false
+        type: boolean
+        default: false
       with_logging:
         description: 'Run logging configuration tests'
         required: false
@@ -102,6 +107,7 @@ jobs:
       run_warehouse: ${{ steps.set-matrix.outputs.run_warehouse }}
       focused_path: ${{ steps.set-matrix.outputs.focused_path }}
       okta: ${{ steps.set-matrix.outputs.okta }}
+      testkit_check_all_table_results: ${{ steps.set-matrix.outputs.testkit_check_all_table_results }}
       logging: ${{ steps.set-matrix.outputs.logging }}
       profiling: ${{ steps.set-matrix.outputs.profiling }}
 
@@ -119,6 +125,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TEST_PATH: ${{ github.event.inputs.test_path }}
           INPUT_WITH_OKTA: ${{ github.event.inputs.with_okta }}
+          INPUT_TESTKIT_CHECK_ALL_TABLE_RESULTS: ${{ github.event.inputs.testkit_check_all_table_results }}
           INPUT_WITH_LOGGING: ${{ github.event.inputs.with_logging }}
           INPUT_WITH_PROFILING: ${{ github.event.inputs.with_profiling }}
         run: |
@@ -272,6 +279,7 @@ jobs:
           AWS_ACCESS_KEY_ID: local_access_key
           AWS_SECRET_ACCESS_KEY: local_secret_key
           TODO_OR_DIE_LOG_ONLY: true
+          TESTKIT_CHECK_ALL_TABLE_RESULTS: ${{ needs.determine_matrix.outputs.testkit_check_all_table_results }}
           FOCUS_PATH: ${{ matrix.test_group.test_path }}
         run: |
           if [ -n "$FOCUS_PATH" ]; then
@@ -385,6 +393,7 @@ jobs:
           BRANCH_NAME: "${{ github.head_ref || github.ref_name }}:${{ github.base_ref || 'stable' }}:stable"
           CHROMIUM_PATH: /usr/bin/chromium
           TARGET_SPECS: ${{ needs.determine_matrix.outputs.focused_path }}
+          TESTKIT_CHECK_ALL_TABLE_RESULTS: ${{ needs.determine_matrix.outputs.testkit_check_all_table_results }}
           TODO_OR_DIE_LOG_ONLY: true
         run: bash ./bin/run_hmis_system_tests.sh
 
@@ -451,6 +460,7 @@ jobs:
           LOG_LEVEL: INFO
           CHROMIUM_PATH: /usr/bin/chromium
           RUN_RAILS_SYSTEM_TESTS: true
+          TESTKIT_CHECK_ALL_TABLE_RESULTS: ${{ needs.determine_matrix.outputs.testkit_check_all_table_results }}
           TODO_OR_DIE_LOG_ONLY: true
         run: |
           FOCUS_PATH="${{ needs.determine_matrix.outputs.focused_path }}"

--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -201,6 +201,7 @@ module HudReports
     # @param question [String] the question name (e.g., 'Question 1')
     def complete(question)
       universe(question).update!(status: 'Completed')
+      @preload_answers&.delete(question) # Clear memoized cells for this question
       complete_report if remaining_questions.empty?
     end
 

--- a/bin/ci_matrix_router.rb
+++ b/bin/ci_matrix_router.rb
@@ -12,6 +12,7 @@ class CiMatrixRouter
     @event_name = ENV['EVENT_NAME']
     @input_test_path = ENV['INPUT_TEST_PATH']
     @input_with_okta = ENV['INPUT_WITH_OKTA'] == 'true'
+    @input_testkit_check_all_table_results = ENV['INPUT_TESTKIT_CHECK_ALL_TABLE_RESULTS'] == 'true'
     @input_with_logging = ENV['INPUT_WITH_LOGGING'] == 'true'
     @input_with_profiling = ENV['INPUT_WITH_PROFILING'] == 'true'
     @buckets_file = ENV['BUCKETS_FILE'] || '.github/rspec_buckets.json'
@@ -30,6 +31,7 @@ class CiMatrixRouter
       run_warehouse: routing[:run_warehouse],
       focused_path: focus_path,
       okta: @input_with_okta || @commit_msg.include?('with-okta'),
+      testkit_check_all_table_results: @input_testkit_check_all_table_results || @commit_msg.include?('testkit-check-all-results'),
       logging: @input_with_logging || @commit_msg.include?('with-logging'),
       profiling: @input_with_profiling || @commit_msg.include?('ci-profile'),
     }

--- a/drivers/datalab_testkit/spec/models/table_comparisons.rb
+++ b/drivers/datalab_testkit/spec/models/table_comparisons.rb
@@ -95,7 +95,7 @@ module DatalabTestkit
         (results_metadata['first_row'] .. results_metadata['last_row']).each do |row_number|
           (results_metadata['first_column'] .. results_metadata['last_column']).each do |column_name|
             cell_name = column_name + row_number.to_s
-            next if cell_name.in?(skip)
+            next if cell_name.in?(skip) && ENV['TESTKIT_CHECK_ALL_TABLE_RESULTS'] != 'true'
 
             column_index = COLUMN_LABELS.find_index(column_name)
             column_index += 1 if external_row_label # Shift column index if the label is outside the table, but included in the goals

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -360,13 +360,17 @@ module HudSpmReport::Fy2026
       bed_nights = bed_nights.sort.uniq(&:date)
 
       # Keep bed nights that are:
-      # - on or after the lookback date
-      # - OR associated with an enrollment that started on or after the lookback date
+      # - on or after the client's date of birth
+      # - AND (on or after the lookback date
+      #   OR associated with an enrollment that started on or after the lookback date)
       #
       # Per spec (Step 5): "include additional nights experiencing homelessness based on
       # [approximate date this episode of homelessness started] up to and including
       # [project start date]... even if response extends prior to [lookback stop date]"
+      client_dob = client&.dob
       bed_nights = bed_nights.select do |bn|
+        next false if client_dob && bn.date < client_dob
+
         bn.date >= lookback_date || bn.enrollment.entry_date >= lookback_date
       end
 
@@ -380,8 +384,8 @@ module HudSpmReport::Fy2026
       return if client_end_date.nil?
 
       # Step 4: Client start date is 365 days prior to end date
-      # (lookback_date constraint already applied in filter above)
-      client_start_date = client_end_date - 365.days
+      # going back no further than the [lookback stop date] or client DOB.
+      client_start_date = [client_end_date - 365.days, lookback_date, client_dob].compact.max
 
       @debugger&.log("client_start_date: #{client_start_date.to_fs(:db)}")
       @debugger&.log("client_end_date: #{client_end_date.to_fs(:db)}")

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -258,7 +258,7 @@ module HudSpmReport::Fy2026
           end_date -= 1.day if end_date.present?
           # Don't include days after the end of the reporting period
           end_date = [end_date, report_end_date].compact.min
-          (start_date .. end_date).map do |date|
+          (start_date .. end_date).each do |date|
             bed_nights[date] = [enrollment, nil, date]
           end
         end
@@ -279,7 +279,7 @@ module HudSpmReport::Fy2026
           else
             report_end_date
           end
-          bed_nights += (enrollment.entry_date .. end_date).to_a
+          (enrollment.entry_date .. end_date).each { |date| bed_nights.add(date) }
         elsif enrollment.project_type.in?(HudHelper.util('2026').project_type_number_from_code(:ph))
           # PH bed nights on or after move in are not considered homeless
           next unless enrollment.move_in_date.present?
@@ -290,7 +290,7 @@ module HudSpmReport::Fy2026
           else
             report_end_date
           end
-          bed_nights += (enrollment.move_in_date .. end_date).to_a
+          (enrollment.move_in_date .. end_date).each { |date| bed_nights.add(date) }
         else
           raise 'Unexpected project type, no exclusion rules'
         end
@@ -325,7 +325,7 @@ module HudSpmReport::Fy2026
           # b.	For night-by-night based shelter stays, determine the client's [earliest bed night] dated >= [project start date] and <= [project exit date].  If [earliest bed night] >= [lookback stop date], then every night from [approximate date this episode of homelessness started] up to and including [earliest bed night] should also be considered nights experiencing homelessness. For example, a response of "9/16/2022" with the client's earliest bed night of 11/15/2022 would effectively include bed nights for 9/16/2022, 9/17/2022, 9/18/2022… up to and including 11/15/2022.  Naturally this does not mean the client was physically present at this specific shelter on these nights, but these dates are nonetheless included in the client's total time experiencing homelessness.
           next unless earliest_bed_night >= lookback_date && start_date < enrollment.entry_date
 
-          (start_date .. earliest_bed_night).map do |date|
+          (start_date .. earliest_bed_night).each do |date|
             bed_nights[date] ||= [enrollment, nil, date] # Add the day if not already present
           end
         else
@@ -334,7 +334,7 @@ module HudSpmReport::Fy2026
           # a.	For entry-exit based project stays, if the [project start date] is >= [lookback stop date], then every night from [approximate date this episode of homelessness started] up to and including [project start date] should also be considered nights experiencing homelessness, even if response in [approximate date this episode of homelessness started] extends prior to [lookback stop date].  For example, a response in [approximate date this episode of homelessness started] of "2/14/2022" with a [project start date] of 5/15/2022 would cause every night from 2/14/2022 through and including 5/15/2022 to be included in the client's dataset of nights experiencing homelessness.
           next unless enrollment.entry_date >= lookback_date && start_date < enrollment.entry_date
 
-          (start_date .. enrollment.entry_date).map do |date|
+          (start_date .. enrollment.entry_date).each do |date|
             bed_nights[date] ||= [enrollment, nil, date] # Add the day if not already present
           end
         end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -6,8 +6,33 @@
 
 # frozen_string_literal: true
 
+### Summary of the Workflow
+# *   **`candidate_bed_nights`**: Gathers all "potential" homeless nights across all relevant projects, even historical ones.
+# *   **`excluded_bed_nights`**: Gathers all "housed" nights (TH stays or PH after move-in).
+# *   **`compute_episode`**: Subtracts the housed nights from the potential homeless nights.
+# *   **`filter_episode`**: Anchors the timeline to a night in the report range and walks backward until it hits a gap.
+
 module HudSpmReport::Fy2026
   class Episode < HudReports::ReportClientBase
+    CandidateBedNight = Data.define(:enrollment, :service_id, :date) do
+      def <=>(other)
+        return nil unless other.is_a?(self.class)
+
+        # Primary sort by date
+        res = date <=> other.date
+        return res unless res.zero?
+
+        # Tie-break by enrollment ID to ensure deterministic behavior.
+        # We use a reverse tie-break (other <=> self) so that the "latest"
+        # enrollment (highest ID) comes first
+        res = other.enrollment.id <=> enrollment.id
+        return res unless res.zero?
+
+        # Further tie-break by service_id for NbN deterministic behavior
+        (other.service_id || 0) <=> (service_id || 0)
+      end
+    end
+
     self.table_name = 'hud_report_spm_episodes'
     include Detail
 
@@ -78,7 +103,7 @@ module HudSpmReport::Fy2026
       @debugger&.log_timeline('calculated_bed_nights', calculated_bed_nights)
       excluded_dates = excluded_bed_nights(enrollments, excluded_project_types)
       @debugger&.log_timeline('excluded_dates', excluded_dates)
-      allowed_bed_nights = calculated_bed_nights.reject { |_, _, date| date.in?(excluded_dates) }
+      allowed_bed_nights = calculated_bed_nights.reject { |bn| bn.date.in?(excluded_dates) }
       @debugger&.log_timeline('allowed_bed_nights', allowed_bed_nights)
 
       # when including 3.917 add days before entry from PH projects where entry was from a literally homeless situation
@@ -92,63 +117,32 @@ module HudSpmReport::Fy2026
       # Or
       # ( [housing move-in date] is null and [project exit date] >= [report start date] and [project exit date] <= [report end date])
 
-      pre_entry_inclusion_dates = if include_self_reported_and_ph
-        ph_enrollments = enrollments.select { |enrollment, _, _| enrollment.project_type.in?(HudHelper.util('2026').project_type_number_from_code(:ph)) }
-        add_self_reported([], ph_enrollments).reject { |_, _, date| date.in?(excluded_dates) }
-      else
-        # when not including 3.917
-        []
-      end
-      @debugger&.log_timeline('pre_entry_inclusion_dates', pre_entry_inclusion_dates)
       # To be included, in both 1a and 1b you need a homeless enrollment overlapping the range
-
-      # Step 1
+      # Step 1d: Preserve every relevant bed night which caused the client to be considered active in the date range.
+      # (Note: Step 1d-iii for PH says dates between start and move-in, which are already in allowed_bed_nights)
       inclusion_dates = allowed_bed_nights
-      # 1b additionally checks time before entry for PH projects
-      inclusion_dates += pre_entry_inclusion_dates
-      # Step 2 D
-      # note, inclusion dates are only used to check if these enrollments should be used, this variable is not used below
       @debugger&.log_timeline('inclusion_dates', inclusion_dates)
       return unless inclusion_dates.present?
 
-      # Steps 3 and 4
-      filtered_bed_nights = filter_episode(allowed_bed_nights) || []
-      @debugger&.log_timeline('filtered_bed_nights', filtered_bed_nights)
-      # step 5
-      # 5.	Measure 1b:  For each relevant project stay the client's response to Data Standards element 3.917.3 –  Approximate date this episode of homelessness started – also represents time the client has experienced homelessness.
-      # Including pre-entry for homeless enrollments
-      # when including 3.917 add days before entry
-      pre_entry_dates = if include_self_reported_and_ph
-        add_self_reported([], enrollments).reject { |_, _, date| date.in?(excluded_dates) }
-      else
-        # when not including 3.917
-        []
+      # Steps 3-6: Determine episode range and include contiguous nights
+      # Collect all possible nights including self-reported (Step 5)
+      all_candidate_nights = allowed_bed_nights
+      if include_self_reported_and_ph
+        # Step 5: For each relevant project stay, add self-reported dates if meeting literal homelessness criteria
+        pre_entry_dates = add_self_reported([], enrollments).reject { |bn| bn.date.in?(excluded_dates) }
+        @debugger&.log_timeline('pre_entry_dates', pre_entry_dates)
+        all_candidate_nights += pre_entry_dates
       end
-      @debugger&.log_timeline('pre_entry_dates', pre_entry_dates)
-      # note, at this point the array is no-longer sorted
-      filtered_bed_nights += pre_entry_dates
-      @debugger&.log_timeline('filtered_bed_nights + pre_entry_dates', filtered_bed_nights)
 
-      filtered_bed_nights = filter_episode(filtered_bed_nights)
-      @debugger&.log_timeline('filtered_episode(filtered_bed_nights + pre_entry_dates)', filtered_bed_nights)
+      filtered_bed_nights = filter_episode(all_candidate_nights)
+      @debugger&.log_timeline('filtered_bed_nights', filtered_bed_nights)
 
       return unless filtered_bed_nights.present?
 
-      bed_nights_array = []
       enrollment_links_array = []
-      any_bed_nights_in_report_range = filtered_bed_nights.any? { |_, _, date| date.between?(report_start_date, report_end_date) }
-      # any_bed_nights_in_report_range = false
-      # filtered_bed_nights.each do |enrollment, service_id, date|
-      #   bed_nights_array << BedNight.new(
-      #     client_id: client.id,
-      #     enrollment_id: enrollment.id,
-      #     service_id: service_id,
-      #     date: date,
-      #   )
-      #   any_bed_nights_in_report_range = true if date.between?(report_start_date, report_end_date)
-      # end
+      any_bed_nights_in_report_range = filtered_bed_nights.any? { |bn| bn.date.between?(report_start_date, report_end_date) }
 
-      enrollment_ids = filtered_bed_nights.map { |enrollment, _, _| enrollment.id }.uniq
+      enrollment_ids = filtered_bed_nights.map { |bn| bn.enrollment.id }.uniq
       enrollment_ids.each do |enrollment_id|
         enrollment_links_array << EnrollmentLink.new(
           enrollment_id: enrollment_id,
@@ -169,21 +163,24 @@ module HudSpmReport::Fy2026
 
       {
         episode: self,
-        bed_nights: bed_nights_array,
+        bed_nights: [],
         enrollment_links: enrollment_links_array,
         any_bed_nights_in_report_range: any_bed_nights_in_report_range,
       }
     end
 
-    # @param bed_nights [Array] an array of [enrollment, index(?), date]
+    # @param bed_nights [Array<CandidateBedNight>]
     private def compute_episode_statistics(bed_nights)
-      min_val = bed_nights[0].last # The date component
-      max_val = bed_nights[0].last
+      min_val = bed_nights[0].date
+      max_val = bed_nights[0].date
       distinct = {}
       distinct_count = 0
       first_date_enrollments = Set.new
 
-      bed_nights.each do |enrollment, _, date|
+      bed_nights.each do |bn|
+        date = bn.date
+        enrollment = bn.enrollment
+
         if date < min_val
           min_val = date
           first_date_enrollments = Set.new([enrollment]) # Reset to just this enrollment
@@ -240,10 +237,10 @@ module HudSpmReport::Fy2026
               map.with_index do |date, i|
                 next unless date.between?(first_night, last_night)
 
-                # return a triple [enrollment, id, date], using the index in place of the id so we don't need to load
+                # return a CandidateBedNight, using the index in place of the id so we don't need to load
                 # it from the DB (middle item needs to be unique within the enrollment)
-                [enrollment, i, date]
-              end.compact.group_by(&:last).
+                CandidateBedNight.new(enrollment: enrollment, service_id: i, date: date)
+              end.compact.group_by(&:date).
               transform_values { |v| Array.wrap(v).last }, # Unique by date
           )
         else
@@ -259,7 +256,7 @@ module HudSpmReport::Fy2026
           # Don't include days after the end of the reporting period
           end_date = [end_date, report_end_date].compact.min
           (start_date .. end_date).each do |date|
-            bed_nights[date] = [enrollment, nil, date]
+            bed_nights[date] = CandidateBedNight.new(enrollment: enrollment, service_id: nil, date: date)
           end
         end
       end
@@ -300,8 +297,10 @@ module HudSpmReport::Fy2026
     end
 
     private def add_self_reported(existing_bed_nights, enrollments)
-      bed_nights = existing_bed_nights.index_by(&:last)
+      bed_nights = existing_bed_nights.index_by(&:date)
       enrollments.each do |enrollment|
+        next unless enrollment_literally_homeless_at_entry(enrollment)
+
         if enrollment.project_type.in?(HudHelper.util('2026').project_type_number_from_code(:es_nbn))
           # NbN only gets service nights in the report range and within the enrollment period
           first_night = [report_start_date, enrollment.entry_date].max
@@ -326,7 +325,7 @@ module HudSpmReport::Fy2026
           next unless earliest_bed_night >= lookback_date && start_date < enrollment.entry_date
 
           (start_date .. earliest_bed_night).each do |date|
-            bed_nights[date] ||= [enrollment, nil, date] # Add the day if not already present
+            bed_nights[date] ||= CandidateBedNight.new(enrollment: enrollment, service_id: nil, date: date) # Add the day if not already present
           end
         else
           # Self-reported dates earlier than the entry date if present and the **project** start is on or after the lookback date
@@ -335,7 +334,7 @@ module HudSpmReport::Fy2026
           next unless enrollment.entry_date >= lookback_date && start_date < enrollment.entry_date
 
           (start_date .. enrollment.entry_date).each do |date|
-            bed_nights[date] ||= [enrollment, nil, date] # Add the day if not already present
+            bed_nights[date] ||= CandidateBedNight.new(enrollment: enrollment, service_id: nil, date: date) # Add the day if not already present
           end
         end
       end
@@ -351,42 +350,74 @@ module HudSpmReport::Fy2026
     # 4.	For each active client, create a [client start date] which is 365 days prior to the [client end date] going back no further than the [lookback stop date].
     #   a.	[Client start date] = [client end date] – 365 days.
     #   b.	A [client start date] will usually be prior to the [report start date].
-    # @param bed_nights [[Enrollment, service_id, Date]] Array of candidate bed nights to be processed
-    private def filter_episode(calculated_bed_nights)
-      return unless calculated_bed_nights.present?
+    #
+    # @param bed_nights [Array<CandidateBedNight>] Array of candidate bed nights to be processed
+    # @return [Array<CandidateBedNight>, nil] Filtered bed nights for the episode, or nil if none qualify
+    private def filter_episode(bed_nights)
+      return if bed_nights.blank?
 
-      # Sort by date to ensure chronological order
-      calculated_bed_nights = calculated_bed_nights.sort_by(&:last).uniq(&:last)
+      # Sort by date to ensure chronological order, dedupe by date
+      bed_nights = bed_nights.sort.uniq(&:date)
+
       # Keep bed nights that are:
       # - on or after the lookback date
       # - OR associated with an enrollment that started on or after the lookback date
-      calculated_bed_nights = calculated_bed_nights.select do |enrollment, _, bed_night_date|
-        bed_night_on_or_after_lookback = bed_night_date >= lookback_date
-        enrollment_on_or_after_lookback = enrollment.entry_date >= lookback_date
-
-        bed_night_on_or_after_lookback || enrollment_on_or_after_lookback
+      #
+      # Per spec (Step 5): "include additional nights experiencing homelessness based on
+      # [approximate date this episode of homelessness started] up to and including
+      # [project start date]... even if response extends prior to [lookback stop date]"
+      bed_nights = bed_nights.select do |bn|
+        bn.date >= lookback_date || bn.enrollment.entry_date >= lookback_date
       end
 
       # If we've filtered out all bed nights, return nil
-      return if calculated_bed_nights.empty?
+      return if bed_nights.empty?
 
-      # Now find the client's end date based on the remaining bed nights
-      client_end_date = calculated_bed_nights.last.last
+      # Step 3: Determine client's end date (latest homeless bed night in report range)
+      # Must be >= report_start_date and <= report_end_date.
+      # bed_nights are already capped at report_end_date.
+      client_end_date = bed_nights.reverse_each.find { |bn| bn.date >= report_start_date }&.date
+      return if client_end_date.nil?
+
+      # Step 4: Client start date is 365 days prior to end date
+      # (lookback_date constraint already applied in filter above)
       client_start_date = client_end_date - 365.days
 
       @debugger&.log("client_start_date: #{client_start_date.to_fs(:db)}")
       @debugger&.log("client_end_date: #{client_end_date.to_fs(:db)}")
 
-      # Include contiguous dates before the calculated client start date:
-      # First, find as close to the start date as possible in the array
-      index = 0
-      index += 1 while index < calculated_bed_nights.length && calculated_bed_nights[index].last <= client_start_date
+      # Step 6a (Forward): Find first index where date >= client_start_date
+      # All nights from here to end are included (gaps allowed in forward direction)
+      forward_start_index = bed_nights.bsearch_index { |bn| bn.date >= client_start_date } || bed_nights.length
 
-      # Then walk back until there is a break
-      index -= 1 while index.positive? && calculated_bed_nights[index - 1].last == calculated_bed_nights[index].last - 1.day
+      # Step 6b (Backward): Include contiguous dates before client_start_date
+      # Walk backwards until there is a gap > 1 day or we hit lookback_date
+      backward_start_index = forward_start_index
 
-      # Finally, return the selected dates
-      calculated_bed_nights[index..]
+      if forward_start_index.positive?
+        # "To be contiguous, a date must be no more than one day earlier than
+        # another date already in the client's dataset or the [client start date]"
+        contiguity_edge = client_start_date
+
+        (forward_start_index - 1).downto(0) do |i|
+          bn = bed_nights[i]
+          night_date = bn.date
+
+          break if night_date < lookback_date && bn.enrollment.entry_date < lookback_date
+
+          break unless (contiguity_edge - night_date).to_i <= 1
+
+          # Contiguous - include this night and continue walking back
+          backward_start_index = i
+          contiguity_edge = night_date
+
+          # Gap > 1 day found - "the period of at least one day when a client
+          # is not experiencing homelessness" - stop here
+        end
+      end
+
+      # Return the selected bed nights (contiguous backward + all forward)
+      bed_nights[backward_start_index..]
     end
 
     private def enrollment_literally_homeless_at_entry(enrollment)
@@ -396,7 +427,7 @@ module HudSpmReport::Fy2026
       enrollment.project_type.in?([2, 3, 9, 10, 13]) &&
         (enrollment.prior_living_situation.in?(100..199) ||
           (enrollment.previous_street_essh? && enrollment.prior_living_situation.in?(200..299) && enrollment.los_under_threshold?) ||
-            (enrollment.previous_street_essh? && enrollment.prior_living_situation.in?(300..499) && enrollment.los_under_threshold?))
+          (enrollment.previous_street_essh? && (enrollment.prior_living_situation.in?(0..99) || enrollment.prior_living_situation.in?(300..499)) && enrollment.los_under_threshold?))
     end
 
     private def include_ph_enrollment?(enrollment)

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -120,9 +120,8 @@ module HudSpmReport::Fy2026
       # To be included, in both 1a and 1b you need a homeless enrollment overlapping the range
       # Step 1d: Preserve every relevant bed night which caused the client to be considered active in the date range.
       # (Note: Step 1d-iii for PH says dates between start and move-in, which are already in allowed_bed_nights)
-      inclusion_dates = allowed_bed_nights
-      @debugger&.log_timeline('inclusion_dates', inclusion_dates)
-      return unless inclusion_dates.present?
+      @debugger&.log_timeline('inclusion_dates', allowed_bed_nights)
+      return if allowed_bed_nights.blank?
 
       # Steps 3-6: Determine episode range and include contiguous nights
       # Collect all possible nights including self-reported (Step 5)
@@ -137,16 +136,12 @@ module HudSpmReport::Fy2026
       filtered_bed_nights = filter_episode(all_candidate_nights)
       @debugger&.log_timeline('filtered_bed_nights', filtered_bed_nights)
 
-      return unless filtered_bed_nights.present?
+      return if filtered_bed_nights.blank?
 
-      enrollment_links_array = []
       any_bed_nights_in_report_range = filtered_bed_nights.any? { |bn| bn.date.between?(report_start_date, report_end_date) }
 
-      enrollment_ids = filtered_bed_nights.map { |bn| bn.enrollment.id }.uniq
-      enrollment_ids.each do |enrollment_id|
-        enrollment_links_array << EnrollmentLink.new(
-          enrollment_id: enrollment_id,
-        )
+      enrollment_links_array = filtered_bed_nights.map { |bn| bn.enrollment.id }.uniq.map do |enrollment_id|
+        EnrollmentLink.new(enrollment_id: enrollment_id)
       end
 
       first_date, last_date, days_homeless, first_date_enrollments = compute_episode_statistics(filtered_bed_nights)
@@ -171,45 +166,27 @@ module HudSpmReport::Fy2026
 
     # @param bed_nights [Array<CandidateBedNight>]
     private def compute_episode_statistics(bed_nights)
-      min_val = bed_nights[0].date
-      max_val = bed_nights[0].date
-      distinct = {}
-      distinct_count = 0
-      first_date_enrollments = Set.new
-
-      bed_nights.each do |bn|
-        date = bn.date
-        enrollment = bn.enrollment
-
-        if date < min_val
-          min_val = date
-          first_date_enrollments = Set.new([enrollment]) # Reset to just this enrollment
-        elsif date == min_val
-          first_date_enrollments.add(enrollment) # Add to enrollments for first date
-        end
-        max_val = date if date > max_val
-
-        next if distinct.key?(date)
-
-        distinct[date] = true
-        distinct_count += 1
-      end
-
-      # Return min date, max date, count of distinct dates, and enrollments for min date
-      [min_val, max_val, distinct_count, first_date_enrollments]
+      # bed_nights are already sorted and unique by date from filter_episode
+      [
+        bed_nights.first.date,
+        bed_nights.last.date,
+        bed_nights.length,
+        Set.new([bed_nights.first.enrollment]),
+      ]
     end
 
     private def candidate_bed_nights(enrollments, project_types, include_self_reported_and_ph)
       bed_nights = {} # Hash with date as key so we only get one candidate per overlapping night
+      ph_project_types = HudHelper.util('2026').project_type_number_from_code(:ph)
+
       enrollments = enrollments.select do |e|
         # For PH projects, only stays meeting the Identifying Clients Experiencing Literal Homelessness at Project Entry criteria are included in time experiencing homelessness.
-        in_project_type = e.project_type.in?(project_types)
         # Always drop PH that wasn't literally homeless at entry or not in report range
         # NOTE: PH is never in the project types, but included because of include_self_reported_and_ph
-        if include_self_reported_and_ph && e.project_type.in?(HudHelper.util('2026').project_type_number_from_code(:ph))
+        if include_self_reported_and_ph && e.project_type.in?(ph_project_types)
           enrollment_literally_homeless_at_entry(e) && include_ph_enrollment?(e)
         else
-          in_project_type
+          e.project_type.in?(project_types)
         end
       end
       enrollments.each do |enrollment|
@@ -240,8 +217,7 @@ module HudSpmReport::Fy2026
                 # return a CandidateBedNight, using the index in place of the id so we don't need to load
                 # it from the DB (middle item needs to be unique within the enrollment)
                 CandidateBedNight.new(enrollment: enrollment, service_id: i, date: date)
-              end.compact.group_by(&:date).
-              transform_values { |v| Array.wrap(v).last }, # Unique by date
+              end.compact.index_by(&:date),
           )
         else
           start_date = enrollment.entry_date
@@ -436,8 +412,8 @@ module HudSpmReport::Fy2026
       return false unless enrollment.project_type.in?([2, 3, 9, 10, 13])
 
       enrollment.entry_date.between?(report_start_date, report_end_date) ||
-        (enrollment.move_in_date.present? && enrollment.move_in_date.between?(report_start_date, report_end_date)) ||
-        (enrollment.move_in_date.blank? && enrollment.exit_date.present? && enrollment.exit_date.between?(report_start_date, report_end_date))
+        enrollment.move_in_date&.between?(report_start_date, report_end_date) ||
+        (enrollment.move_in_date.blank? && enrollment.exit_date&.between?(report_start_date, report_end_date))
     end
 
     private def report_start_date

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -405,18 +405,15 @@ module HudSpmReport::Fy2026
 
         (forward_start_index - 1).downto(0) do |i|
           bn = bed_nights[i]
-          night_date = bn.date
-
-          break if night_date < lookback_date && bn.enrollment.entry_date < lookback_date
-
-          break unless (contiguity_edge - night_date).to_i <= 1
+          # stop if we've exceeded the lookback_date
+          break if bn.date < lookback_date && bn.enrollment.entry_date < lookback_date
+          # Gap > 1 day found - "the period of at least one day when a client
+          # is not experiencing homelessness" - stop here
+          break if (contiguity_edge - bn.date).to_i > 1
 
           # Contiguous - include this night and continue walking back
           backward_start_index = i
-          contiguity_edge = night_date
-
-          # Gap > 1 day found - "the period of at least one day when a client
-          # is not experiencing homelessness" - stop here
+          contiguity_edge = bn.date
         end
       end
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode_batch.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode_batch.rb
@@ -40,15 +40,19 @@ module HudSpmReport::Fy2026
 
       # Services are really expensive to preload, for unknown reasons, however, the overall set of information we need is fairly small
       enrollments_for_clients = @enrollments.where(client_id: client_ids).preload(:client, :enrollment).group_by(&:client_id)
-      batch_personal_ids = enrollments_for_clients.values.flatten.map(&:personal_id).uniq
+      batch_personal_ids = enrollments_for_clients.values.flat_map { |es| es.map(&:personal_id) }.uniq
       # Load all bed nights for these clients regardless of enrollment; we'll look them up as necessary
       # Bednights are indexed on `[EnrollmentID, PersonalID, data_source_id]`
-      batch_services = GrdaWarehouse::Hud::Service.bed_night.
-        between(start_date: nil, end_date: @filter.end). # We don't need anything after the report end date, but may need services before the start date
+
+      lookback_date = @filter.start - 7.years
+      batch_services = Hash.new { |h, k| h[k] = [] }
+      GrdaWarehouse::Hud::Service.bed_night.
+        between(start_date: lookback_date, end_date: @filter.end). # We don't need anything after the report end date, but may need services before the start date
         where(PersonalID: batch_personal_ids). # impose some basic limit so we don't load the entire set of services
         pluck(:EnrollmentID, :PersonalID, :data_source_id, :DateProvided).
-        group_by { |r| r.shift(3) }.
-        transform_values(&:flatten)
+        each do |eid, pid, dsid, date|
+          batch_services[[eid, pid, dsid]] << date
+        end
 
       episodes = []
       bed_nights_per_episode = []

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
@@ -121,7 +121,7 @@ module HudSpmReport::Fy2026
                 and(arel_table[:prior_living_situation].between(200..299)).
                 and(arel_table[:los_under_threshold].eq(true))).
               or(arel_table[:previous_street_essh].eq(true).
-                and(arel_table[:prior_living_situation].between(300..499)).
+                and(arel_table[:prior_living_situation].between(0..99).or(arel_table[:prior_living_situation].between(300..499))).
                 and(arel_table[:los_under_threshold].eq(true)))))),
       )
     end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/hdx_upload.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/hdx_upload.rb
@@ -261,6 +261,14 @@ module HudSpmReport::Generators::Fy2026
       end
     end
 
+    def run!
+      super
+    ensure
+      # The sub-reports generated for DQ are only needed for the CSV generation.
+      # Clear them explicitly to free up memory
+      @reports = nil
+    end
+
     def metadata(column)
       case column
       when 'CocCode'
@@ -337,6 +345,7 @@ module HudSpmReport::Generators::Fy2026
       report = ::HudReports::ReportInstance.from_filter(dq_filter, generator.title, build_for_questions: ['Question 1', 'Question 4'])
       generator.new(report).run!(email: false, manual: false)
 
+      @report.check_halt_status!
       report
     end
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/measure_base.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/measure_base.rb
@@ -71,5 +71,12 @@ module HudSpmReport::Generators::Fy2026
         question_name: self.class.question_number,
       )
     end
+
+    def run!
+      super
+    ensure
+      HudReports::ReportInstance.connection.clear_query_cache
+      GC.start
+    end
   end
 end

--- a/drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb
+++ b/drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe 'Datalab Testkit SPM All-Projects', type: :model do
         question: '1a',
         skip: [
           'B2', # expected '4808.0000' (4808), got '4417.0000' (4417)
-          'D2', # expected '73.9500' (73.95), got '53.2000' (53.20)
           'G2', # expected '37.0000' (37), got '31.0000' (31)
           'B3', # expected '0.0000' (), got '4825.0000' (4825)
           'D3', # expected '0.0000' (), got '73.7400' (73.74)
@@ -54,10 +53,8 @@ RSpec.describe 'Datalab Testkit SPM All-Projects', type: :model do
         skip: [
           'B2', # expected '5749.0000' (5749), got '5437.0000' (5437)
           'D2', # expected '261.2200' (261.22), got '252.9400' (252.94)
-          'G2', # expected '94.0000' (94), got '90.0000' (90)
           'B3', # expected '0.0000' (), got '5814.0000' (5814)
           'D3', # expected '0.0000' (), got '263.0700' (263.07)
-          'G3', # expected '0.0000' (), got '96.0000' (96.0)
         ],
       )
     end

--- a/drivers/hud_spm_report/spec/models/fy2026/hud_validation_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/hud_validation_spec.rb
@@ -1,0 +1,478 @@
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared_context'
+
+RSpec.describe 'SPM Measure 1 HUD Validation Cases', type: :model, exclude_fixpoints: true do
+  # This spec file specifically captures the "Additional Test Cases" and "Programming Instructions"
+  # from the HUD System Performance Measures (SPM) specifications (Measure 1).
+  # These scenarios are used to validate the temporal logic of the Length of Time Homeless calculations,
+  # particularly the complex negation and contiguity rules between project types.
+  include_context '2026 SPM test setup'
+
+  describe 'Measure 1a HUD Test Cases' do
+    # A client with shelter bed nights in the report date range, all of which are negated by that client's residence in permanent housing as indicated by [housing move-in date]. The client should be completely excluded from the report.
+    it 'Total Negation: excludes client when all shelter nights are negated by PH Housing Move-In Date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # Shelter stay: 2022-11-01 to 2022-11-10 (9 nights: 1st through 9th)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2022-11-10'.to_date,
+      )
+
+      # PH stay negating all shelter nights: Move-In on or before shelter entry
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-10-01'.to_date,
+        move_in_date: '2022-10-15'.to_date, # Housed before shelter entry
+        exit_date: '2022-12-01'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      expect(@report.universe('m1a1').members.count).to eq(0)
+    end
+
+    # A client with a [project exit date] in shelter which falls on the same date as that client's [housing move-in date] in PH. The client's shelter bed nights should be unaffected -- the [project exit date] never counts as a bed night.
+    it 'Exit vs. Move-In (Same Day): shelter bed nights are unaffected when exit date equals move-in date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # Shelter stay: 2022-11-01 to 2022-11-10
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2022-11-10'.to_date,
+      )
+
+      # PH move-in on shelter exit date
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-11-10'.to_date,
+        move_in_date: '2022-11-10'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+      # Expected: 2022-11-01 to 2022-11-09 = 9 days
+      expect(episode.days_homeless).to eq(9)
+      expect(episode.last_date).to eq('2022-11-09'.to_date)
+    end
+
+    # A client with a [project exit date] in shelter which falls one day after that client's [housing move-in date] into permanent housing. The [project exit date] from shelter is effectively back-dated one day such that the first day residing in PH does not count as a night experiencing homelessness.
+    it 'Overlap (1 Day): shelter exit date is effectively back-dated by one day when it is after move-in date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # Shelter stay exit is one day AFTER PH move-in
+      # ES: 2022-11-01 to 2022-11-11 (Normally 1st-10th = 10 nights)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2022-11-11'.to_date,
+      )
+
+      # PH move-in on 2022-11-10
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-11-10'.to_date,
+        move_in_date: '2022-11-10'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+      # Expected: 2022-11-01 to 2022-11-09 = 9 days (10th is negated)
+      expect(episode.days_homeless).to eq(9)
+      expect(episode.last_date).to eq('2022-11-09'.to_date)
+    end
+
+    # A client with a shelter [project start date] which falls in the report date range and one day prior to the client's [project exit date] from PH, with the client's [housing move-in date] set prior to that PH exit. The shelter [project start date] is effectively bumped forward one day to equal the permanent housing [project exit date], reducing the client's count of nights experiencing homelessness by one.
+    it 'Start vs. PH Exit (1 Day Gap): shelter start date is bumped forward when it is before PH exit while housed' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # PH stay: client already housed, exits 2022-11-05
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-10-01'.to_date,
+        move_in_date: '2022-10-15'.to_date,
+        exit_date: '2022-11-05'.to_date,
+      )
+
+      # Shelter start is one day PRIOR to PH exit (2022-11-04)
+      # ES: 2022-11-04 to 2022-11-15
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-04'.to_date,
+        exit_date: '2022-11-15'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+      # Expected: Shelter start bumped from 4th to 5th.
+      # nights: 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 = 10 days
+      expect(episode.first_date).to eq('2022-11-05'.to_date)
+      expect(episode.days_homeless).to eq(10)
+    end
+
+    # A client with a shelter [project start date] which falls in the report date range and also on the same day as the client's [project exit date] from permanent housing. The shelter [project start date] should be unaffected.
+    it 'Start vs. PH Exit (Same Day): shelter start date remains unaffected when it equals PH exit date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # PH stay: client already housed, exits 2022-11-05
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-10-01'.to_date,
+        move_in_date: '2022-10-15'.to_date,
+        exit_date: '2022-11-05'.to_date,
+      )
+
+      # Shelter start is SAME day as PH exit (2022-11-05)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-05'.to_date,
+        exit_date: '2022-11-15'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+      # Expected: Shelter start remains 5th.
+      # nights: 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 = 10 days
+      expect(episode.first_date).to eq('2022-11-05'.to_date)
+      expect(episode.days_homeless).to eq(10)
+    end
+
+    # A shelter stay where the [project start date] and [project exit date] are equal. This means the client did not spend a night experiencing homelessness at the shelter, so that date is not included in the client's dataset.
+    it 'Zero-night stay: project start date equals project exit date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @client = create_client_with_warehouse_link
+
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2023-01-01'.to_date,
+        exit_date: '2023-01-01'.to_date,
+      )
+
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      expect(@report.universe('m1a1').members.count).to eq(0)
+    end
+
+    # PH move-in date before project start (Discarded per Glossary rules)
+    it 'Discard move-in date before project start' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # ES: 2022-11-01 to 2022-11-15
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-11-01'.to_date,
+        exit_date: '2022-11-15'.to_date,
+      )
+
+      # PH: Entry 11/05, Move-In 11/01 (Invalid, before entry)
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2022-11-05'.to_date,
+        move_in_date: '2022-11-01'.to_date,
+        exit_date: '2022-11-15'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+      # If move-in date 11/01 is discarded, no negation happens.
+      # Expected: 14 days
+      expect(episode.days_homeless).to eq(14)
+    end
+
+    # To be contiguous, a date must be no more than one day earlier than another date already in the client's dataset or the [client start date].
+    it 'Contiguous nights: expansion stops at a gap of 1 or more days when before client start date' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @client = create_client_with_warehouse_link
+
+      # client_end_date will be 2023-09-30
+      # client_start_date will be 2022-09-30
+
+      # Stay 1: 2022-01-01 to 2022-01-10 (bed nights: 01/01-01/09)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-01-01'.to_date,
+        exit_date: '2022-01-10'.to_date,
+      )
+
+      # GAP: 2022-01-10 (1 day missing) - breaks contiguity
+
+      # Stay 2: 2022-01-11 to 2022-01-21 (bed nights: 01/11-01/20)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-01-11'.to_date,
+        exit_date: '2022-01-21'.to_date,
+      )
+
+      # NO GAP: Stay 2 last bed night is 01/20, Stay 3 first bed night is 01/21
+      # 01/20 is exactly one day earlier than 01/21 - CONTIGUOUS
+
+      # Stay 3: 2022-01-21 to 2023-10-01 (bed nights: 01/21-09/30)
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-01-21'.to_date,
+        exit_date: '2023-10-01'.to_date,
+      )
+
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1a1').members.first.universe_membership
+
+      # client_end_date is 2023-09-30 (report end)
+      # client_start_date is 2022-09-30
+      # Stay 3 starts 2022-01-21, which is before client_start_date
+      # Expansion works backward from client_start_date
+      # Stay 3 is contiguous back to 01/21
+      # Stay 2 ends 01/20, which is exactly 1 day before 01/21 - CONTIGUOUS
+      # Stay 2 is contiguous back to 01/11
+      # Stay 1 ends 01/09, which is 2 days before 01/11 (01/10 missing) - NOT CONTIGUOUS
+      # Expansion stops at 01/11
+
+      expect(episode.first_date).to eq('2022-01-11'.to_date)
+    end
+  end
+
+  describe 'Median Calculation HUD Specs' do
+    it 'correctly calculates median for odd number of clients' do
+      @es_project = create_project(project_type: 0)
+
+      # 3 clients with LOT: 10, 20, 30
+      [10, 20, 30].each_with_index do |days, i|
+        client = create_client_with_warehouse_link(uid: "P#{i}")
+        create_enrollment(
+          client: client,
+          project: @es_project,
+          entry_date: '2023-01-01'.to_date,
+          exit_date: ('2023-01-01'.to_date + days.days),
+        )
+      end
+
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # Median of [10, 20, 30] is 20
+      answer = @report.answer(question: '1a', cell: 'G2')
+      expect(answer.summary.to_f).to eq(20.0)
+    end
+
+    it 'correctly calculates median for even number of clients' do
+      @es_project = create_project(project_type: 0)
+
+      # 4 clients with LOT: 10, 20, 30, 40
+      [10, 20, 30, 40].each_with_index do |days, i|
+        client = create_client_with_warehouse_link(uid: "P#{i}")
+        create_enrollment(
+          client: client,
+          project: @es_project,
+          entry_date: '2023-01-01'.to_date,
+          exit_date: ('2023-01-01'.to_date + days.days),
+        )
+      end
+
+      @report = setup_report([@es_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # Median of [10, 20, 30, 40] is (20 + 30) / 2 = 25.0
+      answer = @report.answer(question: '1a', cell: 'G2')
+      expect(answer.summary.to_f).to eq(25.0)
+    end
+  end
+
+  describe 'Measure 1b HUD Test Cases' do
+    # A client whose [project start date] is 6/1/2022 and response to element [approximate date this episode of homelessness started] is 3/1/2022, effectively back-dating their [project start date] in shelter by 92 days. But 30 days before [project start date] the client has a [project exit date] from PH, with the client's [housing move-in date] set prior to that PH exit. The additional nights experiencing homelessness for that client is 30 instead of 90. This also creates a break in homelessness when working backwards to include contiguous bed nights.
+    it 'Measure 1b: PH stay creates a break in homelessness, stopping backward expansion' do
+      @es_project = create_project(project_type: 0) # ES-EE
+      @ph_project = create_project(project_type: 3) # PSH
+      @client = create_client_with_warehouse_link
+
+      # Shelter start: 6/1/2023
+      # 3.917.3 (Approximate date this episode started): 3/1/2023
+      shelter_start = '2023-06-01'.to_date
+      approx_start = '2023-03-01'.to_date # 92 days back-dated
+
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: shelter_start,
+        exit_date: '2023-06-15'.to_date,
+        date_to_street_essh: approx_start,
+      )
+
+      # PH stay: exits 30 days before shelter start = 2023-05-02
+      # Client was already housed.
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2023-01-01'.to_date,
+        move_in_date: '2023-02-01'.to_date,
+        exit_date: '2023-05-02'.to_date,
+      )
+
+      # Another shelter stay BEFORE the PH stay - should be EXCLUDED due to break
+      # client_end_date is June 2023, so client_start_date is June 2022.
+      # Let's put this stay in Jan 2022 (outside the 365-day window).
+      create_enrollment(
+        client: @client,
+        project: @es_project,
+        entry_date: '2022-01-01'.to_date,
+        exit_date: '2022-02-01'.to_date,
+      )
+
+      @report = setup_report([@es_project.id, @ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      episode = @report.universe('m1b1').members.first.universe_membership
+
+      # If PH stay creates a break, first_date should be 2023-05-02
+      expect(episode.first_date).to eq('2023-05-02'.to_date)
+      # Total days homeless = 30 (pre-entry) + 14 (shelter) = 44.
+      expect(episode.days_homeless).to eq(44)
+    end
+  end
+
+  describe 'Identifying Clients Experiencing Literal Homelessness at Project Entry' do
+    # PH clients who are not literally homeless at entry should be excluded from Measure 1b
+    it 'Measure 1b: excludes PH stays that are NOT literally homeless at entry' do
+      @ph_project = create_project(project_type: 3) # PH-PSH
+      @client = create_client_with_warehouse_link
+
+      # Create PH enrollment that is NOT literally homeless at entry
+      # Entry from Rental by Client (Code 435) without meeting the additional criteria
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2023-01-01'.to_date,
+        exit_date: nil, # Still active, no housing move-in yet
+        living_situation: 435, # Rental by client - in range 300:499
+        los_under_threshold: 0, # Did NOT stay less than 7 nights
+        previous_street_essh: 0, # Did NOT come from streets/ES/SH the night before
+      )
+
+      @report = setup_report([@ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # PH clients who are not literally homeless at entry should be excluded from Measure 1b
+      expect(@report.universe('m1b1').members.count).to eq(0)
+      expect(@report.universe('m1b2').members.count).to eq(0)
+    end
+
+    # PH clients who are literally homeless at entry should be included in Measure 1b
+    it 'Measure 1b: includes PH stays that ARE literally homeless at entry' do
+      @ph_project = create_project(project_type: 3) # PH-PSH
+      @client = create_client_with_warehouse_link
+
+      # Create PH enrollment that IS literally homeless at entry
+      # Entry from Emergency Shelter (Code 101) - in range 100:199
+      create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2023-01-01'.to_date,
+        exit_date: nil, # Still active, no housing move-in yet
+        move_in_date: nil,
+        living_situation: 101, # Emergency shelter - literally homeless
+      )
+
+      @report = setup_report([@ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # PH clients who are literally homeless at entry should be included in Measure 1b
+      expect(@report.universe('m1b1').members.count).to eq(1)
+      expect(@report.universe('m1b2').members.count).to eq(1)
+    end
+
+    # TH clients are included in Measure 1b regardless of prior living situation
+    it 'Measure 1b: includes TH stays regardless of living situation at entry' do
+      @th_project = create_project(project_type: 2) # TH
+      @client = create_client_with_warehouse_link
+
+      # Create TH enrollment with non-homeless prior living situation
+      # TH clients are included in the base universe without the literal homelessness check
+      create_enrollment(
+        client: @client,
+        project: @th_project,
+        entry_date: '2023-01-01'.to_date,
+        exit_date: '2023-02-01'.to_date,
+        living_situation: 435, # Rental by client - doesn't matter for TH
+      )
+
+      @report = setup_report([@th_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # TH clients are included in Measure 1b regardless of prior living situation
+      # They appear in metric 2 (which includes TH) but not metric 1 (which excludes TH)
+      expect(@report.universe('m1b1').members.count).to eq(0) # m1b1 excludes TH
+      expect(@report.universe('m1b2').members.count).to eq(1) # m1b2 includes TH
+    end
+
+    # TH stayers who were literally homeless at entry should be included in Metric 2
+    it 'Measure 1b Metric 2: includes TH stayers who were literally homeless at entry' do
+      @th_project = create_project(project_type: 2) # TH
+      @client = create_client_with_warehouse_link
+
+      # TH stayer: started 2022-01-01, active during report range (2022-10-01 to 2023-09-30)
+      # Literally homeless at entry (Living Situation 101)
+      create_enrollment(
+        client: @client,
+        project: @th_project,
+        entry_date: '2022-01-01'.to_date,
+        living_situation: 101,
+      )
+
+      @report = setup_report([@th_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+
+      # Metric 2 (m1b2) should include this client.
+      expect(@report.universe('m1b2').members.count).to eq(1)
+    end
+  end
+end

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
       end
 
-      it 'creates SpmEnrollment records correctly' do
-        expect(@report.spm_enrollments.count).to be > 0
-
-        spm_enrollment = @report.spm_enrollments.first
-        expect(spm_enrollment.entry_date).to eq('2022-11-01'.to_date)
-        expect(spm_enrollment.exit_date).to eq('2023-01-15'.to_date)
-      end
-
       it 'correctly calculates the length of time homeless without prior living situation' do
         # Verify that the universe was created for measure 1a
         expect(@report.universe('m1a1').members.count).to eq(1)

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
           project: @th_project,
           entry_date: '2022-11-10'.to_date,
           exit_date: '2023-01-10'.to_date,
+          living_situation: 116, # Literally Homeless at Entry
         )
 
         # Create PH enrollment with move-in date
@@ -328,12 +329,12 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         episode = @report.universe('m1b2').members.first.universe_membership
 
         # Expected homeless days:
-        # Sept 15 (date to street) to Nov 15 (ES exit) = 62 days
+        # Sept 15 (date to street) to Nov 15 (ES exit) = 61 days
         # Nov 10 (TH entry) to Jan 10 (TH exit) = 62 days
         # Jan 15 (PH entry) to Feb 1 (PH move-in) = 17 days
-        # Total = 141 days
-        # But, TH overrides ES for Nov 10-15 (6 days overlap), so 135 days total
-        expect(episode.days_homeless).to be_within(5).of(135)
+        # Total = 140 days
+        # But, TH overrides ES for Nov 10-15 (6 days overlap), so 134 days total
+        expect(episode.days_homeless).to eq(134)
       end
     end
 
@@ -428,9 +429,9 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         @es_project = create_project(project_type: 0) # ES-EE
 
         # Create household members
-        @head_of_household = create_client_with_warehouse_link
-        @child = create_client_with_warehouse_link(dob: '2020-06-01')
-        @adult_member = create_client_with_warehouse_link
+        @head_of_household = create_client_with_warehouse_link(dob: '1980-01-01')
+        @child = create_client_with_warehouse_link(dob: '2015-01-01')
+        @adult_member = create_client_with_warehouse_link(dob: '1990-01-01')
 
         # Create household ID
         household_id = 'test_household_123'
@@ -513,7 +514,7 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         expect(answer_b2.summary.to_i).to eq(3)
 
         # Average should be (106 + 106 + 87) / 3 = 99.67 days
-        expect(answer_d2.summary.to_f).to be_within(1).of(99.67)
+        expect(answer_d2.summary.to_f).to eq(99.67)
 
         # Median should be 106 days
         expect(answer_g2.summary.to_i).to eq(106)
@@ -560,10 +561,40 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         # is after the lookback stop date
         expect(episode.first_date).to eq('2014-10-15'.to_date)
 
-        # Expected days homeless should include the time from date_to_street_essh to project exit
-        # (minus one day since exit date doesn't count as a bed night)
-        expected_days = ('2023-01-15'.to_date - '2014-10-15'.to_date).to_i - 1
-        expect(episode.days_homeless).to be_within(5).of(expected_days)
+        # Expected days homeless should include the time from date_to_street_essh to project exit.
+        # Note: (exit_date - first_date) gives the number of nights, excluding the exit date.
+        expected_days = ('2023-01-15'.to_date - '2014-10-15'.to_date).to_i
+        expect(episode.days_homeless).to eq(expected_days)
+      end
+    end
+
+    context 'with project entry before lookback stop date' do
+      before do
+        @es_project = create_project(project_type: 0) # ES-EE
+        @client = create_client_with_warehouse_link
+
+        # When project start date is BEFORE lookback stop date,
+        # the 3.917 data should NOT be used (per step 5a condition)
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          date_to_street_essh: '2014-01-01'.to_date,
+          entry_date: '2015-06-01'.to_date, # BEFORE lookback stop date (2015-10-01)
+          exit_date: '2023-01-15'.to_date,
+        )
+
+        @report = setup_report([@es_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'does not include DateToStreetESSH time when project start is before lookback stop date' do
+        expect(@report.universe('m1b1').members.count).to eq(1)
+        episode = @report.universe('m1b1').members.first.universe_membership
+
+        # Since project start date (2015-06-01) is before lookback stop date (2015-10-01),
+        # the condition in step 5a is not met, so DateToStreetESSH should not be prepended
+        # The first_date should be based on the actual enrollment, not the 3.917 data
+        expect(episode.first_date).not_to eq('2014-01-01'.to_date)
       end
     end
 
@@ -622,35 +653,34 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
           date_to_street_essh: '2014-10-01'.to_date, # Before lookback stop date
         )
 
-        # Add bed night services after lookback stop date
-        create_bed_night_service(enrollment: enrollment, date: '2016-11-05'.to_date)
-        create_bed_night_service(enrollment: enrollment, date: '2016-11-10'.to_date)
-        create_bed_night_service(enrollment: enrollment, date: '2016-11-15'.to_date)
+        # Bed nights - earliest is 2022-12-01
         create_bed_night_service(enrollment: enrollment, date: '2022-12-01'.to_date)
-        create_bed_night_service(enrollment: enrollment, date: '2022-12-15'.to_date)
+        create_bed_night_service(enrollment: enrollment, date: '2022-12-02'.to_date)
+        create_bed_night_service(enrollment: enrollment, date: '2022-12-03'.to_date)
 
         # Setup and run the report
         @report = setup_report([@nbn_project.id])
         run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
       end
 
-      it 'includes time from DateToStreetESSH to first bed night after lookback stop date' do
+      it 'includes time from DateToStreetESSH even when before lookback stop date' do
         expect(@report.universe('m1b1').members.count).to eq(1)
 
         episode = @report.universe('m1b1').members.first.universe_membership
 
         # For night-by-night shelters, we should include all nights from date_to_street_essh
         # up to and including the earliest bed night, plus all actual bed nights
-        # The earliest bed night is 2016-11-05
 
         # First date should be date_to_street_essh
         expect(episode.first_date).to eq('2014-10-01'.to_date)
 
-        # Expected homeless days should include:
-        # 2014-10-01 to 2016-11-05 = 767 days
-        # Plus 5 actual bed nights = 772 days total
-        # We allow some flexibility in the exact count since the implementation may handle edge cases differently
-        expect(episode.days_homeless).to be > 700
+        # Prepended days (2014-10-01 through 2022-12-01 inclusive): 2984 days
+        # Additional bed nights after earliest (2022-12-02, 2022-12-03): 2 days
+        # Total: 2986 days
+        prepended_days = ('2022-12-01'.to_date - '2014-10-01'.to_date).to_i + 1 # inclusive
+        additional_bed_nights = 2 # 12/02 and 12/03
+
+        expect(episode.days_homeless).to eq(prepended_days + additional_bed_nights)
       end
     end
 
@@ -691,6 +721,29 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
       end
     end
 
+    context 'with DateToStreetESSH before date of birth' do
+      before do
+        @es_project = create_project(project_type: 0)
+        @client = create_client_with_warehouse_link(dob: '2010-01-01'.to_date)
+
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2018-01-15'.to_date,
+          exit_date: '2023-01-15'.to_date,
+          date_to_street_essh: '2008-06-15'.to_date,
+        )
+
+        @report = setup_report([@es_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'does not count homelessness before date of birth' do
+        episode = @report.universe('m1b1').members.first.universe_membership
+        expect(episode.first_date).to be >= '2010-01-01'.to_date
+      end
+    end
+
     context 'with very old DateToStreetESSH (decades ago)' do
       before do
         # Create an ES project
@@ -721,9 +774,9 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         # First date should be the old date_to_street_essh per the spec
         expect(episode.first_date).to eq('1990-10-15'.to_date)
 
-        # Expected days homeless should be from date_to_street_essh to exit date (minus one day)
-        expected_days = ('2023-01-15'.to_date - '1990-10-15'.to_date).to_i - 1
-        expect(episode.days_homeless).to be_within(5).of(expected_days)
+        # Expected days homeless should be from date_to_street_essh to exit date
+        expected_days = ('2023-01-15'.to_date - '1990-10-15'.to_date).to_i
+        expect(episode.days_homeless).to eq(expected_days)
       end
     end
 
@@ -855,7 +908,7 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
       end
 
-      it 'correctly calculates homelessness period' do
+      it 'correctly calculates homelessness period including time before lookback stop date' do
         expect(@report.universe('m1b1').members.count).to eq(1)
 
         episode = @report.universe('m1b1').members.first.universe_membership
@@ -868,8 +921,11 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         # Expected days homeless calculation:
         # - Time from date_to_street_essh (2014-06-01) to PSH move-in (2022-10-03)
         # - Plus time from NBN date_to_street_essh (2023-01-01) to the bed night (2023-08-15)
-        expected_days = 3273 # how many days?
+        psh_days = ('2022-10-02'.to_date - '2014-06-01'.to_date).to_i + 1
+        nbn_days = ('2023-08-15'.to_date - '2023-01-01'.to_date).to_i + 1
+        expected_days = psh_days + nbn_days
         expect(episode.days_homeless).to eq(expected_days)
+
         answer = @report.answer(question: '1b', cell: 'D2')
         expect(answer.summary.to_f).to eq(expected_days)
       end

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -1130,6 +1130,45 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
     end
   end
 
+  context 'with Literal Homelessness at Entry for PH projects (0..99 living situation)' do
+    before do
+      # Create a PH project (PSH)
+      @ph_project = create_project(project_type: 3)
+
+      # Create a client
+      @client = create_client_with_warehouse_link
+
+      # Create PH enrollment with living situation 0-99 (Other/Unknown)
+      # PLUS previous_street_essh: true and los_under_threshold: true
+      # This SHOULD qualify as literally homeless at entry
+      @enrollment = create_enrollment(
+        client: @client,
+        project: @ph_project,
+        entry_date: '2023-01-01'.to_date,
+        exit_date: '2023-03-01'.to_date,
+        living_situation: 99, # Other
+        previous_street_essh: 1,
+        los_under_threshold: 1,
+        date_to_street_essh: '2022-12-01'.to_date,
+      )
+
+      # Setup and run the report
+      @report = setup_report([@ph_project.id])
+      run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+    end
+
+    it 'correctly identifies PH stays with 0-99 living situation as literally homeless' do
+      # Verify that the universe was created for measure 1b
+      expect(@report.universe('m1b1').members.count).to eq(1)
+
+      episode = @report.universe('m1b1').members.first.universe_membership
+
+      # Should include self-reported time
+      expect(episode.first_date).to eq('2022-12-01'.to_date)
+      expect(episode.days_homeless).to eq(90) # 2022-12-01 to 2023-02-28
+    end
+  end
+
   context 'with propagation of date to street from HoH to child household members' do
     before do
       # Create an ES project

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -598,6 +598,77 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
       end
     end
 
+    context 'when client is not literally homeless at project entry' do
+      before do
+        @th_project = create_project(project_type: 2) # TH
+        @client = create_client_with_warehouse_link
+
+        # Client is entering from a non-homeless situation (e.g., Living with friends - 300)
+        # Even if they provide a 3.917.3 date, it should be ignored per spec step 5
+        create_enrollment(
+          client: @client,
+          project: @th_project,
+          date_to_street_essh: '2022-01-01'.to_date,
+          entry_date: '2022-11-01'.to_date,
+          exit_date: '2023-01-15'.to_date,
+          living_situation: 300, # Living in a friend's room (not literally homeless)
+        )
+
+        @report = setup_report([@th_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'does not include DateToStreetESSH time' do
+        # TH is included in Metric 2 (m1b2), but not Metric 1 (m1b1)
+        expect(@report.universe('m1b2').members.count).to eq(1)
+        episode = @report.universe('m1b2').members.first.universe_membership
+
+        # The first_date should be the entry_date, not the date_to_street_essh
+        expect(episode.first_date).to eq('2022-11-01'.to_date)
+        expect(episode.first_date).not_to eq('2022-01-01'.to_date)
+      end
+    end
+
+    context 'when self-reported data bridges a gap to a historical enrollment' do
+      before do
+        @es_project = create_project(project_type: 0)
+        @client = create_client_with_warehouse_link
+
+        # Enrollment 1: Historical documented nights (Jan 1 - Jan 10)
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2022-01-01'.to_date,
+          exit_date: '2022-01-11'.to_date,
+        )
+
+        # Enrollment 2: Active documented nights (Nov 1 - Dec 1)
+        # with a self-reported date that bridges back to Jan 5
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2022-11-01'.to_date,
+          exit_date: '2022-12-02'.to_date,
+          date_to_street_essh: '2022-01-05'.to_date, # The "Bridge"
+        )
+
+        @report = setup_report([@es_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'includes the historical nights that are now contiguous via the self-reported bridge' do
+        expect(@report.universe('m1b1').members.count).to eq(1)
+        episode = @report.universe('m1b1').members.first.universe_membership
+
+        # The episode should now start at Jan 1 (the start of the historical enrollment)
+        # because the self-reported date (Jan 5) made it contiguous.
+        expect(episode.first_date).to eq('2022-01-01'.to_date)
+
+        # Total days should be Jan 1 to Dec 1 (inclusive) = 335 days
+        expect(episode.days_homeless).to eq(335)
+      end
+    end
+
     context 'with DateToStreetESSH before lookback stop date AND project entry before lookback stop date' do
       before do
         # Create an ES project

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -598,20 +598,22 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
       end
     end
 
-    context 'when client is not literally homeless at project entry' do
+    context 'when TH client does not meet literal homelessness criteria (3.917.3 should be ignored)' do
       before do
         @th_project = create_project(project_type: 2) # TH
         @client = create_client_with_warehouse_link
 
-        # Client is entering from a non-homeless situation (e.g., Living with friends - 300)
-        # Even if they provide a 3.917.3 date, it should be ignored per spec step 5
+        # Client is entering from living situation 336 (Living with friends)
+        # WITHOUT los_under_threshold or previous_street_essh
+        # Therefore does NOT meet literal homelessness criteria
+        # So 3.917.3 date should be ignored per spec step 5
         create_enrollment(
           client: @client,
           project: @th_project,
           date_to_street_essh: '2022-01-01'.to_date,
           entry_date: '2022-11-01'.to_date,
           exit_date: '2023-01-15'.to_date,
-          living_situation: 300, # Living in a friend's room (not literally homeless)
+          living_situation: 336,
         )
 
         @report = setup_report([@th_project.id])
@@ -620,6 +622,7 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
 
       it 'does not include DateToStreetESSH time' do
         # TH is included in Metric 2 (m1b2), but not Metric 1 (m1b1)
+        expect(@report.universe('m1b1').members.count).to eq(0)
         expect(@report.universe('m1b2').members.count).to eq(1)
         episode = @report.universe('m1b2').members.first.universe_membership
 

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -815,6 +815,70 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
       end
     end
 
+    context 'with enrollment entry date before DOB (erroneous data)' do
+      before do
+        @es_project = create_project(project_type: 0)
+        @client = create_client_with_warehouse_link(dob: '2020-01-01'.to_date)
+
+        # Erroneous enrollment starting before DOB
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2019-01-01'.to_date, # Before DOB
+          exit_date: '2023-02-01'.to_date,  # Active in report
+        )
+
+        @report = setup_report([@es_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'caps homelessness at Date of Birth' do
+        expect(@report.universe('m1a1').members.count).to eq(1)
+        episode = @report.universe('m1a1').members.first.universe_membership
+
+        # First date should be capped at DOB
+        expect(episode.first_date).to eq('2020-01-01'.to_date)
+
+        # Days homeless should be from 2020-01-01 to 2023-01-31 (day before exit)
+        expected_days = ('2023-01-31'.to_date - '2020-01-01'.to_date).to_i + 1
+        expect(episode.days_homeless).to eq(expected_days)
+      end
+    end
+
+    context 'with contiguous walk-back reaching before DOB' do
+      before do
+        @es_project = create_project(project_type: 0)
+        @client = create_client_with_warehouse_link(dob: '2022-11-01'.to_date)
+
+        # Enrollment 1: Active in report
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2022-12-01'.to_date,
+          exit_date: '2023-02-01'.to_date,
+        )
+
+        # Enrollment 2: Contiguous but before DOB (erroneous)
+        create_enrollment(
+          client: @client,
+          project: @es_project,
+          entry_date: '2022-10-15'.to_date,
+          exit_date: '2022-11-02'.to_date, # Overlaps DOB
+        )
+
+        @report = setup_report([@es_project.id])
+        run_measure(@report, HudSpmReport::Generators::Fy2026::MeasureOne)
+      end
+
+      it 'prevents walking back contiguity before DOB' do
+        expect(@report.universe('m1a1').members.count).to eq(1)
+        episode = @report.universe('m1a1').members.first.universe_membership
+
+        # Should start at DOB
+        expect(episode.first_date).to eq('2022-11-01'.to_date)
+      end
+    end
+
     context 'with very old DateToStreetESSH (decades ago)' do
       before do
         # Create an ES project

--- a/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb
@@ -634,22 +634,24 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         @es_project = create_project(project_type: 0)
         @client = create_client_with_warehouse_link
 
-        # Enrollment 1: Historical documented nights (Jan 1 - Jan 10)
+        # Enrollment A: Historical documented nights (Nov 20 - Nov 25, 2021)
+        # This ends before the Client Start Date (Dec 1, 2021)
         create_enrollment(
           client: @client,
           project: @es_project,
-          entry_date: '2022-01-01'.to_date,
-          exit_date: '2022-01-11'.to_date,
+          entry_date: '2021-11-20'.to_date,
+          exit_date: '2021-11-26'.to_date, # Last bed night is 25th
         )
 
-        # Enrollment 2: Active documented nights (Nov 1 - Dec 1)
-        # with a self-reported date that bridges back to Jan 5
+        # Enrollment B: Active documented nights (Nov 1 - Dec 1, 2022)
+        # Client End Date: 2022-12-01
+        # Client Start Date: 2021-12-01
         create_enrollment(
           client: @client,
           project: @es_project,
           entry_date: '2022-11-01'.to_date,
-          exit_date: '2022-12-02'.to_date,
-          date_to_street_essh: '2022-01-05'.to_date, # The "Bridge"
+          exit_date: '2022-12-02'.to_date, # Last bed night is Dec 1st
+          date_to_street_essh: '2021-11-22'.to_date, # The "Bridge"
         )
 
         @report = setup_report([@es_project.id])
@@ -660,12 +662,14 @@ RSpec.describe HudSpmReport::Generators::Fy2026::MeasureOne, type: :model, exclu
         expect(@report.universe('m1b1').members.count).to eq(1)
         episode = @report.universe('m1b1').members.first.universe_membership
 
-        # The episode should now start at Jan 1 (the start of the historical enrollment)
-        # because the self-reported date (Jan 5) made it contiguous.
-        expect(episode.first_date).to eq('2022-01-01'.to_date)
+        # The episode should start at Nov 20 (the start of the historical enrollment)
+        # because the self-reported bridge (starting Nov 22) overlaps the historical
+        # enrollment and connects it to the current episode.
+        expect(episode.first_date).to eq('2021-11-20'.to_date)
 
-        # Total days should be Jan 1 to Dec 1 (inclusive) = 335 days
-        expect(episode.days_homeless).to eq(335)
+        # Total days: Nov 20, 2021 to Dec 1, 2022
+        # (2022-12-01 - 2021-11-20) = 376 days + 1 for inclusive = 377
+        expect(episode.days_homeless).to eq(377)
       end
     end
 

--- a/drivers/hud_spm_report/spec/models/fy2026/shared_context.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/shared_context.rb
@@ -42,6 +42,10 @@ RSpec.shared_context '2026 SPM test setup', shared_context: :metadata do
     # Build ServiceHistoryEnrollments
     GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
 
+    # Prepare report (builds household context)
+    generator = HudSpmReport::Generators::Fy2026::Generator.new(report)
+    generator.prepare_report
+
     # Generate the SpmEnrollment records
     HudSpmReport::Fy2026::SpmEnrollment.create_enrollment_set(report)
 

--- a/drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb
@@ -72,4 +72,36 @@ RSpec.describe HudSpmReport::Fy2026::SpmEnrollment, type: :model, exclude_fixpoi
       expect(child_spm.move_in_date).to eq(@head[:enrollment].move_in_date)
     end
   end
+
+  describe '.create_enrollment_set data isolation' do
+    it 'correctly isolates contexts by data_source_id when EnrollmentIDs collide' do
+      ds1 = create(:source_data_source)
+      ds2 = create(:source_data_source)
+      shared_id = 'ENR-COLLISION-123'
+
+      project1 = create(:hud_project, data_source: ds1, ProjectType: 0)
+      create(:hud_project_coc, project: project1, data_source: ds1, CoCCode: 'MA-500')
+
+      project2 = create(:hud_project, data_source: ds2, ProjectType: 0)
+      create(:hud_project_coc, project: project2, data_source: ds2, CoCCode: 'MA-500')
+
+      client1 = create(:hud_client, data_source: ds1, dob: Date.parse('1990-01-01'))
+      create(:warehouse_client, source: client1)
+      create(:hud_enrollment, data_source: ds1, EnrollmentID: shared_id, PersonalID: client1.PersonalID, ProjectID: project1.ProjectID, EntryDate: '2022-01-01')
+
+      client2 = create(:hud_client, data_source: ds2, dob: Date.parse('1970-01-01'))
+      create(:warehouse_client, source: client2)
+      create(:hud_enrollment, data_source: ds2, EnrollmentID: shared_id, PersonalID: client2.PersonalID, ProjectID: project2.ProjectID, EntryDate: '2022-01-01')
+
+      report = setup_report([project1.id, project2.id])
+
+      spm_enrollments = HudSpmReport::Fy2026::SpmEnrollment.where(report_instance: report).index_by(&:data_source_id)
+
+      expect(spm_enrollments.count).to eq(2)
+
+      # We expect this to fail if the bug exists (one will have the wrong age due to collision)
+      expect(spm_enrollments[ds1.id].age).to eq(32)
+      expect(spm_enrollments[ds2.id].age).to eq(52)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Summary
Refactor `HudSpmReport::Fy2026::Episode` to fix logic bugs and ensure strict compliance with HUD SPM FY2026 Length of Time (LOT) specifications.

## Changes
- **Fixed "Broken Bridge" Bug (Measure 1b)**: Combined documented and self-reported bed nights *before* filtering. This ensures historical nights are not discarded if they are bridged by 3.917 data (Step 5).
- Restricted self-reported data inclusion to clients "Literally Homeless at Project Entry (Step 5)."
- **Anchored `client_end_date` (Step 3)**: Fixed lookback window calculation by explicitly anchoring to the latest homeless night within the reporting period.
- Expanded criteria for Literal Homelessness to include living situation codes `0-99` per the latest HUD Reporting Glossary.
-  Implemented capping to exclude any bed nights occurring before the client's Date of Birth.
- Replaced bed night tuples with a `CandidateBedNight` struct, improved readability and  deterministic sorting
- Simplified compute_episode_statistics as the input is already sorted and unique by date from filter_episode

## Tests
Verified via `measure_1b_spec.rb`:
- [x] 3.917 data correctly bridges gaps to historical stays.
- [x] Self-reported dates are ignored for non-literally homeless entries.
- [x] Episodes are skipped if no homeless nights fall within the report range.
- [x] Bed nights before client DOB are correctly excluded.
- [x] Updated literal homelessness codes (0-99) are correctly processed.

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
