### PR TITLE
8990 chort tab config

### DIFF
--- a/app/models/grda_warehouse/cohort_tab.rb
+++ b/app/models/grda_warehouse/cohort_tab.rb
@@ -90,6 +90,13 @@ module GrdaWarehouse
         rule_query(composed_query, rule['left']).and(rule_query(composed_query, rule['right']))
       when 'or'
         rule_query(composed_query, rule['left']).or(rule_query(composed_query, rule['right']))
+      when 'not'
+        # COALESCE ensures NULL inner expressions become FALSE so NOT NULL → TRUE (keeps the row).
+        # Without it, PostgreSQL three-valued logic would silently exclude rows where the inner
+        # expression evaluates to NULL (e.g. user_boolean_1 IS NULL).
+        inner = Arel::Nodes::Grouping.new(rule_query(composed_query, rule['operand']))
+        coalesced = Arel::Nodes::NamedFunction.new('COALESCE', [inner, Arel.sql('FALSE')])
+        Arel::Nodes::Not.new(coalesced)
       else
         raise "Unknown Operator #{rule['operator']}"
       end

--- a/lib/tasks/cohort_matched_tab.rake
+++ b/lib/tasks/cohort_matched_tab.rake
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# One-time task to add a "Matched" tab to a specific cohort and update the
+# "Active Clients" tab to exclude fully-matched clients (user_boolean_1 = true
+# AND user_string_1 is present).
+#
+# Usage:
+#   rails "cohort:add_matched_tab[<cohort_id>]"
+#
+# The task is idempotent — it aborts cleanly if the "Matched" tab already exists.
+namespace :cohort do
+  desc 'Add a Matched tab to a cohort and update Active Clients to exclude matched clients'
+  task :add_matched_tab, [:cohort_id] => [:environment] do |_t, args|
+    cohort_id = args[:cohort_id].presence&.to_i
+    abort 'Usage: rails "cohort:add_matched_tab[<cohort_id>]"' unless cohort_id
+
+    cohort = GrdaWarehouse::Cohort.find_by(id: cohort_id)
+    abort "Cohort #{cohort_id} not found." unless cohort
+
+    existing_matched = cohort.cohort_tabs.find_by(name: 'Matched')
+    abort "Cohort #{cohort_id} already has a 'Matched' tab (id=#{existing_matched.id}). Aborting." if existing_matched
+
+    active_tab = cohort.cohort_tabs.find_by(name: 'Active Clients')
+    abort "Cohort #{cohort_id} has no 'Active Clients' tab. Aborting." unless active_tab
+
+    # The "matched" condition: user_boolean_1 = TRUE AND user_string_1 is present.
+    matched_condition = {
+      'operator' => 'and',
+      'left' => { 'column' => 'user_boolean_1', 'operator' => '==', 'value' => true },
+      'right' => { 'column' => 'user_string_1', 'operator' => '<>', 'value' => nil },
+    }
+
+    # Wrap the existing Active Clients rules (preserving any prior customizations)
+    # with a NOT-matched exclusion.
+    updated_active_rules = {
+      'operator' => 'and',
+      'left' => active_tab.rules,
+      'right' => { 'operator' => 'not', 'operand' => matched_condition },
+    }
+
+    # Matched tab: existing Active Clients criteria plus the matched condition.
+    matched_rules = {
+      'operator' => 'and',
+      'left' => active_tab.rules,
+      'right' => matched_condition,
+    }
+
+    matched_order = active_tab.order + 1
+
+    GrdaWarehouse::Cohort.transaction do
+      active_tab.update!(rules: updated_active_rules)
+
+      # Bump tabs currently at or beyond the insertion point to make room.
+      cohort.cohort_tabs.where('order >= ?', matched_order).find_each do |t|
+        t.update!(order: t.order + 1)
+      end
+
+      matched_tab = cohort.cohort_tabs.create!(
+        name: 'Matched',
+        order: matched_order,
+        permissions: [],
+        base_scope: 'current_scope',
+        rules: matched_rules,
+      )
+
+      puts "Cohort #{cohort_id} updated successfully.\n\n"
+
+      tab_instance = GrdaWarehouse::CohortTab.new
+
+      puts "Active Clients SQL:\n  #{tab_instance.rule_query(nil, active_tab.reload.rules).to_sql}\n\n"
+      puts "Matched SQL:\n  #{tab_instance.rule_query(nil, matched_tab.rules).to_sql}\n\n"
+
+      puts 'Verify the SQL above looks correct. If not, roll back with:'
+      puts '  rails db:rollback  (or restore from backup)'
+    end
+  end
+end

