### PR TITLE
9173-notify-on-api-errs

### DIFF
--- a/app/models/eto_api/base.rb
+++ b/app/models/eto_api/base.rb
@@ -104,21 +104,9 @@ module EtoApi
       debug_log "=> GET #{url}"
       begin
         body = RestClient.get(url, headers).body
-      rescue RestClient::Unauthorized => e
+      rescue RestClient::Unauthorized, RestClient::InternalServerError, RestClient::BadGateway, RestClient::BadRequest => e
         @failures += 1
-        @notifier.ping "Failed to fetch #{url}: #{e.inspect}"
-        sleep(@failures * 10)
-      rescue RestClient::InternalServerError => e
-        @failures += 1
-        @notifier.ping "Failed to fetch #{url}: #{e.inspect}"
-        sleep(@failures * 10)
-      rescue RestClient::BadGateway => e
-        @failures += 1
-        @notifier.ping "Failed to fetch #{url}: #{e.inspect}"
-        sleep(@failures * 10)
-      rescue RestClient::BadRequest => e
-        @failures += 1
-        @notifier.ping "Failed to fetch #{url}: #{e.inspect}"
+        UnifiedErrorReporter.call(e, "Failed to fetch #{url}: #{e.inspect}", slack_notifier: @notifier)
         sleep(@failures * 10)
       end
       debug_log "<= #{body}"
@@ -136,8 +124,9 @@ module EtoApi
       debug_log "   #{body_text}"
       begin
         r = RestClient.post(url, body_text, headers.merge('Content-type' => 'application/json'))
-      rescue Exception => e
+      rescue StandardError => e
         debug_log "<= FAILED - ERROR #{e.message}"
+        UnifiedErrorReporter.call(e, "ETO API POST failed for #{url}: #{e.message}", slack_notifier: @notifier)
         return false
       end
       debug_log "<= #{r.body}"
@@ -150,7 +139,8 @@ module EtoApi
       debug_log "   #{body_text}"
       r = begin
             RestClient.post(url, body_text, headers.merge('Content-type' => 'application/x-www-form-urlencoded'))
-          rescue StandardError
+          rescue StandardError => e
+            UnifiedErrorReporter.call(e, "ETO API url-encoded POST failed for #{url}: #{e.message}", slack_notifier: @notifier)
             '[]'
           end
       debug_log "<= #{r.body}"

--- a/app/models/grda_warehouse/us_census_api/variable_importer.rb
+++ b/app/models/grda_warehouse/us_census_api/variable_importer.rb
@@ -49,7 +49,7 @@ module GrdaWarehouse
           end.body
           vars = JSON.parse(body)['variables']
         rescue JSON::ParserError => e
-          Rails.logger.error e.message
+          UnifiedErrorReporter.call(e, "Census API: failed to parse variables response for #{dataset}/#{year}")
         end
 
         records = []
@@ -86,7 +86,7 @@ module GrdaWarehouse
         begin
           groups = JSON.parse(Curl.get(lookup_url).body)['groups']
         rescue JSON::ParserError => e
-          Rails.logger.error e.message
+          UnifiedErrorReporter.call(e, "Census API: failed to parse groups response for #{dataset}/#{year}")
         end
 
         records = []

--- a/app/models/weather/noaa_service.rb
+++ b/app/models/weather/noaa_service.rb
@@ -74,9 +74,9 @@ class Weather::NoaaService
     url = "#{@endpoint}#{path}?#{query_args.to_param}"
     begin
       JSON.parse(RestClient.get(url, token: @token).body)
-    rescue StandardError
+    rescue StandardError => e
       setup_notifier('WeatherWarning')
-      @notifier.ping("Error contacting the weather API at #{url}") if @send_notifications
+      UnifiedErrorReporter.call(e, "Error contacting the weather API at #{url}", slack_notifier: @notifier)
     end
   end
 end

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -34,15 +34,17 @@ module Superset
   # NOTE: this needs to be kept in sync with
   # https://github.com/greenriver/superset-sync/blob/main/docker/superset/superset_config.py
   def self.available_superset_roles
+    api = Superset::Api.new
+    return default_roles unless api.available?
+
     begin
-      roles = Superset::Api.new.roles['result']&.map { |role| role['name'] } || []
+      roles = api.roles['result']&.map { |role| role['name'] } || []
       roles.reject! { |role| ignored_roles.include?(role) }
