### PR TITLE
9209-rds-disk-space-checks

### DIFF
--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'aws-sdk-rds'
+
+module GrdaWarehouse
+  module DbMonitor
+    class Error < StandardError; end
+
+    def self.assert_healthy!
+      config = FreeStorageSpaceConfiguration.new
+      return unless config.enabled?
+
+      instance_id = resolve_instance_id
+      raise Error, 'DbMonitor: could not resolve warehouse RDS instance' unless instance_id
+
+      free_gb = GrdaWarehouse::DbMonitor::FreeStorageSpace.call(instance_id)&.round(2)
+      return unless free_gb
+
+      if free_gb < config.block_threshold_gb
+        raise Error, "DbMonitor: block threshold reached for #{instance_id} (#{free_gb} GB free)"
+      elsif free_gb < config.alert_threshold_gb
+        Sentry.capture_message('DbMonitor: warehouse RDS instance is low on storage', level: :warning, extra: { free_storage_gb: free_gb })
+      end
+    rescue Aws::Errors::ServiceError => e
+      Sentry.capture_exception(e)
+      Rails.logger.warn("DbMonitor: AWS error during health check: #{e.message}")
+    end
+
+    # Iterates all RDS instances to find one whose endpoint address matches
+    # WAREHOUSE_DATABASE_HOST. RDS hostnames are of the form
+    # <identifier>.xxxxxxxx.<region>.rds.amazonaws.com, so we match on the
+    # leading segment rather than an exact hostname comparison in case the env
+    # var is set to a CNAME or partial hostname.
+    def self.resolve_instance_id
+      warehouse_host = ENV.fetch('WAREHOUSE_DATABASE_HOST', nil)
+      return nil unless warehouse_host.present?
+
+      rds = Aws::RDS::Client.new
+      rds.describe_db_instances.each do |page|
+        page.db_instances.each do |instance|
+          endpoint = instance.endpoint&.address&.to_s
+          return instance.db_instance_identifier if endpoint == warehouse_host || endpoint.start_with?("#{warehouse_host}.")
+        end
+      end
+
+      nil
+    end
+  end
+end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -28,8 +28,11 @@ module GrdaWarehouse
       allocated_gb = instance.allocated_storage_gb
 
       if config.block_threshold_pct
-        block_gb = (allocated_gb * config.block_threshold_pct / 100.0).round(2)
-        block_gb = block_gb.clamp(config.min_block_threshold_gb, config.max_block_threshold_gb)
+        block_gb = threshold_gb(
+          allocated_gb, config.block_threshold_pct,
+          min_gb: config.min_block_threshold_gb,
+          max_gb: config.max_block_threshold_gb
+        )
         if free_gb < block_gb
           raise Error, "DbMonitor: block threshold reached for #{instance.id} " \
                        "(#{free_gb} GB free, threshold #{block_gb} GB = #{config.block_threshold_pct}% of #{allocated_gb} GB allocated)"
@@ -38,7 +41,7 @@ module GrdaWarehouse
 
       return unless config.alert_threshold_pct
 
-      alert_gb = (allocated_gb * config.alert_threshold_pct / 100.0).round(2)
+      alert_gb = threshold_gb(allocated_gb, config.alert_threshold_pct)
       return unless free_gb < alert_gb
 
       capture_warning(
@@ -47,6 +50,12 @@ module GrdaWarehouse
       )
     rescue Aws::Errors::ServiceError => e
       capture_warning("AWS error during health check: #{e.message}")
+    end
+
+    # Converts a percentage of allocated storage to an absolute GB threshold,
+    # clamped to keep it sensible on very small or very large instances.
+    def self.threshold_gb(allocated_gb, pct, min_gb: 0, max_gb: Float::INFINITY)
+      (allocated_gb * pct / 100.0).round(2).clamp(min_gb, max_gb)
     end
 
     def self.capture_warning(message, extra: nil)

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -63,11 +63,8 @@ module GrdaWarehouse
       nil
     end
 
-    # Iterates all RDS instances to find one whose endpoint address matches
-    # WAREHOUSE_DATABASE_HOST. RDS hostnames are of the form
-    # <identifier>.xxxxxxxx.<region>.rds.amazonaws.com, so we match on the
-    # leading segment rather than an exact hostname comparison in case the env
-    # var is set to a CNAME or partial hostname.
+    # Finds the RDS instance whose endpoint address exactly matches
+    # WAREHOUSE_DATABASE_HOST, then fetches its CloudWatch free-storage metric.
     def self.resolve_instance
       warehouse_host = ENV.fetch('WAREHOUSE_DATABASE_HOST', nil)
       return nil unless warehouse_host.present?
@@ -76,7 +73,7 @@ module GrdaWarehouse
       rds.describe_db_instances.each do |page|
         page.db_instances.each do |instance|
           endpoint = instance.endpoint&.address.to_s
