### PR TITLE
Fix bugs with Instance Project/Enrollment Match

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/form_definition.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_definition.rb
@@ -69,7 +69,7 @@ module Types
       # ...then forms A and B would still return a match for Project X.
 
       # Fetching all projects is slow, so here we do it only once and pass the scope to project_matches below.
-      project_scope = Hmis::Hud::Project.hmis
+      project_scope = Hmis::Hud::Project.hmis.where(data_source_id: object.data_source_id)
       instance_scope = object.instances.active
 
       # If there is a default, then all projects are fair game.

--- a/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
+++ b/drivers/hmis/app/graphql/types/forms/pick_list_option.rb
@@ -660,7 +660,7 @@ module Types
       # get all form rules for custom assessments (active and inactive)
       scope = Hmis::Form::Instance.with_role(:CUSTOM_ASSESSMENT)
       # filter down to rules that match this project, if project is specified
-      scope = scope.filter { |fi| fi.project_match(project) } if project
+      scope = scope.in_data_source(project.data_source_id).filter { |fi| fi.project_match(project) } if project
       # { code: definition.identifier, label: definition.title }
       custom_options = scope.map(&:to_pick_list_option).uniq.sort_by { |opt| opt[:label] }
       hud_options = Hmis::Form::Definition::FORM_DATA_COLLECTION_STAGES.excluding(:CUSTOM_ASSESSMENT).keys.
@@ -695,8 +695,7 @@ module Types
     end
 
     def self.projects_receiving_referrals(data_source_id)
-      Hmis::Hud::Project.where(data_source_id: data_source_id).
-        receiving_legacy_referrals.
+      Hmis::Hud::Project.receiving_legacy_referrals(data_source_id).
         joins(:organization).preload(:organization).
         sort_by_option(:organization_and_name).
         map(&:to_pick_list_option)

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -119,7 +119,8 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   end
 
   scope :for_project_through_entities, ->(project) do
-    ids = all.map { |i| i.project_match(project) ? i.id : nil }.compact
+    ids = in_data_source(project.data_source_id).
+      map { |i| i.project_match(project) ? i.id : nil }.compact
     where(id: ids)
   end
 
@@ -169,13 +170,15 @@ class Hmis::Form::Instance < ::GrdaWarehouseBase
   end
 
   def self.detect_best_instance_for_project(project:)
-    matches = all.map { |i| i.project_match(project) }.compact
+    matches = in_data_source(project.data_source_id).
+      map { |i| i.project_match(project) }.compact
     # with_index for stable sort
     matches.sort_by.with_index { |match, idx| [match.rank, idx] }.first&.instance
   end
 
   def self.detect_best_instance_for_enrollment(enrollment:)
-    matches = all.map { |i| i.project_and_enrollment_match(project: enrollment.project, enrollment: enrollment) }.compact
+    matches = in_data_source(enrollment.data_source_id).
+      map { |i| i.project_and_enrollment_match(project: enrollment.project, enrollment: enrollment) }.compact
     # with_index for stable sort
     matches.sort_by.with_index { |match, idx| [match.rank, idx] }.first&.instance
   end

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -295,7 +295,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   def data_collection_features
     # Create OpenStruct for each enabled feature
     Hmis::Form::Definition::DATA_COLLECTION_FEATURE_ROLES.map do |role|
-      instance_scope = Hmis::Form::Instance.with_role(role).active.published
+      instance_scope = Hmis::Form::Instance.in_data_source(data_source_id).with_role(role).active.published
       # Service instances must specify a service type or category.
       instance_scope = instance_scope.for_services if role == :SERVICE
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -163,7 +163,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     # We do not check `viewable_by` because providers can refer to projects they can't otherwise view.
     # NOTE: is not optimized, could be refactored if performance is an issue. Used this approach to minimize
     # duplication of project_match logic.
-    referral_project_ids = Hmis::Hud::Project.in_data_source(data_source_id).open_on_date(Date.current).select do |project|
+    referral_project_ids = Hmis::Hud::Project.where(data_source_id: data_source_id).open_on_date(Date.current).select do |project|
       instance_scope.any? { |instance| instance.project_match(project) }
     end.map(&:id)
 

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -154,16 +154,16 @@ class Hmis::Hud::Project < Hmis::Hud::Base
     )
   end
 
-  scope :receiving_legacy_referrals, -> do
-    # Find all active instances that enable the Referral functionality
-    instance_scope = Hmis::Form::Instance.active.with_role(:REFERRAL).published
+  scope :receiving_legacy_referrals, ->(data_source_id) do
+    # Find all active instances that enable the Referral functionality, scoped to the given data source
+    instance_scope = Hmis::Form::Instance.in_data_source(data_source_id).active.with_role(:REFERRAL).published
     # Find open projects that have an instance that match the criteria, which indicates that the
     # project accepts referrals.
 
     # We do not check `viewable_by` because providers can refer to projects they can't otherwise view.
     # NOTE: is not optimized, could be refactored if performance is an issue. Used this approach to minimize
     # duplication of project_match logic.
-    referral_project_ids = Hmis::Hud::Project.open_on_date(Date.current).select do |project|
+    referral_project_ids = Hmis::Hud::Project.in_data_source(data_source_id).open_on_date(Date.current).select do |project|
       instance_scope.any? { |instance| instance.project_match(project) }
     end.map(&:id)
 
@@ -222,7 +222,7 @@ class Hmis::Hud::Project < Hmis::Hud::Base
   end
 
   def receives_legacy_referrals?
-    Hmis::Form::Instance.active.published.with_role(:REFERRAL).any? { |instance| instance.project_match(self) }
+    Hmis::Form::Instance.in_data_source(data_source_id).active.published.with_role(:REFERRAL).any? { |instance| instance.project_match(self) }
   end
 
   def receives_direct_ce_referrals?

--- a/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/pick_list_spec.rb
@@ -505,7 +505,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     it 'should only return the project that has an active, non-draft instance' do
       response, result = post_graphql(pick_list_type: 'PROJECTS_RECEIVING_REFERRALS') { query }
-      expect(response.status).to eq 200
+      expect(response.status).to eq(200), result.inspect
       options = result.dig('data', 'pickList')
       expect(options.size).to eq(1)
       expect(options.first['code']).to eq(referral_dest_project.id.to_s)


### PR DESCRIPTION
## _Merging this PR_
- this PR targets the long-lived feature branch https://github.com/greenriver/hmis-warehouse/pull/6355

## Description
Since we added a `raise` when `InstanceProjectMatch` and `InstanceEnrollmentMatch` are called on mismatched data sources, we need to narrow the scopes whenever we call those match methods, otherwise the user will see an error. Paths to check:
- Form definition "Project Matches" table in the admin ui
- Project Assessments page filter by assessment name
- Dropdown of projects receiving legacy referrals - I haven't tested this one manually from the UI, since I think we are no longer rendering this picklist anywhere
- Loading an Enrollment dashboard to check data collection features
- Loading a Project dashboard to check data collection features
- Creating a new Service in an enrollment (checks available service types)
- Loading an assessment form for an enrollment (checks find_definition_for_role)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
