### PR TITLE
9155 service history processing job tracking

### DIFF
--- a/app/jobs/service_history/rebuild_enrollments_by_batch_job.rb
+++ b/app/jobs/service_history/rebuild_enrollments_by_batch_job.rb
@@ -25,14 +25,27 @@ module ServiceHistory
           where(id: id).
           each(&:rebuild_service_history!)
       end
+
+      clear_processing_job_id
     end
 
     def enqueue(job)
       job.priority = BaseJob::PRE_BULK_PROCESSING_PRIORITY_9
     end
 
+    def failure(_job)
+      clear_processing_job_id
+    end
+
     def max_attempts
       2
+    end
+
+    private
+
+    def clear_processing_job_id
+      GrdaWarehouse::Hud::Enrollment.where(id: @enrollment_ids).
+        update_all(service_history_processing_job_id: nil)
     end
   end
 end

--- a/app/jobs/service_history/rebuild_enrollments_by_batch_job.rb
+++ b/app/jobs/service_history/rebuild_enrollments_by_batch_job.rb
@@ -33,6 +33,10 @@ module ServiceHistory
       job.priority = BaseJob::PRE_BULK_PROCESSING_PRIORITY_9
     end
 
+    # DJ calls this only after all max_attempts are exhausted (failed_at is set at that point).
+    # Between retries, failed_at remains nil, so the job stays in the active_job_ids set
+    # used by wait_for_processing / clients_still_processing? — enrollment stamps are correctly
+    # treated as in-progress until the retry either succeeds or permanently fails.
     def failure(_job)
       clear_processing_job_id
     end

--- a/app/models/concerns/service_history/builder.rb
+++ b/app/models/concerns/service_history/builder.rb
@@ -61,7 +61,7 @@ module ServiceHistory::Builder
         Delayed::Worker.new.work_off(2)
       else
         started = Time.current
-        while builder_batch_job_scope.exists?
+        while GrdaWarehouse::Hud::Enrollment.where.not(service_history_processing_job_id: nil).exists?
           return if (Time.current - started) > max_wait_seconds
 
           sleep(interval)
@@ -117,20 +117,7 @@ module ServiceHistory::Builder
 
       GrdaWarehouse::Hud::Enrollment.where(
         id: builder_client_enrollment_ids(client_ids),
-        service_history_processing_job_id: builder_batch_job_scope.pluck(:id),
-      ).exists?
-    end
-
-    # Class method
-    private def builder_batch_job_scope
-      @counter ||= 1
-      Delayed::Job.uncached do
-        Delayed::Job.where(failed_at: nil).
-          # Cache buster - for whatever reason `uncached` is completely inconsistent.
-          # We ALWAYS want this to query the database.
-          where("1 != #{@counter += 1}").
-          jobs_for_class('ServiceHistory::RebuildEnrollments')
-      end
+      ).where.not(service_history_processing_job_id: nil).exists?
     end
 
     # Class method
@@ -144,13 +131,19 @@ module ServiceHistory::Builder
 
     # Class method
     private def builder_create_enrollment_jobs(scope)
-      en_ids = scope.distinct.joins(:project, :destination_client).order(:data_source_id).pluck(:id, :data_source_id).map(&:first).uniq
-      already_queued = Set.new
-      builder_batch_job_scope.each do |dj|
-        queued_ids = dj.payload_object.instance_variable_get(:@enrollment_ids)
-        already_queued += queued_ids
-      end
-      en_ids -= already_queued.to_a
+      # Clear stale job references where the DJ row is gone or has permanently failed.
+      # This recovers enrollments left stamped after a worker crash bypassed the failure callback.
+      # Delayed::Job lives in the app DB; Enrollment is in the warehouse DB, so we must
+      # materialize active job IDs in Ruby rather than using a cross-database subquery.
+      active_job_ids = Delayed::Job.where(failed_at: nil).pluck(:id)
+      scope.where.not(service_history_processing_job_id: nil)
+        .where.not(service_history_processing_job_id: active_job_ids)
+        .update_all(service_history_processing_job_id: nil)
+
+      en_ids = scope.distinct.joins(:project, :destination_client)
+        .where(service_history_processing_job_id: nil)
+        .order(:data_source_id).pluck(:id, :data_source_id).map(&:first).uniq
+
       Rails.logger.info "Found #{en_ids.count} enrollments needing processing"
       en_ids.each_slice(400) do |batch|
         job = Delayed::Job.enqueue(

--- a/app/models/concerns/service_history/builder.rb
+++ b/app/models/concerns/service_history/builder.rb
@@ -61,7 +61,12 @@ module ServiceHistory::Builder
         Delayed::Worker.new.work_off(2)
       else
         started = Time.current
-        while GrdaWarehouse::Hud::Enrollment.where.not(service_history_processing_job_id: nil).exists?
+        loop do
+          active_job_ids = Delayed::Job.where(failed_at: nil).
+            jobs_for_class('ServiceHistory::RebuildEnrollmentsByBatchJob').pluck(:id)
+          break unless active_job_ids.any? &&
+            GrdaWarehouse::Hud::Enrollment.where(service_history_processing_job_id: active_job_ids).exists?
+
           return if (Time.current - started) > max_wait_seconds
 
           sleep(interval)
@@ -115,9 +120,14 @@ module ServiceHistory::Builder
     def clients_still_processing?(client_ids:)
       client_ids = Array.wrap(client_ids)
 
+      active_job_ids = Delayed::Job.where(failed_at: nil).
+        jobs_for_class('ServiceHistory::RebuildEnrollmentsByBatchJob').pluck(:id)
+      return false if active_job_ids.empty?
+
       GrdaWarehouse::Hud::Enrollment.where(
         id: builder_client_enrollment_ids(client_ids),
-      ).where.not(service_history_processing_job_id: nil).exists?
+        service_history_processing_job_id: active_job_ids,
+      ).exists?
     end
 
     # Class method