-          next unless endpoint == warehouse_host || endpoint.start_with?("#{warehouse_host}.")
+          next unless endpoint == warehouse_host
 
           free_gb = FreeStorageSpace.call(instance.db_instance_identifier)&.round(2)
           return RdsInstance.new(

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -9,39 +9,41 @@
 require 'aws-sdk-rds'
 
 module GrdaWarehouse
+  # Pre-flight health check for the warehouse RDS instance. Called before
+  # db-intensive operations (imports, bulk deletes) to avoid exhausting disk
+  # space. Fail-open: AWS errors degrade to Sentry warnings, never block work.
   module DbMonitor
     class Error < StandardError; end
+    RdsInstance = Data.define(:id, :allocated_storage_gb, :free_storage_gb)
 
     def self.assert_healthy!
       config = FreeStorageSpaceConfiguration.new
       return unless config.enabled?
 
-      instance_id = resolve_instance_id
-      return capture_warning('could not resolve warehouse RDS instance') if instance_id.nil?
+      instance = resolve_instance
+      return capture_warning('could not resolve warehouse RDS instance') if instance.nil?
+      return capture_warning("unable to retrieve free storage space for #{instance.id}") if instance.free_storage_gb.nil?
 
-      free_gb = GrdaWarehouse::DbMonitor::FreeStorageSpace.call(instance_id)&.round(2)
-      return capture_warning("unable to retrieve free storage space for #{instance_id}") if free_gb.nil?
-
-      db_size_gb = database_size_gb
-      return capture_warning("unable to determine warehouse database size") if db_size_gb.nil?
+      free_gb = instance.free_storage_gb
+      allocated_gb = instance.allocated_storage_gb
 
       if config.block_threshold_pct
-        block_gb = (db_size_gb * config.block_threshold_pct / 100.0).round(2)
+        block_gb = (allocated_gb * config.block_threshold_pct / 100.0).round(2)
         block_gb = block_gb.clamp(config.min_block_threshold_gb, config.max_block_threshold_gb)
         if free_gb < block_gb
-          raise Error, "DbMonitor: block threshold reached for #{instance_id} " \
-                       "(#{free_gb} GB free, threshold #{block_gb} GB = #{config.block_threshold_pct}% of #{db_size_gb.round(2)} GB)"
+          raise Error, "DbMonitor: block threshold reached for #{instance.id} " \
+                       "(#{free_gb} GB free, threshold #{block_gb} GB = #{config.block_threshold_pct}% of #{allocated_gb} GB allocated)"
         end
       end
 
       return unless config.alert_threshold_pct
 
-      alert_gb = (db_size_gb * config.alert_threshold_pct / 100.0).round(2)
+      alert_gb = (allocated_gb * config.alert_threshold_pct / 100.0).round(2)
       return unless free_gb < alert_gb
 
       capture_warning(
         'warehouse RDS instance is low on storage',
-        extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
+        extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, allocated_storage_gb: allocated_gb },
       )
     rescue Aws::Errors::ServiceError => e
       capture_warning("AWS error during health check: #{e.message}")
@@ -57,7 +59,7 @@ module GrdaWarehouse
     # <identifier>.xxxxxxxx.<region>.rds.amazonaws.com, so we match on the
     # leading segment rather than an exact hostname comparison in case the env
     # var is set to a CNAME or partial hostname.
-    def self.resolve_instance_id
+    def self.resolve_instance
       warehouse_host = ENV.fetch('WAREHOUSE_DATABASE_HOST', nil)
       return nil unless warehouse_host.present?
 
@@ -65,21 +67,18 @@ module GrdaWarehouse
       rds.describe_db_instances.each do |page|
         page.db_instances.each do |instance|
           endpoint = instance.endpoint&.address.to_s
-          return instance.db_instance_identifier if endpoint == warehouse_host || endpoint.start_with?("#{warehouse_host}.")
+          next unless endpoint == warehouse_host || endpoint.start_with?("#{warehouse_host}.")
+
+          free_gb = FreeStorageSpace.call(instance.db_instance_identifier)&.round(2)
+          return RdsInstance.new(
+            id: instance.db_instance_identifier,
+            allocated_storage_gb: instance.allocated_storage,
+            free_storage_gb: free_gb,
+          )
         end
       end
 
       nil
-    end
-
-    # Returns the warehouse database size in GB via pg_database_size().
-    # Used as a scaling factor so thresholds grow with the database,
-    # staying safely below the RDS autoscaling trigger.
-    def self.database_size_gb
-      bytes = GrdaWarehouseBase.connection.select_value('SELECT pg_database_size(current_database())')
-      return nil unless bytes
-
-      bytes / FreeStorageSpace::BYTES_PER_GB
     end
   end
 end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -43,6 +43,8 @@ module GrdaWarehouse
         'warehouse RDS instance is low on storage',
         extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
       )
+    rescue Aws::Errors::ServiceError => e
+      capture_warning("AWS error during health check: #{e.message}")
     end
 
     def self.capture_warning(message, extra: nil)
@@ -75,6 +77,8 @@ module GrdaWarehouse
     # staying safely below the RDS autoscaling trigger.
     def self.database_size_gb
       bytes = GrdaWarehouseBase.connection.select_value('SELECT pg_database_size(current_database())')
+      return nil unless bytes
+
       bytes / FreeStorageSpace::BYTES_PER_GB
     end
   end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -41,6 +41,7 @@ module GrdaWarehouse
 
       return unless config.alert_threshold_pct
 
+      # Alert threshold is intentionally unclamped as it's advisory-only
       alert_gb = threshold_gb(allocated_gb, config.alert_threshold_pct)
       return unless free_gb < alert_gb
 
@@ -48,8 +49,6 @@ module GrdaWarehouse
         'warehouse RDS instance is low on storage',
         extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, allocated_storage_gb: allocated_gb },
       )
-    rescue Aws::Errors::ServiceError => e
-      capture_warning("AWS error during health check: #{e.message}")
     end
 
     # Converts a percentage of allocated storage to an absolute GB threshold,
@@ -65,6 +64,8 @@ module GrdaWarehouse
 
     # Finds the RDS instance whose endpoint address exactly matches
     # WAREHOUSE_DATABASE_HOST, then fetches its CloudWatch free-storage metric.
+    # AWS ServiceErrors are caught here so they never propagate into assert_healthy!,
+    # keeping the block-threshold raise Error on a clean path.
     def self.resolve_instance
       warehouse_host = ENV.fetch('WAREHOUSE_DATABASE_HOST', nil)
       return nil unless warehouse_host.present?
@@ -72,7 +73,7 @@ module GrdaWarehouse
       rds = Aws::RDS::Client.new
       rds.describe_db_instances.each do |page|
         page.db_instances.each do |instance|
-          endpoint = instance.endpoint&.address.to_s
+          endpoint = instance.endpoint&.address&.to_s
           next unless endpoint == warehouse_host
 
           free_gb = FreeStorageSpace.call(instance.db_instance_identifier)&.round(2)
@@ -85,6 +86,8 @@ module GrdaWarehouse
       end
 
       nil
+    rescue Aws::Errors::ServiceError => e
+      capture_warning("AWS error during health check: #{e.message}")
     end
   end
 end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -64,8 +64,6 @@ module GrdaWarehouse
 
     # Finds the RDS instance whose endpoint address exactly matches
     # WAREHOUSE_DATABASE_HOST, then fetches its CloudWatch free-storage metric.