--- a/lib/tasks/cohort_matched_tab.rake
+++ b/lib/tasks/cohort_matched_tab.rake
@@ -5,7 +5,7 @@
 # AND user_string_1 is present).
 #
 # Usage:
-#   rails "cohort:add_matched_tab[<cohort_id>]"
+#   rails cohort:add_matched_tab[<cohort_id>]
 #
 # The task is idempotent — it aborts cleanly if the "Matched" tab already exists.
 namespace :cohort do
@@ -51,7 +51,7 @@ namespace :cohort do
       active_tab.update!(rules: updated_active_rules)
 
       # Bump tabs currently at or beyond the insertion point to make room.
-      cohort.cohort_tabs.where('order >= ?', matched_order).find_each do |t|
+      cohort.cohort_tabs.where('"order" >= ?', matched_order).find_each do |t|
         t.update!(order: t.order + 1)
       end
 
@@ -70,8 +70,7 @@ namespace :cohort do
       puts "Active Clients SQL:\n  #{tab_instance.rule_query(nil, active_tab.reload.rules).to_sql}\n\n"
       puts "Matched SQL:\n  #{tab_instance.rule_query(nil, matched_tab.rules).to_sql}\n\n"
 
-      puts 'Verify the SQL above looks correct. If not, roll back with:'
-      puts '  rails db:rollback  (or restore from backup)'
+      puts 'Verify the SQL above looks correct.'
     end
   end
 end

--- a/spec/models/cohort_tab_spec.rb
+++ b/spec/models/cohort_tab_spec.rb
@@ -37,4 +37,39 @@ RSpec.describe GrdaWarehouse::CohortTab, type: :model do
       expect(tab.rule_query(nil, rule[:rules]).to_sql).to eq(query.strip)
     end
   end
+
+  describe 'NOT operator' do
+    it 'generates NOT COALESCE SQL for a simple not rule' do
+      rule = {
+        'operator' => 'not',
+        'operand' => {
+          'column' => 'active',
+          'operator' => '==',
+          'value' => true,
+        },
+      }
+      expect(tab.rule_query(nil, rule).to_sql).to eq(
+        'NOT (COALESCE(("cohort_clients"."active" = TRUE), FALSE))',
+      )
+    end
+
+    it 'generates correct NOT COALESCE SQL for a compound not rule' do
+      rule = {
+        'operator' => 'not',
+        'operand' => {
+          'operator' => 'and',
+          'left' => { 'column' => 'user_boolean_1', 'operator' => '==', 'value' => true },
+          'right' => { 'column' => 'user_string_1', 'operator' => '<>', 'value' => nil },
+        },
+      }
+      expect(tab.rule_query(nil, rule).to_sql).to eq(
+        'NOT (COALESCE(("cohort_clients"."user_boolean_1" = TRUE AND "cohort_clients"."user_string_1" IS NOT NULL AND "cohort_clients"."user_string_1" != \'\'), FALSE))',
+      )
+    end
+
+    it 'raises for unknown operators' do
+      rule = { 'operator' => 'xor', 'left' => {}, 'right' => {} }
+      expect { tab.rule_query(nil, rule) }.to raise_error(RuntimeError, /Unknown Operator/)
+    end
+  end
 end

