### PR TITLE
User search bug fixes

### DIFF
--- a/app/controllers/admin/inactive_users/search_queries_controller.rb
+++ b/app/controllers/admin/inactive_users/search_queries_controller.rb
@@ -13,6 +13,11 @@ module Admin::InactiveUsers
 
     def create
       safe_params = GrdaWarehouse::ClientSearchQuery.permit_params(params)
+      if safe_params['q'].to_s.strip.blank? # if no search query, redirect to users index
+        redirect_to admin_inactive_users_path
+        return
+      end
+
       query = GrdaWarehouse::ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
       if query.valid?
         redirect_to inactive_user_search_query_admin_inactive_users_path(id: query.id)

--- a/app/controllers/admin/users/search_queries_controller.rb
+++ b/app/controllers/admin/users/search_queries_controller.rb
@@ -13,6 +13,11 @@ module Admin::Users
 
     def create
       safe_params = GrdaWarehouse::ClientSearchQuery.permit_params(params)
+      if safe_params['q'].to_s.strip.blank? # if no search query, redirect to users index
+        redirect_to admin_users_path
+        return
+      end
+
       query = GrdaWarehouse::ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
       if query.valid?
         redirect_to user_search_query_admin_users_path(id: query.id)

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -497,7 +497,7 @@ module UserConcern
       "Account deactivated by #{name} on #{version.created_at}"
     end
 
-    # Search for users by name or email using prefix matching
+    # Search for users by name (prefix) or email (substring, e.g. domain).
     #
     # @param text [String] the search query
     # @param sort_by_best_match [Boolean] whether to order results by similarity to query
@@ -514,9 +514,10 @@ module UserConcern
       return none if terms.empty?
 
       scope = terms.map do |term|
-        prefix_condition = arel_table[:first_name].matches("#{term}%").
-          or(arel_table[:last_name].matches("#{term}%")).
-          or(arel_table[:email].matches("#{term}%"))
+        escaped = sanitize_sql_like(term)
+        prefix_condition = arel_table[:first_name].matches("#{escaped}%").
+          or(arel_table[:last_name].matches("#{escaped}%")).
+          or(arel_table[:email].matches("%#{escaped}%"))
 
         where(prefix_condition)
       end.inject(&:or)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe User, type: :model do
 
   describe '.text_search' do
     let!(:user1) { create(:user, first_name: 'Alice', last_name: 'Smith', email: 'alice.smith@example.com') }
-    let!(:user2) { create(:user, first_name: 'Alicea', last_name: 'Smythe', email: 'alicia.smythe@example.com') }
-    let!(:user3) { create(:user, first_name: 'Bob', last_name: 'Jones', email: 'bob.jones@example.com') }
+    let!(:user2) { create(:user, first_name: 'Alicea', last_name: 'Smythe', email: 'alicia.smythe@green.com') }
+    let!(:user3) { create(:user, first_name: 'Bob', last_name: 'Jones', email: 'bob.jones@green.com') }
 
     it 'finds users by first name' do
       results = User.text_search('Alice')
@@ -85,6 +85,12 @@ RSpec.describe User, type: :model do
       results = User.text_search('alice.smith@example.com')
       expect(results).to include(user1)
       expect(results).not_to include(user3)
+    end
+
+    it 'finds users by email domain (substring match)' do
+      results = User.text_search('green')
+      expect(results).to include(user2, user3) # accounts with email domain 'green.com'
+      expect(results).not_to include(user1)
     end
 
     it 'returns none for no match' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8531

Fixes 2 bugs:
1. Searching users by email domain (like "greenriver") no longer worked.
2. After searching users, there was no way to "clear" the search aside from manually manipulating the URL. This change makes it so that searching an empty string redirects to the all users page with no search applied.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
