### PR TITLE
Add data source to HMIS project configs

### DIFF
--- a/db/warehouse/migrate/20260413070708_add_data_source_id_to_hmis_project_configs.rb
+++ b/db/warehouse/migrate/20260413070708_add_data_source_id_to_hmis_project_configs.rb
@@ -13,7 +13,7 @@ class AddDataSourceIdToHmisProjectConfigs < ActiveRecord::Migration[7.2]
         )
       SQL
 
-      # If there are project configs but no HMIS data source, this raises ActiveRecord::NotNullViolation
+      # If there are project configs but no HMIS data source (which would be unexpected), this raises ActiveRecord::NotNullViolation
       change_column_null :hmis_project_configs, :data_source_id, false
     end
   end

--- a/db/warehouse/migrate/20260413070708_add_data_source_id_to_hmis_project_configs.rb
+++ b/db/warehouse/migrate/20260413070708_add_data_source_id_to_hmis_project_configs.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddDataSourceIdToHmisProjectConfigs < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      add_reference :hmis_project_configs, :data_source, null: true, foreign_key: true
+
+      # This does nothing if there are no project configs or HMIS data sources.
+      execute <<-SQL.squish
+        UPDATE hmis_project_configs
+        SET data_source_id = (
+          SELECT id FROM data_sources WHERE hmis IS NOT NULL ORDER BY id ASC LIMIT 1
+        )
+      SQL
+
+      # If there are project configs but no HMIS data source, this raises ActiveRecord::NotNullViolation
+      change_column_null :hmis_project_configs, :data_source_id, false
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_reference :hmis_project_configs, :data_source
+    end
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260413070708
+# rails db:migrate:down:warehouse VERSION=20260413070708

--- a/drivers/hmis/app/graphql/mutations/create_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/create_project_config.rb
@@ -14,7 +14,7 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(input:)
-      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_create?
 
       errors = HmisErrors::Errors.new
       errors.add :config_type, :required if input.config_type.blank?

--- a/drivers/hmis/app/graphql/mutations/create_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/create_project_config.rb
@@ -14,6 +14,7 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(input:)
+      # todo @martha - policy?
       access_denied! unless current_user.can_configure_data_collection?
 
       errors = HmisErrors::Errors.new
@@ -22,6 +23,7 @@ module Mutations
 
       record = Hmis::ProjectConfig.config_factory(input.config_type)
       record.assign_attributes(input.to_params.excluding(:config_type))
+      record.data_source_id = current_user.hmis_data_source_id
       if record.valid?
         record.save!
       else

--- a/drivers/hmis/app/graphql/mutations/create_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/create_project_config.rb
@@ -14,8 +14,7 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(input:)
-      # todo @martha - policy?
-      access_denied! unless current_user.can_configure_data_collection?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
 
       errors = HmisErrors::Errors.new
       errors.add :config_type, :required if input.config_type.blank?

--- a/drivers/hmis/app/graphql/mutations/delete_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project_config.rb
@@ -14,6 +14,7 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:)
+      # todo @martha - policy?
       record = Hmis::ProjectConfig.find(id)
       access_denied! unless current_user.can_configure_data_collection?
 

--- a/drivers/hmis/app/graphql/mutations/delete_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project_config.rb
@@ -14,10 +14,8 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:)
-      # todo @martha - policy?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
       record = Hmis::ProjectConfig.find(id)
-      access_denied! unless current_user.can_configure_data_collection?
-
       record.destroy!
 
       {

--- a/drivers/hmis/app/graphql/mutations/delete_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_project_config.rb
@@ -14,8 +14,8 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:)
-      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
       record = Hmis::ProjectConfig.find(id)
+      access_denied! unless policy_for(record, policy_type: :project_config).can_destroy?
       record.destroy!
 
       {

--- a/drivers/hmis/app/graphql/mutations/update_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_config.rb
@@ -15,6 +15,7 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:, input:)
+      # TODO @martha - policy?
       record = Hmis::ProjectConfig.find(id)
       access_denied! unless current_user.can_configure_data_collection?
 
@@ -28,7 +29,7 @@ module Mutations
       end
 
       {
-        record: record,
+        project_config: record,
         errors: errors,
       }
     end

--- a/drivers/hmis/app/graphql/mutations/update_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_config.rb
@@ -15,10 +15,9 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:, input:)
-      # TODO @martha - policy?
-      record = Hmis::ProjectConfig.find(id)
-      access_denied! unless current_user.can_configure_data_collection?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
 
+      record = Hmis::ProjectConfig.find(id)
       record.assign_attributes(**input.to_params)
 
       if record.valid?

