### PR TITLE
Threshold Monitoring Gets Repeatable Read

### DIFF
--- a/app/jobs/collect_client_metrics_job.rb
+++ b/app/jobs/collect_client_metrics_job.rb
@@ -8,19 +8,41 @@
 
 class CollectClientMetricsJob < BaseJob
   queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
-  queue_with_priority 15
+  queue_with_priority MAINTENANCE_PRIORITY_15
 
-  def perform(calculation_date = Date.current)
-    lock_name = 'collect_client_metrics_job'
-    GrdaWarehouseBase.with_advisory_lock(lock_name, timeout_seconds: 0) do
-      GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector.run_daily_collection(
+  REQUEUE_WAIT_MINUTES = 5
+  RETRY_DEADLINE_HOUR = 10 # Don't retry after 10 AM — avoids infinite loops on persistent instability, gives it roughly 8 hours to stabilize
+
+  def perform(calculation_date = Date.current, metric_names: nil)
+    GrdaWarehouseBase.with_advisory_lock('collect_client_metrics_job', timeout_seconds: 0) do
+      skipped_metric_names = GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector.run_daily_collection(
         entity_type: 'GrdaWarehouse::Hud::Client',
         calculation_date: calculation_date,
+        metric_names: metric_names,
       )
+
+      schedule_retry(calculation_date, skipped_metric_names) if skipped_metric_names.any?
     end
   end
 
-  def priority
-    15
+  private
+
+  def schedule_retry(calculation_date, skipped_metric_names)
+    if Time.current.hour >= RETRY_DEADLINE_HOUR
+      Rails.logger.warn(
+        "#{self.class.name}: past retry deadline (#{RETRY_DEADLINE_HOUR}:00), " \
+        "giving up on #{skipped_metric_names.join(', ')} for #{calculation_date}",
+      )
+      return
+    end
+
+    Rails.logger.info(
+      "#{self.class.name}: requeueing #{skipped_metric_names.join(', ')} " \
+      "in #{REQUEUE_WAIT_MINUTES} minutes for #{calculation_date}",
+    )
+    self.class.set(wait: REQUEUE_WAIT_MINUTES.minutes).perform_later(
+      calculation_date,
+      metric_names: skipped_metric_names,
+    )
   end
 end

--- a/app/jobs/update_warehouse_clients_caches_job.rb
+++ b/app/jobs/update_warehouse_clients_caches_job.rb
@@ -9,11 +9,12 @@
 class UpdateWarehouseClientsCachesJob < BaseJob
   queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
   WAIT_MINUTES = 4
+  ADVISORY_LOCK_NAME = 'UpdateWarehouseClientsCachesJob'
 
   def perform(client_ids: [], include_cas_and_cohorts: false, skip_expensive_calculations: false)
     # If any for this class are already running, requeue for a few minutes in the future
     lock_obtained = nil
-    GrdaWarehouse::WarehouseClientsProcessed.with_advisory_lock('UpdateWarehouseClientsCachesJob', timeout_seconds: 20) do
+    GrdaWarehouse::WarehouseClientsProcessed.with_advisory_lock(ADVISORY_LOCK_NAME, timeout_seconds: 20) do
       GrdaWarehouse::WarehouseClientsProcessed.update_cached_counts(client_ids: client_ids, include_cas_and_cohorts: include_cas_and_cohorts, skip_expensive_calculations: skip_expensive_calculations)
       lock_obtained = true
     end

--- a/app/models/grda_warehouse/monitoring/metric_calculators/base_calculator.rb
+++ b/app/models/grda_warehouse/monitoring/metric_calculators/base_calculator.rb
@@ -36,6 +36,13 @@ module GrdaWarehouse::Monitoring::MetricCalculators
       '1.0.0'
     end
 
+    # Returns true if the calculator's data source is currently stable enough to snapshot.
+    # Subclasses override this when their source table has a known concurrent writer.
+    # Called by MetricSnapshotCollector before opening the REPEATABLE READ transaction.
+    def self.data_stable?
+      true
+    end
+
     # Helper: get lookback window
     def lookback_window
       metric_definition&.calculation_window_days&.days || 3.years

--- a/app/models/grda_warehouse/monitoring/metric_calculators/homeless_days_last_three_years_calculator.rb
+++ b/app/models/grda_warehouse/monitoring/metric_calculators/homeless_days_last_three_years_calculator.rb
@@ -32,6 +32,17 @@ module GrdaWarehouse::Monitoring::MetricCalculators
         to_h
     end
 
+    # warehouse_clients_processed is written by UpdateWarehouseClientsCachesJob.
+    # Try to acquire its advisory lock non-blocking; if we get it, no batch is
+    # actively writing right now and we release immediately.
+    def self.data_stable?
+      stable = false
+      GrdaWarehouseBase.with_advisory_lock(UpdateWarehouseClientsCachesJob::ADVISORY_LOCK_NAME, timeout_seconds: 0) do
+        stable = true
+      end
+      stable
+    end
+
     # Return metric definition attributes for this calculator
     def self.metric_definition_attributes
       {

--- a/app/models/grda_warehouse/monitoring/metric_calculators/max_household_size_calculator.rb
+++ b/app/models/grda_warehouse/monitoring/metric_calculators/max_household_size_calculator.rb
@@ -43,6 +43,12 @@ module GrdaWarehouse::Monitoring::MetricCalculators
         compact
     end
 
+    # hud_enrollments is written by HmisAutoMigrateJob while an import is running.
+    # Delayed::Job.running? checks locked_at IS NOT NULL AND failed_at IS NULL.
+    def self.data_stable?
+      !Delayed::Job.running?('HmisAutoMigrateJob')
+    end
+
     def self.metric_definition_attributes
       {
         name: 'max_household_size',

--- a/app/models/grda_warehouse/monitoring/metric_calculators/min_household_size_calculator.rb
+++ b/app/models/grda_warehouse/monitoring/metric_calculators/min_household_size_calculator.rb
@@ -44,6 +44,12 @@ module GrdaWarehouse::Monitoring::MetricCalculators
         compact
     end
 
+    # hud_enrollments is written by HmisAutoMigrateJob while an import is running.
+    # Delayed::Job.running? checks locked_at IS NOT NULL AND failed_at IS NULL.
+    def self.data_stable?
+      !Delayed::Job.running?('HmisAutoMigrateJob')
+    end
+
     def self.metric_definition_attributes
       {
         name: 'min_household_size',

--- a/app/models/grda_warehouse/monitoring/tasks/metric_snapshot_collector.rb
+++ b/app/models/grda_warehouse/monitoring/tasks/metric_snapshot_collector.rb
@@ -45,14 +45,34 @@ module GrdaWarehouse::Monitoring::Tasks
       GrdaWarehouse::Monitoring::MetricDefinition.maintain!
 
       run_record = create_run_record
-
-      metrics = load_metrics
+      all_metrics = load_metrics
       entities = load_entities
 
-      Rails.logger.info "Collecting #{metrics.count} metrics for #{entities.count} #{@entity_type} records"
+      # Check every metric's stability consecutively, then open the transaction
+      # immediately after. The window between the last check and the snapshot is
+      # minimal. Once inside REPEATABLE READ, any write that starts during
+      # collection is invisible to all metrics' reads — all share the same snapshot.
+      stable_metrics, skipped_metrics = all_metrics.partition do |metric|
+        metric.calculator_class.constantize.data_stable?
+      end
 
-      entities.find_in_batches(batch_size: BATCH_SIZE) do |entity_batch|
-        collect_batch(entity_batch, metrics)
+      skipped_metric_names = skipped_metrics.map(&:name)
+
+      if skipped_metric_names.any?
+        Rails.logger.warn(
+          "MetricSnapshotCollector: deferring #{skipped_metric_names.join(', ')} — " \
+          'data source not stable, will retry',
+        )
+      end
+
+      Rails.logger.info "Collecting #{stable_metrics.count} metrics for #{@entity_type} records"
+
+      if stable_metrics.any?
+        GrdaWarehouseBase.transaction(isolation: :repeatable_read) do
+          entities.find_in_batches(batch_size: BATCH_SIZE) do |entity_batch|
+            collect_batch(entity_batch, stable_metrics)
+          end
+        end
       end
 
       cleanup_old_snapshots
@@ -60,6 +80,9 @@ module GrdaWarehouse::Monitoring::Tasks
 
       # Trigger alert notifications for threshold crossings
       NotifyMetricThresholdCrossingsJob.perform_later(@calculation_date)
+
+      # Return skipped metric names so the caller can schedule targeted retries
+      skipped_metric_names
     end
 
     private

--- a/spec/jobs/collect_client_metrics_job_spec.rb
+++ b/spec/jobs/collect_client_metrics_job_spec.rb
@@ -1,0 +1,100 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectClientMetricsJob, type: :job do
+  let(:calculation_date) { Date.current }
+
+  before do
+    allow(GrdaWarehouseBase).to receive(:with_advisory_lock).and_yield
+  end
+
+  describe '#perform' do
+    context 'when all metrics are stable' do
+      before do
+        allow(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).
+          to receive(:run_daily_collection).and_return([])
+      end
+
+      it 'runs metric snapshot collection' do
+        expect(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).to receive(:run_daily_collection).
+          with(
+            entity_type: 'GrdaWarehouse::Hud::Client',
+            calculation_date: calculation_date,
+            metric_names: nil,
+          ).and_return([])
+        described_class.new.perform(calculation_date)
+      end
+
+      it 'does not enqueue a follow-up job' do
+        expect(described_class).not_to receive(:perform_later)
+        described_class.new.perform(calculation_date)
+      end
+    end
+
+    context 'when some metrics are skipped and before the retry deadline' do
+      before do
+        allow(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).
+          to receive(:run_daily_collection).and_return(['max_household_size', 'min_household_size'])
+        allow(Time).to receive(:current).and_return(
+          Time.current.change(hour: described_class::RETRY_DEADLINE_HOUR - 1),
+        )
+      end
+
+      it 'enqueues a targeted follow-up job for the skipped metrics' do
+        skipped_metric_names = ['max_household_size', 'min_household_size']
+        expect do
+          described_class.new.perform(calculation_date)
+        end.to have_enqueued_job(described_class).
+          with(calculation_date, metric_names: skipped_metric_names).
+          at(a_value > Time.current)
+      end
+    end
+
+    context 'when some metrics are skipped but past the retry deadline' do
+      before do
+        allow(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).
+          to receive(:run_daily_collection).and_return(['max_household_size'])
+      end
+
+      it 'does not enqueue a follow-up job when hour is past the deadline' do
+        allow(Time).to receive(:current).and_return(
+          Time.current.change(hour: described_class::RETRY_DEADLINE_HOUR + 1),
+        )
+        expect(described_class).not_to receive(:perform_later)
+        described_class.new.perform(calculation_date)
+      end
+
+      it 'does not enqueue a follow-up job when hour equals the deadline exactly' do
+        allow(Time).to receive(:current).and_return(
+          Time.current.change(hour: described_class::RETRY_DEADLINE_HOUR),
+        )
+        expect(described_class).not_to receive(:perform_later)
+        described_class.new.perform(calculation_date)
+      end
+    end
+
+    context 'when called with specific metric_names for a targeted retry' do
+      before do
+        allow(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).
+          to receive(:run_daily_collection).and_return([])
+      end
+
+      it 'passes metric_names through to the collector' do
+        expect(GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector).to receive(:run_daily_collection).
+          with(
+            entity_type: 'GrdaWarehouse::Hud::Client',
+            calculation_date: calculation_date,
+            metric_names: ['max_household_size'],
+          ).and_return([])
+        described_class.new.perform(calculation_date, metric_names: ['max_household_size'])
+      end
+    end
+  end
+end

--- a/spec/models/grda_warehouse/monitoring/metric_calculators/base_calculator_spec.rb
+++ b/spec/models/grda_warehouse/monitoring/metric_calculators/base_calculator_spec.rb
@@ -1,0 +1,59 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Monitoring::MetricCalculators::BaseCalculator do
+  describe '.data_stable?' do
+    it 'returns true by default' do
+      expect(described_class.data_stable?).to be true
+    end
+  end
+end
+
+RSpec.describe GrdaWarehouse::Monitoring::MetricCalculators::HomelessDaysLastThreeYearsCalculator do
+  describe '.data_stable?' do
+    it 'returns true when the UpdateWarehouseClientsCachesJob lock is available' do
+      allow(GrdaWarehouseBase).to receive(:with_advisory_lock).and_yield
+      expect(described_class.data_stable?).to be true
+    end
+
+    it 'returns false when the UpdateWarehouseClientsCachesJob lock cannot be acquired' do
+      allow(GrdaWarehouseBase).to receive(:with_advisory_lock)
+      expect(described_class.data_stable?).to be false
+    end
+  end
+end
+
+RSpec.describe GrdaWarehouse::Monitoring::MetricCalculators::MaxHouseholdSizeCalculator do
+  describe '.data_stable?' do
+    it 'returns true when no HmisAutoMigrateJob is running' do
+      allow(Delayed::Job).to receive(:running?).with('HmisAutoMigrateJob').and_return(false)
+      expect(described_class.data_stable?).to be true
+    end
+
+    it 'returns false when an HmisAutoMigrateJob is running' do
+      allow(Delayed::Job).to receive(:running?).with('HmisAutoMigrateJob').and_return(true)
+      expect(described_class.data_stable?).to be false
+    end
+  end
+end
+
+RSpec.describe GrdaWarehouse::Monitoring::MetricCalculators::MinHouseholdSizeCalculator do
+  describe '.data_stable?' do
+    it 'returns true when no HmisAutoMigrateJob is running' do
+      allow(Delayed::Job).to receive(:running?).with('HmisAutoMigrateJob').and_return(false)
+      expect(described_class.data_stable?).to be true
+    end
+
+    it 'returns false when an HmisAutoMigrateJob is running' do
+      allow(Delayed::Job).to receive(:running?).with('HmisAutoMigrateJob').and_return(true)
+      expect(described_class.data_stable?).to be false
+    end
+  end
+end

--- a/spec/models/grda_warehouse/monitoring/tasks/metric_snapshot_collector_spec.rb
+++ b/spec/models/grda_warehouse/monitoring/tasks/metric_snapshot_collector_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector, type: 
     )
   end
 
+  # RSpec wraps each example in a transaction for rollback-based cleanup.
+  # PostgreSQL does not allow setting isolation level inside a nested transaction,
+  # so we stub the REPEATABLE READ call to simply yield for all tests that do not
+  # specifically test transaction behavior. Tests that do care override this stub.
+  before do
+    allow(GrdaWarehouseBase).to receive(:transaction).and_call_original
+    allow(GrdaWarehouseBase).to receive(:transaction).
+      with(isolation: :repeatable_read).
+      and_yield
+  end
+
   describe '.run_daily_collection' do
     it 'creates metric calculation run record' do
       expect do
@@ -301,6 +312,104 @@ RSpec.describe GrdaWarehouse::Monitoring::Tasks::MetricSnapshotCollector, type: 
           expect(new_snapshot.initial_value).to eq(140)
           expect(new_snapshot.current_value).to eq(140)
         end
+      end
+    end
+  end
+
+  describe 'transaction isolation' do
+    it 'wraps all stable metrics in a single repeatable read transaction' do
+      allow(GrdaWarehouseBase).to receive(:transaction).and_call_original
+      # The test suite wraps everything in a transaction, so REPEATABLE READ
+      # isolation cannot actually be set in a nested call — stub it to just yield.
+      expect(GrdaWarehouseBase).to receive(:transaction).
+        with(isolation: :repeatable_read).
+        once.
+        and_yield
+
+      described_class.run_daily_collection(
+        entity_type: entity_type,
+        calculation_date: calculation_date,
+        entity_ids: [client1.id],
+        metric_names: ['test_metric'],
+      )
+    end
+  end
+
+  describe 'stability partitioning' do
+    before do
+      allow(GrdaWarehouse::Monitoring::MetricCalculators::HomelessDaysLastThreeYearsCalculator).
+        to receive(:data_stable?).and_return(false)
+    end
+
+    it 'returns the skipped metric name' do
+      skipped = described_class.run_daily_collection(
+        entity_type: entity_type,
+        calculation_date: calculation_date,
+        entity_ids: [client1.id],
+        metric_names: ['test_metric'],
+      )
+      expect(skipped).to eq(['test_metric'])
+    end
+
+    it 'does not create snapshots for skipped metrics' do
+      expect do
+        described_class.run_daily_collection(
+          entity_type: entity_type,
+          calculation_date: calculation_date,
+          entity_ids: [client1.id],
+          metric_names: ['test_metric'],
+        )
+      end.not_to change(GrdaWarehouse::Monitoring::MetricSnapshot, :count)
+    end
+
+    it 'does not open a transaction when all metrics are skipped' do
+      # maintain! and other internal calls may still use transaction; we only care
+      # that no REPEATABLE READ transaction is opened when all metrics are unstable
+      allow(GrdaWarehouseBase).to receive(:transaction).and_call_original
+      expect(GrdaWarehouseBase).not_to receive(:transaction).
+        with(isolation: :repeatable_read)
+      described_class.run_daily_collection(
+        entity_type: entity_type,
+        calculation_date: calculation_date,
+        entity_ids: [client1.id],
+        metric_names: ['test_metric'],
+      )
+    end
+
+    context 'when a second metric uses a stable calculator' do
+      let!(:second_metric_definition) do
+        create(
+          :grda_warehouse_monitoring_metric_definition,
+          name: 'second_metric',
+          entity_type: entity_type,
+          calculator_class: 'GrdaWarehouse::Monitoring::MetricCalculators::MinHouseholdSizeCalculator',
+          count_change_threshold: 1,
+          active: true,
+        )
+      end
+
+      before do
+        allow(GrdaWarehouse::Monitoring::MetricCalculators::MinHouseholdSizeCalculator).
+          to receive(:data_stable?).and_return(true)
+        allow(GrdaWarehouse::Monitoring::MetricCalculators::MinHouseholdSizeCalculator).
+          to receive(:calculate_batch).and_return({ client1.id => 2 })
+        # The test suite runs inside a transaction, so REPEATABLE READ isolation
+        # cannot be set in a nested transaction. Stub the outer transaction to
+        # simply yield so the inner database writes are visible to assertions.
+        allow(GrdaWarehouseBase).to receive(:transaction).and_call_original
+        allow(GrdaWarehouseBase).to receive(:transaction).
+          with(isolation: :repeatable_read).
+          and_yield
+      end
+
+      it 'collects the stable metric and skips the unstable one' do
+        skipped = described_class.run_daily_collection(
+          entity_type: entity_type,
+          calculation_date: calculation_date,
+          entity_ids: [client1.id],
+        )
+        expect(skipped).to eq(['test_metric'])
+        expect(GrdaWarehouse::Monitoring::MetricSnapshot.count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The threshold monitoring system collects metrics in batches — e.g., checking days-homeless counts across all clients batch by batch. If a background job was concurrently updating the underlying data (the warehouse client cache, or HMIS enrollment records), different batches could see different snapshots of the data, causing spurious threshold crossings.                                                                                                                                                                     
                                                                                                                                                                                 
### What Changed:                                                                                                                                                               
1. REPEATABLE READ transaction — the entire batch collection now runs inside a single PostgreSQL REPEATABLE READ transaction, so all batches see the same consistent snapshot of the database, regardless of what's being written concurrently.
2. Per-calculator stability checks (`data_stable?`) — before opening that snapshot, each calculator declares whether its data source is currently stable:
    - `HomelessDaysLastThreeYearsCalculator` checks that `UpdateWarehouseClientsCachesJob` isn't actively running (via advisory lock probe)
    - `MaxHouseholdSizeCalculator` and `MinHouseholdSizeCalculator` check that no `HmisAutoMigrateJob` is running
    - If a calculator's data source is unstable, that metric is skipped rather than blocking the others                                                                          
3. Targeted retry — if any metrics were skipped, `CollectClientMetricsJob` re-queues itself 5 minutes later, passing only the skipped metric names. This repeats until 10am, after which it gives up and logs a warning rather than retrying indefinitely.                                                                                                       

**The result:** each metric only runs when its source data is stable, and when it does run, all batches see a consistent view of that data.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
