### PR TITLE
fix: 8751-tt-dry-up-csv-config

### DIFF
--- a/app/models/concerns/hud_report_archival.rb
+++ b/app/models/concerns/hud_report_archival.rb
@@ -13,7 +13,30 @@ module HudReportArchival
   self.generator_registry = {}
 
   def self.register_archival_generator(report_name, klass)
+    raise NotImplementedError, "#{klass} must implement self.archival_csv_config to register as an archival generator" unless klass.respond_to?(:archival_csv_config)
+
     generator_registry[report_name] = klass
+  end
+
+  # Common archival entries shared by every HUD report driver: the universe_members
+  # and report_cells tables that back all report types. Call from each driver's
+  # archival_csv_config and merge in driver-specific entries.
+  #
+  # prefix: short lowercase identifier for this report type (e.g. 'apr', 'spm', 'dq').
+  # Used only for human-readable CSV filenames; has no functional effect on restore.
+  def self.shared_archival_entries(report_instance, prefix:)
+    {
+      universe_members_csv: {
+        scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
+        filename: -> { "hud-#{prefix}-#{report_instance.id}-universe-members.csv" },
+        delete_order: 1,
+      },
+      report_cells_csv: {
+        scope: -> { report_instance.report_cells },
+        filename: -> { "hud-#{prefix}-#{report_instance.id}-cells.csv" },
+        delete_order: 99,
+      },
+    }
   end
 
   included do

--- a/drivers/hud_apr/app/models/hud_apr/archival.rb
+++ b/drivers/hud_apr/app/models/hud_apr/archival.rb
@@ -22,25 +22,10 @@ module HudApr
     end
 
     module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-apr-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-apr-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
       def archival_csv_config(report_instance)
         client_ids = HudApr::Fy2020::AprClient.where(report_instance_id: report_instance.id).select(:id)
 
