### PR TITLE
CAS Sync Active Clients Project Group

### DIFF
--- a/app/models/concerns/cas_client_data.rb
+++ b/app/models/concerns/cas_client_data.rb
@@ -21,15 +21,20 @@ module CasClientData
       when :release_present
         where(housing_release_status: [full_release_string, partial_release_string])
       when :active_clients
+        # Clients with service in the configured date range at projects from
+        # active_clients_project_ids_for_cas_sync (project group if set, else homeless+CE+override)
         range = GrdaWarehouse::Config.cas_sync_range
         project_ids = active_clients_project_ids_for_cas_sync
-        return none if project_ids.blank?
-
-        service_options = { start_date: range.first, end_date: range.last }
-        service_options[:service_scope] = GrdaWarehouse::ServiceHistoryService.service_excluding_extrapolated unless GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
-        enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.in_project(project_ids).
-          with_service_between(**service_options)
-        where(id: enrollment_scope.select(:client_id))
+        if project_ids.blank?
+          scope = none
+        else
+          service_options = { start_date: range.first, end_date: range.last }
+          service_options[:service_scope] = GrdaWarehouse::ServiceHistoryService.service_excluding_extrapolated unless GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
+          enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.in_project(project_ids).
+            with_service_between(**service_options)
+          scope = where(id: enrollment_scope.select(:client_id))
+        end
+        scope
       when :project_group
         project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids
         return none if project_ids.blank?
@@ -62,6 +67,16 @@ module CasClientData
       scope.or(where(sync_with_cas: true))
     end
 
+    # Returns project IDs whose enrollments count as "active" for CAS when using the
+    # "Active clients within range" sync method. Two modes:
+    #
+    # 1. Project group selected (cas_sync_project_group_id): Uses only that group's
+    #    effective_project_ids (after exclusions). Projects with active_homeless_status_override
+    #    are NOT auto-included; add them to the group explicitly if needed.
+    #
+    # 2. No project group: All homeless project types + CE (14) + projects with
+    #    active_homeless_status_override (Project → Edit → "Consider enrolled clients as
+    #    actively homeless for CAS and Cohorts?").
     def self.active_clients_project_ids_for_cas_sync
       project_group = GrdaWarehouse::Config.cas_sync_project_group
       if project_group.present?
@@ -71,7 +86,7 @@ module CasClientData
         return []
       end
 
-      # Default to all homeless and CE projects
+      # Default: all homeless + CE + override projects
       homeless_ce_project_ids = GrdaWarehouse::Hud::Project.with_project_type(HudHelper.util.homeless_project_types + [14]).pluck(:id)
       override_project_ids = GrdaWarehouse::Hud::Project.where(active_homeless_status_override: true).pluck(:id)
       (homeless_ce_project_ids + override_project_ids).uniq
@@ -494,22 +509,25 @@ module CasClientData
       when :release_present
         any_release_on_file?
       when :active_clients
+        # This client has service in range at a project from active_clients_project_ids_for_cas_sync?
         range = GrdaWarehouse::Config.cas_sync_range
         project_ids = self.class.active_clients_project_ids_for_cas_sync
-        return false if project_ids.blank?
-
-        enrollment_scope = service_history_enrollments.in_project(project_ids)
-        if GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
-          enrollment_scope.with_service_between(
-            start_date: range.first,
-            end_date: range.last,
-          ).exists?
+        if project_ids.blank?
+          false
         else
-          enrollment_scope.with_service_between(
-            start_date: range.first,
-            end_date: range.last,
-            service_scope: GrdaWarehouse::ServiceHistoryService.service_excluding_extrapolated,
-          ).exists?
+          enrollment_scope = service_history_enrollments.in_project(project_ids)
+          if GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
+            enrollment_scope.with_service_between(
+              start_date: range.first,
+              end_date: range.last,
+            ).exists?
+          else
+            enrollment_scope.with_service_between(
+              start_date: range.first,
+              end_date: range.last,
+              service_scope: GrdaWarehouse::ServiceHistoryService.service_excluding_extrapolated,
+            ).exists?
+          end
         end
       when :project_group
         project_ids = GrdaWarehouse::Config.cas_sync_project_group&.projects&.ids

