### PR TITLE
Monthly Project Utilization 2026 DS

### DIFF
--- a/db/warehouse/migrate/20260203101104_add_sex_to_ma_monthly_performance_enrollments.rb
+++ b/db/warehouse/migrate/20260203101104_add_sex_to_ma_monthly_performance_enrollments.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddSexToMaMonthlyPerformanceEnrollments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :ma_monthly_performance_enrollments, :sex, :integer
+  end
+end

--- a/drivers/ma_reports/app/controllers/ma_reports/warehouse_reports/monthly_project_utilizations_controller.rb
+++ b/drivers/ma_reports/app/controllers/ma_reports/warehouse_reports/monthly_project_utilizations_controller.rb
@@ -77,7 +77,8 @@ module MaReports::WarehouseReports
     end
 
     def report_options(filter)
-      filter.for_params[:filters].select { |k, _| report_class.report_options.include?(k) }
+      filter_options = filter.for_params[:filters].select { |k, _| report_class.report_options.include?(k) }
+      filter_options.merge(version: report_class.current_version)
     end
 
     private def set_report

--- a/drivers/ma_reports/app/models/ma_reports/monthly_performance/enrollment.rb
+++ b/drivers/ma_reports/app/models/ma_reports/monthly_performance/enrollment.rb
@@ -27,15 +27,15 @@ module MaReports::MonthlyPerformance
       where(exit_date.gteq(range.first).or(exit_date.eq(nil)).and(entry_date.lteq(range.last)))
     end
 
-    def self.detail_headers
+    def self.detail_headers(report = nil)
       # On the details page, only show the race columns stored in the database record
-      headers.
+      headers_for_report(report).
         reject { |k| HudHelper.util.race_ethnicity_combinations.include?(k) }.
         merge(HudHelper.util.races.except('RaceNone').map { |k, v| [k.underscore.to_sym, v] }.to_h)
     end
 
-    def self.headers
-      {
+    def self.headers_for_report(report = nil)
+      base_headers = {
         client_id: 'Warehouse Client ID',
         personal_id: 'HMIS Personal ID',
         first_name: 'First Name',
@@ -63,19 +63,37 @@ module MaReports::MonthlyPerformance
         multi_racial: HudHelper.util.race_ethnicity_combinations[:multi_racial],
         multi_racial_hispanic_latinaeo: HudHelper.util.race_ethnicity_combinations[:multi_racial_hispanic_latinaeo],
         race_none: HudHelper.util.race_ethnicity_combinations[:race_none],
-        man: 'Man',
-        woman: 'Woman',
-        culturally_specific: 'Culturally Specific Identity (e.g., Two-Spirit)',
-        different_identity: 'Different Identity',
-        transgender: 'Transgender',
-        questioning: 'Questioning',
-        non_binary: 'Non-Binary',
+      }
+
+      # Show gender as a default. It was included in the original version of the report
+      show_gender = report.nil? || report.show_gender?
+      show_sex = report&.show_sex? || false
+
+      if show_gender
+        base_headers.merge!(
+          man: 'Man',
+          woman: 'Woman',
+          culturally_specific: 'Culturally Specific Identity (e.g., Two-Spirit)',
+          different_identity: 'Different Identity',
+          transgender: 'Transgender',
+          questioning: 'Questioning',
+          non_binary: 'Non-Binary',
+        )
+      end
+
+      base_headers[:sex] = 'Sex' if show_sex
+
+      base_headers.merge!(
         disabling_condition: 'Disabling Condition',
         reporting_age: 'Reporting Age',
         prior_living_situation: 'Prior Living Situation',
         months_homeless_past_three_years: 'Months homeless in the past three years',
         times_homeless_past_three_years: 'Times homeless in the past three years',
-      }
+      )
+    end
+
+    def self.headers
+      headers_for_report(nil)
     end
   end
 end

--- a/drivers/ma_reports/app/models/ma_reports/monthly_performance/report.rb
+++ b/drivers/ma_reports/app/models/ma_reports/monthly_performance/report.rb
@@ -95,7 +95,9 @@ module MaReports::MonthlyPerformance
     end
 
     def show_gender?
