### PR TITLE
1. Add DS to HMIS form/instance; enable multi-hmis seed

### DIFF
--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -408,10 +408,9 @@ class SeedMaker
     return unless ENV['ENABLE_HMIS_API'] == 'true'
     return unless GrdaWarehouse::DataSource.hmis.exists? # data source must be added in the warehouse UI
 
-    ::HmisUtil::JsonForms.seed_all
-
-    # Ensure service type and category records exist for each HUD service type
+    # For each HMIS data source, seed JSON form definitions, HUD form instances, and HUD service type and category records
     GrdaWarehouse::DataSource.hmis.pluck(:id).each do |data_source_id|
+      ::HmisUtil::JsonForms.seed_all(data_source_id: data_source_id)
       ::HmisUtil::ServiceTypes.seed_hud_service_types(data_source_id)
     end
   end

--- a/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
+++ b/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+##
+# This migration adds a data_source_id column to the hmis_form_definitions and hmis_form_instances tables.
+# It migrates existing rows to point to the oldest HMIS data source,
+# and updates appropriate indexes to use the data_source_id.
+#
+# Note about the use of safety_assured in this migration:
+# StrongMigrations had a lot of suggestions about avoiding locking the whole table while building indexes or changing column nullability.
+# But these tables are expected to be tiny (dozens to a couple hundred rows in prod), so the operations will be fast, and a short lock is acceptable.
+#
+class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      # Add references to data source. Nullable at first since we need to back-populate existing rows.
+      add_reference :hmis_form_definitions, :data_source, null: true
+      add_reference :hmis_form_instances, :data_source, null: true
+    end
+
+    oldest_id = GrdaWarehouse::DataSource.hmis.order(:created_at).limit(1).pick(:id)
+    unless oldest_id
+      # handle non-HMIS installations where no data source exists:
+      # Raise only if there exist rows in the relevant tables.
+      def_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_definitions').to_i
+      inst_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_instances').to_i
+      raise ActiveRecord::MigrationError, 'No HMIS data source found; configure an HMIS data source before this migration.' if def_count.positive? || inst_count.positive?
+    end
+
+    if oldest_id
+      safety_assured do
+        # Update the new DS column to point to the oldest existing HMIS data source
+        execute <<~SQL.squish
+          UPDATE hmis_form_definitions SET data_source_id = #{connection.quote(oldest_id)} WHERE data_source_id IS NULL;
+          UPDATE hmis_form_instances SET data_source_id = #{connection.quote(oldest_id)} WHERE data_source_id IS NULL;
+        SQL
+      end
+    end
+
+    safety_assured do
+      # Require the data_source_id column
+      change_column_null :hmis_form_definitions, :data_source_id, false
+      change_column_null :hmis_form_instances, :data_source_id, false
+    end
+
+    # Remove existing uniqueness indexes
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+
+    safety_assured do
+      # Re-add uniqueness indexes with data_source_id.
+      add_index :hmis_form_definitions,
+                [:data_source_id, :identifier, :version],
+                unique: true,
+                where: 'deleted_at IS NULL',
+                name: 'uidx_hmis_form_definitions_ds_identifier_version'
+
+      add_index :hmis_form_definitions,
+                [:data_source_id, :identifier],
+                unique: true,
+                where: "status = 'draft' AND deleted_at IS NULL",
+                name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
+
+      add_index :hmis_form_definitions,
+                [:data_source_id, :identifier],
+                unique: true,
+                where: "status = 'published' AND deleted_at IS NULL",
+                name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+
+      add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'uidx_hmis_form_instances_on_ds_and_identifier'
+    end
+  end
+
+  def down
+    remove_index :hmis_form_instances, name: 'uidx_hmis_form_instances_on_ds_and_identifier'
+
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_ds_identifier_version'
+
+    change_column_null :hmis_form_instances, :data_source_id, true
+    change_column_null :hmis_form_definitions, :data_source_id, true
+
+    add_index :hmis_form_definitions,
+              [:identifier, :version],
+              unique: true,
+              where: '(deleted_at IS NULL)',
+              name: 'uidx_hmis_form_definitions_identifier'
+
+    add_index :hmis_form_definitions,
+              [:identifier],
+              unique: true,
+              where: "((status)::text = 'draft'::text) AND (deleted_at IS NULL)",
+              name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
+
+    add_index :hmis_form_definitions,
+              [:identifier],
+              unique: true,
+              where: "((status)::text = 'published'::text) AND (deleted_at IS NULL)",
+              name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+
+    remove_reference :hmis_form_instances, :data_source
+    remove_reference :hmis_form_definitions, :data_source
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260326130000
+# rails db:migrate:down:warehouse VERSION=20260326130000

