### PR TITLE
Remove inactive and unauthorized users during referral assignment

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
@@ -22,14 +22,9 @@ module Mutations
 
       swimlane_ids = participants.map(&:swimlane_id).uniq
       swimlanes = referral.workflow_instance.template.swimlanes.where(id: swimlane_ids)
-      raise 'Not found' unless swimlanes.size == swimlane_ids.size
+      raise "Failed to assign to swimlanes #{swimlane_ids.join(', ')}, not all swimlanes found on template" unless swimlanes.size == swimlane_ids.size
 
-      # Verify that the given users have permission to perform referral tasks in this project
-      user_ids = participants.map(&:user_id).uniq
-      users = Hmis::User.can_perform_any_referral_tasks_for(project).
-        or(Hmis::User.can_perform_own_referral_tasks_for(project)).
-        where(id: user_ids)
-      raise 'Not found' unless users.size == user_ids.size
+      participants = filter_to_authorized_participants(participants, project)
 
       referral.with_lock do
         # Create a participant for each user in the input, if one doesn't already exist
@@ -46,6 +41,28 @@ module Mutations
       end
 
       { referral: referral.reload }
+    end
+
+    private
+
+    # Users not in scope (inactive or lost access) are dropped and reported to Sentry.
+    # This can happen if a user was previously assigned but is no longer active/authorized,
+    # or lost access between loading the assignee pick list (ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS)
+    # and submitting the mutation.
+    def filter_to_authorized_participants(participants, project)
+      user_ids = participants.map(&:user_id).map(&:to_i).to_set
+      authorized_user_ids = Hmis::User.active.can_perform_any_referral_tasks_for(project).
+        or(Hmis::User.can_perform_own_referral_tasks_for(project)).
+        where(id: user_ids).pluck(:id).to_set
+
+      missing_user_ids = user_ids - authorized_user_ids
+      return participants if missing_user_ids.empty?
+
+      msg = 'Referral assignment: some users were not in scope (inactive or lost access), removed from assignee list'
+      Sentry.capture_message(msg, extra: { missing_user_ids: missing_user_ids.to_a, project_id: project.id })
+      Rails.logger.warn(msg)
+
+      participants.filter { |p| authorized_user_ids.include?(p.user_id.to_i) }
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -26,232 +26,245 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
 
   let!(:hmis_user2) { create(:hmis_user, data_source: ds1) }
 
