### PR TITLE
8509 phase 2: FY2026 APR/CAPER/DQ generation

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2026/generator.rb
@@ -33,6 +33,11 @@ module HudApr::Generators::Apr::Fy2026
       hud_reports_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
 
+    def prepare_report
+      super
+      HudReports::HouseholdContextBuilder.call(self, report, enrollment_scope: base_enrollment_scope)
+    end
+
     def self.filter_class
       ::Filters::HudFilterBase
     end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2026/generator.rb
@@ -34,6 +34,11 @@ module HudApr::Generators::Caper::Fy2026
       hud_reports_caper_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
 
+    def prepare_report
+      super
+      HudReports::HouseholdContextBuilder.call(self, report, enrollment_scope: base_enrollment_scope)
+    end
+
     def self.filter_class
       ::Filters::HudFilterBase
     end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/generator.rb
@@ -31,6 +31,11 @@ module HudApr::Generators::CeApr::Fy2026
       hud_reports_ce_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
 
+    def prepare_report
+      super
+      HudReports::HouseholdContextBuilder.call(self, report, enrollment_scope: base_enrollment_scope)
+    end
+
     def self.default_project_type_codes
       HudHelper.util('2026').performance_reporting.keys
     end

--- a/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2026/generator.rb
@@ -9,6 +9,15 @@
 module HudApr::Generators::Dq::Fy2026
   class Generator < ::HudReports::GeneratorBase
     include HudApr::CellDetailsConcern
+
+    # When set, HouseholdContext records are copied from this report instead of being
+    # recomputed. Used by the SPM, which runs DQ sub-reports and passes its own report ID
+    # so that both reports share the same pre-computed household context.
+    def source_report_id_for_contexts
+      @source_report_id_for_contexts ||= report.options&.with_indifferent_access&.[](:source_report_id_for_contexts)
+    end
+    attr_writer :source_report_id_for_contexts
+
     def self.fiscal_year
       'FY 2026'
     end
@@ -31,6 +40,11 @@ module HudApr::Generators::Dq::Fy2026
 
     def url
       hud_reports_dq_url(report, { host: ENV['FQDN'], protocol: 'https' })
