### PR TITLE
8775 hopwa caper strmu update

### DIFF
--- a/drivers/hopwa_caper/app/controllers/hopwa_caper/cells_controller.rb
+++ b/drivers/hopwa_caper/app/controllers/hopwa_caper/cells_controller.rb
@@ -18,6 +18,10 @@ module HopwaCaper
         preload(enrollment: :project).
         joins(hud_reports_universe_members: { report_cell: :report_instance }).
         merge(::HudReports::ReportCell.for_table(@table).for_cell(@cell))
+      @services = @report.hopwa_caper_services.
+        preload(enrollment: { enrollment: :project }).
+        joins(hud_reports_universe_members: { report_cell: :report_instance }).
+        merge(::HudReports::ReportCell.for_table(@table).for_cell(@cell))
       @name = "#{generator.file_prefix} #{@question} #{@cell}"
       respond_to do |format|
         format.html {}

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/service_filters/strmu_service_type_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/service_filters/strmu_service_type_filter.rb
@@ -33,7 +33,7 @@ module HopwaCaper::Generators::Fy2026::ServiceFilters
           types: ['Rental assistance', 'Security deposits'],
         ),
         new(
-          label: 'utilities assistance',
+          label: 'utility assistance',
           types: ['Utility deposits', 'Utility payments'],
         ),
       ]

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -103,11 +103,11 @@ module HopwaCaper::Generators::Fy2026::Sheets
       sheet.append_row(label: 'What were the HOPWA funds expended for the following budget line items?')
       total_expenditures = 0
       service_type_filters.all.each do |filter|
-        expenditures = filter.apply(relevant_services).sum(:fa_amount)
-        total_expenditures += expenditures
-
         sheet.append_row(label: "STRMU #{filter.label}") do |row|
-          row.append_cell_value(value: expenditures)
+          services = filter.apply(relevant_services)
+          value = services.sum(&:fa_amount)
+          total_expenditures += value
+          row.append_cell_members(value: value, members: services.as_report_members)
         end
       end
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -101,10 +101,19 @@ module HopwaCaper::Generators::Fy2026::Sheets
 
     def expenditures_sheet(sheet)
       sheet.append_row(label: 'What were the HOPWA funds expended for the following budget line items?')
+      total_expenditures = 0
       service_type_filters.all.each do |filter|
-        sheet.append_row(label: "STRMU #{filter.label}")
+        expenditures = filter.apply(relevant_services).sum(:fa_amount)
+        total_expenditures += expenditures
+
+        sheet.append_row(label: "STRMU #{filter.label}") do |row|
+          row.append_cell_value(value: expenditures)
+        end
       end
-      sheet.append_row(label: 'Total STRMU Expenditures')
+
+      sheet.append_row(label: 'Total STRMU Expenditures') do |row|
+        row.append_cell_value(value: total_expenditures)
+      end
     end
 
     def longevity_sheet(sheet)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/service.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/service.rb
@@ -40,10 +40,15 @@ module HopwaCaper
     scope :hud_services, -> { where(service_source: HUD_SERVICE_SOURCE) }
     scope :custom_services, -> { where(service_source: CUSTOM_SERVICE_SOURCE) }
 
-    delegate :first_name, :last_name, :personal_id, :hmis_enrollment_id, to: :enrollment
+    delegate :first_name, :last_name, :personal_id, :hmis_enrollment_id, :project_id, to: :enrollment
 
-    def project_id
-      enrollment.project.id
+    def self.as_report_members
+      current_scope.map do |record|
+        ::HudReports::UniverseMember.new(
+          universe_membership_type: sti_name,
+          universe_membership_id: record.id,
+        )
+      end
     end
 
     def self.from_hud_service(service:, enrollment:, report:, client:)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/service_drilldown_presenter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/service_drilldown_presenter.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module HopwaCaper
