### PR TITLE
9211 csv import fix process existing

### DIFF
--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
@@ -910,38 +910,13 @@ module HmisCsvImporter::Importer
         batch = []
         upsert_columns = destination_class.upsert_column_names(version: importer_log.version)
 
-        Rails.logger.info "Processing existing records for #{file_name} in batches"
+        flush_batch = lambda do |label|
+          return if batch.empty?
 
-        existing_destination_data_scope(klass).in_batches(of: SELECT_BATCH_SIZE) do |relation|
-          hud_keys = relation.pluck(klass.hud_key)
-          klass.should_import.where(
-            importer_log_id: @importer_log.id,
-            klass.hud_key => hud_keys,
-          ).find_each(batch_size: SELECT_BATCH_SIZE) do |source|
-            batch << prepare_destination_for_update(klass, source.as_destination_record)
-            if batch.count == INSERT_BATCH_SIZE
-              # Client model doesn't have a uniqueness constraint because of the warehouse data source
-              # so these must be processed more slowly
-              if klass.hud_key == :PersonalID
-                Rails.logger.info "Processing #{batch.count} records individually for #{file_name}"
-                batch.each do |incoming|
-                  destination_class.where(
-                    data_source_id: incoming.data_source_id,
-                    PersonalID: incoming.PersonalID,
-                  ).with_deleted.update_all(incoming.slice(klass.upsert_column_names(version: importer_log.version)))
-                end
-                note_processed(file_name, batch.count, 'updated')
-              else
-                Rails.logger.info "Processing #{batch.count} records in bulk for #{file_name}"
-                process_batch!(destination_class, batch, file_name, type: 'updated', upsert: true, columns: upsert_columns)
-              end
-              batch = []
-            end
-          end
-        end
-        if batch.present? # ensure we get the last batch
+          # Client model doesn't have a uniqueness constraint because of the warehouse data source
+          # so these must be processed more slowly
           if klass.hud_key == :PersonalID