@@ -135,14 +145,15 @@ module ServiceHistory::Builder
       # This recovers enrollments left stamped after a worker crash bypassed the failure callback.
       # Delayed::Job lives in the app DB; Enrollment is in the warehouse DB, so we must
       # materialize active job IDs in Ruby rather than using a cross-database subquery.
-      active_job_ids = Delayed::Job.where(failed_at: nil).pluck(:id)
-      scope.where.not(service_history_processing_job_id: nil)
-        .where.not(service_history_processing_job_id: active_job_ids)
-        .update_all(service_history_processing_job_id: nil)
+      active_job_ids = Delayed::Job.where(failed_at: nil).
+        jobs_for_class('ServiceHistory::RebuildEnrollmentsByBatchJob').pluck(:id)
+      scope.where.not(service_history_processing_job_id: nil).
+        where.not(service_history_processing_job_id: active_job_ids).
+        update_all(service_history_processing_job_id: nil)
 
-      en_ids = scope.distinct.joins(:project, :destination_client)
-        .where(service_history_processing_job_id: nil)
-        .order(:data_source_id).pluck(:id, :data_source_id).map(&:first).uniq
+      en_ids = scope.distinct.joins(:project, :destination_client).
+        where(service_history_processing_job_id: nil).
+        order(:data_source_id).pluck(:id, :data_source_id).map(&:first).uniq
 
       Rails.logger.info "Found #{en_ids.count} enrollments needing processing"
       en_ids.each_slice(400) do |batch|

--- a/app/models/concerns/service_history/builder.rb
+++ b/app/models/concerns/service_history/builder.rb
@@ -153,8 +153,11 @@ module ServiceHistory::Builder
       en_ids -= already_queued.to_a
       Rails.logger.info "Found #{en_ids.count} enrollments needing processing"
       en_ids.each_slice(400) do |batch|
-        Delayed::Job.enqueue(::ServiceHistory::RebuildEnrollmentsByBatchJob.new(enrollment_ids: batch), queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running))
-        # GrdaWarehouse::Hud::Enrollment.where(id: batch).update_all(service_history_processing_job_id: job.id)
+        job = Delayed::Job.enqueue(
+          ::ServiceHistory::RebuildEnrollmentsByBatchJob.new(enrollment_ids: batch),
+          queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running),
+        )
+        GrdaWarehouse::Hud::Enrollment.where(id: batch).update_all(service_history_processing_job_id: job.id)
       end
     end
   end

--- a/app/models/grda_warehouse/hud/enrollment.rb
+++ b/app/models/grda_warehouse/hud/enrollment.rb
@@ -211,13 +211,6 @@ module GrdaWarehouse::Hud
       where.not(processed_as: nil)
     end
 
-    scope :unassigned, -> do
-      jobs = GrdaWarehouse::Tasks::ServiceHistory::Enrollment.batch_job_ids
-      return current_scope unless jobs.present?
-
-      where(e_t[:service_history_processing_job_id].eq(nil).or(e_t[:service_history_processing_job_id].not_in(jobs)))
-    end
-
     def self.related_item_keys
       [
         :PersonalID,

--- a/app/models/grda_warehouse/tasks/service_history/enrollment.rb
+++ b/app/models/grda_warehouse/tasks/service_history/enrollment.rb
@@ -18,10 +18,6 @@ module GrdaWarehouse::Tasks::ServiceHistory
 
     SO = HudHelper.util.residential_project_type_numbers_by_code[:so]
 
-    def self.batch_job_ids
-      builder_batch_job_scope.pluck(:id)
-    end
-
     def self.batch_process_unprocessed!(max_wait_seconds: DEFAULT_MAX_WAIT_SECONDS)
       queue_batch_process_unprocessed!
       wait_for_processing(max_wait_seconds: max_wait_seconds)

--- a/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
+++ b/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
@@ -317,5 +317,12 @@ RSpec.describe GrdaWarehouse::Tasks::ServiceHistory::Enrollment, type: :model do
 
       expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: destination_client.id)).to be false
     end
