### PR TITLE
Update system test assertion to remove flakiness

### DIFF
--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -133,6 +133,14 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
         # Submit both intakes and wait for submission to complete
         submit_household_intakes(household_size: 2)
 
+        # Confirm all intakes are submitted
+        # FIXME: seems like there is a frontend bug causing the page to sometimes
+        # navigate to the submitted HoH's assessment, instead of staying on the summary
+        # tab. That needs to be fixed on the frontend. This test uses the below assertion
+        # to wait for submission to complete (rather than asserting on the Summary Tab
+        # showing submitted status) to get around that bug.
+        expect(page).not_to have_button('Submit (2) Intake Assessments')
+
         # HoH enrollment entry date is updated
         expect(hoh_enrollment.reload.entry_date).to eq(new_entry_date.to_date)
         # Non-HoH enrollment entry date is not updated

--- a/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/intake_assessment_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature 'Intake Assessment for Household', type: :system do
         submit_household_intakes(household_size: 2)
 
         # Confirm all intakes are submitted
-        # FIXME: seems like there is a frontend bug causing the page to sometimes
+        # FIXME(#9121): there is a frontend bug causing the page to sometimes
         # navigate to the submitted HoH's assessment, instead of staying on the summary
         # tab. That needs to be fixed on the frontend. This test uses the below assertion
         # to wait for submission to complete (rather than asserting on the Summary Tab


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
This system test was added with https://github.com/greenriver/hmis-warehouse/pull/6387, it was failing due to insufficient assertions waiting for form submission to complete.


The approach of waiting for the specific button to not be present is different from other tests in this file, due to a frontend bug: https://github.com/open-path/Green-River/issues/9121

## Type of change
Test fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
