### PR TITLE
Bugfix for HH with no DOB showing up in Unaccompanied Youth category

### DIFF
--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/base.rb
@@ -105,11 +105,14 @@ module HudPit::Generators::Pit::Fy2025
           # Note these should be the same across all household members and could be cached
           hh_id = get_hh_id(last_service_history_enrollment)
           household_type = household_types[hh_id]
+          hh_members = households[hh_id] || []
+          # Record max age for the household (from known DOBs) to determine if it's a youth household
+          # use nil if no DOB exists to prevent from being included in youth filters
+          hh_max_age = hh_members.filter_map { |m| GrdaWarehouse::Hud::Client.age(date: pit_date, dob: m['dob']) }.max
           hh_member_count = 0
-          hh_max_age = 0
           hh_has_minor_children = false
           hh_max_age_of_parents = 0
-          households[hh_id]&.each do |member|
+          hh_members.each do |member|
             hh_member_count += 1
 
             # age related hh calculations
@@ -117,8 +120,6 @@ module HudPit::Generators::Pit::Fy2025
             member_age = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: member['dob'])
             next unless member_age
 
-            # Record max age for the household to determine if it's a youth household
-            hh_max_age = member_age if member_age > hh_max_age
             hh_has_minor_children = true if member_relationship_to_hoh == 2 && member_age < 18
             hh_max_age_of_parents = member_age if member_relationship_to_hoh.in?([1, 3]) && member_age > hh_max_age_of_parents
           end

--- a/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_household_max_age_spec.rb
+++ b/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_household_max_age_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+require_relative 'hud_pit_context'
+
+RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
+  describe 'PitClient max_age after running the report' do
+    include_context 'HUD pit context'
+
+    let(:es_project) { create_project(project_type: 0) }
+    let(:question) { HudPit::Generators::Pit::Fy2025::Adults::QUESTION_NUMBER }
+
+    context 'when one ES household has a single member with no DOB' do
+      let!(:source_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_single_no_dob', dob: nil)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_no_dob',
+        )
+        hoh
+      end
+
+      it 'persists nil max_age on the PIT client row (not 0)' do
+        report = run_report(questions: [question])
+        pit_client = HudPit::Fy2025::PitClient.find_by!(
+          report_instance_id: report.id,
+          client_id: source_client.id,
+        )
+        expect(pit_client.max_age).to be_nil
+        expect(pit_client.household_member_count).to eq(1)
+      end
+    end
+
+    context 'when one ES household has a single member with a known DOB' do
+      let(:dob_adult_30) { pit_date - 30.years }
+
+      let!(:source_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_single_age_known', dob: dob_adult_30)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_single_known',
+        )
+        hoh
+      end
+
+      it 'persists max_age as that member age on PIT night' do
+        report = run_report(questions: [question])
+        pit_client = HudPit::Fy2025::PitClient.find_by!(
+          report_instance_id: report.id,
+          client_id: source_client.id,
+        )
+        expected_age = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_adult_30)
+        expect(pit_client.max_age).to eq(expected_age)
+        expect(pit_client.household_member_count).to eq(1)
+      end
+    end
+
+    context 'when a household has two members with known DOBs' do
+      let(:dob_hoh_22) { pit_date - 22.years }
+      let(:dob_child_8) { pit_date - 8.years }
+
+      let!(:hoh_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_hh2_hoh', dob: dob_hoh_22)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_two_members',
+        )
+        hoh
+      end
+
+      let!(:child_client) do
+        child = create_client_with_warehouse_link(uid: 'pit_hh2_child', dob: dob_child_8)
+        create_enrollment(
+          client: child,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_child,
+          household_id: 'hh_pit_max_age_two_members',
+        )
+        child
+      end
+
+      it 'persists the same max_age for each member (oldest age in the household)' do
+        report = run_report(questions: [question])
+        expected_max = [
+          GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_hoh_22),
+          GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_child_8),
+        ].compact.max
+
+        pit_hoh = HudPit::Fy2025::PitClient.find_by!(
+          report_instance_id: report.id,
+          client_id: hoh_client.id,
+        )
+        pit_child = HudPit::Fy2025::PitClient.find_by!(
+          report_instance_id: report.id,
+          client_id: child_client.id,
+        )
+
+        expect(pit_hoh.max_age).to eq(expected_max)
+        expect(pit_child.max_age).to eq(expected_max)
+        expect(pit_hoh.household_member_count).to eq(2)
+        expect(pit_child.household_member_count).to eq(2)
+      end
+    end
+
+    context 'when a household has multiple members and the HoH has no DOB but another member does' do
+      let(:dob_spouse_22) { pit_date - 22.years }
+
+      let!(:hoh_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_hh_mixed_hoh_no_dob', dob: nil)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_mixed_hoh_missing',
+        )
+        hoh
+      end
+
+      let!(:spouse_client) do
+        spouse = create_client_with_warehouse_link(uid: 'pit_hh_mixed_spouse_dob', dob: dob_spouse_22)
+        create_enrollment(
+          client: spouse,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_spouse,
+          household_id: 'hh_pit_max_age_mixed_hoh_missing',
+        )
+        spouse
+      end
+
+      it 'persists max_age from members with a DOB only' do
+        report = run_report(questions: [question])
+        expected_max = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_spouse_22)
+
+        pit_hoh = HudPit::Fy2025::PitClient.find_by!(report_instance_id: report.id, client_id: hoh_client.id)
+        pit_spouse = HudPit::Fy2025::PitClient.find_by!(report_instance_id: report.id, client_id: spouse_client.id)
+
+        expect(pit_hoh.max_age).to eq(expected_max)
+        expect(pit_spouse.max_age).to eq(expected_max)
+        expect(pit_hoh.household_member_count).to eq(2)
+      end
+    end
+
+    context 'when a household has multiple members and one member has no DOB but others do' do
+      let(:dob_hoh_35) { pit_date - 35.years }
+
+      let!(:hoh_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_hh_mixed_hoh_dob', dob: dob_hoh_35)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_mixed_other_missing',
+        )
+        hoh
+      end
+
+      let!(:other_client) do
+        other = create_client_with_warehouse_link(uid: 'pit_hh_mixed_other_no_dob', dob: nil)
+        create_enrollment(
+          client: other,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_other_adult,
+          household_id: 'hh_pit_max_age_mixed_other_missing',
+        )
+        other
+      end
+
+      it 'persists max_age as the max of known ages (ignores members without DOB)' do
+        report = run_report(questions: [question])
+        expected_max = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_hoh_35)
+
+        pit_hoh = HudPit::Fy2025::PitClient.find_by!(report_instance_id: report.id, client_id: hoh_client.id)
+        pit_other = HudPit::Fy2025::PitClient.find_by!(report_instance_id: report.id, client_id: other_client.id)
+
+        expect(pit_hoh.max_age).to eq(expected_max)
+        expect(pit_other.max_age).to eq(expected_max)
+        expect(pit_hoh.household_member_count).to eq(2)
+      end
+    end
+  end
+end

