### PR TITLE
Fix slow tests

### DIFF
--- a/.github/rspec_buckets.json
+++ b/.github/rspec_buckets.json
@@ -1,412 +1,3567 @@
 [
   {
     "id": "bucket-1",
-    "total_time": 1997.3041592858,
+    "total_time": 2497.5185970584994,
+    "specs": [
+      {
+        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb",
+        "total_time": 2382.7637225055,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb:20",
+            "total_time": 1588.509148337,
+            "description": "ClientAccessControl::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/base_spec.rb",
+        "total_time": 16.546769084,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/base_spec.rb:6",
+            "total_time": 16.546769084,
+            "description": "Filters::Criteria::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/fix_household_ids_spec.rb",
+        "total_time": 16.290875981,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/fix_household_ids_spec.rb:11",
+            "total_time": 16.290875981,
+            "description": "Fix Household IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_race_ethnicity_combinations_spec.rb",
+        "total_time": 15.122921958,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_race_ethnicity_combinations_spec.rb:6",
+            "total_time": 15.122921958,
+            "description": "Filters::Criteria::FilterForRaceEthnicityCombinations"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_organziations_spec.rb",
+        "total_time": 14.790933048,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_organziations_spec.rb:6",
+            "total_time": 14.790933048,
+            "description": "Filters::Criteria::FilterForOrganizations"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb",
+        "total_time": 14.395867766,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb:7",
+            "total_time": 14.395867766,
+            "description": "Mutations::Ce::CreateCeReferral"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_user_access_spec.rb",
+        "total_time": 13.934990207,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_user_access_spec.rb:6",
+            "total_time": 13.934990207,
+            "description": "Filters::Criteria::FilterForUserAccess"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_config_spec.rb",
+        "total_time": 12.609284885,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_config_spec.rb:13",
+            "total_time": 12.609284885,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/service_history_enrollment_spec.rb",
+        "total_time": 11.063231624,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/service_history_enrollment_spec.rb:16",
+            "total_time": 11.063231624,
+            "description": "GrdaWarehouse::ServiceHistoryEnrollment"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-2",
+    "total_time": 2497.9778726870004,
+    "specs": [
+      {
+        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb",
+        "total_time": 1872.562128285,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb:20",
+            "total_time": 1248.37475219,
+            "description": "ClientAccessControl::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb",
+        "total_time": 42.779507065,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb:11",
+            "total_time": 42.779507065,
+            "description": "GrdaWarehouse::Tasks::IdentifyDuplicates"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/delete_service_spec.rb",
+        "total_time": 38.985558369,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/delete_service_spec.rb:13",
+            "total_time": 38.985558369,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/requests/health/team_patients_performance_spec.rb",
+        "total_time": 37.330205385,
+        "groups": [
+          {
+            "location": "./spec/requests/health/team_patients_performance_spec.rb:11",
+            "total_time": 37.330205385,
+            "description": "Health::TeamPatientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/app_resource_monitor/report_spec.rb",
+        "total_time": 35.172437698,
+        "groups": [
+          {
+            "location": "./spec/models/app_resource_monitor/report_spec.rb:5",
+            "total_time": 35.172437698,
+            "description": "AppResourceMonitor::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_spec.rb",
+        "total_time": 33.067801489,
+        "groups": [
+          {
+            "location": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_spec.rb:11",
+            "total_time": 33.067801489,
+            "description": "MaReports::CsgEngage::ReportComponents::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb",
+        "total_time": 31.454253738,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb:12",
+            "total_time": 31.454253738,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_project_related_exports_spec.rb",
+        "total_time": 30.789579388,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_project_related_exports_spec.rb:13",
+            "total_time": 30.789579388,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/client_spec.rb",
+        "total_time": 30.162952961,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/client_spec.rb:12",
+            "total_time": 30.162952961,
+            "description": "Hmis::Hud::Client"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/manual_entry_spec.rb",
+        "total_time": 29.091685893,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/manual_entry_spec.rb:11",
+            "total_time": 29.091685893,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/client_access_spec.rb",
+        "total_time": 28.44788305,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/client_access_spec.rb:12",
+            "total_time": 28.44788305,
+            "description": "Hmis::Hud::Client"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/allowlist_spec.rb",
+        "total_time": 27.685451192,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/allowlist_spec.rb:11",
+            "total_time": 27.685451192,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/get_projects_spec.rb",
+        "total_time": 27.381188287,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/get_projects_spec.rb:13",
+            "total_time": 27.381188287,
+            "description": "GetProjects query"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/hopwa_caper/drilldown_presenter_spec.rb",
+        "total_time": 24.490681089,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/hopwa_caper/drilldown_presenter_spec.rb:6",
+            "total_time": 24.490681089,
+            "description": "HopwaCaper::DrilldownPresenter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb",
+        "total_time": 23.055088191,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb:12",
+            "total_time": 23.055088191,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb",
+        "total_time": 20.468076416,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb:6",
+            "total_time": 20.468076416,
+            "description": "Hmis::Ce::Match::Engine"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/user_ce_steps_spec.rb",
+        "total_time": 18.510686687,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/user_ce_steps_spec.rb:12",
+            "total_time": 18.510686687,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/requests/clients/notes_controller_spec.rb",
+        "total_time": 18.048628477,
+        "groups": [
+          {
+            "location": "./spec/requests/clients/notes_controller_spec.rb:7",
+            "total_time": 18.048628477,
+            "description": "Clients::NotesController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb",
+        "total_time": 16.603008001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb:11",
+            "total_time": 16.603008001,
+            "description": "Hmis::Ce::ReferralEnroller"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/cell_detail_export_builder_spec.rb",
+        "total_time": 16.540044306,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/cell_detail_export_builder_spec.rb:6",
+            "total_time": 16.540044306,
+            "description": "HudSpmReport::CellDetailExportBuilder"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/publish_form_definition_spec.rb",
+        "total_time": 16.242428424,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/publish_form_definition_spec.rb:13",
+            "total_time": 16.242428424,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_psh_move_in_spec.rb",
+        "total_time": 14.882738621,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_psh_move_in_spec.rb:6",
+            "total_time": 14.882738621,
+            "description": "Filters::Criteria::FilterForPshMoveIn"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/active_record_preload_spec.rb",
+        "total_time": 14.447163224,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/active_record_preload_spec.rb:11",
+            "total_time": 14.447163224,
+            "description": "Active Record Preload API"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_project_cocs_spec.rb",
+        "total_time": 14.035702858,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_project_cocs_spec.rb:6",
+            "total_time": 14.035702858,
+            "description": "Filters::Criteria::FilterForProjectCocs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/merge_clients_spec.rb",
+        "total_time": 13.0607709,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/merge_clients_spec.rb:13",
+            "total_time": 13.0607709,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_opportunities_spec.rb",
+        "total_time": 12.145740853,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_opportunities_spec.rb:5",
+            "total_time": 12.145740853,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/external_form_submissions_spec.rb",
+        "total_time": 10.53648184,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/external_form_submissions_spec.rb:13",
+            "total_time": 10.53648184,
+            "description": "External Referral Form Submissions"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-3",
+    "total_time": 2498.2478941739996,
+    "specs": [
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb",
+        "total_time": 1825.201324803,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb:13",
+            "total_time": 1216.800883202,
+            "description": "Datalab Testkit SPM All-Projects"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_basic_counts_spec.rb",
+        "total_time": 48.332104832,
+        "groups": [
+          {
+            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_basic_counts_spec.rb:12",
+            "total_time": 48.332104832,
+            "description": "PIT Basic Counts"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/loader_errors_spec.rb",
+        "total_time": 42.559792793,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/loader_errors_spec.rb:11",
+            "total_time": 42.559792793,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/get_units_spec.rb",
+        "total_time": 38.945701567,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/get_units_spec.rb:13",
+            "total_time": 38.945701567,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_service_filter_spec.rb",
+        "total_time": 37.266276649,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_service_filter_spec.rb:13",
+            "total_time": 37.266276649,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/delete_file_spec.rb",
+        "total_time": 35.05167391,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/delete_file_spec.rb:13",
+            "total_time": 35.05167391,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_service_filter_spec.rb",
+        "total_time": 32.81266796,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/enrollment_service_filter_spec.rb:13",
+            "total_time": 32.81266796,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/auto_exit_job_spec.rb",
+        "total_time": 31.397975366,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/auto_exit_job_spec.rb:11",
+            "total_time": 31.397975366,
+            "description": "Hmis::AutoExitJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_exports_spec.rb",
+        "total_time": 30.497248785,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_exports_spec.rb:17",
+            "total_time": 30.497248785,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/access_control_spec.rb",
+        "total_time": 30.230948605,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/access_control_spec.rb:13",
+            "total_time": 30.230948605,
+            "description": "Hmis::AccessControl"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_services_visibility_spec.rb",
+        "total_time": 29.133691876,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/enrollment_services_visibility_spec.rb:13",
+            "total_time": 29.133691876,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/validations_spec.rb",
+        "total_time": 28.384028555,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/validations_spec.rb:11",
+            "total_time": 28.384028555,
+            "description": "Validate import files"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/ad_hoc_batch_spec.rb",
+        "total_time": 27.711715397,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/ad_hoc_batch_spec.rb:11",
+            "total_time": 27.711715397,
+            "description": "GrdaWarehouse::AdHocBatch"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/project_validation_constraint_spec.rb",
+        "total_time": 27.388881729,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/project_validation_constraint_spec.rb:11",
+            "total_time": 27.388881729,
+            "description": "Project validation with constraint lambda"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb",
+        "total_time": 24.458220167,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb:12",
+            "total_time": 24.458220167,
+            "description": "HmisCsvImporter::Cleanup::ExpireImportersJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/activity_log_processor_job_spec.rb",
+        "total_time": 23.330513768,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/activity_log_processor_job_spec.rb:11",
+            "total_time": 23.330513768,
+            "description": "Hmis::ActivityLogProcessorJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/get_unit_spec.rb",
+        "total_time": 20.319227114,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/get_unit_spec.rb:7",
+            "total_time": 20.319227114,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb",
+        "total_time": 18.509678059,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb:11",
+            "total_time": 18.509678059,
+            "description": "Hmis::Ce::ReferralCeEventManager"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/talentlms/facade_spec.rb",
+        "total_time": 17.7007015,
+        "groups": [
+          {
+            "location": "./spec/models/talentlms/facade_spec.rb:10",
+            "total_time": 17.7007015,
+            "description": "Talentlms::Facade"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_3_spec.rb",
+        "total_time": 16.949445076,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_3_spec.rb:12",
+            "total_time": 16.949445076,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureThree"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/warehouse_clients_processed_spec.rb",
+        "total_time": 16.479384709,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/warehouse_clients_processed_spec.rb:5",
+            "total_time": 16.479384709,
+            "description": "GrdaWarehouse::WarehouseClientsProcessed"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_veteran_counts_spec.rb",
+        "total_time": 15.492453009,
+        "groups": [
+          {
+            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_veteran_counts_spec.rb:12",
+            "total_time": 15.492453009,
+            "description": "PIT Veteran Counts"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_times_homeless_spec.rb",
+        "total_time": 15.039998074,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_times_homeless_spec.rb:6",
+            "total_time": 15.039998074,
+            "description": "Filters::Criteria::FilterForTimesHomeless"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_destination_spec.rb",
+        "total_time": 14.574150811,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_destination_spec.rb:6",
+            "total_time": 14.574150811,
+            "description": "Filters::Criteria::FilterForDestination"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_rrh_move_in_spec.rb",
+        "total_time": 14.361915479,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_rrh_move_in_spec.rb:6",
+            "total_time": 14.361915479,
+            "description": "Filters::Criteria::FilterForRrhMoveIn"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb",
+        "total_time": 13.865684873,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb:13",
+            "total_time": 13.865684873,
+            "description": "BulkRemoveService"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/client_file_spec.rb",
+        "total_time": 11.253651233,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/client_file_spec.rb:11",
+            "total_time": 11.253651233,
+            "description": "GrdaWarehouse::ClientFile"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/hmis_activity_log_spec.rb",
+        "total_time": 10.998837475,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/hmis_activity_log_spec.rb:13",
+            "total_time": 10.998837475,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-4",
+    "total_time": 2488.9113953465,
+    "specs": [
+      {
+        "file_path": "./drivers/hud_apr/spec/models/fy2026/datalab_2_0_spec.rb",
+        "total_time": 1746.0347882355,
+        "groups": [
+          {
+            "location": "./drivers/hud_apr/spec/models/fy2026/datalab_2_0_spec.rb:26",
+            "total_time": 1164.023192157,
+            "description": "Datalab 2026"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb",
+        "total_time": 51.6284343,
+        "groups": [
+          {
+            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb:12",
+            "total_time": 51.6284343,
+            "description": "PIT Parenting Youth Counts"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/users_access_summary_spec.rb",
+        "total_time": 49.667771186,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/users_access_summary_spec.rb:13",
+            "total_time": 49.667771186,
+            "description": "User access summary query"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb",
+        "total_time": 45.885085929,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb:13",
+            "total_time": 45.885085929,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/update_relationship_to_ho_h_spec.rb",
+        "total_time": 39.320377096,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/update_relationship_to_ho_h_spec.rb:13",
+            "total_time": 39.320377096,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb",
+        "total_time": 37.548324322,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb:13",
+            "total_time": 37.548324322,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/include_deleted_spec.rb",
+        "total_time": 35.72443153,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/include_deleted_spec.rb:12",
+            "total_time": 35.72443153,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/custom_file_exports_spec.rb",
+        "total_time": 33.534930815,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/custom_file_exports_spec.rb:12",
+            "total_time": 33.534930815,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb",
+        "total_time": 31.568381781,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb:13",
+            "total_time": 31.568381781,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/coc_exports_spec.rb",
+        "total_time": 30.877331273,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/coc_exports_spec.rb:17",
+            "total_time": 30.877331273,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/data_source_project_related_exports_spec.rb",
+        "total_time": 30.322154095,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/data_source_project_related_exports_spec.rb:18",
+            "total_time": 30.322154095,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/organization_project_related_exports_spec.rb",
+        "total_time": 29.923167531,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/organization_project_related_exports_spec.rb:18",
+            "total_time": 29.923167531,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/manual_entry_spec.rb",
+        "total_time": 28.728878256,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/manual_entry_spec.rb:11",
+            "total_time": 28.728878256,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_special_populations_spec.rb",
+        "total_time": 28.315893434,
+        "groups": [
+          {
+            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_special_populations_spec.rb:12",
+            "total_time": 28.315893434,
+            "description": "PIT Special Population Counts"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/inventory_spec.rb",
+        "total_time": 27.413338005,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/inventory_spec.rb:12",
+            "total_time": 27.413338005,
+            "description": "Hmis::Hud::Inventory"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb",
+        "total_time": 27.038558503,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb:11",
+            "total_time": 27.038558503,
+            "description": "Hmis::ProjectAutoExitConfig"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/client_access_control/spec/requests/clients_legacy_spec.rb",
+        "total_time": 24.178988785,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/requests/clients_legacy_spec.rb:11",
+            "total_time": 24.178988785,
+            "description": "ClientAccessControl::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/process_pools_job_spec.rb",
+        "total_time": 21.38277848,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/hmis/ce/process_pools_job_spec.rb:12",
+            "total_time": 21.38277848,
+            "description": "Hmis::Ce::ProcessPoolsJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/split_household_spec.rb",
+        "total_time": 19.218837153,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/split_household_spec.rb:13",
+            "total_time": 19.218837153,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/submit_ce_referral_step_spec.rb",
+        "total_time": 18.261723825,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/submit_ce_referral_step_spec.rb:7",
+            "total_time": 18.261723825,
+            "description": "Mutations::Ce::SubmitCeReferralStep"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/merge_clients_job_spec.rb",
+        "total_time": 17.314984408,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/merge_clients_job_spec.rb:11",
+            "total_time": 17.314984408,
+            "description": "Hmis::MergeClientsJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/ch_enrollment_spec.rb",
+        "total_time": 16.549407892,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/ch_enrollment_spec.rb:5",
+            "total_time": 16.549407892,
+            "description": "GrdaWarehouse::ChEnrollment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb",
+        "total_time": 16.300123155,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb:12",
+            "total_time": 16.300123155,
+            "description": "HudSpmReport::Fy2026::SpmEnrollment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb",
+        "total_time": 15.127686218,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb:7",
+            "total_time": 15.127686218,
+            "description": "Mutations::Ce::CreateDirectCeReferral"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb",
+        "total_time": 14.831453192,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb:13",
+            "total_time": 14.831453192,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::AccessToCareSheet"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/episode_batch_spec.rb",
+        "total_time": 14.403211259,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/episode_batch_spec.rb:6",
+            "total_time": 14.403211259,
+            "description": "HudSpmReport::Fy2026::EpisodeBatch"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb",
+        "total_time": 14.032420505,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb:13",
+            "total_time": 14.032420505,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb",
+        "total_time": 12.707320356,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb:13",
+            "total_time": 12.707320356,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb",
+        "total_time": 11.070613827,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb:11",
+            "total_time": 11.070613827,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-5",
+    "total_time": 2487.711231869899,
+    "specs": [
+      {
+        "file_path": "./drivers/hud_path_report/spec/models/fy2026/datalab_2026_spec.rb",
+        "total_time": 1000.7898478724999,
+        "groups": [
+          {
+            "location": "./drivers/hud_path_report/spec/models/fy2026/datalab_2026_spec.rb:15",
+            "total_time": 667.193231915,
+            "description": "PATH Datalab 2026"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_organization_ids_spec.rb",
+        "total_time": 164.6463615346,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_organization_ids_spec.rb:11",
+            "total_time": 149.678510486,
+            "description": "Append Organization IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/performance_measurement/spec/models/performance_measurement/report_spec.rb",
+        "total_time": 143.1583154815,
+        "groups": [
+          {
+            "location": "./drivers/performance_measurement/spec/models/performance_measurement/report_spec.rb:11",
+            "total_time": 130.143923165,
+            "description": "PerformanceMeasurement::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_relationships_spec.rb",
+        "total_time": 124.36291410180002,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_relationships_spec.rb:11",
+            "total_time": 113.057194638,
+            "description": "Ensure Relationships"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/clean_up_move_in_dates_spec.rb",
+        "total_time": 92.86576400530001,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/clean_up_move_in_dates_spec.rb:11",
+            "total_time": 84.423421823,
+            "description": "Clean Up Move In Dates"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb",
+        "total_time": 79.83364925800001,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb:12",
+            "total_time": 72.57604478,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb",
+        "total_time": 66.46289477520001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb:13",
+            "total_time": 60.420813432,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/hud/enrollment_spec.rb",
+        "total_time": 56.490978525,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/hud/enrollment_spec.rb:6",
+            "total_time": 56.490978525,
+            "description": "GrdaWarehouse::Hud::Enrollment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/importer/custom_files_integration_spec.rb",
+        "total_time": 51.91749873,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/importer/custom_files_integration_spec.rb:11",
+            "total_time": 51.91749873,
+            "description": "Custom Files Integration"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb",
+        "total_time": 50.47043371,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb:13",
+            "total_time": 50.47043371,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb",
+        "total_time": 47.620872467,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb:13",
+            "total_time": 47.620872467,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/organization_spec.rb",
+        "total_time": 39.845799175,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/organization_spec.rb:13",
+            "total_time": 39.845799175,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb",
+        "total_time": 38.34442722,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb:13",
+            "total_time": 38.34442722,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb",
+        "total_time": 37.051365027,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb:13",
+            "total_time": 37.051365027,
+            "description": "Hmis::Hud::Enrollment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb",
+        "total_time": 34.085112515,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb:12",
+            "total_time": 34.085112515,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb",
+        "total_time": 32.531826235,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb:13",
+            "total_time": 32.531826235,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat_spec.rb",
+        "total_time": 30.950522953,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat_spec.rb:5",
+            "total_time": 30.950522953,
+            "description": "GrdaWarehouse::CasProjectClientCalculator::TcHat"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/project_group_project_related_exports_spec.rb",
+        "total_time": 30.783604806,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
+            "total_time": 30.783604806,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb",
+        "total_time": 29.989098783,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb:12",
+            "total_time": 29.989098783,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::TbraSheet"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/rounding_spec.rb",
+        "total_time": 29.862492194,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/rounding_spec.rb:12",
+            "total_time": 29.862492194,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/combine_enrollments_spec.rb",
+        "total_time": 28.317603813,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/combine_enrollments_spec.rb:11",
+            "total_time": 28.317603813,
+            "description": "Combine Enrollments"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/user_permission_spec.rb",
+        "total_time": 27.553603487,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/user_permission_spec.rb:13",
+            "total_time": 27.553603487,
+            "description": "Hmis::User"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/ad_hoc_data_source_spec.rb",
+        "total_time": 27.113441518,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/ad_hoc_data_source_spec.rb:6",
+            "total_time": 27.113441518,
+            "description": "GrdaWarehouse::AdHocDataSource"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb",
+        "total_time": 24.440202375,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb:12",
+            "total_time": 24.440202375,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb",
+        "total_time": 22.914132725,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb:13",
+            "total_time": 22.914132725,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_race_spec.rb",
+        "total_time": 20.84156153,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_race_spec.rb:6",
+            "total_time": 20.84156153,
+            "description": "Filters::Criteria::FilterForRace"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_services_spec.rb",
+        "total_time": 18.325831092,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_services_spec.rb:13",
+            "total_time": 18.325831092,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/concurrent_processing_spec.rb",
+        "total_time": 17.533693398,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/hmis/ce/concurrent_processing_spec.rb:12",
+            "total_time": 17.533693398,
+            "description": "Concurrent CE Processing"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_sub_population_spec.rb",
+        "total_time": 17.182659907,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_sub_population_spec.rb:6",
+            "total_time": 17.182659907,
+            "description": "Filters::Criteria::FilterForSubPopulation"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_household_type_spec.rb",
+        "total_time": 16.380205368,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_household_type_spec.rb:6",
+            "total_time": 16.380205368,
+            "description": "Filters::Criteria::FilterForHouseholdType"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_projects_hud_spec.rb",
+        "total_time": 15.263845647,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_projects_hud_spec.rb:6",
+            "total_time": 15.263845647,
+            "description": "Filters::Criteria::FilterForProjectsHud"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_project_type_spec.rb",
+        "total_time": 15.094381117,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_project_type_spec.rb:6",
+            "total_time": 15.094381117,
+            "description": "Filters::Criteria::FilterForProjectType"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/users_spec.rb",
+        "total_time": 14.657715987,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/users_spec.rb:13",
+            "total_time": 14.657715987,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_head_of_household_spec.rb",
+        "total_time": 14.388287417,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_head_of_household_spec.rb:6",
+            "total_time": 14.388287417,
+            "description": "Filters::Criteria::FilterForHeadOfHousehold"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_6_spec.rb",
+        "total_time": 13.884986946,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_6_spec.rb:12",
+            "total_time": 13.884986946,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureSix"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb",
+        "total_time": 11.755300174,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb:13",
+            "total_time": 11.755300174,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-6",
+    "total_time": 2497.900472951999,
+    "specs": [
+      {
+        "file_path": "./drivers/datalab_testkit/spec/empty_spec.rb",
+        "total_time": 903.998175231,
+        "groups": [
+          {
+            "location": "./drivers/datalab_testkit/spec/empty_spec.rb:12",
+            "total_time": 602.665450154,
+            "description": "Empty test to load fixpoints"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/features/accounts_spec.rb",
+        "total_time": 224.857521493,
+        "groups": [
+          {
+            "location": "./spec/features/accounts_spec.rb:5",
+            "total_time": 204.41592863,
+            "description": "Accounts"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_project_ids_spec.rb",
+        "total_time": 144.5962311728,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_project_ids_spec.rb:11",
+            "total_time": 131.451119248,
+            "description": "Append Project IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_threshold_spec.rb",
+        "total_time": 129.04925219120003,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_threshold_spec.rb:11",
+            "total_time": 117.317501992,
+            "description": "GrdaWarehouse::ImportThreshold"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/client_access_control/spec/requests/clients_spec.rb",
+        "total_time": 93.91889413060001,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/requests/clients_spec.rb:14",
+            "total_time": 85.380812846,
+            "description": "ClientAccessControl::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cas_active_spec.rb",
+        "total_time": 83.17745629160001,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cas_active_spec.rb:5",
+            "total_time": 75.615869356,
+            "description": "GrdaWarehouse::ServiceHistoryService"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_search_spec.rb",
+        "total_time": 70.43151339180001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_search_spec.rb:13",
+            "total_time": 64.028648538,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb",
+        "total_time": 58.557123999,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb:91",
+            "total_time": 29.89031379,
+            "description": "Project and organization confidential items"
+          },
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb:12",
+            "total_time": 28.666810209,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb",
+        "total_time": 53.472878198,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb:13",
+            "total_time": 53.472878198,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb",
+        "total_time": 51.574740129,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb:19",
+            "total_time": 51.574740129,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/public_reports/spec/models/public_reports_spec.rb",
+        "total_time": 48.446614697,
+        "groups": [
+          {
+            "location": "./drivers/public_reports/spec/models/public_reports_spec.rb:11",
+            "total_time": 48.446614697,
+            "description": "PublicReports::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb",
+        "total_time": 45.574616993,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb:13",
+            "total_time": 45.574616993,
+            "description": "Update External Form Submission"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb",
+        "total_time": 39.137147836,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb:13",
+            "total_time": 39.137147836,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_filter_spec.rb",
+        "total_time": 37.493658936,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_filter_spec.rb:12",
+            "total_time": 37.493658936,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/health/comprehensive_health_assessment_spec.rb",
+        "total_time": 35.215240971,
+        "groups": [
+          {
+            "location": "./spec/models/health/comprehensive_health_assessment_spec.rb:5",
+            "total_time": 35.215240971,
+            "description": "Health::ComprehensiveHealthAssessment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/deidentified_spec.rb",
+        "total_time": 33.312455987,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/deidentified_spec.rb:11",
+            "total_time": 33.312455987,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_related_exports_spec.rb",
+        "total_time": 31.491233334,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_related_exports_spec.rb:13",
+            "total_time": 31.491233334,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_hashed_exports_spec.rb",
+        "total_time": 30.80584352,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_hashed_exports_spec.rb:12",
+            "total_time": 30.80584352,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/client_processing_spec.rb",
+        "total_time": 30.243960071,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/client_processing_spec.rb:11",
+            "total_time": 30.243960071,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb",
+        "total_time": 29.89419175,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb:17",
+            "total_time": 29.89419175,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb",
+        "total_time": 28.559298803,
+        "groups": [
+          {
+            "location": "./drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb:11",
+            "total_time": 28.559298803,
+            "description": "LongitudinalSpm::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb",
+        "total_time": 28.260480176,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb:12",
+            "total_time": 28.260480176,
+            "description": "Hmis::Hud::Project"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/client_alert_spec.rb",
+        "total_time": 27.396260488,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/client_alert_spec.rb:12",
+            "total_time": 27.396260488,
+            "description": "Hmis::ClientAlert"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb",
+        "total_time": 26.971204738,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb:11",
+            "total_time": 26.971204738,
+            "description": "Hmis::ProjectAutoEnterConfig"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb",
+        "total_time": 21.218972671,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb:12",
+            "total_time": 21.218972671,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureOne"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_clients_spec.rb",
+        "total_time": 19.200832245,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_clients_spec.rb:5",
+            "total_time": 19.200832245,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_7_spec.rb",
+        "total_time": 18.217150733,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_7_spec.rb:12",
+            "total_time": 18.217150733,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureSeven"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb",
+        "total_time": 17.21430496,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb:13",
+            "total_time": 17.21430496,
+            "description": "Bulk Review External Submission"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_households_spec.rb",
+        "total_time": 16.355122872,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_households_spec.rb:11",
+            "total_time": 16.355122872,
+            "description": "Ensure Households"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/fitler_for_enrollment_cocs_spec.rb",
+        "total_time": 15.767939941,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/fitler_for_enrollment_cocs_spec.rb:6",
+            "total_time": 15.767939941,
+            "description": "Filters::Criteria::FilterForEnrollmentCocs"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_indefinite_disabilities_spec.rb",
+        "total_time": 15.024867635,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_indefinite_disabilities_spec.rb:6",
+            "total_time": 15.024867635,
+            "description": "Filters::Criteria::FilterForIndefiniteDisabilities"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_veteran_status_spec.rb",
+        "total_time": 14.463977822,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_veteran_status_spec.rb:6",
+            "total_time": 14.463977822,
+            "description": "Filters::Criteria::FilterForVeteranStatus"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_first_time_homelessness_in_past_two_years_spec.rb",
+        "total_time": 14.309518564,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_first_time_homelessness_in_past_two_years_spec.rb:6",
+            "total_time": 14.309518564,
+            "description": "Filters::Criteria::FilterForFirstTimeHomelessInPastTwoYears"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/requests/cohorts/clients_spec.rb",
+        "total_time": 13.127486104,
+        "groups": [
+          {
+            "location": "./spec/requests/cohorts/clients_spec.rb:12",
+            "total_time": 13.127486104,
+            "description": "Cohorts::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/warehouse_reports/youth/homeless_youth_report_spec.rb",
+        "total_time": 12.121558709,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/warehouse_reports/youth/homeless_youth_report_spec.rb:5",
+            "total_time": 12.121558709,
+            "description": "GrdaWarehouse::WarehouseReports::Youth::HomelessYouthReport"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/delete_client_spec.rb",
+        "total_time": 10.437756469,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/delete_client_spec.rb:13",
+            "total_time": 10.437756469,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-7",
+    "total_time": 2497.6744450476,
+    "specs": [
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/base_spec.rb",
+        "total_time": 556.9880918376,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/base_spec.rb:11",
+            "total_time": 464.156743198,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb",
+        "total_time": 239.74044523330002,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb:14",
+            "total_time": 217.945859303,
+            "description": "ClientAccessControl::ClientsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/force_prioritization_status_spec.rb",
+        "total_time": 227.64810579610003,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/force_prioritization_status_spec.rb:11",
+            "total_time": 206.952823451,
+            "description": "Force Assessment Prioritization Status"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/controllers/hmis_csv_importer/importer_errors_controller_spec.rb",
+        "total_time": 161.64527919210002,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/controllers/hmis_csv_importer/importer_errors_controller_spec.rb:7",
+            "total_time": 146.950253811,
+            "description": "HmisCsvImporter::ImporterErrorsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_threshold_spec.rb",
+        "total_time": 136.4579478372,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_threshold_spec.rb:11",
+            "total_time": 124.052679852,
+            "description": "GrdaWarehouse::ImportThreshold"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb",
+        "total_time": 120.63785955870001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb:16",
+            "total_time": 109.670781417,
+            "description": "Hmis::SessionsController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_project_ids_spec.rb",
+        "total_time": 85.66699281470001,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_project_ids_spec.rb:11",
+            "total_time": 77.879084377,
+            "description": "Prepend Project IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb",
+        "total_time": 74.0891574159,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb:5",
+            "total_time": 67.353779469,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_race_ethnicity_spec.rb",
+        "total_time": 68.007860558,
+        "groups": [
+          {
+            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_race_ethnicity_spec.rb:12",
+            "total_time": 61.82532778,
+            "description": "PIT Race and Ethnicity Counts"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_override_spec.rb",
+        "total_time": 57.601445125,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_override_spec.rb:11",
+            "total_time": 57.601445125,
+            "description": "Applies overrides as expected"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb",
+        "total_time": 51.953053563,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb:91",
+            "total_time": 31.050445252,
+            "description": "Project and organization confidential items"
+          },
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb:12",
+            "total_time": 20.902608311,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/get_project_unit_types_spec.rb",
+        "total_time": 51.276906479,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/get_project_unit_types_spec.rb:13",
+            "total_time": 51.276906479,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/unit_spec.rb",
+        "total_time": 46.397795793,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/unit_spec.rb:13",
+            "total_time": 46.397795793,
+            "description": "Hmis::Unit"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb",
+        "total_time": 41.732377812,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb:12",
+            "total_time": 41.732377812,
+            "description": "GrdaWarehouse::Hud::Client"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_filter_spec.rb",
+        "total_time": 37.886092772,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_filter_spec.rb:12",
+            "total_time": 37.886092772,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_components/report_spec.rb",
+        "total_time": 36.609803295,
+        "groups": [
+          {
+            "location": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_components/report_spec.rb:11",
+            "total_time": 36.609803295,
+            "description": "MaReports::CsgEngage::ReportComponents::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb",
+        "total_time": 33.919535727,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb:13",
+            "total_time": 33.919535727,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb",
+        "total_time": 32.103612761,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb:6",
+            "total_time": 32.103612761,
+            "description": "Mutations::Ce::AssignReferralParticipants"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/form_identifier_spec.rb",
+        "total_time": 31.199053213,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/form_identifier_spec.rb:13",
+            "total_time": 31.199053213,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/mdha_spec.rb",
+        "total_time": 30.543196935,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/mdha_spec.rb:5",
+            "total_time": 30.543196935,
+            "description": "GrdaWarehouse::CasProjectClientCalculator::Mdha"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/rounding_spec.rb",
+        "total_time": 30.203803068,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/rounding_spec.rb:12",
+            "total_time": 30.203803068,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb",
+        "total_time": 28.841137802,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb:12",
+            "total_time": 28.841137802,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/active_record_extended_merge_regression_spec.rb",
+        "total_time": 28.512516645,
+        "groups": [
+          {
+            "location": "./spec/models/active_record_extended_merge_regression_spec.rb:13",
+            "total_time": 28.512516645,
+            "description": "ActiveRecord merge with SqlLiteral canary"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb",
+        "total_time": 27.912364546,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb:11",
+            "total_time": 27.912364546,
+            "description": "Validate import files"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/project_config_spec.rb",
+        "total_time": 27.286157966,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/project_config_spec.rb:11",
+            "total_time": 27.286157966,
+            "description": "Hmis::ProjectConfig"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/join_household_spec.rb",
+        "total_time": 25.8359657,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/join_household_spec.rb:13",
+            "total_time": 25.8359657,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb",
+        "total_time": 22.032395226,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb:13",
+            "total_time": 22.032395226,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb",
+        "total_time": 19.728668329,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb:13",
+            "total_time": 19.728668329,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/process_clients_job_spec.rb",
+        "total_time": 18.980614414,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/jobs/hmis/ce/process_clients_job_spec.rb:12",
+            "total_time": 18.980614414,
+            "description": "Hmis::Ce::ProcessClientsJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_disabilities_spec.rb",
+        "total_time": 17.828162549,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_disabilities_spec.rb:6",
+            "total_time": 17.828162549,
+            "description": "Filters::Criteria::FilterForDisabilities"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/requests/clients/notes_controller_legacy_spec.rb",
+        "total_time": 16.934768275,
+        "groups": [
+          {
+            "location": "./spec/requests/clients/notes_controller_legacy_spec.rb:7",
+            "total_time": 16.934768275,
+            "description": "Clients::NotesController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/fix_household_ids_spec.rb",
+        "total_time": 16.456680401,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/fix_household_ids_spec.rb:11",
+            "total_time": 16.456680401,
+            "description": "Fix Household IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb",
+        "total_time": 15.628780754,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb:12",
+            "total_time": 15.628780754,
+            "description": "HopwaCaper::Generators::Fy2026::Generator"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_dv_status_spec.rb",
+        "total_time": 15.037883524,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_dv_status_spec.rb:6",
+            "total_time": 15.037883524,
+            "description": "Filters::Criteria::FilterForDvStatus"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/client_ce_referrals_spec.rb",
+        "total_time": 14.485029246,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/client_ce_referrals_spec.rb:11",
+            "total_time": 14.485029246,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_funders_spec.rb",
+        "total_time": 14.335883008,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_funders_spec.rb:6",
+            "total_time": 14.335883008,
+            "description": "Filters::Criteria::FilterForFunders"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/clear_mci_spec.rb",
+        "total_time": 13.378337965,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/clear_mci_spec.rb:13",
+            "total_time": 13.378337965,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb",
+        "total_time": 12.01263991,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb:13",
+            "total_time": 12.01263991,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_services_client_search_spec.rb",
+        "total_time": 10.138042001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/bulk_services_client_search_spec.rb:13",
+            "total_time": 10.138042001,
+            "description": "BulkAssignService"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-8",
+    "total_time": 2498.1110923569004,
+    "specs": [
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/base_spec.rb",
+        "total_time": 510.2449790016,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/base_spec.rb:11",
+            "total_time": 425.204149168,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/force_prioritization_status_spec.rb",
+        "total_time": 234.5006892591,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/force_prioritization_status_spec.rb:11",
+            "total_time": 213.182444781,
+            "description": "Force Assessment Prioritization Status"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/export_date_spec.rb",
+        "total_time": 208.80326054280002,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/export_date_spec.rb:11",
+            "total_time": 189.821145948,
+            "description": "HUD ExportDate Tests"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/export_date_spec.rb",
+        "total_time": 134.4342735076,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/export_date_spec.rb:11",
+            "total_time": 122.212975916,
+            "description": "HUD ExportDate Tests"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/date_updated_spec.rb",
+        "total_time": 101.6751346754,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/date_updated_spec.rb:11",
+            "total_time": 92.431940614,
+            "description": "HUD DateUpdated Tests"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/homeless_summary_report/spec/models/smoketest_spec.rb",
+        "total_time": 89.14609907830001,
+        "groups": [
+          {
+            "location": "./drivers/homeless_summary_report/spec/models/smoketest_spec.rb:12",
+            "total_time": 81.041908253,
+            "description": "HomelessSummaryReport::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_spec.rb",
+        "total_time": 78.35469547070001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_spec.rb:13",
+            "total_time": 71.231541337,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_spec.rb",
+        "total_time": 66.14923778320001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_spec.rb:13",
+            "total_time": 60.135670712,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_override_spec.rb",
+        "total_time": 54.216341262,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_override_spec.rb:11",
+            "total_time": 54.216341262,
+            "description": "Applies overrides as expected"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb",
+        "total_time": 52.841494207,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb:13",
+            "total_time": 52.841494207,
+            "description": "BulkAssignService"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb",
+        "total_time": 51.475795168,
+        "groups": [
+          {
+            "location": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb:12",
+            "total_time": 51.475795168,
+            "description": "GrdaWarehouse::Hud::Client"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_visibility_spec.rb",
+        "total_time": 47.94559982,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_visibility_spec.rb:5",
+            "total_time": 47.94559982,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/loader_errors_spec.rb",
+        "total_time": 39.386217702,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/loader_errors_spec.rb:11",
+            "total_time": 39.386217702,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb",
+        "total_time": 38.754106783,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb:12",
+            "total_time": 38.754106783,
+            "description": "HudSpmReport::Generators::Fy2026::HdxUpload"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb",
+        "total_time": 37.013832936,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb:13",
+            "total_time": 37.013832936,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb",
+        "total_time": 34.275193321,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb:13",
+            "total_time": 34.275193321,
+            "description": "Mutations::Ce::MarkUnitsAvailable"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/organization_spec.rb",
+        "total_time": 32.137982837,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/organization_spec.rb:12",
+            "total_time": 32.137982837,
+            "description": "Hmis::Hud::Organization"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_related_exports_spec.rb",
+        "total_time": 31.252114661,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_related_exports_spec.rb:13",
+            "total_time": 31.252114661,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb",
+        "total_time": 30.711542133,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb:13",
+            "total_time": 30.711542133,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/include_deleted_spec.rb",
+        "total_time": 30.159087143,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/include_deleted_spec.rb:12",
+            "total_time": 30.159087143,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/household_spec.rb",
+        "total_time": 28.801530846,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/household_spec.rb:12",
+            "total_time": 28.801530846,
+            "description": "Hmis::Hud::Household"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb",
+        "total_time": 28.455425802,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb:12",
+            "total_time": 28.455425802,
+            "description": "HmisCsvImporter::Cleanup::ExpireLoadersJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/allowlist_spec.rb",
+        "total_time": 28.11722748,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/allowlist_spec.rb:11",
+            "total_time": 28.11722748,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/project_access_spec.rb",
+        "total_time": 27.123226128,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/project_access_spec.rb:12",
+            "total_time": 27.123226128,
+            "description": "Hmis::Hud::Project"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/boston_spec.rb",
+        "total_time": 25.3751155,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/boston_spec.rb:11",
+            "total_time": 25.3751155,
+            "description": "GrdaWarehouse::CasProjectClientCalculator::Boston"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb",
+        "total_time": 22.605645851,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb:7",
+            "total_time": 22.605645851,
+            "description": "Hmis::ClientFilesController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cohort_automation_spec.rb",
+        "total_time": 19.360333435,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cohort_automation_spec.rb:6",
+            "total_time": 19.360333435,
+            "description": "GrdaWarehouse::Cohort"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb",
+        "total_time": 19.18883665,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb:7",
+            "total_time": 19.18883665,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/hud/disability_spec.rb",
+        "total_time": 18.051055476,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/hud/disability_spec.rb:6",
+            "total_time": 18.051055476,
+            "description": "GrdaWarehouse::Hud::Disability"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_age_spec.rb",
+        "total_time": 16.85415536,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_age_spec.rb:6",
+            "total_time": 16.85415536,
+            "description": "Filters::Criteria::FilterForAge"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_4_spec.rb",
+        "total_time": 16.34363173,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_4_spec.rb:12",
+            "total_time": 16.34363173,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureFour"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb",
+        "total_time": 14.944328179,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb:13",
+            "total_time": 14.944328179,
+            "description": "Mutations::Ce::MarkUnitsUnavailable"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_gender_spec.rb",
+        "total_time": 14.450383501,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_gender_spec.rb:6",
+            "total_time": 14.450383501,
+            "description": "Filters::Criteria::FilterForGender"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb",
+        "total_time": 14.273914067,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb:12",
+            "total_time": 14.273914067,
+            "description": "HmisDataCleanup::Util"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_housing_info_spec.rb",
+        "total_time": 13.343582056,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_housing_info_spec.rb:13",
+            "total_time": 13.343582056,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::HousingInfoSheet"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_permission_spec.rb",
+        "total_time": 11.892801737,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/ce/referral_permission_spec.rb:13",
+            "total_time": 11.892801737,
+            "description": "Hmis::Ce::Referral"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/client_file_legacy_spec.rb",
+        "total_time": 10.682402568,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/client_file_legacy_spec.rb:5",
+            "total_time": 10.682402568,
+            "description": "GrdaWarehouse::ClientFile"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-9",
+    "total_time": 2498.1631156777994,
     "specs": [
       {
         "file_path": "./drivers/client_access_control/spec/requests/client_visibility_spec.rb",
-        "total_time": 323.21395200820007,
+        "total_time": 259.9262274466,
         "groups": [
           {
             "location": "./drivers/client_access_control/spec/requests/client_visibility_spec.rb:14",
-            "total_time": 293.830865462,
+            "total_time": 236.296570406,
             "description": "ClientAccessControl::ClientsController"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/bad_data_spec.rb",
-        "total_time": 251.28714277370003,
+        "total_time": 232.0012969208,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/bad_data_spec.rb:11",
-            "total_time": 228.442857067,
+            "total_time": 210.910269928,
             "description": "HmisCsvImporter"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_organization_ids_spec.rb",
-        "total_time": 175.29388320950002,
+        "total_time": 175.39587151130002,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_organization_ids_spec.rb:11",
-            "total_time": 159.358075645,
+            "total_time": 159.450792283,
             "description": "Prepend Organization IDs"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb",
-        "total_time": 131.26155117460002,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb:13",
-            "total_time": 119.328682886,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_project_ids_spec.rb",
-        "total_time": 113.64458887430001,
+        "total_time": 141.9473823504,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_project_ids_spec.rb:11",
-            "total_time": 103.313262613,
+            "total_time": 129.043074864,
             "description": "Prepend Project IDs"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb",
+        "total_time": 121.68851756270001,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb:13",
+            "total_time": 110.625925057,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
         "file_path": "./spec/requests/sessions_controller_spec.rb",
-        "total_time": 88.6177871535,
+        "total_time": 90.1196959267,
         "groups": [
           {
             "location": "./spec/requests/sessions_controller_spec.rb:14",
-            "total_time": 80.561624685,
+            "total_time": 81.926996297,
             "description": "Users::SessionsController"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb",
+        "total_time": 77.8726561877,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb:13",
+            "total_time": 70.793323807,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/delete_empty_enrollments_spec.rb",
-        "total_time": 59.556820444,
+        "total_time": 59.027578459,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/delete_empty_enrollments_spec.rb:11",
-            "total_time": 59.556820444,
+            "total_time": 59.027578459,
             "description": "Delete empty SO enrollments"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb",
-        "total_time": 58.962189195,
+        "total_time": 57.83348606,
         "groups": [
           {
             "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb:12",
-            "total_time": 58.962189195,
+            "total_time": 57.83348606,
             "description": "HmisCsvTwentyTwentySix::Exporter::Base"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb",
-        "total_time": 56.802856189,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb:11",
-            "total_time": 56.802856189,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb",
-        "total_time": 54.68207817,
+        "total_time": 53.117172656,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb:11",
-            "total_time": 54.68207817,
+            "total_time": 53.117172656,
             "description": "Delete empty SO enrollments"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb",
-        "total_time": 47.328265977,
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb",
+        "total_time": 51.539142224,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb:13",
-            "total_time": 47.328265977,
-            "description": "Hmis::GraphqlController"
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb:11",
+            "total_time": 51.539142224,
+            "description": "HmisCsvImporter"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb",
-        "total_time": 46.023387128,
+        "file_path": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb",
+        "total_time": 48.097286104,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb:7",
-            "total_time": 46.023387128,
+            "location": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb:13",
+            "total_time": 48.097286104,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
         "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb",
-        "total_time": 41.672431651,
+        "total_time": 42.364893387,
         "groups": [
           {
             "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb:12",
-            "total_time": 41.672431651,
+            "total_time": 42.364893387,
             "description": "HudSpmReport::Generators::Fy2026::MeasureOne"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb",
+        "total_time": 38.708564903,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb:13",
+            "total_time": 38.708564903,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb",
+        "total_time": 37.13042998,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb:13",
+            "total_time": 37.13042998,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb",
-        "total_time": 33.816326378,
+        "total_time": 34.081419399,
         "groups": [
           {
             "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb:18",
-            "total_time": 33.816326378,
+            "total_time": 34.081419399,
             "description": "HmisCsvTwentyTwentySix::Exporter::Base"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb",
-        "total_time": 31.544501298,
+        "total_time": 32.150837514,
         "groups": [
           {
             "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb:17",
-            "total_time": 31.544501298,
+            "total_time": 32.150837514,
             "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb",
-        "total_time": 31.076313025,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb:12",
-            "total_time": 31.076313025,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivingSituationSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb",
-        "total_time": 30.201493166,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb:13",
-            "total_time": 30.201493166,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb",
-        "total_time": 29.9458141,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
-            "total_time": 29.9458141,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb",
-        "total_time": 29.790909441,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb:13",
-            "total_time": 29.790909441,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb",
-        "total_time": 29.566288478,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb:18",
-            "total_time": 29.566288478,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb",
-        "total_time": 29.437301087,
+        "total_time": 31.412302354,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb:11",
-            "total_time": 29.437301087,
+            "total_time": 31.412302354,
             "description": "HmisCsvImporter"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb",
+        "total_time": 30.498221091,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
+            "total_time": 30.498221091,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb",
+        "total_time": 30.209602506,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb:18",
+            "total_time": 30.209602506,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb",
-        "total_time": 28.691057831,
+        "total_time": 29.460163376,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb:13",
-            "total_time": 28.691057831,
+            "total_time": 29.460163376,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/models/hmis/access_group_spec.rb",
-        "total_time": 27.552448942,
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb",
+        "total_time": 28.338824223,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/models/hmis/access_group_spec.rb:13",
-            "total_time": 27.552448942,
-            "description": "Hmis::AccessGroup"
+            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb:7",
+            "total_time": 28.338824223,
+            "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb",
-        "total_time": 26.526528395,
+        "total_time": 27.682466116,
         "groups": [
           {
             "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb:12",
-            "total_time": 26.526528395,
+            "total_time": 27.682466116,
             "description": "HmisDataQualityTool::Report"
           }
         ]
       },
       {
-        "file_path": "./spec/models/filters/criteria/filter_for_projects_spec.rb",
-        "total_time": 23.963797601,
+        "file_path": "./drivers/hmis/spec/models/hmis/access_group_spec.rb",
+        "total_time": 27.122000447,
         "groups": [
           {
-            "location": "./spec/models/filters/criteria/filter_for_projects_spec.rb:6",
-            "total_time": 23.963797601,
-            "description": "Filters::Criteria::FilterForProjects"
+            "location": "./drivers/hmis/spec/models/hmis/access_group_spec.rb:13",
+            "total_time": 27.122000447,
+            "description": "Hmis::AccessGroup"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb",
+        "total_time": 25.054560988,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb:12",
+            "total_time": 25.054560988,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivingSituationSheet"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb",
-        "total_time": 22.042297225,
+        "total_time": 22.794410415,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb:13",
-            "total_time": 22.042297225,
+            "total_time": 22.794410415,
             "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb",
-        "total_time": 20.660542884,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb:13",
-            "total_time": 20.660542884,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb",
-        "total_time": 20.123963069,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb:12",
-            "total_time": 20.123963069,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/service_history_service_spec.rb",
-        "total_time": 17.583577061,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/service_history_service_spec.rb:6",
-            "total_time": 17.583577061,
-            "description": "GrdaWarehouse::ServiceHistoryService"
           }
         ]
       },
       {
         "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb",
-        "total_time": 16.870458221,
+        "total_time": 20.005543711,
         "groups": [
           {
             "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb:12",
-            "total_time": 16.870458221,
+            "total_time": 20.005543711,
             "description": "HudSpmReport::Generators::Fy2026::MeasureFive"
           }
         ]
       },
       {
-        "file_path": "./spec/models/access_control_upload_spec.rb",
-        "total_time": 15.988152366,
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb",
+        "total_time": 18.657291788,
         "groups": [
           {
-            "location": "./spec/models/access_control_upload_spec.rb:5",
-            "total_time": 15.988152366,
-            "description": "AccessControlUpload"
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb:12",
+            "total_time": 18.657291788,
+            "description": "HmisDataQualityTool::Report"
           }
         ]
       },
       {
-        "file_path": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb",
-        "total_time": 15.421132572,
+        "file_path": "./drivers/hmis/spec/models/hmis/reminder_spec.rb",
+        "total_time": 18.074007086,
         "groups": [
           {
-            "location": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb:6",
-            "total_time": 15.421132572,
-            "description": "WarehouseReports::ClientDetails::ActivesController"
+            "location": "./drivers/hmis/spec/models/hmis/reminder_spec.rb:12",
+            "total_time": 18.074007086,
+            "description": "Hmis::Reminders::ReminderGenerator"
           }
         ]
       },
       {
-        "file_path": "./spec/models/filters/criteria/filter_for_range_spec.rb",
-        "total_time": 15.102147831,
+        "file_path": "./spec/models/filters/criteria/filter_for_projects_spec.rb",
+        "total_time": 16.784376343,
         "groups": [
           {
-            "location": "./spec/models/filters/criteria/filter_for_range_spec.rb:6",
-            "total_time": 15.102147831,
-            "description": "Filters::Criteria::FilterForRange"
+            "location": "./spec/models/filters/criteria/filter_for_projects_spec.rb:6",
+            "total_time": 16.784376343,
+            "description": "Filters::Criteria::FilterForProjects"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/service_history_service_spec.rb",
+        "total_time": 16.414336345,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/service_history_service_spec.rb:6",
+            "total_time": 16.414336345,
+            "description": "GrdaWarehouse::ServiceHistoryService"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb",
-        "total_time": 14.511413996,
+        "total_time": 15.47226045,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb:6",
-            "total_time": 14.511413996,
+            "total_time": 15.47226045,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
+        "file_path": "./spec/models/access_control_upload_spec.rb",
+        "total_time": 15.060495814,
+        "groups": [
+          {
+            "location": "./spec/models/access_control_upload_spec.rb:5",
+            "total_time": 15.060495814,
+            "description": "AccessControlUpload"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_range_spec.rb",
+        "total_time": 14.562837918,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_range_spec.rb:6",
+            "total_time": 14.562837918,
+            "description": "Filters::Criteria::FilterForRange"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb",
+        "total_time": 14.384052456,
+        "groups": [
+          {
+            "location": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb:6",
+            "total_time": 14.384052456,
+            "description": "WarehouseReports::ClientDetails::ActivesController"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb",
-        "total_time": 14.180581531,
+        "total_time": 13.491590596,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb:7",
-            "total_time": 14.180581531,
+            "total_time": 13.491590596,
             "description": "Mutations::Ce::StartCeReferralStep"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/update_unit_group_spec.rb",
-        "total_time": 12.804664315,
+        "total_time": 11.766347712,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/update_unit_group_spec.rb:13",
-            "total_time": 12.804664315,
+            "total_time": 11.766347712,
             "description": "UpdateUnitGroup Mutation"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb",
-        "total_time": 11.555514525,
+        "total_time": 10.762473085,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb:13",
-            "total_time": 11.555514525,
+            "total_time": 10.762473085,
             "description": "Graphql HMIS Assessment Eligibility"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bucket-10",
+    "total_time": 2497.8987589343005,
+    "specs": [
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/submit_form_spec.rb",
+        "total_time": 470.1292389264,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/submit_form_spec.rb:15",
+            "total_time": 391.774365772,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/requests/rack_attack_spec.rb",
+        "total_time": 283.6108071698,
+        "groups": [
+          {
+            "location": "./spec/requests/rack_attack_spec.rb:13",
+            "total_time": 257.828006518,
+            "description": "Rack::Attack"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/bad_data_spec.rb",
+        "total_time": 238.1913479979,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/bad_data_spec.rb:11",
+            "total_time": 216.537589089,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_organization_ids_spec.rb",
+        "total_time": 213.3747349184,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_organization_ids_spec.rb:11",
+            "total_time": 193.977031744,
+            "description": "Prepend Organization IDs"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_relationships_spec.rb",
+        "total_time": 131.46300704790002,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_relationships_spec.rb:11",
+            "total_time": 119.511824589,
+            "description": "Ensure Relationships"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/date_updated_spec.rb",
+        "total_time": 109.36758407960001,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/date_updated_spec.rb:11",
+            "total_time": 99.425076436,
+            "description": "HUD DateUpdated Tests"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/clean_up_move_in_dates_spec.rb",
+        "total_time": 84.8332533697,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/clean_up_move_in_dates_spec.rb:11",
+            "total_time": 77.121139427,
+            "description": "Clean Up Move In Dates"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/form/form_processor_spec.rb",
+        "total_time": 73.9294525453,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/form/form_processor_spec.rb:13",
+            "total_time": 67.208593223,
+            "description": "Hmis::Form::FormProcessor"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb",
+        "total_time": 66.7611350703,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb:13",
+            "total_time": 60.691940973,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/warehouse_reports/project/data_quality/version_four_spec.rb",
+        "total_time": 57.592318,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/warehouse_reports/project/data_quality/version_four_spec.rb:12",
+            "total_time": 57.592318,
+            "description": "GrdaWarehouse::WarehouseReports::Project::DataQuality::VersionFour"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/duplicate_primary_keys_spec.rb",
+        "total_time": 51.829172936,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/duplicate_primary_keys_spec.rb:11",
+            "total_time": 51.829172936,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb",
+        "total_time": 50.178971737,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb:13",
+            "total_time": 50.178971737,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb",
+        "total_time": 46.629883519,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb:13",
+            "total_time": 46.629883519,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_active_enrollment_spec.rb",
+        "total_time": 41.752288045,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_active_enrollment_spec.rb:13",
+            "total_time": 41.752288045,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/tasks/client_cleanup_spec.rb",
+        "total_time": 38.195412221,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/tasks/client_cleanup_spec.rb:40",
+            "total_time": 38.195412221,
+            "description": "GrdaWarehouse::Tasks::ClientCleanup"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb",
+        "total_time": 35.841534511,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb:13",
+            "total_time": 35.841534511,
+            "description": "Hmis::Hud::CustomAssessment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollment_visibility_spec.rb",
+        "total_time": 35.01282985,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/project_enrollment_visibility_spec.rb:13",
+            "total_time": 35.01282985,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/system_cohorts/system_cohort_spec.rb",
+        "total_time": 32.020279499,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/system_cohorts/system_cohort_spec.rb:5",
+            "total_time": 32.020279499,
+            "description": "GrdaWarehouse::SystemCohorts::CurrentlyHomeless"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb",
+        "total_time": 30.926652554,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb:11",
+            "total_time": 30.926652554,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hat_spec.rb",
+        "total_time": 30.335966136,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hat_spec.rb:5",
+            "total_time": 30.335966136,
+            "description": "GrdaWarehouse::CasProjectClientCalculator::TcHat"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/filter_coc_spec.rb",
+        "total_time": 30.239501656,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/filter_coc_spec.rb:12",
+            "total_time": 30.239501656,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/jobs/importing/run_daily_imports_job_spec.rb",
+        "total_time": 29.4994173,
+        "groups": [
+          {
+            "location": "./spec/jobs/importing/run_daily_imports_job_spec.rb:5",
+            "total_time": 29.4994173,
+            "description": "Importing::RunDailyImportsJob"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb",
+        "total_time": 28.359424049,
+        "groups": [
+          {
+            "location": "./drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb:11",
+            "total_time": 28.359424049,
+            "description": "BostonProjectScorecard::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/hud/assessment_spec.rb",
+        "total_time": 27.579030215,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/hud/assessment_spec.rb:13",
+            "total_time": 27.579030215,
+            "description": "Hmis::Hud::Assessment"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/combine_enrollments_spec.rb",
+        "total_time": 27.164980914,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/combine_enrollments_spec.rb:11",
+            "total_time": 27.164980914,
+            "description": "Combine Enrollments"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb",
+        "total_time": 25.924683179,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb:5",
+            "total_time": 25.924683179,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb",
+        "total_time": 22.010595274,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb:13",
+            "total_time": 22.010595274,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb",
+        "total_time": 19.513412305,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb:11",
+            "total_time": 19.513412305,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hap_report/spec/models/report_spec.rb",
+        "total_time": 19.081846269,
+        "groups": [
+          {
+            "location": "./drivers/hap_report/spec/models/report_spec.rb:11",
+            "total_time": 19.081846269,
+            "description": "HapReport::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/custom_imports_boston_service/spec/models/import_file_spec.rb",
+        "total_time": 18.11674524,
+        "groups": [
+          {
+            "location": "./drivers/custom_imports_boston_service/spec/models/import_file_spec.rb:11",
+            "total_time": 18.11674524,
+            "description": "CustomImportsBostonService::ImportFile"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_data_sources_spec.rb",
+        "total_time": 16.672380166,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_data_sources_spec.rb:6",
+            "total_time": 16.672380166,
+            "description": "Filters::Criteria::FilterForDataSources"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/warehouse_reports/hud_lot_spec.rb",
+        "total_time": 16.498550486,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/warehouse_reports/hud_lot_spec.rb:5",
+            "total_time": 16.498550486,
+            "description": "GrdaWarehouse::WarehouseReports::HudLot"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_households_spec.rb",
+        "total_time": 16.199350227,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_households_spec.rb:11",
+            "total_time": 16.199350227,
+            "description": "Ensure Households"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_dv_currently_fleeing_spec.rb",
+        "total_time": 14.900382532,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_dv_currently_fleeing_spec.rb:6",
+            "total_time": 14.900382532,
+            "description": "Filters::Criteria::FilterForDvCurrentlyFleeing"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/filters/criteria/filter_for_prior_living_situation_spec.rb",
+        "total_time": 14.448194075,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_prior_living_situation_spec.rb:6",
+            "total_time": 14.448194075,
+            "description": "Filters::Criteria::FilterForPriorLivingSituation"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_2_spec.rb",
+        "total_time": 14.185398698,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_2_spec.rb:12",
+            "total_time": 14.185398698,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureTwo"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb",
+        "total_time": 13.038106217,
+        "groups": [
+          {
+            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb:13",
+            "total_time": 13.038106217,
+            "description": "HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb",
+        "total_time": 12.043232362,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb:13",
+            "total_time": 12.043232362,
+            "description": "DeleteFormDefinition mutation"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb",
+        "total_time": 10.447657637,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb:13",
+            "total_time": 10.447657637,
+            "description": "Manage Scan Card Mutations"
           }
         ]
       }

--- a/.github/rspec_buckets.json
+++ b/.github/rspec_buckets.json
@@ -1,3567 +1,412 @@
 [
   {
     "id": "bucket-1",
-    "total_time": 2497.5185970584994,
-    "specs": [
-      {
-        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb",
-        "total_time": 2382.7637225055,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb:20",
-            "total_time": 1588.509148337,
-            "description": "ClientAccessControl::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/base_spec.rb",
-        "total_time": 16.546769084,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/base_spec.rb:6",
-            "total_time": 16.546769084,
-            "description": "Filters::Criteria::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/fix_household_ids_spec.rb",
-        "total_time": 16.290875981,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/fix_household_ids_spec.rb:11",
-            "total_time": 16.290875981,
-            "description": "Fix Household IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_race_ethnicity_combinations_spec.rb",
-        "total_time": 15.122921958,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_race_ethnicity_combinations_spec.rb:6",
-            "total_time": 15.122921958,
-            "description": "Filters::Criteria::FilterForRaceEthnicityCombinations"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_organziations_spec.rb",
-        "total_time": 14.790933048,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_organziations_spec.rb:6",
-            "total_time": 14.790933048,
-            "description": "Filters::Criteria::FilterForOrganizations"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb",
-        "total_time": 14.395867766,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/create_ce_referral_spec.rb:7",
-            "total_time": 14.395867766,
-            "description": "Mutations::Ce::CreateCeReferral"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_user_access_spec.rb",
-        "total_time": 13.934990207,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_user_access_spec.rb:6",
-            "total_time": 13.934990207,
-            "description": "Filters::Criteria::FilterForUserAccess"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_config_spec.rb",
-        "total_time": 12.609284885,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_config_spec.rb:13",
-            "total_time": 12.609284885,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/service_history_enrollment_spec.rb",
-        "total_time": 11.063231624,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/service_history_enrollment_spec.rb:16",
-            "total_time": 11.063231624,
-            "description": "GrdaWarehouse::ServiceHistoryEnrollment"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-2",
-    "total_time": 2497.9778726870004,
-    "specs": [
-      {
-        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb",
-        "total_time": 1872.562128285,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb:20",
-            "total_time": 1248.37475219,
-            "description": "ClientAccessControl::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb",
-        "total_time": 42.779507065,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb:11",
-            "total_time": 42.779507065,
-            "description": "GrdaWarehouse::Tasks::IdentifyDuplicates"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/delete_service_spec.rb",
-        "total_time": 38.985558369,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/delete_service_spec.rb:13",
-            "total_time": 38.985558369,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/requests/health/team_patients_performance_spec.rb",
-        "total_time": 37.330205385,
-        "groups": [
-          {
-            "location": "./spec/requests/health/team_patients_performance_spec.rb:11",
-            "total_time": 37.330205385,
-            "description": "Health::TeamPatientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/app_resource_monitor/report_spec.rb",
-        "total_time": 35.172437698,
-        "groups": [
-          {
-            "location": "./spec/models/app_resource_monitor/report_spec.rb:5",
-            "total_time": 35.172437698,
-            "description": "AppResourceMonitor::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_spec.rb",
-        "total_time": 33.067801489,
-        "groups": [
-          {
-            "location": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_spec.rb:11",
-            "total_time": 33.067801489,
-            "description": "MaReports::CsgEngage::ReportComponents::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb",
-        "total_time": 31.454253738,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_hashed_exports_spec.rb:12",
-            "total_time": 31.454253738,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_project_related_exports_spec.rb",
-        "total_time": 30.789579388,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_project_related_exports_spec.rb:13",
-            "total_time": 30.789579388,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/client_spec.rb",
-        "total_time": 30.162952961,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/client_spec.rb:12",
-            "total_time": 30.162952961,
-            "description": "Hmis::Hud::Client"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/manual_entry_spec.rb",
-        "total_time": 29.091685893,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/manual_entry_spec.rb:11",
-            "total_time": 29.091685893,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/client_access_spec.rb",
-        "total_time": 28.44788305,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/client_access_spec.rb:12",
-            "total_time": 28.44788305,
-            "description": "Hmis::Hud::Client"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/allowlist_spec.rb",
-        "total_time": 27.685451192,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/allowlist_spec.rb:11",
-            "total_time": 27.685451192,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/get_projects_spec.rb",
-        "total_time": 27.381188287,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/get_projects_spec.rb:13",
-            "total_time": 27.381188287,
-            "description": "GetProjects query"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/hopwa_caper/drilldown_presenter_spec.rb",
-        "total_time": 24.490681089,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/hopwa_caper/drilldown_presenter_spec.rb:6",
-            "total_time": 24.490681089,
-            "description": "HopwaCaper::DrilldownPresenter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb",
-        "total_time": 23.055088191,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_strmu_spec.rb:12",
-            "total_time": 23.055088191,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::StrmuSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb",
-        "total_time": 20.468076416,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/ce/match_engine_spec.rb:6",
-            "total_time": 20.468076416,
-            "description": "Hmis::Ce::Match::Engine"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/user_ce_steps_spec.rb",
-        "total_time": 18.510686687,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/user_ce_steps_spec.rb:12",
-            "total_time": 18.510686687,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/requests/clients/notes_controller_spec.rb",
-        "total_time": 18.048628477,
-        "groups": [
-          {
-            "location": "./spec/requests/clients/notes_controller_spec.rb:7",
-            "total_time": 18.048628477,
-            "description": "Clients::NotesController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb",
-        "total_time": 16.603008001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/ce/referral_enroller_spec.rb:11",
-            "total_time": 16.603008001,
-            "description": "Hmis::Ce::ReferralEnroller"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/cell_detail_export_builder_spec.rb",
-        "total_time": 16.540044306,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/cell_detail_export_builder_spec.rb:6",
-            "total_time": 16.540044306,
-            "description": "HudSpmReport::CellDetailExportBuilder"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/publish_form_definition_spec.rb",
-        "total_time": 16.242428424,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/publish_form_definition_spec.rb:13",
-            "total_time": 16.242428424,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_psh_move_in_spec.rb",
-        "total_time": 14.882738621,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_psh_move_in_spec.rb:6",
-            "total_time": 14.882738621,
-            "description": "Filters::Criteria::FilterForPshMoveIn"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/active_record_preload_spec.rb",
-        "total_time": 14.447163224,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/active_record_preload_spec.rb:11",
-            "total_time": 14.447163224,
-            "description": "Active Record Preload API"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_project_cocs_spec.rb",
-        "total_time": 14.035702858,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_project_cocs_spec.rb:6",
-            "total_time": 14.035702858,
-            "description": "Filters::Criteria::FilterForProjectCocs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/merge_clients_spec.rb",
-        "total_time": 13.0607709,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/merge_clients_spec.rb:13",
-            "total_time": 13.0607709,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_opportunities_spec.rb",
-        "total_time": 12.145740853,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_opportunities_spec.rb:5",
-            "total_time": 12.145740853,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/external_form_submissions_spec.rb",
-        "total_time": 10.53648184,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/external_form_submissions_spec.rb:13",
-            "total_time": 10.53648184,
-            "description": "External Referral Form Submissions"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-3",
-    "total_time": 2498.2478941739996,
-    "specs": [
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb",
-        "total_time": 1825.201324803,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/datalab_testkit/all_projects_spec.rb:13",
-            "total_time": 1216.800883202,
-            "description": "Datalab Testkit SPM All-Projects"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_basic_counts_spec.rb",
-        "total_time": 48.332104832,
-        "groups": [
-          {
-            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_basic_counts_spec.rb:12",
-            "total_time": 48.332104832,
-            "description": "PIT Basic Counts"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/loader_errors_spec.rb",
-        "total_time": 42.559792793,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/loader_errors_spec.rb:11",
-            "total_time": 42.559792793,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/get_units_spec.rb",
-        "total_time": 38.945701567,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/get_units_spec.rb:13",
-            "total_time": 38.945701567,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_service_filter_spec.rb",
-        "total_time": 37.266276649,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_service_filter_spec.rb:13",
-            "total_time": 37.266276649,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/delete_file_spec.rb",
-        "total_time": 35.05167391,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/delete_file_spec.rb:13",
-            "total_time": 35.05167391,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_service_filter_spec.rb",
-        "total_time": 32.81266796,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/enrollment_service_filter_spec.rb:13",
-            "total_time": 32.81266796,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/auto_exit_job_spec.rb",
-        "total_time": 31.397975366,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/auto_exit_job_spec.rb:11",
-            "total_time": 31.397975366,
-            "description": "Hmis::AutoExitJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_exports_spec.rb",
-        "total_time": 30.497248785,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_exports_spec.rb:17",
-            "total_time": 30.497248785,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/access_control_spec.rb",
-        "total_time": 30.230948605,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/access_control_spec.rb:13",
-            "total_time": 30.230948605,
-            "description": "Hmis::AccessControl"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_services_visibility_spec.rb",
-        "total_time": 29.133691876,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/enrollment_services_visibility_spec.rb:13",
-            "total_time": 29.133691876,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/validations_spec.rb",
-        "total_time": 28.384028555,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/validations_spec.rb:11",
-            "total_time": 28.384028555,
-            "description": "Validate import files"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/ad_hoc_batch_spec.rb",
-        "total_time": 27.711715397,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/ad_hoc_batch_spec.rb:11",
-            "total_time": 27.711715397,
-            "description": "GrdaWarehouse::AdHocBatch"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/project_validation_constraint_spec.rb",
-        "total_time": 27.388881729,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/project_validation_constraint_spec.rb:11",
-            "total_time": 27.388881729,
-            "description": "Project validation with constraint lambda"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb",
-        "total_time": 24.458220167,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb:12",
-            "total_time": 24.458220167,
-            "description": "HmisCsvImporter::Cleanup::ExpireImportersJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/activity_log_processor_job_spec.rb",
-        "total_time": 23.330513768,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/activity_log_processor_job_spec.rb:11",
-            "total_time": 23.330513768,
-            "description": "Hmis::ActivityLogProcessorJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/get_unit_spec.rb",
-        "total_time": 20.319227114,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/get_unit_spec.rb:7",
-            "total_time": 20.319227114,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb",
-        "total_time": 18.509678059,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb:11",
-            "total_time": 18.509678059,
-            "description": "Hmis::Ce::ReferralCeEventManager"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/talentlms/facade_spec.rb",
-        "total_time": 17.7007015,
-        "groups": [
-          {
-            "location": "./spec/models/talentlms/facade_spec.rb:10",
-            "total_time": 17.7007015,
-            "description": "Talentlms::Facade"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_3_spec.rb",
-        "total_time": 16.949445076,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_3_spec.rb:12",
-            "total_time": 16.949445076,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureThree"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/warehouse_clients_processed_spec.rb",
-        "total_time": 16.479384709,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/warehouse_clients_processed_spec.rb:5",
-            "total_time": 16.479384709,
-            "description": "GrdaWarehouse::WarehouseClientsProcessed"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_veteran_counts_spec.rb",
-        "total_time": 15.492453009,
-        "groups": [
-          {
-            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_veteran_counts_spec.rb:12",
-            "total_time": 15.492453009,
-            "description": "PIT Veteran Counts"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_times_homeless_spec.rb",
-        "total_time": 15.039998074,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_times_homeless_spec.rb:6",
-            "total_time": 15.039998074,
-            "description": "Filters::Criteria::FilterForTimesHomeless"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_destination_spec.rb",
-        "total_time": 14.574150811,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_destination_spec.rb:6",
-            "total_time": 14.574150811,
-            "description": "Filters::Criteria::FilterForDestination"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_rrh_move_in_spec.rb",
-        "total_time": 14.361915479,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_rrh_move_in_spec.rb:6",
-            "total_time": 14.361915479,
-            "description": "Filters::Criteria::FilterForRrhMoveIn"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb",
-        "total_time": 13.865684873,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/bulk_remove_service_spec.rb:13",
-            "total_time": 13.865684873,
-            "description": "BulkRemoveService"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/client_file_spec.rb",
-        "total_time": 11.253651233,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/client_file_spec.rb:11",
-            "total_time": 11.253651233,
-            "description": "GrdaWarehouse::ClientFile"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/hmis_activity_log_spec.rb",
-        "total_time": 10.998837475,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/hmis_activity_log_spec.rb:13",
-            "total_time": 10.998837475,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-4",
-    "total_time": 2488.9113953465,
-    "specs": [
-      {
-        "file_path": "./drivers/hud_apr/spec/models/fy2026/datalab_2_0_spec.rb",
-        "total_time": 1746.0347882355,
-        "groups": [
-          {
-            "location": "./drivers/hud_apr/spec/models/fy2026/datalab_2_0_spec.rb:26",
-            "total_time": 1164.023192157,
-            "description": "Datalab 2026"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb",
-        "total_time": 51.6284343,
-        "groups": [
-          {
-            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_parenting_youth_spec.rb:12",
-            "total_time": 51.6284343,
-            "description": "PIT Parenting Youth Counts"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/users_access_summary_spec.rb",
-        "total_time": 49.667771186,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/users_access_summary_spec.rb:13",
-            "total_time": 49.667771186,
-            "description": "User access summary query"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb",
-        "total_time": 45.885085929,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_enrollments_visibility_spec.rb:13",
-            "total_time": 45.885085929,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/update_relationship_to_ho_h_spec.rb",
-        "total_time": 39.320377096,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/update_relationship_to_ho_h_spec.rb:13",
-            "total_time": 39.320377096,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb",
-        "total_time": 37.548324322,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb:13",
-            "total_time": 37.548324322,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/include_deleted_spec.rb",
-        "total_time": 35.72443153,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/include_deleted_spec.rb:12",
-            "total_time": 35.72443153,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/custom_file_exports_spec.rb",
-        "total_time": 33.534930815,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/custom_file_exports_spec.rb:12",
-            "total_time": 33.534930815,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb",
-        "total_time": 31.568381781,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb:13",
-            "total_time": 31.568381781,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/coc_exports_spec.rb",
-        "total_time": 30.877331273,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/coc_exports_spec.rb:17",
-            "total_time": 30.877331273,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/data_source_project_related_exports_spec.rb",
-        "total_time": 30.322154095,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/data_source_project_related_exports_spec.rb:18",
-            "total_time": 30.322154095,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/organization_project_related_exports_spec.rb",
-        "total_time": 29.923167531,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/organization_project_related_exports_spec.rb:18",
-            "total_time": 29.923167531,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/manual_entry_spec.rb",
-        "total_time": 28.728878256,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/manual_entry_spec.rb:11",
-            "total_time": 28.728878256,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_special_populations_spec.rb",
-        "total_time": 28.315893434,
-        "groups": [
-          {
-            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_special_populations_spec.rb:12",
-            "total_time": 28.315893434,
-            "description": "PIT Special Population Counts"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/inventory_spec.rb",
-        "total_time": 27.413338005,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/inventory_spec.rb:12",
-            "total_time": 27.413338005,
-            "description": "Hmis::Hud::Inventory"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb",
-        "total_time": 27.038558503,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/project_auto_exit_config_spec.rb:11",
-            "total_time": 27.038558503,
-            "description": "Hmis::ProjectAutoExitConfig"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/client_access_control/spec/requests/clients_legacy_spec.rb",
-        "total_time": 24.178988785,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/requests/clients_legacy_spec.rb:11",
-            "total_time": 24.178988785,
-            "description": "ClientAccessControl::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/process_pools_job_spec.rb",
-        "total_time": 21.38277848,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/hmis/ce/process_pools_job_spec.rb:12",
-            "total_time": 21.38277848,
-            "description": "Hmis::Ce::ProcessPoolsJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/split_household_spec.rb",
-        "total_time": 19.218837153,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/split_household_spec.rb:13",
-            "total_time": 19.218837153,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/submit_ce_referral_step_spec.rb",
-        "total_time": 18.261723825,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/submit_ce_referral_step_spec.rb:7",
-            "total_time": 18.261723825,
-            "description": "Mutations::Ce::SubmitCeReferralStep"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/merge_clients_job_spec.rb",
-        "total_time": 17.314984408,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/merge_clients_job_spec.rb:11",
-            "total_time": 17.314984408,
-            "description": "Hmis::MergeClientsJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/ch_enrollment_spec.rb",
-        "total_time": 16.549407892,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/ch_enrollment_spec.rb:5",
-            "total_time": 16.549407892,
-            "description": "GrdaWarehouse::ChEnrollment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb",
-        "total_time": 16.300123155,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb:12",
-            "total_time": 16.300123155,
-            "description": "HudSpmReport::Fy2026::SpmEnrollment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb",
-        "total_time": 15.127686218,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/create_direct_ce_referral_spec.rb:7",
-            "total_time": 15.127686218,
-            "description": "Mutations::Ce::CreateDirectCeReferral"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb",
-        "total_time": 14.831453192,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb:13",
-            "total_time": 14.831453192,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::AccessToCareSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/episode_batch_spec.rb",
-        "total_time": 14.403211259,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/episode_batch_spec.rb:6",
-            "total_time": 14.403211259,
-            "description": "HudSpmReport::Fy2026::EpisodeBatch"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb",
-        "total_time": 14.032420505,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/update_form_definition_spec.rb:13",
-            "total_time": 14.032420505,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb",
-        "total_time": 12.707320356,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/staff_assignment_spec.rb:13",
-            "total_time": 12.707320356,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb",
-        "total_time": 11.070613827,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb:11",
-            "total_time": 11.070613827,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-5",
-    "total_time": 2487.711231869899,
-    "specs": [
-      {
-        "file_path": "./drivers/hud_path_report/spec/models/fy2026/datalab_2026_spec.rb",
-        "total_time": 1000.7898478724999,
-        "groups": [
-          {
-            "location": "./drivers/hud_path_report/spec/models/fy2026/datalab_2026_spec.rb:15",
-            "total_time": 667.193231915,
-            "description": "PATH Datalab 2026"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_organization_ids_spec.rb",
-        "total_time": 164.6463615346,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_organization_ids_spec.rb:11",
-            "total_time": 149.678510486,
-            "description": "Append Organization IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/performance_measurement/spec/models/performance_measurement/report_spec.rb",
-        "total_time": 143.1583154815,
-        "groups": [
-          {
-            "location": "./drivers/performance_measurement/spec/models/performance_measurement/report_spec.rb:11",
-            "total_time": 130.143923165,
-            "description": "PerformanceMeasurement::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_relationships_spec.rb",
-        "total_time": 124.36291410180002,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_relationships_spec.rb:11",
-            "total_time": 113.057194638,
-            "description": "Ensure Relationships"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/clean_up_move_in_dates_spec.rb",
-        "total_time": 92.86576400530001,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/clean_up_move_in_dates_spec.rb:11",
-            "total_time": 84.423421823,
-            "description": "Clean Up Move In Dates"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb",
-        "total_time": 79.83364925800001,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb:12",
-            "total_time": 72.57604478,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb",
-        "total_time": 66.46289477520001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb:13",
-            "total_time": 60.420813432,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/hud/enrollment_spec.rb",
-        "total_time": 56.490978525,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/hud/enrollment_spec.rb:6",
-            "total_time": 56.490978525,
-            "description": "GrdaWarehouse::Hud::Enrollment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/importer/custom_files_integration_spec.rb",
-        "total_time": 51.91749873,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/importer/custom_files_integration_spec.rb:11",
-            "total_time": 51.91749873,
-            "description": "Custom Files Integration"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb",
-        "total_time": 50.47043371,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/custom_data_elements_spec.rb:13",
-            "total_time": 50.47043371,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb",
-        "total_time": 47.620872467,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb:13",
-            "total_time": 47.620872467,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/organization_spec.rb",
-        "total_time": 39.845799175,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/organization_spec.rb:13",
-            "total_time": 39.845799175,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb",
-        "total_time": 38.34442722,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/filter_assessment_spec.rb:13",
-            "total_time": 38.34442722,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb",
-        "total_time": 37.051365027,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/enrollment_spec.rb:13",
-            "total_time": 37.051365027,
-            "description": "Hmis::Hud::Enrollment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb",
-        "total_time": 34.085112515,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/income_benefits_metrics_spec.rb:12",
-            "total_time": 34.085112515,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb",
-        "total_time": 32.531826235,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/open_enrollment_summary_spec.rb:13",
-            "total_time": 32.531826235,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat_spec.rb",
-        "total_time": 30.950522953,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hmis_hat_spec.rb:5",
-            "total_time": 30.950522953,
-            "description": "GrdaWarehouse::CasProjectClientCalculator::TcHat"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/project_group_project_related_exports_spec.rb",
-        "total_time": 30.783604806,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
-            "total_time": 30.783604806,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb",
-        "total_time": 29.989098783,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_tbra_spec.rb:12",
-            "total_time": 29.989098783,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::TbraSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/rounding_spec.rb",
-        "total_time": 29.862492194,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/rounding_spec.rb:12",
-            "total_time": 29.862492194,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/combine_enrollments_spec.rb",
-        "total_time": 28.317603813,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/combine_enrollments_spec.rb:11",
-            "total_time": 28.317603813,
-            "description": "Combine Enrollments"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/user_permission_spec.rb",
-        "total_time": 27.553603487,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/user_permission_spec.rb:13",
-            "total_time": 27.553603487,
-            "description": "Hmis::User"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/ad_hoc_data_source_spec.rb",
-        "total_time": 27.113441518,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/ad_hoc_data_source_spec.rb:6",
-            "total_time": 27.113441518,
-            "description": "GrdaWarehouse::AdHocDataSource"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb",
-        "total_time": 24.440202375,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/services_metrics_spec.rb:12",
-            "total_time": 24.440202375,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb",
-        "total_time": 22.914132725,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/delete_assessment_spec.rb:13",
-            "total_time": 22.914132725,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_race_spec.rb",
-        "total_time": 20.84156153,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_race_spec.rb:6",
-            "total_time": 20.84156153,
-            "description": "Filters::Criteria::FilterForRace"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_services_spec.rb",
-        "total_time": 18.325831092,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_services_spec.rb:13",
-            "total_time": 18.325831092,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/concurrent_processing_spec.rb",
-        "total_time": 17.533693398,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/hmis/ce/concurrent_processing_spec.rb:12",
-            "total_time": 17.533693398,
-            "description": "Concurrent CE Processing"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_sub_population_spec.rb",
-        "total_time": 17.182659907,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_sub_population_spec.rb:6",
-            "total_time": 17.182659907,
-            "description": "Filters::Criteria::FilterForSubPopulation"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_household_type_spec.rb",
-        "total_time": 16.380205368,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_household_type_spec.rb:6",
-            "total_time": 16.380205368,
-            "description": "Filters::Criteria::FilterForHouseholdType"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_projects_hud_spec.rb",
-        "total_time": 15.263845647,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_projects_hud_spec.rb:6",
-            "total_time": 15.263845647,
-            "description": "Filters::Criteria::FilterForProjectsHud"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_project_type_spec.rb",
-        "total_time": 15.094381117,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_project_type_spec.rb:6",
-            "total_time": 15.094381117,
-            "description": "Filters::Criteria::FilterForProjectType"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/users_spec.rb",
-        "total_time": 14.657715987,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/users_spec.rb:13",
-            "total_time": 14.657715987,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_head_of_household_spec.rb",
-        "total_time": 14.388287417,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_head_of_household_spec.rb:6",
-            "total_time": 14.388287417,
-            "description": "Filters::Criteria::FilterForHeadOfHousehold"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_6_spec.rb",
-        "total_time": 13.884986946,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_6_spec.rb:12",
-            "total_time": 13.884986946,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureSix"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb",
-        "total_time": 11.755300174,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/delete_enrollment_spec.rb:13",
-            "total_time": 11.755300174,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-6",
-    "total_time": 2497.900472951999,
-    "specs": [
-      {
-        "file_path": "./drivers/datalab_testkit/spec/empty_spec.rb",
-        "total_time": 903.998175231,
-        "groups": [
-          {
-            "location": "./drivers/datalab_testkit/spec/empty_spec.rb:12",
-            "total_time": 602.665450154,
-            "description": "Empty test to load fixpoints"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/features/accounts_spec.rb",
-        "total_time": 224.857521493,
-        "groups": [
-          {
-            "location": "./spec/features/accounts_spec.rb:5",
-            "total_time": 204.41592863,
-            "description": "Accounts"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_project_ids_spec.rb",
-        "total_time": 144.5962311728,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/append_project_ids_spec.rb:11",
-            "total_time": 131.451119248,
-            "description": "Append Project IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_threshold_spec.rb",
-        "total_time": 129.04925219120003,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_threshold_spec.rb:11",
-            "total_time": 117.317501992,
-            "description": "GrdaWarehouse::ImportThreshold"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/client_access_control/spec/requests/clients_spec.rb",
-        "total_time": 93.91889413060001,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/requests/clients_spec.rb:14",
-            "total_time": 85.380812846,
-            "description": "ClientAccessControl::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cas_active_spec.rb",
-        "total_time": 83.17745629160001,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cas_active_spec.rb:5",
-            "total_time": 75.615869356,
-            "description": "GrdaWarehouse::ServiceHistoryService"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_search_spec.rb",
-        "total_time": 70.43151339180001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_search_spec.rb:13",
-            "total_time": 64.028648538,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb",
-        "total_time": 58.557123999,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb:91",
-            "total_time": 29.89031379,
-            "description": "Project and organization confidential items"
-          },
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/confidential_spec.rb:12",
-            "total_time": 28.666810209,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb",
-        "total_time": 53.472878198,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb:13",
-            "total_time": 53.472878198,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb",
-        "total_time": 51.574740129,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/form_definition_rules_spec.rb:19",
-            "total_time": 51.574740129,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/public_reports/spec/models/public_reports_spec.rb",
-        "total_time": 48.446614697,
-        "groups": [
-          {
-            "location": "./drivers/public_reports/spec/models/public_reports_spec.rb:11",
-            "total_time": 48.446614697,
-            "description": "PublicReports::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb",
-        "total_time": 45.574616993,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/update_external_form_submission_spec.rb:13",
-            "total_time": 45.574616993,
-            "description": "Update External Form Submission"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb",
-        "total_time": 39.137147836,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_chronic_homelessness_spec.rb:13",
-            "total_time": 39.137147836,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_filter_spec.rb",
-        "total_time": 37.493658936,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/date_range_filter_spec.rb:12",
-            "total_time": 37.493658936,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/health/comprehensive_health_assessment_spec.rb",
-        "total_time": 35.215240971,
-        "groups": [
-          {
-            "location": "./spec/models/health/comprehensive_health_assessment_spec.rb:5",
-            "total_time": 35.215240971,
-            "description": "Health::ComprehensiveHealthAssessment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/deidentified_spec.rb",
-        "total_time": 33.312455987,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/deidentified_spec.rb:11",
-            "total_time": 33.312455987,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_related_exports_spec.rb",
-        "total_time": 31.491233334,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/single_enrollment_related_exports_spec.rb:13",
-            "total_time": 31.491233334,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_hashed_exports_spec.rb",
-        "total_time": 30.80584352,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_hashed_exports_spec.rb:12",
-            "total_time": 30.80584352,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/client_processing_spec.rb",
-        "total_time": 30.243960071,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/client_processing_spec.rb:11",
-            "total_time": 30.243960071,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb",
-        "total_time": 29.89419175,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/coc_exports_spec.rb:17",
-            "total_time": 29.89419175,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb",
-        "total_time": 28.559298803,
-        "groups": [
-          {
-            "location": "./drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb:11",
-            "total_time": 28.559298803,
-            "description": "LongitudinalSpm::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb",
-        "total_time": 28.260480176,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/organization_access_spec.rb:12",
-            "total_time": 28.260480176,
-            "description": "Hmis::Hud::Project"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/client_alert_spec.rb",
-        "total_time": 27.396260488,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/client_alert_spec.rb:12",
-            "total_time": 27.396260488,
-            "description": "Hmis::ClientAlert"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb",
-        "total_time": 26.971204738,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb:11",
-            "total_time": 26.971204738,
-            "description": "Hmis::ProjectAutoEnterConfig"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb",
-        "total_time": 21.218972671,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_1a_spec.rb:12",
-            "total_time": 21.218972671,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureOne"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_clients_spec.rb",
-        "total_time": 19.200832245,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_clients_spec.rb:5",
-            "total_time": 19.200832245,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_7_spec.rb",
-        "total_time": 18.217150733,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_7_spec.rb:12",
-            "total_time": 18.217150733,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureSeven"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb",
-        "total_time": 17.21430496,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/bulk_review_external_submissions_spec.rb:13",
-            "total_time": 17.21430496,
-            "description": "Bulk Review External Submission"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_households_spec.rb",
-        "total_time": 16.355122872,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_households_spec.rb:11",
-            "total_time": 16.355122872,
-            "description": "Ensure Households"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/fitler_for_enrollment_cocs_spec.rb",
-        "total_time": 15.767939941,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/fitler_for_enrollment_cocs_spec.rb:6",
-            "total_time": 15.767939941,
-            "description": "Filters::Criteria::FilterForEnrollmentCocs"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_indefinite_disabilities_spec.rb",
-        "total_time": 15.024867635,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_indefinite_disabilities_spec.rb:6",
-            "total_time": 15.024867635,
-            "description": "Filters::Criteria::FilterForIndefiniteDisabilities"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_veteran_status_spec.rb",
-        "total_time": 14.463977822,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_veteran_status_spec.rb:6",
-            "total_time": 14.463977822,
-            "description": "Filters::Criteria::FilterForVeteranStatus"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_first_time_homelessness_in_past_two_years_spec.rb",
-        "total_time": 14.309518564,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_first_time_homelessness_in_past_two_years_spec.rb:6",
-            "total_time": 14.309518564,
-            "description": "Filters::Criteria::FilterForFirstTimeHomelessInPastTwoYears"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/requests/cohorts/clients_spec.rb",
-        "total_time": 13.127486104,
-        "groups": [
-          {
-            "location": "./spec/requests/cohorts/clients_spec.rb:12",
-            "total_time": 13.127486104,
-            "description": "Cohorts::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/warehouse_reports/youth/homeless_youth_report_spec.rb",
-        "total_time": 12.121558709,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/warehouse_reports/youth/homeless_youth_report_spec.rb:5",
-            "total_time": 12.121558709,
-            "description": "GrdaWarehouse::WarehouseReports::Youth::HomelessYouthReport"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/delete_client_spec.rb",
-        "total_time": 10.437756469,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/delete_client_spec.rb:13",
-            "total_time": 10.437756469,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-7",
-    "total_time": 2497.6744450476,
-    "specs": [
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/base_spec.rb",
-        "total_time": 556.9880918376,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/base_spec.rb:11",
-            "total_time": 464.156743198,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb",
-        "total_time": 239.74044523330002,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb:14",
-            "total_time": 217.945859303,
-            "description": "ClientAccessControl::ClientsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/force_prioritization_status_spec.rb",
-        "total_time": 227.64810579610003,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/force_prioritization_status_spec.rb:11",
-            "total_time": 206.952823451,
-            "description": "Force Assessment Prioritization Status"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/controllers/hmis_csv_importer/importer_errors_controller_spec.rb",
-        "total_time": 161.64527919210002,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/controllers/hmis_csv_importer/importer_errors_controller_spec.rb:7",
-            "total_time": 146.950253811,
-            "description": "HmisCsvImporter::ImporterErrorsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_threshold_spec.rb",
-        "total_time": 136.4579478372,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_threshold_spec.rb:11",
-            "total_time": 124.052679852,
-            "description": "GrdaWarehouse::ImportThreshold"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb",
-        "total_time": 120.63785955870001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb:16",
-            "total_time": 109.670781417,
-            "description": "Hmis::SessionsController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_project_ids_spec.rb",
-        "total_time": 85.66699281470001,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_project_ids_spec.rb:11",
-            "total_time": 77.879084377,
-            "description": "Prepend Project IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb",
-        "total_time": 74.0891574159,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/ce_referral_spec.rb:5",
-            "total_time": 67.353779469,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_race_ethnicity_spec.rb",
-        "total_time": 68.007860558,
-        "groups": [
-          {
-            "location": "./drivers/hud_pit/spec/models/hud_pit/generators/pit/fy2025/pit_race_ethnicity_spec.rb:12",
-            "total_time": 61.82532778,
-            "description": "PIT Race and Ethnicity Counts"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_override_spec.rb",
-        "total_time": 57.601445125,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/import_override_spec.rb:11",
-            "total_time": 57.601445125,
-            "description": "Applies overrides as expected"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb",
-        "total_time": 51.953053563,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb:91",
-            "total_time": 31.050445252,
-            "description": "Project and organization confidential items"
-          },
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/confidential_spec.rb:12",
-            "total_time": 20.902608311,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/get_project_unit_types_spec.rb",
-        "total_time": 51.276906479,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/get_project_unit_types_spec.rb:13",
-            "total_time": 51.276906479,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/unit_spec.rb",
-        "total_time": 46.397795793,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/unit_spec.rb:13",
-            "total_time": 46.397795793,
-            "description": "Hmis::Unit"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb",
-        "total_time": 41.732377812,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_legacy_spec.rb:12",
-            "total_time": 41.732377812,
-            "description": "GrdaWarehouse::Hud::Client"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_filter_spec.rb",
-        "total_time": 37.886092772,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_filter_spec.rb:12",
-            "total_time": 37.886092772,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_components/report_spec.rb",
-        "total_time": 36.609803295,
-        "groups": [
-          {
-            "location": "./drivers/ma_reports/spec/models/ma_reports/csg_engage/report_components/report_spec.rb:11",
-            "total_time": 36.609803295,
-            "description": "MaReports::CsgEngage::ReportComponents::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb",
-        "total_time": 33.919535727,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_household_assessments_spec.rb:13",
-            "total_time": 33.919535727,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb",
-        "total_time": 32.103612761,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/assign_referral_participants_spec.rb:6",
-            "total_time": 32.103612761,
-            "description": "Mutations::Ce::AssignReferralParticipants"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/form_identifier_spec.rb",
-        "total_time": 31.199053213,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/form_identifier_spec.rb:13",
-            "total_time": 31.199053213,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/mdha_spec.rb",
-        "total_time": 30.543196935,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/mdha_spec.rb:5",
-            "total_time": 30.543196935,
-            "description": "GrdaWarehouse::CasProjectClientCalculator::Mdha"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/rounding_spec.rb",
-        "total_time": 30.203803068,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/rounding_spec.rb:12",
-            "total_time": 30.203803068,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb",
-        "total_time": 28.841137802,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_metrics_spec.rb:12",
-            "total_time": 28.841137802,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/active_record_extended_merge_regression_spec.rb",
-        "total_time": 28.512516645,
-        "groups": [
-          {
-            "location": "./spec/models/active_record_extended_merge_regression_spec.rb:13",
-            "total_time": 28.512516645,
-            "description": "ActiveRecord merge with SqlLiteral canary"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb",
-        "total_time": 27.912364546,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/validations_spec.rb:11",
-            "total_time": 27.912364546,
-            "description": "Validate import files"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/project_config_spec.rb",
-        "total_time": 27.286157966,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/project_config_spec.rb:11",
-            "total_time": 27.286157966,
-            "description": "Hmis::ProjectConfig"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/join_household_spec.rb",
-        "total_time": 25.8359657,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/join_household_spec.rb:13",
-            "total_time": 25.8359657,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb",
-        "total_time": 22.032395226,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_search_performance_spec.rb:13",
-            "total_time": 22.032395226,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb",
-        "total_time": 19.728668329,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_can_accept_referral_spec.rb:13",
-            "total_time": 19.728668329,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/jobs/hmis/ce/process_clients_job_spec.rb",
-        "total_time": 18.980614414,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/jobs/hmis/ce/process_clients_job_spec.rb:12",
-            "total_time": 18.980614414,
-            "description": "Hmis::Ce::ProcessClientsJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_disabilities_spec.rb",
-        "total_time": 17.828162549,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_disabilities_spec.rb:6",
-            "total_time": 17.828162549,
-            "description": "Filters::Criteria::FilterForDisabilities"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/requests/clients/notes_controller_legacy_spec.rb",
-        "total_time": 16.934768275,
-        "groups": [
-          {
-            "location": "./spec/requests/clients/notes_controller_legacy_spec.rb:7",
-            "total_time": 16.934768275,
-            "description": "Clients::NotesController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/fix_household_ids_spec.rb",
-        "total_time": 16.456680401,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/fix_household_ids_spec.rb:11",
-            "total_time": 16.456680401,
-            "description": "Fix Household IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb",
-        "total_time": 15.628780754,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb:12",
-            "total_time": 15.628780754,
-            "description": "HopwaCaper::Generators::Fy2026::Generator"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_dv_status_spec.rb",
-        "total_time": 15.037883524,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_dv_status_spec.rb:6",
-            "total_time": 15.037883524,
-            "description": "Filters::Criteria::FilterForDvStatus"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/client_ce_referrals_spec.rb",
-        "total_time": 14.485029246,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/client_ce_referrals_spec.rb:11",
-            "total_time": 14.485029246,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_funders_spec.rb",
-        "total_time": 14.335883008,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_funders_spec.rb:6",
-            "total_time": 14.335883008,
-            "description": "Filters::Criteria::FilterForFunders"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/clear_mci_spec.rb",
-        "total_time": 13.378337965,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/clear_mci_spec.rb:13",
-            "total_time": 13.378337965,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb",
-        "total_time": 12.01263991,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb:13",
-            "total_time": 12.01263991,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_services_client_search_spec.rb",
-        "total_time": 10.138042001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/bulk_services_client_search_spec.rb:13",
-            "total_time": 10.138042001,
-            "description": "BulkAssignService"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-8",
-    "total_time": 2498.1110923569004,
-    "specs": [
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/base_spec.rb",
-        "total_time": 510.2449790016,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/base_spec.rb:11",
-            "total_time": 425.204149168,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/force_prioritization_status_spec.rb",
-        "total_time": 234.5006892591,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/force_prioritization_status_spec.rb:11",
-            "total_time": 213.182444781,
-            "description": "Force Assessment Prioritization Status"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/export_date_spec.rb",
-        "total_time": 208.80326054280002,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/export_date_spec.rb:11",
-            "total_time": 189.821145948,
-            "description": "HUD ExportDate Tests"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/export_date_spec.rb",
-        "total_time": 134.4342735076,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/export_date_spec.rb:11",
-            "total_time": 122.212975916,
-            "description": "HUD ExportDate Tests"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/date_updated_spec.rb",
-        "total_time": 101.6751346754,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/date_updated_spec.rb:11",
-            "total_time": 92.431940614,
-            "description": "HUD DateUpdated Tests"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/homeless_summary_report/spec/models/smoketest_spec.rb",
-        "total_time": 89.14609907830001,
-        "groups": [
-          {
-            "location": "./drivers/homeless_summary_report/spec/models/smoketest_spec.rb:12",
-            "total_time": 81.041908253,
-            "description": "HomelessSummaryReport::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_spec.rb",
-        "total_time": 78.35469547070001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_spec.rb:13",
-            "total_time": 71.231541337,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_spec.rb",
-        "total_time": 66.14923778320001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_spec.rb:13",
-            "total_time": 60.135670712,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_override_spec.rb",
-        "total_time": 54.216341262,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/import_override_spec.rb:11",
-            "total_time": 54.216341262,
-            "description": "Applies overrides as expected"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb",
-        "total_time": 52.841494207,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/bulk_assign_service_spec.rb:13",
-            "total_time": 52.841494207,
-            "description": "BulkAssignService"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb",
-        "total_time": 51.475795168,
-        "groups": [
-          {
-            "location": "./drivers/client_access_control/spec/models/grda_warehouse/hud/client_visibility_spec.rb:12",
-            "total_time": 51.475795168,
-            "description": "GrdaWarehouse::Hud::Client"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_visibility_spec.rb",
-        "total_time": 47.94559982,
-        "groups": [
-          {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/client_visibility_spec.rb:5",
-            "total_time": 47.94559982,
-            "description": "HmisDataQualityTool::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/loader_errors_spec.rb",
-        "total_time": 39.386217702,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/loader_errors_spec.rb:11",
-            "total_time": 39.386217702,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb",
-        "total_time": 38.754106783,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/hdx_upload_spec.rb:12",
-            "total_time": 38.754106783,
-            "description": "HudSpmReport::Generators::Fy2026::HdxUpload"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb",
-        "total_time": 37.013832936,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_households_performance_spec.rb:13",
-            "total_time": 37.013832936,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb",
-        "total_time": 34.275193321,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/mark_units_available_spec.rb:13",
-            "total_time": 34.275193321,
-            "description": "Mutations::Ce::MarkUnitsAvailable"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/organization_spec.rb",
-        "total_time": 32.137982837,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/organization_spec.rb:12",
-            "total_time": 32.137982837,
-            "description": "Hmis::Hud::Organization"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_related_exports_spec.rb",
-        "total_time": 31.252114661,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_related_exports_spec.rb:13",
-            "total_time": 31.252114661,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb",
-        "total_time": 30.711542133,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/ac_hmis/esg_funding_report_spec.rb:13",
-            "total_time": 30.711542133,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/include_deleted_spec.rb",
-        "total_time": 30.159087143,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/include_deleted_spec.rb:12",
-            "total_time": 30.159087143,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/household_spec.rb",
-        "total_time": 28.801530846,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/household_spec.rb:12",
-            "total_time": 28.801530846,
-            "description": "Hmis::Hud::Household"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb",
-        "total_time": 28.455425802,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_loaders_job_spec.rb:12",
-            "total_time": 28.455425802,
-            "description": "HmisCsvImporter::Cleanup::ExpireLoadersJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/allowlist_spec.rb",
-        "total_time": 28.11722748,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/allowlist_spec.rb:11",
-            "total_time": 28.11722748,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/project_access_spec.rb",
-        "total_time": 27.123226128,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/project_access_spec.rb:12",
-            "total_time": 27.123226128,
-            "description": "Hmis::Hud::Project"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/boston_spec.rb",
-        "total_time": 25.3751155,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/boston_spec.rb:11",
-            "total_time": 25.3751155,
-            "description": "GrdaWarehouse::CasProjectClientCalculator::Boston"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb",
-        "total_time": 22.605645851,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb:7",
-            "total_time": 22.605645851,
-            "description": "Hmis::ClientFilesController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cohort_automation_spec.rb",
-        "total_time": 19.360333435,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cohort_automation_spec.rb:6",
-            "total_time": 19.360333435,
-            "description": "GrdaWarehouse::Cohort"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb",
-        "total_time": 19.18883665,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb:7",
-            "total_time": 19.18883665,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/hud/disability_spec.rb",
-        "total_time": 18.051055476,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/hud/disability_spec.rb:6",
-            "total_time": 18.051055476,
-            "description": "GrdaWarehouse::Hud::Disability"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_age_spec.rb",
-        "total_time": 16.85415536,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_age_spec.rb:6",
-            "total_time": 16.85415536,
-            "description": "Filters::Criteria::FilterForAge"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_4_spec.rb",
-        "total_time": 16.34363173,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_4_spec.rb:12",
-            "total_time": 16.34363173,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureFour"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb",
-        "total_time": 14.944328179,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/mark_units_unavailable_spec.rb:13",
-            "total_time": 14.944328179,
-            "description": "Mutations::Ce::MarkUnitsUnavailable"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_gender_spec.rb",
-        "total_time": 14.450383501,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_gender_spec.rb:6",
-            "total_time": 14.450383501,
-            "description": "Filters::Criteria::FilterForGender"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb",
-        "total_time": 14.273914067,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hmis_data_cleanup_util_spec.rb:12",
-            "total_time": 14.273914067,
-            "description": "HmisDataCleanup::Util"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_housing_info_spec.rb",
-        "total_time": 13.343582056,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_housing_info_spec.rb:13",
-            "total_time": 13.343582056,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::HousingInfoSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/ce/referral_permission_spec.rb",
-        "total_time": 11.892801737,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/ce/referral_permission_spec.rb:13",
-            "total_time": 11.892801737,
-            "description": "Hmis::Ce::Referral"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/client_file_legacy_spec.rb",
-        "total_time": 10.682402568,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/client_file_legacy_spec.rb:5",
-            "total_time": 10.682402568,
-            "description": "GrdaWarehouse::ClientFile"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-9",
-    "total_time": 2498.1631156777994,
+    "total_time": 1997.3041592858,
     "specs": [
       {
         "file_path": "./drivers/client_access_control/spec/requests/client_visibility_spec.rb",
-        "total_time": 259.9262274466,
+        "total_time": 323.21395200820007,
         "groups": [
           {
             "location": "./drivers/client_access_control/spec/requests/client_visibility_spec.rb:14",
-            "total_time": 236.296570406,
+            "total_time": 293.830865462,
             "description": "ClientAccessControl::ClientsController"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/bad_data_spec.rb",
-        "total_time": 232.0012969208,
+        "total_time": 251.28714277370003,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/bad_data_spec.rb:11",
-            "total_time": 210.910269928,
+            "total_time": 228.442857067,
             "description": "HmisCsvImporter"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_organization_ids_spec.rb",
-        "total_time": 175.39587151130002,
+        "total_time": 175.29388320950002,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/prepend_organization_ids_spec.rb:11",
-            "total_time": 159.450792283,
+            "total_time": 159.358075645,
             "description": "Prepend Organization IDs"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb",
+        "total_time": 131.26155117460002,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb:13",
+            "total_time": 119.328682886,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_project_ids_spec.rb",
-        "total_time": 141.9473823504,
+        "total_time": 113.64458887430001,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_project_ids_spec.rb:11",
-            "total_time": 129.043074864,
+            "total_time": 103.313262613,
             "description": "Prepend Project IDs"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb",
-        "total_time": 121.68851756270001,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/pick_list_spec.rb:13",
-            "total_time": 110.625925057,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
         "file_path": "./spec/requests/sessions_controller_spec.rb",
-        "total_time": 90.1196959267,
+        "total_time": 88.6177871535,
         "groups": [
           {
             "location": "./spec/requests/sessions_controller_spec.rb:14",
-            "total_time": 81.926996297,
+            "total_time": 80.561624685,
             "description": "Users::SessionsController"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb",
-        "total_time": 77.8726561877,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb:13",
-            "total_time": 70.793323807,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/delete_empty_enrollments_spec.rb",
-        "total_time": 59.027578459,
+        "total_time": 59.556820444,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/delete_empty_enrollments_spec.rb:11",
-            "total_time": 59.027578459,
+            "total_time": 59.556820444,
             "description": "Delete empty SO enrollments"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb",
-        "total_time": 57.83348606,
+        "total_time": 58.962189195,
         "groups": [
           {
             "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/filter_coc_spec.rb:12",
-            "total_time": 57.83348606,
+            "total_time": 58.962189195,
             "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb",
-        "total_time": 53.117172656,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb:11",
-            "total_time": 53.117172656,
-            "description": "Delete empty SO enrollments"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb",
-        "total_time": 51.539142224,
+        "total_time": 56.802856189,
         "groups": [
           {
             "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/duplicate_primary_keys_spec.rb:11",
-            "total_time": 51.539142224,
+            "total_time": 56.802856189,
             "description": "HmisCsvImporter"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb",
-        "total_time": 48.097286104,
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb",
+        "total_time": 54.68207817,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb:13",
-            "total_time": 48.097286104,
-            "description": "Hmis::GraphqlController"
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/delete_empty_enrollments_spec.rb:11",
+            "total_time": 54.68207817,
+            "description": "Delete empty SO enrollments"
           }
         ]
       },
       {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb",
-        "total_time": 42.364893387,
+        "file_path": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb",
+        "total_time": 47.328265977,
         "groups": [
           {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb:12",
-            "total_time": 42.364893387,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureOne"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb",
-        "total_time": 38.708564903,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb:13",
-            "total_time": 38.708564903,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb",
-        "total_time": 37.13042998,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb:13",
-            "total_time": 37.13042998,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb",
-        "total_time": 34.081419399,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb:18",
-            "total_time": 34.081419399,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb",
-        "total_time": 32.150837514,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb:17",
-            "total_time": 32.150837514,
-            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb",
-        "total_time": 31.412302354,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb:11",
-            "total_time": 31.412302354,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb",
-        "total_time": 30.498221091,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
-            "total_time": 30.498221091,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb",
-        "total_time": 30.209602506,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb:18",
-            "total_time": 30.209602506,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb",
-        "total_time": 29.460163376,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb:13",
-            "total_time": 29.460163376,
+            "location": "./drivers/hmis/spec/requests/hmis/assessments/submit_hud_assessments_spec.rb:13",
+            "total_time": 47.328265977,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb",
-        "total_time": 28.338824223,
+        "total_time": 46.023387128,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb:7",
-            "total_time": 28.338824223,
+            "total_time": 46.023387128,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb",
-        "total_time": 27.682466116,
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb",
+        "total_time": 41.672431651,
         "groups": [
           {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb:12",
-            "total_time": 27.682466116,
-            "description": "HmisDataQualityTool::Report"
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_1b_spec.rb:12",
+            "total_time": 41.672431651,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureOne"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/models/hmis/access_group_spec.rb",
-        "total_time": 27.122000447,
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb",
+        "total_time": 33.816326378,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/models/hmis/access_group_spec.rb:13",
-            "total_time": 27.122000447,
-            "description": "Hmis::AccessGroup"
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/data_source_project_related_exports_spec.rb:18",
+            "total_time": 33.816326378,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb",
+        "total_time": 31.544501298,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/date_range_exports_spec.rb:17",
+            "total_time": 31.544501298,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
           }
         ]
       },
       {
         "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb",
-        "total_time": 25.054560988,
+        "total_time": 31.076313025,
         "groups": [
           {
             "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_demographics_and_prior_living_situation_spec.rb:12",
-            "total_time": 25.054560988,
+            "total_time": 31.076313025,
             "description": "HopwaCaper::Generators::Fy2026::Sheets::DemographicsAndPriorLivingSituationSheet"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb",
-        "total_time": 22.794410415,
+        "file_path": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb",
+        "total_time": 30.201493166,
         "groups": [
           {
-            "location": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb:13",
-            "total_time": 22.794410415,
+            "location": "./drivers/hmis/spec/requests/hmis/client_alert_spec.rb:13",
+            "total_time": 30.201493166,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb",
-        "total_time": 20.005543711,
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb",
+        "total_time": 29.9458141,
         "groups": [
           {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb:12",
-            "total_time": 20.005543711,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureFive"
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/project_group_project_related_exports_spec.rb:18",
+            "total_time": 29.9458141,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb",
-        "total_time": 18.657291788,
+        "file_path": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb",
+        "total_time": 29.790909441,
         "groups": [
           {
-            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb:12",
-            "total_time": 18.657291788,
+            "location": "./drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_project_related_exports_spec.rb:13",
+            "total_time": 29.790909441,
+            "description": "HmisCsvTwentyTwentySix::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb",
+        "total_time": 29.566288478,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/organization_project_related_exports_spec.rb:18",
+            "total_time": 29.566288478,
+            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb",
+        "total_time": 29.437301087,
+        "groups": [
+          {
+            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/deidentified_spec.rb:11",
+            "total_time": 29.437301087,
+            "description": "HmisCsvImporter"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb",
+        "total_time": 28.691057831,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/get_project_spec.rb:13",
+            "total_time": 28.691057831,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/models/hmis/access_group_spec.rb",
+        "total_time": 27.552448942,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/models/hmis/access_group_spec.rb:13",
+            "total_time": 27.552448942,
+            "description": "Hmis::AccessGroup"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb",
+        "total_time": 26.526528395,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_length_metrics_spec.rb:12",
+            "total_time": 26.526528395,
             "description": "HmisDataQualityTool::Report"
           }
         ]
       },
       {
-        "file_path": "./drivers/hmis/spec/models/hmis/reminder_spec.rb",
-        "total_time": 18.074007086,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/reminder_spec.rb:12",
-            "total_time": 18.074007086,
-            "description": "Hmis::Reminders::ReminderGenerator"
-          }
-        ]
-      },
-      {
         "file_path": "./spec/models/filters/criteria/filter_for_projects_spec.rb",
-        "total_time": 16.784376343,
+        "total_time": 23.963797601,
         "groups": [
           {
             "location": "./spec/models/filters/criteria/filter_for_projects_spec.rb:6",
-            "total_time": 16.784376343,
+            "total_time": 23.963797601,
             "description": "Filters::Criteria::FilterForProjects"
           }
         ]
       },
       {
-        "file_path": "./spec/models/grda_warehouse/service_history_service_spec.rb",
-        "total_time": 16.414336345,
+        "file_path": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb",
+        "total_time": 22.042297225,
         "groups": [
           {
-            "location": "./spec/models/grda_warehouse/service_history_service_spec.rb:6",
-            "total_time": 16.414336345,
-            "description": "GrdaWarehouse::ServiceHistoryService"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb",
-        "total_time": 15.47226045,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb:6",
-            "total_time": 15.47226045,
+            "location": "./drivers/hmis/spec/requests/hmis/project_outgoing_ce_referrals_spec.rb:13",
+            "total_time": 22.042297225,
             "description": "Hmis::GraphqlController"
           }
         ]
       },
       {
+        "file_path": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb",
+        "total_time": 20.660542884,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/service_type_spec.rb:13",
+            "total_time": 20.660542884,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb",
+        "total_time": 20.123963069,
+        "groups": [
+          {
+            "location": "./drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/insurance_metrics_spec.rb:12",
+            "total_time": 20.123963069,
+            "description": "HmisDataQualityTool::Report"
+          }
+        ]
+      },
+      {
+        "file_path": "./spec/models/grda_warehouse/service_history_service_spec.rb",
+        "total_time": 17.583577061,
+        "groups": [
+          {
+            "location": "./spec/models/grda_warehouse/service_history_service_spec.rb:6",
+            "total_time": 17.583577061,
+            "description": "GrdaWarehouse::ServiceHistoryService"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb",
+        "total_time": 16.870458221,
+        "groups": [
+          {
+            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_5_spec.rb:12",
+            "total_time": 16.870458221,
+            "description": "HudSpmReport::Generators::Fy2026::MeasureFive"
+          }
+        ]
+      },
+      {
         "file_path": "./spec/models/access_control_upload_spec.rb",
-        "total_time": 15.060495814,
+        "total_time": 15.988152366,
         "groups": [
           {
             "location": "./spec/models/access_control_upload_spec.rb:5",
-            "total_time": 15.060495814,
+            "total_time": 15.988152366,
             "description": "AccessControlUpload"
           }
         ]
       },
       {
-        "file_path": "./spec/models/filters/criteria/filter_for_range_spec.rb",
-        "total_time": 14.562837918,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_range_spec.rb:6",
-            "total_time": 14.562837918,
-            "description": "Filters::Criteria::FilterForRange"
-          }
-        ]
-      },
-      {
         "file_path": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb",
-        "total_time": 14.384052456,
+        "total_time": 15.421132572,
         "groups": [
           {
             "location": "./spec/controllers/warehouse_reports/client_details/actives_controller_spec.rb:6",
-            "total_time": 14.384052456,
+            "total_time": 15.421132572,
             "description": "WarehouseReports::ClientDetails::ActivesController"
           }
         ]
       },
       {
+        "file_path": "./spec/models/filters/criteria/filter_for_range_spec.rb",
+        "total_time": 15.102147831,
+        "groups": [
+          {
+            "location": "./spec/models/filters/criteria/filter_for_range_spec.rb:6",
+            "total_time": 15.102147831,
+            "description": "Filters::Criteria::FilterForRange"
+          }
+        ]
+      },
+      {
+        "file_path": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb",
+        "total_time": 14.511413996,
+        "groups": [
+          {
+            "location": "./drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb:6",
+            "total_time": 14.511413996,
+            "description": "Hmis::GraphqlController"
+          }
+        ]
+      },
+      {
         "file_path": "./drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb",
-        "total_time": 13.491590596,
+        "total_time": 14.180581531,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/ce/start_ce_referral_step_spec.rb:7",
-            "total_time": 13.491590596,
+            "total_time": 14.180581531,
             "description": "Mutations::Ce::StartCeReferralStep"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/update_unit_group_spec.rb",
-        "total_time": 11.766347712,
+        "total_time": 12.804664315,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/update_unit_group_spec.rb:13",
-            "total_time": 11.766347712,
+            "total_time": 12.804664315,
             "description": "UpdateUnitGroup Mutation"
           }
         ]
       },
       {
         "file_path": "./drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb",
-        "total_time": 10.762473085,
+        "total_time": 11.555514525,
         "groups": [
           {
             "location": "./drivers/hmis/spec/requests/hmis/client_assessment_eligibility_spec.rb:13",
-            "total_time": 10.762473085,
+            "total_time": 11.555514525,
             "description": "Graphql HMIS Assessment Eligibility"
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "id": "bucket-10",
-    "total_time": 2497.8987589343005,
-    "specs": [
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/submit_form_spec.rb",
-        "total_time": 470.1292389264,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/submit_form_spec.rb:15",
-            "total_time": 391.774365772,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/requests/rack_attack_spec.rb",
-        "total_time": 283.6108071698,
-        "groups": [
-          {
-            "location": "./spec/requests/rack_attack_spec.rb:13",
-            "total_time": 257.828006518,
-            "description": "Rack::Attack"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/bad_data_spec.rb",
-        "total_time": 238.1913479979,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/bad_data_spec.rb:11",
-            "total_time": 216.537589089,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_organization_ids_spec.rb",
-        "total_time": 213.3747349184,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/prepend_organization_ids_spec.rb:11",
-            "total_time": 193.977031744,
-            "description": "Prepend Organization IDs"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_relationships_spec.rb",
-        "total_time": 131.46300704790002,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/ensure_relationships_spec.rb:11",
-            "total_time": 119.511824589,
-            "description": "Ensure Relationships"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/date_updated_spec.rb",
-        "total_time": 109.36758407960001,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/date_updated_spec.rb:11",
-            "total_time": 99.425076436,
-            "description": "HUD DateUpdated Tests"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/clean_up_move_in_dates_spec.rb",
-        "total_time": 84.8332533697,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/clean_up_move_in_dates_spec.rb:11",
-            "total_time": 77.121139427,
-            "description": "Clean Up Move In Dates"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/form/form_processor_spec.rb",
-        "total_time": 73.9294525453,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/form/form_processor_spec.rb:13",
-            "total_time": 67.208593223,
-            "description": "Hmis::Form::FormProcessor"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb",
-        "total_time": 66.7611350703,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/enrollment_last_contact_spec.rb:13",
-            "total_time": 60.691940973,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/warehouse_reports/project/data_quality/version_four_spec.rb",
-        "total_time": 57.592318,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/warehouse_reports/project/data_quality/version_four_spec.rb:12",
-            "total_time": 57.592318,
-            "description": "GrdaWarehouse::WarehouseReports::Project::DataQuality::VersionFour"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/duplicate_primary_keys_spec.rb",
-        "total_time": 51.829172936,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/duplicate_primary_keys_spec.rb:11",
-            "total_time": 51.829172936,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb",
-        "total_time": 50.178971737,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_enrollment_search_spec.rb:13",
-            "total_time": 50.178971737,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb",
-        "total_time": 46.629883519,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/lookup_client_enrollment_spec.rb:13",
-            "total_time": 46.629883519,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_active_enrollment_spec.rb",
-        "total_time": 41.752288045,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_active_enrollment_spec.rb:13",
-            "total_time": 41.752288045,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/tasks/client_cleanup_spec.rb",
-        "total_time": 38.195412221,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/tasks/client_cleanup_spec.rb:40",
-            "total_time": 38.195412221,
-            "description": "GrdaWarehouse::Tasks::ClientCleanup"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb",
-        "total_time": 35.841534511,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/custom_assessment_spec.rb:13",
-            "total_time": 35.841534511,
-            "description": "Hmis::Hud::CustomAssessment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/project_enrollment_visibility_spec.rb",
-        "total_time": 35.01282985,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/project_enrollment_visibility_spec.rb:13",
-            "total_time": 35.01282985,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/system_cohorts/system_cohort_spec.rb",
-        "total_time": 32.020279499,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/system_cohorts/system_cohort_spec.rb:5",
-            "total_time": 32.020279499,
-            "description": "GrdaWarehouse::SystemCohorts::CurrentlyHomeless"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb",
-        "total_time": 30.926652554,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb:11",
-            "total_time": 30.926652554,
-            "description": "HmisCsvImporter"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hat_spec.rb",
-        "total_time": 30.335966136,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/cas_project_client_calculator/tc_hat_spec.rb:5",
-            "total_time": 30.335966136,
-            "description": "GrdaWarehouse::CasProjectClientCalculator::TcHat"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/filter_coc_spec.rb",
-        "total_time": 30.239501656,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_twenty_twenty_four/spec/models/exporter/filter_coc_spec.rb:12",
-            "total_time": 30.239501656,
-            "description": "HmisCsvTwentyTwentyFour::Exporter::Base"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/jobs/importing/run_daily_imports_job_spec.rb",
-        "total_time": 29.4994173,
-        "groups": [
-          {
-            "location": "./spec/jobs/importing/run_daily_imports_job_spec.rb:5",
-            "total_time": 29.4994173,
-            "description": "Importing::RunDailyImportsJob"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb",
-        "total_time": 28.359424049,
-        "groups": [
-          {
-            "location": "./drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb:11",
-            "total_time": 28.359424049,
-            "description": "BostonProjectScorecard::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/models/hmis/hud/assessment_spec.rb",
-        "total_time": 27.579030215,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/models/hmis/hud/assessment_spec.rb:13",
-            "total_time": 27.579030215,
-            "description": "Hmis::Hud::Assessment"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/combine_enrollments_spec.rb",
-        "total_time": 27.164980914,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/combine_enrollments_spec.rb:11",
-            "total_time": 27.164980914,
-            "description": "Combine Enrollments"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb",
-        "total_time": 25.924683179,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/admin_ce_referrals_spec.rb:5",
-            "total_time": 25.924683179,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb",
-        "total_time": 22.010595274,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/client_enrollments_performance_spec.rb:13",
-            "total_time": 22.010595274,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb",
-        "total_time": 19.513412305,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb:11",
-            "total_time": 19.513412305,
-            "description": "Hmis::GraphqlController"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hap_report/spec/models/report_spec.rb",
-        "total_time": 19.081846269,
-        "groups": [
-          {
-            "location": "./drivers/hap_report/spec/models/report_spec.rb:11",
-            "total_time": 19.081846269,
-            "description": "HapReport::Report"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/custom_imports_boston_service/spec/models/import_file_spec.rb",
-        "total_time": 18.11674524,
-        "groups": [
-          {
-            "location": "./drivers/custom_imports_boston_service/spec/models/import_file_spec.rb:11",
-            "total_time": 18.11674524,
-            "description": "CustomImportsBostonService::ImportFile"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_data_sources_spec.rb",
-        "total_time": 16.672380166,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_data_sources_spec.rb:6",
-            "total_time": 16.672380166,
-            "description": "Filters::Criteria::FilterForDataSources"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/grda_warehouse/warehouse_reports/hud_lot_spec.rb",
-        "total_time": 16.498550486,
-        "groups": [
-          {
-            "location": "./spec/models/grda_warehouse/warehouse_reports/hud_lot_spec.rb:5",
-            "total_time": 16.498550486,
-            "description": "GrdaWarehouse::WarehouseReports::HudLot"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_households_spec.rb",
-        "total_time": 16.199350227,
-        "groups": [
-          {
-            "location": "./drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_four/ensure_households_spec.rb:11",
-            "total_time": 16.199350227,
-            "description": "Ensure Households"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_dv_currently_fleeing_spec.rb",
-        "total_time": 14.900382532,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_dv_currently_fleeing_spec.rb:6",
-            "total_time": 14.900382532,
-            "description": "Filters::Criteria::FilterForDvCurrentlyFleeing"
-          }
-        ]
-      },
-      {
-        "file_path": "./spec/models/filters/criteria/filter_for_prior_living_situation_spec.rb",
-        "total_time": 14.448194075,
-        "groups": [
-          {
-            "location": "./spec/models/filters/criteria/filter_for_prior_living_situation_spec.rb:6",
-            "total_time": 14.448194075,
-            "description": "Filters::Criteria::FilterForPriorLivingSituation"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hud_spm_report/spec/models/fy2026/measure_2_spec.rb",
-        "total_time": 14.185398698,
-        "groups": [
-          {
-            "location": "./drivers/hud_spm_report/spec/models/fy2026/measure_2_spec.rb:12",
-            "total_time": 14.185398698,
-            "description": "HudSpmReport::Generators::Fy2026::MeasureTwo"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb",
-        "total_time": 13.038106217,
-        "groups": [
-          {
-            "location": "./drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_supportive_services_spec.rb:13",
-            "total_time": 13.038106217,
-            "description": "HopwaCaper::Generators::Fy2026::Sheets::SupportiveServicesSheet"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb",
-        "total_time": 12.043232362,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/delete_form_definition_spec.rb:13",
-            "total_time": 12.043232362,
-            "description": "DeleteFormDefinition mutation"
-          }
-        ]
-      },
-      {
-        "file_path": "./drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb",
-        "total_time": 10.447657637,
-        "groups": [
-          {
-            "location": "./drivers/hmis/spec/requests/hmis/manage_scan_card_spec.rb:13",
-            "total_time": 10.447657637,
-            "description": "Manage Scan Card Mutations"
           }
         ]
       }

--- a/drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb
+++ b/drivers/client_access_control/spec/requests/client_visibility_config_variations_legacy_spec.rb
@@ -20,12 +20,19 @@ end
 RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true do
   include_context 'visibility test context'
 
+  before(:all) do
+    GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
+    AccessGroup.maintain_system_groups
+  end
+
+  after(:all) do
+    GrdaWarehouse::Utility.clear!
+  end
+
   configs_variations = []
   GrdaWarehouse::Config.available_cas_methods.values.product( # cas available method
     [true, false], # consent visible to all
     [true, false], # expose coc code
-    GrdaWarehouse::Config.available_health_emergencies.values, # health emergency
-    GrdaWarehouse::Config.available_health_emergency_tracings.values, # health emergency tracing
     [0, 20, 65], # health priority age
     [true, false], # multi coc installation
   ) do |combination|
@@ -34,8 +41,6 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true
         :cas_available_method,
         :consent_visible_to_all,
         :expose_coc_code,
-        :health_emergency,
-        :health_emergency_tracing,
         :health_priority_age,
         :multi_coc_installation,
       ], combination
@@ -59,8 +64,6 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true
       before do
         GrdaWarehouse::Config.delete_all
         GrdaWarehouse::Config.invalidate_cache
-        GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
-        AccessGroup.maintain_system_groups
       end
       let!(:config) { create :config_b, variation }
       let!(:user) { create :user }

--- a/drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb
+++ b/drivers/client_access_control/spec/requests/client_visibility_config_variations_spec.rb
@@ -20,12 +20,19 @@ end
 RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true do
   include_context 'visibility test context'
 
+  before(:all) do
+    GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
+    Collection.maintain_system_groups
+  end
+
+  after(:all) do
+    GrdaWarehouse::Utility.clear!
+  end
+
   configs_variations = []
   GrdaWarehouse::Config.available_cas_methods.values.product( # cas available method
     [true, false], # consent visible to all
     [true, false], # expose coc code
-    GrdaWarehouse::Config.available_health_emergencies.values, # health emergency
-    GrdaWarehouse::Config.available_health_emergency_tracings.values, # health emergency tracing
     [0, 20, 65], # health priority age
     [true, false], # multi coc installation
   ) do |combination|
@@ -34,8 +41,6 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true
         :cas_available_method,
         :consent_visible_to_all,
         :expose_coc_code,
-        :health_emergency,
-        :health_emergency_tracing,
         :health_priority_age,
         :multi_coc_installation,
       ], combination
@@ -59,8 +64,6 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request, vcr: true
       before do
         GrdaWarehouse::Config.delete_all
         GrdaWarehouse::Config.invalidate_cache
-        GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
-        Collection.maintain_system_groups
       end
       let!(:config) { create :config_b, variation }
       let!(:user) { create :acl_user }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Reduce runtime of client visibility config variation specs by removing obsolete health emergency axes and hoisting expensive setup.

- **Config Variations Spec**: Removed `health_emergency` and `health_emergency_tracing` from the Cartesian product, reducing combinations from 384 to 192
- **Legacy Config Variations Spec**: Same removal of health emergency axes
- **Both specs**: Moved `maintain_report_definitions` and `maintain_system_groups` into a top-level `before(:all)` so they run once per file instead of once per variation

Locally these tests complete in 4 minutes instead of 20. We could probably eliminate the slowness entirely by using pairwise testing but that's a heavier change ([ref](https://github.com/microsoft/pict))

### Type of Change
Code clean-up


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


