### PR TITLE
8509 fix nbn household

### DIFF
--- a/app/models/hud_reports/household_context_builder.rb
+++ b/app/models/hud_reports/household_context_builder.rb
@@ -159,6 +159,27 @@ module HudReports
 
         service_history_enrollments.concat(query.to_a.select { |m| m.enrollment.present? })
       end
+
+      # For NBN projects, pre-compute which SHEs are "active" per Method 2:
+      # must have a bed-night service OR an exit within the report date range.
+      nbn_she_ids = service_history_enrollments.select(&:nbn?).map(&:id)
+      @active_nbn_she_ids_in_batch = if nbn_she_ids.any?
+        with_service = GrdaWarehouse::ServiceHistoryService.bed_night.
+          service_excluding_extrapolated.
+          service_within_date_range(start_date: @report.start_date, end_date: @report.end_date).
+          where(service_history_enrollment_id: nbn_she_ids).
+          pluck(:service_history_enrollment_id)
+
+        with_exit = GrdaWarehouse::ServiceHistoryEnrollment.entry.
+          where(id: nbn_she_ids).
+          exit_within_date_range(start_date: @report.start_date, end_date: @report.end_date).
+          pluck(:id)
+
+        (with_service + with_exit).to_set
+      else
+        Set.new
+      end
+
       service_history_enrollments
     end
 
@@ -167,9 +188,7 @@ module HudReports
 
       # For household composition and veteran stats, only consider SHEs active during the report period.
       # Historical SHEs (from lookback) are used for inheritance but should not affect the current report's household type.
-      active_hh_she_hashes = hh_member_hashes.select do |mh|
-        (mh[:exit_date].nil? || mh[:exit_date] >= @report.start_date) && mh[:entry_date] <= @report.end_date
-      end
+      active_hh_she_hashes = hh_member_hashes.select { |mh| mh[:is_active] }
 
       hoh_data = find_anchor_hoh(hh_member_hashes)
       hoh_adjusted_move_in_date = (household_logic.calculate_move_in_date(hoh_data, hoh_data, report_end_date: @report.end_date) if hoh_data)
@@ -224,6 +243,7 @@ module HudReports
           veteran_status: source_client&.VeteranStatus,
           enrollment_coc: enrollment&.EnrollmentCoC,
           date_to_street: enrollment&.DateToStreetESSH,
+          is_active: nbn_active?(m),
         }
       end
     end
@@ -237,9 +257,8 @@ module HudReports
       hh_member_hashes.
         select { |m| m[:relationship_to_hoh] == 1 }.
         min_by do |m|
-          active = (m[:exit_date].nil? || m[:exit_date] >= @report.start_date) && m[:entry_date] <= @report.end_date
           [
-            active ? 0 : 1, # active records first
+            m[:is_active] ? 0 : 1, # active records first
             -(m[:entry_date] || Date.new(0)).jd, # latest entry date first (negated)
             m[:move_in_date] ? 0 : 1,                 # records with move-in first
             m[:she_id] || 0,                          # lowest ID as tie-break
@@ -321,6 +340,17 @@ module HudReports
         inherited_date_to_street: inherited_date_to_street,
         hh_max_age: hh_stats[:hh_max_age],
       )
+    end
+
+    # Returns true if the enrollment should be counted as active for household composition.
+    # Non-NBN projects use Method 1 (date overlap only). NBN projects use Method 2:
+    # the member must also have a bed-night service or an exit within the report range.
+    def nbn_active?(she)
+      date_active = (she.last_date_in_program.nil? || she.last_date_in_program >= @report.start_date) &&
+                    she.first_date_in_program <= @report.end_date
+      return date_active unless she.nbn?
+
+      date_active && (@active_nbn_she_ids_in_batch || Set.new).include?(she.id)
     end
 
     def household_logic

--- a/spec/models/hud_reports/household_context_builder_spec.rb
+++ b/spec/models/hud_reports/household_context_builder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HudReports::HouseholdContextBuilder, type: :model do
 
   let!(:data_source) { create(:data_source_fixed_id) }
   let!(:organization) { create(:hud_organization, data_source: data_source) }
-  let!(:project) { create(:hud_project, data_source: data_source, organization: organization, ProjectType: 1) } # ES-NBN
+  let!(:project) { create(:hud_project, data_source: data_source, organization: organization, ProjectType: 0) } # ES-Entry/Exit
 
   # Clients: HoH (Adult) + Child
   let(:client_hoh) { create_client_with_warehouse_link(dob: 40.years.ago) }
@@ -625,6 +625,128 @@ RSpec.describe HudReports::HouseholdContextBuilder, type: :model do
           # each member falls back to their own raw chronic status.
           expect(ctx.inherited_chronic_status).to eq(ctx.member_chronic_status || false)
         end
