### PR TITLE
8699 skip empty csvs in identify external clients

### DIFF
--- a/app/jobs/identify_external_clients_job.rb
+++ b/app/jobs/identify_external_clients_job.rb
@@ -40,6 +40,9 @@ class IdentifyExternalClientsJob < BaseJob
         input_key = input_object.key
 
         data_string = s3.get_as_io(key: input_key)&.read
+        # Skip empty files and directory placeholder objects
+        next if data_string.blank?
+
         content_type = Marcel::MimeType.for(data_string, name: File.basename(input_key))
         # If we didn't find a file (or are looking at a directory), just skip
         next if content_type.in?(['application/x-empty', 'application/octet-stream'])

--- a/spec/jobs/identify_external_clients_job_spec.rb
+++ b/spec/jobs/identify_external_clients_job_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe IdentifyExternalClientsJob, type: :job do
   end
 
   describe 'error handling' do
+    it 'silently skips empty files without raising a Sentry error' do
+      allow(s3).to receive(:list_objects).and_return([double(key: 'empty.csv')])
+      allow(s3).to receive(:get_as_io).and_return(StringIO.new(''))
+      allow(Sentry).to receive(:capture_exception_with_info)
+
+      described_class.perform_now(s3: s3, inbox_path: inbox_path, outbox_path: outbox_path, external_id_field: external_id_field)
+      expect(Sentry).not_to have_received(:capture_exception_with_info)
+    end
+
     it 'logs an error for malformed CSV files' do
       malformed_csv_content = "first_name,last_name,ssn4,dob,#{external_id_field}\nJohn,Doe,\"1234,1990-01-01,1" # Unclosed quoted field
       allow(s3).to receive(:list_objects).and_return([double(key: 'test.csv')])


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
don't send errors to sentry for empty csv files in identify external clients job

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail 
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