--- a/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
+++ b/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
@@ -46,6 +46,8 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier'
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+    remove_index :CustomDataElementDefinitions, name: 'unique_index_ensuring_one_key_per_record_type'
+    remove_index :CustomDataElementDefinitions, name: 'index_cded_on_owner_type_and_reporting_key'
 
     safety_assured do
       # Re-add uniqueness indexes with data_source_id.
@@ -68,10 +70,19 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
                 name: 'uidx_hmis_form_definitions_one_published_per_identifier'
 
       add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'uidx_hmis_form_instances_on_ds_and_identifier'
+
+      add_index :CustomDataElementDefinitions, [:data_source_id, :key, :owner_type], unique: true, name: 'unique_index_ensuring_one_key_per_record_type'
+      add_index :CustomDataElementDefinitions,
+                [:owner_type, :reporting_key, :data_source_id],
+                unique: true,
+                where: '"reporting_key" IS NOT NULL AND "DateDeleted" IS NULL',
+                name: 'index_cded_on_owner_type_and_reporting_key'
     end
   end
 
   def down
+    remove_index :CustomDataElementDefinitions, name: 'unique_index_ensuring_one_key_per_record_type'
+    remove_index :CustomDataElementDefinitions, name: 'index_cded_on_owner_type_and_reporting_key'
     remove_index :hmis_form_instances, name: 'uidx_hmis_form_instances_on_ds_and_identifier'
 
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
@@ -98,6 +109,13 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
               unique: true,
               where: "((status)::text = 'published'::text) AND (deleted_at IS NULL)",
               name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+
+    add_index :CustomDataElementDefinitions, [:key, :owner_type], unique: true, name: 'unique_index_ensuring_one_key_per_record_type'
+    add_index :CustomDataElementDefinitions,
+              [:owner_type, :reporting_key],
+              unique: true,
+              where: '"reporting_key" IS NOT NULL AND "DateDeleted" IS NULL',
+              name: 'index_cded_on_owner_type_and_reporting_key'
 
     remove_reference :hmis_form_instances, :data_source
     remove_reference :hmis_form_definitions, :data_source

--- a/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
+++ b/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
@@ -46,8 +46,6 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier'
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
-    remove_index :CustomDataElementDefinitions, name: 'unique_index_ensuring_one_key_per_record_type'
-    remove_index :CustomDataElementDefinitions, name: 'index_cded_on_owner_type_and_reporting_key'
 
     safety_assured do
       # Re-add uniqueness indexes with data_source_id.
@@ -70,19 +68,10 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
                 name: 'uidx_hmis_form_definitions_one_published_per_identifier'
 
       add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'uidx_hmis_form_instances_on_ds_and_identifier'
-
-      add_index :CustomDataElementDefinitions, [:data_source_id, :key, :owner_type], unique: true, name: 'unique_index_ensuring_one_key_per_record_type'
-      add_index :CustomDataElementDefinitions,
-                [:owner_type, :reporting_key, :data_source_id],
-                unique: true,
-                where: '"reporting_key" IS NOT NULL AND "DateDeleted" IS NULL',
-                name: 'index_cded_on_owner_type_and_reporting_key'
     end
   end
 
   def down
-    remove_index :CustomDataElementDefinitions, name: 'unique_index_ensuring_one_key_per_record_type'
-    remove_index :CustomDataElementDefinitions, name: 'index_cded_on_owner_type_and_reporting_key'
     remove_index :hmis_form_instances, name: 'uidx_hmis_form_instances_on_ds_and_identifier'
 
     remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
@@ -109,13 +98,6 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
               unique: true,
               where: "((status)::text = 'published'::text) AND (deleted_at IS NULL)",
               name: 'uidx_hmis_form_definitions_one_published_per_identifier'
-
-    add_index :CustomDataElementDefinitions, [:key, :owner_type], unique: true, name: 'unique_index_ensuring_one_key_per_record_type'
-    add_index :CustomDataElementDefinitions,
-              [:owner_type, :reporting_key],
-              unique: true,
-              where: '"reporting_key" IS NOT NULL AND "DateDeleted" IS NULL',
-              name: 'index_cded_on_owner_type_and_reporting_key'
 
     remove_reference :hmis_form_instances, :data_source
     remove_reference :hmis_form_definitions, :data_source

