### PR TITLE
7767 PIT parenting youth classification for HOH and missing DOB

### DIFF
--- a/docs/features/hud-pit-report.md
+++ b/docs/features/hud-pit-report.md
@@ -1,0 +1,50 @@
+# HUD PIT Report
+
+The HUD Point-in-Time (PIT) Report provides a snapshot of homelessness on a single night. It aggregates data for sheltered and unsheltered individuals across various project types.
+
+## Architecture
+
+The PIT report follows the [HUD Report Framework](hud-report-framework.md) but uses a "Lazy Shared Universe" pattern for data processing.
+
+### Core Components
+
+- **Generator**: `HudPit::Generators::Pit::Fy2025::Generator` orchestrates the report execution.
+- **Snapshot Model**: `HudPit::Fy2025::PitClient` caches calculated client-level data (age, race, chronic status, etc.) for the specific PIT date.
+- **Base Question**: `HudPit::Generators::Pit::Fy2025::Base` contains the logic for populating the `PitClient` snapshot and shared calculation methods.
+- **Questions**: Individual classes (e.g., `AdultAndChild`, `Adults`, `Children`) define specific report sections, their row labels, and project type filters.
+
+### Data Processing Pipeline
+
+1.  **Initialization**: The report is initialized with a specific date (`on`), CoC codes, and project filters.
+2.  **Universe Population (Lazy)**: The first question that runs triggers the `add` method in `HudPit::Generators::Pit::Fy2025::Base`.
+    - It identifies all clients in residential projects on the PIT date.
+    - It filters out clients with a Permanent Housing (PH) move-in date on or before the PIT date.
+    - It calculates derived attributes (e.g., `chronically_homeless`, `pit_race`, `household_type`).
+    - It saves these records to the `hud_pit_pit_clients` table (via `PitClient`).
+3.  **Question Execution**: Each question filters the shared `PitClient` universe (using `filter_pending_associations`) and aggregates data into report cells.
+4.  **Aggregation**: Results are stored in `HudReports::ReportCell` and linked to `PitClient` records via `HudReports::UniverseMember`.
+
+## Key Logic
+
+### PIT Race Calculation
+The report uses a specific race vocabulary defined by HUD for PIT. This is implemented in `HudPit::Fy2025::PitClient.pit_race`. It handles combinations of races and Hispanic/Latina/e/o ethnicity differently than standard HUD reports.
+
+### Household Composition
+Household types (e.g., `adults_and_children`, `adults_only`, `children_only`) are calculated based on the members present in the household on the PIT date.
+
+### Project Types
+The report includes the following project types:
+- **Emergency Shelter (ES)**: Codes 0, 1
+- **Transitional Housing (TH)**: Code 2
+- **Safe Haven (SH)**: Code 8
+- **Street Outreach (SO)**: Code 4
+
+## Entry Points
+
+- **Generator**: `drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/generator.rb`
+- **Controller Concern**: `drivers/hud_pit/app/controllers/hud_pit/pit_concern.rb`
+
+## Related Documentation
+
+- [HUD Report Framework](hud-report-framework.md)
+- [HUD Utility 2024](../../lib/util/hud_utility_2024.rb) (Used for race and project type definitions)

--- a/drivers/hud_pit/README.md
+++ b/drivers/hud_pit/README.md
@@ -1,3 +1,5 @@
 ## HUD Point in Time Count (PIT)
 
-HUD Report to generate data to be entered for the PIT. As of the 2022 PIT, there are no programing specs.
+HUD Report to generate data to be entered for the PIT. As of the 2022 PIT, there are no programming specs.
+
+see docs/features/hud-pit-report.md

--- a/drivers/hud_pit/app/models/hud_pit/fy2025/pit_client.rb
+++ b/drivers/hud_pit/app/models/hud_pit/fy2025/pit_client.rb
@@ -6,6 +6,7 @@
 
 # frozen_string_literal: true
 
+# @see docs/features/hud-pit-report.md
 # This is a wrapper around PIT Clients to associate version-specific logic with a name space,
 # it does not use STI as there is no per-instance behavior associated with these models
 module HudPit::Fy2025

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -44,7 +44,7 @@ module HudPit::Generators::Pit::Fy2025
       @universe ||= @report.universe(self.class.question_number)
     end
 
