### PR TITLE
fix: 9131 avoid clearing source_hash

### DIFF
--- a/app/models/grda_warehouse/tasks/project_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/project_cleanup.rb
@@ -199,10 +199,9 @@ module GrdaWarehouse::Tasks
       outside_cocs = base.where.not(EnrollmentCoC: coc_codes).or(base.where(EnrollmentCoC: nil))
 
       if coc_codes.count == 1
-        outside_cocs.update_all(EnrollmentCoC: coc_codes.first, source_hash: nil)
+        outside_cocs.update_all(EnrollmentCoC: coc_codes.first)
       else
-        # Exclude already-nil rows: setting nil→nil isn't a real change, so don't wipe source_hash
-        outside_cocs.where.not(EnrollmentCoC: nil).update_all(EnrollmentCoC: nil, source_hash: nil)
+        outside_cocs.update_all(EnrollmentCoC: nil)
       end
     end
 

--- a/spec/models/grda_warehouse/tasks/project_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/project_cleanup_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe GrdaWarehouse::Tasks::ProjectCleanup, type: :model do
           expect(enrollment.reload.EnrollmentCoC).to eq('XX-500')
         end
 
-        it 'clears the source_hash on updated enrollments' do
-          enrollment.update_column(:source_hash, 'stale_hash')
+        it 'preserves the source_hash on updated enrollments' do
+          enrollment.update_column(:source_hash, 'current_hash')
           cleaner.fix_client_locations(project)
-          expect(enrollment.reload.source_hash).to be_nil
+          expect(enrollment.reload.source_hash).to eq('current_hash')
         end
       end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Commit `d84124b9` (2026-03-19, "8957 demographic summary bug (#6311)") fixed a bug where enrollments with NULL `EnrollmentCoC` were silently skipped by `fix_client_locations` due to SQL's `NULL != value` semantics. The fix added `.or(base.where(EnrollmentCoC: nil))` to include them.

However, this created a cycle for sources that don't populate `EnrollmentCoC` in the CSV. `fix_client_locations` corrects the null CoC and clears `source_hash`. On the next import, `mark_unchanged` sees a null warehouse `source_hash` against a non-null staging hash and treats the enrollment as changed. `apply_updates` then overwrites the warehouse row with the CSV's null CoC, and `fix_client_locations` runs again, repeating indefinitely.

I think the solution is to stop clearing `source_hash` in `fix_client_locations` - this logic pre-dates `d84124b9`. I'm guessing the intention was to flag that the data had changed and needed reprocessing but `source_hash` doesn't seem to be the right field for that

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

