### PR TITLE
8509 phase 1: Foundation logic

### DIFF
--- a/app/jobs/importing/run_daily_imports_job.rb
+++ b/app/jobs/importing/run_daily_imports_job.rb
@@ -177,6 +177,11 @@ module Importing
         end
       end
 
+      run_maintenance_task('Prune HUD report data') do
+        HudReports::HouseholdContext.prune!
+        @notifier.ping('Pruned old household contexts')
+      end
+
       run_maintenance_task('System maintenance') do
         # Remove any expired export jobs
         PruneDocumentExportsJob.perform_later

--- a/app/models/concerns/hud_reports/households.rb
+++ b/app/models/concerns/hud_reports/households.rb
@@ -6,20 +6,26 @@
 
 # frozen_string_literal: true
 
-# require 'get_process_mem'
-# Required concerns:
-#   HudReports::Ages
+# Provides household-level logic for HUD report generators (FY2021–FY2025).
 #
-# Required accessors:
-#   a_t: Arel Type for the universe model
-#   enrollment_scope: ServiceHistoryEnrollment scope for the enrollments included in the report
-#   client_scope: Client scope for unique clients included in the report
+# This concern operates in two distinct phases:
 #
-# Required universe fields:
-#   household_type: [:adults_only | :adults_and_children | :children_only | :unknown]
-#   head_of_household: Boolean
-#   head_of_household_id: Reference
+# 1. Universe build phase: `calculate_households` builds `@households`, an in-memory hash of
+#    enrollment snapshot data keyed by household_id. Methods like `household_chronic_status`,
+#    `household_makeup`, and `calculate_move_in_date` query this hash to populate universe records.
 #
+# 2. Question answer phase: after snapshot models are persisted, methods like `household_adults`,
+#    `only_youth?`, and `youth_parent?` operate on the snapshot model's `household_members` JSON
+#    column (present on some snapshot types, e.g. AprClient) — not on `@households`.
+#
+# In FY2026+, this concern is largely superseded by HouseholdContextBuilder + HouseholdLogic,
+# which pre-compute all household attributes into HouseholdContext records before report generation.
+# Do not add new functionality here — new household logic belongs in HouseholdLogic, and new
+# report generators should use the HouseholdContext layer instead of this concern.
+#
+# Required concerns:  HudReports::Ages
+# Required accessors: a_t, enrollment_scope, client_scope
+# Required universe fields: household_type, head_of_household, head_of_household_id
 module HudReports::Households
   extend ActiveSupport::Concern
 
@@ -87,102 +93,55 @@ module HudReports::Households
     # NOTE: Client CH status is only inherited if the client was present at the start of the enrollment.
     # per HUD guidance, the HoH should always be present for the entire stay, so we'll compare start dates to them
     # see AirTable Issue ID 30
-    private def calculate_household_chronic_status(hh_id, client_id, chronic_status: :chronic_status)
+    private def calculate_household_chronic_status(hh_id, client_id, chronic_status_key: :chronic_status)
       household_members = households[hh_id]
-      # we couldn't find a household
       return false unless household_members.present?
 
       hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
-      current_member = household_members.detect { |hm| hm[:client_id] == client_id }
+      current_member = household_members.detect { |hm| hm[:client_id] == client_id } || hoh
 
-      # When no specific client_id is provided (PIT), use the HoH as the current_member for the household calculation
-      # This will allow the entire HH to have the same chronic status
-      current_member ||= hoh
-
-      current_member_entry_date = current_member[:entry_date] if current_member.present?
-      hoh_entry_date = hoh[:entry_date] if hoh.present?
-
-      # CH at Project Start: "The members of a household present at project start... can cause other
-      #    household members present at start to be considered chronically homeless" - no HoH/adult restriction.
-      # CH at Point in Time: "at least one adult or minor head of household" - so we check HoH and adults only.
-      # Both require the member to be present at the start of the project (same entry date as the HoH)
-      if chronic_status == :chronic_status
-        # CH at Project Start
-        chronic_member = household_members.detect do |hm|
-          hm[chronic_status] && hm[:entry_date] == hoh_entry_date
-        end
-        return chronic_member if chronic_member.present?
-      else # :pit_chronic_status
-        # CH at Point in Time
-        return hoh if hoh.present? && hoh[chronic_status] && hoh_entry_date == current_member_entry_date
-
-        chronic_adult = household_members.detect do |hm|
-          next false unless hm[:age].present?
-
-          adult_is_chronic = hm[:age] >= 18 && hm[chronic_status]
-          adult_matches_entry_date = hm[:entry_date] == hoh_entry_date
-
-          adult_is_chronic && adult_matches_entry_date
-        end
-        return chronic_adult if chronic_adult.present?
-      end
-
-      # Return false if we don't have a valid member to check
-      return false unless current_member.present?
-
-      # if no adults are either yes or no, use self for adults
-      return current_member if current_member[:age].present? && current_member[:age] >= 18
-      # if the data is bad and we don't have an HoH, use our own record
-      return current_member if hoh.blank?
-
-      # and the HoH enrollment for children if HoH status is unknown
-      return hoh if hoh[:chronic_detail].in?([:dk_or_r, :missing])
-
-      # if we have an indeterminate response for the child, use the hoh
-      return hoh if current_member[:chronic_detail].in?([:dk_or_r, :missing])
-
-      current_member
+      HudReports::HouseholdLogic.calculate_chronic_status(
+        household_members,
+        current_member,
+        hoh,
+        chronic_status_key: chronic_status_key,
+      )
     end
 
     private def household_chronic_status(hh_id, client_id)
-      calculate_household_chronic_status(hh_id, client_id)
+      result = calculate_household_chronic_status(hh_id, client_id)
+      return result unless result
+
+      { chronic_status: !!result[:status], chronic_detail: result[:detail] }.with_indifferent_access
     end
 
     private def pit_household_chronic_status(hh_id)
-      calculate_household_chronic_status(hh_id, nil, chronic_status: :pit_chronic_status)
+      result = calculate_household_chronic_status(hh_id, nil, chronic_status_key: :pit_chronic_status)
+      return result unless result
+
+      { pit_chronic_status: !!result[:status], pit_chronic_detail: result[:detail] }.with_indifferent_access
     end
 
     private def calculate_hh_move_in_date(hh_id, she)
-      # Get HoH for further calculations
       household_members = households[hh_id]
-      hoh = household_members&.detect { |hm| hm[:relationship_to_hoh] == 1 }
+      return nil unless household_members.present?
 
-      # HoH does not exist or does not have a move-in date - cannot do further calculations
-      return nil unless hoh.present? && hoh[:move_in_date].present?
+      # Get HoH for further calculations
+      hoh = household_members.detect { |hm| hm[:relationship_to_hoh] == 1 }
 
-      # [Handling Housing Move-In Dates] - https://files.hudexchange.info/resources/documents/HMIS-Standard-Reporting-Terminology-Glossary-2024.pdf
+      member_data = {
+        entry_date: she.entry_date,
+        exit_date: she.exit_date,
+        move_in_date: she.move_in_date,
+      }
 
-      # Heads of household with [housing move-in dates] prior to their [project start dates] should have the [housing move-in dates] disregarded entirely.
-      return nil unless hoh[:entry_date] <= hoh[:move_in_date]
-
-      # When a household member was already in the household when they became housed (individual's [project
-      # start date] <= head of household's [housing move-in date]), the head of household's [housing move-in date]
-      # should be used as the individual's [housing move-in date]. If the household member exited before the
-      # household moved into housing, they do not inherit this [housing move-in date].
-      return hoh[:move_in_date] if (she.entry_date..she.exit_date).cover?(hoh[:move_in_date])
-
-      # When a household member joins the household after they are already housed (individual's [project start
-      # date] > head of household's [housing move-in date]), the individual's [project start date] should be used as
-      # the individual's [housing move-in date].
-      return she.entry_date if she.entry_date > hoh[:move_in_date]
-
-      # Otherwise this move-in is completely invalid
-      nil
+      HudReports::HouseholdLogic.calculate_move_in_date(member_data, hoh, report_end_date: @report.end_date)
     end
 
+    # Two-step: use the member's own move-in date if it's valid (on or after entry);
+    # otherwise delegate to household inheritance rules via calculate_hh_move_in_date.
     private def calculate_move_in_date(hh_id, she)
       move_in_date = she.move_in_date
-      # If the move-in-date is valid, just use it
       return move_in_date if move_in_date.present? && move_in_date >= she.entry_date
 
       calculate_hh_move_in_date(hh_id, she)
@@ -206,6 +165,8 @@ module HudReports::Households
 
             date = [enrollment.first_date_in_program, @report.start_date].max
             age = GrdaWarehouse::Hud::Client.age(date: date, dob: enrollment.enrollment.client.DOB&.to_date)
+            # PIT reports supply a specific `on` date; for non-PIT reports fall back to entry date
+            # so pit_chronic_status is computed relative to the correct reference point.
             report_date = @generator.filter&.on if @generator.respond_to?(:filter) && @generator.filter.present?
             report_date ||= enrollment.enrollment.EntryDate
 
@@ -218,6 +179,7 @@ module HudReports::Households
               veteran_status: enrollment.enrollment.client.VeteranStatus,
               # Chronic status is calculated as of the report date, use the enrollment start date if no report date is provided
               pit_chronic_status: enrollment.enrollment.chronically_homeless_at_start?(date: report_date),
+              pit_chronic_detail: enrollment.enrollment.chronically_homeless_at_start(date: report_date),
               # Chronic status is calculated as of the enrollment start date
               chronic_status: enrollment.enrollment.chronically_homeless_at_start?,
               chronic_detail: enrollment.enrollment.chronically_homeless_at_start,
@@ -229,7 +191,7 @@ module HudReports::Households
             }.with_indifferent_access
           end
         end
-        GC.start
+        GC.start # release enrollment objects between batches; this loop can hold significant memory
       end
     end
 
@@ -237,13 +199,19 @@ module HudReports::Households
       households[hh_id]&.detect { |household| household[:relationship_to_hoh] == 1 }.try(:[], :client_id)
     end
 
-    private def household_member_data(enrollment, _date = nil) # date is included for CE APR compatibility
-      # return nil unless enrollment[:head_of_household]
-
+    # Returns all household members for the given enrollment from the pre-built households cache.
+    # The _date parameter is accepted for backward compatibility with FY2020-FY2024 generators that
+    # pass a calculation date, but is intentionally ignored here. The CE APR question concern
+    # overrides this method with actual date-scoped filtering. In FY2026+, date-scoped household
+    # composition is handled upstream in AprClientBuilder#ce_scoped_household_members.
+    private def household_member_data(enrollment, _date = nil)
       households[enrollment.household_id] || []
     end
 
-    # Note, you need to pass in a client because the date needs to be calculated
+    # --- Question answer phase ---
+    # The methods below operate on the snapshot model's household_members JSON column
+    # (present on some snapshot types, e.g. AprClient) rather than on the @households hash.
+
     private def household_adults(universe_client)
       return [] unless universe_client.household_members
 
@@ -301,11 +269,7 @@ module HudReports::Households
 
     private def household_makeup(household_id, date)
       household_ages = ages_for(household_id, date)
-      return :adults_and_children if adults?(household_ages) && children?(household_ages)
-      return :adults_only if adults?(household_ages) && ! children?(household_ages) && ! unknown_ages?(household_ages)
-      return :children_only if children?(household_ages) && ! adults?(household_ages) && ! unknown_ages?(household_ages)
-
-      :unknown
+      HudReports::HouseholdLogic.calculate_household_type(household_ages)
     end
 
     private def sub_populations

--- a/app/models/grda_warehouse/utility.rb
+++ b/app/models/grda_warehouse/utility.rb
@@ -77,6 +77,7 @@ class GrdaWarehouse::Utility
       AccessControl,
       User,
       HudReports::ReportInstance,
