### PR TITLE
fix: mechanical rename of rails module name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ require_relative '../lib/util/rails_trusted_proxies_config'
 # common route concerns, included here to avoid class loader issues due to "drivers" load order in dev mode
 require_relative '../lib/hud_reports/route_concerns'
 
-module BostonHmis
+module OpenPath
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1

--- a/config/setup_logging.rb
+++ b/config/setup_logging.rb
@@ -87,7 +87,7 @@ class SetupLogging
         message: message,
         rails_env: Rails.env,
         request_time: time,
-        # application: 'BostonHmis::Application',
+        # application: 'OpenPath::Application',
       }.merge(STANDARD_TAGS).reverse_merge(@tags).to_json + "\r\n"
     end
   end

--- a/drivers/access_logs/config/routes.rb
+++ b/drivers/access_logs/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :access_log do
     # TODO
     # get '/my_path', to: 'access_logs/my_controller'

--- a/drivers/all_neighbors_system_dashboard/config/routes.rb
+++ b/drivers/all_neighbors_system_dashboard/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :all_neighbors_system_dashboard do
     namespace :warehouse_reports do
       resources :reports do

--- a/drivers/analysis_tool/config/routes.rb
+++ b/drivers/analysis_tool/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :analysis_tool do
     namespace :warehouse_reports do
       resources :analysis_tool, only: [:index] do

--- a/drivers/boston_reports/config/routes.rb
+++ b/drivers/boston_reports/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :boston_reports do
     namespace :warehouse_reports do
       resources :street_to_homes, only: [:index] do

--- a/drivers/built_for_zero_report/config/routes.rb
+++ b/drivers/built_for_zero_report/config/routes.rb
@@ -11,7 +11,7 @@
 # License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 ###
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :built_for_zero_report do
     namespace :warehouse_reports do
       resources :bfz, only: [:index] do

--- a/drivers/cas_access/config/routes.rb
+++ b/drivers/cas_access/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :cas_access do
     # TODO
     # get '/my_path', to: 'cas_access/my_controller'

--- a/drivers/cas_ce_data/config/routes.rb
+++ b/drivers/cas_ce_data/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :cas_ce_data do
     # TODO
     # get '/my_path', to: 'cas_ce_events/my_controller'

--- a/drivers/ce_performance/config/routes.rb
+++ b/drivers/ce_performance/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :ce_performance do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :destroy] do

--- a/drivers/claims_reporting/config/routes.rb
+++ b/drivers/claims_reporting/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :claims_reporting do
     namespace :warehouse_reports do
       resources :reconciliation, only: [:index, :create]

--- a/drivers/client_access_control/config/routes.rb
+++ b/drivers/client_access_control/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   resources :clients, only: [:index, :show, :new], controller: 'client_access_control/clients' do
     member do
       get :appropriate

--- a/drivers/client_documents_report/config/routes.rb
+++ b/drivers/client_documents_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :client_documents_report do
     # TODO
     # get '/my_path', to: 'client_documents_report/my_controller'

--- a/drivers/client_location_history/config/routes.rb
+++ b/drivers/client_location_history/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :client_location_history do
     resources :clients, only: [:none] do
       get :map, on: :member

--- a/drivers/custom_imports_boston_assessment_lookups/config/routes.rb
+++ b/drivers/custom_imports_boston_assessment_lookups/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :custom_imports_boston_assessment_lookups do
     resources :files, only: [:show]
   end

--- a/drivers/custom_imports_boston_community_of_origin/config/routes.rb
+++ b/drivers/custom_imports_boston_community_of_origin/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :custom_imports_boston_community_of_origin do
     # TODO
     # get '/my_path', to: 'custom_imports_boston_community_of_origin/my_controller'

--- a/drivers/custom_imports_boston_contacts/config/routes.rb
+++ b/drivers/custom_imports_boston_contacts/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :custom_imports_boston_contacts do
     resources :files, only: [:show]
   end

--- a/drivers/custom_imports_boston_service/config/routes.rb
+++ b/drivers/custom_imports_boston_service/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :custom_imports_boston_services do
     resources :files, only: [:show]
   end