-  describe 'assign participants mutation' do
-    let(:mutation) do
-      <<~GRAPHQL
-        mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
-          assignReferralParticipants(referralId: $referralId, participants: $participants) {
-            referral {
+  let(:mutation) do
+    <<~GRAPHQL
+      mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
+        assignReferralParticipants(referralId: $referralId, participants: $participants) {
+          referral {
+            id
+            swimlanes {
               id
-              swimlanes {
+              name
+              participants {
                 id
                 name
-                participants {
-                  id
-                  name
-                }
               }
-              steps {
+            }
+            steps {
+              id
+              stepId
+              name
+              status
+              swimlane
+              assignees {
                 id
-                stepId
                 name
-                status
-                swimlane
-                assignees {
-                  id
-                  name
-                }
               }
             }
           }
         }
-      GRAPHQL
+      }
+    GRAPHQL
+  end
+
+  let(:variables) do
+    {
+      referralId: referral.id,
+      participants: [
+        {
+          userId: hmis_user.id,
+          swimlaneId: case_manager_swimlane.id,
+        },
+        {
+          userId: hmis_user2.id,
+          swimlaneId: provider_swimlane.id,
+        },
+      ],
+    }
+  end
+
+  def perform_mutation
+    response, result = post_graphql(**variables) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    result.dig('data', 'assignReferralParticipants', 'referral')
+  end
+
+  before(:each) do
+    referral.workflow_engine.start_workflow!(user: hmis_user)
+  end
+  let(:step) { referral.workflow_engine.active_steps.sole }
+
+  it 'creates referral participants' do
+    expect do
+      referral_data = perform_mutation
+      referral_swimlanes = referral_data['swimlanes']
+      expect(referral_swimlanes).to contain_exactly(
+        a_hash_including(
+          'id' => case_manager_swimlane.id.to_s,
+          'name' => case_manager_swimlane.name,
+          'participants' => [
+            a_hash_including(
+              'id' => hmis_user.id.to_s,
+              'name' => hmis_user.name,
+            ),
+          ],
+        ),
+        a_hash_including(
+          'id' => provider_swimlane.id.to_s,
+          'name' => provider_swimlane.name,
+          'participants' => [
+            a_hash_including(
+              'id' => hmis_user2.id.to_s,
+              'name' => hmis_user2.name,
+            ),
+          ],
+        ),
+      )
+    end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+  end
+
+  it 'creates step assignments on active steps' do
+    expect do
+      perform_mutation
+      step.reload
+    end.to change(step.assignments, :count).from(0).to(1).
+      and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
+    expect(step.assignments.sole.user).to eq(hmis_user)
+  end
+
+  context 'when active step is already assigned' do
+    let!(:assignment) { step.assignments.create(user: hmis_user) }
+
+    it 'does not try to create duplicate assignees' do
+      expect do
+        perform_mutation
+        step.reload
+      end.to not_change(step.assignments, :count).from(1)
+      expect(step.assignments.sole.user).to eq(hmis_user)
+    end
+  end
+
+  context 'when active step is already assigned to a different user' do
+    let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
+
+    it 'removes old assignee and assigns new user' do
+      expect do
+        perform_mutation
+        step.reload
+      end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
+
+      expect(other_user_assignment.reload).to be_deleted
+    end
+    context 'when step is completed' do
+      before(:each) do
+        step.start!
+        step.complete!
+      end
+      it 'does not remove old assignee' do
+        expect do
+          perform_mutation
+          step.reload
+        end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
+
+        expect(other_user_assignment.reload).not_to be_deleted
+      end
+    end
+  end
+
+  describe 'referral with existing participant' do
+    let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
+
+    it 'does not create duplicate participants' do
+      expect do
+        perform_mutation
+        existing_participant.reload
+      end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
+        and not_change(existing_participant, :updated_at)
     end
 
+    context 'with input that indicates deletion of a participant' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [],
+        }
+      end
+
+      it 'deletes removed participants' do
+        expect do
+          perform_mutation
+        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
+      end
+    end
+  end
+
+  context 'with invalid user' do
+    let(:variables) do
+      {
+        referralId: referral.id,
+        participants: [
+          {
+            userId: 'abc',
+            swimlaneId: case_manager_swimlane.id,
+          },
+        ],
+      }
+    end
+
+    it 'does not assign invalid user' do
+      expect do
+        perform_mutation
+      end.not_to change(Hmis::Ce::ReferralParticipant, :count)
+    end
+  end
+
+  context 'with invalid swimlane' do
     let(:variables) do
       {
         referralId: referral.id,
         participants: [
           {
             userId: hmis_user.id,
-            swimlaneId: case_manager_swimlane.id,
-          },
-          {
-            userId: hmis_user2.id,
-            swimlaneId: provider_swimlane.id,
+            swimlaneId: 'xyz',
           },
         ],
       }
     end
 
-    before do
-      referral.workflow_engine.start_workflow!(user: hmis_user)
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: /Failed to assign to swimlanes/)
     end
-    let(:step) { referral.workflow_engine.active_steps.sole }
+  end
 
-    it 'creates referral participants' do
+  context 'with no permission' do
+    let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+    it 'raises an error' do
+      expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
+    end
+  end
+
+  context 'when some participants are not in scope (inactive or lack permission)' do
+    # hmis_user2 has no referral-task permission; only hmis_user is authorized
+    let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+    it 'drops ineligible users, succeeds with the rest, and reports to Sentry' do
+      allow(Sentry).to receive(:capture_message)
+
+      referral_data = perform_mutation
+      expect(referral_data).to be_present
+
+      referral_swimlanes = referral_data['swimlanes']
+      case_mgr_swimlane = referral_swimlanes.find { |s| s['id'] == case_manager_swimlane.id.to_s }
+      provider_swimlane_result = referral_swimlanes.find { |s| s['id'] == provider_swimlane.id.to_s }
+      expect(case_mgr_swimlane['participants'].map { |p| p['id'] }).to eq([hmis_user.id.to_s])
+      expect(provider_swimlane_result['participants']).to be_empty
+
+      expect(Sentry).to have_received(:capture_message).with(
+        a_string_including('Referral assignment'),
+        hash_including(extra: hash_including(missing_user_ids: [hmis_user2.id])),
+      )
+    end
+  end
+
+  context 'when the assigned user has permission to do their own tasks' do
+    let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
+
+    it 'successfully creates participants' do
       expect do
         response, result = post_graphql(**variables) { mutation }
         expect(response.status).to eq(200), result.inspect
-
-        referral_swimlanes = result.dig('data', 'assignReferralParticipants', 'referral', 'swimlanes')
-        expect(referral_swimlanes).to contain_exactly(
-          a_hash_including(
-            'id' => case_manager_swimlane.id.to_s,
-            'name' => case_manager_swimlane.name,
-            'participants' => [
-              a_hash_including(
-                'id' => hmis_user.id.to_s,
-                'name' => hmis_user.name,
-              ),
-            ],
-          ),
-          a_hash_including(
-            'id' => provider_swimlane.id.to_s,
-            'name' => provider_swimlane.name,
-            'participants' => [
-              a_hash_including(
-                'id' => hmis_user2.id.to_s,
-                'name' => hmis_user2.name,
-              ),
-            ],
-          ),
-        )
       end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-    end
-
-    it 'creates step assignments on active steps' do
-      expect do
-        response, result = post_graphql(**variables) { mutation }
-        expect(response.status).to eq(200), result.inspect
-        step.reload
-      end.to change(step.assignments, :count).from(0).to(1).
-        and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
-      expect(step.assignments.sole.user).to eq(hmis_user)
-    end
-
-    context 'when active step is already assigned' do
-      let!(:assignment) { step.assignments.create(user: hmis_user) }
-
-      it 'does not try to create duplicate assignees' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          step.reload
-        end.to not_change(step.assignments, :count).from(1)
-        expect(step.assignments.sole.user).to eq(hmis_user)
-      end
-    end
-
-    context 'when active step is already assigned to a different user' do
-      let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
-
-      it 'removes old assignee and assigns new user' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          step.reload
-        end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
-
-        expect(other_user_assignment.reload).to be_deleted
-      end
-      context 'when step is completed' do
-        before(:each) do
-          step.start!
-          step.complete!
-        end
-        it 'does not remove old assignee' do
-          expect do
-            response, result = post_graphql(**variables) { mutation }
-            expect(response.status).to eq(200), result.inspect
-            step.reload
-          end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
-
-          expect(other_user_assignment.reload).not_to be_deleted
-        end
-      end
-    end
-
-    describe 'referral with existing participant' do
-      let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
-
-      it 'does not create duplicate participants' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-          existing_participant.reload
-        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
-          and not_change(existing_participant, :updated_at)
-      end
-
-      context 'with input that indicates deletion of a participant' do
-        let(:variables) do
-          {
-            referralId: referral.id,
-            participants: [],
-          }
-        end
-
-        it 'deletes removed participants' do
-          expect do
-            response, result = post_graphql(**variables) { mutation }
-            expect(response.status).to eq(200), result.inspect
-          end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
-        end
-      end
-    end
-
-    context 'with invalid user' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [
-            {
-              userId: 'abc',
-              swimlaneId: case_manager_swimlane.id,
-            },
-          ],
-        }
-      end
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'with invalid swimlane' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [
-            {
-              userId: hmis_user.id,
-              swimlaneId: 'xyz',
-            },
-          ],
-        }
-      end
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'with no permission' do
-      let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
-      end
-    end
-
-    context 'when the assigned user does not have permission' do
-      let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-      it 'raises an error' do
-        expect_gql_error(post_graphql(**variables) { mutation }, message: 'Not found')
-      end
-    end
-
-    context 'when the assigned user has permission to do their own tasks' do
-      let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
-
-      it 'successfully creates participants' do
-        expect do
-          response, result = post_graphql(**variables) { mutation }
-          expect(response.status).to eq(200), result.inspect
-        end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-      end
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -26,245 +26,247 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
 
   let!(:hmis_user2) { create(:hmis_user, data_source: ds1) }
 