-    # AWS ServiceErrors are caught here so they never propagate into assert_healthy!,
-    # keeping the block-threshold raise Error on a clean path.
     def self.resolve_instance
       warehouse_host = ENV.fetch('WAREHOUSE_DATABASE_HOST', nil)
       return nil unless warehouse_host.present?

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -14,19 +14,20 @@ module GrdaWarehouse
 
     def self.assert_healthy!
       config = FreeStorageSpaceConfiguration.new
-      return unless config.block_threshold_pct || config.alert_threshold_pct
+      return unless config.enabled?
 
       instance_id = resolve_instance_id
-      raise Error, 'DbMonitor: could not resolve warehouse RDS instance' unless instance_id
+      return capture_warning('could not resolve warehouse RDS instance') if instance_id.nil?
 
       free_gb = GrdaWarehouse::DbMonitor::FreeStorageSpace.call(instance_id)&.round(2)
-      raise Error, "DbMonitor: unable to retrieve free storage space for #{instance_id}" unless free_gb
+      return capture_warning("unable to retrieve free storage space for #{instance_id}") if free_gb.nil?
 
       db_size_gb = database_size_gb
-      raise Error, 'DbMonitor: unable to determine warehouse database size' unless db_size_gb
+      return capture_warning("unable to determine warehouse database size") if db_size_gb.nil?
 
       if config.block_threshold_pct
         block_gb = (db_size_gb * config.block_threshold_pct / 100.0).round(2)
+        block_gb = block_gb.clamp(config.min_block_threshold_gb, config.max_block_threshold_gb)
         if free_gb < block_gb
           raise Error, "DbMonitor: block threshold reached for #{instance_id} " \
                        "(#{free_gb} GB free, threshold #{block_gb} GB = #{config.block_threshold_pct}% of #{db_size_gb.round(2)} GB)"
@@ -38,11 +39,15 @@ module GrdaWarehouse
       alert_gb = (db_size_gb * config.alert_threshold_pct / 100.0).round(2)
       return unless free_gb < alert_gb
 
-      Sentry.capture_message(
-        'DbMonitor: warehouse RDS instance is low on storage',
-        level: :warning,
+      capture_warning(
+        'warehouse RDS instance is low on storage',
         extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
       )
+    end
+
+    def self.capture_warning(message, extra: nil)
+      Sentry.capture_message("DbMonitor: #{message}", level: :warning, extra: extra)
+      nil
     end
 
     # Iterates all RDS instances to find one whose endpoint address matches
@@ -57,7 +62,7 @@ module GrdaWarehouse
       rds = Aws::RDS::Client.new
       rds.describe_db_instances.each do |page|
         page.db_instances.each do |instance|
-          endpoint = instance.endpoint&.address&.to_s
+          endpoint = instance.endpoint&.address.to_s
           return instance.db_instance_identifier if endpoint == warehouse_host || endpoint.start_with?("#{warehouse_host}.")
         end
       end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -14,7 +14,7 @@ module GrdaWarehouse
 
     def self.assert_healthy!
       config = FreeStorageSpaceConfiguration.new
-      return unless config.enabled?
+      return unless config.block_threshold_pct || config.alert_threshold_pct
 
       instance_id = resolve_instance_id
       raise Error, 'DbMonitor: could not resolve warehouse RDS instance' unless instance_id
@@ -22,10 +22,26 @@ module GrdaWarehouse
       free_gb = GrdaWarehouse::DbMonitor::FreeStorageSpace.call(instance_id)&.round(2)
       return unless free_gb
 
-      if free_gb < config.block_threshold_gb
-        raise Error, "DbMonitor: block threshold reached for #{instance_id} (#{free_gb} GB free)"
-      elsif free_gb < config.alert_threshold_gb
-        Sentry.capture_message('DbMonitor: warehouse RDS instance is low on storage', level: :warning, extra: { free_storage_gb: free_gb })
+      db_size_gb = database_size_gb
+      return unless db_size_gb
+
+      if config.block_threshold_pct
+        block_gb = (db_size_gb * config.block_threshold_pct / 100.0).round(2)
+        if free_gb < block_gb
+          raise Error, "DbMonitor: block threshold reached for #{instance_id} " \
+                       "(#{free_gb} GB free, threshold #{block_gb} GB = #{config.block_threshold_pct}% of #{db_size_gb.round(2)} GB)"
+        end
+      end
+
+      if config.alert_threshold_pct
+        alert_gb = (db_size_gb * config.alert_threshold_pct / 100.0).round(2)
+        if free_gb < alert_gb
+          Sentry.capture_message(
+            'DbMonitor: warehouse RDS instance is low on storage',
+            level: :warning,
+            extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
+          )
+        end
       end
     rescue Aws::Errors::ServiceError => e
       Sentry.capture_exception(e)
@@ -49,6 +65,18 @@ module GrdaWarehouse
         end
       end
 
+      nil
+    end
+
+    # Returns the warehouse database size in GB via pg_database_size().
+    # Used as a scaling factor so thresholds grow with the database,
+    # staying safely below the RDS autoscaling trigger.
+    def self.database_size_gb
+      bytes = GrdaWarehouseBase.connection.select_value('SELECT pg_database_size(current_database())')
+      bytes / FreeStorageSpace::BYTES_PER_GB
+    rescue ActiveRecord::ActiveRecordError => e
+      Sentry.capture_exception(e)
+      Rails.logger.warn("DbMonitor: failed to query database size: #{e.message}")
       nil
     end
   end

--- a/app/models/grda_warehouse/db_monitor.rb
+++ b/app/models/grda_warehouse/db_monitor.rb
@@ -20,10 +20,10 @@ module GrdaWarehouse
       raise Error, 'DbMonitor: could not resolve warehouse RDS instance' unless instance_id
 
       free_gb = GrdaWarehouse::DbMonitor::FreeStorageSpace.call(instance_id)&.round(2)
-      return unless free_gb
+      raise Error, "DbMonitor: unable to retrieve free storage space for #{instance_id}" unless free_gb
 
       db_size_gb = database_size_gb
-      return unless db_size_gb
+      raise Error, 'DbMonitor: unable to determine warehouse database size' unless db_size_gb
 
       if config.block_threshold_pct
         block_gb = (db_size_gb * config.block_threshold_pct / 100.0).round(2)
@@ -33,19 +33,16 @@ module GrdaWarehouse
         end
       end
 
-      if config.alert_threshold_pct
-        alert_gb = (db_size_gb * config.alert_threshold_pct / 100.0).round(2)
-        if free_gb < alert_gb
-          Sentry.capture_message(
-            'DbMonitor: warehouse RDS instance is low on storage',
-            level: :warning,
-            extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
-          )
-        end
-      end
-    rescue Aws::Errors::ServiceError => e
-      Sentry.capture_exception(e)
-      Rails.logger.warn("DbMonitor: AWS error during health check: #{e.message}")
+      return unless config.alert_threshold_pct
+
+      alert_gb = (db_size_gb * config.alert_threshold_pct / 100.0).round(2)
+      return unless free_gb < alert_gb
+
+      Sentry.capture_message(
+        'DbMonitor: warehouse RDS instance is low on storage',
+        level: :warning,
+        extra: { free_storage_gb: free_gb, alert_threshold_gb: alert_gb, database_size_gb: db_size_gb.round(2) },
+      )
     end
 
     # Iterates all RDS instances to find one whose endpoint address matches
@@ -74,10 +71,6 @@ module GrdaWarehouse
     def self.database_size_gb
       bytes = GrdaWarehouseBase.connection.select_value('SELECT pg_database_size(current_database())')
       bytes / FreeStorageSpace::BYTES_PER_GB
-    rescue ActiveRecord::ActiveRecordError => e
-      Sentry.capture_exception(e)
-      Rails.logger.warn("DbMonitor: failed to query database size: #{e.message}")
-      nil
     end
   end
 end

--- a/app/models/grda_warehouse/db_monitor/free_storage_space.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space.rb
@@ -23,7 +23,7 @@ module GrdaWarehouse
           namespace: 'AWS/RDS',
           metric_name: 'FreeStorageSpace',
           dimensions: [{ name: 'DBInstanceIdentifier', value: instance_id }],
-          start_time: now - 10.minutes.ago,
+          start_time: now - 10.minutes,
           end_time: now,
           period: 60,
           statistics: ['Minimum'],

--- a/app/models/grda_warehouse/db_monitor/free_storage_space.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space.rb
@@ -10,8 +10,8 @@ require 'aws-sdk-cloudwatch'
 
 module GrdaWarehouse
   module DbMonitor
-    # Returns the minimum free storage (GB) observed over the last 10 minutes
-    # as a conservative estimate — short spikes won't mask a real shortage.
+    # Returns the median free storage (GB) over the last 10 minutes. Using the
+    # median filters out transient spikes without masking a genuine shortage.
     class FreeStorageSpace
       BYTES_PER_GB = 1_073_741_824.0
 
@@ -27,23 +27,17 @@ module GrdaWarehouse
           start_time: now - 10.minutes,
           end_time: now,
           period: 60,
-          statistics: ['Minimum'],
+          statistics: ['Average'],
           unit: 'Bytes',
         )
 
