### PR TITLE
fix: crash on the CE Performance report details page

### DIFF
--- a/drivers/ce_performance/app/models/ce_performance/client.rb
+++ b/drivers/ce_performance/app/models/ce_performance/client.rb
@@ -69,8 +69,10 @@ module CePerformance
     end
 
     scope :youth_only_households, -> do
-      # Unclear why, but active record extended isn't working here
-      where(household_type: :adults_only).where('household_ages <@ json_build_array(?)::jsonb', (18..24).to_a).hoh
+      where(household_type: :adults_only).
+        where('jsonb_array_length(household_ages) > 0').
+        where('household_ages <@ ?::jsonb', (18..24).to_a.to_json).
+        hoh
     end
 
     scope :unknown_households, -> do

--- a/drivers/ce_performance/spec/models/ce_performance/client_spec.rb
+++ b/drivers/ce_performance/spec/models/ce_performance/client_spec.rb
@@ -1,0 +1,49 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CePerformance::Client, type: :model do
+  let!(:report) { create(:simple_reports_report_instance, type: 'CePerformance::Report') }
+  let!(:hud_client) { create(:grda_warehouse_hud_client) }
+
+  def create_client(household_ages:)
+    CePerformance::Client.create!(
+      report_id: report.id,
+      destination_client_id: hud_client.id,
+      period: 'reporting',
+      household_type: 'adults_only',
+      household_ages: household_ages,
+      head_of_household: true,
+      q5a_b1: true,
+    )
+  end
+
+  describe '.youth_only_households' do
+    let!(:youth_client) { create_client(household_ages: [20]) }
+    let!(:multi_age_youth_client) { create_client(household_ages: [18, 24]) }
+    let!(:mixed_age_client) { create_client(household_ages: [17, 20]) }
+    let!(:non_youth_client) { create_client(household_ages: [40]) }
+    let!(:empty_ages_client) { create_client(household_ages: []) }
+
+    it 'returns clients whose household ages are all within 18-24' do
+      results = CePerformance::Client.served_in_period('reporting').youth_only_households
+      expect(results.pluck(:id)).to contain_exactly(youth_client.id, multi_age_youth_client.id)
+    end
+
+    it 'excludes households with any member outside 18-24' do
+      results = CePerformance::Client.served_in_period('reporting').youth_only_households
+      expect(results.pluck(:id)).not_to include(mixed_age_client.id, non_youth_client.id)
+    end
+
+    it 'excludes households with empty ages' do
+      results = CePerformance::Client.served_in_period('reporting').youth_only_households
+      expect(results.pluck(:id)).not_to include(empty_ages_client.id)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Fixes a `PG::IndeterminateDatatype` crash on the CE Performance report details page.

- **Youth Only Households Scope**: Replace `json_build_array(?)` with a `.to_json` string cast (`?::jsonb`) so PostgreSQL can resolve the parameter type when executing `COUNT` queries — the previous form left the array type ambiguous at the query planning stage. Also add a `jsonb_array_length > 0` guard to prevent records with empty `household_ages` from vacuously matching the containment check.
- **CE Performance Client specs**: Add first spec coverage for `CePerformance::Client` scopes, including edge cases for multi-age youth households, mixed-age households, and empty arrays.

### Type of Change

Bug fix
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