--- a/drivers/data_source_report/config/routes.rb
+++ b/drivers/data_source_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :data_source_report do
     namespace :warehouse_reports do
       resources :reports, only: [:index] do

--- a/drivers/datalab_testkit/config/routes.rb
+++ b/drivers/datalab_testkit/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :datalab_testkit do
     # TODO
     # get '/my_path', to: 'datalab_testkit/my_controller'

--- a/drivers/destination_report/config/routes.rb
+++ b/drivers/destination_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :destination_report do
     namespace :warehouse_reports do
       resources :reports, only: [:index] do

--- a/drivers/disability_summary/config/routes.rb
+++ b/drivers/disability_summary/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :disability_summary do
     namespace :warehouse_reports do
       resources :disability_summary, only: [:index] do

--- a/drivers/eccovia_data/config/routes.rb
+++ b/drivers/eccovia_data/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :eccovia_datum do
     # TODO
     # get '/my_path', to: 'eccovia_data/my_controller'

--- a/drivers/financial/config/routes.rb
+++ b/drivers/financial/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :financial do
     resources :clients, only: [:show] do
       get 'rollup/:partial', to: 'clients#rollup', as: :rollup

--- a/drivers/health_comprehensive_assessment/config/routes.rb
+++ b/drivers/health_comprehensive_assessment/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   resources :clients, only: [:none] do
     namespace :health_comprehensive_assessment do
       resources :assessments do

--- a/drivers/health_flexible_service/config/routes.rb
+++ b/drivers/health_flexible_service/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   # NOTE: using only: [:none] because leaving it blank inserts the default routes, which we have moved to a driver
   resources :clients, only: [:none] do
     namespace :health_flexible_service do

--- a/drivers/health_ip_followup_report/config/routes.rb
+++ b/drivers/health_ip_followup_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :health_ip_followup_report do
     namespace :warehouse_reports do
       resources :followup_reports, only: [:index]

--- a/drivers/health_pctp/config/routes.rb
+++ b/drivers/health_pctp/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   resources :clients, only: [:none] do
     namespace :health_pctp do
       resources :careplans do

--- a/drivers/health_qa_factory/config/routes.rb
+++ b/drivers/health_qa_factory/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :health_qa_factory do
     # TODO
     # get '/my_path', to: 'health_qa_factory/my_controller'

--- a/drivers/health_thrive_assessment/config/routes.rb
+++ b/drivers/health_thrive_assessment/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   resources :clients, only: [:none] do
     namespace :health_thrive_assessment do
       resources :assessments

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   get 'hmis/system_status/operational', to: 'system_status#operational'
   get 'hmis/system_status/cache_status', to: 'system_status#cache_status'
   get 'hmis/system_status/details', to: 'system_status#details'

--- a/drivers/hmis_csv_importer/config/routes.rb
+++ b/drivers/hmis_csv_importer/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :hmis_csv_importer do
     resources :loader_errors, only: [:show]
     get 'importer_validations/:id/:file', to: 'importer_validations#show', as: :importer_validation

--- a/drivers/hmis_csv_twenty_twenty/config/routes.rb
+++ b/drivers/hmis_csv_twenty_twenty/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :hmis_csv_twenty_twenty do
     resources :loader_errors, only: [:show]
     get 'importer_validations/:id/:file', to: 'importer_validations#show', as: :importer_validation

--- a/drivers/hmis_csv_twenty_twenty_four/config/routes.rb
+++ b/drivers/hmis_csv_twenty_twenty_four/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hmis_csv_twenty_twenty_four do
   end
 end

--- a/drivers/hmis_csv_twenty_twenty_six/config/routes.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hmis_csv_twenty_twenty_six do
   end
 end

--- a/drivers/hmis_csv_twenty_twenty_two/config/routes.rb
+++ b/drivers/hmis_csv_twenty_twenty_two/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hmis_csv_twenty_twenty_two do
     # TODO
     # get '/my_path', to: 'hmis_csv_twenty_twenty_two/my_controller'

--- a/drivers/hmis_data_quality_tool/config/routes.rb
+++ b/drivers/hmis_data_quality_tool/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :hmis_data_quality_tool do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :destroy] do