--- a/drivers/hmis/app/graphql/mutations/update_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_config.rb
@@ -15,9 +15,8 @@ module Mutations
     field :errors, [Types::HmisSchema::ValidationError], null: false, resolver: Resolvers::ValidationErrors
 
     def resolve(id:, input:)
-      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
-
       record = Hmis::ProjectConfig.find(id)
+      access_denied! unless policy_for(record, policy_type: :project_config).can_update?
       record.assign_attributes(**input.to_params)
 
       if record.valid?

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -90,7 +90,7 @@ module Types
       when 'ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS'
         eligible_referral_step_assignment_user_picklist(project, user: user)
       when 'PROJECTS_RECEIVING_DIRECT_CE_REFERRALS'
-        projects_receiving_direct_ce_referrals(from_project: project)
+        projects_receiving_direct_ce_referrals(user: user, from_project: project)
       when 'UNIT_GROUPS_FOR_PROJECT_DIRECT_CE_REFERRAL'
         # pass project_id, not project, since we *don't* want to enforce that the user must be able to view this project
         unit_groups_for_project_direct_ce_referral(project_id: project_id, user: user)
@@ -702,9 +702,11 @@ module Types
         map(&:to_pick_list_option)
     end
 
-    def self.projects_receiving_direct_ce_referrals(from_project:)
+    def self.projects_receiving_direct_ce_referrals(user:, from_project:)
       return [] unless Hmis::Ce.configuration.enabled?
-      return [] unless Hmis::ProjectConfig.with_config_type('COORDINATED_ENTRY').any?
+      return [] unless Hmis::ProjectConfig.with_config_type('COORDINATED_ENTRY').
+        where(data_source_id: user.hmis_data_source_id).
+        any?
 
       # Load all projects in the data source into memory and iterate through them to call detect_best_config_for_project.
       project_scope = Hmis::Hud::Project.where(data_source: from_project.data_source).

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -487,7 +487,7 @@ module Types
       filters_argument Types::HmisSchema::ProjectConfig
     end
     def project_configs(filters: nil)
-      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_view?
 
       scope = Hmis::ProjectConfig.viewable_by(current_user)
       scope = scope.apply_filters(filters) if filters

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -523,7 +523,7 @@ module Types
       filters_argument Types::HmisSchema::ProjectConfig
     end
     def project_configs(filters: nil)
-      access_denied! unless current_user.can_configure_data_collection?
+      access_denied! unless policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
 
       scope = Hmis::ProjectConfig.viewable_by(current_user)
       scope = scope.apply_filters(filters) if filters

--- a/drivers/hmis/app/models/hmis/auth_policies/project_config_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/project_config_policy.rb
@@ -7,8 +7,35 @@
 ###
 
 class Hmis::AuthPolicies::ProjectConfigPolicy < Hmis::AuthPolicies::ResourcePolicy
+  class Instance < Hmis::AuthPolicies::BasePolicy
+    def can_update?
+      in_data_source? && can_manage?
+    end
+
+    def can_destroy?
+      in_data_source? && can_manage?
+    end
+
+    protected
+
+    def in_data_source?
+      resource.data_source_id == user.hmis_data_source_id
+    end
+
+    def can_manage?
+      global_permissions.include?(:can_configure_data_collection)
+    end
+
+    def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::ProjectConfig)
+  end
+
   class Global < Hmis::AuthPolicies::BasePolicy
-    # Whether the user can manage project configs in the current HMIS data source.
+    def can_create? = can_manage?
+
+    def can_view? = can_manage?
+
+    protected
+
     def can_manage?
       global_permissions.include?(:can_configure_data_collection)
     end

--- a/drivers/hmis/app/models/hmis/auth_policies/project_config_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/project_config_policy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+class Hmis::AuthPolicies::ProjectConfigPolicy < Hmis::AuthPolicies::ResourcePolicy
+  class Global < Hmis::AuthPolicies::BasePolicy
+    # Whether the user can manage project configs in the current HMIS data source.
+    def can_manage?
+      global_permissions.include?(:can_configure_data_collection)
+    end
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::ProjectConfig)
+  end
+end

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -41,7 +41,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   validate :validate_consistent_data_source
 
   scope :viewable_by, ->(user) do
-    return none unless user.policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
+    return none unless user.policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_view?
 
     where(data_source_id: user.hmis_data_source_id)
   end

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -9,6 +9,7 @@
 class Hmis::ProjectConfig < Hmis::HmisBase
   self.table_name = 'hmis_project_configs'
 
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :project, optional: true, class_name: 'Hmis::Hud::Project'
   belongs_to :organization, optional: true, class_name: 'Hmis::Hud::Organization'
   validate :exactly_one_of_project_org_type
@@ -37,16 +38,13 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   validates :type, inclusion: { in: CONFIG_TYPE_FACTORIES.values }
 
   validate :validate_config_options_json