+    end
+
+    def prepare_report
+      super
+      HudReports::HouseholdContextBuilder.call(self, report, enrollment_scope: base_enrollment_scope, source_report_id: source_report_id_for_contexts)
     end
 
     def self.filter_class

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/apr_client_builder.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/apr_client_builder.rb
@@ -1,0 +1,514 @@
+# frozen_string_literal: true
+
+module HudApr::Generators::Shared::Fy2026
+  class AprClientBuilder
+    include HudReports::Util
+    include HudReports::Clients
+    include HudReports::Ages
+    include HudReports::Destinations
+    include HudReports::Veterans
+    include HudReports::LengthOfStays
+    include HudReports::Incomes
+
+    HohEnrollmentProxy = Data.define(:entry_date, :first_date_in_program, :head_of_household?, :enrollment)
+    HohEnrollmentProxyInner = Data.define(:DateToStreetESSH) # rubocop:disable Naming/MethodName
+
+    attr_reader :last_service_history_enrollment, :ctx, :source_client
+
+    private def a_t
+      @a_t ||= HudApr::Fy2020::AprClient.arel_table
+    end
+
+    # @param report [HudReports::ReportInstance] The report instance currently being generated.
+    # @param client [GrdaWarehouse::Hud::Client] The unified destination client record.
+    # @param enrollments [Array<GrdaWarehouse::ServiceHistoryEnrollment>] All enrollments for this client.
+    # @param context_map [Hash<Integer, HudReports::HouseholdContext>] A map of ServiceHistoryEnrollment IDs to
+    #   their pre-computed household-level business logic.
+    # @param hoh_enrollment_map [Hash<Integer, GrdaWarehouse::ServiceHistoryEnrollment>] A map of
+    #   ServiceHistoryEnrollment IDs for Head of Households to their raw records with preloaded associations.
+    # @param needs_ce_assessments [Boolean] Whether to process Coordinated Entry specific logic and attributes.
+    # @param households [Hash<Array(String, Integer), Array<Hash>>] A map of [household_id, data_source_id] to
+    #   legacy member hashes for all members in that household.
+    def initialize(report:, client:, enrollments:, context_map:, hoh_enrollment_map:, needs_ce_assessments:, households:)
+      @report = report
+      @client = client # Destination client
+      @raw_enrollments = Array(enrollments)
+      @context_map = context_map
+      @hoh_enrollment_map = hoh_enrollment_map
+      @needs_ce_assessments = needs_ce_assessments
+      @households = households
+    end
+
+    def self.build(...)
+      new(...).resolve_and_build
+    end
+
+    def resolve_and_build
+      resolve_primary_enrollment!
+
+      return { success: false } unless @last_service_history_enrollment
+      raise ArgumentError, "Missing context for SHE #{@last_service_history_enrollment.id}" unless @ctx
+      return { success: false } unless resolve_enrollment_coc!
+
+      raise ArgumentError, "Missing source client for SHE #{@last_service_history_enrollment.id}" unless @source_client
+
+      {
+        success: true,
+        attributes: build_attributes_internal,
+        source_client_id: @source_client.id,
+        enrollment_id: @last_service_history_enrollment.enrollment.id,
+      }
+    end
+
+    private
+
+    def build_attributes_internal
+      options = map_standard_attributes
+      options.merge!(map_ce_attributes) if @needs_ce_assessments
+      options
+    end
+
+    def resolve_primary_enrollment!
+      @last_service_history_enrollment = @raw_enrollments.last
+      return unless @last_service_history_enrollment
+
+      @ctx = @context_map[@last_service_history_enrollment.id]
+      return unless @ctx
+
+      @hoh_enrollment = @hoh_enrollment_map[@ctx.hoh_service_history_enrollment_id]
+
+      if @needs_ce_assessments
+        # CE logic requires a full HoH enrollment. If we don't have one, fall back to current.
+        hoh_for_ce = @hoh_enrollment || @last_service_history_enrollment
+        @ce_latest_assessment = latest_ce_assessment(@last_service_history_enrollment, hoh_for_ce)
+        @ce_latest_event = latest_ce_event(@last_service_history_enrollment, hoh_for_ce, @ce_latest_assessment)
+
+        # Adjust last service history enrollment if falls outside assessment date
+        if @ce_latest_assessment.present?
+          @last_service_history_enrollment = @raw_enrollments.select do |e|
+            @ce_latest_assessment.AssessmentDate.between?(
+              e.first_date_in_program,
+              e.last_date_in_program || @report.end_date,
+            )
+          end.last
+
+          # Try to get context for the newly selected enrollment. Fall back to the original
+          # @ctx if the new enrollment has no entry in the map (e.g. it falls outside the
+          # report universe but is the closest match for the CE assessment date).
+          @ctx = @context_map[@last_service_history_enrollment.id] || @ctx if @last_service_history_enrollment
+        end
+      end
+
+      return unless @last_service_history_enrollment
+
+      @enrollment = @last_service_history_enrollment.enrollment
+      @source_client = @enrollment&.client
+    end
+
+    # Resolves the effective CoC for the enrollment (step 6 of CE APR universe rules) and
+    # stores it in @calculated_enrollment_coc for use in map_standard_attributes.
+    # Returns true if the resolved CoC is in the report's chosen set (step 7), false otherwise.
+    def resolve_enrollment_coc!
+      # If the project only operates in one CoC, use that directly.
+      # Otherwise prefer the pre-computed HoH CoC from context, falling back to the
+      # HoH enrollment record, then the enrollment's own CoC field.
+      @calculated_enrollment_coc = if @enrollment.project.project_cocs.one?
+        @enrollment.project.project_cocs.first.coc_code
+      else
+        @ctx.hoh_coc || @hoh_enrollment&.enrollment&.enrollment_coc || @enrollment.EnrollmentCoC
+      end
+
+      @calculated_enrollment_coc.in?(@report.coc_codes)
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def map_standard_attributes
+      exit_date = @last_service_history_enrollment.last_date_in_program
+      exited_enrollment = @last_service_history_enrollment.enrollment if exit_date.present? && exit_date <= @report.end_date
+
+      income_at_start = @enrollment.income_benefits_at_entry
+      hoh_entry_date = @ctx.hoh_entry_date || @hoh_enrollment&.first_date_in_program || @last_service_history_enrollment.first_date_in_program
+      income_at_annual_assessment = annual_assessment(@enrollment, hoh_entry_date)
+      income_at_exit = exited_enrollment&.income_benefits_at_exit
+
+      disabilities = @enrollment.disabilities.select { |disability| [1, 2, 3].include?(disability.DisabilityResponse) }
+      disabilities_at_entry = @enrollment.disabilities.select { |d| d.DataCollectionStage == 1 }
+      disabilities_at_exit = @enrollment.disabilities.select { |d| d.DataCollectionStage == 3 }
+      max_disability_date = @enrollment.disabilities.select { |d| d.InformationDate <= @report.end_date }.map(&:InformationDate).max
+      disabilities_latest = @enrollment.disabilities.select { |d| d.InformationDate == max_disability_date }
+
+      # Need to sort by information date, then DateUpdated to catch the most-recent
+      # added for the Datalab test kit
+      health_and_dv = @enrollment.health_and_dvs.select do |h|
+        h.InformationDate && h.InformationDate <= @report.end_date && !h.DomesticViolenceSurvivor.nil?
+      end.max_by { |h| [h.InformationDate, h.DateUpdated] }
+
+      last_bed_night = @enrollment.services.select do |service|
+        service.RecordType == 200 && service.DateProvided && service.DateProvided < @report.end_date
+      end&.max_by(&:DateProvided)
+
+      move_on_assistance = @enrollment.services.select do |service|
+        service.RecordType == 300 && service.DateProvided && service.DateProvided < @report.end_date
+      end&.max_by(&:DateProvided)
+
+      youth_education_status_at_entry = @enrollment.youth_education_statuses.filter do |status|
+        status.DataCollectionStage == 1 && status.InformationDate && status.InformationDate < @report.end_date
+      end&.max_by(&:InformationDate)
+
+      youth_education_status_at_exit = @enrollment.youth_education_statuses.filter do |status|
+        status.DataCollectionStage == 3 && status.InformationDate && status.InformationDate < @report.end_date
+      end&.max_by(&:InformationDate)
+
+      # Age is pre-computed in HouseholdContext as of [entry_date, report_start].max per HUD rules.
+      age = @ctx.age
+      hoh_anniversary_date = anniversary_date(entry_date: hoh_entry_date, report_end_date: @report.end_date)
+      hoh_light = @hoh_enrollment || begin
+        hoh_enrollment_proxy = HohEnrollmentProxyInner.new(@ctx.hoh_date_to_street)
+        HohEnrollmentProxy.new(
+          entry_date: hoh_entry_date,
+          first_date_in_program: hoh_entry_date,
+          "head_of_household?": true,
+          enrollment: hoh_enrollment_proxy,
+        )
+      end
+
+      # Households with required assessments are calculated earlier for performance reasons.
+      # An APR is being submitted to verify assessment requirements for non-HoH adults entering the HH at a different date than the HoH.
+      # e.g. If an adult enters 1 day prior HoH assessment date, is their assessment required on the HoH date (1 day later) or on the following year (1 year + 1 day later)
+      #      If an adult enters 1 day after the HoH assessment date is their assessment due on the HoH date (1 year - 1 day later) or on the following year (2 years - 1 day)
+      annual_assessment_expected = if age.present? && age >= 18
+        annual_assessment_expected?(hoh_enrollment: hoh_light, enrollment: @last_service_history_enrollment, report_end_date: @report.end_date) &&
+          @last_service_history_enrollment.first_date_in_program < hoh_anniversary_date
+      else
+        annual_assessment_expected?(hoh_enrollment: hoh_light, enrollment: @last_service_history_enrollment, report_end_date: @report.end_date)
+      end
+
+      destination = @last_service_history_enrollment.destination
+      destination_subsidy_type = exited_enrollment&.exit&.DestinationSubsidyType
+      destination = 99 if destination == 435 && !destination_subsidy_type.in?(HudHelper.util('2026').rental_subsidy_types.keys)
+      destination = 99 unless HudHelper.util('2026').valid_destinations.key?(destination)
+
+      {
+        client_id: @source_client.id,
+        destination_client_id: @client.id,
+        data_source_id: @source_client.data_source_id,
+        personal_id: @source_client.PersonalID,
+        project_id: @last_service_history_enrollment.project.id,
+        report_instance_id: @report.id,
+        source_enrollment_id: @enrollment.id,
+
+        age: age,
+        alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
+        alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
+        alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
+        annual_assessment_expected: annual_assessment_expected,
+        annual_assessment_in_window: annual_assessment_in_window?(hoh_light, income_at_annual_assessment&.InformationDate),
+        approximate_time_to_move_in: approximate_time_to_move_in(@last_service_history_enrollment, age, hoh_light),
+        came_from_street_last_night: @enrollment.PreviousStreetESSH,
+        chronic_disability_entry: disabilities_at_entry.detect(&:chronic?)&.DisabilityResponse,
+        chronic_disability_exit: disabilities_at_exit.detect(&:chronic?)&.DisabilityResponse,
+        chronic_disability_latest: disabilities_latest.detect(&:chronic?)&.DisabilityResponse,
+        chronic_disability: disabilities.detect(&:chronic?).present?,
+        chronically_homeless: @ctx.inherited_chronic_status,
+        chronically_homeless_detail: @ctx.inherited_chronic_detail,
+        currently_fleeing: health_and_dv&.CurrentlyFleeing,
+        date_homeless: @enrollment.DateToStreetESSH,
+        date_of_engagement: @enrollment.DateOfEngagement,
+        date_of_last_bed_night: last_bed_night&.DateProvided,
+        move_on_assistance_provided: move_on_assistance&.TypeProvided,
+
+        current_school_attend_at_entry: youth_education_status_at_entry&.CurrentSchoolAttend,
+        most_recent_ed_status_at_entry: youth_education_status_at_entry&.MostRecentEdStatus,
+        current_ed_status_at_entry: youth_education_status_at_entry&.CurrentEdStatus,
+
+        current_school_attend_at_exit: youth_education_status_at_exit&.CurrentSchoolAttend,
+        most_recent_ed_status_at_exit: youth_education_status_at_exit&.MostRecentEdStatus,
+        current_ed_status_at_exit: youth_education_status_at_exit&.CurrentEdStatus,
+
+        los_under_threshold: @enrollment.LOSUnderThreshold,
+        date_to_street: date_to_street(@last_service_history_enrollment, age, hoh_light),
+        destination: destination,
+        developmental_disability_entry: disabilities_at_entry.detect(&:developmental?)&.DisabilityResponse,
+        developmental_disability_exit: disabilities_at_exit.detect(&:developmental?)&.DisabilityResponse,
+        developmental_disability_latest: disabilities_latest.detect(&:developmental?)&.DisabilityResponse,
+        developmental_disability: disabilities.detect(&:developmental?).present?,
+        disabling_condition: @enrollment.DisablingCondition,
+        dob_quality: apr_client_dob_quality(@source_client),
+        dob: @source_client.DOB,
+        client_created_at: @source_client.DateCreated || @source_client.DateUpdated || DateTime.current,
+        domestic_violence: health_and_dv&.DomesticViolenceSurvivor,
+        domestic_violence_occurred: health_and_dv&.WhenOccurred,
+        drug_abuse_entry: [2, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
+        drug_abuse_exit: [2, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
+        drug_abuse_latest: [2, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
+        enrollment_coc: @calculated_enrollment_coc,
+        enrollment_created: @enrollment.DateCreated || @enrollment.DateUpdated || DateTime.current,
+        exit_created: exited_enrollment&.exit&.DateCreated,
+        exit_destination_subsidy_type: destination_subsidy_type,
+        first_date_in_program: @last_service_history_enrollment.first_date_in_program,
+        first_name: @source_client.FirstName,
+        sex: @source_client.Sex || 99,
+        head_of_household_id: @ctx.hoh_personal_id,
+        head_of_household: @ctx.is_hoh,
+        hiv_aids_entry: disabilities_at_entry.detect(&:hiv?)&.DisabilityResponse,
+        hiv_aids_exit: disabilities_at_exit.detect(&:hiv?)&.DisabilityResponse,
+        hiv_aids_latest: disabilities_latest.detect(&:hiv?)&.DisabilityResponse,
+        hiv_aids: disabilities.detect(&:hiv?).present?,
+        household_id: @ctx.household_id,
+        household_members: @households[[@ctx.household_id, @ctx.data_source_id]] || [],
+        household_type: @ctx.household_type,
+        housing_assessment: @enrollment.exit&.HousingAssessment,
+        income_date_at_annual_assessment: income_at_annual_assessment&.InformationDate,
+        income_date_at_exit: income_at_exit&.InformationDate,
+        income_date_at_start: income_at_start&.InformationDate,
+
+        # Income from any source needs to be present in both a "cleaned" form and a "raw" form
+        # The cleaned form ensures alignment between IncomeFromAnySource and the calculated TotalMonthlyIncome
+        # as noted in the HMIS Glossary under the Determining Total and Earned Income section
+
+        # raw
+        income_from_any_source_at_annual_assessment_raw: income_at_annual_assessment&.IncomeFromAnySource,
+        income_from_any_source_at_exit_raw: income_at_exit&.IncomeFromAnySource,
+        income_from_any_source_at_start_raw: income_at_start&.IncomeFromAnySource,
+
+        # cleaned
+        income_from_any_source_at_annual_assessment: income_at_annual_assessment&.hud_income_from_any_source,
+        income_from_any_source_at_exit: income_at_exit&.hud_income_from_any_source,
+        income_from_any_source_at_start: income_at_start&.hud_income_from_any_source,
+        income_sources_at_annual_assessment: income_sources(income_at_annual_assessment),
+        income_sources_at_exit: income_sources(income_at_exit),
+        income_sources_at_start: income_sources(income_at_start),
+        income_total_at_annual_assessment: income_at_annual_assessment&.hud_total_monthly_income,
+        income_total_at_exit: income_at_exit&.hud_total_monthly_income,
+        income_total_at_start: income_at_start&.hud_total_monthly_income,
+        # NOTE: this is used for data quality, and should only look at the most recent disability
+        indefinite_and_impairs: disabilities_latest.detect(&:indefinite_and_impairs?),
+        insurance_from_any_source_at_annual_assessment: income_at_annual_assessment&.InsuranceFromAnySource,
+        insurance_from_any_source_at_exit: income_at_exit&.InsuranceFromAnySource,
+        insurance_from_any_source_at_start: income_at_start&.InsuranceFromAnySource,
+        last_date_in_program: @last_service_history_enrollment.last_date_in_program,
+        last_name: @source_client.LastName,
+        length_of_stay: stay_length(@last_service_history_enrollment),
+        bed_nights: bed_nights(@last_service_history_enrollment),
+        mental_health_problem_entry: disabilities_at_entry.detect(&:mental?)&.DisabilityResponse,
+        mental_health_problem_exit: disabilities_at_exit.detect(&:mental?)&.DisabilityResponse,
+        mental_health_problem_latest: disabilities_latest.detect(&:mental?)&.DisabilityResponse,
+        mental_health_problem: disabilities.detect(&:mental?).present?,
+        months_homeless: @enrollment.MonthsHomelessPastThreeYears,
+        move_in_date: @last_service_history_enrollment.move_in_date,
+        hoh_move_in_date: @ctx.hoh_move_in_date,
+        adjusted_move_in_date: begin
+          calculated_move_in_date = @ctx.inherited_move_in_date
+          is_ph_or_pfs_project = @last_service_history_enrollment.ph? ||
+            (@last_service_history_enrollment.other? && @enrollment.project.pay_for_success?)
+          calculated_move_in_date || (is_ph_or_pfs_project ? nil : @last_service_history_enrollment.first_date_in_program)
+        end,
+        name_quality: @source_client.NameDataQuality,
+        non_cash_benefits_from_any_source_at_annual_assessment: income_at_annual_assessment&.BenefitsFromAnySource,
+        non_cash_benefits_from_any_source_at_exit: income_at_exit&.BenefitsFromAnySource,
+        non_cash_benefits_from_any_source_at_start: income_at_start&.BenefitsFromAnySource,
+        other_clients_over_25: @ctx.non_youth_household,
+        overlapping_enrollments: overlapping_enrollments(@raw_enrollments, @last_service_history_enrollment),
+        parenting_youth: @ctx.is_parenting_youth,
+        pit_enrollments: pit_enrollment_info(@raw_enrollments, @context_map),
+        physical_disability_entry: disabilities_at_entry.detect(&:physical?)&.DisabilityResponse,
+        physical_disability_exit: disabilities_at_exit.detect(&:physical?)&.DisabilityResponse,
+        physical_disability_latest: disabilities_latest.detect(&:physical?)&.DisabilityResponse,
+        physical_disability: disabilities.detect(&:physical?).present?,
+        prior_length_of_stay: @enrollment.LengthOfStay,
+        prior_living_situation: @enrollment.LivingSituation,
+        project_tracking_method: @last_service_history_enrollment.project_tracking_method,
+        project_type: @last_service_history_enrollment.project_type,
+        race_multi: @source_client.race_multi.sort.join(','),
+        # For data quality checks, we want all data instead of filtering out RaceNone responses when additional race data is included.
+        # HMIS Reporting Glossary Reference: Data Quality - Q2: include records with an 8 or 9 indicated even if there is also a value of 1, 2, 3, 4, 5, 6, or 7 in the same field
+        race_multi_include_race_none: @source_client.race_multi_include_race_none.sort,
+        relationship_to_hoh: @enrollment.RelationshipToHoH,
+        sexual_orientation: @enrollment.sexual_orientation,
+        ssn_quality: @source_client.SSNDataQuality,
+        ssn: @source_client.SSN,
+        subsidy_information: @enrollment.exit&.SubsidyInformation,
+        substance_abuse_entry: disabilities_at_entry.detect(&:substance?)&.DisabilityResponse,
+        substance_abuse_exit: disabilities_at_exit.detect(&:substance?)&.DisabilityResponse,
+        substance_abuse_latest: disabilities_latest.detect(&:substance?)&.DisabilityResponse,
+        substance_abuse: disabilities.detect(&:substance?).present?,
+        time_to_move_in: time_to_move_in(@last_service_history_enrollment),
+        times_homeless: @enrollment.TimesHomelessPastThreeYears,
+        translation_needed: @enrollment.TranslationNeeded,
+        preferred_language: @enrollment.PreferredLanguage,
+        preferred_language_different: @enrollment.PreferredLanguageDifferent,
+        veteran_status: @source_client.VeteranStatus,
+        pay_for_success: @enrollment.project.pay_for_success?,
+      }
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    # Per CE APR spec, household composition is determined at the latest CE assessment date,
+    # not across the full report period. This overrides the standard household_members,
+    # household_type, other_clients_over_25, and parenting_youth set in map_standard_attributes.
+    #
+    # Age uses the standard HUD rule ([project_start, report_start].max), so we keep the
+    # pre-computed age from context rather than recomputing at the assessment date.
+    def map_ce_attributes
+      ce_members = ce_scoped_household_members
+      member_hash = { age: @ctx.age, relationship_to_hoh: @ctx.relationship_to_hoh }
+
+      {
+        household_members: ce_members,
+        household_type: HudReports::HouseholdLogic.calculate_household_type(ce_members.map { |m| m[:age] }),
+        other_clients_over_25: !HudReports::HouseholdLogic.only_youth?(ce_members),
+        parenting_youth: HudReports::HouseholdLogic.calculate_is_parenting_youth(member_hash, ce_members),
+        ce_assessment_date: @ce_latest_assessment&.AssessmentDate,
+        ce_assessment_type: @ce_latest_assessment&.AssessmentType, # for Q9a
+        ce_assessment_prioritization_status: @ce_latest_assessment&.PrioritizationStatus, # for Q9b, Q9d
+        ce_event_date: @ce_latest_event&.EventDate,
+        ce_event_event: @ce_latest_event&.Event, # Q9c, Q9d
+        ce_event_problem_sol_div_rr_result: @ce_latest_event&.ProbSolDivRRResult,
+        ce_event_referral_case_manage_after: @ce_latest_event&.ReferralCaseManageAfter,
+        ce_event_referral_result: @ce_latest_event&.ReferralResult,
+      }
+    end
+
+    # Returns the subset of household members who were active on the CE assessment date.
+    # Members are those whose enrollment spans the assessment date:
+    #   entry_date <= assessment_date AND (exit_date.nil? OR exit_date >= assessment_date)
+    # Falls back to the full member list if no assessment date is available.
+    def ce_scoped_household_members
+      all_members = @households[[@ctx.household_id, @ctx.data_source_id]] || []
+      assessment_date = @ce_latest_assessment&.AssessmentDate
+      return all_members unless assessment_date
+
+      all_members.select do |m|
+        entry = m[:entry_date]
+        exit  = m[:exit_date]
+        entry.present? && entry <= assessment_date && (exit.nil? || exit >= assessment_date)
+      end
+    end
+
+    # Assessments are only collected (and reported on) for HoH
+    # Return the most_recent assessment completed for the latest enrollment
+    # where the assessment occurred within the report range
+    # NOTE: there _should_ always be one of these based on the enrollment_scope and client_scope
+    def latest_ce_assessment(she_enrollment, hoh_enrollment)
+      range = @report.start_date..@report.end_date
+      assessments = valid_ce_assessment(she_enrollment, range).presence || valid_ce_assessment(hoh_enrollment, range)
+      assessments.max_by(&:AssessmentDate)
+    end
+
+    def valid_ce_assessment(she, range)
+      she.enrollment.assessments.select do |a|
+        in_report_range = a.AssessmentDate.present? && a.AssessmentDate.between?(range.first, range.last)
+        in_ce_participation_range = a.enrollment.project.participating_in_ce_on?(a.AssessmentDate)
+        in_report_range && in_ce_participation_range
+      end
+    end
+
+    # Returns the appropriate CE Event for the client
+    # Search for [Coordinated Entry Event] (4.20) records assigned to the same head of household with a [date of event] (4.20.1) where all of the following are
+    # true:
+    # a. [Date of event] >= [date of assessment] from step 1
+    # b. [Date of event] <= ([report end date] + 90 days)
+    # c. [Date of event] < Any [dates of assessment] which are between [report end date] and ([report end date] + 90 days)
+    # Refer to the example below for clarification.
+    # 4. For each client, if any of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the
+    # client in the table above.
+    # 5. If, for a given client, none of the records found belong to the same [project id] as the CE assessment from step 1, use the latest of those to report the client in the table above.
+    # 6. The intention of the criteria is to locate the most recent logically relevant record pertaining to the CE assessment record reported in Q9a and Q9b by giving preference to data entered by the same project.
+    def latest_ce_event(latest_she_for_client, latest_enrollment_for_hoh, latest_ce_assessment)
+      # If the client doesn't have any CE events, use the HoH to look for events
+      client = if latest_she_for_client.client.source_events.present?
+        latest_she_for_client.client
+      else
+        latest_enrollment_for_hoh.client
+      end
+      return unless client.present?
+
+      # 1. Determine the [date of assessment] (4.19.1) from the latest [Coordinated Entry Assessment] (4.19) for each household in the report universe as described in the report universe instructions and the determining latest assessment instructions.
+      # already determined using `latest_ce_assessment`
+
+      max_assessment_date_post_report_end_date = client.source_assessments.map(&:AssessmentDate).select do |d|
+        d.present? && d.between?(@report.end_date, @report.end_date + 90.days)
+      end.max
+
+      # 2. For all source event for the client
+      potential_events = client.source_events.select do |event|
+        # because we are using a preload, we don't filter earlier events in the SQL, make sure they all occur
+        # on or after the report start
+        next false if event.EventDate <= @report.start_date
+        # Everyone _should_ have a CE Assessment, but occassionally we get someone who doesn't have one
+        next false if latest_ce_assessment.blank? || latest_ce_assessment.AssessmentDate.blank?
+
+        # 2.a [Date of event] >= [date of assessment] from step 1
+        after_assessment = event.EventDate >= latest_ce_assessment.AssessmentDate
+        # 2.b Date of event] <= ([report end date] + 90 days)
+        within_90_days_of_report_end = event.EventDate <= (@report.end_date + 90.days)
+        # 2.c [Date of event] < Any [dates of assessment] which are between [report end date] and ([report end date] + 90 days)
+        before_next_assessment = max_assessment_date_post_report_end_date.blank? || event.EventDate < max_assessment_date_post_report_end_date
+        project_ce_participating = event.enrollment.project.participating_in_ce_on?(event.EventDate)
+
+        after_assessment && within_90_days_of_report_end && before_next_assessment && project_ce_participating
+      end
+
+      # 3. For each client, if any of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the client in the table above.
+      events_from_project = potential_events.select do |event|
+        event.enrollment.project.id == latest_ce_assessment.enrollment.project.id
+      end
+      return events_from_project.max_by(&:EventDate) if events_from_project.present?
+
+      # 4. If, for a given client, none of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the client in the table above.
+      potential_events.max_by(&:EventDate)
+    end
+
+    def apr_client_dob_quality(source_client)
+      return source_client.DOBDataQuality if source_client.DOB.present? && source_client.DOBDataQuality.in?([1, 2])
+      return source_client.DOBDataQuality if source_client.DOB.blank? && source_client.DOBDataQuality.in?([8, 9, 99])
+
+      99
+    end
+
+    def pit_enrollment_info(enrollments, contexts_by_she_id)
+      pit_dates = [1, 4, 7, 10].map { |month| pit_date(month: month, before: @report.end_date) }
+      pit_dates.map do |pit_date|
+        enrollments_for_date = enrollments.select do |enrollment|
+          enrolled = if enrollment.project_type.in?([3, 13]) || enrollment.enrollment.project.pay_for_success?
+            move_in_date = contexts_by_she_id[enrollment.id]&.inherited_move_in_date
+            enrollment.first_date_in_program <= pit_date &&
+              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) &&
+              move_in_date.present? &&
+              move_in_date <= pit_date &&
+              move_in_date >= enrollment.first_date_in_program
+          elsif enrollment.project_type.in?([0, 1, 2, 8, 9, 10])
+            enrollment.first_date_in_program <= pit_date &&
+              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date)
+          else
+            enrollment.first_date_in_program <= pit_date &&
+              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program >= pit_date)
+          end
+          next false unless enrolled
+          next true if enrollment.project_type != 1 || enrollment.project_tracking_method != 3
+
+          enrollment.service_history_services.bed_night.on_date(pit_date).exists?
+        end.map do |enrollment|
+          {
+            first_date_in_program: enrollment.first_date_in_program,
+            last_date_in_program: enrollment.last_date_in_program,
+            project_type: enrollment.project_type,
+            project_tracking_method: enrollment.project_tracking_method,
+            move_in_date: contexts_by_she_id[enrollment.id]&.inherited_move_in_date,
+            relationship_to_hoh: enrollment.enrollment.relationship_to_hoh,
+          }
+        end
+        [pit_date, enrollments_for_date]
+      end.to_h.select { |_, v| v.present? }
+    end
+
+    def report_end_date
+      @report.end_date
+    end
+
+    # Override LengthOfStays implementation to use pre-computed context
+    def appropriate_move_in_date(_enrollment)
+      @ctx.inherited_move_in_date
+    end
+  end
+end

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/base.rb
@@ -65,374 +65,73 @@ module HudApr::Generators::Shared::Fy2026
       false
     end
 
