### PR TITLE
Collect CE Participation services provided as multi select

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1062,19 +1062,42 @@ enum CeOpportunityStatus {
 
 type CeParticipation {
   accessPoint: NoYes
+  ceParticipationServices: [CeParticipationServices!]!
   ceParticipationStatusEndDate: ISO8601Date
   ceParticipationStatusStartDate: ISO8601Date
   createdBy: ApplicationUser
-  crisisAssessment: NoYes
+  crisisAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
-  directServices: NoYes
-  housingAssessment: NoYes
+  directServices: NoYes @deprecated(reason: "Use ceParticipationServices instead")
+  housingAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   id: ID!
-  preventionAssessment: NoYes
+  preventionAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   receivesReferrals: NoYes
   user: ApplicationUser
+}
+
+enum CeParticipationServices {
+  """
+  Shelter Assessment, Screening, and/or Referral
+  """
+  CRISIS_ASSESSMENT
+
+  """
+  Direct Services (search and/or placement support)
+  """
+  DIRECT_SERVICES
+
+  """
+  Housing Assessment, Screening, and/or Referral
+  """
+  HOUSING_ASSESSMENT
+
+  """
+  Homelessness Prevention Assessment, Screening, and/or Referral
+  """
+  PREVENTION_ASSESSMENT
 }
 
 type CeParticipationsPaginated {

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
@@ -27,9 +27,5 @@ module Types
     hud_field :housing_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
     hud_field :prevention_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
     hud_field :receives_referrals, HmisSchema::Enums::Hud::NoYes
-
-    def ce_participation_services
-      HudHelper.util.ce_participation_services_fields.select { |k| object.send(k) == 1 }.values
-    end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
@@ -21,10 +21,15 @@ module Types
     # nullable to be generous with imported data, even though its required.
     hud_field :ce_participation_status_start_date, null: true
     hud_field :ce_participation_status_end_date
-    hud_field :crisis_assessment, HmisSchema::Enums::Hud::NoYes
-    hud_field :direct_services, HmisSchema::Enums::Hud::NoYes
-    hud_field :housing_assessment, HmisSchema::Enums::Hud::NoYes
-    hud_field :prevention_assessment, HmisSchema::Enums::Hud::NoYes
+    hud_field :ce_participation_services, [HmisSchema::Enums::CeParticipationServices], null: false
+    hud_field :crisis_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
+    hud_field :direct_services, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
+    hud_field :housing_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
+    hud_field :prevention_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
     hud_field :receives_referrals, HmisSchema::Enums::Hud::NoYes
+
+    def ce_participation_services
+      HudHelper.util.ce_participation_services_fields.select { |k| object.send(k) == 1 }.values
+    end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/ce_participation_services.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/ce_participation_services.rb
@@ -1,0 +1,20 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Types
+  class HmisSchema::Enums::CeParticipationServices < Types::BaseEnum
+    graphql_name 'CeParticipationServices'
+    # Used for multi-select on 2.09 Coordinated Entry Participation Status to indicate CE services provided by the project.
+    # See HMIS Data Dictionary for more information
+
+    value 'PREVENTION_ASSESSMENT', 'Homelessness Prevention Assessment, Screening, and/or Referral', value: 1
+    value 'CRISIS_ASSESSMENT', 'Shelter Assessment, Screening, and/or Referral', value: 2
+    value 'HOUSING_ASSESSMENT', 'Housing Assessment, Screening, and/or Referral', value: 3
+    value 'DIRECT_SERVICES', 'Direct Services (search and/or placement support)', value: 4
+  end
+end

--- a/drivers/hmis/app/models/hmis/hud/ce_participation.rb
+++ b/drivers/hmis/app/models/hmis/hud/ce_participation.rb
@@ -17,4 +17,8 @@ class Hmis::Hud::CeParticipation < Hmis::Hud::Base
   belongs_to :project, **hmis_relation(:ProjectID, 'Project')
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects, optional: true
+
+  def ce_participation_services
+    HudHelper.util.ce_participation_services_fields.select { |k| send(k) == 1 }.values
+  end
 end

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -330,14 +330,13 @@ class Hmis::Hud::Processors::Base
   # a hash of 0/1 attributes for the record. Example:
   #
   # attributes_from_multi_select(
-  #     "aftercare_methods",                                    # Field name in the form
   #     ["TELEPHONE", "IN_PERSON_GROUP"],                       # Array of selected enum values
   #     enum: Types::HmisSchema::Enums::CounselingMethod,       # GraphQL Enum for transforming Enum => numeric value
   #     attribute_map: HudHelper.util.counseling_method_fields  # Hash of attribute name => numeric value
   # )
   #
   # => { email_social_media: 0, telephone: 1, in_person_individual: 0, in_person_group: 1 }
-  def attributes_from_multi_select(field, value, enum:, attribute_map:)
+  def attributes_from_multi_select(value, enum:, attribute_map:)
     # If hidden, set all fields to nil
     return attribute_map.transform_values { |_| nil } if value == HIDDEN_FIELD_VALUE
 

--- a/drivers/hmis/app/models/hmis/hud/processors/base.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/base.rb
@@ -326,6 +326,33 @@ class Hmis::Hud::Processors::Base
     raise "unexpected value for date \"#{string}\""
   end
 
+  # Converts a multi-select form value (e.g. aftercare_methods, counseling_methods) into
+  # a hash of 0/1 attributes for the record. Example:
+  #
+  # attributes_from_multi_select(
+  #     "aftercare_methods",                                    # Field name in the form
+  #     ["TELEPHONE", "IN_PERSON_GROUP"],                       # Array of selected enum values
+  #     enum: Types::HmisSchema::Enums::CounselingMethod,       # GraphQL Enum for transforming Enum => numeric value
+  #     attribute_map: HudHelper.util.counseling_method_fields  # Hash of attribute name => numeric value
+  # )
+  #
+  # => { email_social_media: 0, telephone: 1, in_person_individual: 0, in_person_group: 1 }
+  def attributes_from_multi_select(field, value, enum:, attribute_map:)
+    # If hidden, set all fields to nil
+    return attribute_map.transform_values { |_| nil } if value == HIDDEN_FIELD_VALUE
+
+    # Transform enum values to their integer IDs
+    attribute_value = attribute_value_for_enum(enum, value)
+    # If all empty, set all fields to 99
+    values = Array.wrap(attribute_value).compact
+    return attribute_map.transform_values { |_| 99 } if values.empty?
+
+    # Map each attribute to 1 (if selected) or 0 (if not selected)
+    attribute_map.map do |field_name, id|
+      [field_name, values.include?(id) ? 1 : 0]
+    end.to_h
+  end
+
   private def process_files(cded, value, existing_cdes)
     if cded.repeats?
       Array.wrap(value).map do |val|

--- a/drivers/hmis/app/models/hmis/hud/processors/ce_participation_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/ce_participation_processor.rb
@@ -14,7 +14,7 @@ module Hmis::Hud::Processors
 
       attributes = case attribute_name
       when 'ce_participation_services'
-        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.ce_participation_services_fields)
+        attributes_from_multi_select(value, enum: enum, attribute_map: HudHelper.util.ce_participation_services_fields)
       else
         { attribute_name => attribute_value_for_enum(enum, value) }
       end

--- a/drivers/hmis/app/models/hmis/hud/processors/ce_participation_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/ce_participation_processor.rb
@@ -8,6 +8,19 @@
 
 module Hmis::Hud::Processors
   class CeParticipationProcessor < Base
+    def process(field, value)
+      attribute_name = ar_attribute_name(field)
+      enum = graphql_enum(field)
+
+      attributes = case attribute_name
+      when 'ce_participation_services'
+        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.ce_participation_services_fields)
+      else
+        { attribute_name => attribute_value_for_enum(enum, value) }
+      end
+      @processor.send(factory_name).assign_attributes(attributes)
+    end
+
     def factory_name
       # Assumes that this record is only edited via its own form.
       # To support creating/editing from the Project form, we'd need to add a separate ce_participation_factory

