### PR TITLE
Add max_depth and max_complexity to HMIS schema

### DIFF
--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -66,26 +66,25 @@ class HmisSchema < GraphQL::Schema
     nil
   end
 
-  module QueryAnalysisLoggers
-    class Depth < GraphQL::Analysis::QueryDepth
-      def result
-        depth = super
-        Rails.logger.info("[HmisSchema] GraphQL query depth=#{depth}")
-        depth
-      end
-    end
-
-    class Complexity < GraphQL::Analysis::QueryComplexity
-      def result
-        complexity = super
-        Rails.logger.info("[HmisSchema] GraphQL query complexity=#{complexity}")
-        complexity
-      end
-    end
-  end
-
   # Set HMIS_GQL_LOG_DEPTH_COMPLEXITY=1 in `.env.development.local` to enable local logging, for tuning max_depth/max_complexity
   if Rails.env.development? && ENV['HMIS_GQL_LOG_DEPTH_COMPLEXITY'].present?
+    module QueryAnalysisLoggers
+      class Depth < GraphQL::Analysis::QueryDepth
+        def result
+          depth = super
+          Rails.logger.info("[HmisSchema] GraphQL query depth=#{depth}")
+          depth
+        end
+      end
+
+      class Complexity < GraphQL::Analysis::QueryComplexity
+        def result
+          complexity = super
+          Rails.logger.info("[HmisSchema] GraphQL query complexity=#{complexity}")
+          complexity
+        end
+      end
+    end
     query_analyzer(QueryAnalysisLoggers::Depth)
     query_analyzer(QueryAnalysisLoggers::Complexity)
   end

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -27,7 +27,7 @@ class HmisSchema < GraphQL::Schema
   # GraphQL-Ruby calls this when something goes wrong while running a query:
   def self.type_error(err, context)
     # if err.is_a?(GraphQL::InvalidNullError)
-    #   # report to your bug tracker heres
+    #   # report to your bug tracker here
     #   return nil
     # end
     super

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -10,6 +10,10 @@ class HmisSchema < GraphQL::Schema
   mutation(Types::HmisSchema::MutationType)
   query(Types::HmisSchema::QueryType)
 
+  # Reject abusive queries during static analysis (before resolvers run), see https://graphql-ruby.org/queries/complexity_and_depth
+  max_depth 30, count_introspection_fields: false # Don't count introspection fields which are only enabled in development
+  max_complexity 1_500
+
   trace_with(GraphqlTraceBehavior)
   trace_with(GraphQL::Tracing::SentryTrace) if Sentry.configuration&.traces_sample_rate&.positive?
 
@@ -23,7 +27,7 @@ class HmisSchema < GraphQL::Schema
   # GraphQL-Ruby calls this when something goes wrong while running a query:
   def self.type_error(err, context)
     # if err.is_a?(GraphQL::InvalidNullError)
-    #   # report to your bug tracker here
+    #   # report to your bug tracker heres
     #   return nil
     # end
     super
@@ -57,8 +61,32 @@ class HmisSchema < GraphQL::Schema
     raise GraphQL::UnauthorizedError, "#{error.type.graphql_name}##{error.object&.id} failed authorization check"
   end
 
-  # Return nil for unauthorized fields. This is expeced in some cases, for example non-summary fields on Enrollment.
+  # Return nil for unauthorized fields. This is expected in some cases, for example non-summary fields on Enrollment.
   def self.unauthorized_field(_error)
     nil
