### PR TITLE
Add framework for calculated CDEs

### DIFF
--- a/db/warehouse/migrate/20260421182915_add_calculation_expression_to_custom_data_element_definitions.rb
+++ b/db/warehouse/migrate/20260421182915_add_calculation_expression_to_custom_data_element_definitions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddCalculationExpressionToCustomDataElementDefinitions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :CustomDataElementDefinitions, :calculation_expression, :text
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260421182915
+# rails db:migrate:down:warehouse VERSION=20260421182915

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -265,6 +265,21 @@ module Types
       source_referral if policy.can_view_summary?
     end
 
+    # Override the auto-generated resolver from custom_data_elements_field to also inject synthetic CDEs
+    # for any calculated CDEDs referenced by the enrollment's active occurrence point form definitions.
+    # Not for batch anymore; causes n+1 on object.occurrence_point_forms.
+    # Other fields that use HasCustomDataElements out of the box can still query in batch though. Is that acceptable?
+    def custom_data_elements
+      # Only include active (non-legacy) forms since calculated CDEDs have no stored fallback value
+      active_form_identifiers = object.occurrence_point_forms.map { |opf| opf.definition.identifier }
+
+      # Single query for all calculated CDEDs across all relevant form definitions
+      calculated_cdeds_for_enrollment = Hmis::Hud::CustomDataElementDefinition.
+        calculated.where(form_definition_identifier: active_form_identifiers)
+
+      resolve_custom_data_elements(object, calculated_cdeds: calculated_cdeds_for_enrollment)
+    end
+
     # N+1, not performant for queries on collections
     def geolocations
       return [] unless current_permission?(permission: :can_view_enrollment_location_map, entity: project)

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_custom_data_elements.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_custom_data_elements.rb
@@ -34,20 +34,55 @@ module Types
         end
       end
 
-      def resolve_custom_data_elements(record)
-        # Load all CustomDataElement values for this record
+      # Build GraphqlCdeValueAdapter instances for a record's custom data elements.
+      #
+      # calculated_cdeds: optional array of Hmis::Hud::CustomDataElementDefinition records with a
+      # calculation_expression. These have no persisted CustomDataElement rows (values are derived at query
+      # time via Dentaku). The caller is responsible for supplying the relevant set (pre-batched). For each
+      # CDED in this list, a synthetic unpersisted CDE carrying the computed value is injected into the result.
+      def resolve_custom_data_elements(record, calculated_cdeds: [])
+        # cde_definitions comes from has_many :through :custom_data_elements, so it only includes CDEDs that
+        # already have at least one persisted row. Calculated CDEDs (no stored rows) are passed in separately.
         cde_values = load_ar_association(record, :custom_data_elements).group_by(&:data_element_definition_id)
-
-        # Load all CustomDataElementDefinitions that have values for this record
         cde_definitions = load_ar_association(record, :custom_data_element_definitions).sort_by(&:id)
 
-        # Array of relevant CustomDataElementDefinitions, with value(s)
-        cde_definitions.uniq.map do |cded|
+        adapters = cde_definitions.uniq.map do |cded|
           Hmis::Hud::GraphqlCdeValueAdapter.new(
             definition: cded,
             custom_data_elements: cde_values[cded.id]&.sort_by(&:id) || [],
           )
         end
+
+        return adapters if calculated_cdeds.empty?
+
+        evaluator = Hmis::CalculatedField::Evaluator.new
+
+        calculated_cdeds.each do |cded|
+          result = evaluator.evaluate(cded, enrollment: record)
+          # Evaluation yields nil when required resolvers are disabled or variables are unavailable
+          next if result.nil?
+
+          value_column = Hmis::Hud::CustomDataElementDefinition::FIELD_TYPE_TO_COLUMN[cded.field_type.to_sym]
+
+          synthetic_cde = Hmis::Hud::CustomDataElement.new(
+            owner: record,
+            data_element_definition: cded,
+            data_source_id: record.data_source_id,
+            value_column => result,
+          )
+
+          # Unpersisted rows have no DB id; CustomDataElementValue requires a stable non-null id.
+          # Use "#{cded.id}:synthetic" — deterministic and won't collide with real persisted CDE ids.
+          stable_id = "#{cded.id}:synthetic"
+          synthetic_cde.define_singleton_method(:id) { stable_id }
+
+          adapters << Hmis::Hud::GraphqlCdeValueAdapter.new(
+            definition: cded,
+            custom_data_elements: [synthetic_cde],
+          )
+        end
+
+        adapters
       end
     end
   end