-        if resp.datapoints.empty?
-          Sentry.capture_message(
-            'DbMonitor: no CloudWatch FreeStorageSpace datapoints returned -- monitor may be misconfigured',
-            level: :warning,
-            extra: { db_instance_identifier: instance_id },
-          )
-          return nil
-        end
+        return nil if resp.datapoints.empty?
 
-        minimum_bytes = resp.datapoints.max_by(&:timestamp).minimum
-        return nil if minimum_bytes.nil?
+        values = resp.datapoints.filter_map(&:average).sort
+        return nil if values.empty?
 
-        minimum_bytes / BYTES_PER_GB
+        median_bytes = values[(values.size - 1) / 2]
+        median_bytes / BYTES_PER_GB
       end
     end
   end

--- a/app/models/grda_warehouse/db_monitor/free_storage_space.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'aws-sdk-cloudwatch'
+
+module GrdaWarehouse
+  module DbMonitor
+    # Checks the warehouse RDS instance's FreeStorageSpace via CloudWatch
+    class FreeStorageSpace
+      BYTES_PER_GB = 1_073_741_824.0
+
+      def self.call(...) = new.call(...)
+
+      def call(instance_id)
+        cw = Aws::CloudWatch::Client.new
+        now = Time.current
+        resp = cw.get_metric_statistics(
+          namespace: 'AWS/RDS',
+          metric_name: 'FreeStorageSpace',
+          dimensions: [{ name: 'DBInstanceIdentifier', value: instance_id }],
+          start_time: now - 10.minutes.ago,
+          end_time: now,
+          period: 60,
+          statistics: ['Minimum'],
+          unit: 'Bytes',
+        )
+
+        if resp.datapoints.empty?
+          Sentry.capture_message(
+            'DbMonitor: no CloudWatch FreeStorageSpace datapoints returned -- monitor may be misconfigured',
+            level: :warning,
+            extra: { db_instance_identifier: instance_id },
+          )
+          return nil
+        end
+
+        # use the most recent reading
+        minimum_bytes = resp.datapoints.max_by(&:timestamp).minimum
+        minimum_bytes / BYTES_PER_GB
+      end
+    end
+  end
+end

--- a/app/models/grda_warehouse/db_monitor/free_storage_space.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space.rb
@@ -10,7 +10,8 @@ require 'aws-sdk-cloudwatch'
 
 module GrdaWarehouse
   module DbMonitor
-    # Checks the warehouse RDS instance's FreeStorageSpace via CloudWatch
+    # Returns the minimum free storage (GB) observed over the last 10 minutes
+    # as a conservative estimate — short spikes won't mask a real shortage.
     class FreeStorageSpace
       BYTES_PER_GB = 1_073_741_824.0
 
@@ -39,8 +40,9 @@ module GrdaWarehouse
           return nil
         end
 
-        # use the most recent reading
         minimum_bytes = resp.datapoints.max_by(&:timestamp).minimum
+        return nil if minimum_bytes.nil?
+
         minimum_bytes / BYTES_PER_GB
       end
     end

--- a/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
@@ -9,7 +9,6 @@
 module GrdaWarehouse
   module DbMonitor
     class FreeStorageSpaceConfiguration
-
       def enabled? = alert_threshold_pct.present? || block_threshold_pct.present?
 
       # Alert (Sentry warning) when free space drops below this percentage of database size.

