### PR TITLE
Add new picklist for CE Access Point projects

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -7757,6 +7757,11 @@ enum PickListType {
   AVAILABLE_UNIT_TYPES
 
   """
+  Projects with an active CE Participation record with Access Point = Yes
+  """
+  CE_ACCESS_POINT_PROJECT_NAMES
+
+  """
   Grouped HUD CE Event types
   """
   CE_EVENTS

--- a/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
+++ b/drivers/hmis/app/graphql/types/forms/enums/pick_list_type.rb
@@ -57,6 +57,7 @@ module Types
     value 'ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS', 'Users who can be assigned to referral steps in the specified project'
     value 'AUDITABLE_USERS', 'Current and historical user accounts'
     value 'CONTINUUM_PROJECTS', 'Continuum Projects'
+    value 'CE_ACCESS_POINT_PROJECT_NAMES', 'Projects with an active CE Participation record with Access Point = Yes'
     value 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS', 'Templates for CE workflow definitions'
     value 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED', 'Templates for CE workflow definitions, including fully retired workflows'
     value 'CE_REFERRAL_STATUSES'

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -59,6 +59,8 @@ module Types
           preload(:organization).
           sort_by_option(:organization_and_name).
           map(&:to_pick_list_option)
+      when 'CE_ACCESS_POINT_PROJECT_NAMES'
+        ce_access_point_project_names_picklist(user)
       when 'ORGANIZATION'
         Hmis::Hud::Organization.viewable_by(user).sort_by_option(:name).map(&:to_pick_list_option)
       when 'AVAILABLE_SERVICE_TYPES'
@@ -666,6 +668,21 @@ module Types
       return [] unless project&.staff_assignments_enabled?
 
       Hmis::StaffAssignmentRelationship.all.map(&:to_pick_list_option)
+    end
+
+    def self.ce_access_point_project_names_picklist(user)
+      project_ids = Hmis::Hud::Project.viewable_by(user).
+        open_on_date. # Projects that are currently active
+        joins(:ce_participations).
+        # project has an active CE Participation record where Access Point = Yes
+        merge(Hmis::Hud::CeParticipation.active_on_date.access_point).
+        distinct.
+        pluck(Hmis::Hud::Project.arel_table[:id]) # Pluck project IDs to avoid complexity from the join
+
+      Hmis::Hud::Project.where(id: project_ids).
+        preload(:organization).
+        sort_by_option(:organization_and_name).
+        map(&:to_pick_list_option)
     end
 
     def self.projects_receiving_referrals(data_source_id)

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -683,7 +683,7 @@ module Types
         preload(:organization).
         sort_by_option(:organization_and_name).
         map do |project|
-          # Codes are "Project Name (ID)" so that stored values are human-readable.
+          # Codes are "Project Name (ID)" so that stored values are human-readable but still unique.
           # Use case: collecting CE Assessment Location
           project.to_pick_list_option.merge(code: "#{project.project_name} (#{project.id})")
         end

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -683,8 +683,9 @@ module Types
         preload(:organization).
         sort_by_option(:organization_and_name).
         map do |project|
-          # Codes are project names (not IDs) so that stored values are human-readable project name strings
-          project.to_pick_list_option.merge(code: project.project_name)
+          # Codes are "Project Name (ID)" so that stored values are human-readable.
+          # Use case: collecting CE Assessment Location
+          project.to_pick_list_option.merge(code: "#{project.project_name} (#{project.id})")
         end
     end
 

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -682,7 +682,10 @@ module Types
       Hmis::Hud::Project.where(id: project_ids).
         preload(:organization).
         sort_by_option(:organization_and_name).
-        map(&:to_pick_list_option)
+        map do |project|
+          # Codes are project names (not IDs) so that stored values are human-readable project name strings
+          project.to_pick_list_option.merge(code: project.project_name)
+        end
     end
 
     def self.projects_receiving_referrals(data_source_id)

--- a/drivers/hmis/app/models/hmis/hud/ce_participation.rb
+++ b/drivers/hmis/app/models/hmis/hud/ce_participation.rb
@@ -28,7 +28,7 @@ class Hmis::Hud::CeParticipation < Hmis::Hud::Base
 
   # "Project is a Coordinated Entry Access Point" = Yes (HUD)
   scope :access_point, -> do
-    where(arel_table[:AccessPoint].eq(1))
+    where(access_point: 1)
   end
 
   def ce_participation_services

--- a/drivers/hmis/app/models/hmis/hud/ce_participation.rb
+++ b/drivers/hmis/app/models/hmis/hud/ce_participation.rb
@@ -18,6 +18,19 @@ class Hmis::Hud::CeParticipation < Hmis::Hud::Base
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :user, **hmis_relation(:UserID, 'User'), inverse_of: :projects, optional: true
 
+  # CE Participation Status is active on the given date
+  scope :active_on_date, ->(date = Date.current) do
+    ce_t = arel_table
+    on_or_after_start = ce_t[:CEParticipationStatusStartDate].lteq(date)
+    on_or_before_end = ce_t[:CEParticipationStatusEndDate].eq(nil).or(ce_t[:CEParticipationStatusEndDate].gteq(date))
+    where(on_or_after_start.and(on_or_before_end))
+  end
+
+  # "Project is a Coordinated Entry Access Point" = Yes (HUD)
+  scope :access_point, -> do
+    where(arel_table[:AccessPoint].eq(1))
+  end
+
   def ce_participation_services
     HudHelper.util.ce_participation_services_fields.select { |k| send(k) == 1 }.values
   end

--- a/drivers/hmis/spec/models/hmis/hud/ce_participation_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/ce_participation_spec.rb
@@ -1,0 +1,70 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hmis::Hud::CeParticipation, type: :model do
+  let(:ref_date) { Date.new(2025, 6, 15) }
+
+  describe '.active_on_date' do
+    it 'includes records with no end date when the start is on or before the date' do
+      rec = create(
+        :hmis_hud_ce_participation,
+        CEParticipationStatusStartDate: Date.new(2020, 1, 1),
+        CEParticipationStatusEndDate: nil,
+      )
+      expect(described_class.active_on_date(ref_date)).to include(rec)
+    end
+
+    it 'includes records when the date falls between start and end (inclusive)' do
+      rec = create(
+        :hmis_hud_ce_participation,
+        CEParticipationStatusStartDate: Date.new(2025, 6, 1),
+        CEParticipationStatusEndDate: Date.new(2025, 6, 30),
+      )
+      expect(described_class.active_on_date(ref_date)).to include(rec)
+    end
+
+    it 'includes records when the date equals the end date' do
+      rec = create(
+        :hmis_hud_ce_participation,
+        CEParticipationStatusStartDate: Date.new(2025, 1, 1),
+        CEParticipationStatusEndDate: ref_date,
+      )
+      expect(described_class.active_on_date(ref_date)).to include(rec)
+    end
+
+    it 'excludes records when the status ended before the date' do
+      rec = create(
+        :hmis_hud_ce_participation,
+        CEParticipationStatusStartDate: Date.new(2020, 1, 1),
+        CEParticipationStatusEndDate: Date.new(2025, 6, 1),
+      )
+      expect(described_class.active_on_date(ref_date)).not_to include(rec)
+    end
+
+    it 'excludes records when the status has not started yet' do
+      rec = create(
+        :hmis_hud_ce_participation,
+        CEParticipationStatusStartDate: Date.new(2025, 7, 1),
+        CEParticipationStatusEndDate: nil,
+      )
+      expect(described_class.active_on_date(ref_date)).not_to include(rec)
+    end
+  end
+
+  describe '.access_point' do
+    it 'includes only AccessPoint = 1' do
+      yes = create(:hmis_hud_ce_participation, AccessPoint: 1)
+      no = create(:hmis_hud_ce_participation, AccessPoint: 0)
+
+      expect(described_class.access_point).to include(yes)
+      expect(described_class.access_point).not_to include(no)
+    end
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/pick_list_ce_access_point_project_names_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_ce_access_point_project_names_spec.rb
@@ -1,0 +1,123 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/graphql_helpers'
+
+RSpec.describe 'PickList CE_ACCESS_POINT_PROJECT_NAMES', type: :request do
+  include GraphqlHelpers
+  include LoginAndPermissionsSpecHelper
+
+  let!(:ds1) { create(:hmis_primary_data_source) }
+  let!(:user) { create(:user) }
+  let(:hmis_user) { user.related_hmis_user(ds1) }
+
+  let!(:o1) { create(:hmis_hud_organization, data_source: ds1) } # Visible to current user
+  let!(:o2) { create(:hmis_hud_organization, data_source: ds1) } # Not visible to current user
+  let!(:access_control) { create_access_control(hmis_user, o1) }
+
+  let(:today) { Date.current }
+
+  # Viewable (o1); open; CE access point Yes; CE status active — should appear in pick list
+  let!(:included_access_point_project) { create(:hmis_hud_project, project_name: 'Access Point Yes', organization: o1, data_source: ds1) }
+  # Viewable; CE participation exists but AccessPoint is not Yes
+  let!(:not_access_point_project) { create(:hmis_hud_project, project_name: 'Not Access Point', organization: o1, data_source: ds1) }
+  # Viewable; CE access point Yes but participation status ended before today
+  let!(:inactive_ce_status_project) { create(:hmis_hud_project, project_name: 'Inactive CE Status', organization: o1, data_source: ds1) }
+  # Viewable; CE access point Yes and active, but project operating period ended before today
+  let!(:inactive_project) { create(:hmis_hud_project, project_name: 'Inactive Project', organization: o1, data_source: ds1, operating_end_date: today - 2.weeks) }
+  # Same CE setup as included_access_point_project, but org is not in the user’s access
+  let!(:unauthorized_project) { create(:hmis_hud_project, project_name: 'Unauthorized Project', organization: o2, data_source: ds1) }
+
+  let!(:included_ce_participation) do
+    create(
+      :hmis_hud_ce_participation,
+      project: included_access_point_project,
+      data_source: ds1,
+      AccessPoint: 1,
+      CEParticipationStatusStartDate: today - 10.years,
+      CEParticipationStatusEndDate: nil,
+    )
+  end
+
+  let!(:not_access_point_ce_participation) do
+    create(
+      :hmis_hud_ce_participation,
+      project: not_access_point_project,
+      data_source: ds1,
+      AccessPoint: 0,
+      CEParticipationStatusStartDate: today - 10.years,
+      CEParticipationStatusEndDate: nil,
+    )
+  end
+
+  let!(:inactive_ce_status_participation) do
+    create(
+      :hmis_hud_ce_participation,
+      project: inactive_ce_status_project,
+      data_source: ds1,
+      AccessPoint: 1,
+      CEParticipationStatusStartDate: today - 10.years,
+      CEParticipationStatusEndDate: today - 2.weeks,
+    )
+  end
+
+  let!(:inactive_operating_ce_participation) do
+    create(
+      :hmis_hud_ce_participation,
+      project: inactive_project,
+      data_source: ds1,
+      AccessPoint: 1,
+      CEParticipationStatusStartDate: today - 10.years,
+      CEParticipationStatusEndDate: nil,
+    )
+  end
+
+  let!(:unauthorized_ce_participation) do
+    create(
+      :hmis_hud_ce_participation,
+      project: unauthorized_project,
+      data_source: ds1,
+      AccessPoint: 1,
+      CEParticipationStatusStartDate: today - 10.years,
+      CEParticipationStatusEndDate: nil,
+    )
+  end
+
+  let(:query) do
+    <<~GRAPHQL
+      query GetPickList($pickListType: PickListType!) {
+        pickList(pickListType: $pickListType) {
+          code
+          label
+        }
+      }
+    GRAPHQL
+  end
+
+  before do
+    hmis_login(user)
+  end
+
+  it 'returns only projects that are open, viewable, and have an active CE access-point participation' do
+    response, result = post_graphql(pick_list_type: 'CE_ACCESS_POINT_PROJECT_NAMES') { query }
+    expect(response.status).to eq(200)
+
+    # Picklist option codes are intentionally project names, NOT ids
+    codes = result.dig('data', 'pickList').map { |o| o['code'] }
+    expect(codes).to contain_exactly(included_access_point_project.project_name)
+    expect(codes).not_to include(not_access_point_project.project_name)
+    expect(codes).not_to include(inactive_ce_status_project.project_name)
+    expect(codes).not_to include(inactive_project.project_name)
+    expect(codes).not_to include(unauthorized_project.project_name)
+
+    # Expect the label to also show project name
+    expect(result.dig('data', 'pickList', 0, 'label')).to eq(included_access_point_project.project_name)
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/pick_list_ce_access_point_project_names_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_ce_access_point_project_names_spec.rb
@@ -109,15 +109,11 @@ RSpec.describe 'PickList CE_ACCESS_POINT_PROJECT_NAMES', type: :request do
     response, result = post_graphql(pick_list_type: 'CE_ACCESS_POINT_PROJECT_NAMES') { query }
     expect(response.status).to eq(200)
 
-    # Picklist option codes are intentionally project names, NOT ids
     codes = result.dig('data', 'pickList').map { |o| o['code'] }
-    expect(codes).to contain_exactly(included_access_point_project.project_name)
-    expect(codes).not_to include(not_access_point_project.project_name)
-    expect(codes).not_to include(inactive_ce_status_project.project_name)
-    expect(codes).not_to include(inactive_project.project_name)
-    expect(codes).not_to include(unauthorized_project.project_name)
+    # Picklist option codes are intentionally "Project Name (ID)", not just ID.
+    # contain_exactly ensures that the other cruft projects defined in fixtures are not included.
+    expect(codes).to contain_exactly("#{included_access_point_project.project_name} (#{included_access_point_project.id})")
 
-    # Expect the label to also show project name
     expect(result.dig('data', 'pickList', 0, 'label')).to eq(included_access_point_project.project_name)
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Add new picklist type CE_ACCESS_POINT_PROJECT_NAMES that returns project *names* (not ids) according to the logic outlined in the ticket
- To support the new picklist, add new scopes `active_on_date` and `access_point` on the `Hmis::Hud::CeParticipation` model

Frontend schema update: https://github.com/greenriver/hmis-frontend/pull/1418

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