-    private def add_apr_clients # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize
+    private def add_apr_clients(batch_size: 500) # rubocop:disable Metrics/AbcSize
       @generator.client_scope.find_in_batches(batch_size: batch_size) do |batch|
         enrollments_by_client_id = clients_with_enrollments(batch)
-        # Pre-calculate some values
-        household_types = {}
-        household_assessment_required = {}
-        times_to_move_in = {}
-        move_in_dates = {}
-        approximate_move_in_dates = {}
-        dates_to_street = {}
-        enrollments_by_client_id.each do |_, enrollments|
-          last_service_history_enrollment = enrollments.last
-          enrollment = last_service_history_enrollment.enrollment
-          source_client = enrollment.client
-          next unless source_client.present?
 
-          client_start_date = [@report.start_date, last_service_history_enrollment.first_date_in_program].max
-          age = source_client.age_on(client_start_date)
+        # Load pre-computed household context for this batch
+        enrollment_ids = enrollments_by_client_id.values.flatten.map(&:id)
+        contexts_by_she_id = HudReports::HouseholdContext.where(
+          report_instance_id: @report.id,
+          service_history_enrollment_id: enrollment_ids,
+        ).index_by(&:service_history_enrollment_id)
 
-          hh_id = get_hh_id(last_service_history_enrollment)
-          hoh_enrollment = hoh_enrollments[hh_id]
-          household_assessment_required[last_service_history_enrollment.client_id] = annual_assessment_expected?(hoh_enrollment: hoh_enrollment, enrollment: last_service_history_enrollment, report_end_date: @report.end_date)
-          end_date = if needs_ce_assessments?
-            # Only HoHs get CE assessments, so we prefer their entry date
-            hoh_enrollment&.first_date_in_program || last_service_history_enrollment.first_date_in_program
-          else
-            last_service_history_enrollment.first_date_in_program
+        # Load ALL members for households in this batch to build legacy JSON blobs
+        # Must isolate by data_source_id to prevent PII leakage across vendors
+        batch_hh_keys = contexts_by_she_id.values.map { |c| [c.household_id, c.data_source_id] }.uniq
+        batch_households = if batch_hh_keys.any?
+          conn = ActiveRecord::Base.connection
+          values = batch_hh_keys.map { |id, ds| "(#{conn.quote(id)}, #{conn.quote(ds)})" }.join(', ')
+          HudReports::HouseholdContext.where(
+            report_instance_id: @report.id,
+          ).where("(household_id, data_source_id) IN (#{values})").group_by { |c| [c.household_id, c.data_source_id] }.transform_values do |members|
+            members.map(&:to_legacy_member_hash)
           end
