### PR TITLE
fix: race condition causing invalid SHEs

### DIFF
--- a/app/models/hud_reports/household_context.rb
+++ b/app/models/hud_reports/household_context.rb
@@ -35,10 +35,10 @@ module HudReports
     # Efficiently copies contexts from a source report for a specific set of enrollments
     # Used when sharing logic between reports (e.g. SPM -> DQ)
     # NOTE: this could be done more efficiently in SQL, room for future optimization
-    def self.copy_subset!(source_report_id:, target_report_id:, service_history_enrollment_ids:)
+    def self.copy_subset!(source_report_id:, target_report_id:, source_enrollment_ids:)
       source_contexts = where(
         report_instance_id: source_report_id,
-        service_history_enrollment_id: service_history_enrollment_ids,
+        source_enrollment_id: source_enrollment_ids,
       )
 
       source_contexts.find_in_batches(batch_size: 1000) do |batch|

--- a/app/models/hud_reports/household_context_builder.rb
+++ b/app/models/hud_reports/household_context_builder.rb
@@ -38,13 +38,13 @@ module HudReports
         raise ArgumentError, "Cannot share contexts: date ranges don't match"
       end
 
-      # Discover which SHE IDs this report needs
-      needed_she_ids = enrollment_scope.pluck(:id)
+      enrollment_id_col = GrdaWarehouse::Hud::Enrollment.arel_table[:id]
+      needed_source_enrollment_ids = enrollment_scope.joins(:enrollment).pluck(enrollment_id_col)
 
       HudReports::HouseholdContext.copy_subset!(
         source_report_id: @source_report_id,
         target_report_id: @report.id,
-        service_history_enrollment_ids: needed_she_ids,
+        source_enrollment_ids: needed_source_enrollment_ids,
       )
     end
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
@@ -141,27 +141,20 @@ module HudSpmReport::Fy2026
     def self.create_enrollment_set(report_instance)
       filter = ::Filters::HudFilterBase.new(user_id: report_instance.user.id).update(report_instance.options)
 
-      # Iterate over ServiceHistoryEnrollment records directly to avoid re-mapping
-      # for the HouseholdContext.
-      she_scope(report_instance).
-        preload(enrollment: [:client, :destination_client, :exit, :income_benefits_at_exit, :income_benefits_at_entry, :income_benefits, project: :funders]).
-        find_in_batches(batch_size: 500) do |batch|
+      # Iterate over HouseholdContext records
+      HudReports::HouseholdContext.where(report_instance_id: report_instance.id).find_in_batches(batch_size: 500) do |batch|
         report_instance.check_halt_status!
 
-        contexts_by_she_id = HudReports::HouseholdContext.
-          where(report_instance_id: report_instance.id, service_history_enrollment_id: batch.map(&:id)).
-          index_by(&:service_history_enrollment_id)
+        enrollments_by_id = GrdaWarehouse::Hud::Enrollment.
+          where(id: batch.map(&:source_enrollment_id)).
+          preload(:client, :destination_client, :exit, :income_benefits_at_exit, :income_benefits_at_entry, :income_benefits, project: :funders).
+          index_by(&:id)
 
         members = []
 
-        batch.each do |she|
-          enrollment = she.enrollment
+        batch.each do |context|
+          enrollment = enrollments_by_id[context.source_enrollment_id]
           next if enrollment&.client.blank?
-
-          context = contexts_by_she_id[she.id]
-
-          # Skip enrollments that appeared after HouseholdContext was built (e.g. during a long report run)
-          next unless context
 
           current_income_benefits = current_income_benefits(enrollment, filter.end)
           previous_income_benefits = previous_income_benefits(enrollment, current_income_benefits&.information_date, filter.end)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Fix a race condition where background SHE rebuilds during long report runs invalidate the SHE ID keys used to look up pre-computed household context, causing enrollments to be silently excluded from reports.

- **SPM Enrollment Set Creation**: Invert the outer iteration loop to drive off `HouseholdContext` records rather than SHEs, loading `GrdaWarehouse::Hud::Enrollment` records directly
- **Context Sharing (SPM→DQ)**: Apply the same fix to `HouseholdContext.copy_subset!` 

Note, this issue also exists in the APR, we are leaving that for now.

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