-    private def add # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    private def add
       pit_date = @generator.filter.on
       @generator.client_scope.find_in_batches(batch_size: batch_size) do |batch|
         enrollments_by_client_id = clients_with_enrollments(batch)
@@ -115,14 +115,12 @@ module HudPit::Generators::Pit::Fy2025
             # age related hh calculations
             member_relationship_to_hoh = member['relationship_to_hoh']
             member_age = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: member['dob'])
+            next unless member_age
 
             # Record max age for the household to determine if it's a youth household
-            if member_age.present?
-              hh_max_age = member_age if member_age > hh_max_age
-              hh_max_age_of_parents = member_age if member_relationship_to_hoh.in?([1, 3]) && member_age > hh_max_age_of_parents
-            end
-
-            hh_has_minor_children = true if member_relationship_to_hoh == 2 && member_age.present? && member_age < 18
+            hh_max_age = member_age if member_age > hh_max_age
+            hh_has_minor_children = true if member_relationship_to_hoh == 2 && member_age < 18
+            hh_max_age_of_parents = member_age if member_relationship_to_hoh.in?([1, 3]) && member_age > hh_max_age_of_parents
           end
 
           options = {

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -8,6 +8,7 @@
 
 # frozen_string_literal: true
 
+# @see docs/features/hud-pit-report.md
 # PIT Notes
 #   CoCs should report on people based on where they are sleeping on the night of the count, as opposed to the program they are enrolled in.
 #    RRH + PH (don't count)

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -44,7 +44,7 @@ module HudPit::Generators::Pit::Fy2025
       @universe ||= @report.universe(self.class.question_number)
     end
 
-    private def add
+    private def add # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       pit_date = @generator.filter.on
       @generator.client_scope.find_in_batches(batch_size: batch_size) do |batch|
         enrollments_by_client_id = clients_with_enrollments(batch)
@@ -115,11 +115,14 @@ module HudPit::Generators::Pit::Fy2025
             # age related hh calculations
             member_relationship_to_hoh = member['relationship_to_hoh']
             member_age = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: member['dob'])
-            next unless member_age
 
