### PR TITLE
Bug Fix for Missing Drilldown in DQ Tool

### DIFF
--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -1854,11 +1854,9 @@ module HmisDataQualityTool
           title: 'Discharge Status',
           description: 'Discharge Status is "Data not collected" (99) or blank for veterans',
           required_for: 'Veterans',
-          detail_columns: [
-            default_detail_columns + [
-              :veteran,
-              :discharge_status,
-            ],
+          detail_columns: default_detail_columns + [
+            :veteran,
+            :discharge_status,
           ],
           denominator: ->(item) {
             funding_sources = [


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Bug fix for discharge status drilldown in the DQ Tool Report. Remove the extra brackets surrounding the detail_columns. This was causing empty drilldowns with no columns for the field.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
