### PR TITLE
Update DestinationClientLatestAssessment view with data source

### DIFF
--- a/db/views/hmis_destination_client_latest_assessments_v02.sql
+++ b/db/views/hmis_destination_client_latest_assessments_v02.sql
@@ -1,0 +1,19 @@
+-- View that provides latest custom assessments for destination clients per form identifier per HMIS data source
+-- This enables easy joining to get CDE values from the most recent assessments per form type
+SELECT DISTINCT ON (wc.destination_id, def.identifier, def.data_source_id)
+  wc.destination_id AS destination_client_id,
+  ca.id AS custom_assessment_id,
+  def.identifier AS form_identifier,
+  def.data_source_id AS data_source_id
+FROM "warehouse_clients" wc
+INNER JOIN "Client" c ON c."DateDeleted" IS NULL
+  AND c.id = wc.source_id
+INNER JOIN "CustomAssessments" ca ON ca."DateDeleted" IS NULL
+  AND ca."data_source_id" = c."data_source_id"
+  AND ca."PersonalID" = c."PersonalID"
+INNER JOIN "hmis_form_processors" fp ON fp.owner_type = 'Hmis::Hud::CustomAssessment'
+  AND fp.owner_id = ca.id
+INNER JOIN "hmis_form_definitions" def ON def."deleted_at" IS NULL
+  AND def.id = fp.definition_id
+WHERE wc.destination_id IS NOT NULL
+ORDER BY wc.destination_id, def.identifier, def.data_source_id, ca."AssessmentDate" DESC, ca.id DESC;

--- a/db/warehouse/migrate/20260424202316_update_hmis_destination_client_latest_assessments_to_v2.rb
+++ b/db/warehouse/migrate/20260424202316_update_hmis_destination_client_latest_assessments_to_v2.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Adds data_source_id to hmis_destination_client_latest_assessments
+class UpdateHmisDestinationClientLatestAssessmentsToV2 < ActiveRecord::Migration[7.2]
+  # Re-create the "no_modify" trigger originally added in StandardizeIdsToBigint
+  # (20260207120000). scenic's update_view drops and re-creates the view, which
+  # cascades away any triggers attached to it.
+  TRIGGER_NAME = 'no_modify_hmis_destination_client_latest_assessments'
+  VIEW_NAME = 'hmis_destination_client_latest_assessments'
+
+  def up
+    update_view :hmis_destination_client_latest_assessments, version: 2, revert_to_version: 1
+    safety_assured do
+      execute(<<~SQL)
+        CREATE TRIGGER #{TRIGGER_NAME}
+          INSTEAD OF UPDATE OR DELETE ON public."#{VIEW_NAME}"
+          FOR EACH ROW EXECUTE FUNCTION prevent_modification();
+      SQL
+    end
+  end
+
+  def down
+    update_view :hmis_destination_client_latest_assessments, version: 1, revert_to_version: 2
+    safety_assured do
+      execute(<<~SQL)
+        CREATE TRIGGER #{TRIGGER_NAME}
+          INSTEAD OF UPDATE OR DELETE ON public."#{VIEW_NAME}"
+          FOR EACH ROW EXECUTE FUNCTION prevent_modification();
+      SQL
+    end
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260424202316
+# rails db:migrate:down:warehouse VERSION=20260424202316

--- a/drivers/hmis/app/models/hmis/ce/filtered_candidates_query.rb
+++ b/drivers/hmis/app/models/hmis/ce/filtered_candidates_query.rb
@@ -87,6 +87,8 @@ module Hmis::Ce
         joins(:unit_groups).
         where(arel.ug_t[:id].eq(@unit_group_id)).
         distinct
+
+      # TODO(#9074): Prevent relevant_form_definition_identifiers from returning form definitions from the wrong data source
       form_identifiers = candidate_pools.flat_map(&:relevant_form_definition_identifiers).uniq
 
       # Get most recent assessment date per client

