### PR TITLE
Support per-HMIS name in multi-HMIS installations

### DIFF
--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -718,6 +718,10 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     hmis.present?
   end
 
+  def hmis_name
+    name if hmis?
+  end
+
   def hmis_link_available?
     hmis? || external_hmis_configuration&.active?
   end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -9,6 +9,7 @@
 class Translation < ApplicationRecord
   include NotifierConfig
 
+  # @return [String] the translation if it exists, otherwise the original text
   def self.translate(text)
     # The cache is updated via BuildTranslationCacheJob, but without an expiration is uses the default
     # expiration of 5 minutes in development, 8 hours in production
@@ -20,6 +21,13 @@ class Translation < ApplicationRecord
       translation.text
     end
     translated.presence || text
+  end
+
+  # @return [String, nil] the translation if it exists, otherwise nil
+  def self.translate_if_present(text)
+    Rails.cache.fetch(cache_key(text), expires_in: 8.hours) do
+      where(key: text).order(:id).first&.text
+    end
   end
 
   def self.cache_key(text)

--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -28,7 +28,10 @@ class Hmis::AppSettingsController < Hmis::BaseController
       logoPath: logo_path,
       warehouseUrl: "https://#{hostname}",
       warehouseName: Translation.translate('Open Path HMIS Warehouse'),
-      appName: Translation.translate('Open Path HMIS'), # TODO: app name should be configurable per data source
+      # for appName, return the 'Open Path HMIS' translation if it exists, otherwise return the data source name.
+      # This ensures backwards compatibility for existing single-OP-HMIS installations that rely on Translations,
+      # while adding support for multi-OP-HMIS installations with distinct names.
+      appName: Translation.translate_if_present('Open Path HMIS') || current_data_source.name,
       resetPasswordUrl: "https://#{hostname}/users/password/new",
       unlockAccountUrl: "https://#{hostname}/users/unlock/new",
       manageAccountUrl: "https://#{hostname}/account/edit",

--- a/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/app_settings_controller.rb
@@ -31,7 +31,7 @@ class Hmis::AppSettingsController < Hmis::BaseController
       # for appName, return the 'Open Path HMIS' translation if it exists, otherwise return the data source name.
       # This ensures backwards compatibility for existing single-OP-HMIS installations that rely on Translations,
       # while adding support for multi-OP-HMIS installations with distinct names.
-      appName: Translation.translate_if_present('Open Path HMIS') || current_data_source.name,
+      appName: Translation.translate_if_present('Open Path HMIS') || current_data_source.hmis_name,
       resetPasswordUrl: "https://#{hostname}/users/password/new",
       unlockAccountUrl: "https://#{hostname}/users/unlock/new",
       manageAccountUrl: "https://#{hostname}/account/edit",

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -43,14 +43,19 @@ class Hmis::BaseController < ActionController::Base
     raise 'cannot determine HMIS host'
   end
 
+  def current_data_source
+    @current_data_source ||= begin
+      data_source = GrdaWarehouse::DataSource.hmis.find_by(hmis: current_hmis_host)
+      raise "HMIS data source not configured: #{current_hmis_host}" unless ds.present?
+
+      data_source
+    end
+  end
+
   # Binds the current request to an HMIS data source using the request host
   # @see docs/architecture/multi-hmis-support.md
   def attach_data_source_id
-    domain = current_hmis_host
-    data_source_id = GrdaWarehouse::DataSource.hmis.find_by(hmis: domain)&.id
-    raise "HMIS data source not configured: #{domain}" unless data_source_id.present?
-
-    current_hmis_user.hmis_data_source_id = data_source_id
+    current_hmis_user.hmis_data_source_id = current_data_source.id
   end
 
   # PaperTrail whodunnit (set in ApplicationController) uses this method to determine the label to be stored

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -44,12 +44,10 @@ class Hmis::BaseController < ActionController::Base
   end
 
   def current_data_source
-    @current_data_source ||= begin
-      data_source = GrdaWarehouse::DataSource.hmis.find_by(hmis: current_hmis_host)
-      raise "HMIS data source not configured: #{current_hmis_host}" unless data_source.present?
+    data_source = GrdaWarehouse::DataSource.hmis.find_by(hmis: current_hmis_host)
+    raise "HMIS data source not configured: #{current_hmis_host}" unless data_source.present?
 
-      data_source
-    end
+    data_source
   end
 
   # Binds the current request to an HMIS data source using the request host

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -46,7 +46,7 @@ class Hmis::BaseController < ActionController::Base
   def current_data_source
     @current_data_source ||= begin
       data_source = GrdaWarehouse::DataSource.hmis.find_by(hmis: current_hmis_host)
-      raise "HMIS data source not configured: #{current_hmis_host}" unless ds.present?
+      raise "HMIS data source not configured: #{current_hmis_host}" unless data_source.present?
 
       data_source
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add new logic to HMIS `AppSettingsController` for the `appName`: use a translation if there is one, fall back to the data source name if there isn't.
- Add new method to the `Translation` model API: `translate_if_present`. Returns the translation if one exists, `nil` otherwise, unlike the existing `.translate` method, which returns the original text if no translation exists.
- Dry up HMIS `BaseController` with a common method for `current_data_source` ~which memoizes the value.~

**Why this approach**: See ticket comment https://github.com/open-path/Green-River/issues/8830#issuecomment-4031394297 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) - see QA instructions on ticket.

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
