### PR TITLE
Performance Measurement Age range hotfix

### DIFF
--- a/drivers/performance_measurement/app/models/performance_measurement/equity_analysis/age_data.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/equity_analysis/age_data.rb
@@ -26,14 +26,19 @@ module PerformanceMeasurement::EquityAnalysis
 
     def client_scope(period, investigate_by)
       age_range = census_age_range_to_range(investigate_by.to_sym)
-      ages = age_range.to_a
       age_column = case period
       when 'reporting'
         :reporting_age
       else
         :comparison_age
       end
-      metric_scope(period).where(age_column => ages)
+
+      # Handle infinity ranges for 85+ age group
+      if age_range.end == Float::INFINITY
+        metric_scope(period).where(age_column => age_range.begin..)
+      else
+        metric_scope(period).where(age_column => age_range)
+      end
     end
   end
 end

--- a/drivers/performance_measurement/app/models/performance_measurement/equity_analysis/data.rb
+++ b/drivers/performance_measurement/app/models/performance_measurement/equity_analysis/data.rb
@@ -234,14 +234,28 @@ module PerformanceMeasurement::EquityAnalysis
     def apply_params(scope, period)
       if age_params.any?
         age_ranges = age_params.map { |d| census_age_range_to_range(d) }
-        ages = age_ranges.flat_map(&:to_a).uniq
         age_column = case period
         when 'reporting'
           :reporting_age
         else
           :comparison_age
         end
-        scope = scope.where(age_column => ages)
+
+        # Separate finite and infinite ranges (only 85+ is infinite)
+        finite_ranges = age_ranges.reject { |r| r.end == Float::INFINITY }
+        infinite_range = age_ranges.find { |r| r.end == Float::INFINITY }
+
+        # Process finite ranges
+        if finite_ranges.any?
+          ages = finite_ranges.flat_map(&:to_a).uniq
+          scope = scope.where(age_column => ages)
+        end
+
+        # Add infinite range (85+) if present
+        if infinite_range
+          infinite_where = scope.where(age_column => infinite_range.begin..)
+          scope = finite_ranges.any? ? scope.or(infinite_where) : infinite_where
+        end
       end
 
       if gender_params.any?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixed timeout when selecting 85+ age in equity analysis by preventing infinite array creation. The code was trying to convert 85..Float::INFINITY to an array with .to_a, which loops forever.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