--- a/app/models/concerns/cas_client_data.rb
+++ b/app/models/concerns/cas_client_data.rb
@@ -22,15 +22,12 @@ module CasClientData
         where(housing_release_status: [full_release_string, partial_release_string])
       when :active_clients
         range = GrdaWarehouse::Config.cas_sync_range
-
-        # Homeless and Coordinated Entry Projects
-        homeless_ce_project_ids = GrdaWarehouse::Hud::Project.with_project_type(HudHelper.util.homeless_project_types + [14]).pluck(:id)
-        # Projects with override to consider enrolled clients as actively homeless for CAS and Cohorts
-        override_project_ids = GrdaWarehouse::Hud::Project.where(active_homeless_status_override: true).pluck(:id)
+        project_ids = active_clients_project_ids_for_cas_sync
+        return none if project_ids.blank?
 
         service_options = { start_date: range.first, end_date: range.last }
         service_options[:service_scope] = GrdaWarehouse::ServiceHistoryService.service_excluding_extrapolated unless GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
-        enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.in_project(homeless_ce_project_ids + override_project_ids).
+        enrollment_scope = GrdaWarehouse::ServiceHistoryEnrollment.in_project(project_ids).
           with_service_between(**service_options)
         where(id: enrollment_scope.select(:client_id))
       when :project_group
@@ -63,6 +60,21 @@ module CasClientData
 
       # Include anyone who should be included by virtue of their data, and anyone who has the checkbox checked
       scope.or(where(sync_with_cas: true))
+    end
+
+    def self.active_clients_project_ids_for_cas_sync
+      project_group = GrdaWarehouse::Config.cas_sync_project_group
+      if project_group.present?
+        ids = project_group.effective_project_ids.reject { |id| id.blank? || id.zero? }
+        return ids if ids.any?
+
+        return []
+      end
+
+      # Default to all homeless and CE projects
+      homeless_ce_project_ids = GrdaWarehouse::Hud::Project.with_project_type(HudHelper.util.homeless_project_types + [14]).pluck(:id)
+      override_project_ids = GrdaWarehouse::Hud::Project.where(active_homeless_status_override: true).pluck(:id)
+      (homeless_ce_project_ids + override_project_ids).uniq
     end
 
     scope :full_housing_release_on_file, -> do
@@ -483,12 +495,10 @@ module CasClientData
         any_release_on_file?
       when :active_clients
         range = GrdaWarehouse::Config.cas_sync_range
+        project_ids = self.class.active_clients_project_ids_for_cas_sync
+        return false if project_ids.blank?
 
