### PR TITLE
Remove conditional logic for LOS on PLS B

### DIFF
--- a/drivers/hmis/lib/form_data/default/fragments/prior_living_situation_b.json
+++ b/drivers/hmis/lib/form_data/default/fragments/prior_living_situation_b.json
@@ -60,23 +60,7 @@
       "mapping": {
         "record_type": "ENROLLMENT",
         "field_name": "lengthOfStay"
-      },
-      "_comment": "Only enabled for non-Homeless situations. If previous situation was homeless, you only need to ask about the approx date started.",
-      "enable_behavior": "ALL",
-      "enable_when": [
-        {
-          "_comment": "PriorLivingSituation has been answered",
-          "question": "q_3_917B_1",
-          "operator": "EXISTS",
-          "answer_boolean": true
-        },
-        {
-          "_comment": "PriorLivingSituation is a non-Homeless situation",
-          "question": "q_3_917B_1",
-          "operator": "NOT_EQUAL",
-          "answer_group_code": "HOMELESS"
-        }
-      ]
+      }
     },
     {
       "type": "GROUP",

--- a/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
+++ b/drivers/hmis/spec/system/hmis/hud_assessment_data_elements_spec.rb
@@ -84,7 +84,6 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
         assert_text 'Where did the client spend the night before project entry?'
 
         # These aren't visible on pageload since we are in the conditional version
-        assert_no_text 'Length of stay'
         assert_no_text 'Approximate date this episode of homelessness started'
         assert_no_text 'number of times the client has been on the streets'
         assert_no_text 'Total number of months homeless'
@@ -93,10 +92,12 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
 
       it 'displays correct options and saves correctly when PLS is homeless situation' do
         mui_select 'Safe Haven', from: 'Prior Living Situation'
+        assert_text 'Length of stay'
         assert_text 'Approximate date this episode of homelessness started'
         assert_text 'number of times the client has been on the streets'
         assert_text 'Total number of months homeless'
 
+        mui_select 'One week or more, but less than one month', from: /Length of stay/
         mui_date_select 'Approximate date this episode of homelessness started', date: today - 4.weeks
         mui_select 'Four or more times', from: /Regardless of where they stayed the night before/
         mui_select 'More than 12 months', from: /Total number of months homeless/
@@ -104,6 +105,7 @@ RSpec.feature 'Hmis Form behavior for HUD elements', type: :system do
         expect do
           save_ignoring_warnings
         end.to change(e1, :living_situation).to(118).
+          and change(e1, :length_of_stay).to(2).
           and change(e1, :date_to_street_essh).to(today - 4.weeks).
           and change(e1, :times_homeless_past_three_years).to(4).
           and change(e1, :months_homeless_past_three_years).to(113)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- **Note** I'm proposing to merge this to release-208 (instead of 209) since the change is small, and we don't want the communications that already went out to be too far away from the actual prod update. Let me know if you agree! I can retarget to 209 otherwise.

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
Remove conditional logic for Length of Stay collection on the Prior Living Situation B fragment. Length of Stay is now collected regardless of if the PLS was a homeless situation.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Data collection expansion

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable) - see QA instructions on ticket

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