+      HudReports::HouseholdContext,
       HudReports::UniverseMember,
       HudReports::ReportCell,
       GrdaWarehouse::WarehouseReports::ReportDefinition,

--- a/app/models/hud_reports/generator_base.rb
+++ b/app/models/hud_reports/generator_base.rb
@@ -68,6 +68,15 @@ module HudReports
       Reporting::Hud::RunReportJob.perform_now(self.class.name, @report.id, email: email)
     end
 
+    def base_enrollment_scope(start_date: @report.start_date, end_date: @report.end_date)
+      report_scope_source.
+        where(client_id: client_scope(start_date: start_date, end_date: end_date)).
+        merge(report_scope_source.open_between(
+                start_date: start_date,
+                end_date: end_date,
+              ))
+    end
+
     # This selects just ids for the clients, to ensure uniqueness, but uses select instead of pluck
     # so that we can find in batches.
     def client_scope(start_date: @report.start_date, end_date: @report.end_date)

--- a/app/models/hud_reports/household_context.rb
+++ b/app/models/hud_reports/household_context.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module HudReports
+  # Represents a "Logic Snapshot" for a specific report instance.
+  #
+  # ## Role & Responsibility
+  # This model stores pre-computed, household-level business logic that is shared across
+  # multiple HUD reports. It sits between the global Service History (raw data) and
+  # report-specific snapshots like AprClient or SpmEnrollment.
+  #
+  # Its primary goal is to resolve complex inheritance and composition rules once per report run,
+  # allowing Question classes to use simple SQL joins instead of expensive Ruby runtime loops. The
+  # context records maybe shared between reports and sub-reports, for example the SPM uses APR DQ
+  # reports internally, both reports can share these records to avoid duplicate or work and
+  # inconsistent results.
+  #
+  # ## Lifecycle
+  # - Ephemeral: Records are created during the 'Preparation' phase of a report job.
+  # - Idempotent: Cleared and rebuilt if a report is retried.
+  # - Scoped: Always tied to a specific `ReportInstance`
+  class HouseholdContext < GrdaWarehouseBase
+    self.table_name = 'hud_report_household_contexts'
+
+    belongs_to :report_instance, class_name: 'HudReports::ReportInstance'
+    belongs_to :service_history_enrollment, class_name: 'GrdaWarehouse::ServiceHistoryEnrollment'
+
+    def self.prune!
+      # Delete contexts for reports older than 2 weeks or reports where the report instance no longer exists
+      old_report_ids = HudReports::ReportInstance.where(created_at: ..2.weeks.ago).select(:id)
+      where(report_instance_id: old_report_ids).
+        or(where.not(report_instance_id: HudReports::ReportInstance.select(:id))).
+        delete_all
+    end
+
+    # Efficiently copies contexts from a source report for a specific set of enrollments
+    # Used when sharing logic between reports (e.g. SPM -> DQ)
+    # NOTE: this could be done more efficiently in SQL, room for future optimization
+    def self.copy_subset!(source_report_id:, target_report_id:, service_history_enrollment_ids:)
+      source_contexts = where(
+        report_instance_id: source_report_id,
+        service_history_enrollment_id: service_history_enrollment_ids,
+      )
+
+      source_contexts.find_in_batches(batch_size: 1000) do |batch|
+        new_contexts = batch.map do |ctx|
+          ctx.dup.tap { |new_ctx| new_ctx.report_instance_id = target_report_id }
+        end
+        import!(new_contexts)
+      end
+    end
+
+    # Returns a hash compatible with the legacy hash-based household logic.
+    # Used to pass pre-computed context into older logic modules (e.g. HudReports::Households)
+    # that expect a hash representation of a member rather than a database record.
+    def to_legacy_member_hash
+      {
+        client_id: destination_client_id,
+        source_client_id: source_client_id,
+        dob: dob,
+        age: age,
+        veteran_status: veteran_status,
+        chronic_status: member_chronic_status,
+        chronic_detail: member_chronic_detail,
+        relationship_to_hoh: relationship_to_hoh,
+        entry_date: member_entry_date,
+        exit_date: member_exit_date,
+        move_in_date: inherited_move_in_date,
+        effective_move_in_date: inherited_move_in_date,
+      }.with_indifferent_access
+    end
+  end
+end

--- a/app/models/hud_reports/household_context_builder.rb
+++ b/app/models/hud_reports/household_context_builder.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+module HudReports
+  class HouseholdContextBuilder
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(generator, report, enrollment_scope:, source_report_id: nil, lookback_years: 2)
+      @generator = generator
+      @report = report
+      @source_report_id = source_report_id
+      @enrollment_scope = enrollment_scope
+      @lookback_years = lookback_years
+    end
+
+    def call
+      # Idempotency: clear existing context for this report run
+      @report.household_contexts.delete_all
+
+      if @source_report_id.present?
+        copy_contexts_from_source
+      else
+        build_contexts_from_scratch
+      end
+
+      # Update count on report instance
+      @report.update!(household_context_count: @report.household_contexts.count)
+    end
+
+    private
+
+    def copy_contexts_from_source
+      # Validate date ranges match
+      source_report = HudReports::ReportInstance.find(@source_report_id)
+      unless source_report.start_date == @report.start_date &&
+             source_report.end_date == @report.end_date
+        raise ArgumentError, "Cannot share contexts: date ranges don't match"
+      end
+
+      # Discover which SHE IDs this report needs
+      needed_she_ids = enrollment_scope.pluck(:id)
+
+      HudReports::HouseholdContext.copy_subset!(
+        source_report_id: @source_report_id,
+        target_report_id: @report.id,
+        service_history_enrollment_ids: needed_she_ids,
+      )
+    end
+
+    attr_reader :enrollment_scope
+
+    def build_contexts_from_scratch
+      contexts = []
+      universe_ids = enrollment_scope.pluck(:id).to_set
+      each_household_batch do |batch|
+        # batch is array of [hh_id, data_source_id]
+        all_service_history_enrollments = load_unfiltered_service_history_enrollments(batch)
+        all_she_by_hh = all_service_history_enrollments.group_by { |she| [get_hh_id(she), she.data_source_id] }
+
+        all_she_by_hh.each do |(hh_id, data_source_id), service_history_enrollments|
+          household_contexts = build_contexts_for_household(hh_id, data_source_id, service_history_enrollments)
+          # Only keep contexts for SHEs that are part of the report universe
+          contexts.concat(household_contexts.select { |c| universe_ids.include?(c.service_history_enrollment_id) })
+
+          # Flush per-household so a batch of large households can't exceed the import limit
+          if contexts.size >= import_batch_size
+            HudReports::HouseholdContext.import!(contexts)
+            contexts = []
+          end
+        end
+      end
+
+      HudReports::HouseholdContext.import!(contexts) if contexts.any?
+    end
+
+    def batch_size
+      500
+    end
+
+    def import_batch_size
+      2000
+    end
+
+    def get_hh_id(she)
+      # If a HUD HouseholdID is missing, we use the EnrollmentID as a synthetic household ID.
+      # We append '*HH' to these synthetic IDs to prevent accidental collisions with real
+      # HouseholdIDs that might share the same string value within the same data source.
+      she.household_id || "#{she.enrollment_group_id}*HH"
+    end
+
+    def each_household_batch
+      # Get unique HH IDs + data_source_id for the report universe
+      hh_ids_query = enrollment_scope
+
+      she_table = GrdaWarehouse::ServiceHistoryEnrollment.arel_table
+
+      # We drive batching using the same synthetic ID logic as get_hh_id.
+      # The '*HH' suffix ensures we don't conflate a real HouseholdID with a synthetic one
+      # derived from an EnrollmentID of the same value within the same data source.
+      hh_id_expr = Arel::Nodes::NamedFunction.new(
+        'COALESCE',
+        [
+          she_table[:household_id],
+          Arel::Nodes::InfixOperation.new('||', she_table[:enrollment_group_id], Arel::Nodes.build_quoted('*HH')),
+        ],
+      )
+
+      base_query = hh_ids_query.
+        distinct.
+        order(hh_id_expr, she_table[:data_source_id])
+
+      last_hh_id = nil
+      last_ds_id = nil
+
+      loop do
+        query = base_query.limit(batch_size)
+
+        if last_hh_id
+          # Seek logic for composite order
+          condition = hh_id_expr.gt(last_hh_id).or(
+            hh_id_expr.eq(last_hh_id).and(she_table[:data_source_id].gt(last_ds_id)),
+          )
+          query = query.where(condition)
+        end
+
+        # We need both values
+        batch = query.pluck(hh_id_expr, she_table[:data_source_id])
+        break if batch.empty?
+
+        yield batch
+        last_hh_id, last_ds_id = batch.last
+      end
+    end
+
+    def load_unfiltered_service_history_enrollments(batch)
+      # batch is array of [hh_id, data_source_id]
+      # We group by data_source_id to make queries more efficient (fewer IN clauses)
+      service_history_enrollments = []
+      batch.group_by(&:last).each do |ds_id, pairs|
+        hh_ids = pairs.map(&:first)
+        real_hh_ids = hh_ids.reject { |id| id.end_with?('*HH') }
+        synthetic_eg_ids = hh_ids.select { |id| id.end_with?('*HH') }.map { |id| id.sub('*HH', '') }
+
+        lookback_start = @report.start_date - @lookback_years.years
+
+        scope = GrdaWarehouse::ServiceHistoryEnrollment.entry.
+          where(data_source_id: ds_id).
+          open_between(start_date: lookback_start, end_date: @report.end_date).
+          preload(enrollment: [:client, :disabilities_at_entry, :project])
+
+        query = if real_hh_ids.any? && synthetic_eg_ids.any?
+          scope.where(household_id: real_hh_ids).or(scope.where(enrollment_group_id: synthetic_eg_ids, household_id: nil))
+        elsif real_hh_ids.any?
+          scope.where(household_id: real_hh_ids)
+        else
+          scope.where(enrollment_group_id: synthetic_eg_ids, household_id: nil)
+        end
+
+        service_history_enrollments.concat(query.to_a.select { |m| m.enrollment.present? })
+      end
+      service_history_enrollments
+    end
+
+    def build_contexts_for_household(hh_id, data_source_id, service_history_enrollments)
+      hh_member_hashes = precalculate_member_data(service_history_enrollments)
+
+      # For household composition and veteran stats, only consider SHEs active during the report period.
+      # Historical SHEs (from lookback) are used for inheritance but should not affect the current report's household type.
+      active_hh_she_hashes = hh_member_hashes.select do |mh|
+        (mh[:exit_date].nil? || mh[:exit_date] >= @report.start_date) && mh[:entry_date] <= @report.end_date
+      end
+
+      hoh_data = find_anchor_hoh(hh_member_hashes)
+      hoh_adjusted_move_in_date = (household_logic.calculate_move_in_date(hoh_data, hoh_data, report_end_date: @report.end_date) if hoh_data)
+      hoh_length_of_stay = household_logic.calculate_length_of_stay(hoh_data, report_end_date: @report.end_date)
+
+      hh_stats = calculate_hh_stats(active_hh_she_hashes)
+
+      service_history_enrollments.map do |m|
+        member_hash = hh_member_hashes.detect { |mh| mh[:she_id] == m.id }
+        build_context_for_member(m, member_hash, hoh_data,
+                                 hh_member_hashes: hh_member_hashes,
+                                 hoh_length_of_stay: hoh_length_of_stay,
+                                 hoh_move_in_date: hoh_adjusted_move_in_date,
+                                 hh_id: hh_id,
+                                 data_source_id: data_source_id,
+                                 active_hh_she_hashes: active_hh_she_hashes,
+                                 hh_stats: hh_stats)
+      end
+    end
+
+    def precalculate_member_data(service_history_enrollments)
+      service_history_enrollments.map do |m|
+        enrollment = m.enrollment
+        source_client = enrollment&.client
+        date = [m.first_date_in_program, @report.start_date].max
+        age = GrdaWarehouse::Hud::Client.age(date: date, dob: source_client&.DOB)
+
+        # Determine report_date for chronic calculation
+        report_date = @generator.filter&.on if @generator.respond_to?(:filter) && @generator.filter.present?
+
+        # Use the PIT date if provided (e.g. PIT reports), otherwise use entry date
+        chronic_detail = if report_date.present? && report_date != enrollment&.EntryDate
+          enrollment&.chronically_homeless_at_start(date: report_date)
+        else
+          enrollment&.chronically_homeless_at_start
+        end
+
+        {
+          she_id: m.id,
+          enrollment_id: enrollment&.id,
+          destination_client_id: m.client_id,
+          source_client_id: source_client&.id,
+          personal_id: source_client&.PersonalID,
+          entry_date: m.first_date_in_program,
+          exit_date: m.last_date_in_program,
+          age: age,
+          dob: source_client&.DOB,
+          chronic_status: chronic_detail == :yes,
+          chronic_detail: chronic_detail,
+          relationship_to_hoh: enrollment&.RelationshipToHoH,
+          move_in_date: m.move_in_date,
+          veteran_status: source_client&.VeteranStatus,
+          enrollment_coc: enrollment&.EnrollmentCoC,
+          date_to_street: enrollment&.DateToStreetESSH,
+        }
+      end
+    end
+
+    def find_anchor_hoh(hh_member_hashes)
+      # Select the "Anchor" HoH for inheritance, in priority order:
+      # 1. Prefer HoH records active during the report period.
+      # 2. Prefer the most recent enrollment (latest entry date).
+      # 3. Prefer records with a move-in date.
+      # 4. Deterministic tie-break via ID.
+      hh_member_hashes.
+        select { |m| m[:relationship_to_hoh] == 1 }.
+        min_by do |m|
+          active = (m[:exit_date].nil? || m[:exit_date] >= @report.start_date) && m[:entry_date] <= @report.end_date
+          [
+            active ? 0 : 1, # active records first
+            -(m[:entry_date] || Date.new(0)).jd, # latest entry date first (negated)
+            m[:move_in_date] ? 0 : 1,                 # records with move-in first
+            m[:she_id] || 0,                          # lowest ID as tie-break
+          ]
+        end
+    end
+
+    def calculate_hh_stats(active_hh_she_hashes)
+      hh_all_ages = active_hh_she_hashes.map { |m| m[:age] }
+      hh_type = household_logic.calculate_household_type(hh_all_ages)
+
+      {
+        hh_type: hh_type,
+        hh_max_age: hh_all_ages.compact.max || 0,
+      }
+    end
+
+    def build_context_for_member(
+      she,
+      member_hash,
+      hoh_data,
+      hh_member_hashes:,
+      hoh_length_of_stay:,
+      hoh_move_in_date:,
+      hh_id:,
+      data_source_id:,
+      active_hh_she_hashes:,
+      hh_stats:
+    )
+      # Inherited values
+      chronic_source = household_logic.calculate_chronic_status(hh_member_hashes, member_hash, hoh_data)
+      inherited_move_in_date = household_logic.calculate_move_in_date(member_hash, hoh_data, report_end_date: @report.end_date)
+
+      # SPM-specific: Calculate inherited date to street for Measure 1b
+      inherited_date_to_street = household_logic.calculate_date_to_street(
+        member_hash,
+        hoh_data,
+      )
+
+      # Parenting youth logic (active SHEs only)
+      is_parenting_youth = household_logic.calculate_is_parenting_youth(member_hash, active_hh_she_hashes)
+      has_other_clients_over_25 = !household_logic.only_youth?(active_hh_she_hashes)
+
+      HudReports::HouseholdContext.new(
+        report_instance_id: @report.id,
+        service_history_enrollment_id: she.id,
+        data_source_id: data_source_id,
+        source_enrollment_id: member_hash[:enrollment_id],
+        source_client_id: member_hash[:source_client_id],
+        destination_client_id: member_hash[:destination_client_id],
+        age: member_hash[:age],
+        dob: member_hash[:dob],
+        veteran_status: member_hash[:veteran_status],
+        household_id: hh_id,
+        hoh_destination_client_id: hoh_data&.[](:destination_client_id),
+        hoh_personal_id: hoh_data&.[](:personal_id),
+        hoh_service_history_enrollment_id: hoh_data&.[](:she_id),
+        hoh_entry_date: hoh_data&.[](:entry_date),
+        hoh_exit_date: hoh_data&.[](:exit_date),
+        hoh_length_of_stay: hoh_length_of_stay,
+        hoh_coc: hoh_data&.[](:enrollment_coc),
+        hoh_date_to_street: hoh_data&.[](:date_to_street),
+        hoh_move_in_date: hoh_move_in_date,
+        hoh_age: hoh_data&.[](:age),
+        hoh_veteran_status: hoh_data&.[](:veteran_status),
+        is_hoh: she.enrollment&.RelationshipToHoH == 1,
+        relationship_to_hoh: member_hash[:relationship_to_hoh],
+        member_chronic_status: member_hash[:chronic_status],
+        member_chronic_detail: member_hash[:chronic_detail],
+        household_type: hh_stats[:hh_type],
+        is_parenting_youth: is_parenting_youth,
+        non_youth_household: has_other_clients_over_25,
+        inherited_chronic_status: chronic_source&.[](:status) || false,
+        inherited_chronic_detail: chronic_source&.[](:detail),
+        inherited_move_in_date: inherited_move_in_date,
+        member_entry_date: member_hash[:entry_date],
+        member_exit_date: member_hash[:exit_date],
+        member_date_to_street: member_hash[:date_to_street],
+        inherited_date_to_street: inherited_date_to_street,
+        hh_max_age: hh_stats[:hh_max_age],
+      )
+    end
+
+    def household_logic
+      HudReports::HouseholdLogic
+    end
+  end
+end