-        # Homeless and Coordinated Entry Projects
-        homeless_ce_project_ids = GrdaWarehouse::Hud::Project.with_project_type(HudHelper.util.homeless_project_types + [14]).pluck(:id)
-        # Projects with override to consider enrolled clients as actively homeless for CAS and Cohorts
-        override_project_ids = GrdaWarehouse::Hud::Project.where(active_homeless_status_override: true).pluck(:id)
-        enrollment_scope = service_history_enrollments.in_project(homeless_ce_project_ids + override_project_ids)
+        enrollment_scope = service_history_enrollments.in_project(project_ids)
         if GrdaWarehouse::Config.get(:ineligible_uses_extrapolated_days)
           enrollment_scope.with_service_between(
             start_date: range.first,

--- a/app/models/grda_warehouse/project_group.rb
+++ b/app/models/grda_warehouse/project_group.rb
@@ -204,7 +204,8 @@ module GrdaWarehouse
     end
 
     def used_for_cas_sync?
-      return unless GrdaWarehouse::Config.get(:cas_available_method).to_sym == :project_group
+      method = GrdaWarehouse::Config.get(:cas_available_method).to_sym
+      return false unless method.in?([:project_group, :boston, :active_clients])
 
       GrdaWarehouse::Config.get(:cas_sync_project_group_id) == id
     end

--- a/app/views/admin/configs/_cas.haml
+++ b/app/views/admin/configs/_cas.haml
@@ -7,7 +7,7 @@
     .jCasSyncMonths
       = f.input :cas_sync_months, as: :select_two, collection: GrdaWarehouse::Config.available_cas_sync_months, label: 'Clients active within prior'
     .jCasSyncProjectGroup
-      = f.input :cas_sync_project_group_id, collection: GrdaWarehouse::ProjectGroup.viewable_by(current_user), label: 'Project Group to sync', hint: 'Optional for Active clients within range (leave blank to include all homeless/CE projects). Required for Project group and Boston.', as: :select_two
+      = f.input :cas_sync_project_group_id, collection: GrdaWarehouse::ProjectGroup.viewable_by(current_user), label: 'Project Group to sync', hint: 'Optional for Active clients within range (leave blank to include all homeless/CE projects including projects that act as homeless for CAS). Required for Project group and Boston.', as: :select_two
     = f.input :cas_flag_method, collection: GrdaWarehouse::Config.available_cas_flag_methods,  label: 'Should the CAS Readiness form require additional human review, or is the existence of a file flagged with the appropriate tag sufficient for matching in CAS?', as: :select_two
     = f.input :rrh_cas_readiness, label: 'Include RRH section in CAS Readiness?'
     = f.input :client_details, collection: GrdaWarehouse::Hud::Client.cas_columns.invert.to_a.sort, label: 'Checkboxes displayed in CAS Readiness', as: :select_two, input_html: { multiple: true }

--- a/app/views/admin/configs/_cas.haml
+++ b/app/views/admin/configs/_cas.haml
@@ -7,7 +7,7 @@
     .jCasSyncMonths
       = f.input :cas_sync_months, as: :select_two, collection: GrdaWarehouse::Config.available_cas_sync_months, label: 'Clients active within prior'
     .jCasSyncProjectGroup
-      = f.input :cas_sync_project_group_id, collection: GrdaWarehouse::ProjectGroup.viewable_by(current_user), label: 'Project Group to sync', as: :select_two
+      = f.input :cas_sync_project_group_id, collection: GrdaWarehouse::ProjectGroup.viewable_by(current_user), label: 'Project Group to sync', hint: 'Optional for Active clients within range (leave blank to include all homeless/CE projects). Required for Project group and Boston.', as: :select_two
     = f.input :cas_flag_method, collection: GrdaWarehouse::Config.available_cas_flag_methods,  label: 'Should the CAS Readiness form require additional human review, or is the existence of a file flagged with the appropriate tag sufficient for matching in CAS?', as: :select_two
     = f.input :rrh_cas_readiness, label: 'Include RRH section in CAS Readiness?'
     = f.input :client_details, collection: GrdaWarehouse::Hud::Client.cas_columns.invert.to_a.sort, label: 'Checkboxes displayed in CAS Readiness', as: :select_two, input_html: { multiple: true }

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -35,7 +35,7 @@
           show: '.jCasSyncMonths',
         },
         {
-          value: ['project_group', 'boston'],
+          value: ['active_clients', 'project_group', 'boston'],
           show: '.jCasSyncProjectGroup',
         }
       ],