--- a/drivers/hmis/app/models/hmis/calculated_field/calculator_factory.rb
+++ b/drivers/hmis/app/models/hmis/calculated_field/calculator_factory.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'dentaku'
+
+module Hmis::CalculatedField
+  # May combine with Hmis::Ce::Match::Expression::CalculatorFactory ?
+  module CalculatorFactory
+    def self.build
+      Dentaku::Calculator.new(case_sensitive: true)
+    end
+  end
+end

--- a/drivers/hmis/app/models/hmis/calculated_field/evaluator.rb
+++ b/drivers/hmis/app/models/hmis/calculated_field/evaluator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Hmis::CalculatedField
+  # Resolves registry variables for a client (derived from enrollment), then evaluates
+  # the CDED's Dentaku expression. Matches the CE pattern: stateless calculator + pre-loaded bindings.
+  class Evaluator
+    def initialize(enabled_resolvers: nil)
+      @enabled_resolvers = enabled_resolvers
+    end
+
+    def evaluate(cded, enrollment:)
+      return nil unless cded.calculated?
+
+      client = enrollment.client
+      variables = {}
+
+      enabled_resolvers.each do |var_name, resolver_class|
+        variables[var_name] = resolver_class.new.call(client)
+      end
+
+      calculator.evaluate!(cded.calculation_expression, **variables)
+    end
+
+    private
+
+    def enabled_resolvers
+      @enabled_resolvers ||= Registry.enabled
+    end
+
+    def calculator
+      @calculator ||= CalculatorFactory.build
+    end
+  end
+end

--- a/drivers/hmis/app/models/hmis/calculated_field/registry.rb
+++ b/drivers/hmis/app/models/hmis/calculated_field/registry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Hmis::CalculatedField
+  # Maps Dentaku variable names to resolver classes. Resolvers are off by default;
+  # enable via AppConfigProperty key `calculated_fields/resolvers/<name>`.
+  module Registry
+    RESOLVERS = {
+      hopwa_weeks_of_service: 'Hmis::CalculatedField::Resolvers::HopwaWeeksOfService',
+      enrollments_count: 'Hmis::CalculatedField::Resolvers::EnrollmentsCount',
+    }.freeze
+
+    def self.enabled
+      enabled_keys = AppConfigProperty.
+        where(key: RESOLVERS.keys.map { |k| "calculated_fields/resolvers/#{k}" }).
+        where(value: true).
+        pluck(:key).
+        to_set
+
+      RESOLVERS.filter_map do |var_name, class_name|
+        next unless enabled_keys.include?("calculated_fields/resolvers/#{var_name}")
+
+        [var_name, class_name.constantize]
+      end.to_h
+    end
+  end
+end

--- a/drivers/hmis/app/models/hmis/calculated_field/resolvers/enrollments_count.rb
+++ b/drivers/hmis/app/models/hmis/calculated_field/resolvers/enrollments_count.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Hmis::CalculatedField::Resolvers
+  class EnrollmentsCount
+    def call(client)
+      client.enrollments.count
+    end
+
+    # def batch_call(client_ids)
+    # preload clients with their enrollments and count enrollments by client id
+    # ...
+  end
+end

--- a/drivers/hmis/app/models/hmis/calculated_field/resolvers/hopwa_weeks_of_service.rb
+++ b/drivers/hmis/app/models/hmis/calculated_field/resolvers/hopwa_weeks_of_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module Hmis::CalculatedField::Resolvers
+  class HopwaWeeksOfService
+    def call(_client)
+      raise NotImplementedError, 'HopwaWeeksOfService resolver not yet implemented'
+    end
+
+    private
+
+    def fiscal_year_start
+      today = Date.current
+      today.month >= 7 ? Date.new(today.year, 7, 1) : Date.new(today.year - 1, 7, 1)
+    end
+
+    def fiscal_year_end
+      fiscal_year_start + 1.year - 1.day
+    end
+  end
+end

