### PR TITLE
Nullify form submission FK when enrollment is deleted

### DIFF
--- a/drivers/hmis/app/models/hmis/hud/enrollment.rb
+++ b/drivers/hmis/app/models/hmis/hud/enrollment.rb
@@ -84,6 +84,8 @@ class Hmis::Hud::Enrollment < Hmis::Hud::Base
   has_many :annual_assessments, -> { annuals }, **hmis_enrollment_relation('CustomAssessment')
   has_many :post_exit_assessments, -> { post_exits }, **hmis_enrollment_relation('CustomAssessment')
 
+  has_many :external_form_submissions, class_name: 'HmisExternalApis::ExternalForms::FormSubmission', dependent: :nullify, inverse_of: :enrollment
+
   # Files
   has_many :files, class_name: '::Hmis::File', dependent: :destroy, inverse_of: :enrollment
 

--- a/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
@@ -155,6 +155,16 @@ RSpec.describe Hmis::Hud::Enrollment, type: :model do
         expect(enrollment.send(assoc)).not_to be_present, "expected #{assoc} not to be present"
       end
     end
+
+    it 'nullifies external_form_submissions on destroy' do
+      submission = create(:hmis_external_form_submission, enrollment: enrollment)
+      expect(submission.enrollment_id).to eq(enrollment.id)
+
+      enrollment.destroy
+
+      submission.reload
+      expect(submission.enrollment_id).to be_nil
+    end
   end
 
   describe 'enrollments status is set correctly:' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Nullify external form submission's FK to enrollment when enrollment is deleted

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Data fix

How to test: Delete an enrollment that's associated with a form submission. Check that the submission's enrollment column was nulled.

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
