### PR TITLE
HUD Report History Status & Stacktrace

### DIFF
--- a/app/models/hud_reports/report_instance.rb
+++ b/app/models/hud_reports/report_instance.rb
@@ -71,10 +71,14 @@ module HudReports
       )
     end
 
-    def current_status
+    def current_status(include_error_details: true)
       # Sometimes the report attempts to run again and ends up in the Started state, short circuit if we know this
       # isn't going to run successfully
-      return "Failed: #{error_details}" if error_details.present?
+      if error_details.present?
+        return "Failed: #{error_details}" if include_error_details
+
+        return 'Failed'
+      end
 
       case state
       when 'Waiting'
@@ -105,7 +109,7 @@ module HudReports
           state
         end
       when 'Failed'
-        if error_details.present?
+        if error_details.present? && include_error_details
           "#{state}: #{error_details}"
         else
           state

--- a/app/views/hud_reports/_reports.haml
+++ b/app/views/hud_reports/_reports.haml
@@ -20,7 +20,7 @@
               - if report.running?
                 = render 'hud_reports/spinner'
             %td
-              = link_to_if report.completed?, report.current_status, path_for_report(report)
+              = link_to_if report.completed?, report.current_status(include_error_details: false), path_for_report(report)
               .text-muted.description Run by: #{report.user.name}
             %td= render 'hud_reports/parameters', report: report
             %td


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Only display the state on the hud report history page when pulling the current status. Previously it was including the error details which exposed the stack trace on the history page.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
