### PR TITLE
get Trivy DB digest from GHCR

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -160,13 +160,10 @@ jobs:
 
       - name: Check trivy db sha
         id: trivy-db
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          endpoint='/orgs/aquasecurity/packages/container/trivy-db/versions'
-          headers='Accept: application/vnd.github+json'
-          jqFilter='.[] | select(.metadata.container.tags[] | contains("latest")) | .name | sub("sha256:";"")'
-          sha=$(gh api -H "${headers}" "${endpoint}" | jq --raw-output "${jqFilter}")
+          token=$(curl -s "https://ghcr.io/token?scope=repository:aquasecurity/trivy-db:pull" | jq -r '.token')
+          sha=$(curl -sI -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+            "https://ghcr.io/v2/aquasecurity/trivy-db/manifests/latest" | grep -i docker-content-digest | awk '{print $2}' | tr -d '\r' | sed 's/sha256://')
           echo "Trivy DB sha256:${sha}"
           echo "sha=${sha}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/service_images.yml
+++ b/.github/workflows/service_images.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Cache Docker layers
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

1. Trivy DB cache key (build images)
The “Check trivy db sha” step used gh api against the org Packages API, which returned HTTP 403 when the org restricts access by IP, and jq failed on the non-JSON error body. ([Slack thread](https://greenriver.slack.com/archives/C03GCTC2C/p1774274389025249))

2. Pinned docker/setup-buildx-action (service images)
Replaces docker/setup-buildx-action@master with the same full commit SHA used elsewhere (e.g. build_images.yml) so the workflow passes the allow list for pinned actions.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Dependency update

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