--- a/drivers/hmis/app/models/hmis/ce/match/expression/cde_field_map.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/cde_field_map.rb
@@ -20,6 +20,7 @@ module Hmis::Ce::Match::Expression
       cde_t = Hmis::Hud::CustomDataElement.arel_table
       values = Hmis::DestinationClientLatestAssessment.
         where(destination_client_id: client_ids).
+        where(data_source_id: cded.data_source_id).
         where(form_identifier: cded.form_definition_identifier).
         joins(custom_assessment: :custom_data_elements).
         where(cde_t[:data_element_definition_id].eq(cded.id)).

--- a/drivers/hmis/app/models/hmis/ce/match/expression/custom_assessment_field_map.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/custom_assessment_field_map.rb
@@ -13,10 +13,15 @@ module Hmis::Ce::Match::Expression
       column = column_for_field(field_name)
       client_ids = clients.pluck(:id)
 
+      # TODO(#9095): DestinationClientLatestAssessment returns one row per (destination_client, form_identifier, data_source).
+      # But based on the `field`, at this point we don't know what data source we are interested in.
+      # For now, just order by recency and keep the single most recent assessment with that identifier across data sources.
       result = Hmis::DestinationClientLatestAssessment.
         where(destination_client_id: client_ids).
         where(form_identifier: form_definition_identifier).
         joins(:custom_assessment).
+        # order oldest-first so the most recent row wins when collapsed with to_h
+        order(arel.cas_t[:AssessmentDate].asc, arel.cas_t[:id].asc).
         pluck(:destination_client_id, column).
         to_h
 

--- a/drivers/hmis/app/models/hmis/destination_client_latest_assessment.rb
+++ b/drivers/hmis/app/models/hmis/destination_client_latest_assessment.rb
@@ -9,4 +9,5 @@ class Hmis::DestinationClientLatestAssessment < GrdaWarehouseBase
 
   belongs_to :destination_client, class_name: 'GrdaWarehouse::Hud::Client'
   belongs_to :custom_assessment, class_name: 'Hmis::Hud::CustomAssessment'
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 end

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/cde_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/cde_field_map_spec.rb
@@ -4,14 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Hmis::Ce::Match::Expression::CdeFieldMap, type: :model do
   let!(:destination_data_source) { create :destination_data_source }
+  let!(:hmis_data_source) { create(:hmis_data_source) }
   let(:current_date) { Date.new(2024, 12, 26) }
   let(:field_map) { described_class.new(current_date: current_date) }
 
-  let(:client1) { create(:hmis_hud_client_with_warehouse_client) }
+  let(:client1) { create(:hmis_hud_client_with_warehouse_client, data_source: hmis_data_source) }
   let(:destination_client1) { client1.destination_client }
-  let(:client2) { create(:hmis_hud_client_with_warehouse_client) }
+  let(:client2) { create(:hmis_hud_client_with_warehouse_client, data_source: hmis_data_source) }
   let(:destination_client2) { client2.destination_client }
-  let(:client3_no_assessment) { create(:hmis_hud_client_with_warehouse_client) }
+  let(:client3_no_assessment) { create(:hmis_hud_client_with_warehouse_client, data_source: hmis_data_source) }
   let(:destination_client3) { client3_no_assessment.destination_client }
 
   let(:all_destination_clients) { GrdaWarehouse::Hud::Client.where(id: [destination_client1.id, destination_client2.id, destination_client3.id]) }
@@ -22,13 +23,14 @@ RSpec.describe Hmis::Ce::Match::Expression::CdeFieldMap, type: :model do
   let(:allergies_field) { 'custom_assessment.allergies' }
   let(:invalid_field) { 'custom_assessment.nonexistent_field' }
 