--- a/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
+++ b/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
@@ -10,96 +10,135 @@
 # But these tables are expected to be tiny (dozens to a couple hundred rows in prod), so the operations will be fast, and a short lock is acceptable.
 #
 class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7.2]
-  def up
-    oldest_id = GrdaWarehouse::DataSource.hmis.order(:created_at).limit(1).pick(:id)
-    unless oldest_id
-      # handle non-HMIS installations where no data source exists:
-      # Raise only if there exist rows in the relevant tables.
-      def_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_definitions').to_i
-      inst_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_instances').to_i
-      raise ActiveRecord::MigrationError, 'Unexpected state: Environment has HMIS forms but no HMIS data source. Delete forms or configure HMIS data source before this migration can run' if def_count.positive? || inst_count.positive?
+  def change
+    reversible do |dir|
+      dir.up { validate_hmis_exists_if_needed }
+      dir.down {}
     end
 
     safety_assured do
-      # Add references to data source. Nullable at first since we need to back-populate existing rows.
-      add_reference :hmis_form_definitions, :data_source, null: true
-      add_reference :hmis_form_instances, :data_source, null: true
+      add_data_source_refs
+      populate_data_source_refs
+      make_data_source_refs_non_nullable
+      drop_old_indices
+      add_new_indices
     end
+  end
 
-    if oldest_id
-      safety_assured do
-        # Update the new DS column to point to the oldest existing HMIS data source
+  protected
+
+  def validate_hmis_exists_if_needed
+    oldest_id = GrdaWarehouse::DataSource.hmis.order(:created_at).limit(1).pick(:id)
+    return if oldest_id
+
+    def_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_definitions').to_i
+    inst_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_instances').to_i
+    return unless def_count.positive? || inst_count.positive?
+
+    raise ActiveRecord::MigrationError, 'Unexpected state: Environment has HMIS forms but no HMIS data source. Delete forms or configure HMIS data source before this migration can run'
+  end
+
+  def add_data_source_refs
+    reversible do |dir|
+      dir.up do
+        add_reference :hmis_form_definitions, :data_source, null: true
+        add_reference :hmis_form_instances, :data_source, null: true
+      end
+      dir.down do
+        remove_reference :hmis_form_instances, :data_source
+        remove_reference :hmis_form_definitions, :data_source
+      end
+    end
+  end
+
+  def populate_data_source_refs
+    reversible do |dir|
+      dir.up do
+        oldest_id = GrdaWarehouse::DataSource.hmis.order(:created_at).limit(1).pick(:id)
+        next unless oldest_id
+
         quoted_id = connection.quote(oldest_id)
         execute "UPDATE hmis_form_definitions SET data_source_id = #{quoted_id} WHERE data_source_id IS NULL"
         execute "UPDATE hmis_form_instances SET data_source_id = #{quoted_id} WHERE data_source_id IS NULL"
       end
-    end
-
-    safety_assured do
-      # Require the data_source_id column
-      change_column_null :hmis_form_definitions, :data_source_id, false
-      change_column_null :hmis_form_instances, :data_source_id, false
-    end
-
-    # Remove existing uniqueness indexes
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier', if_exists: true
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
-
-    safety_assured do
-      # Re-add uniqueness indexes with data_source_id.
-      add_index :hmis_form_definitions,
-                [:data_source_id, :identifier, :version],
-                unique: true,
-                where: 'deleted_at IS NULL',
-                name: 'uidx_hmis_form_definitions_ds_identifier_version'
-
-      add_index :hmis_form_definitions,
-                [:data_source_id, :identifier],
-                unique: true,
-                where: "status = 'draft' AND deleted_at IS NULL",
-                name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
-
-      add_index :hmis_form_definitions,
-                [:data_source_id, :identifier],
-                unique: true,
-                where: "status = 'published' AND deleted_at IS NULL",
-                name: 'uidx_hmis_form_definitions_one_published_per_identifier'
-
-      add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'index_hmis_form_instances_on_ds_and_identifier'
+      dir.down do
+        # Column is dropped in add_data_source_refs; no backfill needed on rollback.
+      end
     end
   end
 
