### PR TITLE
8751 tt fixes

### DIFF
--- a/app/services/hud_reports/archive_report_service.rb
+++ b/app/services/hud_reports/archive_report_service.rb
@@ -99,14 +99,13 @@ module HudReports
           end
         end
 
-        File.open(temp_file.path, 'rb') do |file_handle|
-          report.send(attachment_name).attach(
-            io: file_handle,
-            filename: filename,
-            content_type: 'text/csv',
-          )
-          report.save(validate: false)
-        end
+        temp_file.rewind
+        report.send(attachment_name).attach(
+          io: temp_file,
+          filename: filename,
+          content_type: 'text/csv',
+        )
+        report.save(validate: false)
       end
     end
 

--- a/app/services/hud_reports/archive_report_service.rb
+++ b/app/services/hud_reports/archive_report_service.rb
@@ -89,8 +89,7 @@ module HudReports
         select { |_, t| [:json, :jsonb].include?(t.type) }.
         keys.to_set
 
-      temp_file = Tempfile.new(['hud_archive', '.csv'])
-      begin
+      Tempfile.create(['hud_archive', '.csv']) do |temp_file|
         CSV.open(temp_file.path, 'wb') do |csv|
           csv << column_names
           relation.find_in_batches(batch_size: 1_000) do |batch|
@@ -100,20 +99,14 @@ module HudReports
           end
         end
 
-        file_handle = File.open(temp_file.path, 'rb')
-        begin
+        File.open(temp_file.path, 'rb') do |file_handle|
           report.send(attachment_name).attach(
             io: file_handle,
             filename: filename,
             content_type: 'text/csv',
           )
           report.save(validate: false)
-        ensure
-          file_handle.close
         end
-      ensure
-        temp_file.close
-        temp_file.unlink
       end
     end
 

--- a/app/services/hud_reports/restore_archived_report_data_service.rb
+++ b/app/services/hud_reports/restore_archived_report_data_service.rb
@@ -49,8 +49,12 @@ module HudReports
 
             count = restore_from_csv(attachment_name, entry)
             restored_counts[attachment_name] = count
+          rescue StandardError => e
+            raise e.class, "#{attachment_name}: #{e.message}", e.backtrace
           end
 
+          # reset_sequences uses DDL (setval). In PostgreSQL DDL *is* transactional,
+          # so a rollback will undo the sequence reset — the correct behaviour here.
           reset_sequences(config)
           clear_purged_at
         end
@@ -62,8 +66,10 @@ module HudReports
           "HudReports::RestoreArchivedReportDataService: #{@errors.last}\n#{e.backtrace.first(5).join("\n")}",
         )
       ensure
-        report.reload
-        report.update_column(:updated_at, original_updated_at) if report.updated_at != original_updated_at
+        # Guard with rescue nil: if the DB connection was the cause of the rollback,
+        # these calls would raise a second exception and swallow the original error.
+        report.reload rescue nil # rubocop:disable Style/RescueModifier
+        report.update_column(:updated_at, original_updated_at) if report.updated_at != original_updated_at rescue nil # rubocop:disable Style/RescueModifier
       end
 
       { success: @errors.empty?, restored_counts: restored_counts, errors: @errors }

--- a/app/services/hud_reports/restore_archived_report_data_service.rb
+++ b/app/services/hud_reports/restore_archived_report_data_service.rb
@@ -39,27 +39,28 @@ module HudReports
       restored_counts = {}
 
       begin
-        # Restore in reverse delete_order (highest delete_order first)
-        sorted_entries = config.sort_by { |_k, v| -v[:delete_order] }
+        report.class.transaction do
+          # Restore in reverse delete_order (highest delete_order first)
+          sorted_entries = config.sort_by { |_k, v| -v[:delete_order] }
 