-        shared_archival_entries(report_instance).merge(
+        HudReportArchival.shared_archival_entries(report_instance, prefix: 'apr').merge(
           apr_living_situations_csv: {
             scope: -> { HudApr::Fy2020::AprLivingSituation.where(hud_report_apr_client_id: client_ids) },
             filename: -> { "hud-apr-#{report_instance.id}-living-situations.csv" },

--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2020/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2020/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Apr::Fy2020
       'APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def url
       hud_reports_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -68,5 +63,10 @@ module HudApr::Generators::Apr::Fy2020
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2021/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2021/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Apr::Fy2021
       'APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys
     end
@@ -72,5 +67,10 @@ module HudApr::Generators::Apr::Fy2021
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2023/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2023/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Apr::Fy2023
       'APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys
     end
@@ -72,5 +67,10 @@ module HudApr::Generators::Apr::Fy2023
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2024/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2024/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Apr::Fy2024
       'APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -77,5 +72,10 @@ module HudApr::Generators::Apr::Fy2024
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/apr/fy2026/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Apr::Fy2026
       'APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -76,5 +71,10 @@ module HudApr::Generators::Apr::Fy2026
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2020/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2020/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Caper::Fy2020
       'CAPER'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def url
       hud_reports_caper_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -69,5 +64,10 @@ module HudApr::Generators::Caper::Fy2020
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2021/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2021/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Caper::Fy2021
       'CAPER'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys + [:prevention]
     end
@@ -73,5 +68,10 @@ module HudApr::Generators::Caper::Fy2021
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2023/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2023/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Caper::Fy2023
       'CAPER'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys + [:prevention]
     end
@@ -73,5 +68,10 @@ module HudApr::Generators::Caper::Fy2023
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2024/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2024/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Caper::Fy2024
       'CAPER'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -77,5 +72,10 @@ module HudApr::Generators::Caper::Fy2024
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/caper/fy2026/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Caper::Fy2026
       'CAPER'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -76,5 +71,10 @@ module HudApr::Generators::Caper::Fy2026
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 4'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2020/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2020/generator.rb
@@ -23,11 +23,6 @@ module HudApr::Generators::CeApr::Fy2020
       'CE-APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def url
       hud_reports_ce_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -90,5 +85,10 @@ module HudApr::Generators::CeApr::Fy2020
 
       scope.select(:id)
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2021/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2021/generator.rb
@@ -23,11 +23,6 @@ module HudApr::Generators::CeApr::Fy2021
       'CE-APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def url
       hud_reports_ce_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -134,5 +129,10 @@ module HudApr::Generators::CeApr::Fy2021
 
       project_ids & @report.project_ids
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2023/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2023/generator.rb
@@ -23,11 +23,6 @@ module HudApr::Generators::CeApr::Fy2023
       'CE-APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def url
       hud_reports_ce_apr_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -134,5 +129,10 @@ module HudApr::Generators::CeApr::Fy2023
 
       project_ids & @report.project_ids
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2024/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2024/generator.rb
@@ -23,11 +23,6 @@ module HudApr::Generators::CeApr::Fy2024
       'CE-APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.0 #{short_name} #{fiscal_year}"
     end
@@ -148,5 +143,10 @@ module HudApr::Generators::CeApr::Fy2024
 
       project_ids & @report.project_ids
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/generator.rb
@@ -23,11 +23,6 @@ module HudApr::Generators::CeApr::Fy2026
       'CE-APR'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "v1.0 #{short_name} #{fiscal_year}"
     end
@@ -167,5 +162,10 @@ module HudApr::Generators::CeApr::Fy2026
 
       project_ids & @report.project_ids
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2024/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2024/generator.rb
@@ -22,11 +22,6 @@ module HudApr::Generators::Dq::Fy2024
       'DQ'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "#{short_name} #{fiscal_year}"
     end
@@ -60,5 +55,10 @@ module HudApr::Generators::Dq::Fy2024
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 1'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2026/generator.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/dq/fy2026/generator.rb
@@ -30,11 +30,6 @@ module HudApr::Generators::Dq::Fy2026
       'DQ'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudApr::Archival
-
     def self.file_prefix
       "#{short_name} #{fiscal_year}"
     end
@@ -68,5 +63,10 @@ module HudApr::Generators::Dq::Fy2026
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 1'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudApr::Archival
   end
 end

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/archival.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/archival.rb
@@ -20,25 +20,10 @@ module HudDataQualityReport
     end
 
     module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-dq-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-dq-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
       def archival_csv_config(report_instance)
         client_ids = HudDataQualityReport::Fy2020::DqClient.where(report_instance_id: report_instance.id).select(:id)
 
-        shared_archival_entries(report_instance).merge(
+        HudReportArchival.shared_archival_entries(report_instance, prefix: 'dq').merge(
           dq_living_situations_csv: {
             scope: -> { HudDataQualityReport::Fy2020::DqLivingSituation.where(hud_report_dq_client_id: client_ids) },
             filename: -> { "hud-dq-#{report_instance.id}-living-situations.csv" },

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/generator.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2020/generator.rb
@@ -20,11 +20,6 @@ module HudDataQualityReport::Generators::Fy2020
       'DQ'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudDataQualityReport::Archival
-
     def url
       hud_reports_past_dq_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -50,5 +45,10 @@ module HudDataQualityReport::Generators::Fy2020
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 1'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudDataQualityReport::Archival
   end
 end

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2022/generator.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/generators/fy2022/generator.rb
@@ -20,11 +20,6 @@ module HudDataQualityReport::Generators::Fy2022
       'DQ'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudDataQualityReport::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys
     end
@@ -54,5 +49,10 @@ module HudDataQualityReport::Generators::Fy2022
     def self.valid_question_number(question_number)
       questions.keys.detect { |q| q == question_number } || 'Question 1'
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudDataQualityReport::Archival
   end
 end

--- a/drivers/hud_hic/app/models/hud_hic/archival.rb
+++ b/drivers/hud_hic/app/models/hud_hic/archival.rb
@@ -23,23 +23,8 @@ module HudHic
     end
 
     module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-hic-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-hic-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
       def archival_csv_config(report_instance)
-        shared_archival_entries(report_instance).merge(
+        HudReportArchival.shared_archival_entries(report_instance, prefix: 'hic').merge(
           hic_funders_csv: {
             scope: -> { HudHic::Fy2022::Funder.where(report_instance_id: report_instance.id) },
             filename: -> { "hud-hic-#{report_instance.id}-funders.csv" },

--- a/drivers/hud_hic/app/models/hud_hic/generators/hic/fy2022/generator.rb
+++ b/drivers/hud_hic/app/models/hud_hic/generators/hic/fy2022/generator.rb
@@ -20,11 +20,6 @@ module  HudHic::Generators::Hic::Fy2022
       'HIC'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudHic::Archival
-
     # Project Types (HIC):
     #   ES, TH, SH, PH (PSH, RRH, Other PH (OPH) – consists of PH – Housing with Services (no disability required for entry) and PH – Housing Only)
     #   OR numerically
@@ -113,5 +108,10 @@ module  HudHic::Generators::Hic::Fy2022
         HudHic::Fy2022::Funder,
       ].freeze
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudHic::Archival
   end
 end

--- a/drivers/hud_lsa/app/models/hud_lsa/archival.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/archival.rb
@@ -17,26 +17,5 @@ module HudLsa
 
       ::HudReportArchival.register_archival_generator(title, self)
     end
-
-    module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-lsa-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-lsa-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
-      def archival_csv_config(_report_instance)
-        raise NotImplementedError, "#{name} must implement self.archival_csv_config"
-      end
-    end
   end
 end

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2022/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2022/lsa.rb
@@ -407,7 +407,7 @@ module HudLsa::Generators::Fy2022
     end
 
     def self.archival_csv_config(report_instance)
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'lsa').merge(
         lsa_summary_results_csv: {
           scope: -> { HudLsa::Fy2022::SummaryResult.where(hud_report_instance_id: report_instance.id) },
           filename: -> { "hud-lsa-fy2022-#{report_instance.id}-summary-results.csv" },

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2022/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2022/lsa.rb
@@ -22,10 +22,6 @@ module HudLsa::Generators::Fy2022
     include MissingDataConcern
     include ViewRelatedConcern
     include StatusProgressionConcern
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. title is defined on ViewRelatedConcern (generic_title and
-    # fiscal_year); keep HudLsa::Archival immediately after ViewRelatedConcern.
-    include HudLsa::Archival
 
     attr_accessor :report, :destroy_rds, :hmis_export_id, :test
     has_one_attached :result_file
@@ -415,5 +411,10 @@ module HudLsa::Generators::Fy2022
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudLsa::Archival
   end
 end

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
@@ -27,10 +27,6 @@ module HudLsa::Generators::Fy2023
     include MissingDataConcern
     include ViewRelatedConcern
     include StatusProgressionConcern
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. title is defined on ViewRelatedConcern (generic_title and
-    # fiscal_year); keep HudLsa::Archival immediately after ViewRelatedConcern.
-    include HudLsa::Archival
 
     attr_accessor :report, :destroy_rds, :hmis_export_id, :test
     has_one_attached :result_file
@@ -441,5 +437,10 @@ module HudLsa::Generators::Fy2023
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudLsa::Archival
   end
 end

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2023/lsa.rb
@@ -433,7 +433,7 @@ module HudLsa::Generators::Fy2023
     end
 
     def self.archival_csv_config(report_instance)
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'lsa').merge(
         lsa_summary_results_csv: {
           scope: -> { HudLsa::Fy2023::SummaryResult.where(hud_report_instance_id: report_instance.id) },
           filename: -> { "hud-lsa-fy2023-#{report_instance.id}-summary-results.csv" },

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2024/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2024/lsa.rb
@@ -30,10 +30,6 @@ module HudLsa::Generators::Fy2024
     include MissingDataConcern
     include ViewRelatedConcern
     include StatusProgressionConcern
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. title is defined on ViewRelatedConcern (generic_title and
-    # fiscal_year); keep HudLsa::Archival immediately after ViewRelatedConcern.
-    include HudLsa::Archival
 
     attr_accessor :report, :destroy_rds, :hmis_export_id, :test, :test_type
     has_one_attached :result_file
@@ -594,5 +590,10 @@ module HudLsa::Generators::Fy2024
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudLsa::Archival
   end
 end

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2024/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2024/lsa.rb
@@ -586,7 +586,7 @@ module HudLsa::Generators::Fy2024
     end
 
     def self.archival_csv_config(report_instance)
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'lsa').merge(
         lsa_summary_results_csv: {
           scope: -> { HudLsa::Fy2024::SummaryResult.where(hud_report_instance_id: report_instance.id) },
           filename: -> { "hud-lsa-fy2024-#{report_instance.id}-summary-results.csv" },

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
@@ -586,7 +586,7 @@ module HudLsa::Generators::Fy2026
     end
 
     def self.archival_csv_config(report_instance)
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'lsa').merge(
         lsa_summary_results_csv: {
           scope: -> { HudLsa::Fy2026::SummaryResult.where(hud_report_instance_id: report_instance.id) },
           filename: -> { "hud-lsa-fy2026-#{report_instance.id}-summary-results.csv" },

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
@@ -30,10 +30,6 @@ module HudLsa::Generators::Fy2026
     include MissingDataConcern
     include ViewRelatedConcern
     include StatusProgressionConcern
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. title is defined on ViewRelatedConcern (generic_title and
-    # fiscal_year); keep HudLsa::Archival immediately after ViewRelatedConcern.
-    include HudLsa::Archival
 
     attr_accessor :report, :destroy_rds, :hmis_export_id, :test, :test_type
     has_one_attached :result_file
@@ -594,5 +590,10 @@ module HudLsa::Generators::Fy2026
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudLsa::Archival
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/archival.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/archival.rb
@@ -19,23 +19,8 @@ module HudPathReport
     end
 
     module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-path-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-path-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
       def archival_csv_config(report_instance)
-        shared_archival_entries(report_instance).merge(
+        HudReportArchival.shared_archival_entries(report_instance, prefix: 'path').merge(
           path_clients_csv: {
             scope: -> { HudPathReport::Fy2020::PathClient.where(report_instance_id: report_instance.id) },
             filename: -> { "hud-path-#{report_instance.id}-clients.csv" },

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2020/generator.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2020/generator.rb
@@ -20,11 +20,6 @@ module HudPathReport::Generators::Fy2020
       'PATH'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPathReport::Archival
-
     def url
       hud_reports_path_url(report, { host: ENV['FQDN'], protocol: 'https' })
     end
@@ -49,5 +44,10 @@ module HudPathReport::Generators::Fy2020
     def self.filter_class
       ::HudPathReport::Filters::PathFilter
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPathReport::Archival
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/generator.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2021/generator.rb
@@ -20,11 +20,6 @@ module HudPathReport::Generators::Fy2021
       'PATH'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPathReport::Archival
-
     def self.file_prefix
       "v3.5 #{short_name} #{fiscal_year}"
     end
@@ -69,5 +64,10 @@ module HudPathReport::Generators::Fy2021
         :project_group_ids,
       ]
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPathReport::Archival
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/generator.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2024/generator.rb
@@ -20,11 +20,6 @@ module HudPathReport::Generators::Fy2024
       'PATH'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPathReport::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -69,5 +64,10 @@ module HudPathReport::Generators::Fy2024
         :project_group_ids,
       ]
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPathReport::Archival
   end
 end

--- a/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/generator.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/generators/fy2026/generator.rb
@@ -20,11 +20,6 @@ module HudPathReport::Generators::Fy2026
       'PATH'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPathReport::Archival
-
     def self.file_prefix
       "v1.2 #{short_name} #{fiscal_year}"
     end
@@ -69,5 +64,10 @@ module HudPathReport::Generators::Fy2026
         :project_group_ids,
       ]
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPathReport::Archival
   end
 end

--- a/drivers/hud_pit/app/models/hud_pit/archival.rb
+++ b/drivers/hud_pit/app/models/hud_pit/archival.rb
@@ -19,23 +19,8 @@ module HudPit
     end
 
     module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-pit-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-pit-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
       def archival_csv_config(report_instance)
-        shared_archival_entries(report_instance).merge(
+        HudReportArchival.shared_archival_entries(report_instance, prefix: 'pit').merge(
           pit_clients_csv: {
             scope: -> { HudPit::Fy2022::PitClient.where(report_instance_id: report_instance.id) },
             filename: -> { "hud-pit-#{report_instance.id}-clients.csv" },

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2022/generator.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2022/generator.rb
@@ -20,11 +20,6 @@ module  HudPit::Generators::Pit::Fy2022
       'PIT'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPit::Archival
-
     def self.default_project_type_codes
       HudHelper.util('2024').residential_project_type_numbers_by_code.keys
     end
@@ -101,5 +96,10 @@ module  HudPit::Generators::Pit::Fy2022
     def self.client_class(_question)
       HudPit::Fy2022::PitClient
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPit::Archival
   end
 end

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/generator.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2023/generator.rb
@@ -20,11 +20,6 @@ module  HudPit::Generators::Pit::Fy2023
       'PIT'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPit::Archival
-
     def self.allowed_options(_)
       [
         :on,
@@ -112,5 +107,10 @@ module  HudPit::Generators::Pit::Fy2023
     def self.client_class(_question)
       HudPit::Fy2022::PitClient
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPit::Archival
   end
 end

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/generator.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2024/generator.rb
@@ -22,11 +22,6 @@ module  HudPit::Generators::Pit::Fy2024
       'PIT'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPit::Archival
-
     def self.allowed_options(_)
       [
         :on,
@@ -114,5 +109,10 @@ module  HudPit::Generators::Pit::Fy2024
     def self.client_class(_question)
       HudPit::Fy2022::PitClient
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPit::Archival
   end
 end

--- a/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/generator.rb
+++ b/drivers/hud_pit/app/models/hud_pit/generators/pit/fy2025/generator.rb
@@ -23,11 +23,6 @@ module  HudPit::Generators::Pit::Fy2025
       'PIT'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudPit::Archival
-
     def self.allowed_options(_)
       [
         :on,
@@ -115,5 +110,10 @@ module  HudPit::Generators::Pit::Fy2025
     def self.client_class(_question)
       HudPit::Fy2025::PitClient
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudPit::Archival
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
@@ -25,25 +25,6 @@ module HudSpmReport
       ::HudReportArchival.register_archival_generator(title, self)
     end
 
-    module ClassMethods
-      def shared_archival_entries(report_instance)
-        {
-          universe_members_csv: {
-            scope: -> { ::HudReports::UniverseMember.where(report_cell_id: report_instance.report_cells.select(:id)) },
-            filename: -> { "hud-spm-#{report_instance.id}-universe-members.csv" },
-            delete_order: 1,
-          },
-          report_cells_csv: {
-            scope: -> { report_instance.report_cells },
-            filename: -> { "hud-spm-#{report_instance.id}-cells.csv" },
-            delete_order: 99,
-          },
-        }
-      end
-
-      def archival_csv_config(_report_instance)
-        raise NotImplementedError, "#{name} must implement self.archival_csv_config"
-      end
     end
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
@@ -24,7 +24,5 @@ module HudSpmReport
 
       ::HudReportArchival.register_archival_generator(title, self)
     end
-
-    end
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2020/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2020/generator.rb
@@ -71,7 +71,7 @@ module HudSpmReport::Generators::Fy2020
     end
 
     def self.archival_csv_config(report_instance)
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'spm').merge(
         spm_clients_csv: {
           scope: -> { HudSpmReport::Fy2020::SpmClient.where(report_instance_id: report_instance.id) },
           filename: -> { "hud-spm-fy2020-#{report_instance.id}-spm-clients.csv" },

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2020/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2020/generator.rb
@@ -12,11 +12,6 @@ module HudSpmReport::Generators::Fy2020
     def self.generic_title = 'System Performance Measures'
     def self.short_name = 'SPM'
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudSpmReport::Archival
-
     def self.filter_class = ::Filters::HudFilterBase
 
     def self.default_project_type_codes
@@ -79,5 +74,10 @@ module HudSpmReport::Generators::Fy2020
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudSpmReport::Archival
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
@@ -80,7 +80,7 @@ module HudSpmReport::Generators::Fy2023
         universe_membership_type: 'HudSpmReport::Fy2023::Episode',
       ).select(:universe_membership_id)
 
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'spm').merge(
         spm_enrollment_links_csv: {
           scope: -> { HudSpmReport::Fy2023::EnrollmentLink.where(enrollment_id: enrollment_ids) },
           filename: -> { "hud-spm-fy2023-#{report_instance.id}-spm-enrollment-links.csv" },

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2023/generator.rb
@@ -12,11 +12,6 @@ module HudSpmReport::Generators::Fy2023
     def self.generic_title = 'System Performance Measures'
     def self.short_name = 'SPM'
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudSpmReport::Archival
-
     def self.filter_class = ::Filters::HudFilterBase
 
     def self.default_project_type_codes
@@ -103,5 +98,10 @@ module HudSpmReport::Generators::Fy2023
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudSpmReport::Archival
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
@@ -80,7 +80,7 @@ module HudSpmReport::Generators::Fy2024
         universe_membership_type: 'HudSpmReport::Fy2024::Episode',
       ).select(:universe_membership_id)
 
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'spm').merge(
         spm_enrollment_links_csv: {
           scope: -> { HudSpmReport::Fy2024::EnrollmentLink.where(enrollment_id: enrollment_ids) },
           filename: -> { "hud-spm-fy2024-#{report_instance.id}-spm-enrollment-links.csv" },

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2024/generator.rb
@@ -12,11 +12,6 @@ module HudSpmReport::Generators::Fy2024
     def self.generic_title = 'System Performance Measures'
     def self.short_name = 'SPM'
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudSpmReport::Archival
-
     def self.filter_class = ::Filters::HudFilterBase
 
     def self.default_project_type_codes
@@ -103,5 +98,10 @@ module HudSpmReport::Generators::Fy2024
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudSpmReport::Archival
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
@@ -22,11 +22,6 @@ module HudSpmReport::Generators::Fy2026
       'SPM'
     end
 
-    # HudReportArchival.register_archival_generator(self.title, self) runs when this
-    # concern is included. HudReports::GeneratorBase.title interpolates generic_title and
-    # fiscal_year; define those class methods above before including Archival.
-    include HudSpmReport::Archival
-
     def self.supports_idempotent_retry?
       true
     end
@@ -128,6 +123,11 @@ module HudSpmReport::Generators::Fy2026
         },
       )
     end
+
+    # HudReportArchival.register_archival_generator(self.title, self) runs when this
+    # concern is included. Include at the end of the class to ensure all required fields
+    # are loaded for registration
+    include HudSpmReport::Archival
 
     private
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/generator.rb
@@ -100,7 +100,7 @@ module HudSpmReport::Generators::Fy2026
         universe_membership_type: 'HudSpmReport::Fy2026::Episode',
       ).select(:universe_membership_id)
 
-      shared_archival_entries(report_instance).merge(
+      HudReportArchival.shared_archival_entries(report_instance, prefix: 'spm').merge(
         spm_bed_nights_csv: {
           scope: -> { HudSpmReport::Fy2026::BedNight.where(enrollment_id: enrollment_ids) },
           filename: -> { "hud-spm-fy2026-#{report_instance.id}-spm-bed-nights.csv" },

--- a/spec/models/concerns/hud_report_archival_spec.rb
+++ b/spec/models/concerns/hud_report_archival_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe HudReportArchival, type: :model do
   describe '.register_archival_generator / .generator_registry' do
     it 'registers a generator class by report name' do
       fake_class = Class.new
+      fake_class.define_singleton_method(:archival_csv_config) { |_| {} }
       HudReportArchival.register_archival_generator('My Report - FY 9999', fake_class)
       expect(HudReportArchival.generator_registry['My Report - FY 9999']).to eq(fake_class)
     end
@@ -130,6 +131,7 @@ RSpec.describe HudReportArchival, type: :model do
   describe '#archival_generator_klass' do
     it 'returns the registered generator for this report_name' do
       fake_class = Class.new
+      fake_class.define_singleton_method(:archival_csv_config) { |_| {} }
       HudReportArchival.register_archival_generator(report.report_name, fake_class)
       expect(report.archival_generator_klass).to eq(fake_class)
     end
@@ -147,6 +149,7 @@ RSpec.describe HudReportArchival, type: :model do
 
     it 'falls back to registry lookup when generator_class is absent from metadata' do
       fake_class = Class.new
+      fake_class.define_singleton_method(:archival_csv_config) { |_| {} }
       HudReportArchival.register_archival_generator(report.report_name, fake_class)
       # No generator_class key in metadata — legacy report or pre-archive state.
       report.update_column(:archival_metadata, {})


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

AI suggested we prune out some repeated config. Maybe worthwhile?

DRY `shared_archival_entries` logic across all HUD report drivers into a single canonical implementation on the `HudReportArchival` concern.

Added a `respond_to?` guard in `register_archival_generator` so any class that registers without implementing `self.archival_csv_config` raises `NotImplementedError` at class-load time

### Type of Change

Refactor

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

