### PR TITLE
Don't return form if user is not super-admin

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -459,7 +459,10 @@ module Types
     def form_identifier(identifier:)
       access_denied! unless current_user.can_configure_data_collection?
 
-      Hmis::Form::Definition.non_static.latest_versions.where(identifier: identifier).first
+      scope = Hmis::Form::Definition.non_static.latest_versions.where(identifier: identifier)
+      # Return nil (Not Found in the UI) if the user doesn't have can_administrate_config permission and is trying to access a non-admin form
+      scope = scope.with_role(Hmis::Form::Definition::NON_ADMIN_FORM_ROLES) unless current_user.can_administrate_config?
+      scope.first
     end
 
     field :form_identifiers, Types::Forms::FormIdentifier.page_type, null: false do

--- a/drivers/hmis/spec/requests/hmis/form_identifier_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_identifier_spec.rb
@@ -11,13 +11,6 @@ require_relative 'login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
 RSpec.describe Hmis::GraphqlController, type: :request do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   include_context 'hmis base setup'
 
   let!(:access_control) { create_access_control(hmis_user, ds1) }
@@ -31,7 +24,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     hmis_login(user)
   end
 
-  describe 'Form identifier query' do
+  describe 'Form identifiers query' do
     let(:query) do
       <<~GRAPHQL
         query GetFormIdentifiers(
@@ -89,6 +82,60 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(response.status).to eq(200), result.inspect
       identifiers = result.dig('data', 'formIdentifiers', 'nodes')
       expect(identifiers.count).to eq(1)
+    end
+  end
+
+  describe 'Form identifier query' do
+    let(:query) do
+      <<~GRAPHQL
+        query GetFormIdentifier($identifier: String!) {
+          formIdentifier(identifier: $identifier) {
+            id
+            identifier
+            publishedVersion {
+              id
+            }
+            draftVersion {
+              id
+            }
+            allVersions {
+              nodesCount
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it 'returns the form identifier for the given identifier (latest version per identifier, same shape as formIdentifiers)' do
+      response, result = post_graphql(identifier: 'identifier_1') { query }
+      expect(response.status).to eq(200), result.inspect
+      node = result.dig('data', 'formIdentifier')
+      expect(node).to be_present
+      expect(node['identifier']).to eq('identifier_1')
+      expect(node.dig('publishedVersion', 'id')).to eq(id1_published.id.to_s)
+      expect(node.dig('draftVersion', 'id')).to eq(id1_draft.id.to_s)
+      expect(node['allVersions']['nodesCount']).to eq(4)
+    end
+
+    it 'returns null when the identifier does not exist' do
+      response, result = post_graphql(identifier: 'no_such_identifier') { query }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'formIdentifier')).to be_nil
+    end
+
+    it 'returns null for admin-only form roles when user lacks can_administrate_config' do
+      create(
+        :hmis_form_definition,
+        identifier: 'external_form_identifier',
+        version: 1,
+        status: Hmis::Form::Definition::PUBLISHED,
+        title: 'External form',
+        role: 'EXTERNAL_FORM',
+      )
+      remove_permissions(access_control, :can_administrate_config)
+      response, result = post_graphql(identifier: 'external_form_identifier') { query }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'formIdentifier')).to be_nil
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Return nil if user who isn't a super-admin tries to fetch a non-admin form identifier.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