--- a/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_household_max_age_spec.rb
+++ b/drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_household_max_age_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
 
     let(:es_project) { create_project(project_type: 0) }
     let(:question) { HudPit::Generators::Pit::Fy2025::Adults::QUESTION_NUMBER }
+    let(:uy_question) { HudPit::Generators::Pit::Fy2025::UnaccompaniedYouth::QUESTION_NUMBER }
+
+    shared_examples 'excluded from unaccompanied youth universe' do
+      it 'is excluded from the unaccompanied youth question universe' do
+        report = run_report(questions: [uy_question])
+        expect(report.universe(uy_question).members.count).to eq(0)
+      end
+    end
+
+    shared_examples 'included in unaccompanied youth universe' do
+      it 'is included in the unaccompanied youth question universe' do
+        report = run_report(questions: [uy_question])
+        expect(report.universe(uy_question).members.count).to eq(1)
+      end
+    end
 
     context 'when one ES household has a single member with no DOB' do
       let!(:source_client) do
@@ -38,6 +53,8 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
         expect(pit_client.max_age).to be_nil
         expect(pit_client.household_member_count).to eq(1)
       end
+
+      it_behaves_like 'excluded from unaccompanied youth universe'
     end
 
     context 'when one ES household has a single member with a known DOB' do
@@ -65,6 +82,37 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
         expect(pit_client.max_age).to eq(expected_age)
         expect(pit_client.household_member_count).to eq(1)
       end
+
+      it_behaves_like 'excluded from unaccompanied youth universe'
+    end
+
+    context 'when one ES household has a single member under 25 with a known DOB' do
+      let(:dob_youth_20) { pit_date - 20.years }
+
+      let!(:source_client) do
+        hoh = create_client_with_warehouse_link(uid: 'pit_single_youth_known_dob', dob: dob_youth_20)
+        create_enrollment(
+          client: hoh,
+          project: es_project,
+          entry_date: pit_date,
+          relationship_to_ho_h: rel_hoh,
+          household_id: 'hh_pit_max_age_single_youth',
+        )
+        hoh
+      end
+
+      it 'persists max_age as that member age on PIT night' do
+        report = run_report(questions: [question])
+        pit_client = HudPit::Fy2025::PitClient.find_by!(
+          report_instance_id: report.id,
+          client_id: source_client.id,
+        )
+        expected_age = GrdaWarehouse::Hud::Client.age(date: pit_date, dob: dob_youth_20)
+        expect(pit_client.max_age).to eq(expected_age)
+        expect(pit_client.household_member_count).to eq(1)
+      end
+
+      it_behaves_like 'included in unaccompanied youth universe'
     end
 
     context 'when a household has two members with known DOBs' do
@@ -116,6 +164,8 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
         expect(pit_hoh.household_member_count).to eq(2)
         expect(pit_child.household_member_count).to eq(2)
       end
+
+      it_behaves_like 'excluded from unaccompanied youth universe'
     end
 
     context 'when a household has multiple members and the HoH has no DOB but another member does' do
@@ -156,6 +206,8 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
         expect(pit_spouse.max_age).to eq(expected_max)
         expect(pit_hoh.household_member_count).to eq(2)
       end
+
+      it_behaves_like 'excluded from unaccompanied youth universe'
     end
 
     context 'when a household has multiple members and one member has no DOB but others do' do
@@ -196,6 +248,8 @@ RSpec.describe HudPit::Generators::Pit::Fy2025::Base, type: :model do
         expect(pit_other.max_age).to eq(expected_max)
         expect(pit_hoh.household_member_count).to eq(2)
       end
+
+      it_behaves_like 'excluded from unaccompanied youth universe'
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix bug in PIT where hh without a DOB had a max hh age of 0 which included the hh in the unaccompanied youth filter. This instead sets the max hh age ot nil in these scenariaos which excluded the hh from the youth filter

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
