### PR TITLE
SPM Gender/Race Filter Bug

### DIFF
--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -642,16 +642,9 @@ module Filters
 
     def apply_criteria(scope, tags:, except: [], **opts)
       except = Array.wrap(except)
-      # default configuration options.
-      defaults = {
-        project_types: @project_types,
-        all_project_types: nil,
-        include_date_range: true,
-        chronic_at_entry: true,
-        report_scope_source: nil,
-        join_clients_method: :client,
-      }
-      config = ::Filters::Criteria::Configuration.new(**defaults.merge(opts))
+      # Only inject filter-specific state that Configuration cannot default on its own.
+      # All other defaults (report_scope_source, include_date_range, etc.) are owned by Configuration.
+      config = ::Filters::Criteria::Configuration.new(project_types: @project_types, **opts)
 
       # instantiate criteria
       criteria = ::Filters::Criteria.classes_for_tags(tags).map do |criteria_class|

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -668,6 +668,8 @@ module GrdaWarehouse
         incoming_client_ids = filter.apply_criteria(
           GrdaWarehouse::ServiceHistoryEnrollment.all,
           tags: [:warehouse],
+          # nil disables report_scope_source-dependent criteria (gender, race); cohort
+          # automation filters do not expose those options.
           report_scope_source: nil,
           all_project_types: true,
         ).pluck(:client_id).uniq

--- a/drivers/hud_spm_report/app/models/hud_spm_report/adapters/service_history_enrollment_filter.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/adapters/service_history_enrollment_filter.rb
@@ -38,7 +38,7 @@ module HudSpmReport::Adapters
 
       # ATTN: coc filter is needed for testkit
       scope = filter_for_cocs(scope)
-      scope = @filter.apply_criteria(scope, tags: [:warehouse, :client])
+      scope = @filter.apply_criteria(scope, tags: [:warehouse, :client], report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry)
       scope
     end
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/adapters/service_history_enrollment_filter.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/adapters/service_history_enrollment_filter.rb
@@ -38,7 +38,7 @@ module HudSpmReport::Adapters
 
       # ATTN: coc filter is needed for testkit
       scope = filter_for_cocs(scope)
-      scope = @filter.apply_criteria(scope, tags: [:warehouse, :client], report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry)
+      scope = @filter.apply_criteria(scope, tags: [:warehouse, :client])
       scope
     end
 

--- a/drivers/hud_spm_report/spec/models/adapters/service_history_enrollment_filter_spec.rb
+++ b/drivers/hud_spm_report/spec/models/adapters/service_history_enrollment_filter_spec.rb
@@ -1,0 +1,81 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../fy2026/shared_context'
+
+RSpec.describe HudSpmReport::Adapters::ServiceHistoryEnrollmentFilter, type: :model, exclude_fixpoints: true do
+  include_context '2026 SPM test setup'
+
+  let(:project) { create_project(project_type: 0) }
+
+  def create_gendered_client(gender_attrs)
+    client = create_client_with_warehouse_link
+    GrdaWarehouse::WarehouseClient.find_by(source_id: client.id).destination.update!(gender_attrs)
+    create_enrollment(client: client, project: project, entry_date: '2022-10-01'.to_date)
+    client
+  end
+
+  def build_spm_report(filter_overrides = {})
+    filter = default_filter.dup
+    filter.update({ project_ids: [project.id] }.merge(filter_overrides))
+    report = HudReports::ReportInstance.from_filter(filter, 'System Performance Measures - FY 2026', build_for_questions: ['Measure 1'])
+    report.question_names = ['Measure 1']
+    report.save!
+    report
+  end
+
+  before do
+    @woman = create_gendered_client(Woman: 1)
+    @man = create_gendered_client(Man: 1)
+    @nonbinary = create_gendered_client(NonBinary: 1)
+
+    GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+  end
+
+  def destination_id_for(source_client)
+    GrdaWarehouse::WarehouseClient.find_by(source_id: source_client.id).destination.id
+  end
+
+  describe '#service_history_enrollment_scope' do
+    context 'with a gender filter' do
+      it 'does not raise' do
+        report = build_spm_report(genders: [0])
+        expect { described_class.new(report).service_history_enrollment_scope.load }.not_to raise_error
+      end
+
+      it 'returns only enrollments for the selected gender' do
+        report = build_spm_report(genders: [0]) # Woman only
+        client_ids = described_class.new(report).service_history_enrollment_scope.pluck(:client_id)
+
+        expect(client_ids).to include(destination_id_for(@woman))
+        expect(client_ids).not_to include(destination_id_for(@man))
+        expect(client_ids).not_to include(destination_id_for(@nonbinary))
+      end
+    end
+
+    context 'with a race filter' do
+      before do
+        GrdaWarehouse::WarehouseClient.find_by(source_id: @woman.id).destination.update!(AmIndAKNative: 1)
+      end
+
+      it 'does not raise' do
+        report = build_spm_report(races: ['AmIndAKNative'])
+        expect { described_class.new(report).service_history_enrollment_scope.load }.not_to raise_error
+      end
+
+      it 'returns only enrollments for the selected race' do
+        report = build_spm_report(races: ['AmIndAKNative'])
+        client_ids = described_class.new(report).service_history_enrollment_scope.pluck(:client_id)
+
+        expect(client_ids).to include(destination_id_for(@woman))
+        expect(client_ids).not_to include(destination_id_for(@man))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Running an SPM report with a gender or race filter selected caused the job to fail with a
`NoMethodError` because `apply_criteria` defaulted `report_scope_source` to `nil`, and both
`FilterForGender` and `FilterForRace` call `config.report_scope_source.joins(...)` when building
their sub-queries. Fixed by passing `report_scope_source: GrdaWarehouse::ServiceHistoryEnrollment.entry`
to the `apply_criteria` call in `ServiceHistoryEnrollmentFilter`, matching the pattern used by
`HudFilterBase` for standard HUD reports. Added integration specs covering both gender and race filters to prevent regression.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
