### PR TITLE
fix: Correct FY2026 HOPWA CAPER tab labels and order

### DIFF
--- a/db/warehouse/migrate/20260410000000_rename_hopwa_caper_fy2026_question_labels.rb
+++ b/db/warehouse/migrate/20260410000000_rename_hopwa_caper_fy2026_question_labels.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Removes the Q\d+: numeric prefixes from FY2026 HOPWA CAPER question labels.
+# These labels are persisted in hud_report_cells.question (universe rows) and in
+# the json/jsonb arrays on hud_report_instances (question_names, build_for_questions, remaining_questions).
+class RenameHopwaCaperFy2026QuestionLabels < ActiveRecord::Migration[7.2]
+  REPORT_NAME = 'HOPWA CAPER - FY 2026'
+
+  RENAMES = {
+    'Q1: Demographics and Prior Living Situation' => 'Demographics and Prior Living Situation',
+    'Q2: TBRA' => 'TBRA',
+    'Q3: STRMU' => 'STRMU',
+    'Q4: PHP' => 'PHP',
+    'Q5: Housing Information Services' => 'Housing Information Services',
+    'Q6: Supportive Services' => 'Supportive Services',
+    'Q7: Access To Care' => 'Access To Care',
+    'Q9: ST-TFBH' => 'ST-TFBH',
+    'Q10: P-FBH' => 'P-FBH',
+  }.freeze
+
+  def up
+    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).select(:id)
+
+    RENAMES.each do |old_label, new_label|
+      # Universe rows on report cells
+      HudReports::ReportCell.where(report_instance_id: fy2026_instance_ids, question: old_label).
+        update_all(question: new_label)
+
+      # JSON arrays on report instances — replace each old string in-place
+      HudReports::ReportInstance.where(id: fy2026_instance_ids).find_each do |instance|
+        changed = false
+
+        [:question_names, :build_for_questions, :remaining_questions].each do |col|
+          arr = instance.send(col)
+          next unless arr.is_a?(Array) && arr.include?(old_label)
+
+          instance.send(:"#{col}=", arr.map { |v| v == old_label ? new_label : v })
+          changed = true
+        end
+
+        instance.save!(validate: false) if changed
+      end
+    end
+  end
+
+  def down
+    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).select(:id)
+
+    RENAMES.each do |old_label, new_label|
+      HudReports::ReportCell.where(report_instance_id: fy2026_instance_ids, question: new_label).
+        update_all(question: old_label)
+
+      HudReports::ReportInstance.where(id: fy2026_instance_ids).find_each do |instance|
+        changed = false
+
+        [:question_names, :build_for_questions, :remaining_questions].each do |col|
+          arr = instance.send(col)
+          next unless arr.is_a?(Array) && arr.include?(new_label)
+
+          instance.send(:"#{col}=", arr.map { |v| v == new_label ? old_label : v })
+          changed = true
+        end
+
+        instance.save!(validate: false) if changed
+      end
+    end
+  end
+end

--- a/db/warehouse/migrate/20260410000000_rename_hopwa_caper_fy2026_question_labels.rb
+++ b/db/warehouse/migrate/20260410000000_rename_hopwa_caper_fy2026_question_labels.rb
@@ -25,50 +25,45 @@ class RenameHopwaCaperFy2026QuestionLabels < ActiveRecord::Migration[7.2]
   }.freeze
 
   def up
-    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).select(:id)
+    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).pluck(:id)
 
     RENAMES.each do |old_label, new_label|
-      # Universe rows on report cells
       HudReports::ReportCell.where(report_instance_id: fy2026_instance_ids, question: old_label).
         update_all(question: new_label)
-
-      # JSON arrays on report instances — replace each old string in-place
-      HudReports::ReportInstance.where(id: fy2026_instance_ids).find_each do |instance|
-        changed = false
-
-        [:question_names, :build_for_questions, :remaining_questions].each do |col|
-          arr = instance.send(col)
-          next unless arr.is_a?(Array) && arr.include?(old_label)
-
-          instance.send(:"#{col}=", arr.map { |v| v == old_label ? new_label : v })
-          changed = true
-        end
-
-        instance.save!(validate: false) if changed
-      end
     end
