### PR TITLE
Deprecate unused form rule queries and filters

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5255,11 +5255,11 @@ type FormRule {
 
 input FormRuleFilterOptions {
   activeStatus: [ActiveStatus!]
-  appliedToProject: ID
-  definition: ID
-  formType: [FormRole!]
-  projectType: [ProjectType!]
-  systemForm: [SystemStatus!]
+  appliedToProject: ID @deprecated(reason: "No longer used by the frontend")
+  definition: ID @deprecated(reason: "No longer used by the frontend")
+  formType: [FormRole!] @deprecated(reason: "No longer used by the frontend")
+  projectType: [ProjectType!] @deprecated(reason: "No longer used by the frontend")
+  systemForm: [SystemStatus!] @deprecated(reason: "No longer used by the frontend")
 }
 
 input FormRuleInput {

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -5255,11 +5255,9 @@ type FormRule {
 
 input FormRuleFilterOptions {
   activeStatus: [ActiveStatus!]
-  appliedToProject: ID @deprecated(reason: "No longer used by the frontend")
-  definition: ID @deprecated(reason: "No longer used by the frontend")
-  formType: [FormRole!] @deprecated(reason: "No longer used by the frontend")
-  projectType: [ProjectType!] @deprecated(reason: "No longer used by the frontend")
-  systemForm: [SystemStatus!] @deprecated(reason: "No longer used by the frontend")
+  appliedToProject: ID
+  projectType: [ProjectType!]
+  systemForm: [SystemStatus!]
 }
 
 input FormRuleInput {
@@ -10058,8 +10056,6 @@ type Query {
   formDefinition(id: ID!): FormDefinition
   formIdentifier(identifier: String!): FormIdentifier
   formIdentifiers(filters: FormIdentifierFilterOptions, limit: Int, offset: Int): FormIdentifiersPaginated!
-  formRule(id: ID!): FormRule @deprecated(reason: "No longer used by the frontend")
-  formRules(filters: FormRuleFilterOptions, limit: Int, offset: Int, sortOrder: FormRuleSortOption): FormRulesPaginated! @deprecated(reason: "No longer used by the frontend; form rules are queried by their FormDefinition")
 
   """
   Funder lookup
@@ -10145,8 +10141,6 @@ type Query {
   Service lookup
   """
   service(id: ID!): Service
-  serviceCategories(limit: Int, offset: Int): ServiceCategoriesPaginated! @deprecated(reason: "No longer used by the frontend")
-  serviceCategory(id: ID!): ServiceCategory @deprecated(reason: "No longer used by the frontend")
 
   """
   Get most relevant form definition for the specified service type
@@ -11371,16 +11365,6 @@ type Service {
   subTypeProvided: ServiceSubTypeProvided
   typeProvided: ServiceTypeProvided
   user: ApplicationUser
-}
-
-type ServiceCategoriesPaginated {
-  hasMoreAfter: Boolean!
-  hasMoreBefore: Boolean!
-  limit: Int!
-  nodes: [ServiceCategory!]!
-  nodesCount: Int!
-  offset: Int!
-  pagesCount: Int!
 }
 
 type ServiceCategory {

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -10145,8 +10145,8 @@ type Query {
   Service lookup
   """
   service(id: ID!): Service
-  serviceCategories(limit: Int, offset: Int): ServiceCategoriesPaginated!
-  serviceCategory(id: ID!): ServiceCategory
+  serviceCategories(limit: Int, offset: Int): ServiceCategoriesPaginated! @deprecated(reason: "No longer used by the frontend")
+  serviceCategory(id: ID!): ServiceCategory @deprecated(reason: "No longer used by the frontend")
 
   """
   Get most relevant form definition for the specified service type

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -10058,8 +10058,8 @@ type Query {
   formDefinition(id: ID!): FormDefinition
   formIdentifier(identifier: String!): FormIdentifier
   formIdentifiers(filters: FormIdentifierFilterOptions, limit: Int, offset: Int): FormIdentifiersPaginated!
-  formRule(id: ID!): FormRule
-  formRules(filters: FormRuleFilterOptions, limit: Int, offset: Int, sortOrder: FormRuleSortOption): FormRulesPaginated!
+  formRule(id: ID!): FormRule @deprecated(reason: "No longer used by the frontend")
+  formRules(filters: FormRuleFilterOptions, limit: Int, offset: Int, sortOrder: FormRuleSortOption): FormRulesPaginated! @deprecated(reason: "No longer used by the frontend; form rules are queried by their FormDefinition")
 
   """
   Funder lookup

--- a/drivers/hmis/app/graphql/types/admin/form_rule.rb
+++ b/drivers/hmis/app/graphql/types/admin/form_rule.rb
@@ -13,11 +13,9 @@ module Types
 
     available_filter_options do
       arg :active_status, [Types::HmisSchema::Enums::ActiveStatus]
-      arg :form_type, [Types::Forms::Enums::FormRole], deprecation_reason: 'No longer used by the frontend'
-      arg :system_form, [Types::HmisSchema::Enums::SystemStatus], deprecation_reason: 'No longer used by the frontend'
-      arg :project_type, [Types::HmisSchema::Enums::ProjectType], deprecation_reason: 'No longer used by the frontend'
-      arg :applied_to_project, ID, deprecation_reason: 'No longer used by the frontend'
-      arg :definition, ID, deprecation_reason: 'No longer used by the frontend'
+      arg :system_form, [Types::HmisSchema::Enums::SystemStatus]
+      arg :project_type, [Types::HmisSchema::Enums::ProjectType]
+      arg :applied_to_project, ID
     end
 
     field :id, ID, null: false

--- a/drivers/hmis/app/graphql/types/admin/form_rule.rb
+++ b/drivers/hmis/app/graphql/types/admin/form_rule.rb
@@ -12,12 +12,12 @@ module Types
     graphql_name 'FormRule'
 
     available_filter_options do
-      arg :form_type, [Types::Forms::Enums::FormRole] # FIXME: static roles should be excluded
       arg :active_status, [Types::HmisSchema::Enums::ActiveStatus]
-      arg :system_form, [Types::HmisSchema::Enums::SystemStatus]
-      arg :project_type, [Types::HmisSchema::Enums::ProjectType]
-      arg :applied_to_project, ID
-      arg :definition, ID
+      arg :form_type, [Types::Forms::Enums::FormRole], deprecation_reason: 'No longer used by the frontend'
+      arg :system_form, [Types::HmisSchema::Enums::SystemStatus], deprecation_reason: 'No longer used by the frontend'
+      arg :project_type, [Types::HmisSchema::Enums::ProjectType], deprecation_reason: 'No longer used by the frontend'
+      arg :applied_to_project, ID, deprecation_reason: 'No longer used by the frontend'
+      arg :definition, ID, deprecation_reason: 'No longer used by the frontend'
     end
 
     field :id, ID, null: false

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -426,23 +426,6 @@ module Types
         preload(:project, :client, :organization)
     end
 
-    field :service_category, Types::HmisSchema::ServiceCategory, null: true, deprecation_reason: 'No longer used by the frontend' do
-      argument :id, ID, required: true
-    end
-    def service_category(id:)
-      raise 'Access denied' unless current_user.can_configure_data_collection?
-
-      Hmis::Hud::CustomServiceCategory.find_by(id: id)
-    end
-
-    field :service_categories, Types::HmisSchema::ServiceCategory.page_type, null: false, deprecation_reason: 'No longer used by the frontend'
-    def service_categories
-      raise 'Access denied' unless current_user.can_configure_data_collection?
-
-      # TODO: add sort and filter capabilities
-      Hmis::Hud::CustomServiceCategory.all
-    end
-
     field :service_types, Types::HmisSchema::ServiceType.page_type, null: false do
       filters_argument HmisSchema::ServiceType
     end
@@ -498,25 +481,6 @@ module Types
       scope = scope.apply_filters(filters) if filters
       # Sort system-managed forms last, because they aren't edited through the config tool. Then sort by most recently updated.
       scope.order(managed_in_version_control: :asc, updated_at: :desc, id: :desc)
-    end
-
-    form_rules_field deprecation_reason: 'No longer used by the frontend; form rules are queried by their FormDefinition'
-    def form_rules(**args)
-      access_denied! unless current_user.can_configure_data_collection?
-
-      scope = Hmis::Form::Instance.all
-      scope = scope.with_role(Hmis::Form::Definition::NON_ADMIN_FORM_ROLES) unless current_user.can_administrate_config?
-
-      resolve_form_rules(scope, **args)
-    end
-
-    field :form_rule, Types::Admin::FormRule, null: true, deprecation_reason: 'No longer used by the frontend' do
-      argument :id, ID, required: true
-    end
-    def form_rule(id:)
-      access_denied! unless current_user.can_configure_data_collection?
-
-      Hmis::Form::Instance.find_by(id: id)
     end
 
     field :project_configs, Types::HmisSchema::ProjectConfig.page_type, null: false do

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -426,7 +426,7 @@ module Types
         preload(:project, :client, :organization)
     end
 
-    field :service_category, Types::HmisSchema::ServiceCategory, null: true do
+    field :service_category, Types::HmisSchema::ServiceCategory, null: true, deprecation_reason: 'No longer used by the frontend' do
       argument :id, ID, required: true
     end
     def service_category(id:)
@@ -435,7 +435,7 @@ module Types
       Hmis::Hud::CustomServiceCategory.find_by(id: id)
     end
 
-    field :service_categories, Types::HmisSchema::ServiceCategory.page_type, null: false
+    field :service_categories, Types::HmisSchema::ServiceCategory.page_type, null: false, deprecation_reason: 'No longer used by the frontend'
     def service_categories
       raise 'Access denied' unless current_user.can_configure_data_collection?
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -500,7 +500,7 @@ module Types
       scope.order(managed_in_version_control: :asc, updated_at: :desc, id: :desc)
     end
 
-    form_rules_field
+    form_rules_field deprecation_reason: 'No longer used by the frontend; form rules are queried by their FormDefinition'
     def form_rules(**args)
       access_denied! unless current_user.can_configure_data_collection?
 
@@ -510,7 +510,7 @@ module Types
       resolve_form_rules(scope, **args)
     end
 
-    field :form_rule, Types::Admin::FormRule, null: true do
+    field :form_rule, Types::Admin::FormRule, null: true, deprecation_reason: 'No longer used by the frontend' do
       argument :id, ID, required: true
     end
     def form_rule(id:)

--- a/drivers/hmis/app/models/hmis/filter/form_instance_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/form_instance_filter.rb
@@ -10,8 +10,6 @@ class Hmis::Filter::FormInstanceFilter < Hmis::Filter::BaseFilter
   def filter_scope(scope)
     scope = ensure_scope(scope)
     scope.
-      yield_self(&method(:with_form_type)).
-      yield_self(&method(:with_definition)).
       yield_self(&method(:with_project_type)).
       yield_self(&method(:for_project)).
       yield_self(&method(:with_active_status)).
@@ -20,20 +18,6 @@ class Hmis::Filter::FormInstanceFilter < Hmis::Filter::BaseFilter
   end
 
   protected
-
-  def with_form_type(scope)
-    with_filter(scope, :form_type) do
-      identifiers = Hmis::Form::Definition.where(role: input.form_type).pluck(:identifier)
-      scope.where(definition_identifier: identifiers)
-    end
-  end
-
-  def with_definition(scope)
-    with_filter(scope, :definition) do
-      identifier = Hmis::Form::Definition.find_by(id: input.definition)&.identifier
-      scope.where(definition_identifier: identifier)
-    end
-  end
 
   def with_project_type(scope)
     with_filter(scope, :project_type) { scope.where(project_type: input.project_type) }

--- a/drivers/hmis/spec/requests/hmis/form_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/form_rules_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   let!(:assessment) { create :hmis_form_definition, identifier: 'test-custom-assessment', role: :CUSTOM_ASSESSMENT }
   let!(:assessment_rule) { create :hmis_form_instance, definition_identifier: 'test-custom-assessment', entity: p1, active: true }
-
-  let!(:service) { create :hmis_form_definition, identifier: 'test-service', role: :SERVICE }
-  let!(:service_rule) { create :hmis_form_instance, definition_identifier: 'test-service', entity: p1, active: true, custom_service_category: create(:hmis_custom_service_category, data_source: ds1) }
+  let!(:inactive_rule) { create :hmis_form_instance, definition_identifier: 'test-custom-assessment', active: false }
 
   before(:each) do
     hmis_login(user)
@@ -30,25 +28,26 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let(:query) do
       <<~GRAPHQL
         query GetFormRules(
+          $id: ID!
+          $limit: Int = 25
+          $offset: Int = 0
           $filters: FormRuleFilterOptions
-          $limit: Int
+          $sortOrder: FormRuleSortOption
         ) {
-          formRules(
-            filters: $filters
-            limit: $limit
-          ) {
-            nodesCount
-            nodes {
-              id
-              definitionId
-              definitionRole
-              definitionTitle
-              projectId
-              projectName
-              organizationId
-              organization {
-                id
-                organizationName
+          formDefinition(id: $id) {
+            id
+            cacheKey
+            formRules(
+              limit: $limit
+              offset: $offset
+              filters: $filters
+              sortOrder: $sortOrder
+            ) {
+              offset
+              limit
+              nodesCount
+              nodes {
+                #{scalar_fields(Types::Admin::FormRule)}
               }
             }
           }
@@ -56,30 +55,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       GRAPHQL
     end
 
-    def query_form_rules(filters: nil, limit: 25)
-      response, result = post_graphql(filters: filters, limit: limit) { query }
+    def query_form_rules(id:, filters: nil, limit: 25)
+      response, result = post_graphql(id: id, filters: filters, limit: limit) { query }
       expect(response.status).to eq(200), result.inspect
-      result.dig('data', 'formRules', 'nodes')
+      result.dig('data', 'formDefinition', 'formRules', 'nodes')
     end
 
-    it 'should return all form rules when the user has full access' do
-      rules = query_form_rules
-      expect(rules.count).to be >= 10 # includes rules we created as well as seeded HUD rules
+    it 'should return all custom form rules for a definition' do
+      rules = query_form_rules(id: assessment.id)
+      expect(rules.count).to eq(2)
     end
 
-    it 'should return filtered form rules' do
-      rules = query_form_rules(filters: { form_type: [:INTAKE] })
+    it 'should return all seeded form rules for a hud service' do
+      service_definition = Hmis::Form::Definition.with_role(:SERVICE).first
+      rules = query_form_rules(id: service_definition.id)
+      expect(rules.count).to be >= 10
+    end
+
+    it 'should filter form rules' do
+      rules = query_form_rules(id: assessment.id, filters: { activeStatus: [:ACTIVE] })
       expect(rules.count).to eq(1)
-      expect(rules.dig(0, 'definitionRole')).to eq('INTAKE')
-    end
-
-    it 'should return only rules with appropriate roles when the user is not a super admin' do
-      remove_permissions(access_control, :can_administrate_config)
-      rules = query_form_rules(limit: 100)
-      expect(rules.pluck('definitionRole').uniq).to contain_exactly('CUSTOM_ASSESSMENT', 'SERVICE')
-
-      rules = query_form_rules(filters: { form_type: [:INTAKE] })
-      expect(rules.count).to eq(0)
+      expect(rules.pluck('id')).not_to include(inactive_rule.id)
     end
 
     context 'when there are many form rules' do
@@ -96,7 +92,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
       it 'avoids n+1' do
         expect do
-          rules = query_form_rules(limit: 100)
+          rules = query_form_rules(id: assessment.id, limit: 100)
           expect(rules.count).to eq(100)
         end.to make_database_queries(count: 5..15)
       end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Linked frontend PR: https://github.com/greenriver/hmis-frontend/pull/1433

I noticed these unused api surfaces while working on #6691, but split the deprecations to a separate PR since this work can target the base release branch, instead of the long-lived feature branch for that ticket.

Changes this PR proposes:
- Remove `formRule` query, which is not used anywhere on the frontend. There isn't anywhere in the UI where we query for only 1 form rule at once.
- Remove `formRules` root query, which is also no longer used on the frontend. We now only query form rules under a given `formDefinition`.
- Remove form rule `FilterOptions` which are not used anywhere in the UI.
- Remove the `serviceCategory` and `serviceCategories` queries, which are also not used by the frontend.
  - Unlike the above, which I think were previously used and are now unused, I believe these were always unused, and added on the assumption we'd use them later. 
  - I'd still propose to remove them so we aren't maintaining unused code.
- Update the existing form rules spec file so that it tests a query more similar to the one the frontend actually resolves.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