--- a/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
@@ -10,15 +10,15 @@ module Hmis::Hud::Processors
   class ExitProcessor < Base
     def process(field, value)
       attribute_name = ar_attribute_name(field)
-      attribute_value = attribute_value_for_enum(graphql_enum(field), value)
+      enum = graphql_enum(field)
 
       attributes = case attribute_name
       when 'aftercare_methods'
-        multi_select_attributes(value, attribute_value, enum_map: HudHelper.util.aftercare_method_fields)
+        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.aftercare_method_fields)
       when 'counseling_methods'
-        multi_select_attributes(value, attribute_value, enum_map: HudHelper.util.counseling_method_fields)
+        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.counseling_method_fields)
       else
-        { attribute_name => attribute_value }
+        { attribute_name => attribute_value_for_enum(enum, value) }
       end
       @processor.send(factory_name).assign_attributes(attributes)
     end
@@ -37,19 +37,6 @@ module Hmis::Hud::Processors
 
     def information_date(_)
       # Exits don't have an information date to be set
-    end
-
-    def multi_select_attributes(raw_value, attribute_value, enum_map:)
-      # If hidden, set all fields to nil
-      return enum_map.transform_values { |_| nil } if raw_value == Base::HIDDEN_FIELD_VALUE
-
-      # If all empty, set all fields to 99
-      values = Array.wrap(attribute_value).compact
-      return enum_map.transform_values { |_| 99 } if values.empty?
-
-      enum_map.map do |field_name, id|
-        [field_name, values.include?(id) ? 1 : 0]
-      end.to_h
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
+++ b/drivers/hmis/app/models/hmis/hud/processors/exit_processor.rb
@@ -14,9 +14,9 @@ module Hmis::Hud::Processors
 
       attributes = case attribute_name
       when 'aftercare_methods'