+  validate :validate_consistent_data_source
 
   scope :viewable_by, ->(user) do
-    # Special case this, rather than using ProjectRelated concern, because project isn't a direct relationship.
-    # Project config can apply to a project, an organization, or a project type.
-    # Right now we have no way to gate viewability by data source for ProjectConfigs defined by project type - TODO(#6691)
-    project_ids = Hmis::Hud::Project.viewable_by(user).pluck(:id)
-    organization_ids = Hmis::Hud::Organization.viewable_by(user).pluck(:id)
-    where(project_id: project_ids).
-      or(where(organization_id: organization_ids)).
-      or(where(project_id: nil, organization_id: nil))
+    # todo @martha - waiting for more discussion, should put in a policy?
+    return none unless user.policy_context.global_permissions.include?(:can_configure_data_collection)
+
+    where(data_source_id: user.hmis_data_source_id)
   end
 
   def validate_config_options_json
@@ -71,7 +69,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   end
 
   scope :for_project, ->(project) do
-    where(
+    where(data_source_id: project.data_source_id).where(
       arel_table[:project_id].eq(project.id).
         or(arel_table[:organization_id].eq(project.organization.id)).
         or(arel_table[:project_type].eq(project.project_type)),
@@ -79,7 +77,12 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   end
 
   scope :for_projects, ->(projects) do
-    where(
+    return none if projects.empty?
+
+    # Expect all projects to be from the same data source; raise otherwise
+    data_source_id = projects.pluck(:data_source_id).uniq.sole
+
+    where(data_source_id: data_source_id).where(
       arel_table[:project_id].in(projects.map(&:id)).
         or(arel_table[:organization_id].in(projects.map { |p| p.organization.id })).
         or(arel_table[:project_type].in(projects.map(&:project_type).uniq)),
@@ -123,6 +126,11 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   end
 
   private
+
+  def validate_consistent_data_source
+    errors.add(:base, 'Data source must be the same as project') if project.present? && data_source != project.data_source
+    errors.add(:base, 'Data source must be the same as organization') if organization.present? && data_source != organization.data_source
+  end
 
   def set_config_option(key, value)
     new_options = { key => value }.stringify_keys

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -41,8 +41,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   validate :validate_consistent_data_source
 
   scope :viewable_by, ->(user) do
-    # todo @martha - waiting for more discussion, should put in a policy?
-    return none unless user.policy_context.global_permissions.include?(:can_configure_data_collection)
+    return none unless user.policy_for(Hmis::ProjectConfig, policy_type: :project_config).can_manage?
 
     where(data_source_id: user.hmis_data_source_id)
   end

--- a/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
@@ -7,30 +7,31 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :hmis_project_auto_enter_config, class: 'Hmis::ProjectAutoEnterConfig' do
+  # Shared defaults for all Hmis::ProjectConfig STI types.
+  factory :hmis_project_config_base, class: 'Hmis::ProjectConfig' do
     association :data_source, factory: :hmis_data_source
     created_at { Time.current }
     updated_at { Time.current }
+
+    # Match data source when project or organization is set.
+    after(:build) do |config, evaluator|
+      config.data_source = evaluator.project.data_source if evaluator.project.present?
+      config.data_source = evaluator.organization.data_source if evaluator.organization.present?
+    end
   end
 
-  factory :hmis_project_auto_exit_config, class: 'Hmis::ProjectAutoExitConfig' do
-    association :data_source, factory: :hmis_data_source
-    created_at { Time.current }
-    updated_at { Time.current }
+  factory :hmis_project_auto_enter_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectAutoEnterConfig' do
+  end
+
+  factory :hmis_project_auto_exit_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectAutoExitConfig' do
     config_options { { 'length_of_absence_days': 30 }.to_json }
   end
 
-  factory :hmis_project_staff_assignment_config, class: 'Hmis::ProjectStaffAssignmentConfig' do
-    association :data_source, factory: :hmis_data_source
+  factory :hmis_project_staff_assignment_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectStaffAssignmentConfig' do
     association :project, factory: :hmis_hud_project
-    created_at { Time.current }
-    updated_at { Time.current }
   end
 
-  factory :hmis_project_ce_config, class: 'Hmis::ProjectCeConfig' do
-    association :data_source, factory: :hmis_data_source
-    created_at { Time.current }
-    updated_at { Time.current }
+  factory :hmis_project_ce_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectCeConfig' do
     enabled { true }
 
     transient do
@@ -48,9 +49,6 @@ FactoryBot.define do
     end
   end
 
-  factory :hmis_project_sends_direct_ce_referrals_config, class: 'Hmis::ProjectSendsDirectCeReferralsConfig' do
-    association :data_source, factory: :hmis_data_source
-    created_at { Time.current }
-    updated_at { Time.current }
+  factory :hmis_project_sends_direct_ce_referrals_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectSendsDirectCeReferralsConfig' do
   end
 end

--- a/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
@@ -8,23 +8,27 @@
 
 FactoryBot.define do
   factory :hmis_project_auto_enter_config, class: 'Hmis::ProjectAutoEnterConfig' do
+    association :data_source, factory: :hmis_data_source
     created_at { Time.current }
     updated_at { Time.current }
   end
 
   factory :hmis_project_auto_exit_config, class: 'Hmis::ProjectAutoExitConfig' do
+    association :data_source, factory: :hmis_data_source
     created_at { Time.current }
     updated_at { Time.current }
     config_options { { 'length_of_absence_days': 30 }.to_json }
   end
 
   factory :hmis_project_staff_assignment_config, class: 'Hmis::ProjectStaffAssignmentConfig' do
+    association :data_source, factory: :hmis_data_source
     association :project, factory: :hmis_hud_project
     created_at { Time.current }
     updated_at { Time.current }
   end
 
   factory :hmis_project_ce_config, class: 'Hmis::ProjectCeConfig' do
+    association :data_source, factory: :hmis_data_source
     created_at { Time.current }
     updated_at { Time.current }
     enabled { true }
@@ -45,6 +49,7 @@ FactoryBot.define do
   end
 
   factory :hmis_project_sends_direct_ce_referrals_config, class: 'Hmis::ProjectSendsDirectCeReferralsConfig' do
+    association :data_source, factory: :hmis_data_source
     created_at { Time.current }
     updated_at { Time.current }
   end

--- a/drivers/hmis/spec/models/hmis/auth_policies/project_config_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/project_config_policy_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hmis::AuthPolicies::ProjectConfigPolicy, type: :model do
+  let(:data_source) { create(:hmis_data_source) }
+  let(:user) { create(:hmis_user, data_source: data_source) }
+
+  describe 'Global#can_manage?' do
+    let(:policy) { user.policy_for(Hmis::ProjectConfig, policy_type: :project_config) }
+
+    context 'when user has can_configure_data_collection in the data source' do
+      let!(:access_control) { create_access_control(user, data_source, with_permission: [:can_configure_data_collection]) }
+
+      it 'returns true' do
+        expect(policy.can_manage?).to be true
+      end
+    end
+
+    context 'when user lacks can_configure_data_collection in the data source' do
+      let!(:access_control) { create_access_control(user, data_source, without_permission: [:can_configure_data_collection]) }
+
+      it 'returns false' do
+        expect(policy.can_manage?).to be false
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/models/hmis/auth_policies/project_config_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/project_config_policy_spec.rb
@@ -5,23 +5,60 @@ require 'rails_helper'
 RSpec.describe Hmis::AuthPolicies::ProjectConfigPolicy, type: :model do
   let(:data_source) { create(:hmis_data_source) }
   let(:user) { create(:hmis_user, data_source: data_source) }
+  let(:other_data_source) { create(:hmis_data_source) }
 
-  describe 'Global#can_manage?' do
+  describe 'Global#can_create? and #can_view?' do
     let(:policy) { user.policy_for(Hmis::ProjectConfig, policy_type: :project_config) }
+
+    it 'returns false' do
+      expect(policy.can_create?).to be false
+      expect(policy.can_view?).to be false
+    end
 
     context 'when user has can_configure_data_collection in the data source' do
       let!(:access_control) { create_access_control(user, data_source, with_permission: [:can_configure_data_collection]) }
 
       it 'returns true' do
-        expect(policy.can_manage?).to be true
+        expect(policy.can_create?).to be true
+        expect(policy.can_view?).to be true
       end
     end
 
-    context 'when user lacks can_configure_data_collection in the data source' do
-      let!(:access_control) { create_access_control(user, data_source, without_permission: [:can_configure_data_collection]) }
+    context 'when user has permission in another data source' do
+      let!(:access_control) { create_access_control(user, other_data_source, with_permission: [:can_configure_data_collection]) }
 
       it 'returns false' do
-        expect(policy.can_manage?).to be false
+        expect(policy.can_create?).to be false
+        expect(policy.can_view?).to be false
+      end
+    end
+  end
+
+  describe 'Instance#can_update? and #can_destroy?' do
+    let(:project) { create(:hmis_hud_project, data_source: data_source) }
+    let(:project_config) { create(:hmis_project_auto_enter_config, project: project, data_source: data_source) }
+    let(:policy) { user.policy_for(project_config, policy_type: :project_config) }
+
+    it 'returns false' do
+      expect(policy.can_update?).to be false
+      expect(policy.can_destroy?).to be false
+    end
+
+    context 'when user has can_configure_data_collection' do
+      let!(:access_control) { create_access_control(user, data_source, with_permission: [:can_configure_data_collection]) }
+
+      it 'returns true' do
+        expect(policy.can_update?).to be true
+        expect(policy.can_destroy?).to be true
+      end
+    end
+
+    context 'when user has permission in another data source' do
+      let!(:access_control) { create_access_control(user, other_data_source, with_permission: [:can_configure_data_collection]) }
+
+      it 'returns false' do
+        expect(policy.can_update?).to be false
+        expect(policy.can_destroy?).to be false
       end
     end
   end

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -249,18 +249,18 @@ RSpec.describe Hmis::Hud::Project, type: :model do
     let!(:other_project) { create :hmis_hud_project }
 
     it 'returns true if a config exists for this project' do
-      Hmis::ProjectStaffAssignmentConfig.new(project_id: project.id).save!
+      Hmis::ProjectStaffAssignmentConfig.new(project_id: project.id, data_source: data_source).save!
       expect(project.staff_assignments_enabled?).to eq(true)
       expect(other_project.staff_assignments_enabled?).to eq(false)
     end
 
     it 'returns true if a config exists for this project type' do
-      Hmis::ProjectStaffAssignmentConfig.new(project_type: project.project_type).save!
+      Hmis::ProjectStaffAssignmentConfig.new(project_type: project.project_type, data_source: data_source).save!
       expect(project.staff_assignments_enabled?).to eq(true)
     end
 
     it 'returns true if a config exist for this project organization' do
-      Hmis::ProjectStaffAssignmentConfig.new(organization: project.organization).save!
+      Hmis::ProjectStaffAssignmentConfig.new(organization: project.organization, data_source: data_source).save!
       expect(project.staff_assignments_enabled?).to eq(true)
     end
   end
@@ -276,7 +276,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
 
     context 'with config matching by project_type' do
       let!(:project) { create(:hmis_hud_project, data_source: data_source, project_type: 2) }
-      let!(:config) { create(:hmis_project_ce_config, project_type: 2) }
+      let!(:config) { create(:hmis_project_ce_config, project_type: 2, data_source: data_source) }
 
       it 'returns all open projects with matching project_type' do
         expect(Hmis::Hud::Project.with_ce_enabled).to contain_exactly(project)
@@ -298,7 +298,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       let!(:project_2) { create(:hmis_hud_project, data_source: data_source, project_type: 2) }
       let!(:project_3) { create(:hmis_hud_project, data_source: data_source, project_type: 3) }
       let!(:config_1) { create(:hmis_project_ce_config, project: project_1) }
-      let!(:config_2) { create(:hmis_project_ce_config, project_type: 2) }
+      let!(:config_2) { create(:hmis_project_ce_config, project_type: 2, data_source: data_source) }
       let!(:config_3) { create(:hmis_project_ce_config, organization: project_3.organization) }
 
       it 'returns all matching open projects' do
@@ -323,7 +323,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
     context 'with closed project matching config' do
       let!(:project) { create(:hmis_hud_project, data_source: data_source, project_type: 1) }
       let!(:closed_project) { create(:hmis_hud_project, data_source: data_source, project_type: 1, operating_end_date: 1.year.ago) }
-      let!(:config) { create(:hmis_project_ce_config, project_type: 1) }
+      let!(:config) { create(:hmis_project_ce_config, project_type: 1, data_source: data_source) }
 
       it 'does not return closed projects' do
         expect(Hmis::Hud::Project.with_ce_enabled).to contain_exactly(project)
@@ -363,7 +363,7 @@ RSpec.describe Hmis::Hud::Project, type: :model do
     context 'with config matching by project_type' do
       let!(:project) { create(:hmis_hud_project, data_source: data_source, project_type: 1) }
       let!(:closed_project) { create(:hmis_hud_project, data_source: data_source, project_type: 1, operating_end_date: 1.year.ago) }
-      let!(:config) { create(:hmis_project_ce_config, project_type: 1, supports_waitlist_referrals: true) }
+      let!(:config) { create(:hmis_project_ce_config, project_type: 1, supports_waitlist_referrals: true, data_source: data_source) }
 
       it 'returns all open projects with matching project_type' do
         expect(Hmis::Hud::Project.with_ce_waitlists_enabled).to contain_exactly(project)

--- a/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
@@ -9,46 +9,39 @@
 require 'rails_helper'
 
 RSpec.describe Hmis::ProjectAutoEnterConfig, type: :model do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   let!(:ds1) { create :hmis_primary_data_source }
   let!(:u1) { create :hmis_hud_user, data_source: ds1 }
   let!(:o1) { create :hmis_hud_organization, data_source: ds1, user: u1 }
   let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1 }
 
   it 'should create an auto entry config' do
-    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1)
+    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
     expect(auto_enter_config.id).not_to be_nil
     expect(auto_enter_config.type).to eq('Hmis::ProjectAutoEnterConfig')
   end
 
   it 'should not create a config if both project and organization are provided' do
     expect do
-      Hmis::ProjectAutoEnterConfig.create!(project: p1, organization: o1)
+      Hmis::ProjectAutoEnterConfig.create!(project: p1, organization: o1, data_source: ds1)
     end.to raise_error(ActiveRecord::RecordInvalid, /Specify exactly one of project, organization, and project type/)
   end
 
   it 'should not create a config if none of project, organization, or project type are provided' do
     expect do
-      Hmis::ProjectAutoEnterConfig.create!
+      Hmis::ProjectAutoEnterConfig.create!(data_source: ds1)
     end.to raise_error(ActiveRecord::RecordInvalid, /Specify exactly one of project, organization, and project type/)
   end
 
   it 'should return nil if no auto-enter config exists, even if auto-exit configs exist' do
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
-    Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90 })
+    Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90 }, data_source: ds1)
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
   end
 
   it 'should return nil if an auto-enter config exists, but is not enabled' do