-  let(:mutation) do
-    <<~GRAPHQL
-      mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
-        assignReferralParticipants(referralId: $referralId, participants: $participants) {
-          referral {
-            id
-            swimlanes {
+  describe 'assign participants mutation' do
+    let(:mutation) do
+      <<~GRAPHQL
+        mutation AssignParticipants($referralId: ID!, $participants: [CeReferralParticipantInput!]!) {
+          assignReferralParticipants(referralId: $referralId, participants: $participants) {
+            referral {
               id
-              name
-              participants {
+              swimlanes {
                 id
                 name
+                participants {
+                  id
+                  name
+                }
               }
-            }
-            steps {
-              id
-              stepId
-              name
-              status
-              swimlane
-              assignees {
+              steps {
                 id
+                stepId
                 name
+                status
+                swimlane
+                assignees {
+                  id
+                  name
+                }
               }
             }
           }
         }
-      }
-    GRAPHQL
-  end
-
-  let(:variables) do
-    {
-      referralId: referral.id,
-      participants: [
-        {
-          userId: hmis_user.id,
-          swimlaneId: case_manager_swimlane.id,
-        },
-        {
-          userId: hmis_user2.id,
-          swimlaneId: provider_swimlane.id,
-        },
-      ],
-    }
-  end
-
-  def perform_mutation
-    response, result = post_graphql(**variables) { mutation }
-    expect(response.status).to eq(200), result.inspect
-    result.dig('data', 'assignReferralParticipants', 'referral')
-  end
-
-  before(:each) do
-    referral.workflow_engine.start_workflow!(user: hmis_user)
-  end
-  let(:step) { referral.workflow_engine.active_steps.sole }
-
-  it 'creates referral participants' do
-    expect do
-      referral_data = perform_mutation
-      referral_swimlanes = referral_data['swimlanes']
-      expect(referral_swimlanes).to contain_exactly(
-        a_hash_including(
-          'id' => case_manager_swimlane.id.to_s,
-          'name' => case_manager_swimlane.name,
-          'participants' => [
-            a_hash_including(
-              'id' => hmis_user.id.to_s,
-              'name' => hmis_user.name,
-            ),
-          ],
-        ),
-        a_hash_including(
-          'id' => provider_swimlane.id.to_s,
-          'name' => provider_swimlane.name,
-          'participants' => [
-            a_hash_including(
-              'id' => hmis_user2.id.to_s,
-              'name' => hmis_user2.name,
-            ),
-          ],
-        ),
-      )
-    end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
-  end
-
-  it 'creates step assignments on active steps' do
-    expect do
-      perform_mutation
-      step.reload
-    end.to change(step.assignments, :count).from(0).to(1).
-      and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
-    expect(step.assignments.sole.user).to eq(hmis_user)
-  end
-
-  context 'when active step is already assigned' do
-    let!(:assignment) { step.assignments.create(user: hmis_user) }
-
-    it 'does not try to create duplicate assignees' do
-      expect do
-        perform_mutation
-        step.reload
-      end.to not_change(step.assignments, :count).from(1)
-      expect(step.assignments.sole.user).to eq(hmis_user)
-    end
-  end
-
-  context 'when active step is already assigned to a different user' do
-    let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
-
-    it 'removes old assignee and assigns new user' do
-      expect do
-        perform_mutation
-        step.reload
-      end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
-
-      expect(other_user_assignment.reload).to be_deleted
-    end
-    context 'when step is completed' do
-      before(:each) do
-        step.start!
-        step.complete!
-      end
-      it 'does not remove old assignee' do
-        expect do
-          perform_mutation
-          step.reload
-        end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
-
-        expect(other_user_assignment.reload).not_to be_deleted
-      end
-    end
-  end
-
-  describe 'referral with existing participant' do
-    let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
-
-    it 'does not create duplicate participants' do
-      expect do
-        perform_mutation
-        existing_participant.reload
-      end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
-        and not_change(existing_participant, :updated_at)
+      GRAPHQL
     end
 
-    context 'with input that indicates deletion of a participant' do
-      let(:variables) do
-        {
-          referralId: referral.id,
-          participants: [],
-        }
-      end
-
-      it 'deletes removed participants' do
-        expect do
-          perform_mutation
-        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
-      end
-    end
-  end
-
-  context 'with invalid user' do
-    let(:variables) do
-      {
-        referralId: referral.id,
-        participants: [
-          {
-            userId: 'abc',
-            swimlaneId: case_manager_swimlane.id,
-          },
-        ],
-      }
-    end
-
-    it 'does not assign invalid user' do
-      expect do
-        perform_mutation
-      end.not_to change(Hmis::Ce::ReferralParticipant, :count)
-    end
-  end
-
-  context 'with invalid swimlane' do
     let(:variables) do
       {
         referralId: referral.id,
         participants: [
           {
             userId: hmis_user.id,
-            swimlaneId: 'xyz',
+            swimlaneId: case_manager_swimlane.id,
+          },
+          {
+            userId: hmis_user2.id,
+            swimlaneId: provider_swimlane.id,
           },
         ],
       }
     end
 
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: /Failed to assign to swimlanes/)
+    def perform_mutation
+      response, result = post_graphql(**variables) { mutation }
+      expect(response.status).to eq(200), result.inspect
+      result.dig('data', 'assignReferralParticipants', 'referral')
     end
-  end
 
-  context 'with no permission' do
-    let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-    it 'raises an error' do
-      expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
+    before(:each) do
+      referral.workflow_engine.start_workflow!(user: hmis_user)
     end
-  end
+    let(:step) { referral.workflow_engine.active_steps.sole }
 
-  context 'when some participants are not in scope (inactive or lack permission)' do
-    # hmis_user2 has no referral-task permission; only hmis_user is authorized
-    let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
-
-    it 'drops ineligible users, succeeds with the rest, and reports to Sentry' do
-      allow(Sentry).to receive(:capture_message)
-
-      referral_data = perform_mutation
-      expect(referral_data).to be_present
-
-      referral_swimlanes = referral_data['swimlanes']
-      case_mgr_swimlane = referral_swimlanes.find { |s| s['id'] == case_manager_swimlane.id.to_s }
-      provider_swimlane_result = referral_swimlanes.find { |s| s['id'] == provider_swimlane.id.to_s }
-      expect(case_mgr_swimlane['participants'].map { |p| p['id'] }).to eq([hmis_user.id.to_s])
-      expect(provider_swimlane_result['participants']).to be_empty
-
-      expect(Sentry).to have_received(:capture_message).with(
-        a_string_including('Referral assignment'),
-        hash_including(extra: hash_including(missing_user_ids: [hmis_user2.id])),
-      )
-    end
-  end
-
-  context 'when the assigned user has permission to do their own tasks' do
-    let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
-
-    it 'successfully creates participants' do
+    it 'creates referral participants' do
       expect do
-        response, result = post_graphql(**variables) { mutation }
-        expect(response.status).to eq(200), result.inspect
+        referral_data = perform_mutation
+        referral_swimlanes = referral_data['swimlanes']
+        expect(referral_swimlanes).to contain_exactly(
+          a_hash_including(
+            'id' => case_manager_swimlane.id.to_s,
+            'name' => case_manager_swimlane.name,
+            'participants' => [
+              a_hash_including(
+                'id' => hmis_user.id.to_s,
+                'name' => hmis_user.name,
+              ),
+            ],
+          ),
+          a_hash_including(
+            'id' => provider_swimlane.id.to_s,
+            'name' => provider_swimlane.name,
+            'participants' => [
+              a_hash_including(
+                'id' => hmis_user2.id.to_s,
+                'name' => hmis_user2.name,
+              ),
+            ],
+          ),
+        )
       end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+    end
+
+    it 'creates step assignments on active steps' do
+      expect do
+        perform_mutation
+        step.reload
+      end.to change(step.assignments, :count).from(0).to(1).
+        and change(Hmis::WorkflowExecution::StepAssignment, :count).by(1)
+      expect(step.assignments.sole.user).to eq(hmis_user)
+    end
+
+    context 'when active step is already assigned' do
+      let!(:assignment) { step.assignments.create(user: hmis_user) }
+
+      it 'does not try to create duplicate assignees' do
+        expect do
+          perform_mutation
+          step.reload
+        end.to not_change(step.assignments, :count).from(1)
+        expect(step.assignments.sole.user).to eq(hmis_user)
+      end
+    end
+
+    context 'when active step is already assigned to a different user' do
+      let!(:other_user_assignment) { step.assignments.create(user: hmis_user2) }
+
+      it 'removes old assignee and assigns new user' do
+        expect do
+          perform_mutation
+          step.reload
+        end.to change { step.assignments.map(&:user) }.from([hmis_user2]).to([hmis_user])
+
+        expect(other_user_assignment.reload).to be_deleted
+      end
+      context 'when step is completed' do
+        before(:each) do
+          step.start!
+          step.complete!
+        end
+        it 'does not remove old assignee' do
+          expect do
+            perform_mutation
+            step.reload
+          end.to not_change { step.assignments.map(&:user) }.from([hmis_user2])
+
+          expect(other_user_assignment.reload).not_to be_deleted
+        end
+      end
+    end
+
+    describe 'referral with existing participant' do
+      let!(:existing_participant) { referral.participants.create(swimlane: case_manager_swimlane, user: hmis_user) }
+
+      it 'does not create duplicate participants' do
+        expect do
+          perform_mutation
+          existing_participant.reload
+        end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(2).
+          and not_change(existing_participant, :updated_at)
+      end
+
+      context 'with input that indicates deletion of a participant' do
+        let(:variables) do
+          {
+            referralId: referral.id,
+            participants: [],
+          }
+        end
+
+        it 'deletes removed participants' do
+          expect do
+            perform_mutation
+          end.to change(Hmis::Ce::ReferralParticipant, :count).from(1).to(0)
+        end
+      end
+    end
+
+    context 'with invalid user' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [
+            {
+              userId: 'abc',
+              swimlaneId: case_manager_swimlane.id,
+            },
+          ],
+        }
+      end
+
+      it 'does not assign invalid user' do
+        expect do
+          perform_mutation
+        end.not_to change(Hmis::Ce::ReferralParticipant, :count)
+      end
+    end
+
+    context 'with invalid swimlane' do
+      let(:variables) do
+        {
+          referralId: referral.id,
+          participants: [
+            {
+              userId: hmis_user.id,
+              swimlaneId: 'xyz',
+            },
+          ],
+        }
+      end
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: /Failed to assign to swimlanes/)
+      end
+    end
+
+    context 'with no permission' do
+      let!(:hmis_user_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+      it 'raises an error' do
+        expect_gql_error(post_graphql(**variables) { mutation }, message: 'access denied')
+      end
+    end
+
+    context 'when some participants are not in scope (inactive or lack permission)' do
+      # hmis_user2 has no referral-task permission; only hmis_user is authorized
+      let!(:hmis_user2_access) { create_access_control(hmis_user, ds1, with_permission: [:can_view_referrals]) }
+
+      it 'drops ineligible users, succeeds with the rest, and reports to Sentry' do
+        allow(Sentry).to receive(:capture_message)
+
+        referral_data = perform_mutation
+        expect(referral_data).to be_present
+
+        referral_swimlanes = referral_data['swimlanes']
+        case_mgr_swimlane = referral_swimlanes.find { |s| s['id'] == case_manager_swimlane.id.to_s }
+        provider_swimlane_result = referral_swimlanes.find { |s| s['id'] == provider_swimlane.id.to_s }
+        expect(case_mgr_swimlane['participants'].map { |p| p['id'] }).to eq([hmis_user.id.to_s])
+        expect(provider_swimlane_result['participants']).to be_empty
+
+        expect(Sentry).to have_received(:capture_message).with(
+          a_string_including('Referral assignment'),
+          hash_including(extra: hash_including(missing_user_ids: [hmis_user2.id])),
+        )
+      end
+    end
+
+    context 'when the assigned user has permission to do their own tasks' do
+      let!(:hmis_user2_access) { create_access_control(hmis_user2, ds1, with_permission: [:can_perform_own_referral_tasks]) }
+
+      it 'successfully creates participants' do
+        expect do
+          response, result = post_graphql(**variables) { mutation }
+          expect(response.status).to eq(200), result.inspect
+        end.to change(Hmis::Ce::ReferralParticipant, :count).by(2)
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/8892

How to test: see issue

Gracefully handle ineligible users when assigning referral participants.

I decided to add a sentry message so we can be alerted if there is a spike in this, which would point to a diverging implementation between the picklist and mutation authorization logic.

* **Before:** if the assigned participant list contains an unauthorized user, page crashed when you try to save the list
* **After:** if the assigned participant list contains an unauthorized user, the user is removed on save and a message is reported to sentry.

## Type of change
Bug fix



## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
