### PR TITLE
[#9091] Re-use Prevention Query

### DIFF
--- a/drivers/ma_yya_report/app/models/ma_yya_report/report.rb
+++ b/drivers/ma_yya_report/app/models/ma_yya_report/report.rb
@@ -354,7 +354,7 @@ module MaYyaReport
     end
 
     private def prevention_clause
-      a_t[:at_risk_of_homelessness].eq(true)
+      a1b_clause.or(a2b_clause).or(a3a_clause).or(a3b_clause)
     end
 
     # A1b: Outreach referral + at-risk
@@ -587,7 +587,7 @@ module MaYyaReport
       {
         TotalYYAServedPrevention: {
           # Explicit union of A1b, A2b, A3a, and A3b as per tooltip description
-          calculation: a1b_clause.or(a2b_clause).or(a3a_clause).or(a3b_clause),
+          calculation: prevention_clause,
           label: 'Number of unduplicated YYA served (update each quarter)',
         },
         TotalYYAServedHomeless: {

--- a/drivers/ma_yya_report/spec/models/ma_yya_report/total_yya_served_prevention_spec.rb
+++ b/drivers/ma_yya_report/spec/models/ma_yya_report/total_yya_served_prevention_spec.rb
@@ -197,4 +197,34 @@ RSpec.describe 'TotalYYAServedPrevention Integration', type: :model do
       end
     end
   end
+
+  describe 'prevention_clause used in downstream cells' do
+    # A3b clients have at_risk_of_homelessness: false but qualify via entry before
+    # period + non-homeless CLS during period. Before the fix, prevention_clause
+    # used only at_risk_of_homelessness, which excluded these clients from section D
+    # demographic cells, F1a, and other places using prevention_clause.
+    let!(:a3b_only_client) do
+      create(
+        :ma_yya_report_client,
+        :a3b,
+        gender: 1,
+      )
+    end
+
+    let(:prevention) { report.send(:prevention_clause) }
+
+    it 'includes A3b clients who are not flagged as at_risk_of_homelessness' do
+      expect(MaYyaReport::Client.where(prevention)).to include(a3b_only_client)
+    end
+
+    it 'passes A3b clients through to section D demographic cells' do
+      d1b_calculation = report.send(
+        :section_d1_e1_cells,
+        section: 'D',
+        clause: prevention,
+      )[:D1b][:calculation]
+
+      expect(MaYyaReport::Client.where(d1b_calculation)).to include(a3b_only_client)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The YYA report was only showing demographic data for a subset of clients in prevention.  This moves the previous fix for Total YYA in Prevention to the `prevention_clause` that is used for all sub-values.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
