### PR TITLE
CVE-2026-39983 basic-ftp npm

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -617,10 +617,10 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
-basic-ftp@^5.0.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.0.tgz#7c2dff63c918bde60e6bad1f2ff93dcf5137a40a"
-  integrity sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==
+basic-ftp@5.2.1, basic-ftp@^5.0.2:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.1.tgz#818ba176e0e52a9e746e8576331f7e9474b94668"
+  integrity sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==
 
 beautifymarker@^1.0.9:
   version "1.0.9"


### PR DESCRIPTION
CVE-2026-39983 basic-ftp npm