-    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1)
+    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).not_to be_nil
     auto_enter_config.enabled = false

--- a/drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb
@@ -9,13 +9,6 @@
 require 'rails_helper'
 
 RSpec.describe Hmis::ProjectAutoExitConfig, type: :model do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   let!(:ds1) { create :hmis_primary_data_source }
   let!(:user) { create(:user) }
   let(:hmis_user) { user.related_hmis_user(ds1) }
@@ -30,7 +23,7 @@ RSpec.describe Hmis::ProjectAutoExitConfig, type: :model do
     expect(Hmis::ProjectAutoExitConfig.detect_best_config_for_project(p1)).to be_nil
 
     # Project type is least specific
-    aec2 = create(:hmis_project_auto_exit_config, project_type: p1.project_type)
+    aec2 = create(:hmis_project_auto_exit_config, project_type: p1.project_type, data_source: ds1)
     expect(Hmis::ProjectAutoExitConfig.for_project(p1)).to contain_exactly(aec2)
     expect(Hmis::ProjectAutoExitConfig.detect_best_config_for_project(p1)).to eq(aec2)
     expect(Hmis::ProjectAutoExitConfig.for_project(p2)).to contain_exactly(aec2)
@@ -66,7 +59,7 @@ RSpec.describe Hmis::ProjectAutoExitConfig, type: :model do
   end
 
   it 'should assign config values even when existing values are present' do