-          date = [
-            @report.start_date,
-            end_date,
-          ].max
-          household_types[hh_id] = household_makeup(hh_id, date)
-          times_to_move_in[last_service_history_enrollment.client_id] = time_to_move_in(last_service_history_enrollment)
-          move_in_dates[last_service_history_enrollment.client_id] = appropriate_move_in_date(last_service_history_enrollment)
-          approximate_move_in_dates[last_service_history_enrollment.client_id] = approximate_time_to_move_in(last_service_history_enrollment, age, hoh_enrollment)
-          dates_to_street[last_service_history_enrollment.client_id] = date_to_street(last_service_history_enrollment, age, hoh_enrollment)
+        else
+          {}
+        end
+
+        # Load HoH enrollments needed for various calculations
+        hoh_enrollments_by_id = if needs_ce_assessments?
+          hoh_she_ids = contexts_by_she_id.values.map(&:hoh_service_history_enrollment_id).compact.uniq
+          GrdaWarehouse::ServiceHistoryEnrollment.where(id: hoh_she_ids).
+            preload(enrollment: [:assessments, :disabilities, client: :source_events, project: :ce_participations]).
+            index_by(&:id)
+        else
+          {}
         end
 
         pending_associations = {}
         processed_source_clients = Set.new
-        # Re-shape client to APR Client shape
+
+        # 1. Build APR Client records
         batch.each do |client|
-          # Fetch enrollments for destination client
           enrollments = enrollments_by_client_id[client.id]
-          next unless enrollments.present?
+          next if enrollments.blank?
 
-          last_service_history_enrollment = enrollments.last
-          hh_id = get_hh_id(last_service_history_enrollment)
-          # Fetch the Head of Household's enrollment, but if we don't have a head, just use ours
-          hoh_enrollment = hoh_enrollments[hh_id] || last_service_history_enrollment
-          if needs_ce_assessments?
-            ce_latest_assessment = latest_ce_assessment(last_service_history_enrollment, hoh_enrollment)
-            ce_latest_event = latest_ce_event(last_service_history_enrollment, hoh_enrollment, ce_latest_assessment)
-            #
-            # Adjust last service history enrollment if falls outside assessment date
-            if ce_latest_assessment.present?
-              last_service_history_enrollment = enrollments.
-                select do |e|
-                  ce_latest_assessment.AssessmentDate.between?(
-                    e.first_date_in_program,
-                    e.last_date_in_program || @report.end_date,
-                  )
-                end.last
-            end
-          end
-          next if last_service_history_enrollment.nil?
+          result = AprClientBuilder.build(
+            report: @report,
+            client: client,
+            enrollments: enrollments,
+            context_map: contexts_by_she_id,
+            hoh_enrollment_map: hoh_enrollments_by_id,
+            needs_ce_assessments: needs_ce_assessments?,
+            households: batch_households,
+          )
 
-          enrollment = last_service_history_enrollment.enrollment
-          source_client = enrollment.client
-          next unless source_client
+          next unless result[:success]
 
-          # ensure enrollment is in the correct CoC (step 6 of report universe for the CE APR)
-          # If the enrolment is in a project that only operates in one CoC, use the project's CoC
-          # Use the HoH's CoC (as CoC is only collected for the HoH)
-          enrollment.enrollment_coc = if enrollment.project.project_cocs.one?
-            enrollment.project.project_cocs.first.coc_code
-          else
-            hoh_enrollment&.enrollment&.enrollment_coc
-          end
-
-          # Ignore any enrollment where the CoC is not in the chosen set
-          # Step 7. of the CE APR, but really all APR related should work this way.  Filter the assessments/events, keeping only those where the CoC code assigned in step 6 matches the CoC on which the report is being run.
-          next unless enrollment.enrollment_coc.in?(@report.coc_codes)
-
-          client_start_date = [@report.start_date, last_service_history_enrollment.first_date_in_program].max
-
-          exit_date = last_service_history_enrollment.last_date_in_program
-          exit_record = last_service_history_enrollment.enrollment if exit_date.present? && exit_date <= @report.end_date
-
-          income_at_start = enrollment.income_benefits_at_entry
-          income_at_annual_assessment = annual_assessment(enrollment, hoh_enrollment.first_date_in_program)
-          income_at_exit = exit_record&.income_benefits_at_exit
-
-          disabilities = enrollment.disabilities.select { |disability| [1, 2, 3].include?(disability.DisabilityResponse) }
-
-          disabilities_at_entry = enrollment.disabilities.select { |d| d.DataCollectionStage == 1 }
-          disabilities_at_exit = enrollment.disabilities.select { |d| d.DataCollectionStage == 3 }
-          max_disability_date = enrollment.disabilities.select { |d| d.InformationDate <= @report.end_date }.
-            map(&:InformationDate).max
-          disabilities_latest = enrollment.disabilities.select { |d| d.InformationDate == max_disability_date }
-
-          # Need to sort by information date, then DateUpdated to catch the most-recent
-          # added for the Datalab test kit
-          health_and_dv = enrollment.health_and_dvs.
-            select do |h|
-              h.InformationDate && h.InformationDate <= @report.end_date && !h.DomesticViolenceSurvivor.nil?
-            end.
-            max_by { |h| [h.InformationDate, h.DateUpdated] }
-
-          last_bed_night = enrollment.services.select do |service|
-            service.RecordType == 200 && service.DateProvided && service.DateProvided < @report.end_date
-          end&.max_by(&:DateProvided)
-
-          move_on_assistance = enrollment.services.select do |service|
-            service.RecordType == 300 && service.DateProvided && service.DateProvided < @report.end_date
-          end&.max_by(&:DateProvided)
-
-          youth_education_status_at_entry = enrollment.youth_education_statuses.filter do |status|
-            status.DataCollectionStage == 1 && status.InformationDate && status.InformationDate < @report.end_date
-          end&.max_by(&:InformationDate)
-
-          youth_education_status_at_exit = enrollment.youth_education_statuses.filter do |status|
-            status.DataCollectionStage == 3 && status.InformationDate && status.InformationDate < @report.end_date
-          end&.max_by(&:InformationDate)
-
-          if processed_source_clients.include?(source_client.id)
-            @notifier.ping "Duplicate source client: #{source_client.id} for destination client: #{client.id} in enrollment: #{enrollment.id}" if @send_notifications
+          # Defensive check: skip if a source client appears twice in this batch (prevents unique constraint failures).
+          if processed_source_clients.include?(result[:source_client_id])
+            @notifier.ping "Duplicate source client: #{result[:source_client_id]} for destination client: #{client.id} in enrollment: #{result[:enrollment_id]}" if @send_notifications
             next
           end
 