--- a/docs/features/cas-sync-active-clients.md
+++ b/docs/features/cas-sync-active-clients.md
@@ -1,0 +1,41 @@
+# CAS Sync: Active Clients with Optional Project Group
+
+## Overview
+
+The "Active clients within range" CAS sync method determines which clients are considered active for CAS based on service history in a configurable date range. Which projects count toward "active" can be controlled in two ways: by default (all homeless + CE + override projects) or by selecting a project group.
+
+## How It Works
+
+### Project Selection
+
+The system uses `active_clients_project_ids_for_cas_sync` (in `CasClientData`) to get the set of project IDs whose enrollments count as active. Two modes:
+
+**1. No project group selected** (`cas_sync_project_group_id` blank)
+
+- Includes all homeless project types (ES, SO, TH, etc.)
+- Includes CE (project type 14)
+- Includes projects with `active_homeless_status_override` (Project → Edit → "Consider enrolled clients as actively homeless for CAS and Cohorts?")
+
+**2. Project group selected**
+
+- Uses only that project group's `effective_project_ids` (projects in the group after applying any exclusions)
+- `active_homeless_status_override` projects are **not** auto-included; add them to the project group explicitly if needed
+
+### Active Client Criteria
+
+A client is active for CAS when they have at least one enrollment with service in the configured date range (`cas_sync_months`) at a project in the selected set. Service may be extrapolated or actual, depending on `ineligible_uses_extrapolated_days`.
+
+### Project Group Exclusions
+
+Project groups can exclude specific projects or project types. Excluded projects are removed from `effective_project_ids`. Clients whose only qualifying enrollment is in an excluded project will not sync to CAS.
+
+## Configuration
+
+- **Admin → Config → CAS**: "Project Group to sync" (optional for Active clients within range; required for Project group and Boston methods)
+- **Project → Edit**: "Consider enrolled clients as actively homeless for CAS and Cohorts?" (`active_homeless_status_override`)
+
+## Related Code
+
+- `app/models/concerns/cas_client_data.rb`: `active_clients_project_ids_for_cas_sync`, `cas_active` scope, `active_in_cas?`
+- `app/models/grda_warehouse/config.rb`: `cas_sync_project_group`, `cas_sync_project_group_id`
+- `app/views/admin/configs/_cas.haml`: Project group selection UI

--- a/spec/models/grda_warehouse/cas_active_spec.rb
+++ b/spec/models/grda_warehouse/cas_active_spec.rb
@@ -87,6 +87,59 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
   end
 
+  describe 'when active_clients with project group excluding some projects' do
+    before(:all) do
+      GrdaWarehouse::Utility.clear!
+      @config = GrdaWarehouse::Config.first_or_create
+      @config.update(
+        so_day_as_month: true,
+        cas_available_method: :active_clients,
+        ineligible_uses_extrapolated_days: true,
+        cas_sync_months: 1,
+      )
+      import_hmis_csv_fixture(
+        'spec/fixtures/files/service_history/cas_activity_methods',
+        version: 'AutoMigrate',
+      )
+      # Project group: homeless+CE types, but exclude the ES project (1-1) so only SO and CE count
+      es_project = GrdaWarehouse::Hud::Project.find_by(project_id: '1-1')
+      @cas_project_group = GrdaWarehouse::ProjectGroup.create!(name: 'CAS sync excluding ES')
+      @cas_project_group.update(
+        options: @cas_project_group.filter.update(
+          project_type_numbers: [1, 4, 14],
+          excluded_project_ids: [es_project.id],
+        ).to_h,
+      )
+      @cas_project_group.maintain_projects!
+      @config.update(cas_sync_project_group_id: @cas_project_group.id)
+    end
+    after(:all) do
+      GrdaWarehouse::Utility.clear!
+      cleanup_hmis_csv_fixtures
+      @cas_project_group.destroy
+    end
+
+    it 'excludes clients whose only service is in excluded projects' do
+      travel_to Time.local(2016, 2, 15) do
+        # Client 1-1 has service only in ES (excluded) - should not be active
+        # Client 1-2 has enrollments in SO and CE - may have extrapolated service there
+        # With ES excluded, client 1-1 should drop out; we expect 1 or fewer clients
+        active_count = GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)
+        expect(active_count).to be <= 1
+        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to be <= 1
+      end
+    end
+
+    it 'with no project group set, uses default homeless+CE (2 clients with extrapolated)' do
+      @config.update(cas_sync_project_group_id: nil)
+      travel_to Time.local(2016, 2, 15) do
+        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(2)
+        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(2)
+      end
+      @config.update(cas_sync_project_group_id: @cas_project_group.id)
+    end
+  end
+
   describe 'when syncing by project group' do
     before(:all) do
       @cas_project_group = GrdaWarehouse::ProjectGroup.create!(name: 'test')

--- a/spec/models/grda_warehouse/cas_active_spec.rb
+++ b/spec/models/grda_warehouse/cas_active_spec.rb
@@ -2,8 +2,12 @@
 
 require 'rails_helper'
 
+# Specs for CAS "active clients" sync: who is considered active for CAS matching based on
+# service history, project groups, and manual overrides.
 RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
