### PR TITLE
8826 followup hopwa caper fbh

### DIFF
--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/enrollment_filters/income_benefit_source_filter.rb
@@ -94,7 +94,7 @@ module HopwaCaper::Generators::Fy2026::EnrollmentFilters
         types: [:NoIncomeSource],
       )
 
-      all_income_types = specific_filters.flat_map(&:types) + [:IncomeFromAnySource]
+      all_income_types = specific_filters.flat_map(&:types) + [:IncomeFromAnySource, :NoIncomeSource]
 
       total_filter = new(
         id: :any_income,

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_fbh_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_fbh_sheet.rb
@@ -8,6 +8,17 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class BaseFbhSheet < Base
+    # Shown when no projects match the program filter, so the sheet always has
+    # at least one data column and doesn't appear broken to users.
+    NullFacility = Data.define(:position) do
+      def id = -1
+      def name = 'No facilities in scope'
+      def medically_assisted_living_facility? = nil
+      def placed_in_service_during_program_year? = false
+      def units_placed_into_service = nil
+    end
+    private_constant :NullFacility
+
     def relevant_services
       service_filter = HopwaCaper::Generators::Fy2026::ServiceFilters::RecordTypeFilter.hopwa_financial_assistance
       service_filter.apply(@report.hopwa_caper_services).
@@ -32,12 +43,11 @@ module HopwaCaper::Generators::Fy2026::Sheets
     end
 
     def facilities
-      @facilities ||= project_scope.order(:project_name, :id).map.with_index do |project, idx|
-        HopwaCaper::Facility.new(
-          project: project,
-          report: @report,
-          position: idx + 1,
-        )
+      @facilities ||= begin
+        result = project_scope.order(:project_name, :id).map.with_index do |project, idx|
+          HopwaCaper::Facility.new(project: project, report: @report, position: idx + 1)
+        end
+        result.presence || [NullFacility.new(position: 1)]
       end
     end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::PFbhSheet, type: :model d
     expect(rows.fetch('MEDICAID Health Program or local program equivalent')).to eq(1)
   end
 
+  it 'includes no-income households in the income sources total' do
+    no_income_client = create(:hud_client, data_source: data_source)
+    no_income_enrollment = create_hiv_positive_enrollment(
+      client: no_income_client,
+      project: project,
+      entry_date: report_start_date + 1.day,
+      household_id: Hmis::Hud::Base.generate_uuid,
+    )
+    create(
+      :hud_income_benefit,
+      enrollment: no_income_enrollment,
+      information_date: report_start_date + 1.day,
+      IncomeFromAnySource: 0,
+      data_source: data_source,
+    )
+
+    _, rows = run_and_extract_rows([project], 'Q10')
+    expect(rows.fetch('How many households maintained no sources of income?')).to eq(1)
+    # Total should include households with income (hoh_client) AND without (no_income_client)
+    expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(2)
+  end
+
   it 'reports housing outcomes correctly' do
     _, rows = run_and_extract_rows([project], 'Q10')
     expect(rows.fetch('How many households exited to private housing?')).to eq(1)

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::PFbhSheet, type: :model d
     expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(2)
   end
 
+  it 'renders a placeholder column when no facility-based projects are in scope' do
+    non_facility_project = create_hopwa_project(funder: funder).tap { |p| p.update!(HousingType: 3) }
+    _, rows = run_and_extract_rows([non_facility_project], 'Q10')
+    expect(rows.fetch('What is the name of the housing facility?')).to eq('No facilities in scope')
+    expect(rows.fetch('Was the housing facility placed into service during this program year? Yes or No.')).to eq('No')
+  end
+
   it 'reports housing outcomes correctly' do
     _, rows = run_and_extract_rows([project], 'Q10')
     expect(rows.fetch('How many households exited to private housing?')).to eq(1)

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_st_tfbh_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_st_tfbh_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StTfbhSheet, type: :model
     expect(rows.fetch('MEDICAID Health Program or local program equivalent')).to eq(1)
   end
 
+  it 'includes no-income households in the income sources total' do
+    no_income_client = create(:hud_client, data_source: data_source)
+    no_income_enrollment = create_hiv_positive_enrollment(
+      client: no_income_client,
+      project: project,
+      entry_date: report_start_date + 1.day,
+      household_id: Hmis::Hud::Base.generate_uuid,
+    )
+    create(
+      :hud_income_benefit,
+      enrollment: no_income_enrollment,
+      information_date: report_start_date + 1.day,
+      IncomeFromAnySource: 0,
+      data_source: data_source,
+    )
+
+    _, rows = run_and_extract_rows([project], 'Q9')
+    expect(rows.fetch('How many households maintained no sources of income?')).to eq(1)
+    # Total should include households with income (hoh_client) AND without (no_income_client)
+    expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(2)
+  end
+
   it 'reports housing outcomes correctly' do
     _, rows = run_and_extract_rows([project], 'Q9')
     expect(rows.fetch('How many households exited to private housing?')).to eq(1)

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_st_tfbh_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_st_tfbh_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StTfbhSheet, type: :model
     expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(2)
   end
 
+  it 'renders a placeholder column when no facility-based projects are in scope' do
+    non_facility_project = create_hopwa_project(funder: funder).tap { |p| p.update!(HousingType: 3) }
+    _, rows = run_and_extract_rows([non_facility_project], 'Q9')
+    expect(rows.fetch('What is the name of the housing facility?')).to eq('No facilities in scope')
+    expect(rows.fetch('Was the housing facility placed into service during this program year? Yes or No.')).to eq('No')
+  end
+
   it 'reports housing outcomes correctly' do
     _, rows = run_and_extract_rows([project], 'Q9')
     expect(rows.fetch('How many households exited to private housing?')).to eq(1)

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb
@@ -384,13 +384,14 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet, type: :model 
       # Total served should now be 3 (enrollment_with_services, no_data_enrollment, no_income_enrollment)
       expect(rows.fetch('STRMU Households Total')).to eq(3)
 
-      # "No Income" should only be 1 (the one with explicit No)
-      # Before the fix, this would have been 2 (including the one with No Data)
+      # "No Income" is only the household with an explicit IncomeFromAnySource: 0 assessment;
+      # the no-data household has no income_benefit record so it doesn't match.
       expect(rows.fetch('How many households maintained no sources of income?')).to eq(1)
 
-      # "Any Income" (the total row for sources) should only be 1 (enrollment_with_services)
-      # Before the fix, this would have been 3 (including everyone with [])
-      expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(1)
+      # "Any Income" total includes households with income sources AND those with explicit "No Income"
+      # (2 = enrollment_with_services + no_income_enrollment). The no-data household is excluded
+      # because it has no income_benefit record at all, so household_income_benefit_source_types is [].
+      expect(rows.fetch('How many households accessed or maintained access to the following sources of income in the past year?')).to eq(2)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Fix two bugs in HOPWA CAPER Facility-Based Housing (FBH) report sheets.

- **Income Sources Total (All FBH Sheets)**: No-income households were excluded from the "How many households accessed or maintained access to the following sources of income?" total row. This is unintuitive but matches the workbook
- **FBH Sheet Layout (Zero Facilities)**: When no projects match the program filter, the sheet rendered with no data columns and appeared broken. Added a placeholder object, rendering blank/zero values 

### Type of Change

Bug fix
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)