-          age = source_client.age_on(client_start_date)
-          household_type = household_types[hh_id]
-          # household_type = if age.blank? || age.negative?
-          #   :unknown
-          # else
-          #   household_types[hh_id]
-          # end
-          hoh_anniversary_date = anniversary_date(entry_date: hoh_enrollment.first_date_in_program, report_end_date: @report.end_date)
-          # Households with required assessments are calculated earlier for performance reasons.
-          # An APR is being submitted to verify assessment requirements for non-HoH adults entering the HH at a different date than the HoH.
-          # e.g. If an adult enters 1 day prior HoH assessment date, is their assessment required on the HoH date (1 day later) or on the following year (1 year + 1 day later)
-          #      If an adult enters 1 day after the HoH assessment date is their assessment due on the HoH date (1 year - 1 day later) or on the following year (2 years - 1 day)
-          annual_assessment_expected = if age.present? && age >= 18
-            household_assessment_required[last_service_history_enrollment.client_id] && last_service_history_enrollment.first_date_in_program < hoh_anniversary_date
-          else
-            household_assessment_required[last_service_history_enrollment.client_id]
-          end
-
-          household_calculation_date = if needs_ce_assessments?
-            ce_latest_assessment&.AssessmentDate || hoh_enrollment&.first_date_in_program
-          else
-            last_service_history_enrollment.first_date_in_program
-          end
-
-          chronic_source = household_chronic_status(hh_id, last_service_history_enrollment.client_id)
-          calculated_move_in_date = calculate_hh_move_in_date(hh_id, last_service_history_enrollment)
-          # For non-PH projects, populate adjusted_move_in_date with entry date
-          # For PH projects, keep nil if they haven't moved in
-          is_ph_or_pfs_project = last_service_history_enrollment.ph? ||
-            (last_service_history_enrollment.other? && last_service_history_enrollment.project.pay_for_success?)
-          adjusted_move_in_date = calculated_move_in_date || (is_ph_or_pfs_project ? nil : last_service_history_enrollment.first_date_in_program)
-          hoh_move_in_date = calculate_move_in_date(hh_id, hoh_enrollment)
-          processed_source_clients << source_client.id
-
-          destination = last_service_history_enrollment.destination
-          destination_subsidy_type = exit_record&.exit&.DestinationSubsidyType
-          # Filter out invalid destinations
-          # requires valid rental subsidy type, this is a fix for bad data that the TUP checks
-          destination = 99 if destination == 435 && ! destination_subsidy_type.in?(HudHelper.util('2026').rental_subsidy_types.keys)
-          destination = 99 unless HudHelper.util('2026').valid_destinations.key?(destination)
-
-          ce_hash = {}
-          options = {
-            client_id: source_client.id,
-            destination_client_id: last_service_history_enrollment.client_id,
-            data_source_id: source_client.data_source_id,
-            personal_id: source_client.PersonalID,
-            project_id: last_service_history_enrollment.project.id,
-            report_instance_id: @report.id,
-            source_enrollment_id: enrollment.id,
-
-            age: age,
-            alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
-            alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
-            alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
-            annual_assessment_expected: annual_assessment_expected,
-            # anniversary dates are always based on HoH enrollment
-            annual_assessment_in_window: annual_assessment_in_window?(hoh_enrollment, income_at_annual_assessment&.InformationDate),
-            approximate_time_to_move_in: approximate_move_in_dates[last_service_history_enrollment.client_id],
-            came_from_street_last_night: enrollment.PreviousStreetESSH,
-            chronic_disability_entry: disabilities_at_entry.detect(&:chronic?)&.DisabilityResponse,
-            chronic_disability_exit: disabilities_at_exit.detect(&:chronic?)&.DisabilityResponse,
-            chronic_disability_latest: disabilities_latest.detect(&:chronic?)&.DisabilityResponse,
-            chronic_disability: disabilities.detect(&:chronic?).present?,
-            chronically_homeless: chronic_source.try(:[], :chronic_status) || false,
-            chronically_homeless_detail: chronic_source.try(:[], :chronic_detail) || {},
-            currently_fleeing: health_and_dv&.CurrentlyFleeing,
-            date_homeless: enrollment.DateToStreetESSH,
-            date_of_engagement: last_service_history_enrollment.enrollment.DateOfEngagement,
-            date_of_last_bed_night: last_bed_night&.DateProvided,
-            move_on_assistance_provided: move_on_assistance&.TypeProvided,
-
-            current_school_attend_at_entry: youth_education_status_at_entry&.CurrentSchoolAttend,
-            most_recent_ed_status_at_entry: youth_education_status_at_entry&.MostRecentEdStatus,
-            current_ed_status_at_entry: youth_education_status_at_entry&.CurrentEdStatus,
-
-            current_school_attend_at_exit: youth_education_status_at_exit&.CurrentSchoolAttend,
-            most_recent_ed_status_at_exit: youth_education_status_at_exit&.MostRecentEdStatus,
-            current_ed_status_at_exit: youth_education_status_at_exit&.CurrentEdStatus,
-
-            los_under_threshold: enrollment.LOSUnderThreshold,
-            date_to_street: dates_to_street[last_service_history_enrollment.client_id],
-            destination: destination,
-            developmental_disability_entry: disabilities_at_entry.detect(&:developmental?)&.DisabilityResponse,
-            developmental_disability_exit: disabilities_at_exit.detect(&:developmental?)&.DisabilityResponse,
-            developmental_disability_latest: disabilities_latest.detect(&:developmental?)&.DisabilityResponse,
-            developmental_disability: disabilities.detect(&:developmental?).present?,
-            disabling_condition: enrollment.DisablingCondition,
-            dob_quality: apr_client_dob_quality(source_client),
-            dob: source_client.DOB,
-            client_created_at: source_client.DateCreated || source_client.DateUpdated || DateTime.current,
-            domestic_violence: health_and_dv&.DomesticViolenceSurvivor,
-            domestic_violence_occurred: health_and_dv&.WhenOccurred,
-            drug_abuse_entry: [2, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
-            drug_abuse_exit: [2, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
-            drug_abuse_latest: [2, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
-            enrollment_coc: enrollment.enrollment_coc,
-            enrollment_created: enrollment.DateCreated || enrollment.DateUpdated || DateTime.current,
-            exit_created: exit_record&.exit&.DateCreated,
-            exit_destination_subsidy_type: destination_subsidy_type,
-            first_date_in_program: last_service_history_enrollment.first_date_in_program,
-            first_name: source_client.FirstName,
-            sex: source_client.Sex || 99,
-            head_of_household_id: last_service_history_enrollment.head_of_household_id,
-            head_of_household: last_service_history_enrollment[:head_of_household],
-            hiv_aids_entry: disabilities_at_entry.detect(&:hiv?)&.DisabilityResponse,
-            hiv_aids_exit: disabilities_at_exit.detect(&:hiv?)&.DisabilityResponse,
-            hiv_aids_latest: disabilities_latest.detect(&:hiv?)&.DisabilityResponse,
-            hiv_aids: disabilities.detect(&:hiv?).present?,
-            household_id: get_hh_id(last_service_history_enrollment),
-            household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-            household_type: household_type,
-            housing_assessment: last_service_history_enrollment.enrollment.exit&.HousingAssessment,
-            income_date_at_annual_assessment: income_at_annual_assessment&.InformationDate,
-            income_date_at_exit: income_at_exit&.InformationDate,
-            income_date_at_start: income_at_start&.InformationDate,
-
-            # Income from any source needs to be present in both a "cleaned" form and a "raw" form
-            # The cleaned form ensures alignment between IncomeFromAnySource and the calculated TotalMonthlyIncome
-            # as noted in the HMIS Glossary under the Determining Total and Earned Income section
-
-            # raw
-            income_from_any_source_at_annual_assessment_raw: income_at_annual_assessment&.IncomeFromAnySource,
-            income_from_any_source_at_exit_raw: income_at_exit&.IncomeFromAnySource,
-            income_from_any_source_at_start_raw: income_at_start&.IncomeFromAnySource,
-
-            # cleaned
-            income_from_any_source_at_annual_assessment: income_at_annual_assessment&.hud_income_from_any_source,
-            income_from_any_source_at_exit: income_at_exit&.hud_income_from_any_source,
-            income_from_any_source_at_start: income_at_start&.hud_income_from_any_source,
-            income_sources_at_annual_assessment: income_sources(income_at_annual_assessment),
-            income_sources_at_exit: income_sources(income_at_exit),
-            income_sources_at_start: income_sources(income_at_start),
-            income_total_at_annual_assessment: income_at_annual_assessment&.hud_total_monthly_income,
-            income_total_at_exit: income_at_exit&.hud_total_monthly_income,
-            income_total_at_start: income_at_start&.hud_total_monthly_income,
-            # NOTE: this is used for data quality, and should only look at the most recent disability
-            indefinite_and_impairs: disabilities_latest.detect(&:indefinite_and_impairs?),
-            insurance_from_any_source_at_annual_assessment: income_at_annual_assessment&.InsuranceFromAnySource,
-            insurance_from_any_source_at_exit: income_at_exit&.InsuranceFromAnySource,
-            insurance_from_any_source_at_start: income_at_start&.InsuranceFromAnySource,
-            last_date_in_program: last_service_history_enrollment.last_date_in_program,
-            last_name: source_client.LastName,
-            bed_nights: bed_nights(last_service_history_enrollment),
-            length_of_stay: stay_length(last_service_history_enrollment),
-            mental_health_problem_entry: disabilities_at_entry.detect(&:mental?)&.DisabilityResponse,
-            mental_health_problem_exit: disabilities_at_exit.detect(&:mental?)&.DisabilityResponse,
-            mental_health_problem_latest: disabilities_latest.detect(&:mental?)&.DisabilityResponse,
-            mental_health_problem: disabilities.detect(&:mental?).present?,
-            months_homeless: enrollment.MonthsHomelessPastThreeYears,
-            move_in_date: last_service_history_enrollment.move_in_date,
-            hoh_move_in_date: hoh_move_in_date,
-            adjusted_move_in_date: adjusted_move_in_date,
-            name_quality: source_client.NameDataQuality,
-            non_cash_benefits_from_any_source_at_annual_assessment: income_at_annual_assessment&.BenefitsFromAnySource,
-            non_cash_benefits_from_any_source_at_exit: income_at_exit&.BenefitsFromAnySource,
-            non_cash_benefits_from_any_source_at_start: income_at_start&.BenefitsFromAnySource,
-            # SHE other_clients_over_25 is computed at entry date, and we need to consider the report start date
-            other_clients_over_25: ! only_youth?(
-              OpenStruct.new(
-                household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-                first_date_in_program: last_service_history_enrollment.first_date_in_program,
-              ),
-            ),
-            overlapping_enrollments: overlapping_enrollments(enrollments, last_service_history_enrollment),
-            # SHE parenting_youth is computed at entry date, and we need to consider the report start date
-            parenting_youth: youth_parent?(
-              OpenStruct.new(
-                head_of_household: last_service_history_enrollment[:head_of_household],
-                household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-                first_date_in_program: last_service_history_enrollment.first_date_in_program,
-                age: age,
-              ),
-            ),
-            pit_enrollments: pit_enrollment_info(enrollments),
-            physical_disability_entry: disabilities_at_entry.detect(&:physical?)&.DisabilityResponse,
-            physical_disability_exit: disabilities_at_exit.detect(&:physical?)&.DisabilityResponse,
-            physical_disability_latest: disabilities_latest.detect(&:physical?)&.DisabilityResponse,
-            physical_disability: disabilities.detect(&:physical?).present?,
-            prior_length_of_stay: enrollment.LengthOfStay,
-            prior_living_situation: enrollment.LivingSituation,
-            project_tracking_method: last_service_history_enrollment.project_tracking_method,
-            project_type: last_service_history_enrollment.project_type,
-            race_multi: source_client.race_multi.sort.join(','),
-            # For data quality checks, we want all data instead of filtering out RaceNone responses when additional race data is included.
-            # HMIS Reporting Glossary Reference: Data Quality - Q2: include records with an 8 or 9 indicated even if there is also a value of 1, 2, 3, 4, 5, 6, or 7 in the same field
-            race_multi_include_race_none: source_client.race_multi_include_race_none.sort,
-            relationship_to_hoh: enrollment.RelationshipToHoH,
-            sexual_orientation: enrollment.sexual_orientation,
-            ssn_quality: source_client.SSNDataQuality,
-            ssn: source_client.SSN,
-            subsidy_information: last_service_history_enrollment.enrollment.exit&.SubsidyInformation,
-            substance_abuse_entry: disabilities_at_entry.detect(&:substance?)&.DisabilityResponse,
-            substance_abuse_exit: disabilities_at_exit.detect(&:substance?)&.DisabilityResponse,
-            substance_abuse_latest: disabilities_latest.detect(&:substance?)&.DisabilityResponse,
-            substance_abuse: disabilities.detect(&:substance?).present?,
-            time_to_move_in: times_to_move_in[last_service_history_enrollment.client_id],
-            times_homeless: enrollment.TimesHomelessPastThreeYears,
-            translation_needed: enrollment.TranslationNeeded,
-            preferred_language: enrollment.PreferredLanguage,
-            preferred_language_different: enrollment.PreferredLanguageDifferent,
-            veteran_status: source_client.VeteranStatus,
-            pay_for_success: enrollment.project.pay_for_success?,
-          }
-          if needs_ce_assessments?
-            ce_hash = {
-              household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-              other_clients_over_25: ! only_youth?(
-                OpenStruct.new(
-                  household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-                  first_date_in_program: last_service_history_enrollment.first_date_in_program,
-                ),
-              ),
-              parenting_youth: youth_parent?(
-                OpenStruct.new(
-                  head_of_household: last_service_history_enrollment[:head_of_household],
-                  household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
-                  first_date_in_program: last_service_history_enrollment.first_date_in_program,
-                  age: age,
-                ),
-              ),
-              ce_assessment_date: ce_latest_assessment&.AssessmentDate,
-              ce_assessment_type: ce_latest_assessment&.AssessmentType, # for Q9a
-              ce_assessment_prioritization_status: ce_latest_assessment&.PrioritizationStatus, # for Q9b, Q9d
-              ce_event_date: ce_latest_event&.EventDate,
-              ce_event_event: ce_latest_event&.Event, # Q9c, Q9d
-              ce_event_problem_sol_div_rr_result: ce_latest_event&.ProbSolDivRRResult,
-              ce_event_referral_case_manage_after: ce_latest_event&.ReferralCaseManageAfter,
-              ce_event_referral_result: ce_latest_event&.ReferralResult,
-            }
-
-          end
-
-          pending_associations[client] = report_client_universe.new(options.merge(ce_hash))
+          processed_source_clients << result[:source_client_id]
+          pending_associations[client] = report_client_universe.new(result[:attributes])
         end
 
-        # Import APR clients
+        # 2. Persist APR Clients
         result = report_client_universe.import(
           pending_associations.values,
           on_duplicate_key_update: {
@@ -442,22 +141,23 @@ module HudApr::Generators::Shared::Fy2026
         )
         apr_clients = report_client_universe.where(id: result.ids)
 
-        # Attach APR Clients to relevant questions
+        # 3. Attach APR Clients to relevant questions
         @report.build_for_questions.each do |question_number|
           universe_cell = @report.universe(question_number)
           generator = @generator.class.questions[question_number]
           universe_cell.add_universe_members(generator.filter_universe_members(pending_associations))
         end
 
-        # Add any associated data that needs to be linked back to the apr clients
+        # 4. Add associated data (Living Situations, CE Assessments/Events)
         client_living_situations = []
         apr_clients.each do |apr_client|
           last_enrollment = enrollments_by_client_id[apr_client.destination_client_id].last.enrollment
           situations = last_enrollment.current_living_situations
           engagement_date = last_enrollment.DateOfEngagement
+
           # If we're looking at SO or ES and don't have a CLS on the engagement date,
           # add one of type "37" - "Worker unable to determine" because it doesn't count as missing.
-          if (last_enrollment.project.so? || last_enrollment.project.night_by_night?) && engagement_date.present? && ! situations.detect { |cls| cls.InformationDate == engagement_date }
+          if (last_enrollment.project.so? || last_enrollment.project.night_by_night?) && engagement_date.present? && !situations.detect { |cls| cls.InformationDate == engagement_date }
             client_living_situations << apr_client.hud_report_apr_living_situations.build(
               information_date: engagement_date,
               living_situation: 37,
@@ -515,17 +215,7 @@ module HudApr::Generators::Shared::Fy2026
           report_ce_event_universe.import(events)
         end
       end
-    end
-
-    private def apr_client_dob_quality(source_client)
-      # Full or partial
-      return source_client.DOBDataQuality if source_client.DOB.present? && source_client.DOBDataQuality.in?([1, 2])
-      # Doesn't know, prefers not to answer, or not collected
-      return source_client.DOBDataQuality if source_client.DOB.blank? && source_client.DOBDataQuality.in?([8, 9, 99])
-
-      # We're in a weird state
-      99
-    end
+    end # rubocop:enable Metrics/AbcSize
 
     private def apr_clients_populated?
       @report.report_cells.joins(universe_members: :apr_client).exists?
@@ -555,7 +245,7 @@ module HudApr::Generators::Shared::Fy2026
         GrdaWarehouse::ServiceHistoryService.bed_night.
           service_excluding_extrapolated.
           service_within_date_range(start_date: @report.start_date, end_date: @report.end_date).
-          where(service_history_enrollment_id: enrollment_scope_without_preloads.select(:id)).
+          where(service_history_enrollment_id: enrollment_scope_without_preloads.select(GrdaWarehouse::ServiceHistoryEnrollment.arel_table[:id])).
           pluck(:service_history_enrollment_id) +
         # plus anyone with an exit within the range
         enrollment_scope_without_preloads.exit_within_date_range(start_date: @report.start_date, end_date: @report.end_date).pluck(:id)).to_set
@@ -625,43 +315,6 @@ module HudApr::Generators::Shared::Fy2026
         )
       scope = scope.in_project(@report.project_ids) if @report.project_ids.present? # for consistency with client_scope
       scope
-    end
-
-    private def pit_enrollment_info(enrollments)
-      pit_dates = [1, 4, 7, 10].map { |month| pit_date(month: month, before: @report.end_date) }
-      pit_dates.map do |pit_date|
-        enrollments_for_date = enrollments.select do |enrollment|
-          enrolled = if enrollment.project_type.in?([3, 13]) || enrollment.enrollment.project.pay_for_success?
-            # PSH/RRH OR project type 7 (other) with Funder 35 (Pay for Success)
-            move_in_date = calculate_hh_move_in_date(enrollment.household_id, enrollment)
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) && # Exclude exit date
-              move_in_date.present? && # Check that move in date is present and is before the PIT data and on or after the entry date
-              move_in_date <= pit_date &&
-              move_in_date >= enrollment.first_date_in_program
-          elsif enrollment.project_type.in?([0, 1, 2, 8, 9, 10]) # Other residential
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) # Exclude exit date
-          else # Other project types (4, 6, 7, 11, 12, 14)
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program >= pit_date) # Include the exit date
-          end
-          next false unless enrolled
-          next true if enrollment.project_type != 1 || enrollment.project_tracking_method != 3 # Not ES or ES and not NbN
-
-          enrollment.service_history_services.bed_night.on_date(pit_date).exists?
-        end.map do |enrollment|
-          {
-            first_date_in_program: enrollment.first_date_in_program,
-            last_date_in_program: enrollment.last_date_in_program,
-            project_type: enrollment.project_type,
-            project_tracking_method: enrollment.project_tracking_method,
-            move_in_date: calculate_hh_move_in_date(enrollment.household_id, enrollment),
-            relationship_to_hoh: enrollment.enrollment.relationship_to_hoh,
-          }
-        end
-        [pit_date, enrollments_for_date]
-      end.to_h.select { |_, v| v.present? }
     end
 
     delegate :client_scope, to: :@generator
