### PR TITLE
Fix apollo cache bug on CE Referral contact assignment by resolving new `cacheKey`

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
@@ -24,7 +24,7 @@ module Mutations
       swimlanes = referral.workflow_instance.template.swimlanes.where(id: swimlane_ids)
       raise "Failed to assign to swimlanes #{swimlane_ids.join(', ')}, not all swimlanes found on template" unless swimlanes.size == swimlane_ids.size
 
-      participants = filter_to_authorized_participants(participants, project: project, referral_id: referral_id)
+      participants = filter_to_authorized_participants(participants, project)
 
       referral.with_lock do
         # Create a participant for each user in the input, if one doesn't already exist
@@ -49,7 +49,7 @@ module Mutations
     # This can happen if a user was previously assigned but is no longer active/authorized,
     # or lost access between loading the assignee pick list (ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS)
     # and submitting the mutation.
-    def filter_to_authorized_participants(participants, project:, referral_id:)
+    def filter_to_authorized_participants(participants, project)
       user_ids = participants.map(&:user_id).map(&:to_i).to_set
       authorized_user_ids = Hmis::User.active.can_perform_any_referral_tasks_for(project).
         or(Hmis::User.can_perform_own_referral_tasks_for(project)).
@@ -59,7 +59,7 @@ module Mutations
       return participants if missing_user_ids.empty?
 
       msg = 'Referral assignment: some users were not in scope (inactive or lost access), removed from assignee list'
-      Sentry.capture_message(msg, extra: { missing_user_ids: missing_user_ids.to_a, project_id: project.id, referral_id: referral_id })
+      Sentry.capture_message(msg, extra: { missing_user_ids: missing_user_ids.to_a, project_id: project.id })
       Rails.logger.warn(msg)
 
       participants.filter { |p| authorized_user_ids.include?(p.user_id.to_i) }

--- a/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
+++ b/drivers/hmis/app/graphql/mutations/ce/assign_referral_participants.rb
@@ -24,7 +24,7 @@ module Mutations
       swimlanes = referral.workflow_instance.template.swimlanes.where(id: swimlane_ids)
       raise "Failed to assign to swimlanes #{swimlane_ids.join(', ')}, not all swimlanes found on template" unless swimlanes.size == swimlane_ids.size
 
-      participants = filter_to_authorized_participants(participants, project)
+      participants = filter_to_authorized_participants(participants, project: project, referral_id: referral_id)
 
       referral.with_lock do
         # Create a participant for each user in the input, if one doesn't already exist
@@ -49,7 +49,7 @@ module Mutations
     # This can happen if a user was previously assigned but is no longer active/authorized,
     # or lost access between loading the assignee pick list (ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS)
     # and submitting the mutation.
-    def filter_to_authorized_participants(participants, project)
+    def filter_to_authorized_participants(participants, project:, referral_id:)
       user_ids = participants.map(&:user_id).map(&:to_i).to_set
       authorized_user_ids = Hmis::User.active.can_perform_any_referral_tasks_for(project).
         or(Hmis::User.can_perform_own_referral_tasks_for(project)).
@@ -59,7 +59,7 @@ module Mutations
       return participants if missing_user_ids.empty?
 
       msg = 'Referral assignment: some users were not in scope (inactive or lost access), removed from assignee list'
