### PR TITLE
Prevent re-merge of split clients in WarehouseChangesJob

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -162,6 +162,11 @@ module HmisExternalApis::AcHmis
           old_destination_id = source_client.warehouse_client_source&.destination_id
           next if old_destination_id == winner_destination_id
 
+          if GrdaWarehouse::ClientSplitHistory.exists?(split_from: winner_destination_id, split_into: old_destination_id)
+            Rails.logger.info "Not moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner.id} because they were previously split"
+            next
+          end
+
           Rails.logger.info "Moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner.id}"
 
           winner.merge_from(
@@ -175,7 +180,6 @@ module HmisExternalApis::AcHmis
 
       return unless any_updates
 
-      # If there were updates, trigger a service history rebuild.
       # If there were updates, trigger a service history rebuild. Records requiring rebuild were marked for re-processing by the merge_from method
       GrdaWarehouse::Tasks::ServiceHistory::Add.new(force_sequential_processing: true).run!
     end

--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job.rb
@@ -163,11 +163,11 @@ module HmisExternalApis::AcHmis
           next if old_destination_id == winner_destination_id
 
           if GrdaWarehouse::ClientSplitHistory.exists?(split_from: winner_destination_id, split_into: old_destination_id)
-            Rails.logger.info "Not moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner.id} because they were previously split"
+            Rails.logger.info "Not moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner_destination_id} because they were previously split"
             next
           end
 
-          Rails.logger.info "Moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner.id}"
+          Rails.logger.info "Moving source Client##{source_client.id} from destination Client##{old_destination_id} to destination Client##{winner_destination_id}"
 
           winner.merge_from(
             source_client.as_warehouse,

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     job.perform(actor_id: user.id)
   end
 
+  before(:each) do
+    stub_api
+  end
+
   it 'finds clients' do
     stub_api
 
@@ -53,8 +57,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'inserts a new MCI unique ID' do
-    stub_api
-
     perform
     expect(HmisExternalApis::ExternalId.count).to eq(1)
     expect(client.external_ids.length).to eq(1)
@@ -62,7 +64,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'updates an existing MCI unique ID' do
-    stub_api
     perform
 
     default_record['mciUniqId'] = '999999'
@@ -73,8 +74,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'soft-merges duplicate MCI unique IDs' do
-    stub_api
-
     destination_id = client.warehouse_id
 
     # Second source client with different destination client but same MCI unique ID
@@ -104,8 +103,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'takes no merge action for duplicate MCI unique IDs when source clients already share same destination' do
-    stub_api
-
     # Second source client sharing the same destination; no repointing needed
     other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
     create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
@@ -133,8 +130,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'takes no merge action for duplicate MCI unique IDs when the source clients were previously split' do
-    stub_api
-
     # Second source client with different destination client but same MCI unique ID
     other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
     create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
@@ -153,6 +148,27 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     expect(client.reload.warehouse_id).not_to eq(other_client.reload.warehouse_id)
   end
 
+  it 'still soft-merges when the source client has a previous split event associated with a different destination client' do
+    # Setup 2 new source clients with the same destination client
+    other_client_1 = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
+    other_client_2 = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
+    other_client_2.warehouse_client_source.update(destination_id: other_client_1.warehouse_id)
+    expect(other_client_1.warehouse_id).to eq(other_client_2.warehouse_id)
+
+    # One of the new source clients has the same MCI unique ID as the original client
+    create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client_1)
+
+    # Split other_client_1 out from other_client_2's dest client
+    other_client_2.destination_client.as_warehouse.split([other_client_1.id], nil, nil, user)
+    expect(other_client_1.reload.warehouse_id).not_to eq(other_client_2.reload.warehouse_id)
+    expect(GrdaWarehouse::ClientSplitHistory.exists?(split_from: other_client_2.destination_client.id)).to be_truthy
+
+    # Perform the WarehouseChangesJob and expect the soft merge between other_client_1 and client to still take place
+    perform
+    expect(client.reload.warehouse_id).to eq(other_client_1.reload.warehouse_id)
+    expect(other_client_2.reload.warehouse_id).not_to eq(other_client_1.reload.warehouse_id)
+  end
+
   context 'when there are multiple sets of multiple duplicate MCIs' do
     let!(:clients_by_mci) do
       # Create 3 sets of 3 clients each with different MCI unique IDs
@@ -169,8 +185,6 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     end
 
     it 'soft-merges all sets of duplicates' do
-      stub_api
-
       expected_winner_destination_ids = clients_by_mci.transform_values do |clients|
         clients.map(&:warehouse_id).min
       end

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
   end
 
   it 'takes no merge action for duplicate MCI unique IDs when the source clients were previously split' do
-    # Second source client with different destination client but same MCI unique ID
+    # Second source client with same destination client and same MCI unique ID
     other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
     create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
     other_client.warehouse_client_source.update(destination_id: client.warehouse_id)
@@ -140,7 +140,7 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     expect(other_client.reload.warehouse_id).not_to eq(client.reload.warehouse_id)
     expect(GrdaWarehouse::ClientSplitHistory.exists?(split_from: client.destination_client.id)).to be_truthy
 
-    # Perform the WarehouseChangesJob again, which should take no action because the source clients were previously split
+    # Perform the WarehouseChangesJob, which should take no action because the source clients were previously split
     perform
     expect(client.reload.warehouse_id).not_to eq(other_client.reload.warehouse_id)
   end

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -132,6 +132,27 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     expect(client.warehouse_id).to eq(other_client.warehouse_id)
   end
 
+  it 'takes no merge action for duplicate MCI unique IDs when the source clients were previously split' do
+    stub_api
+
+    # Second source client with different destination client but same MCI unique ID
+    other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
+    create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
+
+    # Perform the WarehouseChangesJob for the first time, which soft-merges the source clients, pointing them to the same destination
+    perform
+    expect(client.reload.warehouse_id).to eq(other_client.reload.warehouse_id)
+
+    # Split the other_client out
+    client.destination_client.as_warehouse.split([other_client.id], nil, nil, user)
+    expect(other_client.reload.warehouse_id).not_to eq(client.reload.warehouse_id)
+    expect(GrdaWarehouse::ClientSplitHistory.exists?(split_from: client.destination_client.id)).to be_truthy
+
+    # Perform the WarehouseChangesJob again, which should take no action because the source clients were previously split
+    perform
+    expect(client.reload.warehouse_id).not_to eq(other_client.reload.warehouse_id)
+  end
+
   context 'when there are multiple sets of multiple duplicate MCIs' do
     let!(:clients_by_mci) do
       # Create 3 sets of 3 clients each with different MCI unique IDs

--- a/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
+++ b/drivers/hmis_external_apis/spec/jobs/hmis_external_apis/ac_hmis/warehouse_changes_job_spec.rb
@@ -133,10 +133,7 @@ RSpec.describe HmisExternalApis::AcHmis::WarehouseChangesJob, type: :job do
     # Second source client with different destination client but same MCI unique ID
     other_client = create(:hmis_hud_client_with_warehouse_client, data_source: data_source)
     create(:mci_unique_id_external_id, value: '1000119810', remote_credential: remote_credential, source: other_client)
-
-    # Perform the WarehouseChangesJob for the first time, which soft-merges the source clients, pointing them to the same destination
-    perform
-    expect(client.reload.warehouse_id).to eq(other_client.reload.warehouse_id)
+    other_client.warehouse_client_source.update(destination_id: client.warehouse_id)
 
     # Split the other_client out
     client.destination_client.as_warehouse.split([other_client.id], nil, nil, user)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- targets release-201 to go out alongside #6239

## Description
Prevent re-merging clients that were previously split in `WarehouseClientJob`

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) - see ticket comment "Desired behavior in QA"

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