+
+    rename_instance_json(fy2026_instance_ids, RENAMES)
   end
 
   def down
-    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).select(:id)
+    fy2026_instance_ids = HudReports::ReportInstance.where(report_name: REPORT_NAME).pluck(:id)
 
     RENAMES.each do |old_label, new_label|
       HudReports::ReportCell.where(report_instance_id: fy2026_instance_ids, question: new_label).
         update_all(question: old_label)
+    end
 
-      HudReports::ReportInstance.where(id: fy2026_instance_ids).find_each do |instance|
-        changed = false
+    rename_instance_json(fy2026_instance_ids, RENAMES.invert)
+  end
 
-        [:question_names, :build_for_questions, :remaining_questions].each do |col|
-          arr = instance.send(col)
-          next unless arr.is_a?(Array) && arr.include?(new_label)
+  private
 
-          instance.send(:"#{col}=", arr.map { |v| v == new_label ? old_label : v })
-          changed = true
-        end
+  def rename_instance_json(instance_ids, renames)
+    HudReports::ReportInstance.where(id: instance_ids).find_each do |instance|
+      changed = false
 
-        instance.save!(validate: false) if changed
+      [:question_names, :build_for_questions, :remaining_questions].each do |col|
+        arr = instance.public_send(col)
+        next unless arr.is_a?(Array)
+
+        renamed = arr.map { |v| renames.fetch(v, v) }
+        next if renamed == arr
+
+        instance.public_send(:"#{col}=", renamed)
+        changed = true
       end
+
+      instance.save!(validate: false) if changed
     end
   end
 end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/generator.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/generator.rb
@@ -55,22 +55,17 @@ module HopwaCaper::Generators::Fy2026
 
     def self.questions
       sheets = [
-        HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivingSituationSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::TbraSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::PhpSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::HousingInfoSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::StTfbhSheet,
-        HopwaCaper::Generators::Fy2026::Sheets::PFbhSheet,
+        Sheets::DemographicsAndPriorLivingSituationSheet,
+        Sheets::TbraSheet,
+        Sheets::PFbhSheet,
+        Sheets::StTfbhSheet,
+        Sheets::StrmuSheet,
+        Sheets::PhpSheet,
+        Sheets::HousingInfoSheet,
+        Sheets::SupportiveServicesSheet,
       ]
-
-      sheets << HopwaCaper::Generators::Fy2026::Sheets::AccessToCareSheet if HopwaCaper::Configuration.new.atc_tab_enabled?
-
-      sheets = sheets.sort_by { |s| s.question_number.gsub(/\AQ(\d+).*/, '\\1').to_i }
-      sheets.map do |q|
-        [q.question_number, q]
-      end.to_h.freeze
+      sheets << Sheets::AccessToCareSheet if HopwaCaper::Configuration.new.atc_tab_enabled?
+      sheets.map { |q| [q.question_number, q] }.to_h.freeze
     end
 
     def self.valid_question_number(question_number)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/access_to_care_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/access_to_care_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class AccessToCareSheet < Base
-    QUESTION_NUMBER = 'Q7: Access To Care'
+    QUESTION_NUMBER = 'Access To Care'
     QUESTION_NUMBERS = ['Q7'].freeze
     SHEET_TITLE = 'Access to Care (ATC)'
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/demographics_and_prior_living_situation_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/demographics_and_prior_living_situation_sheet.rb
@@ -9,7 +9,7 @@
 # https://files.hudexchange.info/resources/documents/HOPWA-Consolidated-APR-CAPER-User-Manual-Chapter-16.pdf
 module HopwaCaper::Generators::Fy2026::Sheets
   class DemographicsAndPriorLivingSituationSheet < Base