+      end
+    end
+
+    context 'NBN activity filtering (Method 2)' do
+      # Use a separate ES-NBN project (ProjectType: 1) for these tests.
+      let!(:nbn_project) { create(:hud_project, data_source: data_source, organization: organization, ProjectType: 1) }
+
+      let(:nbn_adult) { create_client_with_warehouse_link(dob: 30.years.ago) }
+      let(:nbn_child) { create_client_with_warehouse_link(dob: 8.years.ago) }
+
+      let!(:nbn_enrollment_adult) do
+        create(:hud_enrollment,
+               PersonalID: nbn_adult.PersonalID,
+               ProjectID: nbn_project.ProjectID,
+               HouseholdID: 'HH-NBN',
+               RelationshipToHoH: 1,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      let!(:nbn_enrollment_child) do
+        create(:hud_enrollment,
+               PersonalID: nbn_child.PersonalID,
+               ProjectID: nbn_project.ProjectID,
+               HouseholdID: 'HH-NBN',
+               RelationshipToHoH: 2,
+               EntryDate: '2020-01-01',
+               data_source_id: data_source.id)
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.where(
+          id: [nbn_enrollment_adult.id, nbn_enrollment_child.id],
+        ).each(&:rebuild_service_history!)
+      end
+
+      let(:nbn_she_adult) { GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: nbn_enrollment_adult.EnrollmentID) }
+      let(:nbn_she_child) { GrdaWarehouse::ServiceHistoryEnrollment.find_by(enrollment_group_id: nbn_enrollment_child.EnrollmentID) }
+
+      let(:nbn_generator) do
+        instance_double(
+          HudReports::GeneratorBase,
+          client_scope: GrdaWarehouse::Hud::Client.where(
+            id: [nbn_adult.destination_client.id, nbn_child.destination_client.id],
+          ),
+          report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry,
+          base_enrollment_scope: GrdaWarehouse::ServiceHistoryEnrollment.entry.
+            where(client_id: GrdaWarehouse::Hud::Client.where(
+              id: [nbn_adult.destination_client.id, nbn_child.destination_client.id],
+            )).
+            merge(GrdaWarehouse::ServiceHistoryEnrollment.entry.open_between(
+                    start_date: report.start_date,
+                    end_date: report.end_date,
+                  )),
+        )
+      end
+
+      def create_bed_night_for(she, date:)
+        GrdaWarehouse::ServiceHistoryService.create!(
+          service_history_enrollment_id: she.id,
+          client_id: she.client_id,
+          date: date,
+          record_type: 'service',
+          service_type: 200,
+          project_type: she.project_type,
+        )
+      end
+
+      it 'excludes an enrolled adult with no bed-night service from household composition' do
+        # Neither member has bed-night services or an exit, so both fail Method 2 → no active members → unknown.
+        described_class.new(nbn_generator, report, enrollment_scope: nbn_generator.base_enrollment_scope).call
+        contexts = HudReports::HouseholdContext.where(household_id: 'HH-NBN')
+        expect(contexts.pluck(:household_type).uniq).to eq(['unknown'])
+      end
+
+      it 'treats an adult who exited within the report range as active even without a bed-night service' do
+        # Exit during report range satisfies Method 2
+        create(:hud_exit,
+               data_source: data_source,
+               EnrollmentID: nbn_enrollment_adult.EnrollmentID,
+               PersonalID: nbn_enrollment_adult.PersonalID,
+               ExitDate: '2020-03-01')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(nbn_enrollment_adult.id).rebuild_service_history!
+        create_bed_night_for(nbn_she_child, date: '2020-06-15')
+
+        described_class.new(nbn_generator, report, enrollment_scope: nbn_generator.base_enrollment_scope).call
+        contexts = HudReports::HouseholdContext.where(household_id: 'HH-NBN')
+        expect(contexts.pluck(:household_type).uniq).to eq(['adults_and_children'])
+      end
+
+      it 'correctly identifies children_only when only child has a bed-night service' do
+        create_bed_night_for(nbn_she_child, date: '2020-06-15')
+        # Adult has no service → not active
+
+        described_class.new(nbn_generator, report, enrollment_scope: nbn_generator.base_enrollment_scope).call
+        contexts = HudReports::HouseholdContext.where(household_id: 'HH-NBN')
+        expect(contexts.pluck(:household_type).uniq).to eq(['children_only'])
+      end
+
+      it 'does not count a bed-night outside the report date range as active' do
+        # Bed-night is before report start (2020-01-01) → still fails Method 2
+        create_bed_night_for(nbn_she_adult, date: '2019-12-31')
+        create_bed_night_for(nbn_she_child, date: '2019-12-31')
+
+        described_class.new(nbn_generator, report, enrollment_scope: nbn_generator.base_enrollment_scope).call
+        contexts = HudReports::HouseholdContext.where(household_id: 'HH-NBN')
+        expect(contexts.pluck(:household_type).uniq).to eq(['unknown'])
+      end
+
+      it 'does not count an exit outside the report date range as active' do
+        # Exit before report start does not satisfy Method 2
+        create(:hud_exit,
+               data_source: data_source,
+               EnrollmentID: nbn_enrollment_adult.EnrollmentID,
+               PersonalID: nbn_enrollment_adult.PersonalID,
+               ExitDate: '2019-12-15')
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find(nbn_enrollment_adult.id).rebuild_service_history!
+        create_bed_night_for(nbn_she_child, date: '2020-06-15')
+
+        described_class.new(nbn_generator, report, enrollment_scope: nbn_generator.base_enrollment_scope).call
+        contexts = HudReports::HouseholdContext.where(household_id: 'HH-NBN')
+        expect(contexts.pluck(:household_type).uniq).to eq(['children_only'])
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Align with HUD Active Client Method 2, fixes misclassified household types for Night-by-Night shelters .

Previously, any enrolled household member counted toward composition regardless of whether they ever received a bed night. For example, this caused households to appear as "Adults and Children" when only children were actively sheltered.

- **Household Composition (NBN)**: Members without a bed-night service or exit in the report period are now excluded from household type and parenting youth calculations, matching Method 2 behavior.
- **Household Composition (non-NBN)**: No behavior change; date-overlap logic is preserved.
- **HoH lookup / chronic inheritance**: Unchanged — enrolled-but-inactive members are still visible for relationship validation and chronic status inheritance.

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
