### PR TITLE
fix: 8737 display issues on chart tooltip

### DIFF
--- a/app/assets/javascripts/warehouse_reports/rrh/destination.js.coffee
+++ b/app/assets/javascripts/warehouse_reports/rrh/destination.js.coffee
@@ -29,8 +29,9 @@ class App.WarehouseReports.Rrh.Destination
     # https://github.com/naver/billboard.js/blob/aa91babc6d3173e58e56eef33aad7c7c051b747f/src/internals/tooltip.js#L110
     # console.log(d, defaultValueFormat(d[0].value), @data)
     tooltip_title = defaultTitleFormat(d[0].x)
-    html = "<table class='bb-tooltip'>"
+    html = "<table class='bb-tooltip' style='white-space: normal'>"
     html += "<thead>"
+    html += "<colgroup><col style='width: 150px' /><col style='width: 100px' /><col style='width: 250px' /></colgroup>"
     html += "<tr><th>Destination Group</th><th>Clients</th><th>Destinations</th></tr>"
     html += "</thead>"
     html += "<tbody>"
@@ -41,10 +42,7 @@ class App.WarehouseReports.Rrh.Destination
         bg_color = color(row.id)
         box = "<td class='name'><svg><rect style='fill:#{bg_color}' width='10' height='10'></rect></svg>#{row.name}</td>"
         value = "<td>#{row.value} (#{d3.format(".0%")(row.ratio)})</td>"
-        details = "<td class='text-left'>"
-        for k, v of @data.support[row.name].detailed_destinations
-          details += "#{k} (#{v})<br />"
-        details +="</td>"
+        details = "<td class='text-left'>#{@_destination_list(row.name)}</td>"
         html += box
         html += value
         html += details
@@ -53,6 +51,11 @@ class App.WarehouseReports.Rrh.Destination
     html += "</tbody>"
     html += '</table>'
     html
+
+  _destination_list: (name) =>
+    destinations = @data.support[name]?.detailed_destinations
+    return '' unless destinations?
+    "<ul>#{("<li>#{k} (#{v})</li>" for k, v of destinations).join('')}</ul>"
 
   _follow_link: (d, e) =>
     return unless @support_url.length > 1


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
### Description

Fix display overflow issues in the RRH destination chart tooltip.

- **Tooltip Table Layout**: Hardcode column widths via CSS (`style='width: Npx'`) and enable `white-space: normal` on the table to prevent content overflow
- **Destination Detail Rendering**: Replace `<br />`-separated text with a `<ul>/<li>` list for cleaner wrapping; guard against missing `support` data to avoid runtime errors

### Type of Change
Bug fix## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
