### PR TITLE
Update referral client reference on HMIS merge

### DIFF
--- a/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
+++ b/drivers/hmis/app/jobs/hmis/merge_clients_job.rb
@@ -53,8 +53,6 @@ module Hmis
         merge_mci_unique_ids
         merge_scan_cards
         merge_client_locations
-        # TODO(#8241) - merge CE records such as referrals, and possibly candidacy events?
-
         client_to_retain.reload
         dedup(client_to_retain.names, keepers: dedup(client_to_retain.names.where(primary: true)))
         dedup(client_to_retain.contact_points)
@@ -248,6 +246,7 @@ module Hmis
     def update_client_id_foreign_keys
       candidates = [
         [Hmis::File, 'files'],
+        [Hmis::Ce::Referral, 'ce_referrals'],
       ]
 
       Rails.logger.info "Updating #{candidates.length} tables with foreign keys to merged clients (client_id)"

--- a/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
+++ b/drivers/hmis/spec/jobs/merge_clients_job_spec.rb
@@ -440,6 +440,22 @@ RSpec.describe Hmis::MergeClientsJob, type: :model do
         it_behaves_like 'merge that saves mappings', 'client_locations', 'client_id', 'id'
       end
 
+      context 'with CE Referral records' do
+        let!(:record1) { create(:hmis_ce_referral, data_source: data_source, client: client1) }
+        let!(:record2) { create(:hmis_ce_referral, data_source: data_source, client: client2) }
+
+        it 'transfers referrals from deleted client to retained client and does not delete them' do
+          expect { Hmis::MergeClientsJob.perform_now(client_ids: client_ids, actor_id: actor.id) }.
+            not_to change(Hmis::Ce::Referral, :count)
+
+          expect(record2.reload.client_id).to eq(client1.id)
+          expect(client1.ce_referrals).to include(record1, record2)
+        end
+
+        it_behaves_like 'merge of records related by client_id'
+        it_behaves_like 'merge that saves mappings', 'ce_referrals', 'client_id', 'id'
+      end
+
       context 'with external referral records (legacy)' do
         let!(:referral1) { create :hmis_external_api_ac_hmis_referral }
         let!(:referral1_hhm1) { create :hmis_external_api_ac_hmis_referral_household_member, client: client1, referral: referral1 }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8241

When HMIS source clients are merged, move CE referrals onto the retained client

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
