### PR TITLE
Stop raising in multi-hmis qa on form publish

### DIFF
--- a/drivers/hmis/app/models/hmis/form/definition_validator.rb
+++ b/drivers/hmis/app/models/hmis/form/definition_validator.rb
@@ -22,7 +22,8 @@ class Hmis::Form::DefinitionValidator
     @data_source = if data_source_id
       GrdaWarehouse::DataSource.hmis.find(data_source_id)
     elsif !skip_cded_validation
-      GrdaWarehouse::DataSource.hmis.sole # 'sole' raises if there are >1 HMIS data sources
+      # TODO(#6691): use .sole instead of .first
+      GrdaWarehouse::DataSource.hmis.first
     end # we don't need a data source ID if we are skipping CDED validation
 
     # Validate JSON shape against JSON Schema

--- a/drivers/hmis/spec/models/hmis/form/definition_validator_spec.rb
+++ b/drivers/hmis/spec/models/hmis/form/definition_validator_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Hmis::Form::DefinitionValidator, type: :model do
     context 'with multi-HMIS' do
       let!(:data_source2) { create(:hmis_data_source) }
 
-      it 'fails if data_source_id is not provided' do
+      # TODO(#6691): reinstate this test (xit => it) once data_source_id is required
+      xit 'fails if data_source_id is not provided' do
         expect do
           Hmis::Form::DefinitionValidator.perform(definition)
         end.to raise_error(ActiveRecord::SoleRecordExceeded)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Followup to https://github.com/open-path/Green-River/issues/6690. Reverts the change made there to `DefinitionValidator` which causes multi-hmis envs to raise on form publication. I ran into this in QA, and decided to open a PR to address it, since it's quick to mitigate, and unlikely that #6691 will make it onto release-207.
- Prevents QA and other multi-hmis envs from raising on form publish, by selecting the first HMIS data source instead of expecting `sole`.
- Adds a TODO for #6691

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
QA bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
