### PR TITLE
Fix ROI “All CoCs” matching for supplemental data authorization

### DIFF
--- a/app/models/grda_warehouse/auth_policies/source_client_policy.rb
+++ b/app/models/grda_warehouse/auth_policies/source_client_policy.rb
@@ -63,7 +63,7 @@ class GrdaWarehouse::AuthPolicies::SourceClientPolicy < GrdaWarehouse::AuthPolic
   # An ROI confers some level of visibility to the client under the following circumstances:
   # - the source client must be in a data source with `obeys_consent=true`
   # - the ROI has a valid status (not revoked). ROI fields are stored on the destination client record (for now)
-  # - if the ROI is restricted to certain COCs then the user's COCs must match
+  # - if the ROI is restricted to certain COCs then the user's COCs must match (ROI may include "All CoCs", which matches like legacy consent)
   # - the user has a role granting permission on source client project as follows:
   #   - if the user has `can_search_client_with_roi`, we grant `can_search_own_clients` and `can_search_all_clients`
   #   - if the user has `can_view_client_enrollments_with_roi`, we grant `can_view_clients`

--- a/app/models/grda_warehouse/client_roi_authorization.rb
+++ b/app/models/grda_warehouse/client_roi_authorization.rb
@@ -48,6 +48,10 @@ module GrdaWarehouse
       # if there are no codes, assume visibility not limited by COC
       return true if coc_codes.blank?
 
+      # Mirror valid_in_coc in drivers/client_access_control/extensions/grda_warehouse/hud/client_extension.rb:
+      # an ROI that includes "All CoCs" applies to all CoCs and must not require a literal code intersection
+      return true if coc_codes.include?('All CoCs')
+
       (any_coc_codes & coc_codes).present?
     end
 

--- a/spec/models/auth_policies/context_loaders/client_roi_loader_spec.rb
+++ b/spec/models/auth_policies/context_loaders/client_roi_loader_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe GrdaWarehouse::AuthPolicies::ContextLoaders::ClientRoiLoader, typ
       expect(loader.get(client.destination_id)).to be false
     end
 
+    it 'returns true when ROI is All CoCs and user has specific coc_codes' do
+      create(:client_roi_authorization, destination_client: client.destination, status: 'full', coc_codes: ['All CoCs'])
+      user.coc_codes = ['PA-501']
+
+      expect(loader.get(client.destination_id)).to be true
+    end
+
     it 'caches the result' do
       expect(GrdaWarehouse::ClientRoiAuthorization).to receive(:active).once.and_call_original
       loader.get(client.destination_id)

--- a/spec/models/grda_warehouse/client_roi_authorization_spec.rb
+++ b/spec/models/grda_warehouse/client_roi_authorization_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe GrdaWarehouse::ClientRoiAuthorization, type: :model do
         expect(authorization.matches_coc_codes?(['CODE3', 'CODE4'])).to be false
       end
     end
+
+    context 'when coc_codes include All CoCs' do
+      before { authorization.coc_codes = ['All CoCs'] }
+
+      it 'returns true when user coc codes are specific HUD codes (no literal overlap with All CoCs)' do
+        expect(authorization.matches_coc_codes?(['PA-501', 'PA-502'])).to be true
+      end
+
+      it 'returns true when user has no coc_codes' do
+        expect(authorization.matches_coc_codes?([])).to be true
+      end
+    end
   end
 
   describe 'when clients are merged' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

ClientRoiLoader authorizes supplemental data using ClientRoiAuthorization#matches_coc_codes?, which only checked the intersection of the user’s HUD CoC codes with the ROI’s stored codes. When the ROI stored the sentinel "All CoCs", it never overlapped real codes, so authorization failed and the supplemental data experience behaved as if there were no valid ROI.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
