### PR TITLE
Add ip address and header logging for inbound API requests

### DIFF
--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
@@ -48,10 +48,33 @@ module HmisExternalApis
         initiator: internal_system,
         url: request.original_url,
         http_method: request.method,
-        request: request.raw_post,
+        request: request.raw_post.presence || request.query_parameters&.to_json,
         requested_at: Time.current,
         response: 'pending', # can't be null
+        ip: request.remote_ip,
+        request_headers: inbound_request_headers_for_log,
       )
+    end
+
+    # Small allowlist of inbound headers for support tracing
+    def inbound_request_headers_for_log
+      {
+        'Content-Type' => truncate_header_for_log(request.get_header('CONTENT_TYPE')),
+        'Accept' => truncate_header_for_log(request.get_header('HTTP_ACCEPT')),
+        'User-Agent' => truncate_header_for_log(request.user_agent, 512),
+        'Host' => truncate_header_for_log(request.host),
+        'Referer' => truncate_header_for_log(request.referer),
+        'X-Forwarded-For' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_FOR')),
+        'X-Forwarded-Host' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_HOST')),
+        'X-Forwarded-Proto' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_PROTO')),
+        'X-Real-Ip' => truncate_header_for_log(request.get_header('HTTP_X_REAL_IP')),
+      }.compact_blank
+    end
+
+    def truncate_header_for_log(value, max = 200)
+      return if value.blank?
+
+      value.to_s.truncate(max)
     end
 
     # render a 400 with error messages

--- a/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
+++ b/drivers/hmis_external_apis/app/controllers/hmis_external_apis/base_controller.rb
@@ -67,7 +67,7 @@ module HmisExternalApis
         'X-Forwarded-For' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_FOR')),
         'X-Forwarded-Host' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_HOST')),
         'X-Forwarded-Proto' => truncate_header_for_log(request.get_header('HTTP_X_FORWARDED_PROTO')),
-        'X-Real-Ip' => truncate_header_for_log(request.get_header('HTTP_X_REAL_IP')),
+        'X-Real-IP' => truncate_header_for_log(request.get_header('HTTP_X_REAL_IP')),
       }.compact_blank
     end
 

--- a/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
+++ b/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/involvements_spec.rb
@@ -9,12 +9,12 @@
 require 'rails_helper'
 
 RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request do
-  let(:headers) do
+  let(:api_key_conf) do
     internal_system = HmisExternalApis::InternalSystem.find_by(name: 'Involvements')
     internal_system ||= create(:internal_system, :involvements)
-    conf = create(:inbound_api_configuration, internal_system: internal_system)
-    { 'Authorization' => "Bearer #{conf.plain_text_api_key}" }
+    create(:inbound_api_configuration, internal_system: internal_system)
   end
+  let(:headers) { { 'Authorization' => "Bearer #{api_key_conf.plain_text_api_key}" } }
 
   def api_get(endpoint, params)
     case endpoint
@@ -41,6 +41,11 @@ RSpec.describe HmisExternalApis::AcHmis::InvolvementsController, type: :request 
       logged = HmisExternalApis::ExternalRequestLog.first
       expect(logged.response).to match(/involvements/)
       expect(logged.http_status).to match(200)
+      expect(logged.initiator).to eq(api_key_conf.internal_system)
+      expect(logged.ip).to be_present
+      expect(logged.url).to include(hmis_external_apis_client_involvements_path)
+      expect(logged.request).to eq({ 'start_date' => '2000-01-01', 'end_date' => '2000-01-10', 'mci_ids' => [12345] }.to_json)
+      expect(logged.request_headers.to_json).not_to include(api_key_conf.plain_text_api_key)
     end
   end
 

--- a/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/referral_spec.rb
+++ b/drivers/hmis_external_apis/spec/requests/hmis_external_apis/ac_hmis/referral_spec.rb
@@ -122,10 +122,8 @@ RSpec.describe HmisExternalApis::AcHmis::ReferralsController, type: :request do
       create(:hmis_hud_project, data_source: ds1)
     end
 
-    let(:headers) do
-      conf = create(:inbound_api_configuration, internal_system: create(:internal_system, :referrals))
-      { 'Authorization' => "Bearer #{conf.plain_text_api_key}" }
-    end
+    let(:api_key_conf) { create(:inbound_api_configuration, internal_system: create(:internal_system, :referrals)) }
+    let(:headers) { { 'Authorization' => "Bearer #{api_key_conf.plain_text_api_key}" } }
 
     # Turn off the MPER integration before testing to ensure that all actions work
     # as expected even if the MPER credential is inactive. MPER integration is being deprecated
@@ -144,6 +142,22 @@ RSpec.describe HmisExternalApis::AcHmis::ReferralsController, type: :request do
             relationship_to_hoh: idx.zero? ? 'self_head_of_household' : 'other_relative',
           }
         end
+      end
+
+      it 'logs the request' do
+        params = referral_params(household).
+          merge({ referral_request_id: referral_request.identifier })
+        post hmis_external_apis_referrals_path, params: params, headers: headers, as: :json
+        check_response_okay
+
+        expect(HmisExternalApis::ExternalRequestLog.count).to eq(1)
+        logged = HmisExternalApis::ExternalRequestLog.first
+        expect(logged.request).to eq(params.to_json)
+        expect(logged.request_headers.to_json).not_to include(api_key_conf.plain_text_api_key)
+        expect(logged.http_method).to eq('POST')
+        expect(logged.initiator).to eq(api_key_conf.internal_system)
+        expect(logged.ip).to be_present
+        expect(logged.url).to include(hmis_external_apis_referrals_path)
       end
 
       it 'receives referral for referral request' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Add logging for ExternalRequestLog for **inbound** requests:
- Populate `request` with search params for easier parsing of GET requests (they are also logged in the `url`)
- Populate `ip`
- Populate `request_headers` with some headers (allowlist, does not include auth to prevent API key from leaking into log table)


**How to test:** created API key locally through warehouse; hit API with curl/postman; verify logs in ExternalRequestLog table

## Type of change
Logging


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
