### PR TITLE
Prevents invalid HDX data by skipping generation when multiple CoC co…

### DIFF
--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/hdx_upload.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/hdx_upload.rb
@@ -29,6 +29,9 @@ module HudSpmReport::Generators::Fy2026
     end
 
     def run_question!
+      # HDX 2.0 Upload CSV only supports single-CoC reports
+      return if @report.coc_codes.count > 1
+
       tables = [
         ['csv', :run_csv],
       ]

--- a/drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb
@@ -165,5 +165,21 @@ RSpec.describe HudSpmReport::Generators::Fy2026::HdxUpload, type: :model, exclud
         end
       end
     end
+
+    context 'when multiple CoCs are present in the report universe' do
+      before do
+        @multi_coc_report = setup_report(
+          [@es_project.id],
+          ['HDX Upload'],
+        )
+        @multi_coc_report.update!(coc_codes: ['MA-500', 'MA-501'])
+        run_measure(@multi_coc_report, HudSpmReport::Generators::Fy2026::HdxUpload)
+      end
+
+      it 'skips the HDX Upload question' do
+        # If skipped, the csv table will not be prepared and cells will not be populated
+        expect(@multi_coc_report.answer(question: 'csv', cell: 'A2').summary).to be_blank
+      end
+    end
   end
 end


### PR DESCRIPTION

## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Prevents invalid HDX 2.0 aggregate data submission by skipping the CSV generation when multiple CoC codes are selected.

- **HDX Upload (FY 2026)**: Added an early return in the question run logic to skip CSV generation if the report universe contains more than one CoC.
- Improved test coverage by adding a specific context verifying the skip behavior for multi-CoC reports.

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