-      report_version < 2026
+      return true if report_version < 2026
+
+      HudHelper.show_gender_in_reports?
     end
 
     def show_sex?

--- a/drivers/ma_reports/app/models/ma_reports/monthly_performance/report.rb
+++ b/drivers/ma_reports/app/models/ma_reports/monthly_performance/report.rb
@@ -21,6 +21,10 @@ module MaReports::MonthlyPerformance
     has_many :enrollments
     has_many :projects
 
+    def self.current_version
+      2026
+    end
+
     private def expires_in
       return 5.days if Rails.env.development?
 
@@ -85,6 +89,19 @@ module MaReports::MonthlyPerformance
       ma_reports_warehouse_reports_monthly_project_utilization_url(host: ENV.fetch('FQDN'), id: id, protocol: 'https')
     end
 
+    def report_version
+      # Legacy report did not include a version - default to 2024
+      options['version'] || 2024
+    end
+
+    def show_gender?
+      report_version < 2026
+    end
+
+    def show_sex?
+      report_version >= 2026
+    end
+
     private def create_universe
       # make create_universe repeatable for testing
       MaReports::MonthlyPerformance::Enrollment.where(report_id: id).delete_all
@@ -135,6 +152,7 @@ module MaReports::MonthlyPerformance
               transgender: client.transgender == 1,
               questioning: client.questioning == 1,
               non_binary: client.non_binary == 1,
+              sex: client.Sex,
               disabling_condition: enrollment.enrollment.disabling_condition == 1,
               reporting_age: age,
               relationship_to_hoh: enrollment.enrollment.relationship_to_ho_h,
@@ -294,16 +312,34 @@ module MaReports::MonthlyPerformance
             count: enrollments_for(*key).count,
           }
         end