@@ -735,24 +388,6 @@ module HudApr::Generators::Shared::Fy2026
       }
     end
 
-    # Assessments are only collected (and reported on) for HoH
-    # Return the most_recent assessment completed for the latest enrollment
-    # where the assessment occurred within the report range
-    # NOTE: there _should_ always be one of these based on the enrollment_scope and client_scope
-    private def latest_ce_assessment(she_enrollment, hoh_enrollment)
-      range = @report.start_date .. @report.end_date
-      assessments = valid_ce_assessment(she_enrollment, range).presence || valid_ce_assessment(hoh_enrollment, range)
-      assessments.max_by(&:AssessmentDate)
-    end
-
-    private def valid_ce_assessment(she, range)
-      she.enrollment.assessments.select do |a|
-        in_report_range = a.AssessmentDate.present? && a.AssessmentDate.between?(range.first, range.last)
-        in_ce_participation_range = a.enrollment.project.participating_in_ce_on?(a.AssessmentDate)
-        in_report_range && in_ce_participation_range
-      end
-    end
-
     # TODO: might want to implement something like this for latest_ce_event
     # private def valid_ce_event(she, range)
     #   she.client.source_events.select do |e|
@@ -766,61 +401,6 @@ module HudApr::Generators::Shared::Fy2026
       range = @report.start_date .. @report.end_date + 90.days
       assessments = valid_ce_assessment(she_enrollment, range)
       assessments.min_by(&:AssessmentDate)