-  def down
-    remove_index :hmis_form_instances, name: 'index_hmis_form_instances_on_ds_and_identifier', if_exists: true
+  def make_data_source_refs_non_nullable
+    reversible do |dir|
+      dir.up do
+        change_column_null :hmis_form_definitions, :data_source_id, false
+        change_column_null :hmis_form_instances, :data_source_id, false
+      end
+      dir.down do
+        # no need to remove NOT NULL since the columns are dropped
+      end
+    end
+  end
 
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_ds_identifier_version', if_exists: true
+  def drop_old_indices
+    reversible do |dir|
+      dir.up do # Drop old indices that need to be updated to include data_source_id
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier', if_exists: true
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
+      end
+      dir.down do
+        add_index :hmis_form_definitions,
+                  [:identifier, :version],
+                  unique: true,
+                  where: '(deleted_at IS NULL)',
+                  name: 'uidx_hmis_form_definitions_identifier'
 
-    change_column_null :hmis_form_instances, :data_source_id, true
-    change_column_null :hmis_form_definitions, :data_source_id, true
+        add_index :hmis_form_definitions,
+                  [:identifier],
+                  unique: true,
+                  where: "((status)::text = 'draft'::text) AND (deleted_at IS NULL)",
+                  name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
 
-    add_index :hmis_form_definitions,
-              [:identifier, :version],
-              unique: true,
-              where: '(deleted_at IS NULL)',
-              name: 'uidx_hmis_form_definitions_identifier'
+        add_index :hmis_form_definitions,
+                  [:identifier],
+                  unique: true,
+                  where: "((status)::text = 'published'::text) AND (deleted_at IS NULL)",
+                  name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+      end
+    end
+  end
 
-    add_index :hmis_form_definitions,
-              [:identifier],
-              unique: true,
-              where: "((status)::text = 'draft'::text) AND (deleted_at IS NULL)",
-              name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
+  def add_new_indices
+    reversible do |dir|
+      dir.up do # Replace old uniqueness indices with new ones that include data_source_id
+        add_index :hmis_form_definitions,
+                  [:data_source_id, :identifier, :version],
+                  unique: true,
+                  where: 'deleted_at IS NULL',
+                  name: 'uidx_hmis_form_definitions_ds_identifier_version'
 
-    add_index :hmis_form_definitions,
-              [:identifier],
-              unique: true,
-              where: "((status)::text = 'published'::text) AND (deleted_at IS NULL)",
-              name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+        add_index :hmis_form_definitions,
+                  [:data_source_id, :identifier],
+                  unique: true,
+                  where: "status = 'draft' AND deleted_at IS NULL",
+                  name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
 
-    remove_reference :hmis_form_instances, :data_source
-    remove_reference :hmis_form_definitions, :data_source
+        add_index :hmis_form_definitions,
+                  [:data_source_id, :identifier],
+                  unique: true,
+                  where: "status = 'published' AND deleted_at IS NULL",
+                  name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+
+        add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'index_hmis_form_instances_on_ds_and_identifier'
+      end
+      dir.down do
+        remove_index :hmis_form_instances, name: 'index_hmis_form_instances_on_ds_and_identifier', if_exists: true
+
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
+        remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_ds_identifier_version', if_exists: true
+      end
+    end
   end
 end
 

--- a/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
+++ b/db/warehouse/migrate/20260326130000_add_data_source_to_hmis_form_definitions_and_instances.rb
@@ -11,28 +11,27 @@
 #
 class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7.2]
   def up
-    safety_assured do
-      # Add references to data source. Nullable at first since we need to back-populate existing rows.
-      add_reference :hmis_form_definitions, :data_source, null: true
-      add_reference :hmis_form_instances, :data_source, null: true
-    end
-
     oldest_id = GrdaWarehouse::DataSource.hmis.order(:created_at).limit(1).pick(:id)
     unless oldest_id
       # handle non-HMIS installations where no data source exists:
       # Raise only if there exist rows in the relevant tables.
       def_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_definitions').to_i
       inst_count = connection.select_value('SELECT COUNT(*) FROM hmis_form_instances').to_i
-      raise ActiveRecord::MigrationError, 'No HMIS data source found; configure an HMIS data source before this migration.' if def_count.positive? || inst_count.positive?
+      raise ActiveRecord::MigrationError, 'Unexpected state: Environment has HMIS forms but no HMIS data source. Delete forms or configure HMIS data source before this migration can run' if def_count.positive? || inst_count.positive?
+    end
+
+    safety_assured do
+      # Add references to data source. Nullable at first since we need to back-populate existing rows.
+      add_reference :hmis_form_definitions, :data_source, null: true
+      add_reference :hmis_form_instances, :data_source, null: true
     end
 
     if oldest_id
       safety_assured do
         # Update the new DS column to point to the oldest existing HMIS data source