-  let(:form_definition) { create(:hmis_form_definition, identifier: 'test_form') }
+  let(:form_definition) { create(:hmis_form_definition, identifier: 'test_form', data_source: hmis_data_source) }
   let(:string_cded) do
     create(:hmis_custom_data_element_definition,
            owner_type: 'Hmis::Hud::CustomAssessment',
            key: 'language_preference',
            field_type: 'string',
-           form_definition_identifier: 'test_form')
+           form_definition_identifier: 'test_form',
+           data_source: hmis_data_source)
   end
   let(:repeating_cded) do
     create(:hmis_custom_data_element_definition,
@@ -36,7 +38,8 @@ RSpec.describe Hmis::Ce::Match::Expression::CdeFieldMap, type: :model do
            key: 'allergies',
            field_type: 'string',
            repeats: true,
-           form_definition_identifier: 'test_form')
+           form_definition_identifier: 'test_form',
+           data_source: hmis_data_source)
   end
 
   # Helper method to create assessment with custom data elements
@@ -113,6 +116,23 @@ RSpec.describe Hmis::Ce::Match::Expression::CdeFieldMap, type: :model do
       expect do
         field_map.client_query(all_destination_clients, invalid_field)
       end.to raise_error(ArgumentError, /Unknown CDE in field/)
+    end
+
+    context 'with form definitions that have the same identifier across data sources' do
+      let!(:ds2) { create(:hmis_data_source) }
+      let!(:form_definition2) { create(:hmis_form_definition, identifier: 'test_form', data_source: ds2) }
+      let!(:ds2_client) { create(:hmis_hud_client, data_source: ds2) }
+      let!(:warehouse_client) { create(:warehouse_client, destination_id: destination_client1.id, source_id: ds2_client.id) }
+
+      it 'selects values from the most recent assessment in the correct data source' do
+        # This is the correct form that defines the language_field CDED. It should be returned even though it's less recent.
+        create_assessment_for_client(client1, assessment_date: current_date - 2.days, language_preference: 'English')
+        # This assessment is recent, but the form in ds2 doesn't have a language_field CDED and should be ignored.
+        create(:hmis_custom_assessment, client: ds2_client, data_source: ds2, assessment_date: current_date, definition: form_definition2)
+
+        result = field_map.client_query(GrdaWarehouse::Hud::Client.where(id: destination_client1.id), language_field)
+        expect(result[destination_client1.id]).to eq('English')
+      end
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe Hmis::Ce::Match::Expression::CustomAssessmentFieldMap, type: :mod
       it 'returns the most recent assessment for the form identifier, regardless of data source' do
         dest = client1.destination_client
         result = field_map.client_query(GrdaWarehouse::Hud::Client.where(id: dest.id), identifier + '.assessment_date')
-        # It chooses the assessment date from assessment2, since it's the same form identifier.
-        # TODO(#9095): Update this test when the behavior is corrected
-        expect(result[dest.id]).to eq(current_date - 1.day)
+        # Since both forms use the same identifier, it assessment2.assessment_date, which is more recent.
+        # TODO(#9095): This test will need to be updated if the behavior changes
+        expect(result[dest.id]).to eq(assessment2.assessment_date)
       end
     end
   end

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Hmis::Ce::Match::Expression::CustomAssessmentFieldMap, type: :mod
         expect(result[destination_client2.id]).to be_nil # No intake assessment
       end
     end
+
+    # TODO(#9095): Update this test when the behavior is corrected
+    context 'with multiple forms that have the same identifier across data sources' do
+      let!(:hmis1) { create(:hmis_data_source) }
+      let!(:hmis2) { create(:hmis_data_source) }
+      let(:identifier) { 'my_assessment' }
+      let!(:form1) { create(:hmis_form_definition, identifier: identifier, data_source: hmis1) }
+      let!(:form2) { create(:hmis_form_definition, identifier: identifier, data_source: hmis2) }
+
+      before do
+        create_assessment_for_client(client1, form1, current_date - 2.days)
+        create_assessment_for_client(client1, form2, current_date - 1.day)
+
+        result = field_map.client_query(GrdaWarehouse::Hud::Client.where(id: destination_client1.id), 'my_assessment.assessment_date')
+        expect(result[destination_client1.id]).to eq(current_date - 1.day)
+      end
+    end
   end
 
   describe 'field labels and formatting' do

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/custom_assessment_field_map_spec.rb
@@ -116,20 +116,31 @@ RSpec.describe Hmis::Ce::Match::Expression::CustomAssessmentFieldMap, type: :mod
       end
     end
 