-    end
-
-    # Returns the appropriate CE Event for the client
-    # Search for [Coordinated Entry Event] (4.20) records assigned to the same head of household with a [date of event] (4.20.1) where all of the following are
-    # true:
-    # a. [Date of event] >= [date of assessment] from step 1
-    # b. [Date of event] <= ([report end date] + 90 days)
-    # c. [Date of event] < Any [dates of assessment] which are between [report end date] and ([report end date] + 90 days)
-    # Refer to the example below for clarification.
-    # 4. For each client, if any of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the
-    # client in the table above.
-    # 5. If, for a given client, none of the records found belong to the same [project id] as the CE assessment from step 1, use the latest of those to report the client in the table above.
-    # 6. The intention of the criteria is to locate the most recent logically relevant record pertaining to the CE assessment record reported in Q9a and Q9b by giving preference to data entered by the same project.
-    private def latest_ce_event(latest_she_for_client, latest_enrollment_for_hoh, latest_ce_assessment)
-      # If the client doesn't have any CE events, use the HoH to look for events
-      client = if latest_she_for_client.client.source_events.present?
-        latest_she_for_client.client
-      else
-        latest_enrollment_for_hoh.client
-      end
-      return unless client.present?
-
-      # 1. Determine the [date of assessment] (4.19.1) from the latest [Coordinated Entry Assessment] (4.19) for each household in the report universe as described in the report universe instructions and the determining latest assessment instructions.
-      # already determined using `latest_ce_assessment`
-
-      max_assessment_date_post_report_end_date = client.source_assessments.map(&:AssessmentDate).select do |d|
-        d.present? && d.between?(@report.end_date, @report.end_date + 90.days)
-      end.max
-
-      # 2. For all source event for the client
-      potential_events = client.source_events.select do |event|
-        # because we are using a preload, we don't filter earlier events in the SQL, make sure they all occur
-        # on or after the report start
-        next false if event.EventDate <= @report.start_date
-        # Everyone _should_ have a CE Assessment, but occassionally we get someone who doesn't have one
-        next false if latest_ce_assessment.blank? || latest_ce_assessment.AssessmentDate.blank?
-
-        # 2.a [Date of event] >= [date of assessment] from step 1
-        after_assessment = event.EventDate >= latest_ce_assessment.AssessmentDate
-        # 2.b Date of event] <= ([report end date] + 90 days)
-        within_90_days_of_report_end = event.EventDate <= (@report.end_date + 90.days)
-        # 2.c [Date of event] < Any [dates of assessment] which are between [report end date] and ([report end date] + 90 days)
-        before_next_assessment = max_assessment_date_post_report_end_date.blank? || event.EventDate < max_assessment_date_post_report_end_date
-        project_ce_participating = event.enrollment.project.participating_in_ce_on?(event.EventDate)
-
-        after_assessment && within_90_days_of_report_end && before_next_assessment && project_ce_participating
-      end
-      # 3. For each client, if any of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the client in the table above.
-      events_from_project = potential_events.select do |event|
-        event.enrollment.project.id == latest_ce_assessment.enrollment.project.id
-      end
-      return events_from_project.max_by(&:EventDate) if events_from_project.present?
-
-      # 4. If, for a given client, none of the records found belong to the same [project id] (2.02.1) as the CE assessment from step 1, use the latest of those to report the client in the table above.
-      potential_events.max_by(&:EventDate)
     end
 
     private def apr_age_ranges

--- a/drivers/hud_apr/spec/models/fy2026/ce_apr/household_composition_spec.rb
+++ b/drivers/hud_apr/spec/models/fy2026/ce_apr/household_composition_spec.rb
@@ -1,0 +1,151 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Regression tests for CE APR assessment-date household composition.
+#
+# The CE APR spec requires household composition to be determined as of the latest
+# CE assessment date, not across the full report period. Specifically:
+#   - household_type, household_members, other_clients_over_25, and parenting_youth
+#     must reflect only those members whose enrollment spanned the assessment date.
+#   - Age is still calculated using the standard HUD rule (max of project start / report start).
+#
+# These tests guard against a regression in AprClientBuilder#map_ce_attributes where
+# those fields would otherwise be copied from the full-period HouseholdContext values.
+
+require 'rails_helper'
+require_relative './shared_context'
+
+RSpec.describe 'CE APR FY2026 assessment-date household composition', type: :model, exclude_fixpoints: true do
+  include_context 'HUD CE APR FY2026 setup'
+
+  let(:report_start)    { Date.new(2025, 10, 1) }
+  let(:assessment_date) { Date.new(2026, 3, 1) }
+
+  # A date before assessment_date that a household member can exit on, verifying
+  # that they are excluded from the assessment-date composition snapshot.
+  let(:pre_assessment_exit) { Date.new(2026, 1, 15) }
+
+  def create_ce_project
+    project = create_project(project_type: 14) # CE project type
+    create(
+      :hud_ce_participation,
+      ProjectID: project.project_id,
+      data_source: data_source,
+      CEParticipationStatusStartDate: report_start - 1.year,
+      CEParticipationStatusEndDate: nil,
+      AccessPoint: 1,
+    )
+    project
+  end
+
+  def add_assessment(enrollment:, date: assessment_date)
+    create(
+      :hud_assessment,
+      EnrollmentID: enrollment.EnrollmentID,
+      PersonalID: enrollment.PersonalID,
+      data_source: data_source,
+      AssessmentDate: date,
+      AssessmentType: 1,
+      AssessmentLevel: 1,
+      PrioritizationStatus: 1,
+    )
+  end
+
+  def apr_client_for(report, source_client)
+    HudApr::Fy2020::AprClient.find_by(
+      report_instance_id: report.id,
+      client_id: source_client.id,
+    )
+  end
+
+  let(:hoh_dob) { Date.new(2004, 1, 1) } # age ~21 at report start
+
+  def setup_household(secondary_client:, secondary_exit_date:)
+    @project      = create_ce_project
+    @household_id = Hmis::Hud::Base.generate_uuid
+
+    @youth_hoh = create_client_with_warehouse_link(dob: hoh_dob)
+    hoh_enrollment = create_enrollment(
+      client: @youth_hoh,
+      project: @project,
+      entry_date: Date.new(2025, 11, 1),
+      relationship_to_ho_h: 1,
+      household_id: @household_id,
+    )
+    add_assessment(enrollment: hoh_enrollment)
+
+    create_enrollment(
+      client: secondary_client,
+      project: @project,
+      entry_date: Date.new(2025, 11, 1),
+      exit_date: secondary_exit_date,
+      relationship_to_ho_h: yield,
+      household_id: @household_id,
+    )
+
+    @report = setup_ce_apr_report(@project.id)
+    run_ce_apr_report(@report)
+  end
+
+  # --------------------------------------------------------------------------
+  # household_type and parenting_youth
+  # A youth HoH with a child: child present vs. absent at assessment date.
+  # --------------------------------------------------------------------------
+  describe 'household_type and parenting_youth' do
+    let(:child) { create_client_with_warehouse_link(dob: Date.new(2020, 1, 1)) }
+
+    before { setup_household(secondary_client: child, secondary_exit_date: child_exit_date) { 2 } }
+
+    context 'when the child exits before the assessment date' do
+      let(:child_exit_date) { pre_assessment_exit }
+
+      it 'classifies household as adults_only and does not flag HoH as parenting_youth' do
+        client = apr_client_for(@report, @youth_hoh)
+        expect(client.household_type).to eq('adults_only')
+        expect(client.parenting_youth).to be false
+      end
+    end
+
+    context 'when the child is still present at the assessment date' do
+      let(:child_exit_date) { nil }
+
+      it 'classifies household as adults_and_children and flags HoH as parenting_youth' do
+        client = apr_client_for(@report, @youth_hoh)
+        expect(client.household_type).to eq('adults_and_children')
+        expect(client.parenting_youth).to be true
+      end
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # other_clients_over_25
+  # A youth HoH (18-24) sharing a household with an adult 25+:
+  # adult present vs. absent at assessment date.
+  # --------------------------------------------------------------------------
+  describe 'other_clients_over_25' do
+    let(:adult) { create_client_with_warehouse_link(dob: Date.new(1990, 1, 1)) }
+
+    before { setup_household(secondary_client: adult, secondary_exit_date: adult_exit_date) { 3 } }
+
+    context 'when the adult over 25 exits before the assessment date' do
+      let(:adult_exit_date) { pre_assessment_exit }
+
+      it 'does not set other_clients_over_25' do
+        expect(apr_client_for(@report, @youth_hoh).other_clients_over_25).to be false
+      end
+    end
+
+    context 'when the adult over 25 is present at the assessment date' do
+      let(:adult_exit_date) { nil }
+
+      it 'sets other_clients_over_25' do
+        expect(apr_client_for(@report, @youth_hoh).other_clients_over_25).to be true
+      end
+    end
+  end
+end

