### PR TITLE
Datepicker Modal Clipping

### DIFF
--- a/app/assets/stylesheets/application/base/_modals.scss
+++ b/app/assets/stylesheets/application/base/_modals.scss
@@ -61,6 +61,33 @@
   overflow-y: visible;
 }
 
+// #ajax-modal loads filters and other tall forms via AjaxModal. Global rules above put
+// overflow: scroll on .modal-content and leave .modal-body visible, which differs from
+// Bootstrap's scrollable modal (body scrolls, content clips).
+#ajax-modal.modal .modal-dialog.modal-dialog-scrollable {
+  .modal-content {
+    overflow: hidden;
+  }
+
+  .modal-body {
+    overflow-y: auto;
+  }
+}
+
+// TempusDominus sets .tempus-dominus-widget { z-index: 9999 }, so the calendar sits above
+// the modal chrome. Keep it under the header/footer and the sticky filter actions bar
+#ajax-modal.modal {
+  .modal-header,
+  .modal-footer {
+    position: relative;
+    z-index: 5;
+  }
+
+  .tempus-dominus-widget {
+    z-index: 1 !important;
+  }
+}
+
 .modal-dialog {
   @include media-breakpoint-down(sm) {
     width: calc(100vw - 30px) !important;

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -13,14 +13,8 @@ export default class extends Controller {
     const modalContent =
       modal && (modal.querySelector('.modal-content') || modal);
 
-    let containerOptions = {};
-    if (dropdownMenu) {
-      containerOptions = { container: dropdownMenu };
-    } else if (modalContent) {
-      // Mount the widget inside the modal so it is clipped by .modal-content and Popper
-      // can keep it inside the same box (avoids floating over the page chrome).
-      containerOptions = { container: modalContent };
-    }
+    const container = dropdownMenu ? dropdownMenu : modalContent;  
+    const containerOptions = container ? { container: container } : {};
 
     // Default options, including our custom icons
     const defaultOptions = {

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -7,7 +7,20 @@ export default class extends Controller {
 
   connect() {
     const dropdownMenu = this.element.closest('.dropdown-menu');
-    const containerOptions = dropdownMenu ? { container: dropdownMenu } : {};
+    // When the input lives in a Bootstrap modal (e.g. AjaxModal #ajax-modal), use the
+    // modal shell as the widget container so overflow clipping matches the dialog.
+    const modal = this.element.closest('.modal');
+    const modalContent =
+      modal && (modal.querySelector('.modal-content') || modal);
+
+    let containerOptions = {};
+    if (dropdownMenu) {
+      containerOptions = { container: dropdownMenu };
+    } else if (modalContent) {
+      // Mount the widget inside the modal so it is clipped by .modal-content and Popper
+      // can keep it inside the same box (avoids floating over the page chrome).
+      containerOptions = { container: modalContent };
+    }
 
     // Default options, including our custom icons
     const defaultOptions = {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix bug where datepicker was clipping modal window and user was unable to scroll to view the entire datepicker without adjusting the screen zoom.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