--- a/app/models/hud_reports/household_logic.rb
+++ b/app/models/hud_reports/household_logic.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+module HudReports
+  # Shared business logic for HUD household calculations.
+  #
+  # This class centralizes pure logic for household-level attributes required by HUD reports
+  # (APR, CAPER, SPM, PIT). It ensures consistency across the warehouse by strictly adhering
+  # to the HUD HMIS Reporting Glossary and specific APR/CAPER programming specifications.
+  #
+  # Key logic areas:
+  # - Chronic Status Inheritance: Business rules for how children and households inherit status from adults.
+  # - Housing Move-in Inheritance: Rules for cascading move-in dates from the HoH to other members.
+  # - Youth/Parenting Youth: Specific APR definitions for youth-led households (often differing from general DQ rules).
+  class HouseholdLogic
+    class << self
+      def calculate_household_type(ages)
+        adults = ages.any? { |a| a.present? && a >= 18 }
+        children = ages.any? { |a| a.present? && a < 18 }
+        any_unknown = ages.any?(&:nil?)
+
+        if adults && children
+          :adults_and_children
+        elsif any_unknown
+          :unknown
+        elsif adults
+          :adults_only
+        elsif children
+          :children_only
+        else
+          :unknown
+        end
+      end
+
+      # Determines chronic status for a member or PIT snapshot based on household inheritance rules.
+      #
+      # CH at Project Start (chronic_status): ANY member present at project start can cause other household
+      # members to be considered CH — no HoH/adult restriction.
+      # CH at Point in Time (pit_chronic_status): at least one adult or minor head of household must be CH.
+      # Both modes require the qualifying member to share the HoH's entry date (present at project start).
+      def calculate_chronic_status(hh_members, current_member, hoh, chronic_status_key: :chronic_status)
+        return nil if hh_members.empty?
+
+        # When no specific member is provided (PIT), use the HoH as the anchor for calculation
+        current_member ||= hoh
+        return nil unless current_member
+
+        current_member_entry_date = current_member[:entry_date]
+        hoh_entry_date = hoh&.[](:entry_date)
+        detail_key = chronic_status_key == :pit_chronic_status ? :pit_chronic_detail : :chronic_detail
+
+        if chronic_status_key == :chronic_status
+          # CH at Project Start: any member present at start can cause the household to be CH
+          chronic_member = hh_members.detect { |hm| hm[chronic_status_key] && hm[:entry_date] == hoh_entry_date }
+          return { status: true, detail: chronic_member[detail_key] } if chronic_member
+        else
+          # CH at Point in Time: check HoH first, then any adult present at start
+          return { status: true, detail: hoh[detail_key] } if hoh && hoh[chronic_status_key] && hoh_entry_date == current_member_entry_date
+
+          chronic_adult = hh_members.detect do |hm|
+            next false unless hm[:age]
+
+            hm[:age] >= 18 && hm[chronic_status_key] && hm[:entry_date] == hoh_entry_date
+          end
+          return { status: true, detail: chronic_adult[detail_key] } if chronic_adult
+        end
+
+        # Shared fallback: adults use their own status; children inherit from HoH
+        return { status: current_member[chronic_status_key], detail: current_member[detail_key] } if current_member[:age] && current_member[:age] >= 18
+
+        # Use self if HoH is missing (data quality issue)
+        return { status: current_member[chronic_status_key], detail: current_member[detail_key] } if hoh.blank?
+
+        # Children inherit HoH status if HoH or child has indeterminate (DK/R/Missing) data
+        return { status: hoh[chronic_status_key], detail: hoh[detail_key] } if hoh[detail_key].to_s.in?(['dk_or_r', 'missing'])
+        return { status: hoh[chronic_status_key], detail: hoh[detail_key] } if current_member[detail_key].to_s.in?(['dk_or_r', 'missing'])
+
+        { status: current_member[chronic_status_key], detail: current_member[detail_key] }
+      end
+
+      # [Handling Housing Move-In Dates] - https://files.hudexchange.info/resources/documents/HMIS-Standard-Reporting-Terminology-Glossary-2024.pdf
+      #
+      # Note: Out-of-bounds dates (prior to entry, after exit, or after report end) are
+      # disregarded per HUD HMIS Reporting Glossary rules.
+      def calculate_move_in_date(member, hoh, report_end_date: nil)
+        # Rule: Disregard move-in dates outside of enrollment bounds or after report end
+        # "Individuals with [housing move-in dates] prior to their [project start dates] or [after]
+        # [project exit dates] should have the [housing move-in dates] disregarded entirely."
+        valid_move_in = lambda do |date, m|
+          date.present? &&
+            date >= m[:entry_date] &&
+            (m[:exit_date].nil? || date <= m[:exit_date]) &&
+            (report_end_date.nil? || date <= report_end_date)
+        end
+
+        # 1. If the member has their own valid move-in date, use it
+        return member[:move_in_date] if valid_move_in.call(member[:move_in_date], member)
+
+        # 2. Check if HoH has a valid move-in date to propagate
+        return nil unless hoh && valid_move_in.call(hoh[:move_in_date], hoh)
+
+        # 3. Inheritance Logic for "Standard" household members (in the household when housed)
+        # Rule: "If the household member exited before the household moved into housing,
+        # they do not inherit this date."
+        if member[:entry_date] <= hoh[:move_in_date]
+          # Member was present at time of housing; check if they stayed until the move-in date
+          return hoh[:move_in_date] if member[:exit_date].nil? || member[:exit_date] >= hoh[:move_in_date]
+        end
+
+        # 4. Inheritance Logic for "Late Joiners"
+        # Rule: "If member joins after the household is housed, the member's move-in date = their own project start date"
+        if member[:entry_date] > hoh[:move_in_date]
+          # Ensure this "inherited" entry date is also valid (not after exit or report end)
+          return member[:entry_date] if (member[:exit_date].nil? || member[:entry_date] <= member[:exit_date]) &&
+                                       (report_end_date.nil? || member[:entry_date] <= report_end_date)
+        end
+
+        nil
+      end
+
+      # SPM Measure 1b: Start of homelessness inheritance for children
+      def calculate_date_to_street(member, hoh)
+        # If member has own DateToStreetESSH, use it (capped at DOB)
+        return [member[:date_to_street], member[:dob]].compact.max if member[:date_to_street].present?
+
+        # Inherit from HoH if:
+        # 1. Member is age <= 17 (child)
+        # 2. Member entered on same date as HoH
+        if member[:age].present? &&
+           member[:age] <= 17 &&
+           member[:entry_date] == hoh&.[](:entry_date)
+          date_to_street = hoh&.[](:date_to_street)
+          # Cap at DOB if present
+          return [date_to_street, member[:dob]].compact.max if date_to_street.present?
+        end
+
+        # Otherwise no start of homelessness
+        nil
+      end
+
+      # Computes the length of stay for a member, adjusting for HUD's convention for active stayers.
+      # Rule: "For clients who have not yet exited, the end date is the report end date plus one day."
+      def calculate_length_of_stay(member, report_end_date:)
+        return 0 unless member && member[:entry_date]
+
+        stayer_end_date = [member[:exit_date], report_end_date + 1.day].compact.min
+        (stayer_end_date - member[:entry_date]).to_i
+      end
+
+      # APR Q27: Parenting Youth.
+      # A youth household (all members 0-24) where the youth (12-24) has children.
+      def calculate_is_parenting_youth(member, hh_members)
+        age = member[:age]
+        adult = age && age >= 18
+        (member[:relationship_to_hoh] == 1 || adult) && only_youth?(hh_members) && any_youth_children?(hh_members)
+      end
+
+      def only_youth?(hh_members)
+        hh_members.all? { |m| m[:age] && m[:age] <= 24 }
+      end
+
+      def any_youth_children?(hh_members)
+        # Nuance: APR Q27 considers "children" to be anyone with RelationshipToHoH == 2
+        # who is age 0-24, provided the entire household qualifies as a Youth Household.
+        # This differs from general DQ reports which strictly use age < 18.
+        hh_members.any? { |m| m[:relationship_to_hoh] == 2 && m[:age] && m[:age] <= 24 }
+      end
+    end
+  end
+end