-    # TODO(#9095): Update this test when the behavior is corrected
     context 'with multiple forms that have the same identifier across data sources' do
-      let!(:hmis1) { create(:hmis_data_source) }
-      let!(:hmis2) { create(:hmis_data_source) }
       let(:identifier) { 'my_assessment' }
+
+      let!(:hmis1) { create(:hmis_data_source) }
+      let!(:project1) { create(:hmis_hud_project, data_source: hmis1) }
+      let!(:client1) { create(:hmis_hud_client_with_warehouse_client, data_source: hmis1) }
       let!(:form1) { create(:hmis_form_definition, identifier: identifier, data_source: hmis1) }
+      let!(:enrollment1) { create(:hmis_hud_enrollment, project: project1, client: client1, data_source: hmis1) }
+      let!(:assessment1) { create(:hmis_custom_assessment, definition: form1, enrollment: enrollment1, data_source: hmis1, assessment_date: current_date - 2.days) }
+
+      let!(:hmis2) { create(:hmis_data_source) }
+      let!(:project2) { create(:hmis_hud_project, data_source: hmis2) }
       let!(:form2) { create(:hmis_form_definition, identifier: identifier, data_source: hmis2) }
+      let!(:client2) { create(:hmis_hud_client, data_source: hmis2) }
+      # link client2 to the same destination client as client1
+      let!(:client2_warehouse) { create(:warehouse_client, destination_id: destination_client1.id, source_id: client2.id) }
+      let!(:enrollment2) { create(:hmis_hud_enrollment, project: project2, client: client2, data_source: hmis2) }
+      let!(:assessment2) { create(:hmis_custom_assessment, definition: form2, enrollment: enrollment2, data_source: hmis2, assessment_date: current_date - 1.day) }
 
-      before do
-        create_assessment_for_client(client1, form1, current_date - 2.days)
-        create_assessment_for_client(client1, form2, current_date - 1.day)
-
-        result = field_map.client_query(GrdaWarehouse::Hud::Client.where(id: destination_client1.id), 'my_assessment.assessment_date')
-        expect(result[destination_client1.id]).to eq(current_date - 1.day)
+      it 'returns the most recent assessment for the form identifier, regardless of data source' do
+        dest = client1.destination_client
+        result = field_map.client_query(GrdaWarehouse::Hud::Client.where(id: dest.id), identifier + '.assessment_date')
+        # It chooses the assessment date from assessment2, since it's the same form identifier.
+        # TODO(#9095): Update this test when the behavior is corrected
+        expect(result[dest.id]).to eq(current_date - 1.day)
       end
     end
   end

--- a/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hmis::Ce::Match::Engine, type: :model do
   # must exist for identify duplicates, we match on destination clients
   let!(:destination_data_source) { create :destination_data_source }
   let(:data_source) { create(:hmis_data_source) }
