### PR TITLE
Ensure service types exist for each HUD service type on seed

### DIFF
--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -409,6 +409,11 @@ class SeedMaker
     builder = ::HmisUtil::JsonForms.new
     builder.seed_all
     builder.create_default_occurrence_point_instances! if Rails.env.development?
+
+    # Ensure service type and category records exist for each HUD service type
+    GrdaWarehouse::DataSource.hmis.pluck(:id).each do |data_source_id|
+      ::HmisUtil::ServiceTypes.seed_hud_service_types(data_source_id)
+    end
   end
 
   def populate_internal_system_choices


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Ensure all HUD Service types exist on each deploy. This is a minimal change just to ensure all service types are updated on all environments.

Issue: https://github.com/open-path/Green-River/issues/8859#event-22908114699

Future improvements (planned for after https://github.com/greenriver/hmis-warehouse/pull/5708 is merged):
- Add enforcement to ensure that required system _instances_ for HUD Services exist. (a.k.a. rules that enable hud services to be collected in the right projects)
- Potentially combine into JsonForms seed so there is only one thing to run for HUD-compliance-setup
- Refactor service funder requirements 

## Type of change
hud compliance

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