-        HudHelper.util.gender_id_to_field_name.
-          reject { |k, _| k.in?([8, 9, 99]) }.
-          each do |gender_id, gender_column|
-            label = HudHelper.util.gender(gender_id)
-            key = ['Gender', gender_column]
-            breakdowns["Gender: #{label}"] = {
-              key: key,
-              count: enrollments_for(*key).count,
-            }
-          end
+        if show_gender?
+          HudHelper.util.gender_id_to_field_name.
+            reject { |k, _| k.in?([8, 9, 99]) }.
+            each do |gender_id, gender_column|
+              label = HudHelper.util.gender(gender_id)
+              key = ['Gender', gender_column]
+              breakdowns["Gender: #{label}"] = {
+                key: key,
+                count: enrollments_for(*key).count,
+              }
+            end
+        end
+        if show_sex?
+          HudHelper.util.sexes.
+            reject { |k, _| k.in?([8, 9, 99]) }.
+            each do |sex_id, label|
+              key = ['Sex', sex_id]
+              breakdowns["Sex: #{label}"] = {
+                key: key,
+                count: enrollments_for(*key).count,
+              }
+            end
+          key = ['Sex', 'Unknown']
+          breakdowns['Sex: Unknown (Missing, Prefers not to answer, Unknown)'] = {
+            key: key,
+            count: enrollments_for(*key).count,
+          }
+        end
         key = ['DisablingCondition', nil]
         breakdowns['Disabling Condition'] = {
           key: key,
@@ -350,9 +386,16 @@ module MaReports::MonthlyPerformance
 
         enrollments.where(id: race_ethnicities_breakdowns(enrollments)[race_ethnicity_combinations[sub_key.to_sym]].to_a)
       when 'Gender'
+        return enrollments.none unless show_gender?
         return enrollments.none unless HudHelper.util.gender_id_to_field_name.value?(sub_key)
 
         enrollments.where(sub_key.to_s.underscore => true)
+      when 'Sex'
+        return enrollments.none unless show_sex?
+        return enrollments.where(sex: [8, 9, 99, nil]) if sub_key == 'Unknown'
+        return enrollments.none unless HudHelper.util.sexes.key?(sub_key.to_i)
+
+        enrollments.where(sex: sub_key.to_i)
       when 'DisablingCondition'
         enrollments.where(disabling_condition: true)
       when 'Age'
@@ -384,7 +427,15 @@ module MaReports::MonthlyPerformance
         label = race_ethnicity_combinations[sub_key.to_sym]
         "#{key}: #{label}"
       when 'Gender'
+        return nil unless show_gender?
+
         label = HudHelper.util.gender(sub_key.to_i)
+        "#{key}: #{label}"
+      when 'Sex'
+        return nil unless show_sex?
+        return "#{key}: Unknown (Missing, Prefers not to answer, Unknown)" if sub_key == 'Unknown'
+
+        label = HudHelper.util.sex(sub_key.to_i)
         "#{key}: #{label}"
       when 'DisablingCondition'
         'Disabling Condition'

--- a/drivers/ma_reports/app/views/ma_reports/warehouse_reports/monthly_project_utilizations/details.haml
+++ b/drivers/ma_reports/app/views/ma_reports/warehouse_reports/monthly_project_utilizations/details.haml
@@ -13,12 +13,12 @@
     %table.table.table-sm.table-bordered.table-fixed.datatable{ style: 'margin-top: 0 !important;'}
       %thead.table-dark
         %tr
-          - MaReports::MonthlyPerformance::Enrollment.detail_headers.each_value do |label|
+          - MaReports::MonthlyPerformance::Enrollment.detail_headers(@report).each_value do |label|
             %th= label
       %tbody
         - @report.enrollments_for(@key, @sub_key).each do |enrollment|
           %tr
-            - MaReports::MonthlyPerformance::Enrollment.detail_headers.each_key do |column|
+            - MaReports::MonthlyPerformance::Enrollment.detail_headers(@report).each_key do |column|
               - # TODO: these should probably get formatted, but we'd like to confirm contents first
               %td= enrollment.public_send(column)
 

--- a/drivers/ma_reports/spec/models/ma_reports/monthly_performance/report_spec.rb
+++ b/drivers/ma_reports/spec/models/ma_reports/monthly_performance/report_spec.rb
@@ -1,0 +1,126 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MaReports::MonthlyPerformance::Report, type: :model do
+  let(:user) { create(:user) }
+  let(:report) { described_class.new(user_id: user.id) }
+
+  describe '.current_version' do
+    it 'returns 2026' do
+      expect(described_class.current_version).to eq(2026)
+    end
+  end
+
+  describe '#report_version' do
+    context 'when version is not set' do
+      it 'defaults to 2024' do
+        report.options = {}
+        expect(report.report_version).to eq(2024)
+      end
+    end
+
+    context 'when version is set to 2026' do
+      it 'returns 2026' do
+        report.options = { 'version' => 2026 }
+        expect(report.report_version).to eq(2026)
+      end
+    end
+  end
+
+  describe '#show_gender?' do
+    context 'when version is not set (defaults to 2024)' do
+      it 'returns true' do
+        report.options = {}
+        expect(report.show_gender?).to be true
+      end
+    end
+
+    context 'when version is 2026' do
+      it 'returns false' do
+        report.options = { 'version' => 2026 }
+        expect(report.show_gender?).to be false
+      end
+    end
+  end
+
+  describe '#show_sex?' do
+    context 'when version is not set (defaults to 2024)' do
+      it 'returns false' do
+        report.options = {}
+        expect(report.show_sex?).to be false
+      end
+    end
+
+    context 'when version is 2026' do
+      it 'returns true' do
+        report.options = { 'version' => 2026 }
+        expect(report.show_sex?).to be true
+      end
+    end
+  end
+
+  describe '#demographic_breakdowns' do
+    let(:mock_relation) do
+      double('Relation').tap do |rel|
+        allow(rel).to receive(:select).and_return(rel)
+        allow(rel).to receive(:distinct).and_return(rel)
+        allow(rel).to receive(:count).and_return(5)
+      end
+    end
+
+    before do
+      report.save!
+      allow(report).to receive(:enrollments_for).and_return(mock_relation)
+    end
+
+    context 'when show_gender? is true' do
+      before do
+        Rails.cache.clear
+        allow(report).to receive(:show_gender?).and_return(true)
+        allow(report).to receive(:show_sex?).and_return(false)
+      end
+
+      it 'includes gender breakdowns' do
+        breakdowns = report.demographic_breakdowns
+        gender_keys = breakdowns.keys.select { |k| k.start_with?('Gender:') }
+        expect(gender_keys).not_to be_empty
+      end
+
+      it 'excludes sex breakdowns' do
+        breakdowns = report.demographic_breakdowns
+        sex_keys = breakdowns.keys.select { |k| k.start_with?('Sex:') }
+        expect(sex_keys).to be_empty
+      end
+    end
+
+    context 'when show_sex? is true' do
+      before do
+        Rails.cache.clear
+        allow(report).to receive(:show_gender?).and_return(false)
+        allow(report).to receive(:show_sex?).and_return(true)
+      end
+
+      it 'includes sex breakdowns' do
+        breakdowns = report.demographic_breakdowns
+        sex_keys = breakdowns.keys.select { |k| k.start_with?('Sex:') }
+        expect(sex_keys).not_to be_empty
+        expect(sex_keys).to include('Sex: Male')
+        expect(sex_keys).to include('Sex: Female')
+        expect(sex_keys).to include('Sex: Unknown (Missing, Prefers not to answer, Unknown)')
+      end
+
+      it 'excludes gender breakdowns' do
+        breakdowns = report.demographic_breakdowns
+        gender_keys = breakdowns.keys.select { |k| k.start_with?('Gender:') }
+        expect(gender_keys).to be_empty
+      end
+    end
+  end
+end

--- a/drivers/ma_reports/spec/models/ma_reports/monthly_performance/report_spec.rb
+++ b/drivers/ma_reports/spec/models/ma_reports/monthly_performance/report_spec.rb
@@ -35,17 +35,34 @@ RSpec.describe MaReports::MonthlyPerformance::Report, type: :model do
   end
 
   describe '#show_gender?' do
-    context 'when version is not set (defaults to 2024)' do
-      it 'returns true' do
+    after do
+      AppConfigProperty.find_by(key: 'show_gender_in_reports')&.destroy
+    end
+
+    context 'when version is prior to 2026' do
+      it 'returns true regardless of app config' do
         report.options = {}
         expect(report.show_gender?).to be true
       end
     end
 
-    context 'when version is 2026' do
-      it 'returns false' do
-        report.options = { 'version' => 2026 }
-        expect(report.show_gender?).to be false
+    context 'when version is 2026 or later' do
+      context 'when show_gender_in_reports property is not set' do
+        it 'returns false (default)' do
+          report.options = { 'version' => 2026 }
+          expect(report.show_gender?).to be false
+        end
+      end
+
+      context 'when show_gender_in_reports property is true' do
+        before do
+          AppConfigProperty.create!(key: 'show_gender_in_reports', value: true)
+        end
+
+        it 'returns true' do
+          report.options = { 'version' => 2026 }
+          expect(report.show_gender?).to be true
+        end
       end
     end
   end

--- a/lib/util/hud_helper.rb
+++ b/lib/util/hud_helper.rb
@@ -98,5 +98,14 @@ module HudHelper
     def staging_cutoff
       Date.new(2025, 9, 1)
     end
+
+    # Check if gender should be shown in reports
+    # @return [Boolean] true if gender should be shown
+    def show_gender_in_reports?
+      property = AppConfigProperty.find_by(key: 'show_gender_in_reports')
+      return false if property.nil?
+
+      property.value == true
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Add a metadata version for the Monthly Project Utilization report. This allows us to show gender/sex based on the version of the report. This is defaulting to 2024 to account for legacy reports and new reports are getting flagged with the 2026 version. Legacy (2024) reports will show gender and not sex and current (2026) will show sex and not gender.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