--- a/spec/tasks/cohort_matched_tab_rake_spec.rb
+++ b/spec/tasks/cohort_matched_tab_rake_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'cohort:add_matched_tab', type: :task do
+  let(:task_name) { 'cohort:add_matched_tab' }
+
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.none? { |t| t.name == 'cohort:add_matched_tab' }
+  end
+
+  before do
+    Rake::Task[task_name].reenable
+  end
+
+  let!(:cohort) { create(:cohort) }
+
+  def create_default_tabs_for(cohort)
+    GrdaWarehouse::CohortTab.default_rules.each do |rule|
+      cohort.cohort_tabs.create!(**rule)
+    end
+  end
+
+  context 'with a cohort that has default tabs' do
+    before do
+      create_default_tabs_for(cohort)
+      Rake::Task[task_name].invoke(cohort.id)
+    end
+
+    it 'generates correct SQL for the Matched tab' do
+      matched_tab = cohort.cohort_tabs.find_by(name: 'Matched')
+      sql = GrdaWarehouse::CohortTab.new.rule_query(nil, matched_tab.rules).to_sql
+      expect(sql).to eq(
+        '(("cohort_clients"."destination" IS NULL OR "cohort_clients"."destination" = \'\') OR "cohort_clients"."housed_date" IS NULL) AND ("cohort_clients"."ineligible" IS NULL OR "cohort_clients"."ineligible" = FALSE) AND "cohort_clients"."active" = TRUE AND "cohort_clients"."user_boolean_1" = TRUE AND "cohort_clients"."user_string_1" IS NOT NULL AND "cohort_clients"."user_string_1" != \'\'',
+      )
+    end
+
+    it 'generates correct SQL for the updated Active Clients tab' do
+      active_tab = cohort.cohort_tabs.find_by(name: 'Active Clients')
+      sql = GrdaWarehouse::CohortTab.new.rule_query(nil, active_tab.rules).to_sql
+      expect(sql).to eq(
+        '(("cohort_clients"."destination" IS NULL OR "cohort_clients"."destination" = \'\') OR "cohort_clients"."housed_date" IS NULL) AND ("cohort_clients"."ineligible" IS NULL OR "cohort_clients"."ineligible" = FALSE) AND "cohort_clients"."active" = TRUE AND NOT (COALESCE(("cohort_clients"."user_boolean_1" = TRUE AND "cohort_clients"."user_string_1" IS NOT NULL AND "cohort_clients"."user_string_1" != \'\'), FALSE))',
+      )
+    end
+
+    it 'places Matched tab between Active Clients and Housed' do
+      tab_names_in_order = cohort.cohort_tabs.order(:order).pluck(:name)
+      expect(tab_names_in_order).to eq(
+        ['Active Clients', 'Matched', 'Housed', 'Ineligible', 'Inactive', 'Removed Clients'],
+      )
+    end
+  end
+
+  context 'idempotency' do
+    before { create_default_tabs_for(cohort) }
+
+    it 'aborts on second invocation without duplicating the Matched tab' do
+      Rake::Task[task_name].invoke(cohort.id)
+      Rake::Task[task_name].reenable
+      expect { Rake::Task[task_name].invoke(cohort.id) }.to raise_error(SystemExit)
+      expect(cohort.cohort_tabs.where(name: 'Matched').count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Add a "Matched" tab to cohorts and exclude fully-matched clients from the Active Clients tab.

- **Cohort Tab Rule Engine**: Add `not` operator support with COALESCE NULL-safety to `prepare_rule_combination`
- **Rake Task**: New `cohort:add_matched_tab[cohort_id]` task that inserts a "Matched" tab (user_boolean_1 = true AND user_string_1 present), updates Active Clients to exclude those clients, and reorders existing tabs — idempotent and transaction-wrapped
- **Specs**: NOT operator unit tests and rake task integration tests covering SQL correctness, tab ordering, and idempotency

Note, we will need to run this rake task manually after deployment.
```
rails cohort:add_matched_tab[1234]
```

### QA
run the rake task on a cohort. Check that the new "matched" tab is created in the appropriate order.

### Type of Change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
