### PR TITLE
Prune unused fields from HMIS GraphQL schema

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1513,6 +1513,7 @@ type Client {
   assessments(filters: AssessmentFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
   auditHistory(filters: ClientAuditEventFilterOptions, limit: Int, offset: Int): ClientAuditEventsPaginated!
   ceReferrals(filters: ClientCeReferralFilterOptions, limit: Int, offset: Int): CeReferralsPaginated!
+  contactPoints: [ClientContactPoint!]!
   createdBy: ApplicationUser
   currentLivingSituations(limit: Int, offset: Int): CurrentLivingSituationsPaginated!
   customCaseNotes(limit: Int, offset: Int, sortOrder: CustomCaseNoteSortOption): CustomCaseNotesPaginated!

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1513,7 +1513,6 @@ type Client {
   assessments(filters: AssessmentFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
   auditHistory(filters: ClientAuditEventFilterOptions, limit: Int, offset: Int): ClientAuditEventsPaginated!
   ceReferrals(filters: ClientCeReferralFilterOptions, limit: Int, offset: Int): CeReferralsPaginated!
-  contactPoints: [ClientContactPoint!]!
   createdBy: ApplicationUser
   currentLivingSituations(limit: Int, offset: Int): CurrentLivingSituationsPaginated!
   customCaseNotes(limit: Int, offset: Int, sortOrder: CustomCaseNoteSortOption): CustomCaseNotesPaginated!
@@ -1523,20 +1522,17 @@ type Client {
   dateUpdated: ISO8601DateTime
   desertStorm: NoYesReasonsForMissingData
   differentIdentityText: String
-  disabilities(limit: Int, offset: Int): DisabilitiesPaginated!
   dischargeStatus: DischargeStatus
   dob: ISO8601Date
   dobDataQuality: DOBDataQuality!
   eligibleCeOpportunities(filters: ClientEligibleCeOpportunityFilterOptions, limit: Int, offset: Int, sortOrder: CeOpportunitySortOption): CeOpportunitiesPaginated!
   emailAddresses: [ClientContactPoint!]!
-  employmentEducations(limit: Int, offset: Int): EmploymentEducationsPaginated!
   enabledFeatures: [ClientDashboardFeature!]!
   enrollments(filters: EnrollmentsForClientFilterOptions, includeEnrollmentsWithLimitedAccess: Boolean, limit: Int, offset: Int, sortOrder: EnrollmentSortOption): EnrollmentsPaginated!
   externalIds: [ExternalIdentifier!]!
   files(limit: Int, offset: Int, sortOrder: FileSortOption): FilesPaginated!
   firstName: String
   gender: [Gender!]!
-  healthAndDvs(limit: Int, offset: Int): HealthAndDvsPaginated!
 
   """
   Meets the definition for HUD chronically homeless as of today (time of API request)
@@ -1544,7 +1540,6 @@ type Client {
   hudChronic: Boolean
   id: ID!
   image: ClientImage
-  incomeBenefits(limit: Int, offset: Int): IncomeBenefitsPaginated!
   iraqOif: NoYesReasonsForMissingData
   iraqOnd: NoYesReasonsForMissingData
   koreanWar: NoYesReasonsForMissingData
@@ -1572,7 +1567,6 @@ type Client {
   worldWarIi: NoYesReasonsForMissingData
   yearEnteredService: Int
   yearSeparated: Int
-  youthEducationStatuses(limit: Int, offset: Int): YouthEducationStatusesPaginated!
 }
 
 type ClientAccess {
@@ -2124,53 +2118,6 @@ enum CmExitReason {
   (10) Veteran too ill to participate at this time
   """
   VETERAN_TOO_ILL_TO_PARTICIPATE_AT_THIS_TIME
-}
-
-enum CompleteDisabilityResponse {
-  """
-  Alcohol use disorder
-  """
-  ALCOHOL_USE_DISORDER
-
-  """
-  Both alcohol and drug use disorders
-  """
-  BOTH_ALCOHOL_AND_DRUG_USE_DISORDERS
-
-  """
-  Client doesn't know
-  """
-  CLIENT_DOESN_T_KNOW
-
-  """
-  Client prefers not to answer
-  """
-  CLIENT_PREFERS_NOT_TO_ANSWER
-
-  """
-  Data not collected
-  """
-  DATA_NOT_COLLECTED
-
-  """
-  Drug use disorder
-  """
-  DRUG_USE_DISORDER
-
-  """
-  Invalid Value
-  """
-  INVALID
-
-  """
-  No
-  """
-  NO
-
-  """
-  Yes
-  """
-  YES
 }
 
 enum Component {
@@ -3732,38 +3679,6 @@ input DirectUploadInput {
   filename: String!
 }
 
-type DisabilitiesPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [Disability!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
-}
-
-type Disability {
-  antiRetroviral: NoYesReasonsForMissingData
-  client: Client!
-  createdBy: ApplicationUser
-  dataCollectionStage: DataCollectionStage!
-  dateCreated: ISO8601DateTime
-  dateDeleted: ISO8601DateTime
-  dateUpdated: ISO8601DateTime
-  disabilityResponse: CompleteDisabilityResponse!
-  disabilityType: DisabilityType!
-  enrollment: Enrollment!
-  id: ID!
-  indefiniteAndImpairs: NoYesReasonsForMissingData
-  informationDate: ISO8601Date
-  tCellCount: Int
-  tCellCountAvailable: NoYesReasonsForMissingData
-  tCellSource: TCellSourceViralLoadSource
-  user: ApplicationUser
-  viralLoad: Int
-  viralLoadAvailable: ViralLoadAvailable
-}
-
 """
 Group of disability records that were collected at the same time
 """
@@ -3846,46 +3761,6 @@ enum DisabilityResponse {
   (0) No
   """
   NO
-}
-
-"""
-HUD DisabilityType (1.3)
-"""
-enum DisabilityType {
-  """
-  (7) Chronic health condition
-  """
-  CHRONIC_HEALTH_CONDITION
-
-  """
-  (6) Developmental disability
-  """
-  DEVELOPMENTAL_DISABILITY
-
-  """
-  (8) HIV/AIDS
-  """
-  HIV_AIDS
-
-  """
-  Invalid Value
-  """
-  INVALID
-
-  """
-  (9) Mental health disorder
-  """
-  MENTAL_HEALTH_DISORDER
-
-  """
-  (5) Physical disability
-  """
-  PHYSICAL_DISABILITY
-
-  """
-  (10) Substance use disorder
-  """
-  SUBSTANCE_USE_DISORDER
 }
 
 enum DisabledDisplay {
@@ -3978,16 +3853,6 @@ type EmploymentEducation {
   notEmployedReason: NotEmployedReason
   schoolStatus: SchoolStatus
   user: ApplicationUser
-}
-
-type EmploymentEducationsPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [EmploymentEducation!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
 }
 
 """
@@ -4149,11 +4014,9 @@ type Enrollment {
   dateToStreetEssh: ISO8601Date
   dateUpdated: ISO8601DateTime
   dependentUnder6: DependentUnder6
-  disabilities(limit: Int, offset: Int): DisabilitiesPaginated!
   disabledHoh: NoYesMissing
   disablingCondition: NoYesReasonsForMissingData
   eligibleForRhy: NoYesMissing
-  employmentEducations(limit: Int, offset: Int): EmploymentEducationsPaginated!
   enrollmentCoc: String
   entryDate: ISO8601Date!
   events(limit: Int, offset: Int, sortOrder: EventSortOption): EventsPaginated!
@@ -4169,7 +4032,6 @@ type Enrollment {
   Client Locations that have been collected during this Enrollment
   """
   geolocations: [Geolocation!]!
-  healthAndDvs(limit: Int, offset: Int): HealthAndDvsPaginated!
   hh5Plus: NoYesMissing
   hohLeaseholder: NoYesMissing
   household: Household!
@@ -4181,14 +4043,12 @@ type Enrollment {
   inProgress: Boolean!
   incarceratedAdult: IncarceratedAdult
   incarceratedParent: NoYesReasonsForMissingData
-  incomeBenefits(limit: Int, offset: Int): IncomeBenefitsPaginated!
   insufficientIncome: NoYesReasonsForMissingData
   intakeAssessment: Assessment
   juvenileJusticeMonths: Int
   juvenileJusticeYears: RHYNumberofYears
   lastBedNightDate: ISO8601Date
   lastContact: LastContact
-  lastCurrentLivingSituation: CurrentLivingSituation
   lastServiceDate(serviceTypeId: ID!): ISO8601Date
   lengthOfStay: ResidencePriorLengthOfStay
   literalHomelessHistory: LiteralHomelessHistory
@@ -4250,7 +4110,6 @@ type Enrollment {
   unemploymentFam: NoYesReasonsForMissingData
   user: ApplicationUser
   vamcStation: VamcStationNumber
-  youthEducationStatuses(limit: Int, offset: Int): YouthEducationStatusesPaginated!
 }
 
 type EnrollmentAccess {
@@ -5969,16 +5828,6 @@ type HealthAndDv {
   whenOccurred: WhenDVOccurred
 }
 
-type HealthAndDvsPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [HealthAndDv!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
-}
-
 """
 HUD HealthStatus (R7.1)
 """
@@ -6366,16 +6215,6 @@ type IncomeBenefit {
   wic: NoYesMissing
   workersComp: NoYesMissing
   workersCompAmount: Float
-}
-
-type IncomeBenefitsPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [IncomeBenefit!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
 }
 
 enum InitialBehavior {
@@ -9699,7 +9538,6 @@ type Project {
   HOPWAMedAssistedLivingFac: HOPWAMedAssistedLivingFac
   access: ProjectAccess!
   active: Boolean!
-  affiliatedProjects: [Project!]!
   assessments(filters: AssessmentsForProjectFilterOptions, inProgress: Boolean, limit: Int, offset: Int, sortOrder: AssessmentSortOption): AssessmentsPaginated!
 
   """
@@ -9772,10 +9610,8 @@ type Project {
   projectCocs(limit: Int, offset: Int): ProjectCocsPaginated!
   projectName: String!
   projectType: ProjectType
-  referralRequests(limit: Int, offset: Int): ReferralRequestsPaginated!
   residentialAffiliation: NoYes
   residentialAffiliationProjectIds: [ID!]!
-  residentialAffiliationProjects: [Project!]!
   rrhSubType: RRHSubType
 
   """
@@ -10985,23 +10821,6 @@ type ReferralPostingsPaginated {
 
 type ReferralRequest {
   id: ID!
-  identifier: ID!
-  neededBy: ISO8601Date!
-  requestedOn: ISO8601DateTime!
-  requestorEmail: String!
-  requestorName: String!
-  requestorPhone: String!
-  unitType: UnitTypeObject!
-}
-
-type ReferralRequestsPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [ReferralRequest!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
 }
 
 """
@@ -14134,14 +13953,4 @@ type YouthEducationStatus {
   informationDate: ISO8601Date
   mostRecentEdStatus: MostRecentEdStatus
   user: ApplicationUser
-}
-
-type YouthEducationStatusesPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [YouthEducationStatus!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1581,11 +1581,8 @@ type Client {
 
 type ClientAccess {
   canAuditClients: Boolean!
-  canDeleteAssessments: Boolean!
   canDeleteClient: Boolean!
-  canDeleteEnrollments: Boolean!
   canEditClient: Boolean!
-  canEditEnrollments: Boolean!
   canManageAnyClientFiles: Boolean!
   canManageClientAlerts: Boolean!
   canManageOwnClientFiles: Boolean!
@@ -1593,9 +1590,7 @@ type ClientAccess {
   canMergeClients: Boolean!
   canPrintClientCaseNotes: Boolean!
   canUploadClientFiles: Boolean!
-  canViewAnyConfidentialClientFiles: Boolean!
   canViewAnyFiles: Boolean!
-  canViewAnyNonconfidentialClientFiles: Boolean!
   canViewClientAlerts: Boolean!
   canViewClientEligibleOpportunities: Boolean!
   canViewClientName: Boolean!
@@ -9808,30 +9803,21 @@ type Project {
 }
 
 type ProjectAccess {
-  canAssignReferralTasks: Boolean!
-  canDeleteAssessments: Boolean!
-  canDeleteEnrollments: Boolean!
   canDeleteProject: Boolean!
   canEditEnrollments: Boolean!
   canEditProjectDetails: Boolean!
   canEnrollClients: Boolean!
-  canManageDeniedReferrals: Boolean!
   canManageExternalFormSubmissions: Boolean!
   canManageIncomingReferrals: Boolean!
   canManageOutgoingReferrals: Boolean!
   canManageUnits: Boolean!
-  canPerformAnyReferralTasks: Boolean!
-  canPerformOwnReferralTasks: Boolean!
   canSplitHouseholds: Boolean!
   canStartReferrals: Boolean!
   canUpdateUnitAvailability: Boolean!
-  canViewDob: Boolean!
   canViewEnrollmentDetails: Boolean!
-  canViewFullSsn: Boolean!
   canViewOutgoingReferralDetails: Boolean!
   canViewOutgoingReferralSummaries: Boolean!
   canViewOwnReferrals: Boolean!
-  canViewPartialSsn: Boolean!
   canViewPrioritizedClientLists: Boolean!
   canViewReferrals: Boolean!
   canViewUnits: Boolean!

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1063,14 +1063,10 @@ type CeParticipation {
   ceParticipationStatusEndDate: ISO8601Date
   ceParticipationStatusStartDate: ISO8601Date
   createdBy: ApplicationUser
-  crisisAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   dateCreated: ISO8601DateTime
   dateDeleted: ISO8601DateTime
   dateUpdated: ISO8601DateTime
-  directServices: NoYes @deprecated(reason: "Use ceParticipationServices instead")
-  housingAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   id: ID!
-  preventionAssessment: NoYes @deprecated(reason: "Use ceParticipationServices instead")
   receivesReferrals: NoYes
   user: ApplicationUser
 }
@@ -1976,9 +1972,7 @@ input ClientSearchInput {
   """
   id: ID
   lastName: String
-  organizations: [ID!] @deprecated(reason: "Use the Client Filter instead")
   personalId: String
-  projects: [ID!] @deprecated(reason: "Use the Client Filter instead")
 
   """
   Last 4 digits of SSN
@@ -1989,7 +1983,6 @@ input ClientSearchInput {
   Omnisearch string
   """
   textSearch: String
-  warehouseId: String @deprecated(reason: "Searching by warehouse_id is supported via free text search")
 }
 
 type ClientSearchParams {

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_participation.rb
@@ -22,10 +22,6 @@ module Types
     hud_field :ce_participation_status_start_date, null: true
     hud_field :ce_participation_status_end_date
     hud_field :ce_participation_services, [HmisSchema::Enums::CeParticipationServices], null: false
-    hud_field :crisis_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
-    hud_field :direct_services, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
-    hud_field :housing_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
-    hud_field :prevention_assessment, HmisSchema::Enums::Hud::NoYes, deprecation_reason: 'Use ceParticipationServices instead'
     hud_field :receives_referrals, HmisSchema::Enums::Hud::NoYes
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -76,6 +76,7 @@ module Types
     field :names, [HmisSchema::ClientName], null: false
     field :addresses, [HmisSchema::ClientAddress], null: false
     field :alerts, [HmisSchema::ClientAlert], null: false
+    field :contact_points, [HmisSchema::ClientContactPoint], null: false
     field :phone_numbers, [HmisSchema::ClientContactPoint], null: false
     field :email_addresses, [HmisSchema::ClientContactPoint], null: false
     field :hud_chronic, Boolean, null: true, description: 'Meets the definition for HUD chronically homeless as of today (time of API request)'
@@ -288,6 +289,12 @@ module Types
 
     private def can_view_name
       current_permission?(permission: :can_view_client_name, entity: object)
+    end
+
+    def contact_points
+      return [] unless current_permission?(permission: :can_view_client_contact_info, entity: object)
+
+      load_ar_association(object, :contact_points)
     end
 
     def phone_numbers

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -164,15 +164,10 @@ module Types
       can :view_client_photo
       can :view_dob
       can :view_enrollment_details
-      can :edit_enrollments
-      can :delete_enrollments
-      can :delete_assessments
       can :delete_clients, field_name: :can_delete_client
       can :edit_clients, field_name: :can_edit_client
       can :manage_any_client_files
       can :manage_own_client_files
-      can :view_any_nonconfidential_client_files
-      can :view_any_confidential_client_files
       composite_perm :can_upload_client_files, permissions: [:manage_any_client_files, :manage_own_client_files], mode: :any
       composite_perm :can_view_any_files, permissions: [:manage_own_client_files, :view_any_nonconfidential_client_files, :view_any_confidential_client_files], mode: :any
       can :audit_clients

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -10,11 +10,6 @@ module Types
   class HmisSchema::Client < Types::BaseObject
     include Types::HmisSchema::HasEnrollments
     include Types::HmisSchema::HasServices
-    include Types::HmisSchema::HasIncomeBenefits
-    include Types::HmisSchema::HasDisabilities
-    include Types::HmisSchema::HasHealthAndDvs
-    include Types::HmisSchema::HasYouthEducationStatuses
-    include Types::HmisSchema::HasEmploymentEducations
     include Types::HmisSchema::HasCurrentLivingSituations
     include Types::HmisSchema::HasAssessments
     include Types::HmisSchema::HasCustomCaseNotes
@@ -81,7 +76,6 @@ module Types
     field :names, [HmisSchema::ClientName], null: false
     field :addresses, [HmisSchema::ClientAddress], null: false
     field :alerts, [HmisSchema::ClientAlert], null: false
-    field :contact_points, [HmisSchema::ClientContactPoint], null: false
     field :phone_numbers, [HmisSchema::ClientContactPoint], null: false
     field :email_addresses, [HmisSchema::ClientContactPoint], null: false
     field :hud_chronic, Boolean, null: true, description: 'Meets the definition for HUD chronically homeless as of today (time of API request)'
@@ -105,11 +99,6 @@ module Types
       # Option to include enrollments that the user has "limited" access to
       argument :include_enrollments_with_limited_access, Boolean, required: false
     end
-    income_benefits_field
-    disabilities_field
-    health_and_dvs_field
-    youth_education_statuses_field
-    employment_educations_field
     current_living_situations_field
     assessments_field
     services_field
@@ -211,22 +200,6 @@ module Types
       )
     end
 
-    def income_benefits(**args)
-      resolve_income_benefits(**args)
-    end
-
-    def disabilities(**args)
-      resolve_disabilities(**args)
-    end
-
-    def disability_groups(**args)
-      resolve_disability_groups(**args)
-    end
-
-    def health_and_dvs(**args)
-      resolve_health_and_dvs(**args)
-    end
-
     def assessments(**args)
       resolve_assessments(**args)
     end
@@ -315,12 +288,6 @@ module Types
 
     private def can_view_name
       current_permission?(permission: :can_view_client_name, entity: object)
-    end
-
-    def contact_points
-      return [] unless current_permission?(permission: :can_view_client_contact_info, entity: object)
-
-      load_ar_association(object, :contact_points)
     end
 
     def phone_numbers

--- a/drivers/hmis/app/graphql/types/hmis_schema/client_search_input.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client_search_input.rb
@@ -13,13 +13,10 @@ module Types
     argument :id, ID, 'Client primary key', required: false
     argument :text_search, String, 'Omnisearch string', required: false
     argument :personal_id, String, required: false
-    argument :warehouse_id, String, required: false, deprecation_reason: 'Searching by warehouse_id is supported via free text search'
     argument :first_name, String, required: false
     argument :last_name, String, required: false
     argument :ssn_serial, String, 'Last 4 digits of SSN', required: false
     argument :dob, String, 'Date of birth as format yyyy-mm-dd', required: false
-    argument :projects, [ID], required: false, deprecation_reason: 'Use the Client Filter instead'
-    argument :organizations, [ID], required: false, deprecation_reason: 'Use the Client Filter instead'
 
     def to_params
       OpenStruct.new(to_h.deep_dup)

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -16,11 +16,6 @@ module Types
     include Types::HmisSchema::HasCeAssessments
     include Types::HmisSchema::HasCustomCaseNotes
     include Types::HmisSchema::HasFiles
-    include Types::HmisSchema::HasIncomeBenefits
-    include Types::HmisSchema::HasDisabilities
-    include Types::HmisSchema::HasHealthAndDvs
-    include Types::HmisSchema::HasYouthEducationStatuses
-    include Types::HmisSchema::HasEmploymentEducations
     include Types::HmisSchema::HasCurrentLivingSituations
     include Types::HmisSchema::HasCustomDataElements
     include Types::HmisSchema::HasHudMetadata
@@ -130,14 +125,8 @@ module Types
     custom_case_notes_field
     files_field
     ce_assessments_field
-    income_benefits_field
-    disabilities_field
-    health_and_dvs_field
-    youth_education_statuses_field
-    employment_educations_field
     current_living_situations_field
     field :assessment_eligibilities, [HmisSchema::AssessmentEligibility], null: false
-    field :last_current_living_situation, Types::HmisSchema::CurrentLivingSituation, null: true
     custom_data_elements_field
     # 3.16.1
     field :enrollment_coc, String, null: true
@@ -305,10 +294,6 @@ module Types
       load_ar_association(client, :enrollments).where.not(id: object.id).open_including_wip
     end
 
-    def last_current_living_situation
-      load_ar_association(object, :current_living_situations).max_by(&:information_date)
-    end
-
     def reminders
       # assumption is this is called on a single record; we aren't solving n+1 queries
       project = object.project
@@ -425,22 +410,6 @@ module Types
 
     def files(**args)
       resolve_files(**args)
-    end
-
-    def income_benefits(**args)
-      resolve_income_benefits(**args)
-    end
-
-    def disabilities(**args)
-      resolve_disabilities(**args)
-    end
-
-    def disability_groups(**args)
-      resolve_disability_groups(**args)
-    end
-
-    def health_and_dvs(**args)
-      resolve_health_and_dvs(**args)
     end
 
     def current_unit

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -100,14 +100,9 @@ module Types
     access_field do
       can :delete_project
       can :edit_project_details
-      can :view_partial_ssn
-      can :view_full_ssn
-      can :view_dob
       can :view_enrollment_details
       can :enroll_clients
       can :edit_enrollments
-      can :delete_enrollments
-      can :delete_assessments
       can :manage_units
       can :view_units
       can :manage_incoming_referrals
@@ -115,15 +110,11 @@ module Types
       can :view_outgoing_referral_details
       # TODO(#8067) - reduce duplication of logic with HmisProjectPolicy once we establish a frontend pattern for permission requirements
       composite_perm :can_view_outgoing_referral_summaries, permissions: [:manage_outgoing_referrals, :view_outgoing_referral_details], mode: :any
-      can :manage_denied_referrals
       can :manage_external_form_submissions
       can :split_households
       can :view_referrals
       can :view_own_referrals
       can :start_referrals
-      can :perform_any_referral_tasks
-      can :perform_own_referral_tasks
-      can :assign_referral_tasks
       can :update_unit_availability
       can :view_prioritized_client_lists
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -14,7 +14,6 @@ module Types
     include Types::HmisSchema::HasEnrollments
     include Types::HmisSchema::HasUnits
     include Types::HmisSchema::HasHouseholds
-    include Types::HmisSchema::HasReferralRequests
     include Types::HmisSchema::HasReferralPostings
     include Types::HmisSchema::HasCustomDataElements
     include Types::HmisSchema::HasServices
@@ -82,8 +81,6 @@ module Types
     hud_field :continuum_project, HmisSchema::Enums::Hud::NoYes, null: true
     hud_field :residential_affiliation, HmisSchema::Enums::Hud::NoYes, null: true
     field :residential_affiliation_project_ids, [ID], null: false
-    field :residential_affiliation_projects, [HmisSchema::Project], null: false
-    field :affiliated_projects, [HmisSchema::Project], null: false
     field :active, Boolean, null: false
     field :staff_assignments_enabled, Boolean, null: false, description: 'Whether staff assignment is enabled in this project', method: :staff_assignments_enabled?
     field :auto_enter_enabled, Boolean, null: false, description: 'Whether auto-enter is enabled in this project', method: :should_auto_enter?
@@ -94,7 +91,6 @@ module Types
     field :ce_swimlanes, [HmisSchema::CeSwimlane], null: false, description: 'Coordinated Entry swimlanes that are in templates used by this project'
     enrollments_field filter_args: { omit: [:project_type], type_name: 'EnrollmentsForProject' }
     custom_data_elements_field
-    referral_requests_field :referral_requests
     referral_postings_field :incoming_referral_postings
     referral_postings_field :outgoing_referral_postings
     access_field do
@@ -205,16 +201,8 @@ module Types
       resolve_services(**args, dangerous_skip_permission_check: true)
     end
 
-    def residential_affiliation_projects
-      load_ar_association(object, :residential_projects)
-    end
-
     def residential_affiliation_project_ids
-      residential_affiliation_projects.map(&:id)
-    end
-
-    def affiliated_projects
-      load_ar_association(object, :affiliated_projects)
+      load_ar_association(object, :residential_projects).map(&:id)
     end
 
     # Build OpenStructs to resolve as UnitTypeCapacity
@@ -255,12 +243,6 @@ module Types
       check_enrollment_details_access
 
       resolve_households(object.households, **args, dangerous_skip_permission_check: true)
-    end
-
-    def referral_requests(**args)
-      raise HmisErrors::ApiError, 'Access denied' unless current_permission?(entity: object, permission: :can_manage_incoming_referrals)
-
-      scoped_referral_requests(object.external_referral_requests, **args)
     end
 
     def incoming_referral_postings(**args)

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -44,7 +44,7 @@ module Types
     def client_search(input:, **args)
       # ensure that client search has sufficient search criteria, so as not to allow exposing all clients at once.
       # caller must use some search criteria, OR a service filter by project to limit results (used in Bulk Services)
-      has_search_term = input.to_h.excluding(:projects, :organizations).values.compact_blank.any?
+      has_search_term = input.to_h.values.compact_blank.any?
       has_service_filter = args[:filters]&.service_in_range&.project_id.present?
       raise 'Invalid search. At least 1 search param is required.' unless has_search_term || has_service_filter
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_request.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_request.rb
@@ -9,16 +9,5 @@
 module Types
   class HmisSchema::ReferralRequest < Types::BaseObject
     field :id, ID, null: false
-    field :identifier, ID, null: false
-    field :requested_on, GraphQL::Types::ISO8601DateTime, null: false
-    field :unit_type, HmisSchema::UnitTypeObject, null: false
-    field :needed_by, GraphQL::Types::ISO8601Date, null: false
-    field :requestor_name, String, null: false
-    field :requestor_phone, String, null: false
-    field :requestor_email, String, null: false
-
-    def unit_type
-      load_ar_association(object, :unit_type)
-    end
   end
 end

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -209,13 +209,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     enrollments.any?
   end
 
-  def self.source_for(destination_id:, user:)
-    source_id = GrdaWarehouse::WarehouseClient.find_by(destination_id: destination_id, data_source_id: user.hmis_data_source_id)&.source_id
-    return Hmis::Hud::Client.none unless source_id.present?
-
-    searchable_to(user).where(id: source_id)
-  end
-
   def warehouse_id
     warehouse_client_source&.destination_id
   end
@@ -246,7 +239,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     # Apply ID searches directly, as they can only ever return a single client
     return searchable_to(user).where(id: input.id) if input.id.present?
     return searchable_to(user).where(PersonalID: input.personal_id) if input.personal_id
-    return source_for(destination_id: input.warehouse_id, user: user) if input.warehouse_id
 
     # Build search scope
     scope = Hmis::Hud::Client.where(id: searchable_to(user).select(:id))
@@ -278,9 +270,6 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     # TODO: nicks and/or metaphone searches?
     scope = scope.where(c_t[:SSN].matches("%#{input.ssn_serial}")) if input.ssn_serial.present?
     scope = scope.where(c_t[:DOB].eq(Date.parse(input.dob))) if input.dob.present?
-
-    scope = scope.joins(:projects).merge(Hmis::Hud::Project.viewable_by(user).where(id: input.projects)) if input.projects.present?
-    scope = scope.joins(projects: :organization).merge(Hmis::Hud::Organization.viewable_by(user).where(id: input.organizations)) if input.organizations.present?
 
     Hmis::Hud::Client.where(id: scope.select(:id))
   end

--- a/drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb
@@ -174,14 +174,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           canViewDob
           canViewFullSsn
           canViewPartialSsn
-          canEditEnrollments
-          canDeleteEnrollments
           canViewEnrollmentDetails
-          canDeleteAssessments
           canManageAnyClientFiles
           canManageOwnClientFiles
-          canViewAnyConfidentialClientFiles
-          canViewAnyNonconfidentialClientFiles
+          canViewAnyFiles
           __typename
         }
 

--- a/drivers/hmis/spec/requests/hmis/client_search_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_search_spec.rb
@@ -128,10 +128,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     it 'should not allow search without tokens' do
       expect_gql_error post_graphql(input: {}) { query }, message: /Invalid search/
-
-      # projects and organizations don't count as a query, they are meant to be used as a filter
-      expect_gql_error post_graphql(input: { projects: [p1.id] }) { query }, message: /Invalid search/
-      expect_gql_error post_graphql(input: { organizations: [o1.id] }) { query }, message: /Invalid search/
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb
@@ -53,36 +53,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               #{scalar_fields(Types::HmisSchema::Enrollment)}
             }
           }
-          incomeBenefits {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::IncomeBenefit)}
-            }
-          }
-          disabilities {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::Disability)}
-            }
-          }
-          healthAndDvs {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::HealthAndDv)}
-            }
-          }
-          youthEducationStatuses {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::YouthEducationStatus)}
-            }
-          }
-          employmentEducations {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::EmploymentEducation)}
-            }
-          }
           currentLivingSituations {
             nodesCount
             nodes {
@@ -129,46 +99,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               #{scalar_fields(Types::HmisSchema::Assessment)}
             }
           }
-          services {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::Service)}
-            }
-          }
-          incomeBenefits {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::IncomeBenefit)}
-            }
-          }
-          healthAndDvs {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::HealthAndDv)}
-            }
-          }
-          youthEducationStatuses {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::YouthEducationStatus)}
-            }
-          }
-          employmentEducations {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::EmploymentEducation)}
-            }
-          }
           currentLivingSituations {
             nodesCount
             nodes {
               #{scalar_fields(Types::HmisSchema::CurrentLivingSituation)}
-            }
-          }
-          disabilities {
-            nodesCount
-            nodes {
-              #{scalar_fields(Types::HmisSchema::Disability)}
             }
           }
           currentUnit {
@@ -221,11 +155,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(client['id']).to eq(c1.id.to_s)
       expect(client['enrollments']['nodesCount']).to eq(0)
       expect(client['assessments']['nodesCount']).to eq(0)
-      expect(client['incomeBenefits']['nodesCount']).to eq(0)
-      expect(client['disabilities']['nodesCount']).to eq(0)
-      expect(client['healthAndDvs']['nodesCount']).to eq(0)
-      expect(client['youthEducationStatuses']['nodesCount']).to eq(0)
-      expect(client['employmentEducations']['nodesCount']).to eq(0)
       expect(client['currentLivingSituations']['nodesCount']).to eq(0)
       expect(client['services']['nodesCount']).to eq(0)
     end
@@ -237,11 +166,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(client['id']).to eq(c1.id.to_s)
       expect(client['enrollments']['nodesCount']).to eq(2)
       expect(client['assessments']['nodesCount']).to eq(1)
-      expect(client['incomeBenefits']['nodesCount']).to eq(1)
-      expect(client['disabilities']['nodesCount']).to eq(1)
-      expect(client['healthAndDvs']['nodesCount']).to eq(1)
-      expect(client['youthEducationStatuses']['nodesCount']).to eq(1)
-      expect(client['employmentEducations']['nodesCount']).to eq(1)
       expect(client['currentLivingSituations']['nodesCount']).to eq(1)
       expect(client['services']['nodesCount']).to eq(2)
     end
@@ -283,11 +207,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(enrollment['services']['nodesCount']).to eq(2)
       expect(enrollment['events']['nodesCount']).to eq(1)
       expect(enrollment['assessments']['nodesCount']).to eq(1)
-      expect(enrollment['incomeBenefits']['nodesCount']).to eq(1)
-      expect(enrollment['disabilities']['nodesCount']).to eq(1)
-      expect(enrollment['healthAndDvs']['nodesCount']).to eq(1)
-      expect(enrollment['youthEducationStatuses']['nodesCount']).to eq(1)
-      expect(enrollment['employmentEducations']['nodesCount']).to eq(1)
       expect(enrollment['currentLivingSituations']['nodesCount']).to eq(1)
       expect(enrollment['currentUnit']).to be_nil
       expect(enrollment['numUnitsAssignedToHousehold']).to eq(0)

--- a/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/lookup_client_spec.rb
@@ -112,14 +112,10 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             canViewDob
             canViewFullSsn
             canViewPartialSsn
-            canEditEnrollments
-            canDeleteEnrollments
             canViewEnrollmentDetails
-            canDeleteAssessments
             canManageAnyClientFiles
             canManageOwnClientFiles
-            canViewAnyConfidentialClientFiles
-            canViewAnyNonconfidentialClientFiles
+            canViewAnyFiles
           }
         }
       }
@@ -292,10 +288,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_view_dob, :can_view_project, :can_view_enrollment_details])
     end
 
-    def expected_hash_from_role(role)
-      role.attributes.entries.select { |k, _v| k.match(/^can_/) }.map { |k, v| [k.camelize(:lower), v] }.to_h
-    end
-
     def check_client_access_with_role(hash, role)
       expect(hash).to include(
         'canEditClient' => role.can_edit_clients,
@@ -303,14 +295,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         'canViewDob' => role.can_view_dob,
         'canViewFullSsn' => role.can_view_full_ssn,
         'canViewPartialSsn' => role.can_view_partial_ssn,
-        'canEditEnrollments' => role.can_edit_enrollments,
-        'canDeleteEnrollments' => role.can_delete_enrollments,
         'canViewEnrollmentDetails' => role.can_view_enrollment_details,
-        'canDeleteAssessments' => role.can_delete_assessments,
         'canManageAnyClientFiles' => role.can_manage_any_client_files,
         'canManageOwnClientFiles' => role.can_manage_own_client_files,
-        'canViewAnyConfidentialClientFiles' => role.can_view_any_confidential_client_files,
-        'canViewAnyNonconfidentialClientFiles' => role.can_view_any_nonconfidential_client_files,
+        'canViewAnyFiles' => role.can_manage_own_client_files ||
+          role.can_view_any_nonconfidential_client_files ||
+          role.can_view_any_confidential_client_files,
       )
     end
 

--- a/drivers/hmis/spec/requests/hmis/project_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_spec.rb
@@ -30,9 +30,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   let!(:f2) { create :hmis_hud_funder, data_source: ds1, project: p1 }
   let!(:cep1) { create :hmis_hud_ce_participation, data_source: ds1, project: p1 }
   let!(:hp1) { create :hmis_hud_hmis_participation, data_source: ds1, project: p1 }
-  let!(:referral_request) do
-    create(:hmis_external_api_ac_hmis_referral_request, project: p1)
-  end
 
   # both WIP and non-WIP assessments on a non-WIP enrollment
   let!(:e1) { create(:hmis_hud_enrollment, project: p1, data_source: p1.data_source) }
@@ -87,17 +84,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             access {
               #{scalar_fields(Types::HmisSchema::Project.fields['access'])}
             }
-            referralRequests {
-              nodes  {
-                #{scalar_fields(Types::HmisSchema::ReferralRequest)}
-              }
-            }
           }
         }
       GRAPHQL
     end
 
-    it 'resolves funders, project cocs, referral requests, and inventories' do
+    it 'resolves funders, project cocs, and inventories' do
       response, result = post_graphql(id: p1.id) { query }
 
       aggregate_failures 'checking response' do
@@ -112,7 +104,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         expect(record.dig('funders', 'nodesCount').to_i).to eq(2)
         expect(record.dig('funders', 'nodes').map(&to_id)).to contain_exactly(f1.id, f2.id)
         expect(record.dig('organization', 'id').to_i).to eq(o1.id)
-        expect(record.dig('referralRequests', 'nodes', 0, 'id')).to eq(referral_request.id&.to_s)
         expect(record.dig('ceParticipations', 'nodes', 0, 'id')).to eq(cep1.id&.to_s)
         expect(record.dig('hmisParticipations', 'nodes', 0, 'id')).to eq(hp1.id&.to_s)
       end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Issue: https://github.com/open-path/Green-River/issues/9038

Remove unused fields from the GraphQL API. These are all fields that have been deprecated for several releases or more (or never used at all), so it is safe to remove them.

Frontend PR (codegen): https://github.com/greenriver/hmis-frontend/pull/1429


**Testing instructions:**
- spot-checked app
- tested HUD assessment submission and Project form submission with affiliated projects, since form processing introspects on the schema 

## Type of change
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated spec tests (or not applicable)
