### PR TITLE
Clean up HMIS Data Source factories, clarify usage

### DIFF
--- a/drivers/hmis/spec/factories/hmis/data_sources.rb
+++ b/drivers/hmis/spec/factories/hmis/data_sources.rb
@@ -7,20 +7,22 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  # Builds a new HMIS data source with a unique hostname.
   factory :hmis_data_source, class: 'GrdaWarehouse::DataSource' do
-    sequence(:authoritative, &:zero?)
     sequence(:hmis) { |n| "#{GraphqlHelpers::HMIS_HOSTNAME}.#{n}" }
-    name { 'HMIS' }
-    short_name { 'HMIS' }
-    # association :client, factory: :hmis_hud_client
-    source_type { :sftp }
+    name { |n| "HMIS #{n}" }
+    short_name { |n| "HMIS #{n}" }
+    source_type { :samba }
+    authoritative { true }
   end
 
   # Data source with HMIS hostname matching the one in GraphqlHelpers.
   # This is the one that should be used in almost all of our spec tests,
-  # except when we are testing multi-hmis-data-source scenarios.
+  # except when we are testing multi-HMIS-data-source scenarios.
   factory :hmis_primary_data_source, parent: :hmis_data_source do
     hmis { GraphqlHelpers::HMIS_HOSTNAME }
+    name { 'HMIS' }
+    short_name { 'HMIS' }
   end
 end
 

--- a/drivers/hmis/spec/support/hmis_json_forms_seed.rb
+++ b/drivers/hmis/spec/support/hmis_json_forms_seed.rb
@@ -14,20 +14,22 @@
 # This is a performance improvement that helps us avoid creating these forms in fixtures,
 # which would run per-test and be expensive.
 #
-# When used alongside 'hmis base setup', this context's `let(:ds1)` overrides the factory-based `ds1`.
+# Relationship to 'hmis base setup':
+# - 'hmis base setup' defines `let!(:ds1) { create(:hmis_primary_data_source) }`, a fresh factory data source per example group.
+# - This context defines `let(:ds1)` to resolve the canonical HMIS data source row created in `before(:all)` (same hostname as GraphqlHelpers::HMIS_HOSTNAME).
+# - When both contexts are included in one group, include 'hmis base setup' first, then 'hmis json forms seed', so this `let(:ds1)` wins and every reference to `ds1` in the group uses the seeded data source (JSON forms, HUD service types/categories, etc.) instead of attempting to create a new DS with the same hostname.
 RSpec.shared_context 'hmis json forms seed', shared_context: :metadata do
   before(:all) do
-    ds = GrdaWarehouse::DataSource.find_or_create_by!(
-      hmis: GraphqlHelpers::HMIS_HOSTNAME,
-      name: 'HMIS',
-      short_name: 'HMIS',
-      authoritative: true,
-    )
+    ds = GrdaWarehouse::DataSource.find_or_create_by!(hmis: GraphqlHelpers::HMIS_HOSTNAME) do |d|
+      d.name = 'HMIS'
+      d.short_name = 'HMIS'
+      d.authoritative = true
+    end
     HmisUtil::ServiceTypes.seed_hud_service_types(ds.id)
     HmisUtil::JsonForms.seed_all(data_source_id: ds.id)
   end
 
-  # Use find_by! since we already created ds1 in before_all
+  # Resolves the same row as `before(:all)`
   let(:ds1) { GrdaWarehouse::DataSource.hmis.find_by!(hmis: GraphqlHelpers::HMIS_HOSTNAME) }
 
   after(:all) do

--- a/drivers/hmis/spec/support/hmis_json_forms_seed.rb
+++ b/drivers/hmis/spec/support/hmis_json_forms_seed.rb
@@ -29,7 +29,8 @@ RSpec.shared_context 'hmis json forms seed', shared_context: :metadata do
     HmisUtil::JsonForms.seed_all(data_source_id: ds.id)
   end
 
-  # Resolves the same row as `before(:all)`
+  # Use find_by! since we already created ds1 in before_all.
+  # If used after 'hmis base setup', this context's 'ds1' overrides the factory-based `ds1`.
   let(:ds1) { GrdaWarehouse::DataSource.hmis.find_by!(hmis: GraphqlHelpers::HMIS_HOSTNAME) }
 
   after(:all) do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
- Give NON-primary data source fixture unique `name`/`short_name`s to reduce confusion in debugging
- Update HMIS ds to always be authoritative and user the same `source_type` we us in prod
- Update `hmis json form seed` helper to (1) add comment clarifying how to use with hmis base setup, and (2) find_by hostname only

## Type of change
Test cleanup

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