-  describe 'when including extrapolated enrollments' do
+  # Base setup: active_clients method, extrapolated days enabled, cas_activity_methods fixture
+  # (Client 1-1: ES enrollment + services; Client 1-2: SO + CE enrollments)
+  shared_context 'active_clients with cas_activity_methods fixture' do
     before(:all) do
       GrdaWarehouse::Utility.clear!
       @config = GrdaWarehouse::Config.first_or_create
@@ -22,37 +26,54 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
       GrdaWarehouse::Utility.clear!
       cleanup_hmis_csv_fixtures
     end
+  end
+
+  # Asserts both active_in_cas? and cas_active scope agree on count
+  def expect_active_cas_count(expected)
+    expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(expected)
+    expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(expected)
+  end
+
+  # Creates project group with filter, maintains projects, sets config to use it
+  def setup_active_clients_project_group(name:, project_type_numbers:, excluded_project_ids:)
+    @cas_project_group = GrdaWarehouse::ProjectGroup.create!(name: name)
+    @cas_project_group.update(
+      options: @cas_project_group.filter.update(
+        project_type_numbers: project_type_numbers,
+        excluded_project_ids: excluded_project_ids,
+      ).to_h,
+    )
+    @cas_project_group.maintain_projects!
+    @config.update(cas_sync_project_group_id: @cas_project_group.id)
+  end
+  # Extrapolated days: SO day-as-month counts as service; both clients have enrollments in range
+  describe 'when including extrapolated enrollments' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
     it 'finds two clients who are active for CAS' do
-      travel_to Time.local(2016, 2, 15) do
-        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(2)
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(2)
-      end
+      # Feb 2016: both clients have extrapolated service in ES/SO/CE
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(2) }
     end
 
     it 'finds no client who is active for CAS' do
-      travel_to Time.local(2016, 3, 15) do
-        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(0)
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(0)
-      end
+      # Mar 2016: outside sync range, no one active
+      travel_to Time.local(2016, 3, 15) { expect_active_cas_count(0) }
     end
 
     it 'excludes clients enrolled in non-Homeless/non-CE project types' do
-      GrdaWarehouse::Hud::Project.update_all(ProjectType: 11) # Day Shelter
-      travel_to Time.local(2016, 2, 15) do
-        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(0)
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(0)
-      end
+      # Day Shelter (11) is not homeless/CE; no one qualifies without override
+      GrdaWarehouse::Hud::Project.update_all(ProjectType: 11)
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(0) }
     end
 
     it 'includes clients enrolled in projects active_homeless_status_override' do
-      GrdaWarehouse::Hud::Project.update_all(ProjectType: 11, active_homeless_status_override: true) # Day Shelter with override
-      travel_to Time.local(2016, 2, 15) do
-        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(2)
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(2)
-      end
+      # Day Shelter with override counts as homeless; both clients qualify
+      GrdaWarehouse::Hud::Project.update_all(ProjectType: 11, active_homeless_status_override: true)
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(2) }
     end
   end
 
+  # No extrapolation: only clients with actual service records count
   describe 'when excluding extrapolated enrollments' do
     before(:all) do
       @config = GrdaWarehouse::Config.first_or_create
@@ -73,6 +94,7 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
 
     it 'finds one client who is active for CAS' do
+      # Only client 1-1 has actual services in range; 1-2 has none
       travel_to Time.local(2016, 2, 15) do
         expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(1)
         expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(1)
@@ -80,6 +102,7 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
 
     it 'finds no client who is active for CAS' do
+      # Mar 2016: outside sync range
       travel_to Time.local(2016, 3, 15) do
         expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(0)
         expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(0)
@@ -87,59 +110,125 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
   end
 
+  # Project group with exclusions: ES excluded, only SO and CE count
   describe 'when active_clients with project group excluding some projects' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
     before(:all) do
-      GrdaWarehouse::Utility.clear!
-      @config = GrdaWarehouse::Config.first_or_create
-      @config.update(
-        so_day_as_month: true,
-        cas_available_method: :active_clients,
-        ineligible_uses_extrapolated_days: true,
-        cas_sync_months: 1,
-      )
-      import_hmis_csv_fixture(
-        'spec/fixtures/files/service_history/cas_activity_methods',
-        version: 'AutoMigrate',
-      )
-      # Project group: homeless+CE types, but exclude the ES project (1-1) so only SO and CE count
       es_project = GrdaWarehouse::Hud::Project.find_by(project_id: '1-1')
