### PR TITLE
set local and test lsa rds to not be publicly available

### DIFF
--- a/drivers/hud_lsa/README.md
+++ b/drivers/hud_lsa/README.md
@@ -51,6 +51,10 @@ The system supports two modes of operation:
    - Configured via `LSA_DB_HOST` environment variable
    - Database is dropped after report completion
 
+### Public accessibility
+
+Dynamic RDS instances are created with **`PubliclyAccessible` set to `false`** in `lib/rds_sql_server/rds.rb` (see `create_db_on_aws`). That should stay that way: the SQL Server must only be reachable from trusted network paths (for example the same VPC, VPN, or peering as the app workers), not from the public internet. For developers running the LSA locally, this should be accessible through Tailscale and assuming the correct role for AWS.
+
 ### S3 Integration
 
 For faster data imports, the system can use AWS RDS S3 integration:

--- a/lib/rds_sql_server/rds.rb
+++ b/lib/rds_sql_server/rds.rb
@@ -2,6 +2,7 @@
 
 # https://docs.aws.amazon.com/sdkforruby/api/index.html
 # https://docs.aws.amazon.com/sdkforruby/api/Aws/RDS.html
+# Hud LSA temporary RDS: drivers/hud_lsa/README.md
 
 # frozen_string_literal: true
 
@@ -186,8 +187,8 @@ class Rds
       auto_minor_version_upgrade: true,
       preferred_backup_window: '06:14-06:44',
       preferred_maintenance_window: 'fri:08:13-fri:08:43',
-      # RDS being publicly available allows us to reach the database when running locally. This should always be false in deployed environments.
-      publicly_accessible: Rails.env.development? || Rails.env.test?,
+      # This should always be false - see drivers/hud_lsa/README.md#public-accessibility
+      publicly_accessible: false,
       vpc_security_group_ids: SECURITY_GROUP_IDS,
       db_subnet_group_name: DB_SUBNET_GROUP,
       db_parameter_group_name: 'sqlserver-web-16-custom-parameter-group-lsa',


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

When running the LSA locally or in test environments, set the generated RDS to be `publicly_available=false` even thought there is no real data in the database, this helps with hardening the system.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [X] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