-      Sentry.capture_message(msg, extra: { missing_user_ids: missing_user_ids.to_a, project_id: project.id })
+      Sentry.capture_message(msg, extra: { missing_user_ids: missing_user_ids.to_a, project_id: project.id, referral_id: referral_id })
       Rails.logger.warn(msg)
 
       participants.filter { |p| authorized_user_ids.include?(p.user_id.to_i) }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1428,9 +1428,32 @@ type CeReferralStepsPaginated {
 }
 
 type CeReferralSwimlane {
+  """
+  Referral-scoped key for Apollo cache to avoid collisions across referrals.
+  """
+  cacheKey: ID!
+
+  """
+  Same as swimlaneId (unchanged for backwards compatibility). Can be updated to
+  resolve cacheKey value once frontend is updated to send swimlaneId to
+  assignReferralParticipants.
+  """
   id: ID!
+
+  """
+  Swimlane name
+  """
   name: String!
+
+  """
+  Assigned users for this swimlane on this referral
+  """
   participants: [ApplicationUser!]!
+
+  """
+  Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.
+  """
+  swimlaneId: ID!
 }
 
 type CeReferralsPaginated {

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1429,14 +1429,12 @@ type CeReferralStepsPaginated {
 
 type CeReferralSwimlane {
   """
-  Referral-scoped key for Apollo cache to avoid collisions across referrals.
+  Referral-scoped key for Apollo cache to avoid collisions across referrals
   """
   cacheKey: ID!
 
   """
-  Same as swimlaneId (unchanged for backwards compatibility). Can be updated to
-  resolve cacheKey value once frontend is updated to send swimlaneId to
-  assignReferralParticipants.
+  Swimlane id; client should pass this as assignReferralParticipants.swimlaneId
   """
   id: ID!
 
@@ -1449,11 +1447,6 @@ type CeReferralSwimlane {
   Assigned users for this swimlane on this referral
   """
   participants: [ApplicationUser!]!
-
-  """
-  Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.
-  """
-  swimlaneId: ID!
 }
 
 type CeReferralsPaginated {

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -259,10 +259,11 @@ module Types
           users_by_id[participant.user_id]
         end
 
+        # Object is resolved as HmisSchema::CeReferralSwimlane
         OpenStruct.new(
-          id: swimlane.id.to_s,
+          id: swimlane.id, # unchanged for backwards compatibility
           cache_key: "#{object.id}:#{swimlane.id}",
-          swimlane_id: swimlane.id.to_s,
+          swimlane_id: swimlane.id,
           name: swimlane.name,
           participants: participants,
         )

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -260,7 +260,9 @@ module Types
         end
 
         OpenStruct.new(
-          id: swimlane.id,
+          id: swimlane.id.to_s,
+          cache_key: "#{object.id}:#{swimlane.id}",
+          swimlane_id: swimlane.id.to_s,
           name: swimlane.name,
           participants: participants,
         )

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -259,11 +259,9 @@ module Types
           users_by_id[participant.user_id]
         end
 
-        # Object is resolved as HmisSchema::CeReferralSwimlane
         OpenStruct.new(
-          id: swimlane.id, # unchanged for backwards compatibility
+          id: swimlane.id,
           cache_key: "#{object.id}:#{swimlane.id}",
-          swimlane_id: swimlane.id,
           name: swimlane.name,
           participants: participants,
         )

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_swimlane.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_swimlane.rb
@@ -11,9 +11,16 @@ module Types
     # object is an OpenStruct amalgamation of:
     # - Hmis::WorkflowDefinition::Swimlane, the swimlane definition
     # - [Hmis::Ce::ReferralParticipant], the participants for this swimlane on this referral
+    #
+    # See CeReferral.swimlanes for how this object is constructed.
 
-    field :id, ID, null: false
-    field :name, String, null: false
-    field :participants, [Application::User], null: false
+    field :id, ID, null: false,
+                   description: 'Same as swimlaneId (unchanged for backwards compatibility). Can be updated to resolve cacheKey value once frontend is updated to send swimlaneId to assignReferralParticipants.'
+    field :cache_key, ID, null: false,
+                          description: 'Referral-scoped key for Apollo cache to avoid collisions across referrals.'
+    field :swimlane_id, ID, null: false,
+                            description: 'Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.'
+    field :name, String, null: false, description: 'Swimlane name'
+    field :participants, [Application::User], null: false, description: 'Assigned users for this swimlane on this referral'
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_swimlane.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral_swimlane.rb
@@ -15,11 +15,9 @@ module Types
     # See CeReferral.swimlanes for how this object is constructed.
 
     field :id, ID, null: false,
-                   description: 'Same as swimlaneId (unchanged for backwards compatibility). Can be updated to resolve cacheKey value once frontend is updated to send swimlaneId to assignReferralParticipants.'
+                   description: 'Swimlane id; client should pass this as assignReferralParticipants.swimlaneId'
     field :cache_key, ID, null: false,
-                          description: 'Referral-scoped key for Apollo cache to avoid collisions across referrals.'
-    field :swimlane_id, ID, null: false,
-                            description: 'Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.'
+                          description: 'Referral-scoped key for Apollo cache to avoid collisions across referrals'
     field :name, String, null: false, description: 'Swimlane name'
     field :participants, [Application::User], null: false, description: 'Assigned users for this swimlane on this referral'
   end

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -249,8 +249,8 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
         expect(referral_data).to be_present
 
         referral_swimlanes = referral_data['swimlanes']
-        case_mgr_swimlane = referral_swimlanes.find { |s| s['cacheKey'] == "#{referral.id}:#{case_manager_swimlane.id}" }
-        provider_swimlane_result = referral_swimlanes.find { |s| s['cacheKey'] == "#{referral.id}:#{provider_swimlane.id}" }
+        case_mgr_swimlane = referral_swimlanes.find { |s| s['id'] == case_manager_swimlane.id.to_s }
+        provider_swimlane_result = referral_swimlanes.find { |s| s['id'] == provider_swimlane.id.to_s }
         expect(case_mgr_swimlane['participants'].map { |p| p['id'] }).to eq([hmis_user.id.to_s])
         expect(provider_swimlane_result['participants']).to be_empty
 

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
               swimlanes {
                 id
                 cacheKey
-                swimlaneId
                 name
                 participants {
                   id
@@ -95,7 +94,6 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
           a_hash_including(
             'id' => case_manager_swimlane.id.to_s,
             'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
-            'swimlaneId' => case_manager_swimlane.id.to_s,
             'name' => case_manager_swimlane.name,
             'participants' => [
               a_hash_including(
@@ -107,7 +105,6 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
           a_hash_including(
             'id' => provider_swimlane.id.to_s,
             'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
-            'swimlaneId' => provider_swimlane.id.to_s,
             'name' => provider_swimlane.name,
             'participants' => [
               a_hash_including(

--- a/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
               id
               swimlanes {
                 id
+                cacheKey
+                swimlaneId
                 name
                 participants {
                   id
@@ -92,6 +94,8 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
         expect(referral_swimlanes).to contain_exactly(
           a_hash_including(
             'id' => case_manager_swimlane.id.to_s,
+            'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
+            'swimlaneId' => case_manager_swimlane.id.to_s,
             'name' => case_manager_swimlane.name,
             'participants' => [
               a_hash_including(
@@ -102,6 +106,8 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
           ),
           a_hash_including(
             'id' => provider_swimlane.id.to_s,
+            'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
+            'swimlaneId' => provider_swimlane.id.to_s,
             'name' => provider_swimlane.name,
             'participants' => [
               a_hash_including(
@@ -246,8 +252,8 @@ RSpec.describe Mutations::Ce::AssignReferralParticipants, type: :request do
         expect(referral_data).to be_present
 
         referral_swimlanes = referral_data['swimlanes']
-        case_mgr_swimlane = referral_swimlanes.find { |s| s['id'] == case_manager_swimlane.id.to_s }
-        provider_swimlane_result = referral_swimlanes.find { |s| s['id'] == provider_swimlane.id.to_s }
+        case_mgr_swimlane = referral_swimlanes.find { |s| s['cacheKey'] == "#{referral.id}:#{case_manager_swimlane.id}" }
+        provider_swimlane_result = referral_swimlanes.find { |s| s['cacheKey'] == "#{referral.id}:#{provider_swimlane.id}" }
         expect(case_mgr_swimlane['participants'].map { |p| p['id'] }).to eq([hmis_user.id.to_s])
         expect(provider_swimlane_result['participants']).to be_empty
 

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -274,18 +274,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect(response.status).to eq(200), result.inspect
           swimlanes = result.dig('data', 'ceReferral', 'swimlanes')
           expect(swimlanes).to contain_exactly(
-            a_hash_including(
-              'id' => case_manager_swimlane.id.to_s,
-              'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
-              'name' => case_manager_swimlane.name,
-              'participants' => [],
-            ),
-            a_hash_including(
-              'id' => provider_swimlane.id.to_s,
-              'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
-              'name' => provider_swimlane.name,
-              'participants' => [],
-            ),
+            a_hash_including('id' => case_manager_swimlane.id.to_s, 'name' => case_manager_swimlane.name, 'participants' => []),
+            a_hash_including('id' => provider_swimlane.id.to_s, 'name' => provider_swimlane.name, 'participants' => []),
           )
         end
 

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             swimlanes {
               id
               cacheKey
-              swimlaneId
               name
               participants {
                 id
@@ -278,14 +277,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             a_hash_including(
               'id' => case_manager_swimlane.id.to_s,
               'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
-              'swimlaneId' => case_manager_swimlane.id.to_s,
               'name' => case_manager_swimlane.name,
               'participants' => [],
             ),
             a_hash_including(
               'id' => provider_swimlane.id.to_s,
               'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
-              'swimlaneId' => provider_swimlane.id.to_s,
               'name' => provider_swimlane.name,
               'participants' => [],
             ),
@@ -308,7 +305,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               a_hash_including(
                 'id' => case_manager_swimlane.id.to_s,
                 'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
-                'swimlaneId' => case_manager_swimlane.id.to_s,
                 'name' => case_manager_swimlane.name,
                 'participants' => [
                   a_hash_including('id' => cm1.id.to_s, 'name' => cm1.name),
@@ -318,7 +314,6 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               a_hash_including(
                 'id' => provider_swimlane.id.to_s,
                 'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
-                'swimlaneId' => provider_swimlane.id.to_s,
                 'name' => provider_swimlane.name,
                 'participants' => [
                   a_hash_including('id' => provider.id.to_s, 'name' => provider.name),

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             }
             swimlanes {
               id
+              cacheKey
+              swimlaneId
               name
               participants {
                 id
@@ -273,8 +275,20 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           expect(response.status).to eq(200), result.inspect
           swimlanes = result.dig('data', 'ceReferral', 'swimlanes')
           expect(swimlanes).to contain_exactly(
-            a_hash_including('id' => case_manager_swimlane.id.to_s, 'name' => case_manager_swimlane.name, 'participants' => []),
-            a_hash_including('id' => provider_swimlane.id.to_s, 'name' => provider_swimlane.name, 'participants' => []),
+            a_hash_including(
+              'id' => case_manager_swimlane.id.to_s,
+              'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
+              'swimlaneId' => case_manager_swimlane.id.to_s,
+              'name' => case_manager_swimlane.name,
+              'participants' => [],
+            ),
+            a_hash_including(
+              'id' => provider_swimlane.id.to_s,
+              'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
+              'swimlaneId' => provider_swimlane.id.to_s,
+              'name' => provider_swimlane.name,
+              'participants' => [],
+            ),
           )
         end
 
@@ -293,6 +307,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             expect(swimlanes).to contain_exactly(
               a_hash_including(
                 'id' => case_manager_swimlane.id.to_s,
+                'cacheKey' => "#{referral.id}:#{case_manager_swimlane.id}",
+                'swimlaneId' => case_manager_swimlane.id.to_s,
                 'name' => case_manager_swimlane.name,
                 'participants' => [
                   a_hash_including('id' => cm1.id.to_s, 'name' => cm1.name),
@@ -301,6 +317,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
               ),
               a_hash_including(
                 'id' => provider_swimlane.id.to_s,
+                'cacheKey' => "#{referral.id}:#{provider_swimlane.id}",
+                'swimlaneId' => provider_swimlane.id.to_s,
                 'name' => provider_swimlane.name,
                 'participants' => [
                   a_hash_including('id' => provider.id.to_s, 'name' => provider.name),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Issue: https://github.com/open-path/Green-River/issues/9092 (contains testing/repro instructions)
Frontend PR: https://github.com/greenriver/hmis-frontend/pull/1440

**Summary:**  
`CeReferralSwimlane` is built from an OpenStruct and exposes the workflow template swimlane id as GraphQL `id`. Apollo would cache on this `id`, leading to incorrect participants appearing in the UI due to cache conflicts. This PR adds an explicit `cacheKey` to fix that.

Note: **`id` remains unchanged** (template swimlane id) so we can still deploy backend-only and it won't break when frontends send the `id` value to the assignReferralParticipants mutation.


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
