### PR TITLE
HUD PIT HIV show_links hotfix

### DIFF
--- a/drivers/hud_pit/app/views/hud_pit/questions/result.haml
+++ b/drivers/hud_pit/app/views/hud_pit/questions/result.haml
@@ -8,6 +8,7 @@
 
 .well.mt-6
   = render 'hud_reports/inline_parameters', report: @report
+- show_link = true
 - question_class = generator.questions[@question]
 - if question_class&.const_defined?(:HIV_AIDS_ROW) && !current_user.can_view_hiv_status?
   - hiv_row = question_class::HIV_AIDS_ROW


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

PIT question result pages showed counts as plain text instead of drilldown links for most questions, including Adult & Child. The HIV/AIDS privacy branch only set show_link for Additional Homeless Populations, but the result template always passed show_link into the shared HUD tables partial. On other questions that local was unset, so HAML forwarded nil and the shared partial never defaulted to enabled links.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
