### PR TITLE
Expand support for helper text in external forms

### DIFF
--- a/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
+++ b/drivers/hmis_external_apis/app/helpers/hmis_external_apis/external_forms_helper.rb
@@ -32,17 +32,17 @@ module HmisExternalApis::ExternalFormsHelper
     end
   end
 
-  def render_form_select(label:, name:, required: false, options:)
-    render partial_path('form/select'), label: label, options: options, name: name, required: required, html_id: next_html_id
+  def render_form_select(label:, name:, required: false, options:, helper_text: nil)
+    render partial_path('form/select'), label: label, options: options, name: name, required: required, html_id: next_html_id, helper_text: helper_text
   end
 
   def render_form_geolocation(label:, name:, required: false)
     render partial_path('form/geolocation'), label: label, name: name, required: required, html_id: next_html_id
   end
 
-  def render_form_radio_group(legend:, name:, required: false, options:, &block)
+  def render_form_radio_group(legend:, name:, required: false, options:, helper_text: nil, &block)
     render_form_fieldset(legend: legend, required: required) do
-      radios = render(partial_path('form/radio_group_options'), options: options, name: name, required: required, html_id: next_html_id)
+      radios = render(partial_path('form/radio_group_options'), options: options, name: name, required: required, html_id: next_html_id, helper_text: helper_text)
       extra = capture(&block) if block
       safe_join([radios, extra].compact_blank, "\n")
     end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/external_forms/form_generator.rb
@@ -135,9 +135,9 @@ module HmisExternalApis::ExternalForms
       render_form_group(node: node) do
         case node['component']
         when 'DROPDOWN', nil
-          render_form_select(label: node['text'], name: node_name(node), options: options, required: node['required'])
+          render_form_select(label: node['text'], name: node_name(node), options: options, required: node['required'], helper_text: node['helper_text'])
         when 'RADIO_BUTTONS'
-          render_form_radio_group(legend: node['text'], name: node_name(node), options: options, required: node['required'])
+          render_form_radio_group(legend: node['text'], name: node_name(node), options: options, required: node['required'], helper_text: node['helper_text'])
         else
           raise "component #{node['component']} not supported in #{node.inspect}"
         end

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_radio_group_options.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_radio_group_options.haml
@@ -6,3 +6,5 @@
     %label.form-check-label{for: input_id}= label
     - if option == options.last
       .invalid-feedback This is required
+- if helper_text
+  .form-text.small.text-muted= helper_text

--- a/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_select.haml
+++ b/drivers/hmis_external_apis/app/views/hmis_external_apis/external_forms/form/_select.haml
@@ -4,3 +4,5 @@
   - options.each do |option|
     %option{value: option[:value], selected: option[:initial_selected]}= option[:label]
 .invalid-feedback This is required
+- if helper_text
+  .form-text.small.text-muted= helper_text


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Render `helper_text` on radio and dropdown items on external HTML forms.

Opening against release-210, it felt simpler to add this support rather than refactor existing form to pull `helper_text` into separate display items..


examples:
<img width="540" height="114" alt="Screenshot 2026-04-28 at 4 42 42 PM" src="https://github.com/user-attachments/assets/10255a50-204d-42c9-92dc-fa83dca3d062" />
<img width="448" height="122" alt="Screenshot 2026-04-28 at 4 42 35 PM" src="https://github.com/user-attachments/assets/5c3db2ed-46a1-4aaa-b673-97beeb9ab59d" />


## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