-        execute <<~SQL.squish
-          UPDATE hmis_form_definitions SET data_source_id = #{connection.quote(oldest_id)} WHERE data_source_id IS NULL;
-          UPDATE hmis_form_instances SET data_source_id = #{connection.quote(oldest_id)} WHERE data_source_id IS NULL;
-        SQL
+        quoted_id = connection.quote(oldest_id)
+        execute "UPDATE hmis_form_definitions SET data_source_id = #{quoted_id} WHERE data_source_id IS NULL"
+        execute "UPDATE hmis_form_instances SET data_source_id = #{quoted_id} WHERE data_source_id IS NULL"
       end
     end
 
@@ -43,9 +42,9 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
     end
 
     # Remove existing uniqueness indexes
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier'
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_identifier', if_exists: true
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
 
     safety_assured do
       # Re-add uniqueness indexes with data_source_id.
@@ -67,16 +66,16 @@ class AddDataSourceToHmisFormDefinitionsAndInstances < ActiveRecord::Migration[7
                 where: "status = 'published' AND deleted_at IS NULL",
                 name: 'uidx_hmis_form_definitions_one_published_per_identifier'
 
-      add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'uidx_hmis_form_instances_on_ds_and_identifier'
+      add_index :hmis_form_instances, [:data_source_id, :definition_identifier], name: 'index_hmis_form_instances_on_ds_and_identifier'
     end
   end
 
   def down
-    remove_index :hmis_form_instances, name: 'uidx_hmis_form_instances_on_ds_and_identifier'
+    remove_index :hmis_form_instances, name: 'index_hmis_form_instances_on_ds_and_identifier', if_exists: true
 
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier'
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier'
-    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_ds_identifier_version'
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_published_per_identifier', if_exists: true
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_one_draft_per_identifier', if_exists: true
+    remove_index :hmis_form_definitions, name: 'uidx_hmis_form_definitions_ds_identifier_version', if_exists: true
 
     change_column_null :hmis_form_instances, :data_source_id, true
     change_column_null :hmis_form_definitions, :data_source_id, true

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -39,12 +39,14 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
 
   include Hmis::Hud::Concerns::HasEnums
 
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
   # convenience attr for passing graphql args
   attr_accessor :filter_context
 
   validates :identifier, format: { with: /\A[a-zA-Z][a-zA-Z0-9_-]*\z/, message: 'must contain only alphanumeric characters, underscores, and dashes, and must start with a letter' }
   # Forms that are managed in version control cannot have more than 1 version. To enforce this, we ensure that the identifier is unique.
-  validates_uniqueness_of :identifier, if: :managed_in_version_control?
+  validates_uniqueness_of :identifier, if: :managed_in_version_control?, scope: :data_source_id
 
   # --- Relations by id ----
   has_many :form_processors, dependent: :restrict_with_exception
@@ -235,6 +237,10 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
   scope :with_role, ->(role) { where(role: role) }
 
   scope :managed_in_version_control, -> { where(managed_in_version_control: true) }
+
+  scope :for_data_source, ->(data_source_id) do
+    where(data_source_id: data_source_id)
+  end
 
   before_destroy :can_be_destroyed, prepend: true
   private def can_be_destroyed

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -238,7 +238,7 @@ class Hmis::Form::Definition < ::GrdaWarehouseBase
 
   scope :managed_in_version_control, -> { where(managed_in_version_control: true) }
 
-  scope :for_data_source, ->(data_source_id) do
+  scope :in_data_source, ->(data_source_id) do
     where(data_source_id: data_source_id)
   end
 

--- a/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
@@ -12,7 +12,7 @@ These workflows are generated using the `AcWorkflowBuilder` utility class.
 
 These workflows expect client-specific forms to be available.
 
-The forms can be loaded with `CLIENT=client rails driver:hmis:seed_definitions` or `HmisUtil::JsonForms.new(env_key: 'client').seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])`
+The forms can be loaded with `CLIENT=client rails driver:hmis:seed_definitions` or `HmisUtil::JsonForms.new(env_key: 'client', data_source_id: 1).seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])`
 
 ### Housing Workflow
 This is a simplified diagram of the housing workflow. To see the full generated diagram, run the AcWorkflowBuilder.

--- a/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
@@ -14,7 +14,7 @@ These 3 referrals have differing first steps, but the workflows are the same aft
 ### Usage
 These workflows are generated and updated using the `CeWorkflows::Ph::WorkflowBuilder` utility class. 
 
-These workflows expect client-specific forms to be available. The forms can be loaded with `CLIENT=client rails driver:hmis:seed_definitions` or `HmisUtil::JsonForms.new(env_key: 'client').seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])`
+These workflows expect client-specific forms to be available. The forms can be loaded with `CLIENT=client rails driver:hmis:seed_definitions` or `HmisUtil::JsonForms.new(env_key: 'client', data_source_id: 1).seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])`
 
 #### Updates
 

--- a/drivers/hmis/lib/hmis_util/hud_compliance_form_instance_maintainer.rb
+++ b/drivers/hmis/lib/hmis_util/hud_compliance_form_instance_maintainer.rb
@@ -38,10 +38,9 @@ module HmisUtil
       FORM_IDENTIFIERS[:base_post_exit],
     ].freeze
 