-    QUESTION_NUMBER = 'Q1: Demographics and Prior Living Situation'
+    QUESTION_NUMBER = 'Demographics and Prior Living Situation'
     QUESTION_NUMBERS = ['Q1'].freeze
 
     CONTENTS = {

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/housing_info_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/housing_info_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class HousingInfoSheet < BaseProgramSheet
-    QUESTION_NUMBER = 'Q5: Housing Information Services'
+    QUESTION_NUMBER = 'Housing Information Services'
     QUESTION_NUMBERS = ['Q5'].freeze
     SHEET_TITLE = 'Complete for all households served with HOPWA-funded Housing Information Services by your organization in the reporting year.'
     HOUSING_INFO_CATEGORY_NAME = 'HOPWA Housing Information'

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/p_fbh_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/p_fbh_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class PFbhSheet < BaseFbhSheet
-    QUESTION_NUMBER = 'Q10: P-FBH'
+    QUESTION_NUMBER = 'P-FBH'
     QUESTION_NUMBERS = ['Q10'].freeze
     SHEET_TITLE = 'Complete this section for all Households served with HOPWA Permanent Facility-Based Housing assistance by your organization in the reporting year. NOTE: Scattered-Site Facilities may be reported as one Facility.'
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/php_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/php_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class PhpSheet < BaseProgramSheet
-    QUESTION_NUMBER = 'Q4: PHP'
+    QUESTION_NUMBER = 'PHP'
     QUESTION_NUMBERS = ['Q4'].freeze
     SHEET_TITLE = 'Complete this section for all Households served with HOPWA Permanent Housing Placement (PHP) assistance by your organization in the reporting year.'
     CONTENTS = [

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/st_tfbh_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/st_tfbh_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class StTfbhSheet < BaseFbhSheet
-    QUESTION_NUMBER = 'Q9: ST-TFBH'
+    QUESTION_NUMBER = 'ST-TFBH'
     QUESTION_NUMBERS = ['Q9'].freeze
     SHEET_TITLE = 'Complete this section for Facilities, Households served with HOPWA Short-Term or Transitional Facility-Based Housing assistance by your organization in the reporting year. Note: Scattered-Site Facilities may be reported as one Facility. Examples include Short-Term and Transitional Housing Types, Facility Based Housing with a tenure of fewer than 24 months, short-term treatment or health facilities, hotel-motel vouchers.'
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/strmu_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class StrmuSheet < BaseProgramSheet
-    QUESTION_NUMBER = 'Q3: STRMU'
+    QUESTION_NUMBER = 'STRMU'
     QUESTION_NUMBERS = ['Q3'].freeze
     SHEET_TITLE = 'Complete this section for all Households served with HOPWA Short-Term Rent, Mortgage, and Utilities Assistance (STRMU) by your organization in the reporting year.'
     CONTENTS = [

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/supportive_services_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/supportive_services_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class SupportiveServicesSheet < Base
-    QUESTION_NUMBER = 'Q6: Supportive Services'
+    QUESTION_NUMBER = 'Supportive Services'
     QUESTION_NUMBERS = ['Q6'].freeze
     SHEET_TITLE = 'Complete for all households served with HOPWA funded Supportive Services by your organization in the reporting year.'
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/tbra_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/tbra_sheet.rb
@@ -8,7 +8,7 @@
 
 module HopwaCaper::Generators::Fy2026::Sheets
   class TbraSheet < BaseProgramSheet
-    QUESTION_NUMBER = 'Q2: TBRA'
+    QUESTION_NUMBER = 'TBRA'
     QUESTION_NUMBERS = ['Q2'].freeze
     SHEET_TITLE = 'Complete this section for all Households served with HOPWA Tenant-Based Rental Assistance (TBRA) by your organization in the reporting year.'
     CONTENTS = [


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Reorder FY2026 HOPWA CAPER tabs and remove invented numeric question prefixes to match the HUD spec.

- **All FY2026 Sheet Labels**: Removed the `Q\d+:` numeric prefixes from `QUESTION_NUMBER` in all 9 sheet files (e.g. `'Q3: STRMU'` → `'STRMU'`). These numbers were not part of the HUD spec and cluttered tab labels in the UI.
- **FY2026 Generator**: Replaced the fragile regex-based `sort_by` with an explicit ordered list reflecting the correct spec tab order: Demographics → TBRA → P-FBH → ST-TFBH → STRMU → PHP → Housing Information Services → Supportive Services → Access To Care.
- Data migration to rename persisted question labels in `hud_report_cells.question` (universe rows) and the `question_names`, `build_for_questions`, and `remaining_questions` JSON arrays on `hud_report_instances`, scoped to FY2026 reports only. FY2024 read-only historical data is untouched.

### Type of Change

Code clean-up
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)


