### PR TITLE
fix: CVE-2026-41324 basic-ftp yet again

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^5.8.2"
   },
   "resolutions": {
-    "basic-ftp": "5.2.2",
+    "basic-ftp": "5.3.0",
     "flatted": "3.4.2",
     "picomatch": "^2.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,10 +617,10 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
-basic-ftp@5.2.2, basic-ftp@^5.0.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.2.tgz#4cb2422deddf432896bdb3c9b8f13b944ad4842c"
-  integrity sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==
+basic-ftp@5.3.0, basic-ftp@^5.0.2:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.0.tgz#88f057d1ba8442643c505c4c83bbaa4442b15cfd"
+  integrity sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==
 
 beautifymarker@^1.0.9:
   version "1.0.9"


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes CVE-2026-41324 basic ftp

## Type of change
Dependency update