-    def initialize(dry_run: false, data_source_id: nil)
+    def initialize(data_source_id:, dry_run: false)
       @dry_run = dry_run
-      # TODO(#6691) require data source. Currently this class allows it to be missing because this gets run in rails helper before data sources are created.
-      @data_source = data_source_id ? GrdaWarehouse::DataSource.hmis.find(data_source_id) : GrdaWarehouse::DataSource.hmis.first
+      @data_source = GrdaWarehouse::DataSource.hmis.find(data_source_id)
       @created = []  # ComplianceChangePayload entries for reporting
       @updated = []  # same shape: existing instances changed to system/active
       setup_notifier('HUD Form Compliance')
@@ -52,15 +51,8 @@ module HmisUtil
       ensure_record_form_system_instances!
       # Create required system instances for assessments (Intake, Exit, etc)
       ensure_assessment_system_instances!
-
       # Create required system instances for HUD Service form (identifier = 'service')
-      if Rails.env.test? && @data_source.blank?
-        # Unable to set up service form instances without data source specified
-        # TODO(#6691) when data source is guaranteed to be present during form seeding in test, we can remove this.
-        Rails.logger.info 'No data source found. Skipping service form system instances in test. FIXME(#6691)'
-      else
-        ensure_service_form_system_instances!
-      end
+      ensure_service_form_system_instances!
 
       # Report changes
       report_changes_if_any
@@ -69,8 +61,7 @@ module HmisUtil
     private
 
     def definition_scope
-      # TODO(#6691): add 'where(data_source: @data_source)'
-      Hmis::Form::Definition.published.managed_in_version_control
+      Hmis::Form::Definition.published.managed_in_version_control.for_data_source(@data_source.id)
     end
 
     # Ensures all required system instances exist for HUD record forms: default system form roles,
@@ -175,7 +166,7 @@ module HmisUtil
     end
 
     def create_default_system_instance!(identifier:)
-      instance = Hmis::Form::Instance.defaults.find_or_initialize_by(definition_identifier: identifier)
+      instance = Hmis::Form::Instance.defaults.find_or_initialize_by(definition_identifier: identifier, data_source_id: @data_source.id)
       was_new = instance.new_record?
       instance.assign_attributes(active: true, system: true)
       return unless instance.changed?
@@ -208,6 +199,7 @@ module HmisUtil
         entity_type: nil,
         entity_id: nil,
         custom_service_category_id: service_category&.id,
+        data_source_id: @data_source.id,
       }
       instance = Hmis::Form::Instance.find_or_initialize_by(attrs)
       was_new = instance.new_record?
@@ -238,7 +230,12 @@ module HmisUtil
     def build_summary_lines
       return [] if @created.empty? && @updated.empty?
 
-      title = @dry_run ? 'HUD Form Compliance (dry run) — instances that would be created or updated:' : 'HUD Form Compliance — changes applied:'
+      title = if @dry_run
+        "HUD Form Compliance (dry run) — instances that would be created or updated in DS##{@data_source.id}:"
+      else
+        "HUD Form Compliance — changes applied in DS##{@data_source.id}:"
+      end
+
       created_label = @dry_run ? "Would create (#{@created.size}):" : "Created (#{@created.size}):"
       updated_label = @dry_run ? "Would update (#{@updated.size}):" : "Updated (#{@updated.size}):"
 

