### PR TITLE
CVE-2026-32700 devise

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -6,3 +6,5 @@ ignore:
   - CVE-2024-8796
   # CVE-2022-31160: XSS vulnerability in jquery-ui checkboxes - not applicable since we don't use jquery-ui checkbox components
   - CVE-2022-31160
+  - CVE-2026-32700
+  - GHSA-57hq-95w6-v4fc

--- a/.trivyignore
+++ b/.trivyignore
@@ -27,3 +27,6 @@ CVE-2025-61724
 CVE-2025-61723
 CVE-2025-58189
 CVE-2025-61729
+
+# devise, we monkey patched the user model; avoids major version upgrade as we will replace devise with SSO in the near future
+CVE-2026-32700

--- a/app/models/concerns/devise_user_patch.rb
+++ b/app/models/concerns/devise_user_patch.rb
@@ -1,0 +1,20 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module DeviseUserPatch
+  extend ActiveSupport::Concern
+  included do
+    TodoOrDie('Remove devise patch for CVE-2026-32700', if: !defined?(Devise))
+  end
+
+  # patch CVE-2026-32700, avoids upgrading from 4 to 5. Remove this after we migrate to SSO
+  protected def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
+    unconfirmed_email_will_change!
+    super
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   include Memery
   include UserConcern
   include RailsDrivers::Extensions
+  include DeviseUserPatch
 
   validates :talent_lms_email, format: { with: URI::MailTo::EMAIL_REGEXP }, unless: -> { talent_lms_email.blank? }
 

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -20,6 +20,8 @@ class Hmis::User < ApplicationRecord
 
   include UserConcern
   include HasRecentItems
+  include DeviseUserPatch
+
   self.table_name = :users
 
   has_many :user_group_members, dependent: :destroy, inverse_of: :user

