### PR TITLE
fix: CVE-2026-41316 (erb)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -30,3 +30,6 @@ CVE-2025-61729
 
 # devise, we monkey patched the user model; avoids major version upgrade as we will replace devise with SSO in the near future
 CVE-2026-32700
+
+# our app code is patched but the built-in gem for ruby 3.4 remains. Currently ruby 3.4 has no patch to bump the dependency. Can be removed after we upgrade to ruby 4
+CVE-2026-41316

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -477,7 +477,7 @@ GEM
     ed25519 (1.4.0)
     email_check (1.0.2)
     encryptor (3.0.0)
-    erb (5.0.2)
+    erb (6.0.4)
     erubi (1.13.1)
     erubis (2.7.0)
     excon (0.112.0)
@@ -1515,7 +1515,7 @@ CHECKSUMS
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   email_check (1.0.2) sha256=e1e57c76123289b2ab4c85ac92bc3160f2d7eb2f911bccd889d2a51bf4ec6481
   encryptor (3.0.0) sha256=abf23f94ab4d864b8cea85b43f3432044a60001982cda7c33c1cd90da8db1969
-  erb (5.0.2) sha256=d30f258143d4300fb4ecf430042ac12970c9bb4b33c974a545b8f58c1ec26c0f
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   erubis (2.7.0) sha256=63653f5174a7997f6f1d6f465fbe1494dcc4bdab1fb8e635f6216989fb1148ba
   excon (0.112.0) sha256=daf9ac3a4c2fc9aa48383a33da77ecb44fa395111e973084d5c52f6f214ae0f0

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -175,8 +175,8 @@ ENV RUBYOPT="-r/usr/local/lib/ruby/has_rdoc_patch.rb ${RUBYOPT}"
 # rexml: CVE-2025-58767, rack: CVE in system gem shipped with base image — both must be explicitly updated since they're bundled with ruby
 # gem cleanup removes old gemspecs that vulnerability scanners (e.g. Trivy) would otherwise flag
 RUN gem update --system \
-  && gem update rexml rack \
-  && gem cleanup rexml rack \
+  && gem update rexml rack erb \
+  && gem cleanup rexml rack erb \
   && gem install bundler --version=${BUNDLER_VERSION} \
   && bundle config set --local path /bundle \
   && chown -R app-user:app-user /bundle \


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
upgrade erb CVE-2026-41316

although this is a major version jump, I don't see anything impacting us in the changelog

## Type of change
Dependency update