-    aec = Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90, 'foo': 'bar' })
+    aec = Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90, 'foo': 'bar' }, data_source: ds1)
     aec.length_of_absence_days = 30
     aec.save!
     expect(aec.length_of_absence_days).to eq(30)

--- a/drivers/hmis/spec/models/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_config_spec.rb
@@ -9,51 +9,75 @@
 require 'rails_helper'
 
 RSpec.describe Hmis::ProjectConfig, type: :model do
-  before(:all) do
-    cleanup_test_environment
-  end
-  after(:all) do
-    cleanup_test_environment
-  end
-
   let!(:ds1) { create :hmis_primary_data_source }
   let!(:u1) { create :hmis_hud_user, data_source: ds1 }
   let!(:o1) { create :hmis_hud_organization, data_source: ds1, user: u1 }
   let!(:p1) { create :hmis_hud_project, data_source: ds1, organization: o1, user: u1 }
 
   it 'should create an auto entry config' do
-    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1)
+    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
     expect(auto_enter_config.id).not_to be_nil
     expect(auto_enter_config.type).to eq('Hmis::ProjectAutoEnterConfig')
   end
 
   it 'should not create a config if both project and organization are provided' do
     expect do
-      Hmis::ProjectAutoEnterConfig.create!(project: p1, organization: o1)
+      Hmis::ProjectAutoEnterConfig.create!(project: p1, organization: o1, data_source: ds1)
     end.to raise_error(ActiveRecord::RecordInvalid, /Specify exactly one of project, organization, and project type/)
   end
 
   it 'should not create a config if none of project, organization, or project type are provided' do
     expect do