-      @cas_project_group = GrdaWarehouse::ProjectGroup.create!(name: 'CAS sync excluding ES')
-      @cas_project_group.update(
-        options: @cas_project_group.filter.update(
-          project_type_numbers: [1, 4, 14],
-          excluded_project_ids: [es_project.id],
-        ).to_h,
+      setup_active_clients_project_group(
+        name: 'CAS sync excluding ES',
+        project_type_numbers: [1, 4, 14],
+        excluded_project_ids: [es_project.id],
       )
-      @cas_project_group.maintain_projects!
-      @config.update(cas_sync_project_group_id: @cas_project_group.id)
     end
-    after(:all) do
-      GrdaWarehouse::Utility.clear!
-      cleanup_hmis_csv_fixtures
-      @cas_project_group.destroy
-    end
+    after(:all) { @cas_project_group.destroy }
 
     it 'excludes clients whose only service is in excluded projects' do
-      travel_to Time.local(2016, 2, 15) do
-        # Client 1-1 has service only in ES (excluded) - should not be active
-        # Client 1-2 has enrollments in SO and CE - may have extrapolated service there
-        # With ES excluded, client 1-1 should drop out; we expect 1 or fewer clients
-        active_count = GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)
-        expect(active_count).to be <= 1
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to be <= 1
-      end
+      # Client 1-1: only in ES (excluded) -> not active. Client 1-2: SO+CE (in group) -> active
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(1) }
     end
 
     it 'with no project group set, uses default homeless+CE (2 clients with extrapolated)' do
+      # Clearing project group falls back to all homeless+CE; both clients qualify
       @config.update(cas_sync_project_group_id: nil)
-      travel_to Time.local(2016, 2, 15) do
-        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(2)
-        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(2)
-      end
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(2) }
       @config.update(cas_sync_project_group_id: @cas_project_group.id)
     end
   end
 
+  # Project group includes ES, SO, CE; no exclusions
+  describe 'when active_clients with project group including all projects' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
+    before(:all) do
+      setup_active_clients_project_group(
+        name: 'CAS sync all homeless CE',
+        project_type_numbers: [1, 4, 14],
+        excluded_project_ids: [],
+      )
+    end
+    after(:all) { @cas_project_group.destroy }
+
+    it 'includes es_project enrollment when project group has no exclusions' do
+      # Both clients active: 1-1 via ES, 1-2 via SO/CE
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(2) }
+    end
+  end
+
+  # Project group = SO+CE only. ES is Day Shelter with override but NOT in group.
+  # Override projects are NOT auto-included when a project group is configured.
+  describe 'when active_clients with project group - active_homeless_status_override not auto-included' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
+    before(:all) do
+      GrdaWarehouse::Hud::Project.find_by(project_id: '1-1').
+        update!(ProjectType: 11, active_homeless_status_override: true)
+      setup_active_clients_project_group(
+        name: 'CAS sync SO and CE only',
+        project_type_numbers: [4, 14],
+        excluded_project_ids: [],
+      )
+    end
+    after(:all) { @cas_project_group.destroy }
+
+    it 'does not auto-include override projects when project group is set' do
+      # Client 1-1 only in ES (override, not in group) -> not active. Client 1-2 in SO/CE -> active
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(1) }
+    end
+
+    it 'with no project group, override projects are included (2 clients)' do
+      # No project group: default includes homeless+CE+override; both clients qualify
+      @config.update(cas_sync_project_group_id: nil)
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(2) }
+      @config.update(cas_sync_project_group_id: @cas_project_group.id)
+    end
+  end
+
+  # Project group filters to type 99 (no matching projects) -> empty effective project list
+  describe 'when active_clients with empty project group' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
+    before(:all) do
+      setup_active_clients_project_group(
+        name: 'CAS sync empty',
+        project_type_numbers: [99],
+        excluded_project_ids: [],
+      )
+    end
+    after(:all) { @cas_project_group.destroy }
+
+    it 'finds no client when project group has no projects' do
+      # No projects in group -> no one qualifies by service (no sync_with_cas set in this setup)
+      travel_to Time.local(2016, 2, 15) { expect_active_cas_count(0) }
+    end
+  end
+
+  # All projects Day Shelter (no homeless/CE) -> project_ids blank. Manual sync_with_cas flag overrides.
+  describe 'when active_clients with sync_with_cas override' do
+    include_context 'active_clients with cas_activity_methods fixture'
+
+    before(:all) do
+      GrdaWarehouse::Hud::Project.update_all(ProjectType: 11)
+      @client_with_flag = GrdaWarehouse::Hud::Client.destination.first
+      @client_with_flag.update!(sync_with_cas: true)
+    end
+
+    it 'cas_active scope includes clients with sync_with_cas when no one qualifies by service' do
+      # Scope uses .or(sync_with_cas: true) when project_ids blank; flagged client included
+      travel_to Time.local(2016, 2, 15) do
+        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(1)
+        expect(GrdaWarehouse::Hud::Client.destination.cas_active).to include(@client_with_flag)
+      end
+    end
+
+    it 'active_in_cas? returns true for client with sync_with_cas when no one qualifies by service' do
+      # Instance method also respects sync_with_cas override when project_ids blank
+      travel_to Time.local(2016, 2, 15) { expect(@client_with_flag.active_in_cas?).to be true }
+    end
+  end
+
+  # cas_available_method: project_group — active = ongoing enrollment in group's projects
   describe 'when syncing by project group' do
     before(:all) do
       @cas_project_group = GrdaWarehouse::ProjectGroup.create!(name: 'test')