-        sorted_entries.each do |attachment_name, entry|
-          next unless expected_files.include?(attachment_name.to_s)
-          next unless report.send(attachment_name).attached?
+          sorted_entries.each do |attachment_name, entry|
+            next unless expected_files.include?(attachment_name.to_s)
+            next unless report.send(attachment_name).attached?
 
-          count = restore_from_csv(attachment_name, entry)
-          restored_counts[attachment_name] = count
-        rescue StandardError => e
-          @errors << "Failed to restore #{attachment_name}: #{e.message}"
-          Rails.logger.error(
-            "HudReports::RestoreArchivedReportDataService: #{@errors.last}\n#{e.backtrace.first(5).join("\n")}",
-          )
-        end
+            count = restore_from_csv(attachment_name, entry)
+            restored_counts[attachment_name] = count
+          end
 
-        if @errors.empty?
           reset_sequences(config)
           clear_purged_at
-          Rails.logger.info("HudReports::RestoreArchivedReportDataService: Restored report ##{report.id}: #{restored_counts.inspect}")
         end
+
+        Rails.logger.info("HudReports::RestoreArchivedReportDataService: Restored report ##{report.id}: #{restored_counts.inspect}")
+      rescue StandardError => e
+        @errors << "Failed to restore: #{e.message}"
+        Rails.logger.error(
+          "HudReports::RestoreArchivedReportDataService: #{@errors.last}\n#{e.backtrace.first(5).join("\n")}",
+        )
       ensure
         report.reload
         report.update_column(:updated_at, original_updated_at) if report.updated_at != original_updated_at

--- a/drivers/hud_apr/config/routes.rb
+++ b/drivers/hud_apr/config/routes.rb
@@ -13,9 +13,6 @@ OpenPath::Application.routes.draw do
     # APR (Annual Performance Report)
     resources :aprs do
       concerns :hud_report_actions
-      member do
-        post :restore
-      end
       scope module: :apr do
         concerns :hud_drilldown_actions
       end
@@ -24,9 +21,6 @@ OpenPath::Application.routes.draw do
     # CAPER (Consolidated Annual Performance and Evaluation Report)
     resources :capers do
       concerns :hud_report_actions
-      member do
-        post :restore
-      end
       scope module: :caper do
         concerns :hud_drilldown_actions
       end
@@ -35,9 +29,6 @@ OpenPath::Application.routes.draw do
     # CE APR (Coordinated Entry Annual Performance Report)
     resources :ce_aprs do
       concerns :hud_report_actions
-      member do
-        post :restore
-      end
       scope module: :ce_apr do
         concerns :hud_drilldown_actions
       end
@@ -46,9 +37,6 @@ OpenPath::Application.routes.draw do
     # DQ (Data Quality Report)
     resources :dqs do
       concerns :hud_report_actions
-      member do
-        post :restore
-      end
       scope module: :dq do
         concerns :hud_drilldown_actions
       end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
