### PR TITLE
8812 fix polling bug in pagination on reports

### DIFF
--- a/app/controllers/hud_reports/base_controller.rb
+++ b/app/controllers/hud_reports/base_controller.rb
@@ -142,7 +142,12 @@ module HudReports
           merge(report_cell_source.universe.where(question: @question))
       end
       @reports = apply_view_filters(@reports).order(created_at: :desc)
-      @pagy, @reports = pagy(@reports)
+
+      # use the 'history' action for relative URLs in pagination. This keeps our
+      # crude status polling from breaking pagination links (app/views/hud_reports/_list_refresher.haml)
+      pagy_opts = {}
+      pagy_opts[:request_path] = url_for(action: :history) if request.xhr?
+      @pagy, @reports = pagy(@reports, **pagy_opts)
     end
 
     def apply_view_filters(reports)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Fixes broken pagination links in HUD reports by explicitly setting the request path during pagination generation.

- **HUD Reports**: Enforces the `history` action as the base URL for pagination links, preventing links from incorrectly pointing to the `running` status endpoint during AJAX refreshes.

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
