### PR TITLE
Client cleanup job: batch updates to avoid timeout

### DIFF
--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -45,6 +45,8 @@ module GrdaWarehouse::Tasks
     include ArelHelper
     include VeteranStatusCalculator
 
+    INVALIDATION_BATCH_SIZE = 1_000
+
     def initialize(
       max_allowed = 1_000,
       _bogus_notifier = false,
@@ -324,22 +326,24 @@ module GrdaWarehouse::Tasks
         [project_id, data_source_id]
       end.each do |(project_id, data_source_id), batch|
         household_ids = batch.map(&:first)
-        # This is a bit convoluted, but the usual joins weren't working
-        service_history_query = GrdaWarehouse::ServiceHistoryEnrollment.
-          entry.
-          joins(:enrollment).
-          where(data_source_id: data_source_id, project_id: project_id, household_id: household_ids)
-        query = GrdaWarehouse::Hud::Enrollment.where(
-          EnrollmentID: service_history_query.
-            select(:enrollment_group_id),
-          data_source_id: data_source_id,
-          ProjectID: project_id,
-        )
+        household_ids.each_slice(INVALIDATION_BATCH_SIZE) do |household_id_batch|
+          # This is a bit convoluted, but the usual joins weren't working
+          service_history_query = GrdaWarehouse::ServiceHistoryEnrollment.
+            entry.
+            joins(:enrollment).
+            where(data_source_id: data_source_id, project_id: project_id, household_id: household_id_batch)
+          query = GrdaWarehouse::Hud::Enrollment.where(
+            EnrollmentID: service_history_query.
+              select(:enrollment_group_id),
+            data_source_id: data_source_id,
+            ProjectID: project_id,
+          )
 
-        if @dry_run
-          notes << "Invalidating #{query.count} in ds_id: #{data_source_id} project_id: #{project_id}\n\t#{household_ids.inspect}\n"
-        else
-          query.invalidate_processing!
+          if @dry_run
+            notes << "Invalidating #{query.count} in ds_id: #{data_source_id} project_id: #{project_id}\n\t#{household_id_batch.inspect}\n"
+          else
+            query.invalidate_processing!
+          end
         end
       end
 
@@ -348,12 +352,14 @@ module GrdaWarehouse::Tasks
         [project_id, data_source_id]
       end.each do |(project_id, data_source_id), batch|
         household_ids = batch.map(&:first)
-        query = GrdaWarehouse::Hud::Enrollment.
-          where(data_source_id: data_source_id, ProjectID: project_id, HouseholdID: household_ids)
-        if @dry_run
-          notes << "Invalidating #{query.count} in ds_id: #{data_source_id} project_id: #{project_id}\n\t#{household_ids.inspect}"
-        else
-          query.invalidate_processing!
+        household_ids.each_slice(INVALIDATION_BATCH_SIZE) do |household_id_batch|
+          query = GrdaWarehouse::Hud::Enrollment.
+            where(data_source_id: data_source_id, ProjectID: project_id, HouseholdID: household_id_batch)
+          if @dry_run
+            notes << "Invalidating #{query.count} in ds_id: #{data_source_id} project_id: #{project_id}\n\t#{household_id_batch.inspect}"
+          else
+            query.invalidate_processing!
+          end
         end
       end
 

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -1296,5 +1296,51 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
         end
       end
     end
+
+    context 'when mismatched and correctly classified enrollments exist in different projects' do
+      let!(:project_b) { create_project(project_type: 1) }
+
+      let(:mismatched_hh_id) { Hmis::Hud::Base.generate_uuid }
+      let(:clean_hh_id) { Hmis::Hud::Base.generate_uuid }
+
+      # project (project_a): 2-person household that SH will misclassify as individual
+      let!(:mismatched_enrollments) do
+        [create_client_with_warehouse_link, create_client_with_warehouse_link].map do |client|
+          create_enrollment(client: client, project: project, entry_date: 1.month.ago, household_id: mismatched_hh_id)
+        end
+      end
+
+      # project_b: 2-person household that SH correctly classifies as family
+      let!(:clean_enrollments) do
+        [create_client_with_warehouse_link, create_client_with_warehouse_link].map do |client|
+          create_enrollment(client: client, project: project_b, entry_date: 1.month.ago, household_id: clean_hh_id)
+        end
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+        # Only flip project_a's SH entries to individual, leaving project_b correct
+        GrdaWarehouse::ServiceHistoryEnrollment.entry.where(project_id: project.ProjectID).
+          update_all(presented_as_individual: true)
+        mismatched_enrollments.each { |e| e.update_columns(processed_as: 'stale', processed_hash: 'stale') }
+        clean_enrollments.each { |e| e.update_columns(processed_as: 'current', processed_hash: 'current') }
+      end
+
+      it 'invalidates only the mismatched project enrollments' do
+        cleanup.invalidate_incorrect_family_enrollments
+
+        mismatched_enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to be_nil
+          expect(e.processed_hash).to be_nil
+        end
+
+        clean_enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to eq('current')
+          expect(e.processed_hash).to eq('current')
+        end
+      end
+    end
   end
 end

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -7,6 +7,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../../../shared_contexts/hud_enrollment_builders'
 
 DEFAULT_DEST_ATTR = {
   FirstName: 'Blair',
@@ -1171,5 +1172,129 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
 
   def cleanup_columns
     @cleanup.client_columns.values.map { |c| Arel.sql(c) }
+  end
+
+  describe 'invalidate_incorrect_family_enrollments (infer_from_household_id)' do
+    include_context 'HUD enrollment builders'
+
+    let!(:config) { create(:config_3c) } # infer_family_from_household_id: true
+    let(:cleanup) { described_class.new }
+    let!(:project) { create_project(project_type: 1) }
+
+    before do
+      GrdaWarehouse::Config.invalidate_cache
+      Rails.cache.clear
+    end
+
+    context 'when enrollment data has families but service history says individual' do
+      let(:household_ids) { 3.times.map { Hmis::Hud::Base.generate_uuid } }
+      let!(:enrollments) do
+        household_ids.flat_map do |hh_id|
+          client_a = create_client_with_warehouse_link
+          client_b = create_client_with_warehouse_link
+          [
+            create_enrollment(client: client_a, project: project, entry_date: 1.month.ago, household_id: hh_id),
+            create_enrollment(client: client_b, project: project, entry_date: 1.month.ago, household_id: hh_id),
+          ]
+        end
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+        # Flip SH to individual, creating a mismatch with the multi-person enrollment data
+        GrdaWarehouse::ServiceHistoryEnrollment.entry.update_all(presented_as_individual: true)
+        enrollments.each { |e| e.update_columns(processed_as: 'stale', processed_hash: 'stale') }
+      end
+
+      it 'invalidates all mismatched enrollments' do
+        cleanup.invalidate_incorrect_family_enrollments
+
+        enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to be_nil
+          expect(e.processed_hash).to be_nil
+        end
+      end
+
+      it 'invalidates across batch boundaries' do
+        # Batching is over household_ids (3), not enrollments (6); size 2 splits into [2, 1]
+        stub_const('GrdaWarehouse::Tasks::ClientCleanup::INVALIDATION_BATCH_SIZE', 2)
+        cleanup.invalidate_incorrect_family_enrollments
+
+        enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to be_nil
+          expect(e.processed_hash).to be_nil
+        end
+      end
+    end
+
+    context 'when service history says family but enrollment data says individual' do
+      let(:household_ids) { 3.times.map { Hmis::Hud::Base.generate_uuid } }
+      let!(:enrollments) do
+        household_ids.map do |hh_id|
+          client = create_client_with_warehouse_link
+          create_enrollment(client: client, project: project, entry_date: 1.month.ago, household_id: hh_id)
+        end
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+        # Flip SH to family, creating a mismatch with the single-person enrollment data
+        GrdaWarehouse::ServiceHistoryEnrollment.entry.update_all(presented_as_individual: false)
+        enrollments.each { |e| e.update_columns(processed_as: 'stale', processed_hash: 'stale') }
+      end
+
+      it 'invalidates all mismatched enrollments' do
+        cleanup.invalidate_incorrect_family_enrollments
+
+        enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to be_nil
+          expect(e.processed_hash).to be_nil
+        end
+      end
+
+      it 'invalidates across batch boundaries' do
+        # Batching is over household_ids (3), each single-member; size 2 splits into [2, 1]
+        stub_const('GrdaWarehouse::Tasks::ClientCleanup::INVALIDATION_BATCH_SIZE', 2)
+        cleanup.invalidate_incorrect_family_enrollments
+
+        enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to be_nil
+          expect(e.processed_hash).to be_nil
+        end
+      end
+    end
+
+    context 'when enrollment data matches service history' do
+      let(:hh_id) { Hmis::Hud::Base.generate_uuid }
+      let!(:enrollments) do
+        client_a = create_client_with_warehouse_link
+        client_b = create_client_with_warehouse_link
+        [
+          create_enrollment(client: client_a, project: project, entry_date: 1.month.ago, household_id: hh_id),
+          create_enrollment(client: client_b, project: project, entry_date: 1.month.ago, household_id: hh_id),
+        ]
+      end
+
+      before do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+        # SH already correct: rebuild sets presented_as_individual: false for the 2-person household,
+        # so cleanup should leave these enrollments untouched.
+        enrollments.each { |e| e.update_columns(processed_as: 'current', processed_hash: 'current') }
+      end
+
+      it 'does not invalidate correctly classified enrollments' do
+        cleanup.invalidate_incorrect_family_enrollments
+
+        enrollments.each do |e|
+          e.reload
+          expect(e.processed_as).to eq('current')
+          expect(e.processed_hash).to eq('current')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Attempt to make record invalidation more performant in client cleanup and avoid pg timeout on updates. The `incorrectly_non_individuals` and `missing_non_individuals` loops now batch `invalidate_processing!` calls to prevent timeouts on large data sets

### Type of Change
Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)