+  class ServiceDrilldownPresenter
+    Field = Struct.new(:name, :label, :transform, :not_collected, keyword_init: true)
+
+    def initialize(records, report, user, format: :html)
+      @records = records
+      @report = report
+      @user = user
+      @format = format
+      @services_by_client = {}
+      @field_map = service_fields
+    end
+
+    def headers
+      @field_map.values.map { |f| [f.name, f.label || f.name.humanize] }.to_h
+    end
+
+    def display_value(record, field_name)
+      field = @field_map[field_name.to_s]
+      return record.send(field_name).humanize if field.nil? # Fallback for unexpected fields
+
+      value = record.send(field.name)
+      value = record[field.name] if value.nil? && record.respond_to?(:[]) && record.class.column_names.include?(field.name.to_s)
+
+      pii_policy = pii_policy_for(record)
+
+      if value.is_a?(Array)
+        items = value.map { |v| transform_value(field, v, record, pii_policy) }
+        return items.join("\n") unless html?
+
+        return helpers.content_tag(:ul, class: 'list-unstyled mb-0') do
+          items.map { |v| helpers.content_tag(:li, v) }.join.html_safe
+        end
+      end
+
+      return Reports::ModelApplicationHelper.new.yes_no(value, include_content_tag: html?) if value.in?([true, false])
+
+      transform_value(field, value, record, pii_policy)
+    end
+
+    private
+
+    def service_fields
+      @service_fields ||= [
+        Field.new(name: 'personal_id', label: 'HMIS Personal ID'),
+        Field.new(name: 'hmis_enrollment_id', label: 'HMIS Enrollment ID'),
+        Field.new(name: 'first_name', transform: ->(v, poly) { GrdaWarehouse::PiiProvider.viewable_name(v, policy: poly) }),
+        Field.new(name: 'last_name', transform: ->(v, poly) { GrdaWarehouse::PiiProvider.viewable_name(v, policy: poly) }),
+        Field.new(name: 'destination_client_id', label: 'Warehouse Client ID'),
+        Field.new(name: 'service_id', label: 'HMIS Service ID'),
+        Field.new(name: 'date_provided', label: 'Date Provided'),
+        Field.new(name: 'fa_amount', label: 'FA Amount'),
+        # Field.new(name: 'service_source', label: 'Service Source'),
+        Field.new(name: 'service_category_name', label: 'Service Category'),
+        Field.new(name: 'service_type_name', label: 'Service Type'),
+      ].index_by(&:name).freeze
+    end
+
+    def transform_value(field, value, _record, pii_policy)
+      # Treat nil as 99 (Data not collected) for HUD fields that support it
+      value = 99 if value.nil? && field.not_collected
+
+      if field.transform.respond_to?(:call)
+        field.transform.call(value, pii_policy)
+      else
+        value
+      end
+    end
+
+    def pii_policy_for(record)
+      @user.reporting_policy_for_project(
+        project_id: record.project_id,
+        mode: html? ? :browse : :download,
+      )
+    end
+
+    def html?
+      @format == :html
+    end
+
+    def helpers
+      ActionController::Base.helpers
+    end
+
+    def hud_helper
+      @hud_helper ||= HudHelper.util('2026')
+    end
+  end
+end

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/_list.haml
@@ -1,6 +1,6 @@
 - project_ids = list.map(&:project_id).uniq
 - current_user.policy_context.preload_project_dependencies(project_ids)
-- presenter = HopwaCaper::DrilldownPresenter.new(list, @report, current_user, format: :html)
+- presenter = presenter_class.new(list, @report, current_user, format: :html)
 - display_headers = presenter.headers
 .card
   .overflow-x-scroll

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
@@ -12,7 +12,11 @@
 
 - if @enrollments.any?
   %h3 Enrollments
-  = render_paginated_list(scope: @enrollments, item_name: 'enrollment', list_partial: 'list')
+  = render_paginated_list(scope: @enrollments, item_name: 'enrollment', list_partial: 'list', list_locals: {presenter_class: HopwaCaper::DrilldownPresenter})
 
-- if @enrollments.empty?
+- elsif @services.any?
+  %h3 Services
+  = render_paginated_list(scope: @services, item_name: 'service', list_partial: 'list', list_locals: {presenter_class: HopwaCaper::ServiceDrilldownPresenter})
+
+- else @enrollments.empty?
   .none-found No records found.

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.haml
@@ -18,5 +18,5 @@
   %h3 Services
   = render_paginated_list(scope: @services, item_name: 'service', list_partial: 'list', list_locals: {presenter_class: HopwaCaper::ServiceDrilldownPresenter})
 
-- else @enrollments.empty?
+- else
   .none-found No records found.

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
@@ -4,14 +4,22 @@ wb = xlsx_package.workbook
 wb.add_worksheet(name: @name.slice(0, 30).gsub(':', ' ')) do |sheet|
   title = sheet.styles.add_style(sz: 12, b: true, alignment: { horizontal: :center })
 
-  project_ids = @enrollments.map(&:project_id).uniq
+  if @enrollments.any?
+    list = @enrollments
+    presenter_class = HopwaCaper::DrilldownPresenter
+  elsif @services.any?
+    list = @services
+    presenter_class = HopwaCaper::ServiceDrilldownPresenter
+  end
+
+  project_ids = list.map(&:project_id).uniq
   current_user.policy_context.preload_project_dependencies(project_ids)
 