--- a/drivers/hmis_external_apis/config/routes.rb
+++ b/drivers/hmis_external_apis/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope(module: :hmis_external_apis) do
     scope(module: :ac_hmis) do
       post '/hmis_external_api/ac_hmis/referrals',

--- a/drivers/hmis_supplemental/config/routes.rb
+++ b/drivers/hmis_supplemental/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   resources :data_sources, only: [:none] do
     namespace :hmis_supplemental do
       resources :data_sets do

--- a/drivers/homeless_summary_report/config/routes.rb
+++ b/drivers/homeless_summary_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :homeless_summary_report do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :destroy] do

--- a/drivers/hopwa_caper/config/routes.rb
+++ b/drivers/hopwa_caper/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hopwa_caper, path: :hud_reports, as: :hud_reports do
     resources :hopwa_capers, controller: :reports do
       get :running, on: :collection

--- a/drivers/hud_apr/config/routes.rb
+++ b/drivers/hud_apr/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   extend HudReports::RouteConcerns
 
   scope module: :hud_apr, path: :hud_reports, as: :hud_reports do

--- a/drivers/hud_data_quality_report/config/routes.rb
+++ b/drivers/hud_data_quality_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hud_data_quality_report, path: :hud_reports, as: :hud_reports do
     resources :past_dqs, controller: 'dqs' do
       get :running, on: :collection

--- a/drivers/hud_hic/config/routes.rb
+++ b/drivers/hud_hic/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hud_hic, path: :hud_reports, as: :hud_reports do
     resources :hics do
       get :running, on: :collection

--- a/drivers/hud_lsa/config/routes.rb
+++ b/drivers/hud_lsa/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hud_lsa, path: :hud_reports, as: :hud_reports do
     resources :lsas do
       get :running, on: :collection

--- a/drivers/hud_path_report/config/routes.rb
+++ b/drivers/hud_path_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hud_path_report, path: :hud_reports, as: :hud_reports do
     resources :paths do
       get :running, on: :collection

--- a/drivers/hud_pit/config/routes.rb
+++ b/drivers/hud_pit/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope module: :hud_pit, path: :hud_reports, as: :hud_reports do
     resources :pits do
       get :running, on: :collection

--- a/drivers/hud_spm_report/config/routes.rb
+++ b/drivers/hud_spm_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   extend HudReports::RouteConcerns
 
   # TODO: build this out

--- a/drivers/hud_twenty_twenty_four_to_twenty_twenty_six/config/routes.rb
+++ b/drivers/hud_twenty_twenty_four_to_twenty_twenty_six/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hud_twenty_twenty_four_to_twenty_twenty_six do
     # TODO
     # get '/my_path', to: 'hud_twenty_twenty_four_to_twenty_twenty_six/my_controller'

--- a/drivers/hud_twenty_twenty_to_twenty_twenty_two/config/routes.rb
+++ b/drivers/hud_twenty_twenty_to_twenty_twenty_two/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hud_twenty_twenty_to_twenty_twenty_two do
     # TODO
     # get '/my_path', to: 'hud_twenty_twenty_to_twenty_twenty_two/my_controller'

--- a/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/config/routes.rb
+++ b/drivers/hud_twenty_twenty_two_to_twenty_twenty_four/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :hud_twenty_twenty_two_to_twenty_twenty_four do
   end
 end

--- a/drivers/inactive_client_report/config/routes.rb
+++ b/drivers/inactive_client_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :inactive_client_report do
     namespace :warehouse_reports do
       resources :reports, only: [:index] do

--- a/drivers/longitudinal_spm/config/routes.rb
+++ b/drivers/longitudinal_spm/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :longitudinal_spm do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :destroy] do

--- a/drivers/ma_reports/config/routes.rb
+++ b/drivers/ma_reports/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :ma_reports do
     namespace :warehouse_reports do
       resources :monthly_project_utilizations do

--- a/drivers/manual_hmis_data/config/routes.rb
+++ b/drivers/manual_hmis_data/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :manual_hmis_data do
     resources :projects, only: [:none] do
       resources :funders, shallow: true, except: [:index, :show]