-      Hmis::ProjectAutoEnterConfig.create!
+      Hmis::ProjectAutoEnterConfig.create!(data_source: ds1)
     end.to raise_error(ActiveRecord::RecordInvalid, /Specify exactly one of project, organization, and project type/)
   end
 
   it 'should return nil if no auto-enter config exists, even if auto-exit configs exist' do
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
-    Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90 })
+    Hmis::ProjectAutoExitConfig.create!(project: p1, options: { 'length_of_absence_days': 90 }, data_source: ds1)
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
   end
 
   it 'should return nil if an auto-enter config exists, but is not enabled' do
-    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1)
+    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).not_to be_nil
     auto_enter_config.enabled = false
     auto_enter_config.save!
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
+  end
+
+  describe '.viewable_by' do
+    let!(:ds1) { create(:hmis_data_source) }
+    let!(:ds2) { create(:hmis_data_source) }
+    let!(:o1) { create(:hmis_hud_organization, data_source: ds1) }
+    let!(:p1) { create(:hmis_hud_project, data_source: ds1, organization: o1) }
+    let!(:config_p1) { create(:hmis_project_auto_enter_config, project: p1, data_source: ds1) }
+    let!(:config_ds2_project_type) do
+      create(:hmis_project_auto_enter_config, data_source: ds2, project_type: 0)
+    end
+
+    let(:authorized_user) do
+      u = create(:hmis_user, data_source: ds1)
+      create_access_control(u, ds1)
+      u
+    end
+
+    let(:user_without_perm) do
+      u = create(:hmis_user, data_source: ds1)
+      create_access_control(u, ds1, without_permission: [:can_configure_data_collection])
+      u
+    end
+
+    it 'returns only configs in the user data source when the user has can_configure_data_collection' do
+      expect(described_class.viewable_by(authorized_user)).to contain_exactly(config_p1)
+    end
+
+    it 'returns none when the user lacks can_configure_data_collection in the data source' do
+      expect(described_class.viewable_by(user_without_perm)).to be_empty
+    end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/assign_staff_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assign_staff_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Assign Staff Mutation', type: :request do
 
   before(:each) do
     hmis_login(user)