--- a/drivers/hmis/app/models/hmis/hud/custom_data_element_definition.rb
+++ b/drivers/hmis/app/models/hmis/hud/custom_data_element_definition.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dentaku'
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -42,6 +44,7 @@ class Hmis::Hud::CustomDataElementDefinition < Hmis::Hud::Base
 
   validates :field_type, inclusion: { in: FIELD_TYPES.map(&:to_s) }, allow_blank: false
   validates_format_of :key, with: /\A[a-zA-Z0-9_-]*\z/
+  validate :calculation_expression_syntax, if: -> { calculation_expression.present? }
 
   scope :for_type, ->(owner_type) do
     where(owner_type: owner_type)
@@ -52,8 +55,13 @@ class Hmis::Hud::CustomDataElementDefinition < Hmis::Hud::Base
   scope :for_custom_services, -> { for_type(Hmis::Hud::CustomService.sti_name) }
   scope :for_hud_or_custom_services, -> { for_type([Hmis::Hud::Service.sti_name, Hmis::Hud::CustomService.sti_name]) }
   scope :for_clients, -> { for_type(Hmis::Hud::Client.sti_name) }
+  scope :calculated, -> { where.not(calculation_expression: nil) }
 
   use_enum_with_same_key :form_role_enum_map, FIELD_TYPES.map { |f| [f, f.to_s.humanize] }.to_h
+
+  def calculated?
+    calculation_expression.present?
+  end
 
   def cde_arel_field
     cde_t = Hmis::Hud::CustomDataElement.arel_table
@@ -61,5 +69,13 @@ class Hmis::Hud::CustomDataElementDefinition < Hmis::Hud::Base
     raise ArgumentError, "Invalid field type: #{field_type}" unless column_name
 
     cde_t[column_name]
+  end
+
+  private
+
+  def calculation_expression_syntax
+    Dentaku::Calculator.new(case_sensitive: true).ast(calculation_expression)
+  rescue Dentaku::ParseError, Dentaku::TokenizerError, Dentaku::Error => e
+    errors.add(:calculation_expression, e.message)
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
This is a proof-of-concept/spike PR demonstrating a possible approach for arbitrary calculated values, stored as CDEDs, and calculated on-the-fly using installation-specific custom code organized as "plugins".

### How it works
- Adds a `calculation_expression` column to `CustomDataElementDefinitions`.
- Adds plugin architecture (`Hmis::CalculatedField` module) for registering plugins that map variable names to resolver classes. Each resolver must be individually enabled via an `AppConfigProperty`, so all of this code is off-by-default and inaccessible except if an installation has explicitly opted in. The directory structure looks like this:
```
drivers/hmis/app/models/hmis/
  calculated_field/
    registry.rb               # AppConfigProperty-gated resolver map
    calculator_factory.rb     # builds stateless Dentaku calculator
    evaluator.rb              # builds variables hash, calls evaluate!
    resolvers/
      hopwa_weeks_of_service.rb
      ...
```
- Updates the shared concern `HasCustomDataElements#resolve_custom_data_elements` to receive a list of relevant calculated CDEDs and calculate values on the fly.

### How I've been testing locally

- I've been using the very simple `enrollments_count` resolver to test. (`HopwaWeeksOfService` is stubbed, I haven't tackled that complexity yet)
- Create an occurrence point form with a CDE, and enable it for a project using a form instance
- Manually set `calculation_expression = 'enrollments_count'` on the CDED in the DB.
- Ensure an `AppConfigProperty` row exists: `key: 'calculated_fields/resolvers/enrollments_count', value: true`.
- Open the enrollment dashboard — the CDE field should show the evaluated count.

### What this proof of concept doesn't tackle / Open questions
- [ ] Full implementation of the `HopwaWeeksOfService` resolver - right now it's just stubbed
- [ ] Spec tests are not included
- [ ] Merging `Hmis::CalculatedField::CalculatorFactory` with `Hmis::Ce::Match::Expression::CalculatorFactory` so that resolver helpers and plugins can be shared across both?
- [ ] The evaluator currently resolves client from enrollment. If calculated CDEDs are later added to client-owned records, a separate `evaluate(cded, client:)` path would be needed.
- [ ] Performance: Resolvers are called per-enrollment at query time. Later we plan to batch-calculate, for example on a daily job, in order to export these calculated values to superset without duplicating calculation logic. I've proposed in comments, but not implemented, a `batch_call` method on the resolver. It's a bit analogous to what `ClientFieldMap` does with the `query` field.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