--- a/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
@@ -9,23 +9,19 @@
 module GrdaWarehouse
   module DbMonitor
     class FreeStorageSpaceConfiguration
-      def enabled?
-        !!ActiveModel::Type::Boolean.new.cast(value_for(:enabled))
-      end
+      # Alert (Sentry warning) when free space drops below this percentage of database size.
+      # Returns nil when unconfigured.
+      def alert_threshold_pct = value_for(:alert_threshold_pct)&.to_i
 
-      # Alert (Sentry warning) when free space drops below this threshold
-      def alert_threshold_gb = value_for(:alert_threshold_gb)&.to_i || 20
-
-      # Block imports when free space drops below this threshold
-      def block_threshold_gb = value_for(:block_threshold_gb)&.to_i || 10
+      # Block imports when free space drops below this percentage of database size.
+      # Returns nil when unconfigured.
+      def block_threshold_pct = value_for(:block_threshold_pct)&.to_i
 
       protected
 
-      # read all configuration values from the db
       PROPERTIES = [
-        :enabled,
-        :block_threshold_gb,
-        :alert_threshold_gb,
+        :block_threshold_pct,
+        :alert_threshold_pct,
       ].freeze
       def values
         @values ||= AppConfigProperty.

--- a/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module GrdaWarehouse
+  module DbMonitor
+    class FreeStorageSpaceConfiguration
+      def enabled?
+        !!ActiveModel::Type::Boolean.new.cast(value_for(:enabled))
+      end
+
+      # Alert (Sentry warning) when free space drops below this threshold
+      def alert_threshold_gb = value_for(:alert_threshold_gb)&.to_i || 20
+
+      # Block imports when free space drops below this threshold
+      def block_threshold_gb = value_for(:block_threshold_gb)&.to_i || 10
+
+      protected
+
+      # read all configuration values from the db
+      PROPERTIES = [
+        :enabled,
+        :block_threshold_gb,
+        :alert_threshold_gb,
+      ].freeze
+      def values
+        @values ||= AppConfigProperty.
+          where(key: PROPERTIES.map { |attr| key_for(attr) }).
+          pluck(:key, :value).
+          to_h
+      end
+
+      def value_for(attr)
+        values[key_for(attr)]
+      end
+
+      def key_for(attr)
+        "wh_db_space_monitor/#{attr}"
+      end
+    end
+  end
+end

--- a/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
@@ -39,7 +39,7 @@ module GrdaWarehouse
       end
 
       def value_for(attr)
-        values[key_for(attr)]
+        values[key_for(attr)].presence
       end
 
       def key_for(attr)

--- a/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
+++ b/app/models/grda_warehouse/db_monitor/free_storage_space_configuration.rb
@@ -9,6 +9,9 @@
 module GrdaWarehouse
   module DbMonitor
     class FreeStorageSpaceConfiguration
+
+      def enabled? = alert_threshold_pct.present? || block_threshold_pct.present?
+
       # Alert (Sentry warning) when free space drops below this percentage of database size.
       # Returns nil when unconfigured.
       def alert_threshold_pct = value_for(:alert_threshold_pct)&.to_i
@@ -17,10 +20,16 @@ module GrdaWarehouse
       # Returns nil when unconfigured.
       def block_threshold_pct = value_for(:block_threshold_pct)&.to_i
 
+      # Regardless of database size, constrain the block threshold to absolute GB
+      def min_block_threshold_gb = value_for(:min_block_threshold_gb)&.to_i || 1
+      def max_block_threshold_gb = value_for(:max_block_threshold_gb)&.to_i || 100
+
       protected
 
       PROPERTIES = [
         :block_threshold_pct,
+        :min_block_threshold_gb,
+        :max_block_threshold_gb,
         :alert_threshold_pct,
       ].freeze
       def values

--- a/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_base_job.rb
+++ b/drivers/hmis_csv_importer/app/jobs/hmis_csv_importer/cleanup/expire_base_job.rb
@@ -53,6 +53,9 @@ module HmisCsvImporter::Cleanup
     # @param max_per_run [Integer] stop processing if we delete more records than this
     # @param dry_run [Boolean] do not run delete statements
     def _perform(model_name: nil, retain_item_count: 5, retain_after_date: DateTime.current - 2.weeks, max_per_run: 30_000_000, batch_size: 500_000, dry_run: true)
+      # deleting rows may require additional space
+      GrdaWarehouse::DbMonitor.assert_healthy!
+
       did_run = false
       @retain_item_count = retain_item_count
       @retain_after_date = retain_after_date

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer.rb
@@ -9,6 +9,8 @@
 # @see docs/features/hmis-csv-importer.md
 module HmisCsvImporter
   def self.import!(file_path, data_source_id, upload, deidentified:)
+    GrdaWarehouse::DbMonitor.assert_healthy!
+
     log = ::HmisCsvImporter::ImportLog.create(
       created_at: Time.current,
       upload_id: upload.id,

--- a/spec/models/grda_warehouse/db_monitor_spec.rb
+++ b/spec/models/grda_warehouse/db_monitor_spec.rb
@@ -184,14 +184,6 @@ RSpec.describe GrdaWarehouse::DbMonitor do
       end
     end
 
-    context 'when WAREHOUSE_DATABASE_HOST is a leading segment of the endpoint' do
-      before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host')) }
-
-      it 'returns the matching RdsInstance' do
-        expect(described_class.resolve_instance.id).to eq('my-instance')
-      end
-    end
-
     context 'when no RDS instance matches the host' do
       before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'other-host')) }
 
@@ -212,7 +204,7 @@ RSpec.describe GrdaWarehouse::DbMonitor do
 
     context 'when CloudWatch returns no datapoints' do
       before do
-        stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host'))
+        stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host.abc123.us-east-1.rds.amazonaws.com'))
         allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(nil)
       end
 

--- a/spec/models/grda_warehouse/db_monitor_spec.rb
+++ b/spec/models/grda_warehouse/db_monitor_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe GrdaWarehouse::DbMonitor do
     end
 
     context 'when thresholds are configured' do
+      let(:rds_instance) { GrdaWarehouse::DbMonitor::RdsInstance.new(id: 'my-instance', allocated_storage_gb: 100, free_storage_gb: 15.0) }
+
       before do
         allow(config).to receive(:enabled?).and_return(true)
         allow(config).to receive(:block_threshold_pct).and_return(10)