-    Hmis::ProjectStaffAssignmentConfig.new(project_id: p1.id).save!
+    Hmis::ProjectStaffAssignmentConfig.new(project_id: p1.id, data_source: ds1).save!
   end
 
   subject(:mutation) do

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:receiving_project) { create(:hmis_hud_project, data_source: ds1, user: u1) }
     let!(:unit_group) { create(:hmis_unit_group, project: receiving_project, name: 'Receiving Group') }
     let!(:non_ce_project) { create(:hmis_hud_project, data_source: ds1, user: u1) }
-    let!(:receiving_ce_config) { create(:hmis_project_ce_config, project: receiving_project, receives_direct_referrals: true) }
+    let!(:receiving_ce_config) { create(:hmis_project_ce_config, project: receiving_project, receives_direct_referrals: true, data_source: ds1) }
 
     before(:each) do
       allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
@@ -652,7 +652,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
     context 'when the sending project also receives' do
-      let!(:sending_config) { create(:hmis_project_ce_config, project: sending_project, receives_direct_referrals: true) }
+      let!(:sending_config) { create(:hmis_project_ce_config, project: sending_project, receives_direct_referrals: true, data_source: ds1) }
       let!(:sending_unit_group) { create(:hmis_unit_group, project: sending_project, name: 'Another Group') }
 
       it 'does not include that project' do

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:receiving_project) { create(:hmis_hud_project, data_source: ds1, user: u1) }
     let!(:unit_group) { create(:hmis_unit_group, project: receiving_project, name: 'Receiving Group') }
     let!(:non_ce_project) { create(:hmis_hud_project, data_source: ds1, user: u1) }
-    let!(:receiving_ce_config) { create(:hmis_project_ce_config, project: receiving_project, receives_direct_referrals: true, data_source: ds1) }
+    let!(:receiving_ce_config) { create(:hmis_project_ce_config, project: receiving_project, receives_direct_referrals: true) }
 
     before(:each) do
       allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
@@ -652,7 +652,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
     context 'when the sending project also receives' do
-      let!(:sending_config) { create(:hmis_project_ce_config, project: sending_project, receives_direct_referrals: true, data_source: ds1) }
+      let!(:sending_config) { create(:hmis_project_ce_config, project: sending_project, receives_direct_referrals: true) }
       let!(:sending_unit_group) { create(:hmis_unit_group, project: sending_project, name: 'Another Group') }
 
       it 'does not include that project' do

--- a/drivers/hmis/spec/requests/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_config_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   context 'project configs query' do
     let!(:o2) { create :hmis_hud_organization, data_source: ds1 }
     let!(:p2) { create :hmis_hud_project, organization: o2, data_source: ds1 }
-    let!(:ds1_project_config1) { create :hmis_project_auto_enter_config, project: p1, data_source: ds1 }
-    let!(:ds1_project_config2) { create :hmis_project_auto_exit_config, organization: o2, data_source: ds1 }
+    let!(:ds1_project_config1) { create :hmis_project_auto_enter_config, project: p1 }
+    let!(:ds1_project_config2) { create :hmis_project_auto_exit_config, organization: o2 }
 
     let(:get_project_configs) do
       <<~GRAPHQL