-      return roles.presence || default_roles if Superset::Api.new.available?
+      roles.presence || default_roles
     rescue Curl::Err::HostResolutionError, JSON::ParserError => e
       UnifiedErrorReporter.call(e, "Error fetching Superset roles: #{e.message}, using default roles")
+      default_roles
     end
-    # Fallback to the default roles if the API is not available
-    default_roles
   end
 
   def self.default_roles

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -39,7 +39,7 @@ module Superset
       roles.reject! { |role| ignored_roles.include?(role) }
       return roles.presence || default_roles if Superset::Api.new.available?
     rescue Curl::Err::HostResolutionError, JSON::ParserError => e
-      Rails.logger.error("Error fetching Superset roles: #{e.message}, using default roles")
+      UnifiedErrorReporter.call(e, "Error fetching Superset roles: #{e.message}, using default roles")
     end
     # Fallback to the default roles if the API is not available
     default_roles

--- a/drivers/superset/spec/models/superset_spec.rb
+++ b/drivers/superset/spec/models/superset_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Superset do
+  let(:api) { instance_double(Superset::Api) }
+
+  before do
+    allow(Superset::Api).to receive(:new).and_return(api)
+    allow(Sentry).to receive(:initialized?).and_return(true)
+    allow(Sentry).to receive(:capture_exception_with_info)
+  end
+
+  describe '.available_superset_roles' do
+    context 'when Superset is not configured' do
+      before { allow(api).to receive(:available?).and_return(false) }
+
+      it 'returns default roles without making API calls' do
+        expect(api).not_to receive(:roles)
+        expect(described_class.available_superset_roles).to eq(described_class.default_roles)
+      end
+    end
+
+    context 'when Superset is configured and API returns roles' do
+      before do
+        allow(api).to receive(:available?).and_return(true)
+        allow(api).to receive(:roles).and_return(
+          'result' => [
+            { 'name' => 'Green River Admin' },
+            { 'name' => 'Report Runner' },
+            { 'name' => 'Admin' },
+            { 'name' => 'Public' },
+          ],
+        )
+      end
+
+      it 'returns roles excluding ignored ones' do
+        roles = described_class.available_superset_roles
+        expect(roles).to contain_exactly('Green River Admin', 'Report Runner')
+      end
+    end
+
+    context 'when Superset is configured but API returns no valid roles' do
+      before do
+        allow(api).to receive(:available?).and_return(true)
+        allow(api).to receive(:roles).and_return(
+          'result' => [{ 'name' => 'Admin' }, { 'name' => 'Public' }],
+        )
+      end
+
+      it 'falls back to default roles' do
+        expect(described_class.available_superset_roles).to eq(described_class.default_roles)
+      end
+    end
+
+    context 'when Superset is configured but API raises HostResolutionError' do
+      before do
+        allow(api).to receive(:available?).and_return(true)
+        allow(api).to receive(:roles).and_raise(Curl::Err::HostResolutionError.new('could not resolve'))
+      end
+
+      it 'returns default roles' do
+        expect(described_class.available_superset_roles).to eq(described_class.default_roles)
+      end
+    end
+
+    context 'when Superset is configured but API returns unparseable JSON' do
+      before do
+        allow(api).to receive(:available?).and_return(true)
+        allow(api).to receive(:roles).and_raise(JSON::ParserError.new('unexpected token'))
+      end
+
+      it 'returns default roles' do
+        expect(described_class.available_superset_roles).to eq(described_class.default_roles)
+      end
+    end
+  end
+end

--- a/lib/util/unified_error_reporter.rb
+++ b/lib/util/unified_error_reporter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Unified error reporting: logs, optionally notifies Slack, and captures to Sentry.
+# Decouples call sites from Sentry's API and makes the Slack opt-in explicit.
+module UnifiedErrorReporter
+  def self.call(exception, message = nil, slack_notifier: nil, sentry: true, context: {})
+    msg = message || exception.message
+    # ApplicationNotifier#ping already logs at info level, so skip the duplicate log
+    # when a notifier is provided.
+    Rails.logger.error(msg) unless slack_notifier
+    slack_notifier&.ping(msg)
+    Sentry.capture_exception_with_info(exception, msg, context) if sentry && Sentry.initialized?
+  end
+end