+  end
+
+  module QueryAnalysisLoggers
+    class Depth < GraphQL::Analysis::QueryDepth
+      def result
+        depth = super
+        Rails.logger.info("[HmisSchema] GraphQL query depth=#{depth}")
+        depth
+      end
+    end
+
+    class Complexity < GraphQL::Analysis::QueryComplexity
+      def result
+        complexity = super
+        Rails.logger.info("[HmisSchema] GraphQL query complexity=#{complexity}")
+        complexity
+      end
+    end
+  end
+
+  # Set HMIS_GQL_LOG_DEPTH_COMPLEXITY=1 in `.env.development.local` to enable local logging, for tuning max_depth/max_complexity
+  if Rails.env.development? && ENV['HMIS_GQL_LOG_DEPTH_COMPLEXITY'].present?
+    query_analyzer(QueryAnalysisLoggers::Depth)
+    query_analyzer(QueryAnalysisLoggers::Complexity)
   end
 end

--- a/drivers/hmis/app/graphql/hmis_schema.rb
+++ b/drivers/hmis/app/graphql/hmis_schema.rb
@@ -12,7 +12,7 @@ class HmisSchema < GraphQL::Schema
 
   # Reject abusive queries during static analysis (before resolvers run), see https://graphql-ruby.org/queries/complexity_and_depth
   max_depth 30, count_introspection_fields: false # Don't count introspection fields which are only enabled in development
-  max_complexity 1_500
+  max_complexity 40_000 # Observed max 04/2026: 17k when viewing entry assessments for a 10-person household
 
   trace_with(GraphqlTraceBehavior)
   trace_with(GraphQL::Tracing::SentryTrace) if Sentry.configuration&.traces_sample_rate&.positive?

--- a/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
@@ -10,9 +10,6 @@ require 'rails_helper'
 require_relative 'login_and_permissions'
 require_relative '../../support/graphql_helpers'
 
-# Mirrors defaults in drivers/hmis/app/graphql/hmis_schema.rb (update when those change).
-HMIS_SCHEMA_DEFAULT_MAX_DEPTH = 30
-
 RSpec.describe HmisSchema, 'depth and complexity limits', type: :request do
   include_context 'hmis base setup'
   let!(:access_control) { create_access_control(hmis_user, p1) }
@@ -95,7 +92,7 @@ RSpec.describe HmisSchema, 'depth and complexity limits', type: :request do
     end
 
     it 'rejects pathological depth against schema default max_depth' do
