### PR TITLE
Fix system test failures on 210

### DIFF
--- a/drivers/hmis/lib/form_data/default/assessments/base_intake.json
+++ b/drivers/hmis/lib/form_data/default/assessments/base_intake.json
@@ -16,12 +16,6 @@
           },
           "required": true,
           "assessment_date": true,
-          "initial": [
-            {
-              "initial_behavior": "OVERWRITE",
-              "value_local_constant": "$entryDate"
-            }
-          ],
           "bounds": [
             {
               "id": "max-entry",

--- a/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb
@@ -214,6 +214,8 @@ RSpec.feature 'Assessment definition selection', type: :system do
         find_by_id('select_create_new_mci', visible: :all).set(true)
         expect do
           click_button 'Create & Enroll Client'
+          assert_text 'Incomplete' # the enrollment has been created and is incomplete
+          assert_text 'Household ID' # the household has been created and now has an ID
         end.to change(Hmis::Hud::Client, :count).by(1)
 
         expect(stub_mci).to have_received(:create_mci_id)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Fixes the 2 failures that appear here: https://github.com/greenriver/hmis-warehouse/actions/runs/25007416802/job/73233988185?pr=6390

1. Failure in `drivers/hmis/spec/system/hmis/ac_hmis/mci_clearance_spec.rb`: This is transient and comes from the create+enroll operation not finishing yet by the time the test asserts that the number of clients has been incremented. The fix is to assert on text in the page that we expect to appear after the operation completes.
2. Failure in `drivers/hmis/spec/system/hmis/intake_assessment_spec.rb`:  I think the "overwrite" clause was erroneously re-introduced [here](https://github.com/greenriver/hmis-warehouse/pull/6399/changes#diff-38a04b19c7938a90f621b8aa00a36c55ab3303f5da6895aa6c8daa3d4b890fe6) as part of a bad merge. It should be removed, per https://github.com/greenriver/hmis-warehouse/pull/6387/changes

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
System test failure fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