-  presenter = HopwaCaper::DrilldownPresenter.new(@enrollments, @report, current_user, format: :excel)
+  presenter = presenter_class.new(list, @report, current_user, format: :excel)
   headers = presenter.headers
   sheet.add_row(headers.values, style: title)
 
-  @enrollments.each do |record|
+  list.each do |record|
     row = headers.keys.map { |k| presenter.display_value(record, k) }
     sheet.add_row(row)
   end

--- a/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
+++ b/drivers/hopwa_caper/app/views/hopwa_caper/cells/show.xlsx.axlsx
@@ -12,15 +12,17 @@ wb.add_worksheet(name: @name.slice(0, 30).gsub(':', ' ')) do |sheet|
     presenter_class = HopwaCaper::ServiceDrilldownPresenter
   end
 
-  project_ids = list.map(&:project_id).uniq
-  current_user.policy_context.preload_project_dependencies(project_ids)
+  if list
+    project_ids = list.map(&:project_id).uniq
+    current_user.policy_context.preload_project_dependencies(project_ids)
 
-  presenter = presenter_class.new(list, @report, current_user, format: :excel)
-  headers = presenter.headers
-  sheet.add_row(headers.values, style: title)
+    presenter = presenter_class.new(list, @report, current_user, format: :excel)
+    headers = presenter.headers
+    sheet.add_row(headers.values, style: title)
 
-  list.each do |record|
-    row = headers.keys.map { |k| presenter.display_value(record, k) }
-    sheet.add_row(row)
+    list.each do |record|
+      row = headers.keys.map { |k| presenter.display_value(record, k) }
+      sheet.add_row(row)
+    end
   end
 end

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
         data_source: data_source,
       )
 
-      # Household 2: receives only utilities assistance (single type)
+      # Household 2: receives only utility assistance (single type)
       create(
         :hud_service,
         enrollment: household2_enrollment,
@@ -176,8 +176,17 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
       _, rows = run_and_extract_rows([project], 'Q3')
 
       expect(rows.fetch('STRMU Households Total')).to eq(2)
-      expect(rows.fetch('How many households were served with STRMU utilities assistance only?')).to eq(1)
+      expect(rows.fetch('How many households were served with STRMU utility assistance only?')).to eq(1)
       expect(rows.fetch('How many households received more than one type of STRMU assistance?')).to eq(1)
+    end
+
+    it 'correctly reports expenditures' do
+      _, rows = run_and_extract_rows([project], 'Q3')
+
+      expect(rows.fetch('STRMU mortgage assistance').to_f).to eq(0)
+      expect(rows.fetch('STRMU rental assistance').to_f).to eq(500)
+      expect(rows.fetch('STRMU utility assistance').to_f).to eq(250)
+      expect(rows.fetch('Total STRMU Expenditures').to_f).to eq(750)
     end
 
     it 'correctly categorizes a client with multiple enrollments and different service types' do
@@ -226,10 +235,23 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
       # This client should be in "more than one type" (total 2: household1 and this client)
       expect(rows.fetch('How many households received more than one type of STRMU assistance?')).to eq(2)
 
-      # They should NOT be in "mortgage assistance only" or "utilities assistance only"
+      # They should NOT be in "mortgage assistance only" or "utility assistance only"
       expect(rows.fetch('How many households were served with STRMU mortgage assistance only?')).to eq(0)
-      # (household2 is still utilities only)
-      expect(rows.fetch('How many households were served with STRMU utilities assistance only?')).to eq(1)
+      # (household2 is still utility only)
+      expect(rows.fetch('How many households were served with STRMU utility assistance only?')).to eq(1)
+
+      # Expenditures check for all 3 households:
+      # Household 1: Rental (500), Utility (150)
+      # Household 2: Utility (100)
+      # Client (Household 3/4): Mortgage (500), Utility (100)
+      # Total Mortgage: 500
+      # Total Rental: 500
+      # Total Utility: 150 + 100 + 100 = 350
+      # Grand Total: 500 + 500 + 350 = 1350
+      expect(rows.fetch('STRMU mortgage assistance').to_f).to eq(500)
+      expect(rows.fetch('STRMU rental assistance').to_f).to eq(500)
+      expect(rows.fetch('STRMU utility assistance').to_f).to eq(350)
+      expect(rows.fetch('Total STRMU Expenditures').to_f).to eq(1350)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Adds drilldown support for STRMU expenditures and fixes reporting labels in the FY2026 HOPWA CAPER report.

- **STRMU Sheet**: Calculate expenditure totals
- **Cell Drilldown View**:  support both enrollment and service-based drilldowns with appropriate presenters.
- **STRMU Service Filter**: Corrected "utilities assistance" label
- **Excel Export**: Support spreadsheet generation for service-based drilldowns.

### Type of Change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