--- a/spec/lib/util/unified_error_reporter_spec.rb
+++ b/spec/lib/util/unified_error_reporter_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UnifiedErrorReporter do
+  let(:error) { StandardError.new('something went wrong') }
+
+  before do
+    allow(Sentry).to receive(:initialized?).and_return(true)
+    allow(Sentry).to receive(:capture_exception_with_info)
+  end
+
+  describe '.call' do
+    it 'logs the message' do
+      expect(Rails.logger).to receive(:error).with('custom message')
+      described_class.call(error, 'custom message')
+    end
+
+    it 'uses the exception message when no custom message is given' do
+      expect(Rails.logger).to receive(:error).with('something went wrong')
+      described_class.call(error)
+    end
+
+    it 'sends the exception to Sentry' do
+      allow(Rails.logger).to receive(:error)
+      described_class.call(error, 'custom message')
+      expect(Sentry).to have_received(:capture_exception_with_info).with(error, 'custom message', {})
+    end
+
+    it 'forwards context to Sentry' do
+      allow(Rails.logger).to receive(:error)
+      ctx = { url: 'https://example.com' }
+      described_class.call(error, 'oops', context: ctx)
+      expect(Sentry).to have_received(:capture_exception_with_info).with(error, 'oops', ctx)
+    end
+
+    it 'pings the Slack notifier when provided' do
+      notifier = instance_double(ApplicationNotifier)
+      allow(notifier).to receive(:ping)
+      described_class.call(error, 'boom', slack_notifier: notifier)
+      expect(notifier).to have_received(:ping).with('boom')
+    end
+
+    it 'skips Rails.logger.error when a slack_notifier is provided (notifier already logs)' do
+      allow(Rails.logger).to receive(:error)
+      notifier = instance_double(ApplicationNotifier)
+      allow(notifier).to receive(:ping)
+      described_class.call(error, 'boom', slack_notifier: notifier)
+      expect(Rails.logger).not_to have_received(:error)
+    end
+
+    it 'does not attempt Slack when no notifier is given' do
+      allow(Rails.logger).to receive(:error)
+      expect { described_class.call(error, 'boom') }.not_to raise_error
+    end
+
+    it 'skips Sentry when sentry: false' do
+      allow(Rails.logger).to receive(:error)
+      described_class.call(error, 'boom', sentry: false)
+      expect(Sentry).not_to have_received(:capture_exception_with_info)
+    end
+
+    it 'skips Sentry when Sentry is not initialized' do
+      allow(Sentry).to receive(:initialized?).and_return(false)
+      allow(Rails.logger).to receive(:error)
+      described_class.call(error, 'boom')
+      expect(Sentry).not_to have_received(:capture_exception_with_info)
+    end
+  end
+end

--- a/spec/lib/util/unified_error_reporter_spec.rb
+++ b/spec/lib/util/unified_error_reporter_spec.rb
@@ -49,11 +49,6 @@ RSpec.describe UnifiedErrorReporter do
       expect(Rails.logger).not_to have_received(:error)
     end
 
-    it 'does not attempt Slack when no notifier is given' do
-      allow(Rails.logger).to receive(:error)
-      expect { described_class.call(error, 'boom') }.not_to raise_error
-    end
-
     it 'skips Sentry when sentry: false' do
       allow(Rails.logger).to receive(:error)
       described_class.call(error, 'boom', sentry: false)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Introduce `UnifiedErrorReporter` to centralize error handling (log, Slack, Sentry) and replace scattered ad-hoc rescue patterns across external API integrations.

- **UnifiedErrorReporter**: New utility module that logs, optionally pings Slack, and captures to Sentry in a single call — decouples call sites from Sentry's API
- **ETO API**: Consolidate four duplicate rescue clauses into one, replace bare `Exception` rescue with `StandardError`, and route all failures through `UnifiedErrorReporter`
- **Census API**: Replace `Rails.logger.error` with `UnifiedErrorReporter` to gain Sentry visibility on JSON parse failures
- **NOAA Weather Service**: Replace manual notifier ping with `UnifiedErrorReporter` for consistent error reporting
- **Superset**: Replace `Rails.logger.error` with `UnifiedErrorReporter` for role-fetch failures
- Added unit tests for `UnifiedErrorReporter`

### Type of Change
Refactor

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
