### PR TITLE
Hotfix for PATH Report Failure

### DIFF
--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/base.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/base.rb
@@ -348,7 +348,7 @@ module HudPathReport::Generators::Fy2026
 
       contacts += enrollment.current_living_situations.between(start_date: min_date, end_date: max_date).pluck(:InformationDate)
       contacts += [enrollment.DateOfEngagement] if enrollment.DateOfEngagement.present? && enrollment.DateOfEngagement.between?(min_date, max_date) && ! contacts.include?(enrollment.DateOfEngagement)
-      contacts += [enrollment.DateOfPATHStatus] if enrollment.ClientEnrolledInPATH == 1 && enrollment.DateOfPATHStatus.between?(min_date, max_date) && ! contacts.include?(enrollment.DateOfPATHStatus)
+      contacts += [enrollment.DateOfPATHStatus] if enrollment.ClientEnrolledInPATH == 1 && enrollment.DateOfPATHStatus&.between?(min_date, max_date) && ! contacts.include?(enrollment.DateOfPATHStatus)
       contacts += enrollment.services.path_service.between(start_date: min_date, end_date: max_date).pluck(:DateProvided).uniq.reject { |d| d.in?(contacts) }
       contacts
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

PATH report was failing when running into bad data (i.e. `DateofPATHStatus` was not set but client has `ClientEnrolledInPATH` = 1). This should allow the report to complete while not include contacts for the missing `DateofPATHStatus` date.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
