### PR TITLE
Missing Partial Bug on User Invite

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,6 +13,7 @@ class Users::InvitationsController < Devise::InvitationsController
   # GET /resource/invitation/new
   def new
     @agencies = Agency.order(:name)
+    @system_alerts = GrdaWarehouse::AlertDefinition.system_alerts.active.order(:name)
     user_options = {}
     user_options[:permission_context] = 'acls' if User.anyone_using_acls?
     @user = User.new(user_options)
@@ -47,6 +48,7 @@ class Users::InvitationsController < Devise::InvitationsController
       redirect_to edit_admin_user_path(@user)
     else
       @agencies = Agency.order(:name)
+      @system_alerts = GrdaWarehouse::AlertDefinition.system_alerts.active.order(:name)
       render :new
     end
   end

--- a/app/views/admin/users/_form_fields.haml
+++ b/app/views/admin/users/_form_fields.haml
@@ -63,7 +63,7 @@
                 checked_value: alert.id,
                 unchecked_value: nil
     - unless @user.new_record?
-      = render 'contact_relationships'
+      = render 'admin/users/contact_relationships'
     .form--expiration
       %h3 Account Life-cycle
       .well

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -66,5 +66,22 @@ RSpec.describe Users::InvitationsController, type: :controller do
         expect(assigns(:user).errors).not_to be_empty
       end
     end
+
+    context 'with duplicate email (existing active user)' do
+      let!(:existing_user) { create(:user, email: 'existing@example.com', agency: agency) }
+      let(:duplicate_email_params) do
+        valid_params.deep_merge(user: { email: existing_user.email })
+      end
+
+      it 're-renders new template without raising (partial lookup and @system_alerts)' do
+        expect do
+          post :create, params: duplicate_email_params, format: :html
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:new)
+        expect(assigns(:user).errors).not_to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The user invite was hitting an exception due to a missing partial when rerendering due to a form error. This updates the partial call to be more sepcific, and also updates the intivations controller to build the @system_alerts variable used in the partial.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