--- a/drivers/hmis/spec/requests/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_config_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       project_config = Hmis::ProjectConfig.find(project_config_id)
       expect(project_config.class.name).to eq('Hmis::ProjectAutoEnterConfig')
       expect(project_config.project_type).to eq(0)
+      expect(project_config.data_source_id).to eq(ds1.id)
     end
 
     it 'should throw an error when the user does not have access' do
@@ -67,8 +68,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   context 'project configs query' do
     let!(:o2) { create :hmis_hud_organization, data_source: ds1 }
     let!(:p2) { create :hmis_hud_project, organization: o2, data_source: ds1 }
-    let!(:ds1_project_config1) { create :hmis_project_auto_enter_config, project: p1 }
-    let!(:ds1_project_config2) { create :hmis_project_auto_exit_config, organization: o2 }
+    let!(:ds1_project_config1) { create :hmis_project_auto_enter_config, project: p1, data_source: ds1 }
+    let!(:ds1_project_config2) { create :hmis_project_auto_exit_config, organization: o2, data_source: ds1 }
 
     let(:get_project_configs) do
       <<~GRAPHQL
@@ -114,6 +115,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let!(:ds2_access_control) { create_access_control(hmis_user, ds2) }
       let!(:ds2_project_config) { create :hmis_project_auto_enter_config, project: ds2_project }
 
+      # todo @martha - how is this test passing on release-209?
       it 'should return only the configs in the current data source' do
         response, result = post_graphql { get_project_configs }
         expect(response.status).to eq(200), result.inspect

--- a/drivers/hmis/spec/requests/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_config_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let!(:ds2_project) { create :hmis_hud_project, data_source: ds2 }
       let!(:ds2_access_control) { create_access_control(hmis_user, ds2) }
       let!(:ds2_project_config) { create :hmis_project_auto_enter_config, project: ds2_project }
+      let!(:ds2_project_type_config) { create :hmis_project_auto_enter_config, project_type: 0, data_source: ds2 }
 
-      # todo @martha - how is this test passing on release-209?
       it 'should return only the configs in the current data source' do
         response, result = post_graphql { get_project_configs }
         expect(response.status).to eq(200), result.inspect

--- a/drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
   before(:each) do
     hmis_login(user)
-    Hmis::ProjectStaffAssignmentConfig.new(project_id: p1.id).save!
+    Hmis::ProjectStaffAssignmentConfig.new(project_id: p1.id, data_source: ds1).save!
   end
 
   describe 'household staff assignment query' do

--- a/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe 'Update External Form Submission', type: :request do
         end
 
         it 'should still work when auto enter is turned on in the project' do
-          Hmis::ProjectAutoEnterConfig.create!(project: p1)
+          Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
           expect do
             response, result = post_graphql(input) { mutation }
             expect(response.status).to eq(200), result.inspect

--- a/drivers/hmis_external_apis/lib/ac_hmis/create_ce_project_configs_20251001.rb
+++ b/drivers/hmis_external_apis/lib/ac_hmis/create_ce_project_configs_20251001.rb
@@ -96,7 +96,7 @@ module AcHmis
 
       # Create or update ProjectCeConfig for the projects in scope
       scope.each do |project|
-        record = Hmis::ProjectCeConfig.find_or_initialize_by(project_id: project.id)
+        record = Hmis::ProjectCeConfig.find_or_initialize_by(project_id: project.id, data_source: project.data_source)
         record.supports_waitlist_referrals = waitlists
         record.receives_direct_referrals = direct_referrals
         record.receives_direct_referrals_from = [ce_project.id]

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/current_waitlists_export_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::CurrentWaitlistsExport, type
   let!(:ds) { create(:hmis_data_source) }
   let!(:project) { create(:hmis_hud_project, data_source: ds) }
   let!(:unit_group) { create(:hmis_unit_group, project: project) }
-  let!(:ce_project_config) { create(:hmis_project_ce_config, supports_waitlist_referrals: true, project: project) }
+  let!(:ce_project_config) { create(:hmis_project_ce_config, supports_waitlist_referrals: true, project: project, data_source: ds) }
 
   let!(:destination_client) { create(:grda_warehouse_hud_client) }
   let!(:client_proxy) { create(:hmis_ce_client_proxy, client: destination_client) }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- Migrate to add `data_source_id` column to `hmis_project_configs` table and backfill existing records
- Update `Hmis::ProjectConfig` model with `data_source` association/validations; update existing viewability/applicability scopes to prevent cross-data-source leakage
- Update factories so that they automatically populate the `data_source` based on project or organization, if provided. (Reduces the churn to spec files so we don't have to update all tests that use these factories to explicitly provide `data_source_id`)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
