### PR TITLE
Add custom import file download and route

### DIFF
--- a/app/controllers/data_sources/custom_imports_controller.rb
+++ b/app/controllers/data_sources/custom_imports_controller.rb
@@ -11,7 +11,7 @@ module DataSources
     before_action :require_can_edit_data_sources!
     before_action :require_can_manage_config!
     before_action :set_data_source
-    before_action :set_config, only: [:show, :edit, :update, :destroy]
+    before_action :set_config, only: [:show, :edit, :update, :destroy, :download]
 
     def index
       @configs = config_scope
@@ -21,6 +21,20 @@ module DataSources
       @files = @config.import_type.constantize.where(config_id: @config.id).
         order(created_at: :desc)
       @pagy, @files = pagy(@files)
+    end
+
+    def download
+      object = @config.s3.list_objects(prefix: @config.s3_path).detect { |o| o.key == params[:key] }
+      if object.nil?
+        flash[:error] = 'File not found'
+        redirect_to edit_data_source_custom_import_path(@data_source, @config)
+      else
+        send_data(
+          @config.s3.get_as_io(key: object.key)&.read,
+          type: @config.s3.get_file_type(key: object.key),
+          filename: object.key,
+        )
+      end
     end
 
     def new

--- a/app/views/common/s3/_objects_list.haml
+++ b/app/views/common/s3/_objects_list.haml
@@ -1,3 +1,4 @@
+- download_path_helper = local_assigns.fetch(:download_path_helper) { ->(key) { download_data_source_hmis_import_config_path(key: key) } }
 %h3 Files on S3
 - if @error
   .alert.alert-danger
@@ -14,7 +15,7 @@
       %tbody
         - @bucket_objects_list.each do |obj|
           %tr
-            %td= link_to obj.key.gsub(@config.s3_path, ''), download_data_source_hmis_import_config_path(key: obj.key)
+            %td= link_to obj.key.gsub(@config.s3_path, ''), download_path_helper.call(obj.key)
             %td.nobr= obj.last_modified.in_time_zone
             %td.nobr= number_to_human_size obj.size
 - else

--- a/app/views/data_sources/custom_imports/edit.haml
+++ b/app/views/data_sources/custom_imports/edit.haml
@@ -9,4 +9,4 @@
       = render 'form', f: f
       = f.button :submit, value: 'Update Import Config'
   .col-sm-4
-    = render 'common/s3/objects_list'
+    = render 'common/s3/objects_list', download_path_helper: ->(key) { download_data_source_custom_import_path(@data_source, @config, key: key) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -604,7 +604,9 @@ Rails.application.routes.draw do
   resources :data_sources do
     resources :uploads, except: [:update, :destroy, :edit]
     resources :non_hmis_uploads, except: [:update, :destroy, :edit]
-    resources :custom_imports, controller: 'data_sources/custom_imports'
+    resources :custom_imports, controller: 'data_sources/custom_imports' do
+      get :download, on: :member
+    end
     resource :api_config
     resource :hmis_import_config do
       get :download

--- a/spec/requests/data_sources/custom_imports_controller_spec.rb
+++ b/spec/requests/data_sources/custom_imports_controller_spec.rb
@@ -1,0 +1,77 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataSources::CustomImportsController, type: :request do
+  let(:data_source) { create(:source_data_source) }
+  let(:role) { create(:role, can_edit_data_sources: true, can_manage_config: true) }
+  let(:user) do
+    u = create(:user)
+    u.legacy_roles << role
+    u
+  end
+  let(:config) do
+    GrdaWarehouse::CustomImports::Config.create!(
+      data_source: data_source,
+      user: user,
+      import_type: 'CustomImportsBostonService::ImportFile',
+      description: 'Test Import',
+      s3_bucket: 'test-bucket',
+      s3_prefix: 'prefix/',
+      s3_region: 'us-east-1',
+      s3_access_key_id: 'unknown',
+      s3_secret_access_key: 'unknown',
+      import_hour: 4,
+      active: true,
+    )
+  end
+
+  before do
+    allow(GrdaWarehouse::DataSource).to receive(:viewable_by).with(user).and_return(
+      GrdaWarehouse::DataSource.where(id: data_source.id),
+    )
+    sign_in user
+  end
+
+  describe 'GET download' do
+    let(:s3_double) { instance_double(AwsS3) }
+    let(:s3_object) { double(key: 'prefix/test.csv') }
+
+    before do
+      allow(config).to receive(:s3).and_return(s3_double)
+      allow_any_instance_of(GrdaWarehouse::CustomImports::Config).to receive(:s3).and_return(s3_double)
+    end
+
+    context 'when the file exists on S3' do
+      before do
+        allow(s3_double).to receive(:list_objects).with(prefix: config.s3_path).and_return([s3_object])
+        allow(s3_double).to receive(:get_as_io).with(key: 'prefix/test.csv').and_return(StringIO.new('col1,col2\nval1,val2'))
+        allow(s3_double).to receive(:get_file_type).with(key: 'prefix/test.csv').and_return('text/csv')
+      end
+
+      it 'sends the file' do
+        get download_data_source_custom_import_path(data_source, config, key: 'prefix/test.csv')
+        expect(response).to be_successful
+        expect(response.headers['Content-Disposition']).to include('test.csv')
+      end
+    end
+
+    context 'when the file is not found on S3' do
+      before do
+        allow(s3_double).to receive(:list_objects).with(prefix: config.s3_path).and_return([])
+      end
+
+      it 'redirects to edit with an error flash' do
+        get download_data_source_custom_import_path(data_source, config, key: 'prefix/missing.csv')
+        expect(response).to redirect_to(edit_data_source_custom_import_path(data_source, config))
+        expect(flash[:error]).to eq('File not found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Custom import edit was reusing the shared S3 objects partial but every file link pointed at the HMIS import config download route, so links were wrong for custom imports. This change adds a download_path_helper local on common/s3/_objects_list, with the HMIS path as the default, wires the custom import edit view to pass the custom import download URL builder, and implements a download member action on DataSources::CustomImportsController plus the matching route so files stream from S3 with a safe key check and a clear not-found path. Request specs cover successful download and missing object behavior.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