-        allow(described_class).to receive(:resolve_instance_id).and_return('my-instance')
-        allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
-        allow(described_class).to receive(:database_size_gb).and_return(100.0)
+        allow(described_class).to receive(:resolve_instance).and_return(rds_instance)
       end
 
       context 'when the RDS instance cannot be resolved' do
-        before { allow(described_class).to receive(:resolve_instance_id).and_return(nil) }
+        before { allow(described_class).to receive(:resolve_instance).and_return(nil) }
 
         it 'sends a Sentry warning and does not raise' do
           expect(Sentry).to receive(:capture_message).with(/could not resolve/, hash_including(level: :warning))
@@ -48,7 +48,7 @@ RSpec.describe GrdaWarehouse::DbMonitor do
       end
 
       context 'when free storage space cannot be retrieved' do
-        before { allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(nil) }
+        let(:rds_instance) { GrdaWarehouse::DbMonitor::RdsInstance.new(id: 'my-instance', allocated_storage_gb: 100, free_storage_gb: nil) }
 
         it 'sends a Sentry warning and does not raise' do
           expect(Sentry).to receive(:capture_message).with(/unable to retrieve/, hash_including(level: :warning))
@@ -56,60 +56,52 @@ RSpec.describe GrdaWarehouse::DbMonitor do
         end
       end
 
-      context 'when the database size cannot be determined' do
-        before { allow(described_class).to receive(:database_size_gb).and_return(nil) }
-
-        it 'sends a Sentry warning and does not raise' do
-          expect(Sentry).to receive(:capture_message).with(/unable to determine/, hash_including(level: :warning))
-          expect { described_class.assert_healthy! }.not_to raise_error
-        end
-      end
-
       context 'block threshold' do
-        # 100 GB DB * 10% = 10 GB computed threshold
+        # 100 GB allocated * 10% = 10 GB computed threshold
 
         it 'raises Error when free space is below the threshold' do
-          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(8.0)
+          allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 8.0))
           expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error, /block threshold reached/)
         end
 
         it 'does not raise when free space is above the threshold' do
-          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
           expect { described_class.assert_healthy! }.not_to raise_error
         end
 
         context 'when the computed threshold exceeds max_block_threshold_gb' do
-          # 1000 GB DB * 10% = 100 GB, but max is 50 GB -> clamped to 50 GB
+          # 1000 GB allocated * 10% = 100 GB, but max is 50 GB -> clamped to 50 GB
+          let(:rds_instance) { GrdaWarehouse::DbMonitor::RdsInstance.new(id: 'my-instance', allocated_storage_gb: 1000, free_storage_gb: 15.0) }
+
           before do
-            allow(described_class).to receive(:database_size_gb).and_return(1000.0)
             allow(config).to receive(:max_block_threshold_gb).and_return(50)
           end
 
           it 'does not raise when free space is above the clamped ceiling' do
-            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(60.0)
+            allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 60.0))
             expect { described_class.assert_healthy! }.not_to raise_error
           end
 
           it 'raises when free space is below the clamped ceiling' do
-            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(40.0)
+            allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 40.0))
             expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error)
           end
         end
 
         context 'when the computed threshold is below min_block_threshold_gb' do
-          # 5 GB DB * 10% = 0.5 GB, but min is 2 GB -> clamped to 2 GB
+          # 5 GB allocated * 10% = 0.5 GB, but min is 2 GB -> clamped to 2 GB
+          let(:rds_instance) { GrdaWarehouse::DbMonitor::RdsInstance.new(id: 'my-instance', allocated_storage_gb: 5, free_storage_gb: 15.0) }
+
           before do
-            allow(described_class).to receive(:database_size_gb).and_return(5.0)
             allow(config).to receive(:min_block_threshold_gb).and_return(2)
           end
 
           it 'raises when free space is below the clamped floor' do
-            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(1.0)
+            allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 1.0))
             expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error)
           end
 
           it 'does not raise when free space is above the clamped floor' do
-            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(3.0)
+            allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 3.0))
             expect { described_class.assert_healthy! }.not_to raise_error
           end
         end
@@ -117,7 +109,7 @@ RSpec.describe GrdaWarehouse::DbMonitor do
 
       context 'when an AWS error occurs' do
         before do
