### PR TITLE
fix: 7747-cohort-deadlocks

### DIFF
--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -424,14 +424,33 @@ module GrdaWarehouse
           end
           rows << cc
         end
-        GrdaWarehouse::CohortClient.import(
-          rows,
-          on_duplicate_key_update: {
-            conflict_target: [:id],
-            columns: time_dependent_methods.keys,
-          },
-        )
+        acquired = with_client_update_lock do
+          GrdaWarehouse::CohortClient.import(
+            rows,
+            on_duplicate_key_update: {
+              conflict_target: [:id],
+              columns: time_dependent_methods.keys,
+            },
+          )
+        end
+        # Another process is writing to this cohort's clients; remaining batches
+        # would likely be stale, so yield and let the next scheduled run pick it up.
+        break unless acquired
       end
+    end
+
+    # Acquires a per-cohort advisory lock before writing to cohort_clients, preventing
+    # deadlocks between concurrent writers (e.g. system cohort sync and cache warm).
+    # Non-blocking by default; callers that must complete can pass a short timeout.
+    # Returns true if the lock was acquired (and the block executed), false otherwise.
+    def with_client_update_lock(timeout_seconds: 0)
+      lock_name = "GrdaWarehouse::Cohort:update_clients:#{id}"
+      acquired = false
+      GrdaWarehouseBase.with_advisory_lock(lock_name, timeout_seconds: timeout_seconds) do
+        acquired = true
+        yield
+      end
+      acquired
     end
 
     private def time_dependent_methods
@@ -691,8 +710,7 @@ module GrdaWarehouse
     def maintain
       return unless auto_maintained?
 
-      lock_name = [self.class.name, :maintain, id].join(':')
-      acquired = self.class.with_advisory_lock(lock_name, timeout_seconds: 0) do
+      acquired = with_client_update_lock do
         existing_client_ids = cohort_clients.pluck(:client_id)
         filter = build_automation_filter
         # tags: [:warehouse] keeps the project, HoH, and sub-pop criteria active; other tag mixes drop one or the other.

--- a/app/models/grda_warehouse/system_cohorts/base.rb
+++ b/app/models/grda_warehouse/system_cohorts/base.rb
@@ -50,7 +50,7 @@ module GrdaWarehouse::SystemCohorts
           ).delete_all
 
           # sync returns false when it can't acquire the cohort write lock;
-# rolling back preserves the CohortClientChange rows deleted above.
+          # rolling back preserves the CohortClientChange rows deleted above.
           raise ActiveRecord::Rollback unless find(cohort_id).sync(processing_date: date, date_window: date_window)
         end
       end

--- a/app/models/grda_warehouse/system_cohorts/base.rb
+++ b/app/models/grda_warehouse/system_cohorts/base.rb
@@ -49,7 +49,9 @@ module GrdaWarehouse::SystemCohorts
             changed_at: date.to_time .. (date + 1.days).to_time,
           ).delete_all
 
-          find(cohort_id).sync(processing_date: date, date_window: date_window)
+          # sync returns false when it can't acquire the cohort write lock;
+# rolling back preserves the CohortClientChange rows deleted above.
+          raise ActiveRecord::Rollback unless find(cohort_id).sync(processing_date: date, date_window: date_window)
         end
       end
     end

--- a/app/models/grda_warehouse/system_cohorts/currently_homeless.rb
+++ b/app/models/grda_warehouse/system_cohorts/currently_homeless.rb
@@ -16,11 +16,13 @@ module GrdaWarehouse::SystemCohorts
       @processing_date = processing_date
       @date_window = date_window
 
-      add_missing_clients
+      with_client_update_lock(timeout_seconds: 10) do
+        add_missing_clients
 
-      remove_housed_clients
-      remove_inactive_clients
-      remove_no_longer_meets_criteria
+        remove_housed_clients
+        remove_inactive_clients
+        remove_no_longer_meets_criteria
+      end
     end
 
     private def inactive_date

--- a/lib/util/hud_utility_2024.rb
+++ b/lib/util/hud_utility_2024.rb
@@ -652,7 +652,11 @@ module HudUtility2024
       test_codes['ZZ-000'] = 'Test CoC ZZ-000'
       test_codes['ZZ-100'] = 'Test CoC ZZ-100'
       test_codes['ZZ-999'] = 'Test CoC ZZ-999'
-      (0..100).to_a.each do |n|
+      # Must exceed the number of :hud_project_coc factory instances created across the
+      # full test suite. That factory uses a global FactoryBot sequence for CoCCode
+      # (XX-001, XX-002, …) that never resets, so lookup_coc associations return nil
+      # once the sequence passes the upper bound here.
+      (0..500).to_a.each do |n|
         test_codes["XX-#{n.to_s.rjust(3, '0')}"] = "Test CoC XX-#{n.to_s.rjust(3, '0')}"
       end
     end

--- a/lib/util/hud_utility_2026.rb
+++ b/lib/util/hud_utility_2026.rb
@@ -730,7 +730,11 @@ module HudUtility2026
       test_codes['ZZ-000'] = 'Test CoC ZZ-000'
       test_codes['ZZ-100'] = 'Test CoC ZZ-100'
       test_codes['ZZ-999'] = 'Test CoC ZZ-999'
-      (0..100).to_a.each do |n|
+      # Must exceed the number of :hud_project_coc factory instances created across the
+      # full test suite. That factory uses a global FactoryBot sequence for CoCCode
+      # (XX-001, XX-002, …) that never resets, so lookup_coc associations return nil
+      # once the sequence passes the upper bound here.
+      (0..500).to_a.each do |n|
         test_codes["XX-#{n.to_s.rjust(3, '0')}"] = "Test CoC XX-#{n.to_s.rjust(3, '0')}"
       end
     end

--- a/spec/models/grda_warehouse/cohort_automation_spec.rb
+++ b/spec/models/grda_warehouse/cohort_automation_spec.rb
@@ -307,6 +307,19 @@ RSpec.describe GrdaWarehouse::Cohort, type: :model do
       end
     end
 
+    describe '#with_client_update_lock' do
+      let(:cohort) { create(:cohort) }
+
+      it 'returns true when the lock is acquired' do
+        expect(cohort.with_client_update_lock { 'anything' }).to eq(true)
+      end
+
+      it 'returns false when the lock is already held' do
+        allow(GrdaWarehouseBase).to receive(:with_advisory_lock).and_return(false)
+        expect(cohort.with_client_update_lock { raise 'should not execute' }).to eq(false)
+      end
+    end
+
     describe 'validations' do
       it 'allows valid sub_population' do
         cohort.project_group = project_group


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Fix deadlocks between concurrent `cohort_clients` writers by coordinating all three write paths behind a per-cohort advisory lock.

- **Cohort model**: Add `with_client_update_lock` method using a per-cohort PostgreSQL advisory lock; returns a boolean indicating whether the lock was acquired
- **Cache warm**: Wrap `CohortClient.import` in `refresh_time_dependant_client_data` with the lock per batch; bail out if not acquired
- **System cohort sync**: Wrap `sync` body in `with_client_update_lock` with a 10-second timeout
- **System cohort update**: Roll back the per-date transaction when `sync` fails to acquire the lock, preserving `CohortClientChange` rows
- **Cohort automation**: Replace `maintain`'s standalone `:maintain` advisory lock with the shared `with_client_update_lock`

### Type of Change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

