### PR TITLE
Add Funder patch for Daily Rate

### DIFF
--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
@@ -1,0 +1,30 @@
+[
+  {
+    "form_identifier": "funder",
+    "link_id": "q_1",
+    "append_items": [
+      {
+        "type": "CURRENCY",
+        "required": false,
+        "link_id": "daily_rate",
+        "text": "Daily Rate",
+        "mapping": {
+          "custom_field_key": "funder_daily_rate"
+        },
+        "enable_behavior": "ANY",
+        "enable_when": [
+          {
+            "question": "funder",
+            "operator": "EQUAL",
+            "answer_code": "HUD_HOPWA_PERMANENT_HOUSING"
+          },
+          {
+            "question": "funder",
+            "operator": "EQUAL",
+            "answer_code": "HUD_HOPWA_TRANSITIONAL_HOUSING"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
@@ -1,6 +1,5 @@
 [
   {
-    "form_identifier": "funder",
     "link_id": "funder_grant_info",
     "append_items": [
       {

--- a/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
+++ b/drivers/hmis/lib/form_data/charlotte/fragments/patches/funder_daily_rate.json
@@ -1,7 +1,7 @@
 [
   {
     "form_identifier": "funder",
-    "link_id": "q_1",
+    "link_id": "funder_grant_info",
     "append_items": [
       {
         "type": "CURRENCY",

--- a/drivers/hmis/lib/form_data/default/records/funder.json
+++ b/drivers/hmis/lib/form_data/default/records/funder.json
@@ -57,13 +57,19 @@
           ]
         },
         {
-          "type": "STRING",
-          "required": true,
-          "link_id": "grant_id",
-          "text": "Grant Identifier",
-          "mapping": {
-            "field_name": "grantId"
-          }
+          "type": "GROUP",
+          "link_id": "funder_grant_info",
+          "item": [
+              {
+              "type": "STRING",
+              "required": true,
+              "link_id": "grant_id",
+              "text": "Grant Identifier",
+              "mapping": {
+                "field_name": "grantId"
+              }
+            }
+          ]
         },
         {
           "type": "DISPLAY",

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -171,8 +171,9 @@ module HmisUtil
     # Apply applicable patches to the "tree" which is a top-level item in the form definition.
     # The patches passed may not apply to this tree. They are only applied if the `link_id` matches
     # an item in the tree.
+    # If a patch includes `form_identifier`, it only applies to that form definition.
     # Patches can override item attributes (such as "text") or append/prepend items to Group items.
-    def apply_item_patches(tree, patches)
+    def apply_item_patches(tree, patches, identifier:)
       nodes_by_id = {}
       result = tree.deep_dup
       walk_nodes(result) do |node|
@@ -182,11 +183,14 @@ module HmisUtil
       applied_patches = []
       patches.each do |patch|
         id = patch.fetch('link_id')
+        next if patch['form_identifier'].present? && patch['form_identifier'] != identifier
+
         node = nodes_by_id[id]
         next unless node.present? # ok to skip, just means that this form doesn't contain this link id
 
         applied_patches << id
         children, patch_to_apply = patch.partition { |k, _| ['append_items', 'prepend_items'].include?(k) }.map(&:to_h)
+        patch_to_apply = patch_to_apply.except('form_identifier')
 
         # if patch replaces references with options, remove the reference to avoid schema violation
         node.delete('pick_list_reference') if patch_to_apply.key?('pick_list_options')
@@ -231,7 +235,7 @@ module HmisUtil
 
         # Apply item-level patches (overriding item attributes, and appending/prepending items to groups)
         definition['item'].each do |item|
-          result, applied = apply_item_patches(item, item_patches)
+          result, applied = apply_item_patches(item, item_patches, identifier: identifier)
           item.replace(result)
           applied_patches.push(*applied)
         end

--- a/drivers/hmis/lib/hmis_util/json_forms.rb
+++ b/drivers/hmis/lib/hmis_util/json_forms.rb
@@ -171,9 +171,8 @@ module HmisUtil
     # Apply applicable patches to the "tree" which is a top-level item in the form definition.
     # The patches passed may not apply to this tree. They are only applied if the `link_id` matches
     # an item in the tree.
-    # If a patch includes `form_identifier`, it only applies to that form definition.
     # Patches can override item attributes (such as "text") or append/prepend items to Group items.
-    def apply_item_patches(tree, patches, identifier:)
+    def apply_item_patches(tree, patches)
       nodes_by_id = {}
       result = tree.deep_dup
       walk_nodes(result) do |node|
@@ -183,14 +182,11 @@ module HmisUtil
       applied_patches = []
       patches.each do |patch|
         id = patch.fetch('link_id')
-        next if patch['form_identifier'].present? && patch['form_identifier'] != identifier
-
         node = nodes_by_id[id]
         next unless node.present? # ok to skip, just means that this form doesn't contain this link id
 
         applied_patches << id
         children, patch_to_apply = patch.partition { |k, _| ['append_items', 'prepend_items'].include?(k) }.map(&:to_h)
-        patch_to_apply = patch_to_apply.except('form_identifier')
 
         # if patch replaces references with options, remove the reference to avoid schema violation
         node.delete('pick_list_reference') if patch_to_apply.key?('pick_list_options')
@@ -235,7 +231,7 @@ module HmisUtil
 
         # Apply item-level patches (overriding item attributes, and appending/prepending items to groups)
         definition['item'].each do |item|
-          result, applied = apply_item_patches(item, item_patches, identifier: identifier)
+          result, applied = apply_item_patches(item, item_patches)
           item.replace(result)
           applied_patches.push(*applied)
         end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- ~**confirm deploy timing before merge**~ this can go out as part of the normal release cycle

## Description
- Add client-specific patch on Funder form
- Update base Funder form with a new group for `funder_grant_info`, so that the client-specific patch can be appended in the right place in the form.
  - If we prefer not to create churn on the base Funder form, we might be able to do something like [this](https://github.com/greenriver/hmis-warehouse/pull/6432/commits/1f89237bfc85fe0f924c012e4ec6ff84b2d3f3c6) instead, but it may need more finagling to get the new question positioned in the correct place on the form. Let me know if this is something I should pursue more.

Related frontend PR (merged): https://github.com/greenriver/hmis-frontend/pull/1457

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
- Config update

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