+
+    it 'does not enqueue duplicate jobs when queue_clients is called twice before any job runs' do
+      expect do
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.queue_clients(destination_client.id)
+        GrdaWarehouse::Tasks::ServiceHistory::Enrollment.queue_clients(destination_client.id)
+      end.to change(Delayed::Job, :count).by(1)
+    end
   end
 end

--- a/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
+++ b/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe GrdaWarehouse::Tasks::ServiceHistory::Enrollment, type: :model do
     end
     let!(:exit_record) do
       create :hud_exit, data_source_id: data_source.id, EnrollmentID: enrollment.EnrollmentID,
-             PersonalID: client.PersonalID, ExitDate: '2023-01-10'
+                        PersonalID: client.PersonalID, ExitDate: '2023-01-10'
     end
     let(:destination_client) { GrdaWarehouse::WarehouseClient.find_by(source_id: client.id).destination }
 
@@ -312,10 +312,12 @@ RSpec.describe GrdaWarehouse::Tasks::ServiceHistory::Enrollment, type: :model do
       GrdaWarehouse::Tasks::ServiceHistory::Enrollment.queue_clients(destination_client.id)
 
       expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: destination_client.id)).to be true
+      expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: [destination_client.id])).to be true
 
       Delayed::Worker.new.work_off
 
       expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: destination_client.id)).to be false
+      expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: [destination_client.id])).to be false
     end
 
     it 'does not enqueue duplicate jobs when queue_clients is called twice before any job runs' do

--- a/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
+++ b/spec/models/grda_warehouse/tasks/service_history/enrollment_spec.rb
@@ -282,4 +282,40 @@ RSpec.describe GrdaWarehouse::Tasks::ServiceHistory::Enrollment, type: :model do
       end
     end
   end
+
+  describe 'processing job tracking via service_history_processing_job_id' do
+    let(:project) { create :grda_warehouse_hud_project, data_source: data_source, organization: organization, project_type: 0 }
+    let(:client) { create_client_with_warehouse_link(dob: '2000-01-01') }
+    let!(:enrollment) do
+      create :grda_warehouse_hud_enrollment, data_source: data_source, project: project, client: client, entry_date: '2023-01-01'
+    end
+    let!(:exit_record) do
+      create :hud_exit, data_source_id: data_source.id, EnrollmentID: enrollment.EnrollmentID,
+             PersonalID: client.PersonalID, ExitDate: '2023-01-10'
+    end
+    let(:destination_client) { GrdaWarehouse::WarehouseClient.find_by(source_id: client.id).destination }
+
+    it 'stamps the DJ id on enrollments when queued and clears it after the job runs' do
+      expect(enrollment.reload.service_history_processing_job_id).to be_nil
+
+      GrdaWarehouse::Tasks::ServiceHistory::Enrollment.queue_clients(destination_client.id)
+
+      expect(enrollment.reload.service_history_processing_job_id).to be_present
+
+      # In the test environment, work_off processes the queued jobs synchronously
+      Delayed::Worker.new.work_off
+
+      expect(enrollment.reload.service_history_processing_job_id).to be_nil
+    end
+
+    it 'clients_still_processing? returns true while job is pending and false after completion' do
+      GrdaWarehouse::Tasks::ServiceHistory::Enrollment.queue_clients(destination_client.id)
+
+      expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: destination_client.id)).to be true
+
+      Delayed::Worker.new.work_off
+
+      expect(GrdaWarehouse::Tasks::ServiceHistory::Enrollment.clients_still_processing?(client_ids: destination_client.id)).to be false
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Fix service history processing job tracking, which was never writing the DJ ID to enrollments, causing `clients_still_processing?` to always return false.

- **Job Stamp on Enqueue**: Activate the commented-out `update_all` call in `builder_create_enrollment_jobs` that stamps `service_history_processing_job_id` with the DJ row ID after enqueueing each batch
- **Job Stamp Cleared on Completion/Failure**: Add `clear_processing_job_id` calls in the batch job's success path and `failure` callback so stamps are removed when a job finishes or permanently fails
- **Stale Stamp Recovery**: Before enqueueing new jobs, clear stamps pointing to DJ rows that no longer exist or have permanently failed, recovering enrollments left stranded by worker crashes
- **Dedup via Stamp Column**: Replace the handler-deserializing dedup scan (`builder_batch_job_scope.each { dj.payload_object... }`) with a SQL filter on `service_history_processing_job_id: nil`; eliminates a sequential scan on the unindexed `handler` column
- **`wait_for_processing` Loop Fix**: Replace `builder_batch_job_scope.exists?` with a two-step check — fetch active DJ IDs, then verify any enrolled rows still carry those IDs — so the loop correctly terminates
- **`clients_still_processing?` Fix**: Rewrite to use active DJ IDs from the database rather than the stale `builder_batch_job_scope` pluck
- **Dead Code Removal**: Remove `builder_batch_job_scope` (including its cache-buster hack), `Enrollment.unassigned` scope, and `Tasks::ServiceHistory::Enrollment.batch_job_ids`
- Test coverage for stamp lifecycle, `clients_still_processing?` correctness, and duplicate-enqueue prevention

### Type of Change

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

