### PR TITLE
Fix crash when source client has no recorded name

### DIFF
--- a/app/models/grda_warehouse/source_client_name_set.rb
+++ b/app/models/grda_warehouse/source_client_name_set.rb
@@ -41,6 +41,7 @@ module GrdaWarehouse
           value: patient.pii_provider(user: user).full_name,
         )
       end
+      @names.reject! { |n| n.value.blank? }
       @names.uniq!
     end
 

--- a/spec/models/grda_warehouse/source_client_name_set_spec.rb
+++ b/spec/models/grda_warehouse/source_client_name_set_spec.rb
@@ -1,0 +1,72 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::SourceClientNameSet, type: :model do
+  let(:policy) { GrdaWarehouse::AuthPolicies::AllowPiiPolicy.instance }
+  let(:user) { double('User') }
+  let(:destination_client) { double('DestinationClient', patient: nil) }
+
+  def make_source_client(first_name:, last_name:, ds_name: 'Test DS', ds_id: 1)
+    data_source = double('DataSource', short_name: ds_name, id: ds_id)
+    record = OpenStruct.new(first_name: first_name, last_name: last_name, middle_name: nil)
+    pii = GrdaWarehouse::PiiProvider.new(record, policy: policy)
+    client = double('SourceClient', data_source: data_source)
+    allow(client).to receive(:pii_provider).with(user: user).and_return(pii)
+    client
+  end
+
+  describe '#each' do
+    context 'when all source clients have names' do
+      let(:source_clients) do
+        [
+          make_source_client(first_name: 'Jane', last_name: 'Doe', ds_id: 1),
+          make_source_client(first_name: 'Jane', last_name: 'Smith', ds_id: 2),
+        ]
+      end
+
+      subject { described_class.new(destination_client: destination_client, source_clients: source_clients, user: user) }
+
+      it 'includes all names' do
+        expect(subject.to_a.map(&:value)).to contain_exactly('Jane Doe', 'Jane Smith')
+      end
+    end
+
+    context 'when a source client has no name recorded' do
+      let(:source_clients) do
+        [
+          make_source_client(first_name: 'Jane', last_name: 'Doe', ds_id: 1),
+          make_source_client(first_name: nil, last_name: nil, ds_id: 2),
+        ]
+      end
+
+      subject { described_class.new(destination_client: destination_client, source_clients: source_clients, user: user) }
+
+      it 'excludes the blank-name entry' do
+        expect(subject.to_a.map(&:value)).to eq(['Jane Doe'])
+      end
+
+      it 'does not raise an error' do
+        expect { subject.to_a }.not_to raise_error
+      end
+    end
+
+    context 'when all source clients have no name recorded' do
+      let(:source_clients) do
+        [make_source_client(first_name: nil, last_name: nil, ds_id: 1)]
+      end
+
+      subject { described_class.new(destination_client: destination_client, source_clients: source_clients, user: user) }
+
+      it 'returns an empty set' do
+        expect(subject.to_a).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

### Problem
The client search page threw `NoMethodError: undefined method 'empty?' for nil` when rendering aliases for clients whose source records had no first, middle, or last name.
The chain: `PiiProvider#full_name` returns `nil` via `.presence` when all name fields are blank → `SourceClientName#value` is `nil` → `to_str` returns `nil` → `content_tag` passes it to `html_escape` → `tidy_bytes(nil)` calls `nil.empty?` → crash.

### Solution
Filter blank-value name entries out of `SourceClientNameSet` before they reach the view. A name alias with no value has nothing to display and should never be included in the set.

### Notes
The underlying data — source clients with no name fields — may be worth investigating as a separate issue. This fix prevents the crash regardless of what bad data exists in the database.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