--- a/drivers/hmis/lib/hmis_util/hud_compliance_form_instance_maintainer.rb
+++ b/drivers/hmis/lib/hmis_util/hud_compliance_form_instance_maintainer.rb
@@ -61,7 +61,7 @@ module HmisUtil
     private
 
     def definition_scope
-      Hmis::Form::Definition.published.managed_in_version_control.for_data_source(@data_source.id)
+      Hmis::Form::Definition.published.managed_in_version_control.in_data_source(@data_source.id)
     end
 
     # Ensures all required system instances exist for HUD record forms: default system form roles,

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -25,16 +25,14 @@ module HmisUtil
 
     attr_reader :env_key, :generate_cdeds, :create_instances
 
-    def initialize(env_key: nil, create_instances: true, generate_cdeds: !Rails.env.test?, data_source_id: nil)
+    def initialize(data_source_id:, env_key: nil, create_instances: true, generate_cdeds: !Rails.env.test?)
       @env_key = env_key.presence || compute_default_env_key
       @create_instances = create_instances
       @generate_cdeds = generate_cdeds # default: generate CDEDs from custom_field_key mappings in non-test environments
-      # TODO(#6691) require data source. Currently this class allows it to be missing because this gets run in rails helper before data sources are created.
-      @data_source = data_source_id ? GrdaWarehouse::DataSource.hmis.find(data_source_id) : GrdaWarehouse::DataSource.hmis.first
-      raise 'No HMIS data source found for JsonForms seeding' if @data_source.blank? && !Rails.env.test?
+      @data_source = GrdaWarehouse::DataSource.hmis.find(data_source_id)
     end
 
-    def self.seed_all(data_source_id: nil)
+    def self.seed_all(data_source_id:)
       new(data_source_id: data_source_id).seed_all
     end
 
@@ -56,7 +54,7 @@ module HmisUtil
     protected
 
     def instance_maintainer
-      HmisUtil::HudComplianceFormInstanceMaintainer.new(data_source_id: @data_source&.id)
+      HmisUtil::HudComplianceFormInstanceMaintainer.new(data_source_id: @data_source.id)
     end
 
     def compute_default_env_key
@@ -308,6 +306,7 @@ module HmisUtil
         identifier: identifier,
         role: role,
         version: 0,
+        data_source_id: @data_source.id,
       ).first_or_initialize(title: title || identifier.to_s.humanize)
       record.managed_in_version_control = true
       record.definition = form_definition
@@ -334,7 +333,7 @@ module HmisUtil
         form_definition,
         role,
         skip_cded_validation: !generate_cdeds, # skip validation if we didn't generate CDEDs
-        data_source_id: @data_source&.id,
+        data_source_id: @data_source.id,
       )
       raise(JsonFormException, errors.first.full_message) if errors.any?
 

--- a/drivers/hmis/lib/tasks/setup.rake
+++ b/drivers/hmis/lib/tasks/setup.rake
@@ -1,7 +1,7 @@
 desc 'Seed form definitions'
 task seed_definitions: [:environment, 'log:info_to_stdout'] do
   GrdaWarehouse::DataSource.hmis.pluck(:id, :name).each do |data_source_id, name|
-    Rails.logger.info "Seeding form definitions for DS##{data_source_id} #{name}"
+    puts "Seeding form definitions for DS##{data_source_id} #{name}"
     ::HmisUtil::JsonForms.seed_all(data_source_id: data_source_id)
   end
 end

--- a/drivers/hmis/spec/factories/hmis/form/definitions.rb
+++ b/drivers/hmis/spec/factories/hmis/form/definitions.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     role { 'UPDATE' }
     status { Hmis::Form::Definition::PUBLISHED }
     title { 'Form' }