-      # Nested enough to exceed HMIS_SCHEMA_DEFAULT_MAX_DEPTH
+      # Nested enough to exceed default max_depth
       query = build_nested_project_query(10)
       result = HmisSchema.execute(
         query,

--- a/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/graphql_helpers'
+
+# Mirrors defaults in drivers/hmis/app/graphql/hmis_schema.rb (update when those change).
+HMIS_SCHEMA_DEFAULT_MAX_DEPTH = 30
+HMIS_SCHEMA_DEFAULT_MAX_COMPLEXITY = 1_500
+
+RSpec.describe HmisSchema, 'depth and complexity limits', type: :request do
+  include_context 'hmis base setup'
+  let!(:access_control) { create_access_control(hmis_user, p1) }
+
+  # Build a nested project query
+  def build_nested_project_query(cycles)
+    inner = 'id'
+    cycles.times do
+      inner = "organization { projects(limit: 1) { nodes { #{inner} } } }"
+    end
+    <<~GRAPHQL
+      query TestQuery($id: ID!) {
+        project(id: $id) {
+          #{inner}
+        }
+      }
+    GRAPHQL
+  end
+
+  # Build a complex root query using field aliases
+  def build_high_complexity_root_query(field_count)
+    fields = field_count.times.map { |i| "f#{i}: __typename" }.join("\n")
+    <<~GRAPHQL
+      query {
+        #{fields}
+      }
+    GRAPHQL
+  end
+
+  context 'HmisSchema.execute' do
+    let(:graphql_context) do
+      {
+        current_user: hmis_user,
+        true_user: hmis_user,
+        activity_logger: Hmis::GraphqlFieldLogger.new,
+      }
+    end
+
+    it 'allows a normal shallow project query under default limits' do
+      query = <<~GRAPHQL
+        query TestQuery($id: ID!) {
+          project(id: $id) {
+            id
+            organization { id }
+          }
+        }
+      GRAPHQL
+      result = HmisSchema.execute(
+        query,
+        variables: { 'id' => p1.id.to_s },
+        context: graphql_context,
+      )
+      expect(result['errors']).to be_blank
+      expect(result.dig('data', 'project', 'id')).to eq(p1.id.to_s)
+    end
+
+    it 'rejects queries that exceed max_depth before execution' do
+      query = build_nested_project_query(3)
+      result = HmisSchema.execute(
+        query,
+        variables: { 'id' => p1.id.to_s },
+        context: graphql_context,
+        max_depth: 10,
+      )
+      expect(result['errors']).to be_present
+      expect(result['errors'].first['message']).to match(/depth/i)
+      expect(result['data']).to be_nil
+    end
+
+    it 'rejects queries that exceed max_complexity before execution' do
+      query = build_high_complexity_root_query(50)
+      result = HmisSchema.execute(
+        query,
+        context: graphql_context,
+        max_complexity: 10,
+      )
+      expect(result['errors']).to be_present
+      expect(result['errors'].first['message']).to match(/complexity/i)
+      expect(result['data']).to be_nil
+    end
+
+    it 'rejects pathological depth against schema default max_depth' do
+      # Nested enough to exceed HMIS_SCHEMA_DEFAULT_MAX_DEPTH
+      query = build_nested_project_query(10)
+      result = HmisSchema.execute(
+        query,
+        variables: { 'id' => p1.id.to_s },
+        context: graphql_context,
+      )
+      expect(result['errors']).to be_present
+      expect(result['errors'].first['message']).to match(/depth/i)
+    end
+  end
+
+  context 'POST /hmis/hmis-gql' do
+    include GraphqlHelpers
+
+    before(:each) do
+      hmis_login(user)
+    end
+
+    it 'raises on query that exceeds max_depth' do
+      query = build_nested_project_query(10)
+      expect do
+        post_graphql(id: p1.id) { query }
+      end.to raise_error(RuntimeError, /depth/i)
+    end
+
+    it 'raises on query that exceeds max_complexity' do
+      # Default max_complexity is 1_500; each root __typename alias costs ~1 toward the total.
+      query = build_high_complexity_root_query(HMIS_SCHEMA_DEFAULT_MAX_COMPLEXITY + 100)
+      expect do
+        post_graphql(id: p1.id) { query }
+      end.to raise_error(RuntimeError, /complexity/i)
+    end
+  end
+end

--- a/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_schema_limits_spec.rb
@@ -12,7 +12,6 @@ require_relative '../../support/graphql_helpers'
 
 # Mirrors defaults in drivers/hmis/app/graphql/hmis_schema.rb (update when those change).
 HMIS_SCHEMA_DEFAULT_MAX_DEPTH = 30
-HMIS_SCHEMA_DEFAULT_MAX_COMPLEXITY = 1_500
 
 RSpec.describe HmisSchema, 'depth and complexity limits', type: :request do
   include_context 'hmis base setup'
@@ -120,14 +119,6 @@ RSpec.describe HmisSchema, 'depth and complexity limits', type: :request do
       expect do
         post_graphql(id: p1.id) { query }
       end.to raise_error(RuntimeError, /depth/i)
-    end
-
-    it 'raises on query that exceeds max_complexity' do
-      # Default max_complexity is 1_500; each root __typename alias costs ~1 toward the total.
-      query = build_high_complexity_root_query(HMIS_SCHEMA_DEFAULT_MAX_COMPLEXITY + 100)
-      expect do
-        post_graphql(id: p1.id) { query }
-      end.to raise_error(RuntimeError, /complexity/i)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/9042

Add max depth and complexity constraints to HMIS GraphQL schema.
Reference: https://graphql-ruby.org/queries/complexity_and_depth

## Type of change
DoS mitigation

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