-          allow(described_class).to receive(:resolve_instance_id).and_raise(
+          allow(described_class).to receive(:resolve_instance).and_raise(
             Aws::RDS::Errors::ServiceError.new(nil, 'access denied'),
           )
         end
@@ -129,15 +121,15 @@ RSpec.describe GrdaWarehouse::DbMonitor do
       end
 
       context 'alert threshold' do
+        let(:rds_instance) { GrdaWarehouse::DbMonitor::RdsInstance.new(id: 'my-instance', allocated_storage_gb: 100, free_storage_gb: 15.0) }
+
         before do
           allow(config).to receive(:block_threshold_pct).and_return(nil)
           allow(config).to receive(:alert_threshold_pct).and_return(20)
-          allow(described_class).to receive(:database_size_gb).and_return(100.0)
         end
 
         it 'sends a Sentry warning when free space is below the alert threshold' do
-          # 100 GB * 20% = 20 GB alert threshold; 15 GB free -> alert
-          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
+          # 100 GB allocated * 20% = 20 GB alert threshold; 15 GB free -> alert
           expect(Sentry).to receive(:capture_message).with(
             /low on storage/,
             hash_including(level: :warning, extra: hash_including(:free_storage_gb, :alert_threshold_gb)),
@@ -146,7 +138,7 @@ RSpec.describe GrdaWarehouse::DbMonitor do
         end
 
         it 'does not send a warning when free space is above the alert threshold' do
-          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(25.0)
+          allow(described_class).to receive(:resolve_instance).and_return(rds_instance.with(free_storage_gb: 25.0))
           expect(Sentry).not_to receive(:capture_message)
           described_class.assert_healthy!
         end
@@ -154,20 +146,22 @@ RSpec.describe GrdaWarehouse::DbMonitor do
     end
   end
 
-  describe '.resolve_instance_id' do
+  describe '.resolve_instance' do
     let(:rds_client) { instance_double(Aws::RDS::Client) }
     let(:db_instance) do
-      double(
-        'db_instance',
-        endpoint: double('endpoint', address: 'my-host.abc123.us-east-1.rds.amazonaws.com'),
+      instance_double(
+        Aws::RDS::Types::DBInstance,
+        endpoint: instance_double(Aws::RDS::Types::Endpoint, address: 'my-host.abc123.us-east-1.rds.amazonaws.com'),
         db_instance_identifier: 'my-instance',
+        allocated_storage: 200,
       )
     end
-    let(:page) { double('page', db_instances: [db_instance]) }
+    let(:page) { instance_double(Aws::RDS::Types::DBInstanceMessage, db_instances: [db_instance]) }
 
     before do
       allow(Aws::RDS::Client).to receive(:new).and_return(rds_client)
       allow(rds_client).to receive(:describe_db_instances).and_return([page])
+      allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(42.5)
     end
 
     context 'when WAREHOUSE_DATABASE_HOST is not set' do
@@ -175,23 +169,26 @@ RSpec.describe GrdaWarehouse::DbMonitor do
 
       it 'returns nil without contacting AWS' do
         expect(Aws::RDS::Client).not_to receive(:new)
-        expect(described_class.resolve_instance_id).to be_nil
+        expect(described_class.resolve_instance).to be_nil
       end
     end
 
     context 'when WAREHOUSE_DATABASE_HOST matches an exact endpoint address' do
       before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host.abc123.us-east-1.rds.amazonaws.com')) }
 
-      it 'returns the matching instance identifier' do
-        expect(described_class.resolve_instance_id).to eq('my-instance')
+      it 'returns an RdsInstance with identifier, allocated storage, and free storage' do
+        result = described_class.resolve_instance
+        expect(result.id).to eq('my-instance')
+        expect(result.allocated_storage_gb).to eq(200)
+        expect(result.free_storage_gb).to eq(42.5)
       end
     end
 
     context 'when WAREHOUSE_DATABASE_HOST is a leading segment of the endpoint' do
       before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host')) }
 
-      it 'returns the matching instance identifier' do
-        expect(described_class.resolve_instance_id).to eq('my-instance')
+      it 'returns the matching RdsInstance' do
+        expect(described_class.resolve_instance.id).to eq('my-instance')
       end
     end
 
@@ -199,17 +196,30 @@ RSpec.describe GrdaWarehouse::DbMonitor do
       before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'other-host')) }
 
       it 'returns nil' do
-        expect(described_class.resolve_instance_id).to be_nil
+        expect(described_class.resolve_instance).to be_nil
       end
     end
 
     context 'when an instance has no endpoint' do
-      let(:db_instance) { double('db_instance', endpoint: nil, db_instance_identifier: 'no-endpoint-instance') }
+      let(:db_instance) { instance_double(Aws::RDS::Types::DBInstance, endpoint: nil, db_instance_identifier: 'no-endpoint-instance', allocated_storage: 100) }
 
       before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host')) }
 
       it 'skips the instance and returns nil' do
-        expect(described_class.resolve_instance_id).to be_nil
+        expect(described_class.resolve_instance).to be_nil
+      end
+    end
+
+    context 'when CloudWatch returns no datapoints' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host'))
+        allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(nil)
+      end
+
+      it 'returns an RdsInstance with free_storage_gb nil' do
+        result = described_class.resolve_instance
+        expect(result.id).to eq('my-instance')
+        expect(result.free_storage_gb).to be_nil
       end
     end
   end