--- a/drivers/hmis/spec/models/hmis/user_spec.rb
+++ b/drivers/hmis/spec/models/hmis/user_spec.rb
@@ -1,0 +1,130 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../requests/hmis/login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::User, type: :model do
+  include_context 'hmis base setup'
+
+  let(:hmis_user) { create(:hmis_user) }
+
+  describe '#full_name' do
+    it 'joins first and last name' do
+      user = build(:hmis_user, first_name: 'Jane', last_name: 'Doe')
+      expect(user.full_name).to eq('Jane Doe')
+    end
+
+    it 'returns nil when both names are blank' do
+      user = build(:hmis_user, first_name: '', last_name: '')
+      expect(user.full_name).to be_nil
+    end
+  end
+
+  describe '#update_unique_session_id!' do
+    it 'writes to hmis_unique_session_id' do
+      hmis_user.update_unique_session_id!('hmis-session-abc')
+      hmis_user.reload
+
+      expect(hmis_user.hmis_unique_session_id).to eq('hmis-session-abc')
+    end
+
+    it 'leaves the warehouse unique_session_id column untouched' do
+      # alias_attribute aliases unique_session_id -> hmis_unique_session_id on the model,
+      # so we query the raw column directly to verify isolation.
+      uid = hmis_user.id.to_i
+      raw_before = ApplicationRecord.connection.select_value(
+        ApplicationRecord.sanitize_sql_array(['SELECT unique_session_id FROM users WHERE id = ?', uid]),
+      )
+
+      hmis_user.update_unique_session_id!('hmis-session-abc')
+
+      raw_after = ApplicationRecord.connection.select_value(
+        ApplicationRecord.sanitize_sql_array(['SELECT unique_session_id FROM users WHERE id = ?', uid]),
+      )
+
+      expect(raw_after).to eq(raw_before)
+    end
+
+    it 'raises NotPersistedError when called on an unsaved record' do
+      new_user = build(:hmis_user)
+      expect { new_user.update_unique_session_id!('x') }.to raise_error(Devise::Models::Compatibility::NotPersistedError)
+    end
+  end
+
+  describe '.with_hmis_access' do
+    let!(:user_in_group) { create(:hmis_user) }
+    let!(:user_not_in_group) { create(:hmis_user) }
+
+    before do
+      group = create(:hmis_user_group)
+      group.add(user_in_group)
+    end
+
+    it 'includes users with at least one HMIS user group' do
+      expect(Hmis::User.with_hmis_access).to include(user_in_group)
+    end
+
+    it 'excludes users with no HMIS user group membership' do
+      expect(Hmis::User.with_hmis_access).not_to include(user_not_in_group)
+    end
+  end
+
+  describe 'permission methods' do
+    let!(:user_with_role) { create(:hmis_user, data_source: ds1) }
+    let!(:user_without_role) { create(:hmis_user, data_source: ds1) }
+
+    before do
+      create_access_control(user_with_role, ds1, with_permission: :can_view_project)
+    end
+
+    it 'returns true for a permission granted via a role' do
+      expect(user_with_role.can_view_project?).to be true
+    end
+
+    it 'returns falsey when the user has no roles granting the permission' do
+      expect(user_without_role.can_view_project?).to be_falsey
+    end
+
+    it 'supports multi-permission check with mode: :all' do
+      expect(user_with_role.permissions?(:can_view_project, :can_edit_enrollments, mode: :all)).to be false
+      expect(user_with_role.permissions?(:can_view_project, mode: :all)).to be true
+    end
+  end
+
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+    it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
+      attacker_email = 'attacker@example.com'
+      victim_email   = 'victim@example.com'
+
+      user = create(:hmis_user)
+      # HMIS skips confirmation routes, so stub the notification to avoid routing errors
+      allow(user).to receive(:send_devise_notification)
+
+      # First email change — clears dirty tracking; in-memory clean value is now attacker_email
+      user.update!(email: attacker_email)
+
+      # Simulate a concurrent request stomping unconfirmed_email in the DB
+      # while the attacker's AR instance is still in memory
+      Hmis::User.where(id: user.id).update_all(
+        unconfirmed_email: victim_email,
+        confirmation_token: 'injected_token',
+      )
+
+      # Second update with the same email — without the patch, AR considers
+      # unconfirmed_email unchanged (still attacker_email in memory) and
+      # omits it from the UPDATE, leaving victim_email in the DB
+      user.update!(email: attacker_email)
+
+      user.reload
+      expect(user.unconfirmed_email).to eq(attacker_email)
+      expect(user.confirmation_token).not_to eq('injected_token')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -187,4 +187,32 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+    it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
+      attacker_email = 'attacker@example.com'
+      victim_email   = 'victim@example.com'
+
+      user = create(:user)
+      # First email change — clears dirty tracking; in-memory clean value is now attacker_email
+      user.update!(email: attacker_email)
+
+      # Simulate a concurrent request that stomps unconfirmed_email in the DB
+      # while the attacker's AR instance is still in memory
+      User.where(id: user.id).update_all(
+        unconfirmed_email: victim_email,
+        confirmation_token: 'injected_token',
+      )
+
+      # Second update with the same email — without the patch, AR considers
+      # unconfirmed_email unchanged (still 'attacker_email' in memory) and
+      # omits it from the UPDATE, leaving 'victim_email' in the DB
+      user.update!(email: attacker_email)
+
+      user.reload
+      # The patch ensures unconfirmed_email is always written, correcting the DB
+      expect(user.unconfirmed_email).to eq(attacker_email)
+      expect(user.confirmation_token).not_to eq('injected_token')
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Mitigates a race condition in Devise's email confirmation flow (CVE-2026-32700) and adds testing for the HMIS user model.

- **Devise Security Patch**: Implemented a monkey-patch to force database updates of `unconfirmed_email`, preventing desynchronization during concurrent requests.
- **HMIS User Model**: Added tests.
- **Security Auditing**: Updated Bundler Audit and Trivy configurations to acknowledge the manual patch and suppress alerts.
- **Warehouse User Model**: Added regression testing for the Devise security fix.

### Type of Change
Bug fix | Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)


