### PR TITLE
Local dev improvements for IDP

### DIFF
--- a/docker/auth/generate-dev-auth.sh
+++ b/docker/auth/generate-dev-auth.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Generates oauth2-proxy alpha-config files from templates in docker/auth/.
-# Substitutes ${JWT_SECRET} with the value from .env.development.local.
+# Substitutes ${JWT_SECRET} from .env.development.local into templates and requires
+# OAUTH2_PROXY_COOKIE_SECRET / OAUTH2_PROXY_CLIENT_SECRET to be set there too (compose uses them).
 # Output goes to dev/auth/ which is gitignored.
 #
 # Run once after initial setup and again if a template file changes.
@@ -18,9 +19,41 @@ if [[ ! -f "$ENV_FILE" ]]; then
   exit 1
 fi
 
-JWT_SECRET=$(grep '^JWT_SECRET=' "$ENV_FILE" | sed 's/^JWT_SECRET=//;s/^"//;s/"$//')
+# Echoes trimmed value on stdout with status 0; status 1 and no output when missing or empty.
+read_env_line() {
+  local key="$1" val
+  val="$(grep "^${key}=" "$ENV_FILE" | sed "s/^${key}=//;s/^\"//;s/\"$//" || true)"
+  if [[ -z "$val" ]]; then
+    return 1
+  fi
+  printf '%s' "$val"
+  return 0
+}
+
+# Read and validate JWT_SECRET, OAUTH2_COOKIE_SECRET, OAUTH2_CLIENT_SECRET
+# Note: only JWT_SECRET is required for this script, but we validate all three for completeness.
+JWT_SECRET="$(read_env_line JWT_SECRET || true)"
+OAUTH2_COOKIE_SECRET="$(read_env_line OAUTH2_PROXY_COOKIE_SECRET || true)"
+OAUTH2_CLIENT_SECRET="$(read_env_line OAUTH2_PROXY_CLIENT_SECRET || true)"
+
 if [[ -z "$JWT_SECRET" ]]; then
-  echo "Error: JWT_SECRET is not set in $ENV_FILE" >&2
+  echo "Error: JWT_SECRET is missing, set a JWT_SECRET in: $ENV_FILE" >&2
+  exit 1
+fi
+
+if [[ -z "$OAUTH2_COOKIE_SECRET" ]]; then
+  echo "Error: OAUTH2_PROXY_COOKIE_SECRET is missing, set a OAUTH2_PROXY_COOKIE_SECRET in: $ENV_FILE" >&2
+  exit 1
+fi
+
+if [[ -z "$OAUTH2_CLIENT_SECRET" ]]; then
+  echo "Error: OAUTH2_PROXY_CLIENT_SECRET is missing, set a OAUTH2_PROXY_CLIENT_SECRET in: $ENV_FILE" >&2
+  exit 1
+fi
+
+# ensure JWT_SECRET, OAUTH2_COOKIE_SECRET, OAUTH2_CLIENT_SECRET are set to the same value
+if [[ "$JWT_SECRET" != "$OAUTH2_COOKIE_SECRET" || "$JWT_SECRET" != "$OAUTH2_CLIENT_SECRET" ]]; then
+  echo "Error: JWT_SECRET, OAUTH2_COOKIE_SECRET, OAUTH2_CLIENT_SECRET are not set to the same value in: $ENV_FILE" >&2
   exit 1
 fi
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -293,8 +293,10 @@ services:
         aliases:
           - dex.dev.test
     depends_on:
+      keycloak:
+        condition: service_healthy
       db:
-        condition: "service_healthy"
+        condition: service_healthy
       dex-db-init:
         condition: service_completed_successfully
     # oauth2 proxy kept failing intermittently, added this health check


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
- `generate-dev-auth.sh` would silently fail if JWT_SECRET was missing (due to `set -u`). Update it to print an error message
- Update `generate-dev-auth.sh` to also validate presence of OAUTH2_PROXY_COOKIE_SECRET/OAUTH2_PROXY_CLIENT_SECRET and that they all match
- Update docker-compose to wait for `keycloak` service to be health before `dex` starts. I had problems with this locally

## Type of change
dev updates

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