--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -31,6 +31,7 @@ module HudReports
     has_many :universe_cells, -> do
       universe
     end, class_name: 'ReportCell'
+    has_many :household_contexts, class_name: 'HudReports::HouseholdContext', foreign_key: 'report_instance_id', dependent: :delete_all
     has_many :checkpoints, class_name: 'HudReports::ReportCheckpoint', foreign_key: 'hud_report_instance_id', dependent: :destroy
     scope :manual, -> { where(manual: true) }
     scope :automated, -> { where(manual: false) }

--- a/db/warehouse/migrate/20251221120000_create_hud_report_household_contexts.rb
+++ b/db/warehouse/migrate/20251221120000_create_hud_report_household_contexts.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class CreateHudReportHouseholdContexts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :hud_report_household_contexts do |t|
+      t.references :report_instance, null: false, index: false
+      t.references :service_history_enrollment, null: false
+      t.references :source_enrollment
+      t.references :destination_client
+      t.references :source_client
+      t.integer :age
+      t.date :dob
+      t.integer :veteran_status
+      t.string :household_id
+      t.references :hoh_destination_client
+      t.string :hoh_personal_id
+      t.references :hoh_service_history_enrollment
+      t.date :hoh_entry_date
+      t.date :hoh_exit_date
+      t.integer :hoh_length_of_stay
+      t.string :hoh_coc
+      t.date :hoh_date_to_street
+      t.date :hoh_move_in_date
+      t.integer :hoh_age
+      t.boolean :hoh_veteran
+      t.boolean :is_hoh
+      t.integer :relationship_to_hoh
+      t.boolean :pit_chronic_status
+      t.string :household_type
+      t.boolean :is_parenting_youth
+      t.boolean :has_other_clients_over_25
+      t.boolean :inherited_chronic_status
+      t.string :inherited_chronic_detail
+      t.boolean :inherited_pit_chronic_status
+      t.string :inherited_pit_chronic_detail
+      t.date :inherited_move_in_date
+      t.date :member_entry_date              # Member's entry date for comparison logic
+      t.date :member_date_to_street          # Member's own DateToStreetESSH (before inheritance)
+      t.date :inherited_date_to_street       # Start of homelessness with SPM child inheritance applied
+      t.integer :member_count
+      t.integer :hh_max_age
+      t.boolean :hh_has_minor_children
+      t.integer :hh_max_age_of_parents
+      t.boolean :hh_any_veteran_chronic
+      t.boolean :hh_any_veteran_non_chronic
+      t.boolean :hh_all_adult_non_veteran
+      t.boolean :hh_any_adult_refused_veteran
+      t.boolean :hh_any_adult_missing_veteran
+      t.references :data_source, null: false
+
+      t.timestamps
+    end
+
+    add_index :hud_report_household_contexts, [:report_instance_id, :service_history_enrollment_id],
+              unique: true,
+              name: 'index_hud_report_hh_contexts_on_report_and_she'
+
+    add_column :hud_report_instances, :household_context_count, :integer
+  end
+end

--- a/db/warehouse/migrate/20260115120000_add_raw_chronic_and_exit_date_to_household_contexts.rb
+++ b/db/warehouse/migrate/20260115120000_add_raw_chronic_and_exit_date_to_household_contexts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddRawChronicAndExitDateToHouseholdContexts < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :hud_report_household_contexts do |t|
+        t.boolean :raw_chronic_status
+        t.string :raw_chronic_detail
+        t.boolean :raw_pit_chronic_status
+        t.string :raw_pit_chronic_detail
+        t.date :member_exit_date
+      end
+    end
+  end
+end

--- a/db/warehouse/migrate/20260115130000_tidy_columns_in_household_contexts.rb
+++ b/db/warehouse/migrate/20260115130000_tidy_columns_in_household_contexts.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class TidyColumnsInHouseholdContexts < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      # remove extra fields that are either redundant or not needed for current reports
+      change_table :hud_report_household_contexts do |t|
+        t.remove :pit_chronic_status
+        t.remove :inherited_pit_chronic_status
+        t.remove :inherited_pit_chronic_detail
+        t.remove :raw_pit_chronic_status
+        t.remove :raw_pit_chronic_detail
+        t.remove :hh_any_veteran_chronic
+        t.remove :hh_any_veteran_non_chronic
+        t.remove :hh_all_adult_non_veteran
+        t.remove :hh_any_adult_refused_veteran
+        t.remove :hh_any_adult_missing_veteran
+        t.remove :hh_has_minor_children
+        t.remove :hh_max_age_of_parents
+        t.remove :member_count
+        t.remove :hoh_veteran
+        t.integer :hoh_veteran_status
+      end
+
+      rename_column :hud_report_household_contexts, :has_other_clients_over_25, :non_youth_household
+      rename_column :hud_report_household_contexts, :raw_chronic_status, :member_chronic_status
+      rename_column :hud_report_household_contexts, :raw_chronic_detail, :member_chronic_detail
+    end
+  end
+end

--- a/docs/features/hud-report-framework.md
+++ b/docs/features/hud-report-framework.md
@@ -65,10 +65,10 @@ Questions (or Measures in SPM) extend `HudReports::QuestionBase`. Each class cor
 
 1.  **Initialization**: Create a `ReportInstance` with parameters (date range, project selection)
 2.  **Queuing**: Generator queues `Reporting::Hud::RunReportJob`
-3.  **Execution**: Job instantiates the Generator and iterates through questions, tracking progress via checkpoints
-4.  **Data Gathering**: Questions fetch HMIS data (Enrollments, Clients, Services), filter by report parameters (CoC, Date Range), and calculate derived attributes (Age, Chronic Status)
-5.  **Snapshotting**: Some reports create intermediate snapshot records (e.g., `AprClient`, `SpmEnrollment`) that cache calculated values
-6.  **Aggregation**: Questions aggregate data into report format
+3.  **Execution**: Job instantiates the Generator and calls `prepare_report`, then iterates through questions, tracking progress via checkpoints
+4.  **Preparation** (`prepare_report`): some report generators build `HouseholdContext` records to cache common calculations (chronic inheritance, move-in dates, household type) before any questions run
+5.  **Snapshotting**: Some reports may build report-specific snapshots (e.g., `AprClient`, `SpmEnrollment`)
+6.  **Aggregation**: Questions filter and aggregate data into report format, linking the cell values to universe member snapshot
 7.  **Completion**: Results are saved to `ReportInstance`
 
 ## Progress Tracking
