### PR TITLE
9131 Wire HMIS CSV staging-table expiration to all active HUD CSV versions instead of only 2024.

### DIFF
--- a/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_base_job.rb
+++ b/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_base_job.rb
@@ -26,6 +26,11 @@ module HmisCsvImporter::Cleanup
     include ElapsedTimeHelper
     queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
 
+    # Versions prior to 2024 are intentionally frozen and excluded from expiration.
+    # Any version >= this value will be included automatically, so new HUD CSV versions
+    # (2026, 2028, ...) are picked up without manual changes to the sub-jobs.
+    MINIMUM_EXPIRATION_VERSION = 2024
+
     # low priority - eventual consistency cleanup
     def self.default_priority
       BaseJob::MAINTENANCE_PRIORITY_15
@@ -187,6 +192,12 @@ module HmisCsvImporter::Cleanup
 
     private def sufficient_imports?
       log_model.count > @retain_item_count
+    end
+
+    private def active_data_lake_modules
+      Rails.application.config.hmis_data_lakes.filter_map do |version, module_name|
+        module_name.constantize if version.to_i >= MINIMUM_EXPIRATION_VERSION
+      end
     end
   end
 end

--- a/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_importers_job.rb
+++ b/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_importers_job.rb
@@ -18,11 +18,12 @@ module HmisCsvImporter::Cleanup
       ::HmisCsvImporter::Importer::ImporterLog
     end
 
-    # Depending on your installation cleanup needs, you may also want to expire older versions
-    # ::HmisCsvTwentyTwentyTwo.expiring_importer_classes
-    # ::HmisCsvTwentyTwenty.expiring_importer_classes
     def models
-      (::HmisCsvTwentyTwentyFour.expiring_importer_classes + [])
+      active_data_lake_modules.flat_map do |mod|
+        raise "#{mod.name} registered in hmis_data_lakes but does not implement expiring_importer_classes" unless mod.respond_to?(:expiring_importer_classes)
+
+        mod.expiring_importer_classes
+      end
     end
   end
 end

--- a/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_loaders_job.rb
+++ b/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_loaders_job.rb
@@ -18,11 +18,12 @@ module HmisCsvImporter::Cleanup
       ::HmisCsvImporter::Loader::LoaderLog
     end
 
-    # Depending on your installation cleanup needs, you may also want to expire older versions
-    # ::HmisCsvTwentyTwentyTwo.expiring_loader_classes
-    # ::HmisCsvTwentyTwenty.expiring_loader_classes
     def models
-      (::HmisCsvTwentyTwentyFour.expiring_loader_classes + [])
+      active_data_lake_modules.flat_map do |mod|
+        raise "#{mod.name} registered in hmis_data_lakes but does not implement expiring_loader_classes" unless mod.respond_to?(:expiring_loader_classes)
+
+        mod.expiring_loader_classes
+      end
     end
   end
 end

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
@@ -11,7 +11,7 @@ require_relative 'shared'
 
 RSpec.describe HmisCsvImporter::Cleanup::ExpireImportersJob, type: :model do
   include_context 'HmisCsvImporter cleanup context'
-  include_examples 'HmisCsvImporter cleanup record expiration'
+  it_behaves_like 'HmisCsvImporter cleanup record expiration'
 
   def records
     HmisCsvTwentyTwentyFour::Importer::Organization
@@ -38,6 +38,14 @@ RSpec.describe HmisCsvImporter::Cleanup::ExpireImportersJob, type: :model do
       models = job.send(:models)
       expect(models).not_to include(HmisCsvTwentyTwenty::Importer::Organization)
       expect(models).not_to include(HmisCsvTwentyTwentyTwo::Importer::Organization)
+    end
+
+    it 'never expires Export or Project tables' do
+      models = job.send(:models)
+      expect(models).not_to include(HmisCsvTwentyTwentyFour::Importer::Export)
+      expect(models).not_to include(HmisCsvTwentyTwentyFour::Importer::Project)
+      expect(models).not_to include(HmisCsvTwentyTwentySix::Importer::Export)
+      expect(models).not_to include(HmisCsvTwentyTwentySix::Importer::Project)
     end
 
     it 'raises if an active-version module does not implement expiring_importer_classes' do

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
@@ -24,4 +24,29 @@ RSpec.describe HmisCsvImporter::Cleanup::ExpireImportersJob, type: :model do
     }
     HmisCsvImporter::Cleanup::ExpireImportersJob.new.perform(**default_options.merge(options))
   end