--- a/drivers/hud_apr/spec/models/fy2026/ce_apr/shared_context.rb
+++ b/drivers/hud_apr/spec/models/fy2026/ce_apr/shared_context.rb
@@ -9,14 +9,14 @@
 require 'rails_helper'
 require_relative '../../../../../../spec/shared_contexts/hud_enrollment_builders'
 
-RSpec.shared_context 'HUD DQ FY2026 setup', shared_context: :metadata do
+RSpec.shared_context 'HUD CE APR FY2026 setup', shared_context: :metadata do
   include_context 'HUD enrollment builders'
 
   let(:user) do
     User.setup_system_user
   end
 
-  let(:dq_filter) do
+  let(:ce_apr_filter) do
     Filters::HudFilterBase.new(
       user: user,
       start: Date.new(2025, 10, 1),
@@ -26,14 +26,14 @@ RSpec.shared_context 'HUD DQ FY2026 setup', shared_context: :metadata do
     )
   end
 
-  def setup_dq_report(project_ids, questions = ['Question 2'])
-    filter = dq_filter.dup
-    filter.require_service_during_range = false
-    filter.update(project_ids: project_ids)
+  def setup_ce_apr_report(project_ids)
+    questions = HudApr::Generators::CeApr::Fy2026::Generator.questions.keys
+    filter = ce_apr_filter.dup
+    filter.update(project_ids: Array(project_ids))
 
     report = HudReports::ReportInstance.from_filter(
       filter,
-      HudApr::Generators::Dq::Fy2026::Generator.title,
+      HudApr::Generators::CeApr::Fy2026::Generator.title,
       build_for_questions: questions,
     )
     report.question_names = questions
@@ -41,18 +41,15 @@ RSpec.shared_context 'HUD DQ FY2026 setup', shared_context: :metadata do
 
     GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
 
-    generator = HudApr::Generators::Dq::Fy2026::Generator.new(report)
-    generator.prepare_report
-
     report
   end
 
-  def run_dq_question(report, question_class)
-    report.started_at ||= Time.current
-    report.save! if report.changed?
-
-    generator = HudApr::Generators::Dq::Fy2026::Generator.new(report)
-    question_class.new(generator, report).run!
+  def run_ce_apr_report(report)
+    Reporting::Hud::RunReportJob.new.perform(
+      'HudApr::Generators::CeApr::Fy2026::Generator',
+      report.id,
+      email: false,
+    )
     report.reload
   end
 end

--- a/drivers/hud_apr/spec/models/fy2026/shared/apr_client_builder_spec.rb
+++ b/drivers/hud_apr/spec/models/fy2026/shared/apr_client_builder_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../../../../spec/shared_contexts/hud_enrollment_builders'
+
+RSpec.describe HudApr::Generators::Shared::Fy2026::AprClientBuilder, type: :model do
+  include_context 'HUD enrollment builders'
+
+  let(:report) do
+    create(
+      :hud_reports_report_instance,
+      start_date: '2024-01-01',
+      end_date: '2024-12-31',
+      coc_codes: ['MA-500'],
+    )
+  end
+
+  let!(:project) { create_project(project_type: 1, coc_code: 'MA-500') } # ES-NBN
+
+  # Creates a source client, HUD enrollment, and rebuilds service history.
+  # Returns [source_client, dest_client, hud_enrollment, she]
+  def setup_enrollment(proj, entry_date: '2024-01-15', exit_date: nil, destination: nil)
+    source_client = create_client_with_warehouse_link(dob: 35.years.ago)
+    hud_enrollment = create_enrollment(
+      client: source_client,
+      project: proj,
+      entry_date: entry_date,
+      exit_date: exit_date,
+      destination: destination,
+      relationship_to_ho_h: 1,
+    )
+    GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(hud_enrollment.id).rebuild_service_history!
+    she = GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: hud_enrollment.EnrollmentID)
+    [source_client, source_client.destination_client, hud_enrollment, she]
+  end
+
+  # Builds a HouseholdContext record for a given SHE with sensible defaults.
+  def build_context(she, source_client, dest_client, hud_enrollment, **opts)
+    create(
+      :hud_reports_household_context,
+      report_instance: report,
+      service_history_enrollment: she,
+      household_id: hud_enrollment.HouseholdID,
+      is_hoh: true,
+      hoh_personal_id: source_client.PersonalID,
+      hoh_service_history_enrollment_id: she.id,
+      hoh_entry_date: she.first_date_in_program,
+      age: 35,
+      relationship_to_hoh: 1,
+      household_type: 'adults_only',
+      inherited_chronic_status: false,
+      non_youth_household: true,
+      is_parenting_youth: false,
+      source_client_id: source_client.id,
+      destination_client_id: dest_client.id,
+      **opts,
+    )
+  end
+
+  def invoke(dest_client:, she:, ctx:, needs_ce_assessments: false)
+    households = { [ctx.household_id, ctx.data_source_id] => [ctx.to_legacy_member_hash] }
+    described_class.build(
+      report: report,
+      client: dest_client,
+      enrollments: [she],
+      context_map: { she.id => ctx },
+      hoh_enrollment_map: {},
+      needs_ce_assessments: needs_ce_assessments,
+      households: households,
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # resolve_and_build – early exit paths
+  # ---------------------------------------------------------------------------
+  describe '#resolve_and_build' do
+    it 'returns success: false when no enrollments are provided' do
+      result = described_class.build(
+        report: report,
+        client: double('client'),
+        enrollments: [],
+        context_map: {},
+        hoh_enrollment_map: {},
+        needs_ce_assessments: false,
+        households: {},
+      )
+      expect(result).to eq({ success: false })
+    end
+
+    it 'raises when no context exists for the enrollment (unexpected internal state)' do
+      _, dest_client, _, she = setup_enrollment(project)
+
+      expect do
+        described_class.build(
+          report: report,
+          client: dest_client,
+          enrollments: [she],
+          context_map: {},
+          hoh_enrollment_map: {},
+          needs_ce_assessments: false,
+          households: {},
+        )
+      end.to raise_error(ArgumentError, /Missing context/)
+    end
+
+    context 'when the enrollment CoC is not in the report CoC list' do
+      let!(:other_project) { create_project(project_type: 1, coc_code: 'XX-999') }
+
+      it 'returns success: false' do
+        source_client, dest_client, hud_enrollment, she = setup_enrollment(other_project)
+        ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+        result = described_class.build(
+          report: report,
+          client: dest_client,
+          enrollments: [she],
+          context_map: { she.id => ctx },
+          hoh_enrollment_map: {},
+          needs_ce_assessments: false,
+          households: {},
+        )
+        expect(result).to eq({ success: false })
+      end
+    end
+
+    context 'with a valid enrollment in the report CoC' do
+      it 'returns success: true with correct structural keys' do
+        source_client, dest_client, hud_enrollment, she = setup_enrollment(project)
+        ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+        result = invoke(dest_client: dest_client, she: she, ctx: ctx)
+
+        expect(result[:success]).to be true
+        expect(result[:source_client_id]).to eq(source_client.id)
+        expect(result[:enrollment_id]).to eq(hud_enrollment.id)
+      end
+
+      it 'returns attributes with correct enrollment CoC, age, and HoH flag' do
+        source_client, dest_client, hud_enrollment, she = setup_enrollment(project)
+        ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+        attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+
+        expect(attrs[:enrollment_coc]).to eq('MA-500')
+        expect(attrs[:age]).to eq(35)
+        expect(attrs[:head_of_household]).to be true
+        expect(attrs[:household_type]).to eq('adults_only')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # DOB quality mapping (apr_client_dob_quality)
+  # ---------------------------------------------------------------------------
+  describe 'dob_quality attribute' do
+    it 'returns DOBDataQuality when DOB is present with quality 1' do
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project)
+      # create_client_with_warehouse_link sets dob_data_quality: 1 automatically when DOB present
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:dob_quality]).to eq(1)
+    end
+
+    it 'returns DOBDataQuality when DOB is blank with quality 9 (DK/R)' do
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project)
+      source_client.update!(DOB: nil, DOBDataQuality: 9)
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:dob_quality]).to eq(9)
+    end
+
+    it 'returns 99 for an invalid DOB/quality combination (DOB blank, quality 1)' do
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project)
+      source_client.update!(DOB: nil, DOBDataQuality: 1)
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:dob_quality]).to eq(99)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Destination override logic
+  # ---------------------------------------------------------------------------
+  describe 'destination attribute' do
+    it 'overrides destination 435 to 99 when no DestinationSubsidyType is recorded' do
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project, exit_date: '2024-06-30', destination: 435)
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:destination]).to eq(99)
+    end
+
+    it 'overrides an unrecognized destination code to 99' do
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project, exit_date: '2024-06-30', destination: 999)
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:destination]).to eq(99)
+    end
+
+    it 'keeps a valid FY2026 destination code unchanged' do
+      # 410 = "Rental by client, no ongoing housing subsidy" — valid in 2026 spec
+      source_client, dest_client, hud_enrollment, she = setup_enrollment(project, exit_date: '2024-06-30', destination: 410)
+      ctx = build_context(she, source_client, dest_client, hud_enrollment)
+
+      attrs = invoke(dest_client: dest_client, she: she, ctx: ctx)[:attributes]
+      expect(attrs[:destination]).to eq(410)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
:warning: use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
**Rationale:**
This is the seond of three phased PRs refactoring the HUD reporting architecture. Building on Phase 1, this PR wires the new household context layer into the FY2026 APR-style reports. By pre-computing household logic during the `prepare_report` phase, we can completely remove expensive in-memory Ruby loops from the generator, significantly improving report generation performance.

**Phases**
For review, this work is split into three phases
* https://github.com/greenriver/hmis-warehouse/pull/6303
* https://github.com/greenriver/hmis-warehouse/pull/6304 (you are here)
* https://github.com/greenriver/hmis-warehouse/pull/6305

**Changes:**
* Extract complex client mapping logic from the Base generator into a dedicated `AprClientBuilder`.
* Update FY2026 APR, CAPER, CE APR, and DQ base generators to invoke `HouseholdContextBuilder` during the `prepare_report` lifecycle hook.
* Refactor `add_apr_clients` in the Base generator to consume pre-computed `HouseholdContext` values instead of calculating them inline.
* Update Data Quality specs and shared test contexts to execute the full report job, ensuring the new `prepare_report` context generation is exercised during tests.


## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


