### PR TITLE
Persist WIP changes to Entry Date from incomplete Intake Assessment

### DIFF
--- a/drivers/hmis/lib/form_data/default/assessments/base_intake.json
+++ b/drivers/hmis/lib/form_data/default/assessments/base_intake.json
@@ -16,12 +16,6 @@
           },
           "required": true,
           "assessment_date": true,
-          "initial": [
-            {
-              "initial_behavior": "OVERWRITE",
-              "value_local_constant": "$entryDate"
-            }
-          ],
           "bounds": [
             {
               "id": "max-entry",

--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 require_relative '../../requests/hmis/login_and_permissions'
 require_relative '../../support/hmis_base_setup'
 
-RSpec.feature 'Intake assessment', type: :system do
+RSpec.feature 'Intake Assessment for Household', type: :system do
   include_context 'hmis base setup'
   # could parse CAPYBARA_APP_HOST
   let!(:ds1) { GrdaWarehouse::DataSource.hmis.find_by(hmis: 'localhost') }
@@ -68,12 +68,61 @@ RSpec.feature 'Intake assessment', type: :system do
     end
 
     context 'with wip household' do
+      it 'persists entry date when saved as WIP and shows it when reopening' do
+        hoh_enrollment = c1.enrollments.in_progress.sole
+        new_entry_date = hoh_enrollment.entry_date - 3.days
+
+        visit "/client/#{c1.id}/enrollments/#{hoh_enrollment.id}/intake"
+
+        mui_expect_selected_tab('#tab-1')
+        mui_date_select 'Entry Date', date: new_entry_date
+        complete_individual_assessment
+
+        expect(hoh_enrollment.reload.intake_assessment).to be_present
+        expect(hoh_enrollment.intake_assessment.wip).to eq(true)
+        expect(hoh_enrollment.intake_assessment.form_processor.values['entry_date']).to eq(new_entry_date.strftime('%Y-%m-%d'))
+
+        visit "/client/#{c1.id}/enrollments/#{hoh_enrollment.id}/intake"
+
+        mui_expect_selected_tab('#tab-1')
+        expect(page).to have_field('Entry Date', with: new_entry_date.strftime('%m/%d/%Y'))
+      end
+
+      it 'updates HoH enrollment entry date when household intake is submitted' do
+        hoh_enrollment = c1.enrollments.in_progress.sole
+        hhm_enrollment = c2.enrollments.in_progress.sole
+
+        old_entry_date = hoh_enrollment.entry_date
+        new_entry_date = old_entry_date - 3.days
+
+        visit "/client/#{c1.id}/enrollments/#{hoh_enrollment.id}/intake"
+
+        mui_expect_selected_tab('#tab-1')
+        mui_date_select 'Entry Date', date: new_entry_date
+        complete_individual_assessment
+        click_button 'Next'
+
+        mui_expect_selected_tab('#tab-2')
+        complete_individual_assessment # Fill out other fields for Non-HoH enrollment, but don't change the Entry Date
+        click_button 'Next'
+
+        mui_expect_selected_tab('#tab-summary')
+        with_hidden { check('select all') }
+        click_button 'Submit (2) Intake Assessments'
+        click_button 'Confirm'
+
+        # HoH enrollment entry date is updated
+        expect(hoh_enrollment.reload.entry_date).to eq(new_entry_date.to_date)
+        # Non-HoH enrollment entry date is not updated
+        expect(hhm_enrollment.reload.entry_date).to eq(old_entry_date.to_date)
+      end
+
       it 'can submit an intake assessment' do
         # Confirm setup:
         expect(c1.enrollments.in_progress.count).to eq(1)
         expect(c2.enrollments.in_progress.count).to eq(1)
         e1 = c1.enrollments.in_progress.first
-        e2 = c1.enrollments.in_progress.first
+        e2 = c2.enrollments.in_progress.first
         expect(e1.intake_assessment).to be_nil
         expect(e2.intake_assessment).to be_nil
 

--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -67,21 +67,28 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
       assert_text(/Last saved [0-9] seconds? ago/)
     end
 
-    # Helper to submit all intake assessments for a household from the Summary tab
+    # Helper to submit all in-progress intake assessments for a household from the Summary tab
     def submit_household_intakes(household_size:)
       assert_text 'Complete Entry'
 
-      with_hidden { check('select all') }
-
       row_numbers = (1..household_size).to_a
+      # Confirm all intakes are in progress
       row_numbers.each do |row|
         within(:xpath, "//table/tbody/tr[#{row}]") do
           assert_text('In Progress')
         end
       end
+
+      with_hidden { check('select all') }
+
       click_button "Submit (#{household_size}) Intake Assessments"
 
+      # Confirm warning modal about missing fields
+      assert_text 'Ignore Warnings'
       click_button 'Confirm'
+      assert_no_text 'Ignore Warnings'
+
+      # Confirm all intakes are submitted
       row_numbers.each do |row|
         within(:xpath, "//table/tbody/tr[#{row}]") do
           assert_text('Submitted')

--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -87,13 +87,6 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
       assert_text 'Ignore Warnings'
       click_button 'Confirm'
       assert_no_text 'Ignore Warnings'
-
-      # Confirm all intakes are submitted
-      row_numbers.each do |row|
-        within(:xpath, "//table/tbody/tr[#{row}]") do
-          assert_text('Submitted')
-        end
-      end
     end
 
     context 'with wip household' do
@@ -184,6 +177,13 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
 
         # Submit both intakes and wait for submission to complete
         submit_household_intakes(household_size: 2)
+
+        # Confirm all intakes are submitted
+        [1, 2].each do |row|
+          within(:xpath, "//table/tbody/tr[#{row}]") do
+            assert_text('Submitted')
+          end
+        end
 
         # Enrollments are created as non-WIP
         expect(e1.reload.in_progress?).to eq(false)

--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -67,6 +67,28 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
       assert_text(/Last saved [0-9] seconds? ago/)
     end
 
+    # Helper to submit all intake assessments for a household from the Summary tab
+    def submit_household_intakes(household_size:)
+      assert_text 'Complete Entry'
+
+      with_hidden { check('select all') }
+
+      row_numbers = (1..household_size).to_a
+      row_numbers.each do |row|
+        within(:xpath, "//table/tbody/tr[#{row}]") do
+          assert_text('In Progress')
+        end
+      end
+      click_button "Submit (#{household_size}) Intake Assessments"
+
+      click_button 'Confirm'
+      row_numbers.each do |row|
+        within(:xpath, "//table/tbody/tr[#{row}]") do
+          assert_text('Submitted')
+        end
+      end
+    end
+
     context 'with wip household' do
       it 'persists entry date when saved as WIP and shows it when reopening' do
         hoh_enrollment = c1.enrollments.in_progress.sole
@@ -107,9 +129,9 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
         click_button 'Next'
 
         mui_expect_selected_tab('#tab-summary')
-        with_hidden { check('select all') }
-        click_button 'Submit (2) Intake Assessments'
-        click_button 'Confirm'
+
+        # Submit both intakes and wait for submission to complete
+        submit_household_intakes(household_size: 2)
 
         # HoH enrollment entry date is updated
         expect(hoh_enrollment.reload.entry_date).to eq(new_entry_date.to_date)
@@ -153,22 +175,8 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
         expect(e1.reload.intake_assessment.wip).to eq(true)
         expect(e2.reload.intake_assessment.wip).to eq(true)
 
-        with_hidden { check('select all') }
-
-        row_numbers = [1, 2]
-        row_numbers.each do |row|
-          within(:xpath, "//table/tbody/tr[#{row}]") do
-            assert_text('In Progress')
-          end
-        end
-        click_button 'Submit (2) Intake Assessments'
-
-        click_button 'Confirm'
-        row_numbers.each do |row|
-          within(:xpath, "//table/tbody/tr[#{row}]") do
-            assert_text('Submitted')
-          end
-        end
+        # Submit both intakes and wait for submission to complete
+        submit_household_intakes(household_size: 2)
 
         # Enrollments are created as non-WIP
         expect(e1.reload.in_progress?).to eq(false)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Issue: https://github.com/open-path/Green-River/issues/8970

- **What changed:** The default intake **Entry Date** item no longer has an **`initial`** block (no `$entryDate` / no `IF_EMPTY` / no `OVERWRITE`). The field still maps to `Enrollment.entryDate` for submit and for loading from the assessment graph when not in progress.

- **Behavior for WIP intake assessments (changed):** The form shows the `entry_date` value last written into `FormProcessor.values` (i.e. what was last saved as WIP). If there is no WIP value yet (user is on intake before the first successful save), the field is filled from `Enrollment.EntryDate`. 
  - **Previous Behavior:** The WIP Intake would always show `Enrollment.EntryDate`, even if you had changed the date and clicked "save and finish later". This made the "Save and finish later" function seem broken.

- **Behavior for non-WIP intake (no change):** The intake's Entry Date field reflects `Enrollment.EntryDate` always.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
