### PR TITLE
8775-strmu-distinct-assistance-fix

### DIFF
--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -77,10 +77,13 @@ module HopwaCaper::Generators::Fy2026::Sheets
         )
       end
 
+      # row 7
       # Multi-type: households with more than one distinct service type, aggregated by HOH client ID
+      service_type_filter_cases = service_type_filters.all.
+        map.with_index { |f, idx| "WHEN type_provided IN (#{f.codes.join(', ')}) THEN #{idx}" }
       multi_type_hoh_client_ids = services_with_hoh(relevant_services).
         group('hoh.destination_client_id').
-        having('COUNT(DISTINCT type_provided) > 1').
+        having("COUNT(DISTINCT CASE #{service_type_filter_cases.join(' ')} END) > 1").
         select('hoh.destination_client_id')
 
       add_household_enrollments_row(

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -80,7 +80,7 @@ module HopwaCaper::Generators::Fy2026::Sheets
       # row 7
       # Multi-type: households with more than one distinct service type, aggregated by HOH client ID
       service_type_filter_cases = service_type_filters.all.
-        map.with_index { |f, idx| "WHEN type_provided IN (#{f.codes.join(', ')}) THEN #{idx}" }
+        map.with_index { |f, idx| "WHEN type_provided IN (#{f.codes.map(&:to_i).join(', ')}) THEN #{idx}" }
       multi_type_hoh_client_ids = services_with_hoh(relevant_services).
         group('hoh.destination_client_id').
         having("COUNT(DISTINCT CASE #{service_type_filter_cases.join(' ')} END) > 1").

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -189,6 +189,57 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
       expect(rows.fetch('Total STRMU Expenditures').to_f).to eq(750)
     end
 
+    it 'does not count households receiving multiple codes of the same type in "more than one type"' do
+      # Client with both utility deposits and utility payments (one type: utility)
+      utility_client = create(:hud_client, data_source: data_source)
+      utility_enrollment = create_hiv_positive_enrollment(
+        client: utility_client,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+      create(:hud_service, enrollment: utility_enrollment, record_type: hopwa_financial_assistance,
+                           type_provided: hud_code(:hopwa_financial_assistance_options, 'Utility deposits'),
+                           fa_amount: 100, date_provided: utility_enrollment.entry_date, data_source: data_source)
+      create(:hud_service, enrollment: utility_enrollment, record_type: hopwa_financial_assistance,
+                           type_provided: hud_code(:hopwa_financial_assistance_options, 'Utility payments'),
+                           fa_amount: 200, date_provided: utility_enrollment.entry_date, data_source: data_source)
+
+      # Client with both rental assistance and security deposits (one type: rental)
+      rental_client = create(:hud_client, data_source: data_source)
+      rental_enrollment = create_hiv_positive_enrollment(
+        client: rental_client,
+        project: project,
+        entry_date: report_start_date + 2.days,
+        household_id: Hmis::Hud::Base.generate_uuid,
+      )
+      create(:hud_service, enrollment: rental_enrollment, record_type: hopwa_financial_assistance,
+                           type_provided: hud_code(:hopwa_financial_assistance_options, 'Rental assistance'),
+                           fa_amount: 300, date_provided: rental_enrollment.entry_date, data_source: data_source)
+      create(:hud_service, enrollment: rental_enrollment, record_type: hopwa_financial_assistance,
+                           type_provided: hud_code(:hopwa_financial_assistance_options, 'Security deposits'),
+                           fa_amount: 400, date_provided: rental_enrollment.entry_date, data_source: data_source)
+
+      _, rows = run_and_extract_rows([project], 'Q3')
+
+      # Household 1 from outer before: rental + utility (2 types)
+      # Household 2 from outer before: utility (1 type)
+      # utility_client: utility + utility (1 type)
+      # rental_client: rental + rental (1 type)
+
+      # Total served: 2 (existing) + 2 (new) = 4
+      expect(rows.fetch('STRMU Households Total')).to eq(4)
+
+      # Only Household 1 should be in "more than one type"
+      expect(rows.fetch('How many households received more than one type of STRMU assistance?')).to eq(1)
+
+      # utility_client should be in "utility assistance only"
+      # rental_client should be in "rental assistance only"
+      # (Household 2 is also utility assistance only)
+      expect(rows.fetch('How many households were served with STRMU utility assistance only?')).to eq(2)
+      expect(rows.fetch('How many households were served with STRMU rental assistance only?')).to eq(1)
+    end
+
     it 'correctly categorizes a client with multiple enrollments and different service types' do
       # Create a third client with TWO current enrollments
       client = create(:hud_client, data_source: data_source)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Groups STRMU service codes by category when calculating households receiving multiple types of assistance. Added test cases to verify that households receiving multiple services within the same category (e.g., both utility deposits and payments) are correctly counted as receiving a single type of assistance.

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