--- a/spec/models/grda_warehouse/db_monitor_spec.rb
+++ b/spec/models/grda_warehouse/db_monitor_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::DbMonitor do
+  let(:config) { instance_double(GrdaWarehouse::DbMonitor::FreeStorageSpaceConfiguration) }
+
+  before do
+    allow(GrdaWarehouse::DbMonitor::FreeStorageSpaceConfiguration).to receive(:new).and_return(config)
+    allow(config).to receive(:enabled?).and_return(false)
+    allow(config).to receive(:block_threshold_pct).and_return(nil)
+    allow(config).to receive(:alert_threshold_pct).and_return(nil)
+    allow(config).to receive(:min_block_threshold_gb).and_return(1)
+    allow(config).to receive(:max_block_threshold_gb).and_return(100)
+    allow(Sentry).to receive(:capture_message)
+  end
+
+  describe '.assert_healthy!' do
+    context 'when no thresholds are configured' do
+      it 'returns without contacting AWS' do
+        expect(Aws::RDS::Client).not_to receive(:new)
+        described_class.assert_healthy!
+      end
+    end
+
+    context 'when thresholds are configured' do
+      before do
+        allow(config).to receive(:enabled?).and_return(true)
+        allow(config).to receive(:block_threshold_pct).and_return(10)
+        allow(described_class).to receive(:resolve_instance_id).and_return('my-instance')
+        allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
+        allow(described_class).to receive(:database_size_gb).and_return(100.0)
+      end
+
+      context 'when the RDS instance cannot be resolved' do
+        before { allow(described_class).to receive(:resolve_instance_id).and_return(nil) }
+
+        it 'sends a Sentry warning and does not raise' do
+          expect(Sentry).to receive(:capture_message).with(/could not resolve/, hash_including(level: :warning))
+          expect { described_class.assert_healthy! }.not_to raise_error
+        end
+      end
+
+      context 'when free storage space cannot be retrieved' do
+        before { allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(nil) }
+
+        it 'sends a Sentry warning and does not raise' do
+          expect(Sentry).to receive(:capture_message).with(/unable to retrieve/, hash_including(level: :warning))
+          expect { described_class.assert_healthy! }.not_to raise_error
+        end
+      end
+
+      context 'when the database size cannot be determined' do
+        before { allow(described_class).to receive(:database_size_gb).and_return(nil) }
+
+        it 'sends a Sentry warning and does not raise' do
+          expect(Sentry).to receive(:capture_message).with(/unable to determine/, hash_including(level: :warning))
+          expect { described_class.assert_healthy! }.not_to raise_error
+        end
+      end
+
+      context 'block threshold' do
+        # 100 GB DB * 10% = 10 GB computed threshold
+
+        it 'raises Error when free space is below the threshold' do
+          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(8.0)
+          expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error, /block threshold reached/)
+        end
+
+        it 'does not raise when free space is above the threshold' do
+          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
+          expect { described_class.assert_healthy! }.not_to raise_error
+        end
+
+        context 'when the computed threshold exceeds max_block_threshold_gb' do
+          # 1000 GB DB * 10% = 100 GB, but max is 50 GB -> clamped to 50 GB
+          before do
+            allow(described_class).to receive(:database_size_gb).and_return(1000.0)
+            allow(config).to receive(:max_block_threshold_gb).and_return(50)
+          end
+
+          it 'does not raise when free space is above the clamped ceiling' do
+            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(60.0)
+            expect { described_class.assert_healthy! }.not_to raise_error
+          end
+
+          it 'raises when free space is below the clamped ceiling' do
+            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(40.0)
+            expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error)
+          end
+        end
+
+        context 'when the computed threshold is below min_block_threshold_gb' do
+          # 5 GB DB * 10% = 0.5 GB, but min is 2 GB -> clamped to 2 GB
+          before do
+            allow(described_class).to receive(:database_size_gb).and_return(5.0)
+            allow(config).to receive(:min_block_threshold_gb).and_return(2)
+          end
+
+          it 'raises when free space is below the clamped floor' do
+            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(1.0)
+            expect { described_class.assert_healthy! }.to raise_error(GrdaWarehouse::DbMonitor::Error)
+          end
+
+          it 'does not raise when free space is above the clamped floor' do
+            allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(3.0)
+            expect { described_class.assert_healthy! }.not_to raise_error
+          end
+        end
+      end
+
+      context 'alert threshold' do
+        before do
+          allow(config).to receive(:block_threshold_pct).and_return(nil)
+          allow(config).to receive(:alert_threshold_pct).and_return(20)
+          allow(described_class).to receive(:database_size_gb).and_return(100.0)
+        end
+
+        it 'sends a Sentry warning when free space is below the alert threshold' do
+          # 100 GB * 20% = 20 GB alert threshold; 15 GB free -> alert
+          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(15.0)
+          expect(Sentry).to receive(:capture_message).with(
+            /low on storage/,
+            hash_including(level: :warning, extra: hash_including(:free_storage_gb, :alert_threshold_gb)),
+          )
+          described_class.assert_healthy!
+        end
+
+        it 'does not send a warning when free space is above the alert threshold' do
+          allow(GrdaWarehouse::DbMonitor::FreeStorageSpace).to receive(:call).and_return(25.0)
+          expect(Sentry).not_to receive(:capture_message)
+          described_class.assert_healthy!
+        end
+      end
+    end
+  end
+
+  describe '.resolve_instance_id' do
+    let(:rds_client) { instance_double(Aws::RDS::Client) }
+    let(:db_instance) do
+      double(
+        'db_instance',
+        endpoint: double('endpoint', address: 'my-host.abc123.us-east-1.rds.amazonaws.com'),
+        db_instance_identifier: 'my-instance',
+      )
+    end
+    let(:page) { double('page', db_instances: [db_instance]) }
+
+    before do
+      allow(Aws::RDS::Client).to receive(:new).and_return(rds_client)
+      allow(rds_client).to receive(:describe_db_instances).and_return([page])
+    end
+
+    context 'when WAREHOUSE_DATABASE_HOST is not set' do
+      before { stub_const('ENV', ENV.to_h.except('WAREHOUSE_DATABASE_HOST')) }
+
+      it 'returns nil without contacting AWS' do
+        expect(Aws::RDS::Client).not_to receive(:new)
+        expect(described_class.resolve_instance_id).to be_nil
+      end
+    end
+
+    context 'when WAREHOUSE_DATABASE_HOST matches an exact endpoint address' do
+      before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host.abc123.us-east-1.rds.amazonaws.com')) }
+
+      it 'returns the matching instance identifier' do
+        expect(described_class.resolve_instance_id).to eq('my-instance')
+      end
+    end
+
+    context 'when WAREHOUSE_DATABASE_HOST is a leading segment of the endpoint' do
+      before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host')) }
+
+      it 'returns the matching instance identifier' do
+        expect(described_class.resolve_instance_id).to eq('my-instance')
+      end
+    end
+
+    context 'when no RDS instance matches the host' do
+      before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'other-host')) }
+
+      it 'returns nil' do
+        expect(described_class.resolve_instance_id).to be_nil
+      end
+    end
+
+    context 'when an instance has no endpoint' do
+      let(:db_instance) { double('db_instance', endpoint: nil, db_instance_identifier: 'no-endpoint-instance') }
+
+      before { stub_const('ENV', ENV.to_h.merge('WAREHOUSE_DATABASE_HOST' => 'my-host')) }
+
+      it 'skips the instance and returns nil' do
+        expect(described_class.resolve_instance_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/grda_warehouse/db_monitor_spec.rb
+++ b/spec/models/grda_warehouse/db_monitor_spec.rb
@@ -115,6 +115,19 @@ RSpec.describe GrdaWarehouse::DbMonitor do
         end
       end
 
+      context 'when an AWS error occurs' do
+        before do
+          allow(described_class).to receive(:resolve_instance_id).and_raise(
+            Aws::RDS::Errors::ServiceError.new(nil, 'access denied'),
+          )
+        end
+
+        it 'sends a Sentry warning and does not raise' do
+          expect(Sentry).to receive(:capture_message).with(/AWS error/, hash_including(level: :warning))
+          expect { described_class.assert_healthy! }.not_to raise_error
+        end
+      end
+
       context 'alert threshold' do
         before do
           allow(config).to receive(:block_threshold_pct).and_return(nil)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description

Adds a pre-flight RDS free storage check that runs before db-intensive operations to prevent disk exhaustion from causing a service outage.

Adds guards for `HmisCsvImporter.import!` and `ExpireBaseJob#_perform` which are both jobs that may cause a lot of db churn.

> **Note**: This is opt-in. The check is a no-op until at least one threshold is enabled via `AppConfigProperty` keys under the `wh_db_space_monitor/` namespace. Additionally, the EC2/ECS role running the application must have `cloudwatch:GetMetricStatistics` and `rds:DescribeDBInstances` permissions; without them the check fails open with a Sentry warning.

### Type of Change
New feature

## Type of change
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