-  let(:fd) { create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published, version: 1) }
+  let(:fd) { create(:hmis_form_definition, role: :CUSTOM_ASSESSMENT, status: :published, version: 1, data_source: data_source) }
   let(:project) { create(:hmis_hud_project, data_source: data_source) }
   let(:pool) do
     create(

--- a/drivers/hmis/spec/models/hmis/ce/referral_resolved_match_rule_fields_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_resolved_match_rule_fields_spec.rb
@@ -21,11 +21,12 @@ RSpec.describe Hmis::Ce::Referral, type: :model do
 
   describe 'resolve_match_rule_fields' do
     context 'when resolving custom data element field' do
+      let(:form_definition) { create(:hmis_form_definition, identifier: 'test_form', data_source: ds1) }
+      let(:cded) { create(:hmis_custom_data_element_definition, data_source: ds1, key: 'housing_preference', label: 'Preferred Housing', owner_type: 'Hmis::Hud::CustomAssessment', form_definition_identifier: form_definition.identifier) }
+
       let(:requirement_expression) { '`cde.custom_assessment.housing_preference` = "apartment"' }
       let(:enrollment) { create(:hmis_hud_enrollment, client: client, data_source: ds1) }
-      let(:assessment) { create(:hmis_custom_assessment, enrollment: enrollment, data_source: ds1) }
-
-      let(:cded) { create(:hmis_custom_data_element_definition, data_source: ds1, key: 'housing_preference', label: 'Preferred Housing', owner_type: 'Hmis::Hud::CustomAssessment', form_definition_identifier: assessment.definition.identifier) }
+      let(:assessment) { create(:hmis_custom_assessment, enrollment: enrollment, data_source: ds1, definition: form_definition) }
       let!(:cde) { create(:hmis_custom_data_element, data_element_definition: cded, owner: assessment, value_string: 'house') }
 
       it 'resolves fields for custom data elements correctly' do

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   # Create a candidate pool that depends on a custom data element
-  let!(:form_definition) { create(:custom_assessment_with_custom_fields, role: :CUSTOM_ASSESSMENT, status: :published, version: 1) }
-  # custom_assessment_with_custom_fields factory generates cded "custom_question_1"
-  let!(:cded) { create :hmis_custom_data_element_definition, owner_type: 'Hmis::Hud::CustomAssessment', key: 'custom_question_1', form_definition: form_definition }
+  # custom_assessment_with_custom_fields definition factory generates cded "custom_question_1"
+  let!(:form_definition) { create(:custom_assessment_with_custom_fields, role: :CUSTOM_ASSESSMENT, status: :published, version: 1, generate_cdeds: true) }
   let!(:candidate_pool) { create :hmis_ce_match_candidate_pool, priority_expression: 'cde.custom_assessment.custom_question_1' }
 
   let!(:unit_group) { create(:hmis_unit_group, project: p1, candidate_pool: candidate_pool) }
@@ -254,6 +253,27 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           candidates = result.dig('data', 'ceOpportunity', 'candidates', 'nodes')
           expect(candidates.size).to eq(3)
           expect(candidates.map { |c| c['id'] }).to contain_exactly(candidate1.id.to_s, candidate2.id.to_s, candidate3.id.to_s)
+        end
+      end
+
+      context 'when the destination client has another assessment with the same form identifier in a different data source' do
+        # there's a second HMIS data source that has a form definition with the same identifier
+        let!(:ds2) { create(:hmis_data_source) }
+        let!(:fd2) { create(:hmis_form_definition, identifier: form_definition.identifier, role: :CUSTOM_ASSESSMENT, data_source: ds2) }
+
+        # the declined client, client_1, has another source client in ds2
+        let!(:ds2_client) { create(:hmis_hud_client, data_source: ds2) }
+        let!(:ds2_wh_client) { create(:warehouse_client, destination_id: client_1.destination_client.id, source_id: ds2_client.id) }
+
+        # the declined client has an fd2 assessment since the decline, but this should be irrelevant - it's not the assessment with the CDED that this candidate pool uses
+        let!(:enrollment) { create(:hmis_hud_enrollment, client: ds2_client, data_source: ds2) }
+        let!(:assessment) { create(:hmis_custom_assessment, definition: fd2, client: ds2_client, enrollment: enrollment, date_updated: 1.hour.ago) }
+
+        # TODO(#9074): Reinstate this test when the behavior is corrected
+        xit 'does not return the destination client' do
+          _, result = post_graphql(**variables) { query }
+          candidates = result.dig('data', 'ceOpportunity', 'candidates', 'nodes')
+          expect(candidates.map { |c| c['id'] }).not_to include(candidate1.id.to_s)
         end
       end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- Targets the long-lived feature branch https://github.com/greenriver/hmis-warehouse/pull/6355

## Description
- Update the `Hmis::DestinationClientLatestAssessment` view to return the definition's `data_source_id`, now that definition identifiers are no longer unique across data sources.
- In `CdeFieldMap`, ensure that when we are querying for a CDED's value, we scope the assessments to the CDED's data source.
- For other usages of `DestinationClientLatestAssessment` I've linked to existing tickets where I think we need to discuss more and determine the correct behavior.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Multi-hmis build out

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