-            Rails.logger.info "Processing final batch of #{batch.count} records individually for #{file_name}"
+            Rails.logger.info "Processing #{label} #{batch.count} records individually for #{file_name}"
             batch.each do |incoming|
               destination_class.where(
                 data_source_id: incoming.data_source_id,
@@ -950,10 +925,42 @@ module HmisCsvImporter::Importer
             end
             note_processed(file_name, batch.count, 'updated')
           else
-            Rails.logger.info "Processing final batch of #{batch.count} records in bulk for #{file_name}"
+            Rails.logger.info "Processing #{label} #{batch.count} records in bulk for #{file_name}"
             process_batch!(destination_class, batch, file_name, type: 'updated', upsert: true, columns: upsert_columns)
           end
+          batch = []
         end
+
+        Rails.logger.info "Processing existing records for #{file_name} in batches"
+
+        conn = destination_class.connection
+        tmp_name = tmp_table_name('updates', destination_class)
+        scope = existing_destination_data_scope(klass)
+
+        with_temp_id_key_table(conn, tmp_name, scope, klass.hud_key) do |quoted_temp|
+          last_id = 0
+          loop do
+            rows = conn.execute(<<~SQL)
+              SELECT id, hud_key FROM #{quoted_temp}
+              WHERE id > #{last_id}
+              ORDER BY id LIMIT #{SELECT_BATCH_SIZE}
+            SQL
+            break if rows.ntuples.zero?
+
+            last_id = rows.max_by { |r| r['id'].to_i }.fetch('id').to_i
+            hud_keys = rows.map { |r| r['hud_key'] }
+
+            klass.should_import.where(
+              importer_log_id: @importer_log.id,
+              klass.hud_key => hud_keys,
+            ).find_each(batch_size: SELECT_BATCH_SIZE) do |source|
+              batch << prepare_destination_for_update(klass, source.as_destination_record)
+              flush_batch.call('batch of') if batch.count == INSERT_BATCH_SIZE
+            end
+          end
+        end
+
+        flush_batch.call('final batch of')
 
         flush_dirty_enrollments_for_exit(klass)
         Rails.logger.info "Completed applying updates for #{file_name}"
@@ -1165,6 +1172,22 @@ module HmisCsvImporter::Importer
       conn.execute(<<~SQL)
         CREATE TEMP TABLE #{conn.quote_table_name(name)} AS
           SELECT id FROM (#{scope.select(:id).to_sql}) sub
+      SQL
+      conn.execute("CREATE INDEX ON #{conn.quote_table_name(name)} (id)")
+      yield conn.quote_table_name(name)
+    ensure
+      conn&.execute("DROP TABLE IF EXISTS #{conn.quote_table_name(name)}")
+    end
+
+    # Like with_temp_id_table but also snapshots the hud_key column so callers
+    # can read keys directly from the temp table without round-tripping to the
+    # warehouse. Used by apply_updates where we need hud_keys for staging lookup.
+    private def with_temp_id_key_table(conn, name, scope, hud_key)
+      conn.execute("DROP TABLE IF EXISTS #{conn.quote_table_name(name)}")
+      conn.execute(<<~SQL)
+        CREATE TEMP TABLE #{conn.quote_table_name(name)} AS
+          SELECT id, #{conn.quote_column_name(hud_key)} AS hud_key
+          FROM (#{scope.select(:id, hud_key).to_sql}) sub
       SQL
       conn.execute("CREATE INDEX ON #{conn.quote_table_name(name)} (id)")
       yield conn.quote_table_name(name)

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
@@ -910,6 +910,7 @@ module HmisCsvImporter::Importer
         batch = []
         upsert_columns = destination_class.upsert_column_names(version: importer_log.version)
 
+        # Closes over `batch` from the enclosing scope; resets it after each flush.
         flush_batch = lambda do |label|
           return if batch.empty?
 
@@ -947,7 +948,7 @@ module HmisCsvImporter::Importer
             SQL
             break if rows.ntuples.zero?
 
-            last_id = rows.max_by { |r| r['id'].to_i }.fetch('id').to_i
+            last_id = rows.map { |r| r['id'].to_i }.max
             hud_keys = rows.map { |r| r['hud_key'] }
 
             klass.should_import.where(

--- a/drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb
+++ b/drivers/hmis_csv_importer/spec/models/importer/twenty_twenty_six/client_processing_spec.rb
@@ -141,6 +141,43 @@ RSpec.describe HmisCsvImporter, type: :model do
       end
     end
 
+    # Exercises the bulk upsert path in apply_updates for an enrollment-child model
+    # (Disability uses DisabilitiesID as hud_key, not PersonalID, so it takes the
+    # process_batch! branch rather than the Client one-by-one branch).
+    describe 'when re-importing disabilities after nulling source_hash' do
+      before(:all) do
+        HmisCsvImporter::Utility.clear!
+        GrdaWarehouse::Utility.clear!
+        import_hmis_csv_fixture(
+          'drivers/hmis_csv_importer/spec/fixtures/files/twenty_twenty_six/client_processing',
+          version: 'AutoMigrate',
+          run_jobs: false,
+          stop_version: '2026',
+        )
+        GrdaWarehouse::Hud::Disability.update_all(source_hash: nil)
+        @loader = import_hmis_csv_fixture(
+          'drivers/hmis_csv_importer/spec/fixtures/files/twenty_twenty_six/client_processing',
+          version: 'AutoMigrate',
+          run_jobs: false,
+          stop_version: '2026',
+        )
+      end
+
+      it 'updates all disability records via apply_updates' do
+        expect(@loader.importer_log.summary['Disabilities.csv']['updated']).to eq(12)
+      end
+
+      it 'repopulates source_hash on all disability records' do
+        expect(GrdaWarehouse::Hud::Disability.where.not(source_hash: nil).count).to eq(12)
+      end
+
+      it 'preserves disability column values from the CSV' do
+        disability = GrdaWarehouse::Hud::Disability.find_by(DisabilitiesID: '2')
+        expect(disability.DisabilityType).to eq(6)
+        expect(disability.DisabilityResponse).to eq(1)
+      end
+    end
+
     # Mixed case: only one warehouse client has its source_hash nilled
     describe 'when re-importing with only one client\'s source_hash nilled' do
       before(:all) do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
### Description
Fix `apply_updates` performance regression by materializing the expensive `involved_warehouse_scope` into a temp table once instead of re-evaluating it per batch.

- **CSV Importer — `apply_updates`**: Replace `in_batches` iteration over a 4-table join scope with a temp-table cursor-walk pattern, matching the approach already used by `mark_unchanged`, `mark_incoming_older`, and `add_new_data`. For Disability (the worst-affected model), this eliminates ~70 redundant scope evaluations (61–495s each, ~4.7h total) introduced by `284e75d`.
- **CSV Importer — `with_temp_id_key_table` helper**: Add a variant of `with_temp_id_table` that snapshots both `id` and `hud_key` into the temp table, so `apply_updates` can look up staging records without round-tripping to the warehouse.
- **CSV Importer — batch flush logic**: Extract the duplicated mid-loop and final-batch flush into a shared lambda to reduce repetition.

### Type of Change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