+
+  describe '#models' do
+    let(:job) { described_class.new }
+
+    it 'includes importer classes from all active versions (>= 2024)' do
+      models = job.send(:models)
+      expect(models).to include(HmisCsvTwentyTwentyFour::Importer::Organization)
+      expect(models).to include(HmisCsvTwentyTwentySix::Importer::Organization)
+    end
+
+    it 'excludes importer classes from frozen legacy versions (< 2024)' do
+      models = job.send(:models)
+      expect(models).not_to include(HmisCsvTwentyTwenty::Importer::Organization)
+      expect(models).not_to include(HmisCsvTwentyTwentyTwo::Importer::Organization)
+    end
+
+    it 'raises if an active-version module does not implement expiring_importer_classes' do
+      stub_module = Module.new
+      stub_const('StubDataLake2028', stub_module)
+      allow(Rails.application.config).to receive(:hmis_data_lakes).and_return(
+        Rails.application.config.hmis_data_lakes.merge('2028' => 'StubDataLake2028'),
+      )
+      expect { job.send(:models) }.to raise_error(/StubDataLake2028.*expiring_importer_classes/)
+    end
+  end
 end

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb
@@ -24,4 +24,29 @@ RSpec.describe HmisCsvImporter::Cleanup::ExpireLoadersJob, type: :model do
     }
     HmisCsvImporter::Cleanup::ExpireLoadersJob.new.perform(**default_options.merge(options))
   end
+
+  describe '#models' do
+    let(:job) { described_class.new }
+
+    it 'includes loader classes from all active versions (>= 2024)' do
+      models = job.send(:models)
+      expect(models).to include(HmisCsvTwentyTwentyFour::Loader::Organization)
+      expect(models).to include(HmisCsvTwentyTwentySix::Loader::Organization)
+    end
+
+    it 'excludes loader classes from frozen legacy versions (< 2024)' do
+      models = job.send(:models)
+      expect(models).not_to include(HmisCsvTwentyTwenty::Loader::Organization)
+      expect(models).not_to include(HmisCsvTwentyTwentyTwo::Loader::Organization)
+    end
+
+    it 'raises if an active-version module does not implement expiring_loader_classes' do
+      stub_module = Module.new
+      stub_const('StubDataLake2028', stub_module)
+      allow(Rails.application.config).to receive(:hmis_data_lakes).and_return(
+        Rails.application.config.hmis_data_lakes.merge('2028' => 'StubDataLake2028'),
+      )
+      expect { job.send(:models) }.to raise_error(/StubDataLake2028.*expiring_loader_classes/)
+    end
+  end
 end

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb
@@ -11,7 +11,7 @@ require_relative 'shared'
 
 RSpec.describe HmisCsvImporter::Cleanup::ExpireLoadersJob, type: :model do
   include_context 'HmisCsvImporter cleanup context'
-  include_examples 'HmisCsvImporter cleanup record expiration'
+  it_behaves_like 'HmisCsvImporter cleanup record expiration'
 
   def records
     HmisCsvTwentyTwentyFour::Loader::Organization
@@ -38,6 +38,14 @@ RSpec.describe HmisCsvImporter::Cleanup::ExpireLoadersJob, type: :model do
       models = job.send(:models)
       expect(models).not_to include(HmisCsvTwentyTwenty::Loader::Organization)
       expect(models).not_to include(HmisCsvTwentyTwentyTwo::Loader::Organization)
+    end
+
+    it 'never expires Export or Project tables' do
+      models = job.send(:models)
+      expect(models).not_to include(HmisCsvTwentyTwentyFour::Loader::Export)
+      expect(models).not_to include(HmisCsvTwentyTwentyFour::Loader::Project)
+      expect(models).not_to include(HmisCsvTwentyTwentySix::Loader::Export)
+      expect(models).not_to include(HmisCsvTwentyTwentySix::Loader::Project)
     end
 
     it 'raises if an active-version module does not implement expiring_loader_classes' do

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
@@ -15,12 +15,12 @@ RSpec.shared_context 'HmisCsvImporter cleanup context' do
     GrdaWarehouse::DataSource.create(name: 'Green River', short_name: 'GR', source_type: :sftp)
   end
 
