### PR TITLE
Test Kit CH Household Update from AAQ

### DIFF
--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -79,9 +79,9 @@ module HudReports::Households
       @hoh_enrollments
     end
 
-    # Chronic status should come from the HoH if they are chronically homeless
-    # if not, use any other adult who is,
-    # if no adults are either yes or no, use  self for adults, and the HoH enrollment for children
+    # CH at Project Start (chronic_status): any household member present at start can cause the household to be CH.
+    # CH at Point in Time (pit_chronic_status): at least one adult or minor head of household must be CH.
+    # If no qualifying members are CH, use self for adults, and the HoH enrollment for children.
     # from glossary:
     # In cases where the head of household as well as all other adult household members have an indeterminate CH status (don’t know, refused, missing), any child household members should carry the same CH status as the head of household.
     # NOTE: Client CH status is only inherited if the client was present at the start of the enrollment.
@@ -102,21 +102,30 @@ module HudReports::Households
       current_member_entry_date = current_member[:entry_date] if current_member.present?
       hoh_entry_date = hoh[:entry_date] if hoh.present?
 
-      # HoH if they are chronically homeless
-      return hoh if hoh.present? && hoh[chronic_status] && hoh_entry_date == current_member_entry_date
+      # CH at Project Start: "The members of a household present at project start... can cause other
+      #    household members present at start to be considered chronically homeless" - no HoH/adult restriction.
+      # CH at Point in Time: "at least one adult or minor head of household" - so we check HoH and adults only.
+      # Both require the member to be present at the start of the project (same entry date as the HoH)
+      if chronic_status == :chronic_status
+        # CH at Project Start
+        chronic_member = household_members.detect do |hm|
+          hm[chronic_status] && hm[:entry_date] == hoh_entry_date
+        end
+        return chronic_member if chronic_member.present?
+      else # :pit_chronic_status
+        # CH at Point in Time
+        return hoh if hoh.present? && hoh[chronic_status] && hoh_entry_date == current_member_entry_date
 
-      # If the HoH is not chronically homeless, check if any other adult is
-      # The HH CH status will inherit from a CH adultas long as they have the same entry date as the HoH
-      chronic_adult = household_members.detect do |hm|
-        next false unless hm[:age].present?
+        chronic_adult = household_members.detect do |hm|
+          next false unless hm[:age].present?
 
-        adult_is_chronic = hm[:age] >= 18 && hm[chronic_status]
-        adult_matches_entry_date = hm[:entry_date] == hoh_entry_date
+          adult_is_chronic = hm[:age] >= 18 && hm[chronic_status]
+          adult_matches_entry_date = hm[:entry_date] == hoh_entry_date
 
-        adult_is_chronic && adult_matches_entry_date
+          adult_is_chronic && adult_matches_entry_date
+        end
+        return chronic_adult if chronic_adult.present?
       end
-      # if not, use any other adult who is (with the same entry date)
-      return chronic_adult if chronic_adult.present?
 
       # Return false if we don't have a valid member to check
       return false unless current_member.present?

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/multiple_projects.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/multiple_projects.rb
@@ -59,10 +59,6 @@ RSpec.shared_context 'datalab multiple projects apr', shared_context: :metadata 
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q5a',
-        skip: [
-          'B12', # expected '27.0000' (27), got '24.0000' (24)
-          'C12', # expected '27.0000' (27), got '24.0000' (24)
-        ],
       )
     end
 
@@ -448,12 +444,6 @@ RSpec.shared_context 'datalab multiple projects apr', shared_context: :metadata 
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q26b',
-        skip: [
-          'B2', # expected '27.0000' (27), got '24.0000' (24)
-          'D2', # expected '6.0000' (6), got '3.0000' (3)
-          'B3', # expected '70.0000' (70), got '73.0000' (73)
-          'D3', # expected '27.0000' (27), got '30.0000' (30)
-        ],
       )
     end
 
@@ -469,14 +459,6 @@ RSpec.shared_context 'datalab multiple projects apr', shared_context: :metadata 
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q26d',
-        skip: [
-          'B2', # expected '4.0000' (4), got '2.0000' (2)
-          'D2', # expected '4.0000' (4), got '2.0000' (2)
-          'B4', # expected '3.0000' (3), got '2.0000' (2)
-          'D4', # expected '2.0000' (2), got '1.0000' (1)
-          'B11', # expected '27.0000' (27), got '24.0000' (24)'
-          'D11', # expected '6.0000' (6), got '3.0000' (3)'
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_j_rrh.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_j_rrh.rb
@@ -56,10 +56,6 @@ RSpec.shared_context 'datalab organization j rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q5a',
-        skip: [
-          'B12', # expected '20.0000' (20), got '17.0000' (17)
-          'C12', # expected '20.0000' (20), got '17.0000' (17)
-        ],
       )
     end
 
@@ -437,17 +433,11 @@ RSpec.shared_context 'datalab organization j rrh apr', shared_context: :metadata
       )
     end
 
-    # Pending AAQ: https://www.hudexchange.info/program-support/my-question/?askaquestionaction=public%3Amain.answer&key=15A12C3C-8308-4B95-982B015C693F7CEE
+    # Previous AAQ: https://www.hudexchange.info/program-support/my-question/?askaquestionaction=public%3Amain.answer&key=15A12C3C-8308-4B95-982B015C693F7CEE
     it 'Q26b' do
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q26b',
-        skip: [
-          'B2', # expected '20.0000' (20), got '17.0000' (17)
-          'D2', # expected '4.0000' (4), got '1.0000' (1)
-          'B3', # expected '29.0000' (29), got '32.0000' (32)
-          'D3', # expected '13.0000' (13), got '16.0000' (16)
-        ],
       )
     end
 
@@ -463,14 +453,6 @@ RSpec.shared_context 'datalab organization j rrh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q26d',
-        skip: [
-          'B2', # expected '3.0000' (3), got '1.0000' (1)
-          'D2', # expected '3.0000' (3), got '1.0000' (1)
-          'B4', # expected '2.0000' (2), got '1.0000' (1)
-          'D4', # expected '1.0000' (1), got '0.0000' (0)
-          'B11', # expected '20.0000' (20), got '17.0000' (17)
-          'D11', # expected '4.0000' (4), got '1.0000' (1)
-        ],
       )
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Updates chronic homelessness household logic to match HUD’s "CH at Project Start Because of Other Household Members" guidance: any chronically homeless household member present at project start can make the whole household chronically homeless, not only the head of household or adults. The "adult or minor head of household" rule applies only to CH at Point in Time. calculate_household_chronic_status now uses one "any member" check for CH at Project Start and keeps the HoH/adult-only logic for Point in Time.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