--- a/drivers/medicaid_hmis_interchange/config/routes.rb
+++ b/drivers/medicaid_hmis_interchange/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :medicaid_hmis_interchange do
     # TODO
     # get '/my_path', to: 'medicaid_hmis_interchange/my_controller'

--- a/drivers/override_summary/config/routes.rb
+++ b/drivers/override_summary/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :override_summary do
     namespace :warehouse_reports do
       resources :reports, only: [:index]

--- a/drivers/performance_measurement/config/routes.rb
+++ b/drivers/performance_measurement/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :performance_measurement do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :update, :destroy] do

--- a/drivers/performance_metrics/config/routes.rb
+++ b/drivers/performance_metrics/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :performance_metrics do
     namespace :warehouse_reports do
       resources :reports, only: [:index, :create, :show, :destroy] do

--- a/drivers/prior_living_situation/config/routes.rb
+++ b/drivers/prior_living_situation/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :prior_living_situation do
     namespace :warehouse_reports do
       resources :prior_living_situation, only: [:index] do

--- a/drivers/project_pass_fail/config/routes.rb
+++ b/drivers/project_pass_fail/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :project_pass_fail do
     namespace :warehouse_reports do
       resources :project_pass_fail, only: [:index, :show, :destroy, :create] do

--- a/drivers/public_reports/config/routes.rb
+++ b/drivers/public_reports/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :public_reports do
     namespace :warehouse_reports do
       resources :point_in_time do

--- a/drivers/start_date_dq/config/routes.rb
+++ b/drivers/start_date_dq/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :start_date_dq do
     namespace :warehouse_reports do
       resources :reports, only: [:index]

--- a/drivers/superset/config/routes.rb
+++ b/drivers/superset/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :superset do
     namespace :warehouse_reports do
       resources :reports, only: [:index]

--- a/drivers/supplemental_enrollment_data/config/routes.rb
+++ b/drivers/supplemental_enrollment_data/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :supplemental_enrollment_datum do
   end
 end

--- a/drivers/synthetic_ce_assessment/config/routes.rb
+++ b/drivers/synthetic_ce_assessment/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :synthetic_ce_assessments do
     resources :project_config, only: [:new, :edit, :update]
   end

--- a/drivers/system_pathways/config/routes.rb
+++ b/drivers/system_pathways/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :system_pathways do
     namespace :warehouse_reports do
       resources :reports do

--- a/drivers/text_message/config/routes.rb
+++ b/drivers/text_message/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :text_message do
     namespace :warehouse_reports do
       resources :queue, only: [:index]

--- a/drivers/user_directory_report/config/routes.rb
+++ b/drivers/user_directory_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :user_directory_report do
     namespace :warehouse_reports do
       resources :users, only: [:none] do

--- a/drivers/user_permission_report/config/routes.rb
+++ b/drivers/user_permission_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   namespace :user_permission_report do
     namespace :warehouse_reports do
       resources :reports, only: [:index]

--- a/drivers/vispdats/config/routes.rb
+++ b/drivers/vispdats/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :vispdat do
     # TODO
     # get '/my_path', to: 'vispdats/my_controller'

--- a/drivers/zip_code_report/config/routes.rb
+++ b/drivers/zip_code_report/config/routes.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-BostonHmis::Application.routes.draw do
+OpenPath::Application.routes.draw do
   scope :zip_code_report do
     # TODO
     # get '/my_path', to: 'zip_code_report/my_controller'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Rename the Rails application module from `BostonHmis` to `OpenPath`, aligning the codebase with the platform's canonical name.


**Note**: this will change the session key, which will invalidate all sessions on deploy (everyone is logged out)

**Question**: is "OpenPath"  a good name? It doesn't collide with any existing namespaces. We end up with rails living in "OpenPath::Application".

- **Application Module**: Mechanically Renamed `module BostonHmis` to `module OpenPath` in `config/application.rb`
- **Driver Routes**: Update `routes.draw` call in all 60+ driver `config/routes.rb` files to reference `OpenPath::Application`

### Type of Change

Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

