### PR TITLE
Add ds check to ensure_arg_type

### DIFF
--- a/drivers/hmis/app/models/hmis/auth_policies/base_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/base_policy.rb
@@ -34,11 +34,11 @@ class Hmis::AuthPolicies::BasePolicy
   # sanity check, is the resource what we expect. must be implemented by child policy
   def validate_resource!(_arg) = raise NotImplementedError, 'must implement in subclass'
 
-  # validation helper for instances
+  # validation helper for instances.
+  # checks that resource has the correct class, and if it has a data source, that it belongs to the current user's data source
   def ensure_arg_type!(arg, klass)
-    return if arg.is_a?(klass)
-
-    raise ArgumentError, "Expected an instance of #{klass.name} got #{arg.class}"
+    raise ArgumentError, "Expected an instance of #{klass.name} got #{arg.class}" unless arg.is_a?(klass)
+    raise ArgumentError, "Expected instance #{arg.klass.name}#{arg.id} to belong to data source #{user.hmis_data_source_id}, got #{arg.data_source_id}" if arg.respond_to?(:data_source_id) && arg.data_source_id != user.hmis_data_source_id
   end
 
   # validation helper for classes


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[untested]

Propose adding built-in data source check to all Instance policies in HMIS?

Policies should not be used to validate against resources in data sources that are not the "current" data source. This prevents us from needing to check this in every instance policy.

Another option could be to replace all validates with something like, this provides more flexibility (but may lead to accidentally leaving it out)

```ruby
def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Form::Definition) && ensure_data_source!(arg)
```
## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