+    data_source { association :hmis_data_source }
     definition do
       {
         'item': [

--- a/drivers/hmis/spec/factories/hmis/form/instances.rb
+++ b/drivers/hmis/spec/factories/hmis/form/instances.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
   factory :hmis_form_instance, class: 'Hmis::Form::Instance' do
     entity { association :hmis_hud_project }
     definition { association :hmis_form_definition }
+    data_source { association :hmis_data_source }
     active { true }
     system { false }
     transient do

--- a/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Hmis::Hud::Enrollment, type: :model do
     end
     after(:all) do
       # reset to original state
-      HmisUtil::HudComplianceFormInstanceMaintainer.new.ensure_all_system_instances_exist!
+      HmisUtil::HudComplianceFormInstanceMaintainer.new(data_source_id: ds1.id).ensure_all_system_instances_exist!
     end
 
     it 'does not return the form when no instance exists' do

--- a/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
@@ -37,12 +37,12 @@ RSpec.feature 'Assessment definition selection', type: :system do
 
   before(:all) do
     # Seed MCI-specific client forms
-    ::HmisUtil::JsonForms.new(env_key: 'allegheny').seed_record_form_definitions(roles: [:CLIENT, :NEW_CLIENT_ENROLLMENT]) if ENV['RUN_SYSTEM_TESTS'] == 'true'
+    ::HmisUtil::JsonForms.new(env_key: 'allegheny', data_source_id: ds1.id).seed_record_form_definitions(roles: [:CLIENT, :NEW_CLIENT_ENROLLMENT]) if ENV['RUN_SYSTEM_TESTS'] == 'true'
   end
 
   after(:all) do
     # Return client forms to normal.
-    HmisUtil::JsonForms.new.seed_record_form_definitions(roles: [:CLIENT, :NEW_CLIENT_ENROLLMENT]) if ENV['RUN_SYSTEM_TESTS'] == 'true'
+    HmisUtil::JsonForms.new(data_source_id: ds1.id).seed_record_form_definitions(roles: [:CLIENT, :NEW_CLIENT_ENROLLMENT]) if ENV['RUN_SYSTEM_TESTS'] == 'true'
   end
 
   def enter_client_details

--- a/drivers/hmis/spec/system/hmis/data_collection_features_spec.rb
+++ b/drivers/hmis/spec/system/hmis/data_collection_features_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Data collection features', type: :system do
     end
     after(:all) do
       # re-seed CLS form instances to restore default behavior
-      HmisUtil::HudComplianceFormInstanceMaintainer.new.ensure_all_system_instances_exist! if ENV['RUN_SYSTEM_TESTS'] == 'true'
+      HmisUtil::HudComplianceFormInstanceMaintainer.new(data_source_id: ds1.id).ensure_all_system_instances_exist! if ENV['RUN_SYSTEM_TESTS'] == 'true'
     end
     it 'should not show CLS in the project side nav' do
       visit "/projects/#{p1.id}/overview"


### PR DESCRIPTION
## _Merging this PR_
- This PR targets the long-lived feature branch `mke/6691-form-def-ds-base`
- After merge, I plan to create a draft PR of that branch against the release branch, and target future work on this ticket to that branch.

## Description
- This PR adds a migration that adds `data_source_id` to Form and Instance tables, and updates the structure file.
- The other code changes are related to getting form seeding working for multi-data source installation locally. See below for testing instructions.
- I expect rspec test failures at this stage, since the migration adds a new required column, but most specs haven't been adapted yet. I plan to fix those in later PRs against the same long-lived feature branch.

**How to test:**
- Run the migration locally. Confirm the new DS column is added to both the `hmis_form_definitions` and `hmis_form_instances` tables. It should be auto-populated and non-nullable after the migration completes.
- With a multi-hmis setup locally (see `drivers/hmis/README.md`), run `rails driver:hmis:seed_definitions`. It should succeed, and in your local DB you should see seeded definitions and instances per data source.

**Notes**
- If you try to run the migration in your local test environment, but you have persistent forms/instances in your test db, it will fail. To fix this, you can delete the forms/instances in your local db and retry. (The [`mke/6691-remove-test-seed`](https://github.com/greenriver/hmis-warehouse/pull/6346) branch proposes to always clean up forms/instances between tests.)
- If you follow the test instructions above, then want to `down` the migration to go work on something else, you will have to manually remove the records added at the seed step, since the newly added records violate the db's previous uniqueness indices.
- Some environments have a `CustomDataElementDefinition` that's collected by both the `client` and `new_client_enrollment` forms. Before the `seed` step will work, you will need to manually create that CDED with `form_definition_identifier = nil`, mimicking prod and circumventing ["Form item references a CDED that belongs to a different form"](https://github.com/greenriver/hmis-warehouse/blob/08ded5a542a851df9681f7c375ec68ad76ec0c09/drivers/hmis/app/models/hmis/form/custom_data_element_generator.rb#L185) errors. Example:
```ruby
Hmis::Hud::CustomDataElementDefinition.create!(data_source_id: 5, key: 'sexual_orientation', owner_type: 'H
mis::Hud::Client', field_type: 'string', label: 'Sexual Orientation', repeats: false, form_definition_identifier: nil, rep
orting_key: 'sexual_orientation', user_id: 3)
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature (milestone 1)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
