### PR TITLE
[#8969] Default to yes for RRH desired

### DIFF
--- a/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
+++ b/app/models/grda_warehouse/cas_project_client_calculator/boston.rb
@@ -114,7 +114,6 @@ module GrdaWarehouse::CasProjectClientCalculator
         hiv_positive: 'c_housing_HIV',
         income_maximization_assistance_requested: 'c_interest_income_max',
         sro_ok: 'c_singleadult_sro',
-        rrh_desired: 'c_interested_rrh',
         housing_barrier: 'c_pathways_barriers_yn',
       }.freeze
     end
@@ -170,6 +169,7 @@ module GrdaWarehouse::CasProjectClientCalculator
         :evicted,
         :days_homeless,
         :hmis_days_homeless_all_time,
+        :rrh_desired,
       ]
     end
     # memoize :pathways_questions
@@ -228,6 +228,17 @@ module GrdaWarehouse::CasProjectClientCalculator
 
       # Otherwise unknown
       nil
+    end
+
+    # Everyone should be offered all residential options, for interested in RRH, if we didn't ask the question (or don't have an answer)
+    # indicate the client is interested in RRH.
+    private def rrh_desired(client)
+      answer = most_recent_pathways_or_transfer(client)&.
+        question_matching_requirement('c_interested_rrh')&.AssessmentAnswer&.to_s
+
+      return true if answer.nil? || answer == '1'
+
+      false
     end
 
     private def service_need(client)

--- a/spec/models/grda_warehouse/cas_project_client_calculator/boston_unit_spec.rb
+++ b/spec/models/grda_warehouse/cas_project_client_calculator/boston_unit_spec.rb
@@ -6,6 +6,86 @@ RSpec.describe GrdaWarehouse::CasProjectClientCalculator::Boston, type: :model d
   let(:calculator) { described_class.new }
   let(:client) { create :grda_warehouse_hud_client }
 
+  describe '#rrh_desired' do
+    let(:mock_assessment) { double('GrdaWarehouse::Hud::Assessment') }
+
+    before do
+      allow(calculator).to receive(:most_recent_pathways_or_transfer).with(client).and_return(mock_assessment)
+    end
+
+    it 'returns true when the client answered yes to RRH interest' do
+      allow(mock_assessment).to receive(:question_matching_requirement).with('c_interested_rrh').and_return(
+        double('AssessmentQuestion', AssessmentAnswer: '1'),
+      )
+      expect(calculator.send(:rrh_desired, client)).to be(true)
+    end
+
+    it 'returns false when the client explicitly declined RRH interest' do
+      allow(mock_assessment).to receive(:question_matching_requirement).with('c_interested_rrh').and_return(
+        double('AssessmentQuestion', AssessmentAnswer: '0'),
+      )
+      expect(calculator.send(:rrh_desired, client)).to be(false)
+    end
+
+    it 'returns true when the RRH interest question was not on the assessment' do
+      allow(mock_assessment).to receive(:question_matching_requirement).with('c_interested_rrh').and_return(nil)
+      expect(calculator.send(:rrh_desired, client)).to be(true)
+    end
+
+    it 'returns true when the question exists but has no answer' do
+      allow(mock_assessment).to receive(:question_matching_requirement).with('c_interested_rrh').and_return(
+        double('AssessmentQuestion', AssessmentAnswer: nil),
+      )
+      expect(calculator.send(:rrh_desired, client)).to be(true)
+    end
+
+    it 'returns the computed value from value_for_cas_project_client when a pathways assessment is present' do
+      allow(mock_assessment).to receive(:question_matching_requirement).with('c_interested_rrh').and_return(
+        double('AssessmentQuestion', AssessmentAnswer: '1'),
+      )
+      expect(calculator.value_for_cas_project_client(client: client, column: :rrh_desired)).to be(true)
+    end
+  end
+
+  describe 'boolean_lookups and #for_boolean' do
+    let(:mock_assessment) { double('GrdaWarehouse::Hud::Assessment') }
+
+    before do
+      allow(calculator).to receive(:most_recent_pathways_or_transfer).with(client).and_return(mock_assessment)
+    end
+
+    it 'boolean_lookups includes at least one item' do
+      expect(calculator.send(:boolean_lookups).keys.count).to be > 0
+    end
+
+    it 'maps question_matching_requirement(key, "1") to CAS booleans for each boolean_lookups column' do
+      # Stub return is what Hud::Assessment#question_matching_requirement returns after comparing the stored answer to "1".
+      answer_outcomes = {
+        '1' => [true, true],
+        '0' => [false, false],
+        nil => [nil, false],
+        'foo' => [false, false],
+      }
+
+      aggregate_failures do
+        calculator.send(:boolean_lookups).each do |column, question_key|
+          answer_outcomes.each do |label, (stub_return, expected)|
+            allow(mock_assessment).to receive(:question_matching_requirement).with(question_key, '1').and_return(stub_return)
+            actual = calculator.value_for_cas_project_client(client: client, column: column)
+            expect(actual).to eq(expected), "column #{column} (#{question_key}): expected #{expected} for answer #{label.inspect} (stub #{stub_return.inspect})"
+          end
+        end
+      end
+    end
+
+    it 'returns false from #for_boolean for every boolean question when there is no pathways or transfer assessment' do
+      allow(calculator).to receive(:most_recent_pathways_or_transfer).with(client).and_return(nil)
+      calculator.send(:boolean_lookups).each_value do |question_key|
+        expect(calculator.send(:for_boolean, client, question_key)).to be(false)
+      end
+    end
+  end
+
   describe 'string mutation operations' do
     describe '#pathways_days_homeless method += operations' do
       before do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Moves RRH desired out of the default boolean lookups 
* Adjusts the default behavior of RRH Desired so if the question isn't asked or answered the result is `yes` or `true` (previously `no` or `false`) to align with the need to provide all opportunities to somenoe who hasn't explicitly opted out of an opportunity.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