@@ -77,20 +77,34 @@ The framework tracks report execution progress using checkpoints stored in `HudR
 
 Report duration is calculated from completed checkpoints rather than wall-clock time.
 
-## Data Management
+## Data Management & Refinement Layers
 
-### Universes and Cells
-- **Universe**: A collection of records matching specific criteria (e.g., "All adults in Emergency Shelter")
-- **Cell**: A data point in the report output (e.g., "Question 5, Row 1, Column A")
+The framework uses three distinct layers of data denormalization to balance performance, consistency, and maintenance:
 
-`HudReports::ReportCell` represents a cell and links to underlying data via `HudReports::UniverseMember`, a polymorphic join model. This connects report cells to snapshot models (`SpmEnrollment`, `AprClient`) and caches PII for drill-down tables in the UI.
+| Layer | Responsibility | Lifecycle | Scope |
+| :--- | :--- | :--- | :--- |
+| **Service History** | Flattens HUD enrollments into a queryable "daily" span. The base for all reporting. | Persistent (Nightly/On-change) | Global |
+| **Household Context** | **Logic Layer**. Pre-computes shared business rules like Chronic Inheritance and Household Typing. | Ephemeral (Per Report Run) | Per report run; optionally copied to sub-reports |
+| **Report Snapshots** | **Presentation Layer**. Denormalizes all attributes needed for a specific report (e.g. `AprClient`). | Durable Report | Feature-Specific |
 
-### Snapshot Models
-Many reports use snapshot models to cache calculated values (e.g., "Chronic Homelessness status on entry") in temporary or report-specific tables.
+### Pre-computed Logic Layers (Household Context)
+To optimize the creation of report snapshots (like `AprClient`), the framework uses `HudReports::HouseholdContext` to pre-compute shared household business rules (e.g. Chronic Inheritance, Move-in Date Inheritance, Household Typing).
+
+Pure business logic lives in `HudReports::HouseholdLogic` (a stateless class), and `HudReports::HouseholdContextBuilder` uses it to populate `HouseholdContext` records during `prepare_report`. FY2026 reports consume these pre-computed values when building their snapshot models, replacing expensive in-memory Ruby loops.
+
+Currently only the APR family (APR, CAPER, CE APR, DQ) and SPM use this mechanism. Other reports (PIT, PATH, LSA, etc.) still compute household attributes inline.
+
+`HouseholdContextBuilder` requires an `enrollment_scope:` parameter. This allows different report types to use different enrollment discovery strategies (e.g., SPM uses a 7-year lookback) while sharing the same context-building logic. Context records are scoped per report run but can be shared with sub-reports (e.g., SPM passes its contexts to DQ sub-reports via `source_report_id_for_contexts`) to avoid redundant computation.
+
+### Snapshot Models (Presentation Layer)
+Many reports create secondary snapshots that denormalize all attributes needed for a specific report into a single table, optimized for question calculations, UI drill-down, and CSV exports.
 
 Examples:
-- **APR/CAPER**: `AprClient` stores age, household type, and disability status
-- **SPM**: `SpmEnrollment` normalizes enrollment data across project types
+- **APR/CAPER**: `AprClient` stores age, chronic status, household type, disability flags, income, etc.
+- **SPM**: `SpmEnrollment` normalizes enrollment data across project types, including inherited move-in and start-of-homelessness dates
+
+### Universes and Cells
+`HudReports::ReportCell` represents a single cell in a report output (e.g., "Question 5, Row 1, Column A") and links to underlying records via `HudReports::UniverseMember`, a polymorphic join model. `UniverseMember` connects cells to snapshot models (`AprClient`, `SpmEnrollment`) and caches PII for drill-down tables in the UI.
 
 ## Cell Drilldowns
 

--- a/spec/factories/grda_warehouse/service_history_enrollments.rb
+++ b/spec/factories/grda_warehouse/service_history_enrollments.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory :she_entry, class: 'GrdaWarehouse::ServiceHistoryEnrollment' do
+    association :client, factory: :hud_client
+    data_source_id { client.data_source_id }
     record_type { :entry }
+    date { Date.current }
+    first_date_in_program { Date.current }
   end
   factory :she_exit, class: 'GrdaWarehouse::ServiceHistoryEnrollment' do
     record_type { :exit }

--- a/spec/factories/hud_reports/household_contexts.rb
+++ b/spec/factories/hud_reports/household_contexts.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hud_reports_household_context, class: 'HudReports::HouseholdContext' do
+    association :report_instance, factory: :hud_reports_report_instance
+    association :service_history_enrollment, factory: :she_entry
+    data_source_id { service_history_enrollment.data_source_id }
+    source_client_id { service_history_enrollment.client_id }
+    sequence(:household_id) { |n| "HH#{n}" }
+    household_type { 'adults_only' }
+    is_hoh { true }
+  end
+end

--- a/spec/jobs/importing/run_daily_imports_job_spec.rb
+++ b/spec/jobs/importing/run_daily_imports_job_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Importing::RunDailyImportsJob, type: :job do
     allow(ReportingSetupJob).to receive(:set).and_return(double(perform_later: true))
     allow(Delayed::Job).to receive(:queued?).and_return(false)
     allow(GrdaWarehouse::Report::Base).to receive(:update_fake_materialized_views)
+    allow(HudReports::HouseholdContext).to receive(:prune!)
     allow(Reporting::PopulationDashboardPopulateJob).to receive(:set).and_return(double(perform_later: true))
     allow(PruneDocumentExportsJob).to receive(:perform_later)
     allow(Health::PruneDocumentExportsJob).to receive(:perform_later)

--- a/spec/models/concerns/hud_reports/households_spec.rb
+++ b/spec/models/concerns/hud_reports/households_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudReports::Households do
+  # Minimal host that satisfies the concern's runtime interface.
+  # @households is set directly to bypass calculate_households (which needs a full generator).
+  subject(:host) do
+    Class.new { include HudReports::Households }.new.tap do |h|
+      h.instance_variable_set(:@households, households_data)
+      h.instance_variable_set(:@report, report)
+    end
+  end
+
+  let(:report) { double('report', end_date: Date.parse('2024-01-31')) }
+  let(:households_data) { {} }
+
+  let(:entry_date) { Date.parse('2023-01-01') }
+
+  let(:hoh) do
+    {
+      client_id: 1,
+      relationship_to_hoh: 1,
+      entry_date: entry_date,
+      exit_date: nil,
+      move_in_date: nil,
+      age: 35,
+      chronic_status: true,
+      chronic_detail: :yes,
+      pit_chronic_status: true,
+      pit_chronic_detail: :yes,
+    }
+  end
+
+  let(:adult) do
+    {
+      client_id: 2,
+      relationship_to_hoh: 3,
+      entry_date: entry_date,
+      exit_date: nil,
+      age: 28,
+      chronic_status: false,
+      chronic_detail: :no,
+      pit_chronic_status: false,
+      pit_chronic_detail: :no,
+    }
+  end
+
+  let(:child) do
+    {
+      client_id: 3,
+      relationship_to_hoh: 2,
+      entry_date: entry_date,
+      exit_date: nil,
+      age: 10,
+      chronic_status: false,
+      chronic_detail: :no,
+      pit_chronic_status: false,
+      pit_chronic_detail: :no,
+    }
+  end
+
+  describe '#calculate_household_chronic_status' do
+    let(:hh_id) { 'hh-001' }
+
+    context 'when household is not found' do
+      it 'returns false' do
+        expect(host.send(:calculate_household_chronic_status, 'missing-hh', 1)).to be false
+      end
+    end
+
+    context 'with a household containing a chronic HoH and a child' do
+      let(:households_data) { { hh_id => [hoh, child] } }
+
+      it 'child inherits status from chronic HoH (project start rule)' do
+        result = host.send(:calculate_household_chronic_status, hh_id, child[:client_id])
+        expect(result[:status]).to be true
+        expect(result[:detail]).to eq(:yes)
+      end
+
+      context 'when HoH is not chronic' do
+        before do
+          hoh[:chronic_status] = false
+          hoh[:chronic_detail] = :no
+          hoh[:pit_chronic_status] = false
+          hoh[:pit_chronic_detail] = :no
+        end
+
+        it 'child does not inherit chronic status' do
+          result = host.send(:calculate_household_chronic_status, hh_id, child[:client_id])
+          expect(result[:status]).to be false
+        end
+      end
+
+      context 'when child entered after HoH (not present at project start)' do
+        before { child[:entry_date] = Date.parse('2023-06-01') }
+
+        it 'HoH chronic and present at start satisfies project-start rule' do
+          result = host.send(:calculate_household_chronic_status, hh_id, child[:client_id])
+          expect(result[:status]).to be true
+        end
+      end
+    end
+
+    context 'with a household containing a chronic HoH and a non-chronic adult' do
+      let(:households_data) { { hh_id => [hoh, adult] } }
+
+      it 'adult gets status: true because HoH is chronic and present at same start (project start rule)' do
+        result = host.send(:calculate_household_chronic_status, hh_id, adult[:client_id])
+        expect(result[:status]).to be true
+      end
+
+      context 'when no household member is chronic' do
+        before { hoh[:chronic_status] = false }
+
+        it 'adult gets status: false' do
+          result = host.send(:calculate_household_chronic_status, hh_id, adult[:client_id])
+          expect(result[:status]).to be false
+        end
+      end
+    end
+  end
+
+  describe '#household_chronic_status' do
+    let(:hh_id) { 'hh-001' }
+    let(:households_data) { { hh_id => [hoh, child] } }
+
+    it 'returns chronic_status and chronic_detail keys for legacy callers' do
+      result = host.send(:household_chronic_status, hh_id, child[:client_id])
+      expect(result[:chronic_status]).to be true
+      expect(result[:chronic_detail]).to eq(:yes)
+    end
+  end
+
+  describe '#pit_household_chronic_status' do
+    let(:hh_id) { 'hh-001' }
+    let(:households_data) { { hh_id => [hoh] } }
+
+    it 'returns pit_chronic_status key for legacy callers' do
+      result = host.send(:pit_household_chronic_status, hh_id)
+      expect(result[:pit_chronic_status]).to be true
+    end
+
+    it 'uses the HoH as the anchor when no client_id is given' do
+      households_data[hh_id] = [hoh, child]
+      result = host.send(:pit_household_chronic_status, hh_id)
+      expect(result[:pit_chronic_status]).to be true
+    end
+
+    it 'adult gets pit_chronic_status based on own status (not inherited like project start)' do
+      hoh[:pit_chronic_status] = false
+      households_data[hh_id] = [hoh, adult]
+      result = host.send(:pit_household_chronic_status, hh_id)
+      expect(result[:pit_chronic_status]).to be false
+    end
+  end
+
+  describe '#calculate_hh_move_in_date' do
+    let(:hh_id) { 'hh-001' }
+
+    let(:enrollment) do
+      OpenStruct.new(
+        entry_date: Date.parse('2023-01-01'),
+        exit_date: nil,
+        move_in_date: nil,
+      )
+    end
+
+    context 'when household is not found' do
+      it 'returns nil' do
+        expect(host.send(:calculate_hh_move_in_date, 'missing-hh', enrollment)).to be_nil
+      end
+    end
+
+    context 'when HoH has no move-in date' do
+      let(:households_data) { { hh_id => [hoh] } }
+
+      it 'returns nil' do
+        expect(host.send(:calculate_hh_move_in_date, hh_id, enrollment)).to be_nil
+      end
+    end
+
+    context 'when HoH has a valid move-in date' do
+      let(:households_data) { { hh_id => [hoh] } }
+
+      before { hoh[:move_in_date] = Date.parse('2023-03-01') }
+
+      it 'inherits the HoH move-in date for a member present at housing' do
+        result = host.send(:calculate_hh_move_in_date, hh_id, enrollment)
+        expect(result).to eq(Date.parse('2023-03-01'))
+      end
+
+      it 'uses member entry_date for a late joiner (joined after housing)' do
+        enrollment.entry_date = Date.parse('2023-04-01')
+        result = host.send(:calculate_hh_move_in_date, hh_id, enrollment)
+        expect(result).to eq(Date.parse('2023-04-01'))
+      end
+
+      it 'returns nil when member exited before HoH move-in' do
+        enrollment.exit_date = Date.parse('2023-02-01') # Exited before HoH's 2023-03-01 move-in
+        result = host.send(:calculate_hh_move_in_date, hh_id, enrollment)
+        expect(result).to be_nil
+      end
+
+      it 'returns nil when the HoH move-in date is after the report end date' do
+        hoh[:move_in_date] = Date.parse('2024-06-01') # After report end of 2024-01-31
+        result = host.send(:calculate_hh_move_in_date, hh_id, enrollment)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when HoH move-in date precedes HoH entry date (data quality issue)' do
+      let(:households_data) { { hh_id => [hoh] } }
+
+      before do
+        hoh[:entry_date] = Date.parse('2023-02-01')
+        hoh[:move_in_date] = Date.parse('2023-01-01')
+      end
+
+      it 'disregards the invalid move-in date and returns nil' do
+        result = host.send(:calculate_hh_move_in_date, hh_id, enrollment)
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/hud_reports/household_context_builder_spec.rb
+++ b/spec/models/hud_reports/household_context_builder_spec.rb
@@ -1,0 +1,631 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudReports::HouseholdContextBuilder, type: :model do
+  let(:report) { create(:hud_reports_report_instance, start_date: '2020-01-01', end_date: '2020-12-31') }
+  let(:generator) do
+    instance_double(
+      HudReports::GeneratorBase,
+      client_scope: GrdaWarehouse::Hud::Client.all,
+      report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry,
+      base_enrollment_scope: GrdaWarehouse::ServiceHistoryEnrollment.entry.
+        where(client_id: GrdaWarehouse::Hud::Client.all).
+        merge(GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(
+                start_date: report.start_date,
+                end_date: report.end_date,
+              )),
+    )
+  end
+
+  let!(:data_source) { create(:data_source_fixed_id) }
+  let!(:organization) { create(:hud_organization, data_source: data_source) }
+  let!(:project) { create(:hud_project, data_source: data_source, organization: organization, ProjectType: 1) } # ES-NBN
+
+  # Clients: HoH (Adult) + Child
+  let(:client_hoh) { create_client_with_warehouse_link(dob: 40.years.ago) }
+  let(:client_child) { create_client_with_warehouse_link(dob: 10.years.ago) }
+
+  def create_client_with_warehouse_link(dob:)
+    source_client = create(:hud_client, data_source: data_source, DOB: dob)
+    dest_client = create(:hud_client, data_source: data_source, DOB: dob)
+    create(:warehouse_client, source: source_client, destination: dest_client)
+    create(:grda_warehouse_warehouse_clients_processed, client_id: dest_client.id, warehouse_client: GrdaWarehouse::WarehouseClient.last)
+    source_client
+  end
+
+  # HUD Enrollments
+  let!(:hud_enrollment_hoh) do
+    create(:hud_enrollment,
+           PersonalID: client_hoh.PersonalID,
+           ProjectID: project.ProjectID,
+           HouseholdID: 'HH123',
+           RelationshipToHoH: 1, # Self (HoH)
+           EntryDate: '2020-01-01',
+           data_source_id: data_source.id)
+  end
+
+  let!(:hud_enrollment_child) do
+    create(:hud_enrollment,
+           PersonalID: client_child.PersonalID,
+           ProjectID: project.ProjectID,
+           HouseholdID: 'HH123',
+           RelationshipToHoH: 2, # Child
+           EntryDate: '2020-01-01',
+           data_source_id: data_source.id)
+  end
+
+  before do
+    # Generate ServiceHistoryEnrollment records from HUD records
+    GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+  end
+
+  let(:enrollment_hoh) { GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_enrollment_hoh.EnrollmentID) }
+  let(:enrollment_child) { GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_enrollment_child.EnrollmentID) }
+
+  subject(:builder) { described_class.new(generator, report, enrollment_scope: generator.base_enrollment_scope) }
+
+  describe '#call' do
+    it 'creates a context for each enrollment in the household' do
+      expect { builder.call }.to change(HudReports::HouseholdContext, :count).by(2)
+    end
+
+    it 'assigns correct household attributes' do
+      builder.call
+      contexts = HudReports::HouseholdContext.where(household_id: 'HH123')
+
+      expect(contexts.pluck(:household_type).uniq).to eq(['adults_and_children'])
+      expect(contexts.pluck(:hoh_entry_date).uniq).to eq([Date.parse('2020-01-01')])
+    end
+
+    it 'identifies the Head of Household' do
+      builder.call
+      hoh_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_hoh.id)
+      child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+
+      expect(hoh_context.is_hoh).to be true
+      expect(child_context.is_hoh).to be false
+      expect(child_context.hoh_destination_client_id).to eq(client_hoh.destination_client.id)
+    end
+
+    context 'when re-running (idempotency)' do
+      before do
+        create(:hud_reports_household_context, report_instance: report)
+      end
+
+      it 'clears previous contexts' do
+        expect { builder.call }.to change(HudReports::HouseholdContext, :count).from(1).to(2)
+      end
+    end
+
+    context 'with chronic status inheritance' do
+      before do
+        # Mark HoH as chronic in source data
+        hud_enrollment_hoh.update!(
+          DisablingCondition: 1,
+          ContinuouslyHomelessOneYear: 1,
+          TimesHomelessPastThreeYears: 4,
+          MonthsHomelessPastThreeYears: 112, # 112 = 12 months
+        )
+        # Re-rebuild to pick up changes
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).rebuild_service_history!
+      end
+
+      it 'passes chronic status from HoH to the child' do
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_chronic_status).to be true
+      end
+
+      it 'passes chronic status from another adult to the child if HoH is not chronic' do
+        # HoH not chronic
+        hud_enrollment_hoh.update!(DisablingCondition: 0)
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).rebuild_service_history!
+
+        # Add another adult who is chronic
+        adult_2 = create_client_with_warehouse_link(dob: 30.years.ago)
+        create(:hud_enrollment,
+               PersonalID: adult_2.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 3, # Spouse/Partner
+               EntryDate: '2020-01-01',
+               DisablingCondition: 1,
+               ContinuouslyHomelessOneYear: 1,
+               TimesHomelessPastThreeYears: 4,
+               MonthsHomelessPastThreeYears: 112,
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_chronic_status).to be true
+      end
+
+      it 'passes indeterminate chronic status (DK/R) from HoH to the child' do
+        # HoH has DK/R
+        hud_enrollment_hoh.update!(DisablingCondition: 8) # 8 = DK
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).create_service_history!(true)
+
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_chronic_detail).to eq('dk_or_r')
+      end
+    end
+
+    context 'with move-in date inheritance' do
+      before do
+        hud_enrollment_hoh.update!(MoveInDate: '2020-06-01')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).create_service_history!(true)
+      end
+
+      it 'inherits HoH move-in date when member is present' do
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_move_in_date).to eq(Date.parse('2020-06-01'))
+        expect(child_context.hoh_move_in_date).to eq(Date.parse('2020-06-01'))
+      end
+
+      it 'uses own entry date when joining after HoH move-in' do
+        # Child joins in July
+        hud_enrollment_child.update!(EntryDate: '2020-07-01')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_child.id).create_service_history!(true)
+
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_move_in_date).to eq(Date.parse('2020-07-01'))
+      end
+    end
+
+    context 'with different household types' do
+      it 'identifies adults only households' do
+        # Remove child and add another adult
+        GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_enrollment_child.EnrollmentID).delete_all
+        hud_enrollment_child.destroy
+        adult_2 = create_client_with_warehouse_link(dob: 30.years.ago)
+        create(:hud_enrollment,
+               PersonalID: adult_2.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 3,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        expect(HudReports::HouseholdContext.pluck(:household_type).uniq).to eq(['adults_only'])
+      end
+
+      it 'identifies children only households' do
+        # Change HoH to child
+        GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_enrollment_hoh.EnrollmentID).delete_all
+        hud_enrollment_hoh.destroy
+
+        child_2 = create_client_with_warehouse_link(dob: 12.years.ago)
+        create(:hud_enrollment,
+               PersonalID: child_2.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 1,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        expect(HudReports::HouseholdContext.pluck(:household_type).uniq).to eq(['children_only'])
+      end
+
+      it 'categorizes as unknown if an adult household has a member with a missing DOB' do
+        # Remove the child and add an adult with no DOB
+        GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_enrollment_child.EnrollmentID).delete_all
+        hud_enrollment_child.destroy
+        unknown_adult = create_client_with_warehouse_link(dob: nil)
+        create(:hud_enrollment,
+               PersonalID: unknown_adult.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 3,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        # One 40yo adult + one unknown = unknown type
+        expect(HudReports::HouseholdContext.pluck(:household_type).uniq).to eq(['unknown'])
+      end
+
+      it 'categorizes as unknown if a child household has a member with a missing DOB' do
+        # Change HoH to child and remove the adult HoH
+        GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_enrollment_hoh.EnrollmentID).delete_all
+        hud_enrollment_hoh.destroy
+
+        child_2 = create_client_with_warehouse_link(dob: 12.years.ago)
+        create(:hud_enrollment,
+               PersonalID: child_2.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 1,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        # Child 10yo (from let) + Child 12yo + Unknown age member
+        unknown_member = create_client_with_warehouse_link(dob: nil)
+        create(:hud_enrollment,
+               PersonalID: unknown_member.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 3,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        expect(HudReports::HouseholdContext.pluck(:household_type).uniq).to eq(['unknown'])
+      end
+
+      it 'still categorizes as adults_and_children if both are present even with an unknown age member' do
+        # HoH (40yo) + Child (10yo) + Unknown age member
+        unknown_member = create_client_with_warehouse_link(dob: nil)
+        create(:hud_enrollment,
+               PersonalID: unknown_member.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH123',
+               RelationshipToHoH: 3,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        builder.call
+        # Adults + Children present, so it's known even if one member is missing DOB
+        expect(HudReports::HouseholdContext.pluck(:household_type).uniq).to eq(['adults_and_children'])
+      end
+    end
+
+    context 'with date_to_street inheritance' do
+      before do
+        hud_enrollment_hoh.update!(DateToStreetESSH: '2019-12-01')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).create_service_history!(true)
+      end
+
+      it 'inherits HoH date_to_street for children with same entry date' do
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_date_to_street).to eq(Date.parse('2019-12-01'))
+        expect(child_context.hoh_date_to_street).to eq(Date.parse('2019-12-01'))
+      end
+
+      it 'does not inherit HoH date_to_street for children with different entry date' do
+        # Child joins a day later
+        hud_enrollment_child.update!(EntryDate: '2020-01-02')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_child.id).create_service_history!(true)
+
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        expect(child_context.inherited_date_to_street).to be_nil
+      end
+
+      it 'caps inherited date_to_street at child DOB' do
+        # Child born AFTER the homelessness started
+        hud_enrollment_child.update!(EntryDate: '2020-01-01')
+        client_child.update!(DOB: '2019-12-15')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_child.id).create_service_history!(true)
+
+        builder.call
+        child_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_child.id)
+        # Should be capped at DOB
+        expect(child_context.inherited_date_to_street).to eq(Date.parse('2019-12-15'))
+      end
+    end
+
+    context 'with synthetic household IDs' do
+      let(:generator_synthetic) do
+        instance_double(
+          HudReports::GeneratorBase,
+          client_scope: GrdaWarehouse::Hud::Client.where(id: [client_hoh.destination_client.id]),
+          report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry,
+          base_enrollment_scope: GrdaWarehouse::ServiceHistoryEnrollment.entry.
+            where(client_id: GrdaWarehouse::Hud::Client.where(id: [client_hoh.destination_client.id])).
+            merge(GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(
+                    start_date: report.start_date,
+                    end_date: report.end_date,
+                  )),
+        )
+      end
+
+      before do
+        # Remove household_id from HUD enrollment and rebuild
+        hud_enrollment_hoh.update!(HouseholdID: nil)
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment_hoh.id).create_service_history!(true)
+      end
+
+      it 'generates a synthetic ID using enrollment_group_id' do
+        described_class.new(generator_synthetic, report, enrollment_scope: generator_synthetic.base_enrollment_scope).call
+        expect(HudReports::HouseholdContext.last.household_id).to eq("#{hud_enrollment_hoh.EnrollmentID}*HH")
+      end
+    end
+
+    context 'with parenting youth' do
+      let(:youth_hoh) { create_client_with_warehouse_link(dob: 20.years.ago) }
+      let(:child) { create_client_with_warehouse_link(dob: 2.years.ago) }
+
+      let!(:hud_enrollment_youth) do
+        create(:hud_enrollment,
+               PersonalID: youth_hoh.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH-YOUTH',
+               RelationshipToHoH: 1,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      let!(:hud_enrollment_child_2) do
+        create(:hud_enrollment,
+               PersonalID: child.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH-YOUTH',
+               RelationshipToHoH: 2,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.where(id: [hud_enrollment_youth.id, hud_enrollment_child_2.id]).each(&:rebuild_service_history!)
+      end
+
+      let(:enrollment_youth) { GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_enrollment_youth.EnrollmentID) }
+
+      let(:generator_youth) do
+        instance_double(
+          HudReports::GeneratorBase,
+          client_scope: GrdaWarehouse::Hud::Client.where(id: [youth_hoh.destination_client.id, child.destination_client.id]),
+          report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry,
+          base_enrollment_scope: GrdaWarehouse::ServiceHistoryEnrollment.entry.
+            where(client_id: GrdaWarehouse::Hud::Client.where(id: [youth_hoh.destination_client.id, child.destination_client.id])).
+            merge(GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(
+                    start_date: report.start_date,
+                    end_date: report.end_date,
+                  )),
+        )
+      end
+
+      it 'identifies the HoH as a parenting youth' do
+        described_class.new(generator_youth, report, enrollment_scope: generator_youth.base_enrollment_scope).call
+        youth_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_youth.id)
+        expect(youth_context.is_parenting_youth).to be true
+      end
+
+      it 'does not identify as parenting youth if there is a member over 25' do
+        # Add a 40 year old member
+        adult_over_25 = create_client_with_warehouse_link(dob: 40.years.ago)
+        create(:hud_enrollment,
+               PersonalID: adult_over_25.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH-YOUTH',
+               RelationshipToHoH: 3,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        described_class.new(generator, report, enrollment_scope: generator.base_enrollment_scope).call
+        youth_context = HudReports::HouseholdContext.find_by(service_history_enrollment_id: enrollment_youth.id)
+        expect(youth_context.is_parenting_youth).to be false
+        expect(youth_context.non_youth_household).to be true
+      end
+    end
+
+    describe 'context copying from source report' do
+      let(:user) { create(:user) }
+      let(:start_date) { Date.parse('2020-01-01') }
+      let(:end_date) { Date.parse('2020-12-31') }
+      let(:source_report) { create(:hud_reports_report_instance, user: user, start_date: start_date, end_date: end_date) }
+      let(:target_report) { create(:hud_reports_report_instance, user: user, start_date: start_date, end_date: end_date) }
+
+      # Create a simple test generator class to avoid instance_double issues
+      let(:test_generator_class) do
+        Class.new(HudReports::GeneratorBase) do
+          attr_accessor :client_scope_override
+          def client_scope(...)
+            client_scope_override || super
+          end
+
+          def self.filter_class
+            ::Filters::HudFilterBase
+          end
+        end
+      end
+      let(:source_generator) do
+        test_generator_class.new(source_report).tap do |g|
+          g.client_scope_override = GrdaWarehouse::Hud::Client.all
+        end
+      end
+
+      before do
+        # Create contexts in source report
+        builder = described_class.new(source_generator, source_report, enrollment_scope: source_generator.base_enrollment_scope)
+        builder.call
+      end
+
+      it 'copies relevant contexts from source report' do
+        # Target report has subset of projects
+        target_generator = test_generator_class.new(target_report)
+        target_generator.client_scope_override = GrdaWarehouse::Hud::Client.where(id: client_hoh.destination_client.id)
+
+        builder = described_class.new(target_generator, target_report, enrollment_scope: target_generator.base_enrollment_scope, source_report_id: source_report.id)
+        builder.call
+
+        # Verify contexts were copied with new report_instance_id
+        expect(target_report.reload.household_contexts.count).to be > 0
+        expect(target_report.household_contexts.pluck(:report_instance_id).uniq).to eq([target_report.id])
+
+        # Verify context data matches source
+        source_ctx = source_report.reload.household_contexts.first
+        target_ctx = target_report.household_contexts.find_by(service_history_enrollment_id: source_ctx.service_history_enrollment_id)
+        expect(target_ctx.inherited_chronic_status).to eq(source_ctx.inherited_chronic_status)
+        expect(target_ctx.inherited_move_in_date).to eq(source_ctx.inherited_move_in_date)
+      end
+
+      it 'raises error if date ranges do not match' do
+        mismatched_report = create(:hud_reports_report_instance,
+                                   start_date: start_date + 1.day,
+                                   end_date: end_date)
+
+        builder = described_class.new(source_generator, mismatched_report, enrollment_scope: source_generator.base_enrollment_scope, source_report_id: source_report.id)
+
+        expect { builder.call }.to raise_error(ArgumentError, /date ranges don't match/)
+      end
+    end
+
+    context 'with multiple HoH enrollments (Anchor HoH selection)' do
+      let(:hoh_client) { create_client_with_warehouse_link(dob: 40.years.ago) }
+      let(:child_client) { create_client_with_warehouse_link(dob: 10.years.ago) }
+
+      # Create multiple HoH enrollments for the same household
+      # Enrollment 1: Historical (2018), has move-in
+      let!(:hud_hoh_1) do
+        e = create(:hud_enrollment,
+                   PersonalID: hoh_client.PersonalID,
+                   ProjectID: project.ProjectID,
+                   HouseholdID: 'HH-MULTI',
+                   RelationshipToHoH: 1,
+                   EntryDate: '2018-01-01',
+                   MoveInDate: '2018-02-01',
+                   data_source_id: data_source.id)
+        create(:hud_exit, data_source: data_source, EnrollmentID: e.EnrollmentID, PersonalID: e.PersonalID, ExitDate: '2018-12-31')
+        e
+      end
+
+      # Enrollment 2: More recent (2019), no move-in
+      let!(:hud_hoh_2) do
+        e = create(:hud_enrollment,
+                   PersonalID: hoh_client.PersonalID,
+                   ProjectID: project.ProjectID,
+                   HouseholdID: 'HH-MULTI',
+                   RelationshipToHoH: 1,
+                   EntryDate: '2019-01-01',
+                   data_source_id: data_source.id)
+        create(:hud_exit, data_source: data_source, EnrollmentID: e.EnrollmentID, PersonalID: e.PersonalID, ExitDate: '2019-12-31')
+        e
+      end
+
+      # Enrollment 3: Active in report (2020), no move-in
+      let!(:hud_hoh_3) do
+        create(:hud_enrollment,
+               PersonalID: hoh_client.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH-MULTI',
+               RelationshipToHoH: 1,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      # Current Child enrollment
+      let!(:hud_child_multi) do
+        create(:hud_enrollment,
+               PersonalID: child_client.PersonalID,
+               ProjectID: project.ProjectID,
+               HouseholdID: 'HH-MULTI',
+               RelationshipToHoH: 2,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+      end
+
+      it 'prioritizes the active HoH enrollment even if historical ones have more data' do
+        # hud_hoh_1 has a move-in date, but hud_hoh_3 is active.
+        # Inheritance should come from hud_hoh_3.
+        builder.call
+        child_ctx = HudReports::HouseholdContext.find_by(source_enrollment_id: hud_child_multi.id)
+        expect(child_ctx.hoh_service_history_enrollment_id).to eq(GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_hoh_3.EnrollmentID).id)
+      end
+
+      it 'prioritizes the most recent HoH if none are active' do
+        # Change report date to 2021 so none are active
+        report.update!(start_date: '2021-01-01', end_date: '2021-12-31')
+        # We need to include these historical enrollments in the scope for the builder to process them,
+        # but the builder's lookback (2 years by default in specs, but 7 years in SPM) will find them.
+        # The enrollment_scope provided to builder defines which SHEs get a Context record.
+        # Let's ensure our test SHE is in the scope.
+        scope = GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_child_multi.EnrollmentID)
+        described_class.new(generator, report, enrollment_scope: scope).call
+
+        child_ctx = HudReports::HouseholdContext.find_by(source_enrollment_id: hud_child_multi.id)
+        # Should pick hud_hoh_3 as it has the latest entry date (2020-01-01) among the three.
+        expect(child_ctx.hoh_entry_date).to eq(Date.parse('2020-01-01'))
+      end
+
+      it 'prioritizes HoH with move-in date if entry dates are the same' do
+        # Make hoh_2 and hoh_3 have same entry date, but hoh_2 has move-in
+        # and ensure both are exited before 2021
+        hud_hoh_3.update!(EntryDate: hud_hoh_2.EntryDate)
+        create(:hud_exit, data_source: data_source, EnrollmentID: hud_hoh_3.EnrollmentID, PersonalID: hud_hoh_3.PersonalID, ExitDate: '2019-12-31')
+        hud_hoh_2.update!(MoveInDate: '2019-02-01')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+
+        # Make none active
+        report.update!(start_date: '2021-01-01', end_date: '2021-12-31')
+        scope = GrdaWarehouse::ServiceHistoryEnrollment.where(enrollment_group_id: hud_child_multi.EnrollmentID)
+        described_class.new(generator, report, enrollment_scope: scope).call
+
+        child_ctx = HudReports::HouseholdContext.find_by(source_enrollment_id: hud_child_multi.id)
+        expect(child_ctx.hoh_service_history_enrollment_id).to eq(GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_hoh_2.EnrollmentID).id)
+      end
+    end
+
+    context 'with custom enrollment_scope' do
+      let(:custom_scope) { GrdaWarehouse::ServiceHistoryEnrollment.where(id: [enrollment_hoh.id]) }
+
+      it 'uses provided scope instead of generator discovery' do
+        builder = described_class.new(generator, report, enrollment_scope: custom_scope)
+        builder.call
+
+        # Should only build context for enrollments in custom scope
+        report.reload
+        expect(report.household_contexts.count).to eq(1)
+        expect(report.household_contexts.first.service_history_enrollment_id).to eq(enrollment_hoh.id)
+      end
+    end
+
+    context 'when no member has RelationshipToHoH = 1 (missing HoH)' do
+      before do
+        # Both members are non-HoH; common data quality issue in real imports
+        hud_enrollment_hoh.update!(RelationshipToHoH: 3)
+        hud_enrollment_child.update!(RelationshipToHoH: 3)
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+      end
+
+      it 'does not raise and still creates a context for each enrollment' do
+        expect { builder.call }.not_to raise_error
+        expect(report.reload.household_contexts.count).to eq(2)
+      end
+
+      it 'leaves all hoh_* fields nil' do
+        builder.call
+        report.reload.household_contexts.each do |ctx|
+          expect(ctx.is_hoh).to be false
+          expect(ctx.hoh_destination_client_id).to be_nil
+          expect(ctx.hoh_entry_date).to be_nil
+          expect(ctx.hoh_service_history_enrollment_id).to be_nil
+        end
+      end
+
+      it 'falls back to each member own chronic status' do
+        builder.call
+        report.reload.household_contexts.each do |ctx|
+          # With no HoH, hoh_entry_date is nil so no household-level inheritance can fire;
+          # each member falls back to their own raw chronic status.
+          expect(ctx.inherited_chronic_status).to eq(ctx.member_chronic_status || false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/hud_reports/household_context_spec.rb
+++ b/spec/models/hud_reports/household_context_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudReports::HouseholdContext, type: :model do
+  let(:report_instance) { create(:hud_reports_report_instance) }
+  let!(:data_source) { create :data_source_fixed_id }
+  let!(:client) { create :hud_client, data_source_id: data_source.id }
+  let!(:project) { create :hud_project, data_source: data_source, organization: organization }
+  let!(:organization) { create :hud_organization, data_source: data_source }
+  let!(:enrollment) { create :she_entry, client_id: client.id, project_type: 1, date: '2015-01-05'.to_date, first_date_in_program: '2015-01-05'.to_date, last_date_in_program: '2015-03-10'.to_date, project_id: project.ProjectID, organization_id: organization.OrganizationID, data_source_id: data_source.id }
+
+  it 'can be created with valid attributes' do
+    context = described_class.new(
+      report_instance: report_instance,
+      service_history_enrollment: enrollment,
+      data_source_id: data_source.id,
+      household_id: 'HH123',
+      household_type: 'adults_only',
+      is_hoh: true,
+    )
+
+    expect(context).to be_valid
+    expect(context.save).to be true
+  end
+
+  describe '.prune!' do
+    let!(:recent_report) { create(:hud_reports_report_instance, created_at: 1.day.ago) }
+    let!(:old_report) { create(:hud_reports_report_instance, created_at: 3.weeks.ago) }
+    let!(:deleted_report) { create(:hud_reports_report_instance, created_at: 1.day.ago).tap(&:destroy) }
+
+    let!(:recent_context) { create(:hud_reports_household_context, report_instance: recent_report, service_history_enrollment: enrollment) }
+    let!(:old_context) { create(:hud_reports_household_context, report_instance: old_report, service_history_enrollment: enrollment) }
+    let!(:deleted_report_context) { create(:hud_reports_household_context, report_instance: deleted_report, service_history_enrollment: enrollment) }
+    let!(:orphaned_context) do
+      ctx = build(:hud_reports_household_context, report_instance_id: 0, service_history_enrollment: enrollment)
+      ctx.save!(validate: false)
+      ctx
+    end
+
+    it 'removes old, deleted, and orphaned contexts' do
+      expect { described_class.prune! }.to change(described_class, :count).by(-3)
+
+      expect(described_class.exists?(recent_context.id)).to be true
+      expect(described_class.exists?(old_context.id)).to be false
+      expect(described_class.exists?(deleted_report_context.id)).to be false
+      expect(described_class.exists?(orphaned_context.id)).to be false
+    end
+  end
+end

--- a/spec/models/hud_reports/household_logic_spec.rb
+++ b/spec/models/hud_reports/household_logic_spec.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudReports::HouseholdLogic do
+  describe '.calculate_household_type' do
+    it 'returns :adults_and_children when both adults and children are present' do
+      expect(described_class.calculate_household_type([40, 10])).to eq(:adults_and_children)
+    end
+
+    it 'returns :adults_only when only adults are present' do
+      expect(described_class.calculate_household_type([40, 25])).to eq(:adults_only)
+    end
+
+    it 'returns :children_only when only children are present' do
+      expect(described_class.calculate_household_type([10, 12])).to eq(:children_only)
+    end
+
+    it 'returns :unknown if any age is nil' do
+      expect(described_class.calculate_household_type([40, nil])).to eq(:unknown)
+    end
+
+    it 'returns :unknown if ages are empty' do
+      expect(described_class.calculate_household_type([])).to eq(:unknown)
+    end
+  end
+
+  describe '.calculate_chronic_status' do
+    let(:hoh) do
+      {
+        client_id: 1,
+        entry_date: Date.parse('2020-01-01'),
+        age: 40,
+        chronic_status: true,
+        chronic_detail: 'yes',
+      }
+    end
+
+    let(:child) do
+      {
+        client_id: 2,
+        entry_date: Date.parse('2020-01-01'),
+        age: 10,
+        chronic_status: false,
+        chronic_detail: 'no',
+      }
+    end
+
+    let(:members) { [hoh, child] }
+
+    it 'inherits chronic status from HoH if they are chronic and entry dates match' do
+      result = described_class.calculate_chronic_status(members, child, hoh)
+      expect(result[:status]).to be true
+      expect(result[:detail]).to eq('yes')
+    end
+
+    it 'inherits from another chronic adult if HoH is not chronic' do
+      hoh[:chronic_status] = false
+      hoh[:chronic_detail] = 'no'
+
+      adult2 = {
+        client_id: 3,
+        entry_date: Date.parse('2020-01-01'),
+        age: 35,
+        chronic_status: true,
+        chronic_detail: 'yes',
+      }
+
+      result = described_class.calculate_chronic_status([hoh, child, adult2], child, hoh)
+      expect(result[:status]).to be true
+      expect(result[:detail]).to eq('yes')
+    end
+
+    it 'returns chronic household status for a non-chronic adult when another member is chronic' do
+      adult2 = {
+        client_id: 3,
+        entry_date: Date.parse('2020-01-01'),
+        age: 35,
+        chronic_status: false,
+        chronic_detail: 'no',
+      }
+      result = described_class.calculate_chronic_status([hoh, adult2], adult2, hoh)
+      expect(result[:status]).to be true
+      expect(result[:detail]).to eq('yes') # sourced from the chronic HoH
+    end
+
+    it 'returns own false status for a non-chronic adult when no household member is chronic' do
+      hoh[:chronic_status] = false
+      hoh[:chronic_detail] = 'no'
+      adult2 = {
+        client_id: 3,
+        entry_date: Date.parse('2020-01-01'),
+        age: 35,
+        chronic_status: false,
+        chronic_detail: 'no',
+      }
+      result = described_class.calculate_chronic_status([hoh, adult2], adult2, hoh)
+      expect(result[:status]).to be false
+      expect(result[:detail]).to eq('no')
+    end
+
+    context 'when calculating PIT chronic status' do
+      let(:hoh) do
+        {
+          client_id: 1,
+          entry_date: Date.parse('2020-01-01'),
+          age: 40,
+          pit_chronic_status: false,
+          pit_chronic_detail: 'no',
+        }
+      end
+
+      let(:child) do
+        {
+          client_id: 2,
+          entry_date: Date.parse('2020-01-01'),
+          age: 10,
+          pit_chronic_status: true,
+          pit_chronic_detail: 'yes',
+        }
+      end
+
+      it 'does not allow HoH to inherit from child' do
+        result = described_class.calculate_chronic_status([hoh, child], hoh, hoh, chronic_status_key: :pit_chronic_status)
+        expect(result[:status]).to be false
+      end
+
+      it 'allows child to inherit from another chronic adult' do
+        hoh[:pit_chronic_status] = false
+        adult2 = {
+          client_id: 3,
+          entry_date: Date.parse('2020-01-01'),
+          age: 35,
+          pit_chronic_status: true,
+          pit_chronic_detail: 'yes',
+        }
+
+        result = described_class.calculate_chronic_status([hoh, child, adult2], child, hoh, chronic_status_key: :pit_chronic_status)
+        expect(result[:status]).to be true
+        expect(result[:detail]).to eq('yes')
+      end
+    end
+
+    context 'with indeterminate (DK/R) data' do
+      it 'inherits DK/R status from HoH for children' do
+        hoh[:chronic_status] = false
+        hoh[:chronic_detail] = 'dk_or_r'
+        child[:chronic_status] = false
+        child[:chronic_detail] = 'no'
+
+        result = described_class.calculate_chronic_status(members, child, hoh)
+        expect(result[:status]).to be false
+        expect(result[:detail]).to eq('dk_or_r')
+      end
+
+      it 'inherits from HoH if child has missing status' do
+        hoh[:chronic_status] = true
+        hoh[:chronic_detail] = 'yes'
+        child[:chronic_status] = false
+        child[:chronic_detail] = 'missing'
+
+        result = described_class.calculate_chronic_status(members, child, hoh)
+        expect(result[:status]).to be true
+        expect(result[:detail]).to eq('yes')
+      end
+    end
+  end
+
+  describe '.calculate_is_parenting_youth' do
+    let(:youth_hoh) { { age: 20, relationship_to_hoh: 1 } }
+    let(:child) { { age: 2, relationship_to_hoh: 2 } }
+    let(:members) { [youth_hoh, child] }
+
+    it 'returns true for a youth household with children' do
+      expect(described_class.calculate_is_parenting_youth(youth_hoh, members)).to be true
+    end
+
+    it 'returns false if there is a member over 24' do
+      adult = { age: 25, relationship_to_hoh: 3 }
+      expect(described_class.calculate_is_parenting_youth(youth_hoh, [youth_hoh, child, adult])).to be false
+    end
+
+    it 'returns false if there are no children (relationship 2)' do
+      spouse = { age: 20, relationship_to_hoh: 3 }
+      expect(described_class.calculate_is_parenting_youth(youth_hoh, [youth_hoh, spouse])).to be false
+    end
+
+    it 'considers youth up to age 24 as children for parenting youth status' do
+      # APR nuance: child can be up to 24 in a youth household
+      older_child = { age: 24, relationship_to_hoh: 2 }
+      expect(described_class.calculate_is_parenting_youth(youth_hoh, [youth_hoh, older_child])).to be true
+    end
+  end
+
+  describe '.calculate_move_in_date' do
+    let(:hoh) do
+      {
+        entry_date: Date.parse('2020-01-01'),
+        move_in_date: Date.parse('2020-02-01'),
+      }
+    end
+
+    let(:member) do
+      {
+        entry_date: Date.parse('2020-01-01'),
+        exit_date: nil,
+      }
+    end
+
+    it 'uses members own move-in date if valid' do
+      member[:move_in_date] = Date.parse('2020-03-01')
+      expect(described_class.calculate_move_in_date(member, hoh)).to eq(Date.parse('2020-03-01'))
+    end
+
+    it 'inherits HoH move-in date if member was present' do
+      expect(described_class.calculate_move_in_date(member, hoh)).to eq(Date.parse('2020-02-01'))
+    end
+
+    it 'uses entry date if member joined after HoH moved in' do
+      member[:entry_date] = Date.parse('2020-03-01')
+      expect(described_class.calculate_move_in_date(member, hoh)).to eq(Date.parse('2020-03-01'))
+    end
+
+    it 'returns nil if HoH has no move-in date' do
+      hoh[:move_in_date] = nil
+      expect(described_class.calculate_move_in_date(member, hoh)).to eq(nil)
+    end
+  end
+
+  describe '.calculate_date_to_street' do
+    let(:hoh) do
+      {
+        entry_date: Date.parse('2020-01-01'),
+        date_to_street: Date.parse('2019-12-01'),
+      }
+    end
+
+    let(:member) do
+      {
+        entry_date: Date.parse('2020-01-01'),
+        age: 10,
+        dob: Date.parse('2010-01-01'),
+      }
+    end
+
+    it 'uses members own date_to_street if present' do
+      member[:date_to_street] = Date.parse('2019-12-15')
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(Date.parse('2019-12-15'))
+    end
+
+    it 'caps own date_to_street at DOB' do
+      member[:date_to_street] = Date.parse('2009-12-15') # Before birth
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(member[:dob])
+    end
+
+    it 'inherits from HoH if child under 17 and same entry date' do
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(hoh[:date_to_street])
+    end
+
+    it 'caps inherited date_to_street at DOB' do
+      hoh[:date_to_street] = Date.parse('2000-01-01') # Long before child birth
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(member[:dob])
+    end
+
+    it 'does not inherit if member entry date differs' do
+      member[:entry_date] = Date.parse('2020-01-02')
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(nil)
+    end
+
+    it 'does not inherit if member is over 17' do
+      member[:age] = 18
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(nil)
+    end
+
+    it 'returns nil if HoH has no date_to_street' do
+      hoh[:date_to_street] = nil
+      expect(described_class.calculate_date_to_street(member, hoh)).to eq(nil)
+    end
+
+    it 'returns nil if HoH is missing' do
+      expect(described_class.calculate_date_to_street(member, nil)).to eq(nil)
+    end
+  end
+
+  describe '.calculate_length_of_stay' do
+    let(:report_end_date) { Date.parse('2020-12-31') }
+
+    it 'calculates days from entry to exit for members who exited' do
+      member = { entry_date: Date.parse('2020-01-01'), exit_date: Date.parse('2020-03-01') }
+      expect(described_class.calculate_length_of_stay(member, report_end_date: report_end_date)).to eq(60)
+    end
+
+    it 'uses report_end_date + 1 for active stayers with no exit date' do
+      member = { entry_date: Date.parse('2020-01-01'), exit_date: nil }
+      expect(described_class.calculate_length_of_stay(member, report_end_date: report_end_date)).to eq(366)
+    end
+
+    it 'returns 0 if entry_date is missing' do
+      expect(described_class.calculate_length_of_stay({ entry_date: nil }, report_end_date: report_end_date)).to eq(0)
+    end
+
+    it 'returns 0 if member is nil' do
+      expect(described_class.calculate_length_of_stay(nil, report_end_date: report_end_date)).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
:warning: use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
**Rationale:** This is the first of three phased PRs refactoring the HUD reporting architecture. This PR lays the foundation by centralizing complex household business logic into a pure Ruby module and adding a model to cache these calculated values. It also updates report modules to use this new logic  but does not change the report generators to use the new cached values yet.

**Phases**
For review, this work is split into three phases
* https://github.com/greenriver/hmis-warehouse/pull/6303 (you are here)
* https://github.com/greenriver/hmis-warehouse/pull/6304
* https://github.com/greenriver/hmis-warehouse/pull/6305

**Changes:**
* Add `hud_report_household_contexts` database table and `HudReports::HouseholdContext` model to store household calculations
* Add `HudReports::HouseholdLogic` to centralize pure business rules for chronic inheritance, move-in date propagation, and household typing.
* Implement `HudReports::HouseholdContextBuilder` to batch and process household calculations for a given report universe.
* Update `HudReports::Households` concern to delegate its calculations to the new `HouseholdLogic` module.
* Add daily pruning of expired context records to `RunDailyImportsJob` and register the model in `GrdaWarehouse::Utility`.
* Update framework documentation to reflect the new three-layer data denormalization strategy.

## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