@@ -78,7 +78,7 @@ module HudSpmReport::Generators::Fy2023
       episode_ids = HudReports::UniverseMember.where(
         report_cell_id: report_instance.report_cells.select(:id),
         universe_membership_type: 'HudSpmReport::Fy2023::Episode',
-      ).select(:universe_membership_id)
+      ).pluck(:universe_membership_id)
 
       shared_archival_entries(report_instance).merge(
         spm_enrollment_links_csv: {

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
@@ -78,7 +78,7 @@ module HudSpmReport::Generators::Fy2024
       episode_ids = HudReports::UniverseMember.where(
         report_cell_id: report_instance.report_cells.select(:id),
         universe_membership_type: 'HudSpmReport::Fy2024::Episode',
-      ).select(:universe_membership_id)
+      ).pluck(:universe_membership_id)
 
       shared_archival_entries(report_instance).merge(
         spm_enrollment_links_csv: {

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
@@ -98,7 +98,7 @@ module HudSpmReport::Generators::Fy2026
       episode_ids = HudReports::UniverseMember.where(
         report_cell_id: report_instance.report_cells.select(:id),
         universe_membership_type: 'HudSpmReport::Fy2026::Episode',
-      ).select(:universe_membership_id)
+      ).pluck(:universe_membership_id)
 
       shared_archival_entries(report_instance).merge(
         spm_bed_nights_csv: {

--- a/drivers/hud_spm_report/config/routes.rb
+++ b/drivers/hud_spm_report/config/routes.rb
@@ -14,9 +14,6 @@ OpenPath::Application.routes.draw do
     resources :spms do
       concerns :hud_report_actions
       concerns :hud_drilldown_actions, resource: :measures
-      member do
-        post :restore
-      end
     end
     resources :legacy_spms, only: [:index, :show] do
       resources :legacy_results, only: [:show]

--- a/spec/integration/hud_spm_report/archival_integration_spec.rb
+++ b/spec/integration/hud_spm_report/archival_integration_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe 'SPM Archival Integration', type: :model do
         cell = report.report_cells.create!(question: 'Measure 1', cell_name: 'A1', universe: false)
 
         enrollment_id = enrollment_klass.insert(
-          { report_instance_id: report.id }, returning: [:id],
+          { report_instance_id: report.id }, returning: [:id]
         ).first['id']
         insert_universe_member(report_cell_id: cell.id, type: enrollment_klass.name, membership_id: enrollment_id)
 
@@ -210,9 +210,7 @@ RSpec.describe 'SPM Archival Integration', type: :model do
         link_klass.insert({ enrollment_id: enrollment_id, episode_id: @episode_id })
         return_klass.insert({ report_instance_id: report.id, client_id: 1, exit_enrollment_id: enrollment_id })
 
-        if fy_mod == 'Fy2026'
-          HudSpmReport::Fy2026::BedNight.insert({ enrollment_id: enrollment_id, date: Date.current })
-        end
+        HudSpmReport::Fy2026::BedNight.insert({ enrollment_id: enrollment_id, date: Date.current }) if fy_mod == 'Fy2026'
       end
 
       it 'deletes episode rows even though universe_members are deleted first (delete_order 1 vs 4+)' do
@@ -227,8 +225,8 @@ RSpec.describe 'SPM Archival Integration', type: :model do
         # universe_members which are already deleted, so it returns 0 regardless.
         # This direct lookup will expose any episode rows that were silently skipped.
         expect(episode_klass.where(id: @episode_id).count).to eq(0),
-          "#{fy_mod}::Episode id=#{@episode_id} still exists after purge — " \
-          'episode_ids was a lazy subquery on universe_members already deleted at order 1'
+                                                              "#{fy_mod}::Episode id=#{@episode_id} still exists after purge — " \
+                                                              'episode_ids was a lazy subquery on universe_members already deleted at order 1'
       end
     end
   end

--- a/spec/integration/hud_spm_report/archival_integration_spec.rb
+++ b/spec/integration/hud_spm_report/archival_integration_spec.rb
@@ -177,6 +177,62 @@ RSpec.describe 'SPM Archival Integration', type: :model do
     end
   end
 
+  # ── Episode purge regression (FY2023 / FY2024 / FY2026) ─────────────────────
+  # episode_ids is built as a lazy AR subquery on universe_members. universe_members
+  # are deleted at delete_order 1 and episodes at order 4+. With a lazy relation the
+  # episode scope re-evaluates after universe_members are gone, returns 0 rows, and
+  # silently skips episode deletion. These tests assert the count by querying the
+  # episodes table directly by the seeded ID — no dependency on universe_members —
+  # so they catch any orphaned rows the broken scope misses.
+  {
+    'Fy2023' => HudSpmReport::Generators::Fy2023::Generator,
+    'Fy2024' => HudSpmReport::Generators::Fy2024::Generator,
+    'Fy2026' => HudSpmReport::Generators::Fy2026::Generator,
+  }.each do |fy_mod, generator_klass|
+    describe "#{fy_mod} episode purge regression" do
+      let(:report) { create_completed_report(generator_klass.title) }
+      let(:episode_klass) { "HudSpmReport::#{fy_mod}::Episode".constantize }
+      let(:enrollment_klass) { "HudSpmReport::#{fy_mod}::SpmEnrollment".constantize }
+      let(:link_klass) { "HudSpmReport::#{fy_mod}::EnrollmentLink".constantize }
+      let(:return_klass) { "HudSpmReport::#{fy_mod}::Return".constantize }
+
+      before do
+        cell = report.report_cells.create!(question: 'Measure 1', cell_name: 'A1', universe: false)
+
+        enrollment_id = enrollment_klass.insert(
+          { report_instance_id: report.id }, returning: [:id],
+        ).first['id']
+        insert_universe_member(report_cell_id: cell.id, type: enrollment_klass.name, membership_id: enrollment_id)
+
+        @episode_id = episode_klass.insert({ client_id: nil }, returning: [:id]).first['id']
+        insert_universe_member(report_cell_id: cell.id, type: episode_klass.name, membership_id: @episode_id)
+
+        link_klass.insert({ enrollment_id: enrollment_id, episode_id: @episode_id })
+        return_klass.insert({ report_instance_id: report.id, client_id: 1, exit_enrollment_id: enrollment_id })
+
+        if fy_mod == 'Fy2026'
+          HudSpmReport::Fy2026::BedNight.insert({ enrollment_id: enrollment_id, date: Date.current })
+        end
+      end
+
+      it 'deletes episode rows even though universe_members are deleted first (delete_order 1 vs 4+)' do
+        archive_service = HudReports::ArchiveReportService.new(report)
+        expect(archive_service.archive!).to be(true), "Archive failed: #{archive_service.errors.inspect}"
+
+        purge_service = HudReports::PurgeArchivedReportDataService.new(report, dry_run: false, force: true)
+        result = purge_service.purge!
+        expect(result[:success]).to be(true), "Purge failed: #{result[:errors].inspect}"
+
+        # Query by the captured ID, not through the scope. The scope subqueries
+        # universe_members which are already deleted, so it returns 0 regardless.
+        # This direct lookup will expose any episode rows that were silently skipped.
+        expect(episode_klass.where(id: @episode_id).count).to eq(0),
+          "#{fy_mod}::Episode id=#{@episode_id} still exists after purge — " \
+          'episode_ids was a lazy subquery on universe_members already deleted at order 1'
+      end
+    end
+  end
+
   # ── Current generator (resolved via HudSpmReport.current_generator) ────────
   describe 'current version full cycle' do
     let(:current_gen) { HudSpmReport.current_generator }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Bug fix:
`episode_ids` was a lazy AR relation (a subquery on `universe_members`). The purge service deletes in ascending `delete_order`, so `universe_members` (order 1) are gone by the time the episodes scope (order 4) fires. The subquery returns empty, `Episode.where(id: [])` matches nothing, and episode rows are silently left in the database.

Also some adjustments for archive/restore reliability

#### details

- **Episode Purge**: Changed `select` to `pluck` when building `episode_ids` so IDs are materialized into a Ruby array when the archival config is first built, rather than re-evaluated as a lazy subquery after `universe_members` have already been deleted at a lower delete order
- **Transaction Safety for Restore**: Wrapped in a database transaction so a mid-restore failure rolls back all inserted rows atomically, rather than leaving the report in a partially-restored state
- **Restore Error Handling**: Replaced per-table error accumulation with a single outer rescue that captures the failing table name
- **Archive Tempfile Cleanup**: Replaced `Tempfile.new` + manual `begin/ensure` with `Tempfile.create` block form for guaranteed cleanup
- **Duplicate Restore Routes**: Removed explicit `member { post :restore }` which were already declared via the `hud_report_actions` concern
- Added regression tests covering the episode purge bug

### Type of Change
Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
