### PR TITLE
fix: sentry config adjustments

### DIFF
--- a/app/jobs/identify_external_clients_job.rb
+++ b/app/jobs/identify_external_clients_job.rb
@@ -45,18 +45,18 @@ class IdentifyExternalClientsJob < BaseJob
         next if content_type.in?(['application/x-empty', 'application/octet-stream'])
 
         if ! content_type.in?(['text/csv', 'text/plain'])
-          log("invalid content type #{content_type}", object_key: input_key)
+          log("invalid content type #{content_type}", s3_path: input_key)
           next
         end
 
         input_rows = data_string ? parse_csv_string(data_string, key: input_key) : nil
         if input_rows.blank?
-          log('invalid CSV content', object_key: input_key)
+          log('invalid CSV content', s3_path: input_key)
           next
         end
 
         output_rows = input_rows.map { |row| process_row(row, external_id_field) }.compact
-        log("matched #{output_rows.size} of #{input_rows.size} rows", type: :info, object_key: input_key)
+        log("matched #{output_rows.size} of #{input_rows.size} rows", type: :info, s3_path: input_key)
 
         # s3.store raises on failure
         s3.store(
@@ -109,11 +109,11 @@ class IdentifyExternalClientsJob < BaseJob
         end
       end
     rescue CSV::MalformedCSVError => e
-      log("CSV parsing error: #{e.message}", object_key: key)
+      log("CSV parsing error: #{e.message}", s3_path: key)
     rescue ArgumentError => e
-      log("Argument error (possibly encoding related): #{e.message}", object_key: key)
+      log("Argument error (possibly encoding related): #{e.message}", s3_path: key)
     rescue StandardError => e
-      log("An unexpected error occurred: #{e.message}", object_key: key)
+      log("An unexpected error occurred: #{e.message}", s3_path: key)
     end
     results
   end
@@ -161,13 +161,13 @@ class IdentifyExternalClientsJob < BaseJob
     end
   end
 
-  def log(message, object_key:, type: :error)
-    Rails.logger.send(type, "#{self.class.name} s3:#{object_key}: #{message}")
+  def log(message, s3_path:, type: :error)
+    Rails.logger.send(type, "#{self.class.name} s3:#{s3_path}: #{message}")
     return unless type == :error
 
     Sentry.capture_exception_with_info(
       StandardError.new(message),
-      info: { object_key: object_key },
+      info: { s3_path: s3_path },
     )
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -10,6 +10,8 @@ if sentry_dsn
   Sentry.init do |config|
     config.dsn = sentry_dsn
     config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+    # sending all the gems isn't that helpful in practice, it just adds noise
+    config.send_modules = false
 
     ENV['SENTRY_PERFORMANCE_TRACE_RATE'].presence.yield_self do |base_trace_rate|
       # enable performance monitoring on QA


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Every sentry message includes all the deps. I don't think it's actually useful, we already know what's deployed. Suggest disabling it ([docs](https://docs.sentry.io/platforms/ruby/configuration/options/#send_modules))

Also the `object_key` we were sending to sentry gets scrubbed based on the 'key' in the name

## Type of change
Config
