### PR TITLE
Fix spurious trivy alert

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -172,9 +172,11 @@ WORKDIR /app
 COPY docker/app/has_rdoc_patch.rb /usr/local/lib/ruby/has_rdoc_patch.rb
 ENV RUBYOPT="-r/usr/local/lib/ruby/has_rdoc_patch.rb ${RUBYOPT}"
 
-# CVE-2025-58767, note rexml is bundled with ruby, and must be explicitly pinned
+# rexml: CVE-2025-58767, rack: CVE in system gem shipped with base image — both must be explicitly updated since they're bundled with ruby
+# gem cleanup removes old gemspecs that vulnerability scanners (e.g. Trivy) would otherwise flag
 RUN gem update --system \
-  && gem update rexml \
+  && gem update rexml rack \
+  && gem cleanup rexml rack \
   && gem install bundler --version=${BUNDLER_VERSION} \
   && bundle config set --local path /bundle \
   && chown -R app-user:app-user /bundle \


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
attempt to fix trivy alert on system rack gem (not a real vuln)

## Type of change
Bug fix
