### PR TITLE
Rename the new Most-recent Move-In Date cohort column

### DIFF
--- a/app/models/cohort_columns/most_recent_move_in_date.rb
+++ b/app/models/cohort_columns/most_recent_move_in_date.rb
@@ -9,7 +9,7 @@
 module CohortColumns
   class MostRecentMoveInDate < ReadOnlyDate
     attribute :column, String, lazy: true, default: :most_recent_move_in_date
-    attribute :translation_key, String, lazy: true, default: 'Most-Recent Move-In Date'
+    attribute :translation_key, String, lazy: true, default: 'Most Recent Move-In Date'
     attribute :title, String, lazy: true, default: ->(model, _attr) { Translation.translate(model.translation_key) }
     attribute :description_translation_key, String, lazy: true, default: 'Most recent move-in date for ongoing PH enrollments.'
     attribute :description, String, lazy: true, default: ->(model, _attr) { Translation.translate(model.description_translation_key) }

--- a/spec/models/cohort_columns/most_recent_move_in_date_spec.rb
+++ b/spec/models/cohort_columns/most_recent_move_in_date_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe CohortColumns::MostRecentMoveInDate, type: :model do
     end
 
     it 'has correct title' do
-      expect(column.title).to eq('Most-Recent Move-In Date')
+      expect(column.title).to eq('Most Recent Move-In Date')
     end
 
     it 'has correct column name' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

rename cohort column from "Most-Recent Move-In Date" to "Most Recent Move-In Date"

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug FIx

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