@@ -161,10 +250,10 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
 
     describe 'with no projects in the project group' do
-      before(:all) do
-        @cas_project_group.projects = []
-      end
+      before(:all) { @cas_project_group.projects = [] }
+
       it 'finds no client who is active for CAS' do
+        # Empty group -> no ongoing enrollments in group
         clients = GrdaWarehouse::Hud::Client.destination.select(&:active_in_cas?)
         error_message = "Clients: #{clients.map(&:FirstName).join('; ')}"
         expect(clients.count).to eq(0), error_message
@@ -177,10 +266,10 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
         @cas_project_group.projects.delete_all
         @cas_project_group.projects << GrdaWarehouse::Hud::Project.find_by(project_id: '1-1')
       end
+
       it 'finds one client who is active for CAS' do
+        # Group has only ES (1-1). Client 1-1 enrolled there; client 1-2 in SO/CE only
         aggregate_failures do
-          # This depends on ongoing enrollments so to verify actual functionality, we need to move to a time
-          # where two enrollments are open, but only one is at the chosen project
           travel_to Time.zone.local(2016, 2, 1) do
             expect(GrdaWarehouse::Hud::Project.count).to eq(3)
             expect(@cas_project_group.projects.count).to eq(1)
@@ -193,8 +282,10 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
   end
 
+  # cas_available_method: ce_with_assessment — active = CE enrollment with assessment
   describe 'when syncing by ce enrollment' do
     before(:all) do
+      GrdaWarehouse::Utility.clear!
       @config = GrdaWarehouse::Config.first_or_create
       @config.update(
         so_day_as_month: true,
@@ -211,8 +302,11 @@ RSpec.describe GrdaWarehouse::ServiceHistoryService, type: :model do
     end
 
     it 'finds one client who is active for CAS' do
-      expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(1)
-      expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(1)
+      # Client 1-1 has CE enrollment (1-4) with assessment; CE enrollments start 2017-01-01
+      travel_to Time.local(2017, 2, 15) do
+        expect(GrdaWarehouse::Hud::Client.destination.map(&:active_in_cas?).count(true)).to eq(1)
+        expect(GrdaWarehouse::Hud::Client.destination.cas_active.count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds optional project group support to the "Active clients within range" CAS sync method. When a project group is selected, only enrollments in that group’s projects (after exclusions) count as active for CAS; when none is selected, behavior stays the same (all homeless + CE projects).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