-        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.aftercare_method_fields)
+        attributes_from_multi_select(value, enum: enum, attribute_map: HudHelper.util.aftercare_method_fields)
       when 'counseling_methods'
-        attributes_from_multi_select(attribute_name, value, enum: enum, attribute_map: HudHelper.util.counseling_method_fields)
+        attributes_from_multi_select(value, enum: enum, attribute_map: HudHelper.util.counseling_method_fields)
       else
         { attribute_name => attribute_value_for_enum(enum, value) }
       end

--- a/drivers/hmis/lib/form_data/default/records/ce_participation.json
+++ b/drivers/hmis/lib/form_data/default/records/ce_participation.json
@@ -3,72 +3,37 @@
     {
       "type": "CHOICE",
       "required": true,
-      "link_id": "q_2_09_1",
-      "text": "Access Point",
+      "link_id": "access_point",
+      "text": "Project is a Coordinated Entry Access Point",
       "pick_list_reference": "NoYes",
       "mapping": {
         "field_name": "accessPoint"
       }
     },
     {
-      "type": "GROUP",
-      "link_id": "q_2_09_A_conditionals",
+      "type": "CHOICE",
+      "link_id": "ce_participation_services",
+      "repeats": true,
+      "text": "Provided by CE Project",
+      "required": true,
+      "pick_list_reference": "CeParticipationServices",
+      "mapping": {
+        "field_name": "ceParticipationServices"
+      },
       "enable_behavior": "ALL",
       "enable_when": [
         {
-          "question": "q_2_09_1",
+          "question": "access_point",
           "operator": "EQUAL",
           "answer_code": "YES"
-        }
-      ],
-      "item": [
-        {
-          "type": "CHOICE",
-          "required": true,
-          "link_id": "q_2_09_A_prevention",
-          "text": "Prevention Assessment",
-          "pick_list_reference": "NoYes",
-          "mapping": {
-            "field_name": "preventionAssessment"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "required": true,
-          "link_id": "q_2_09_A_crisis",
-          "text": "Crisis Assessment",
-          "pick_list_reference": "NoYes",
-          "mapping": {
-            "field_name": "crisisAssessment"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "required": true,
-          "link_id": "q_2_09_A_housing",
-          "text": "Housing Assessment",
-          "pick_list_reference": "NoYes",
-          "mapping": {
-            "field_name": "housingAssessment"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "required": true,
-          "link_id": "q_2_09_A_services",
-          "text": "Direct Services",
-          "pick_list_reference": "NoYes",
-          "mapping": {
-            "field_name": "directServices"
-          }
         }
       ]
     },
     {
       "type": "CHOICE",
       "required": true,
-      "link_id": "q_2_09_2",
-      "text": "Receives Referrals",
+      "link_id": "receives_referrals",
+      "text": "Project Receives CE Referrals",
       "pick_list_reference": "NoYes",
       "mapping": {
         "field_name": "receivesReferrals"

--- a/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/form_processor_spec.rb
@@ -1738,6 +1738,34 @@ RSpec.describe Hmis::Form::FormProcessor, type: :model do
     end
   end
 
+  describe 'Form processing for CeParticipations' do
+    let(:definition) { Hmis::Form::Definition.find_by(role: :CE_PARTICIPATION) }
+    let!(:existing_record) { create :hmis_hud_ce_participation, data_source: ds1, project: p1, crisis_assessment: 1, receives_referrals: 1 }
+    let(:complete_hud_values) do
+      {
+        'CeParticipation.accessPoint' => 'YES',
+        'CeParticipation.ceParticipationServices' => ['PREVENTION_ASSESSMENT', 'HOUSING_ASSESSMENT'],
+        'CeParticipation.receivesReferrals' => 'NO',
+        'CeParticipation.ceParticipationStatusStartDate' => '2020-01-01',
+      }
+    end
+
+    it 'creates and updates all fields' do
+      new_record = Hmis::Hud::CeParticipation.new(data_source: ds1, user: u1, project: p1)
+      [existing_record, new_record].each do |record|
+        process_record(record: record, hud_values: complete_hud_values, user: hmis_user, definition: definition)
+
+        expect(record.access_point).to eq(1)
+        expect(record.prevention_assessment).to eq(1)
+        expect(record.crisis_assessment).to eq(0)
+        expect(record.housing_assessment).to eq(1)
+        expect(record.direct_services).to eq(0)
+        expect(record.receives_referrals).to eq(0)
+        expect(record.ce_participation_status_start_date).to eq(Date.parse('2020-01-01'))
+      end
+    end
+  end
+
   describe 'Form processing for Inventory' do
     let(:definition) { Hmis::Form::Definition.find_by(role: :INVENTORY) }
     let!(:pc1) { create :hmis_hud_project_coc, data_source: ds1, project: p1, coc_code: 'CO-500', user: u1 }

--- a/drivers/hmis/spec/support/form_helpers.rb
+++ b/drivers/hmis/spec/support/form_helpers.rb
@@ -216,10 +216,7 @@ module FormHelpers
     }.stringify_keys,
     CE_PARTICIPATION: {
       "accessPoint": 'YES',
-      "preventionAssessment": 'YES',
-      "crisisAssessment": 'YES',
-      "housingAssessment": 'YES',
-      "directServices": 'YES',
+      "ceParticipationServices": ['PREVENTION_ASSESSMENT', 'CRISIS_ASSESSMENT', 'HOUSING_ASSESSMENT', 'DIRECT_SERVICES'],
       "receivesReferrals": 'YES',
       "ceParticipationStatusStartDate": '2020-07-01',
       "ceParticipationStatusEndDate": nil,

--- a/lib/util/hud_utility_2026.rb
+++ b/lib/util/hud_utility_2026.rb
@@ -807,6 +807,16 @@ module HudUtility2026
     }
   end
 
+  # field name => ID from Data Dictionary
+  def ce_participation_services_fields
+    {
+      prevention_assessment: 1,
+      crisis_assessment: 2,
+      housing_assessment: 3,
+      direct_services: 4,
+    }
+  end
+
   def ce_events_referrals_to_housing
     [
       12,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8814


Collect CE Participation "provided by project" field as multi-select. This is a HUD Compliance issue since our current implementation does not match the data dictionary.

- **API:** Added `ceParticipationServices` (array for multi-select) on `CeParticipation`; deprecated the four Yes/No fields (prevention/crisis/housing/direct services). New enum `CeParticipationServices` with the four options.
- **Processing:** Base processor gains `attributes_from_multi_select`; CeParticipation processor uses it for `ce_participation_services`. Exit processor refactored to use the same helper for aftercare/counseling methods.
- **HUD utility:** Added `ce_participation_services_fields` (field name → ID map).
- **Form:** CE Participation record form now has one repeating CHOICE “Provided by CE Project” instead of four separate Yes/No questions. This matches the data dictionary specifications. Also made some wording changes to match the data dictionary.
- **Tests:** New “Form processing for CeParticipations” spec using `process_record` for existing and new records. Processing for Exit aftercare/counseling has test coverage.


Testing instructions: see issue
## Type of change
HUD Compliance

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