-            hh_max_age = member_age if member_age > hh_max_age
-            hh_has_minor_children = true if member_relationship_to_hoh == 2 && member_age < 18
-            hh_max_age_of_parents = member_age if member_relationship_to_hoh.in?([1, 3]) && member_age > hh_max_age_of_parents
+            # Record max age for the household to determine if it's a youth household
+            if member_age.present?
+              hh_max_age = member_age if member_age > hh_max_age
+              hh_max_age_of_parents = member_age if member_relationship_to_hoh.in?([1, 3]) && member_age > hh_max_age_of_parents
+            end
+
+            hh_has_minor_children = true if member_relationship_to_hoh == 2 && member_age.present? && member_age < 18
           end
 
           options = {

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/generator.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/generator.rb
@@ -6,6 +6,7 @@
 
 # frozen_string_literal: true
 
+# @see docs/features/hud-pit-report.md
 module  HudPit::Generators::Pit::Fy2025
   class Generator < ::HudReports::GeneratorBase
     cattr_accessor :write_detail_path

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/parenting_youth.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/parenting_youth.rb
@@ -12,9 +12,15 @@ module HudPit::Generators::Pit::Fy2025
 
     def self.filter_pending_associations(pending_associations)
       pending_associations.filter do |_, row|
-        row[:hoh_age]&.between?(12, 24) && # HoH is between 12 and 24
-        row[:max_age]&.<(25) && # No one over the age of 24
-        row[:household_has_minor_children] # a minor has a child relationship to the HoH
+        # Youth Household criteria:
+        # 1. At least one member is known to be 12-24.
+        next false unless row[:max_age].present? && row[:max_age].between?(12, 24)
+
+        # 2. No member is known to be 25 or older.
+        # (Already covered by max_age.between?(12, 24))
+
+        # 3. Must have child household members (confirmed age < 18 and relationship 2)
+        row[:household_has_minor_children]
       end
     end
 

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/parenting_youth.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/parenting_youth.rb
@@ -13,11 +13,11 @@ module HudPit::Generators::Pit::Fy2025
     def self.filter_pending_associations(pending_associations)
       pending_associations.filter do |_, row|
         # Youth Household criteria:
-        # 1. At least one member is known to be 12-24.
-        next false unless row[:max_age].present? && row[:max_age].between?(12, 24)
+        # 1. At least one "parent" (relation to hoh 1 or 3) is known to be 12-24.
+        next false unless row[:household_max_age_of_parents]&.between?(12, 24)
 
         # 2. No member is known to be 25 or older.
-        # (Already covered by max_age.between?(12, 24))
+        next false if row[:max_age] && row[:max_age] > 24
 
         # 3. Must have child household members (confirmed age < 18 and relationship 2)
         row[:household_has_minor_children]

--- a/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb
+++ b/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb
@@ -680,5 +680,95 @@ RSpec.describe 'PIT Parenting Youth Counts', type: :model do
     end
   end
 
-  # Tests for parenting youth counts
+  describe 'Unknown Ages' do
+    context 'when HoH age is unknown' do
+      # Household:
+      # - HoH: age unknown (missing DOB)
+      # - Spouse: age 20 (youth)
+      # - Child: age 5
+      # Expected: 2 Parenting Youth (HoH and Spouse are parents, both < 25)
+
+      before do
+        household_id = 'py_hoh_age_unknown'
+        hoh_client = create_client_with_warehouse_link(uid: 'py_hoh_unknown', dob: nil)
+        create_enrollment(client: hoh_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_hoh, household_id: household_id)
+
+        spouse_client = create_client_with_warehouse_link(uid: 'py_spouse_20', dob: pit_date - 20.years)
+        create_enrollment(client: spouse_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_spouse, household_id: household_id)
+
+        child_client = create_client_with_warehouse_link(uid: 'py_child_5', dob: dob_child_5)
+        create_enrollment(client: child_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_child, household_id: household_id)
+      end
+
+      it 'counts parenting youth even when HoH age is unknown' do
+        report = run_report(questions: [question])
+        parent_count = report_value(report, question: question, row: :total_parents)
+        expect(parent_count).to eq(2)
+      end
+    end
+
+    context 'when child age is unknown' do
+      # Household:
+      # - HoH: age 20 (youth)
+      # - Child: age unknown (missing DOB)
+      # Expected: 0 Parenting Youth (child age must be known < 18)
+
+      before do
+        household_id = 'py_child_age_unknown'
+        hoh_client = create_client_with_warehouse_link(uid: 'py_hoh_20', dob: pit_date - 20.years)
+        create_enrollment(client: hoh_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_hoh, household_id: household_id)
+
+        child_client = create_client_with_warehouse_link(uid: 'py_child_unknown', dob: nil)
+        create_enrollment(client: child_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_child, household_id: household_id)
+      end
+
+      it 'does not count as parenting youth when child age is unknown' do
+        report = run_report(questions: [question])
+        parent_count = report_value(report, question: question, row: :total_parents)
+        expect(parent_count).to eq(0)
+      end
+    end
+
+    context 'Scenario A: HOH (unknown age) + Child age 5 (relationship = 2)' do
+      # - Youth Household: No — requires at least one member *known* to be 12–24; the 5-year-old is too young and the HOH's age is unknown
+      # - Parenting Youth: No — not a youth household
+      # - Household Type: Unknown
+
+      before do
+        household_id = 'py_scenario_a'
+        hoh_client = create_client_with_warehouse_link(uid: 'py_hoh_unknown_a', dob: nil)
+        create_enrollment(client: hoh_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_hoh, household_id: household_id)
+        child_client = create_client_with_warehouse_link(uid: 'py_child_5_a', dob: dob_child_5)
+        create_enrollment(client: child_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_child, household_id: household_id)
+      end
+
+      it 'is not counted as a youth household or parenting youth' do
+        report = run_report(questions: [question])
+        hh_count = report_value(report, question: question, row: :households)
+        expect(hh_count).to eq(0)
+      end
+    end
+
+    context 'Scenario B: HOH (unknown age) + Child age 12 (relationship = 2)' do
+      # - Youth Household: Yes — the 12-year-old satisfies the "known to be >= 12 and <= 24" requirement; unknown-age HOH doesn't disqualify
+      # - Parenting Youth: No — the 12-year-old is a youth but is the child, not the parent; the HOH is the parent but their age is unknown so they can't be confirmed as a youth
+      # - Household Type: Unknown
+
+      before do
+        household_id = 'py_scenario_b'
+        hoh_client = create_client_with_warehouse_link(uid: 'py_hoh_unknown_b', dob: nil)
+        create_enrollment(client: hoh_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_hoh, household_id: household_id)
+        child_client = create_client_with_warehouse_link(uid: 'py_child_12_b', dob: pit_date - 12.years)
+        create_enrollment(client: child_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_child, household_id: household_id)
+      end
+
+      it 'is counted as a youth household but has 0 parenting youth' do
+        report = run_report(questions: [question])
+        hh_count = report_value(report, question: question, row: :households)
+        parent_count = report_value(report, question: question, row: :total_parents)
+        expect(hh_count).to eq(1)
+        expect(parent_count).to eq(0)
+      end
+    end
+  end
 end

--- a/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb
+++ b/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb
@@ -704,6 +704,8 @@ RSpec.describe 'PIT Parenting Youth Counts', type: :model do
         report = run_report(questions: [question])
         parent_count = report_value(report, question: question, row: :total_parents)
         expect(parent_count).to eq(2)
+        youth_parent_count = report_value(report, question: question, row: :parenting_youth_18_24)
+        expect(youth_parent_count).to eq(1)
       end
     end
 
@@ -744,29 +746,28 @@ RSpec.describe 'PIT Parenting Youth Counts', type: :model do
 
       it 'is not counted as a youth household or parenting youth' do
         report = run_report(questions: [question])
-        hh_count = report_value(report, question: question, row: :households)
+        hh_count = report_value(report, question: question, row: :total_households)
         expect(hh_count).to eq(0)
       end
     end
 
-    context 'Scenario B: HOH (unknown age) + Child age 12 (relationship = 2)' do
-      # - Youth Household: Yes — the 12-year-old satisfies the "known to be >= 12 and <= 24" requirement; unknown-age HOH doesn't disqualify
-      # - Parenting Youth: No — the 12-year-old is a youth but is the child, not the parent; the HOH is the parent but their age is unknown so they can't be confirmed as a youth
+    context 'Scenario B: HOH (unknown age) + Child age 13 (relationship = 2)' do
+      # - Parenting Youth: No — the 13-year-old is a youth but is the child, not the parent; the HOH is the parent but their age is unknown so they can't be confirmed as a youth
       # - Household Type: Unknown
 
       before do
         household_id = 'py_scenario_b'
         hoh_client = create_client_with_warehouse_link(uid: 'py_hoh_unknown_b', dob: nil)
         create_enrollment(client: hoh_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_hoh, household_id: household_id)
-        child_client = create_client_with_warehouse_link(uid: 'py_child_12_b', dob: pit_date - 12.years)
+        child_client = create_client_with_warehouse_link(uid: 'py_child_13_b', dob: pit_date - 13.years)
         create_enrollment(client: child_client, project: es_project, entry_date: pit_date, relationship_to_ho_h: rel_child, household_id: household_id)
       end
 
       it 'is counted as a youth household but has 0 parenting youth' do
         report = run_report(questions: [question])
-        hh_count = report_value(report, question: question, row: :households)
+        hh_count = report_value(report, question: question, row: :total_households)
         parent_count = report_value(report, question: question, row: :total_parents)
-        expect(hh_count).to eq(1)
+        expect(hh_count).to eq(0)
         expect(parent_count).to eq(0)
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Update PIT report logic to include parenting youth households if the HOH has an unknown age but the spouse qualifies as youth (12-24). This interprets "parenting" as implied only by those members with relation-to-hoh of 1 or 3). 

Also added feature documentation for the PIT report

### Type of Change
Bug fix, Documentation

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