-  def import_csv_records(run_at:)
+  def import_csv_records(run_at:, for_data_source: data_source)
     travel_to(run_at) do
       import_hmis_csv_fixture(
         'drivers/hmis_csv_importer/spec/fixtures/files/twenty_twenty_four/allowed_projects',
         version: 'AutoMigrate',
-        data_source: data_source,
+        data_source: for_data_source,
         run_jobs: false,
         allowed_projects: true,
         stop_version: '2024',
@@ -29,13 +29,13 @@ RSpec.shared_context 'HmisCsvImporter cleanup context' do
   end
 end
 
-# imports are retained with the following logic
-# 1. Any imports newer than retain_after_date are kept
-# 2. Any imports older than retain_after_date but within the last retain_item_count are kept
-# 3. If no imports are newer than retain_after_date, the latest import is kept PLUS retain_item_count imports
-# TODO: these don't follow the above logic currently
-RSpec.shared_context 'HmisCsvImporter cleanup record expiration' do
-  describe 'with 3 daily imports' do
+# A record is kept if EITHER of the following is true:
+#   1. Its rank (newest-first by id, partitioned by hud_key + data_source_id) is <= retain_item_count
+#   2. Its log foreign key (loader_id / importer_log_id) belongs to an import run
+#      created on or after retain_after_date
+# Everything else is hard-deleted.
+RSpec.shared_examples 'HmisCsvImporter cleanup record expiration' do
+  describe 'with 5 daily imports' do
     let(:run_times) do
       5.times.map { |day| now - day.days }.reverse
     end
@@ -57,12 +57,6 @@ RSpec.shared_context 'HmisCsvImporter cleanup record expiration' do
       end.to change { records.count }.from(5).to(2)
     end
 
-    it 'retains only the last X records' do
-      expect do
-        run_job(retain_after_date: now, retain_item_count: 1)
-      end.to change { records.count }.from(5).to(1)
-    end
-
     it 'retains all records when retain_item_count is higher than total records' do
       expect do
         run_job(retain_after_date: now, retain_item_count: 6)
@@ -80,5 +74,76 @@ RSpec.shared_context 'HmisCsvImporter cleanup record expiration' do
     expect do
       run_job(retain_after_date: now, retain_item_count: 1)
     end.not_to(change { records.count })
+  end
+
+  # Scenarios below assert on specific record identity (not just counts) to make
+  # the retention rules concrete and verifiable.
+  #
+  # The fixture contains exactly one Organization per import, so each call to
+  # import_csv_records produces one staging row for the Organization hud_key.
+  # IDs are monotonically increasing, so `records.order(:id)` == oldest-to-newest.
+  describe 'retention policy (explicit record identity)' do
+    # Pin time so "recent" vs "old" comparisons are stable within each example.
+    let(:base_time) { DateTime.current.beginning_of_hour }
+
+    # 2.5 days ago splits records into "age-protected" (newer) vs "eligible for deletion" (older).
+    let(:retain_after_date) { base_time - 2.5.days }
+
+    describe 'keeps the last N versions of a HUD key (retain_item_count)' do
+      # All 5 imports are older than the retain window, so age protection plays no role.
+      before do
+        [7, 6, 5, 4, 3].each { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
+      end
+
+      it 'keeps exactly the N newest records and deletes the rest' do
+        ordered_ids = records.order(:id).pluck(:id)
+        expect do
+          run_job(retain_after_date: retain_after_date, retain_item_count: 3)
+        end.to change { records.count }.from(5).to(3)
+        expect(records.order(:id).pluck(:id)).to eq(ordered_ids.last(3))
+      end
+    end
+
+    describe 'age protection: keeps recent imports beyond retain_item_count' do
+      # Imports 1-3 are older than the retain window; imports 4-5 fall within it.
+      before do
+        [5, 4, 3].each { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
+        [2, 1].each    { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
+      end
+
+      it 'keeps age-protected records even when they exceed retain_item_count' do
+        ordered_ids = records.order(:id).pluck(:id)
+        expect do
+          run_job(retain_after_date: retain_after_date, retain_item_count: 1)
+        end.to change { records.count }.from(5).to(2)
+        expect(records.order(:id).pluck(:id)).to eq(ordered_ids.last(2))
+      end
+    end
+
+    describe 'multi-data-source isolation' do
+      let(:second_data_source) do
+        GrdaWarehouse::DataSource.create(name: 'Other Source', short_name: 'OS', source_type: :sftp)
+      end
+
+      # 3 old imports per data source; same hud_key in both because they share the same CSV fixture.
+      before do
+        [8, 7, 6].each do |days_ago|
+          import_csv_records(run_at: base_time - days_ago.days)
+          import_csv_records(run_at: base_time - days_ago.days, for_data_source: second_data_source)
+        end
+      end
+
+      it 'retains the last N records independently per data source' do
+        ds1_ids = records.where(data_source_id: data_source.id).order(:id).pluck(:id)
+        ds2_ids = records.where(data_source_id: second_data_source.id).order(:id).pluck(:id)
+
+        expect do
+          run_job(retain_after_date: retain_after_date, retain_item_count: 1)
+        end.to change { records.count }.from(6).to(2)
+
+        expect(records.where(data_source_id: data_source.id).pluck(:id)).to eq([ds1_ids.last])
+        expect(records.where(data_source_id: second_data_source.id).pluck(:id)).to eq([ds2_ids.last])
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Wire HMIS CSV staging-table expiration to all active HUD CSV versions instead of only 2024.

- **Expire Jobs (Loaders & Importers)**: Replace hardcoded `HmisCsvTwentyTwentyFour` model list with dynamic discovery from the `hmis_data_lakes` registry, filtered to versions >= 2024. HmisCsvTwentyTwentySix staging tables (and any future year) are now pruned automatically; frozen legacy versions (2020, 2022) remain excluded.
- **ExpireBaseJob**: Add `MINIMUM_EXPIRATION_VERSION = '2024'` constant and shared `active_data_lake_modules` helper. Any newly-registered module at version >= 2024 that does not implement `expiring_loader/importer_classes` raises immediately, preventing silent omission.
- Test coverage for model discovery: verifies 2024 and 2026 classes are included, 2020/2022 are excluded, and the guard raises on a missing interface.

### Type of Change

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
