### PR TITLE
Fix runtime regressions from PR #6472 (retire legacy LSA generators)

### DIFF
--- a/app/models/report_results_summaries/lsa/fy2018.rb
+++ b/app/models/report_results_summaries/lsa/fy2018.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2018 (retired, read-only)
+#
+# STI stub for historical ReportResultsSummary records. No new summaries will be
+# generated for this fiscal year. Exists only to prevent STI resolution errors
+# when loading past run data. See Reports::Lsa::Fy2018 for the corresponding Report stub.
+module ReportResultsSummaries::Lsa
+  class Fy2018 < ::ReportResultsSummary
+  end
+end

--- a/app/models/report_results_summaries/lsa/fy2019.rb
+++ b/app/models/report_results_summaries/lsa/fy2019.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2019 (retired, read-only)
+#
+# STI stub for historical ReportResultsSummary records. No new summaries will be
+# generated for this fiscal year. Exists only to prevent STI resolution errors
+# when loading past run data. See Reports::Lsa::Fy2019 for the corresponding Report stub.
+module ReportResultsSummaries::Lsa
+  class Fy2019 < ::ReportResultsSummary
+  end
+end

--- a/app/models/report_results_summaries/lsa/fy2021.rb
+++ b/app/models/report_results_summaries/lsa/fy2021.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2021 (retired, read-only)
+#
+# STI stub for historical ReportResultsSummary records. No new summaries will be
+# generated for this fiscal year. Exists only to prevent STI resolution errors
+# when loading past run data. See Reports::Lsa::Fy2021 for the corresponding Report stub.
+module ReportResultsSummaries::Lsa
+  class Fy2021 < ::ReportResultsSummary
+  end
+end

--- a/app/models/reports/lsa/fy2018/all.rb
+++ b/app/models/reports/lsa/fy2018/all.rb
@@ -1,0 +1,28 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2018 (retired, read-only)
+#
+# This file exists solely to preserve Rails STI resolution for historical report
+# records stored with type = 'Reports::Lsa::Fy2018::All' or '...::Base'.
+# FY 2018 LSA reports can no longer be generated. These classes support view-only
+# access to past run data (downloads, result summaries) and nothing else.
+#
+# Do not add generation logic, update business rules, or extend these classes.
+# The active LSA generator is HudLsa::Generators::Fy2026::Lsa.
+module Reports::Lsa::Fy2018
+  class Base < ::Report
+    def self.report_name = 'LSA - FY 2018'
+    def report_group_name = 'Longitudinal System Analysis '
+    def download_type = :zip
+    def value_for_options(options) = options.present? ? "CoC: #{options['coc_code']}" : ''
+  end
+
+  class All < Base
+  end
+end

--- a/app/models/reports/lsa/fy2019/all.rb
+++ b/app/models/reports/lsa/fy2019/all.rb
@@ -1,0 +1,28 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2019 (retired, read-only)
+#
+# This file exists solely to preserve Rails STI resolution for historical report
+# records stored with type = 'Reports::Lsa::Fy2019::All' or '...::Base'.
+# FY 2019 LSA reports can no longer be generated. These classes support view-only
+# access to past run data (downloads, result summaries) and nothing else.
+#
+# Do not add generation logic, update business rules, or extend these classes.
+# The active LSA generator is HudLsa::Generators::Fy2026::Lsa.
+module Reports::Lsa::Fy2019
+  class Base < ::Report
+    def self.report_name = 'LSA - FY 2019'
+    def report_group_name = 'Longitudinal System Analysis '
+    def download_type = :zip
+    def value_for_options(options) = options.present? ? "CoC: #{options['coc_code']}" : ''
+  end
+
+  class All < Base
+  end
+end

--- a/app/models/reports/lsa/fy2021/all.rb
+++ b/app/models/reports/lsa/fy2021/all.rb
@@ -1,0 +1,28 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# LEGACY REPORT — FY 2021 (retired, read-only)
+#
+# This file exists solely to preserve Rails STI resolution for historical report
+# records stored with type = 'Reports::Lsa::Fy2021::All' or '...::Base'.
+# FY 2021 LSA reports can no longer be generated. These classes support view-only
+# access to past run data (downloads, result summaries) and nothing else.
+#
+# Do not add generation logic, update business rules, or extend these classes.
+# The active LSA generator is HudLsa::Generators::Fy2026::Lsa.
+module Reports::Lsa::Fy2021
+  class Base < ::Report
+    def self.report_name = 'LSA - FY 2021'
+    def report_group_name = 'Longitudinal System Analysis '
+    def download_type = :zip
+    def value_for_options(options) = options.present? ? "CoC: #{options['coc_code']}" : ''
+  end
+
+  class All < Base
+  end
+end

--- a/drivers/hud_lsa/app/controllers/hud_lsa/lsa_hics_controller.rb
+++ b/drivers/hud_lsa/app/controllers/hud_lsa/lsa_hics_controller.rb
@@ -12,7 +12,7 @@ module HudLsa
     include ArelHelper
 
     private def report_scope
-      report_source.hic.where(report_name: possible_titles)
+      hic_scope.where(report_name: possible_titles)
     end
 
     # Last Wednesday of January

--- a/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
+++ b/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
@@ -15,14 +15,24 @@ module HudLsa
     before_action :set_reports, except: [:index, :running_all_questions]
 
     private def report_scope
-      report_source.lsa.where(report_name: possible_titles)
+      lsa_scope.where(report_name: possible_titles)
     end
 
-    # Broaden STI so history includes retired FY stubs, not just FY2026.
-    # Keeps .lsa / .hic scopes available from the FY2026 class.
+    # Query from the STI base so retired FY rows (siblings of Fy2026::Lsa) are valid.
     private def report_source
-      ::HudLsa::Generators::Fy2026::Lsa.unscope(where: :type).
-        where(type: possible_generator_classes.values.map(&:name))
+      ::HudReports::ReportInstance.where(type: possible_generator_classes.values.map(&:name))
+    end
+
+    private def lsa_scope
+      report_source.where("(options->>'lsa_scope')::integer != ? OR options->>'lsa_scope' IS NULL", hic_value)
+    end
+
+    private def hic_scope
+      report_source.where("(options->>'lsa_scope')::integer = ?", hic_value)
+    end
+
+    private def hic_value
+      HudLsa::Fy2026::Report.available_lsa_scopes['HIC']
     end
 
     def new

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/fy2026/lsa.rb
@@ -48,11 +48,11 @@ module HudLsa::Generators::Fy2026
     belongs_to :export, class_name: 'GrdaWarehouse::HmisExport', optional: true
 
     scope :lsa, -> do
-      where("options->>'lsa_scope' != ? OR options->>'lsa_scope' IS NULL", HudLsa::Fy2026::Report.available_lsa_scopes['HIC'])
+      where("(options->>'lsa_scope')::integer != ? OR options->>'lsa_scope' IS NULL", HudLsa::Fy2026::Report.available_lsa_scopes['HIC'])
     end
 
     scope :hic, -> do
-      where("options->>'lsa_scope' = ?", HudLsa::Fy2026::Report.available_lsa_scopes['HIC'])
+      where("(options->>'lsa_scope')::integer = ?", HudLsa::Fy2026::Report.available_lsa_scopes['HIC'])
     end
 
     def self.find_report(user)

--- a/drivers/hud_lsa/app/models/hud_lsa/generators/retired_lsa_stub.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/generators/retired_lsa_stub.rb
@@ -47,6 +47,16 @@ module HudLsa::Generators::RetiredLsaStub
       { 'LSA' => 'All LSA Data' }.freeze
     end
 
+    def describe_table(table_name)
+      table_descriptions[table_name]
+    end
+
+    def allowed_options(report)
+      opts = [:project_ids, :project_group_ids, :data_source_ids, :coc_code, :lsa_scope]
+      opts += report.hic? ? [:on] : [:start, :end]
+      opts
+    end
+
     def archival_csv_config(report_instance)
       HudReportArchival.shared_archival_entries(report_instance, prefix: 'lsa').merge(
         lsa_summary_results_csv: {
@@ -59,7 +69,7 @@ module HudLsa::Generators::RetiredLsaStub
   end
 
   def hic?
-    options&.with_indifferent_access&.dig(:lsa_scope).to_i == 3
+    options&.with_indifferent_access&.dig(:lsa_scope).to_i == HudLsa::Fy2026::Report.available_lsa_scopes['HIC']
   end
 
   def filter

--- a/drivers/hud_lsa/spec/models/retired_lsa_stub_spec.rb
+++ b/drivers/hud_lsa/spec/models/retired_lsa_stub_spec.rb
@@ -1,0 +1,136 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudLsa::Generators::RetiredLsaStub, type: :model do
+  # Use Fy2024::Lsa as the concrete includer under test.
+  let(:klass) { HudLsa::Generators::Fy2024::Lsa }
+
+  def create_lsa_report(**options_hash)
+    record = create(
+      :hud_reports_report_instance,
+      type: 'HudLsa::Generators::Fy2024::Lsa',
+      options: options_hash,
+      question_names: [],
+    )
+    klass.find(record.id)
+  end
+
+  # -- Class methods -----------------------------------------------------------
+
+  describe '.generic_title' do
+    it 'returns the human-readable product name' do
+      expect(klass.generic_title).to eq('Longitudinal System Analysis')
+    end
+  end
+
+  describe '.short_name' do
+    it 'returns LSA' do
+      expect(klass.short_name).to eq('LSA')
+    end
+  end
+
+  describe '.title' do
+    it 'combines generic_title with fiscal_year' do
+      expect(klass.title).to eq('Longitudinal System Analysis - FY 2024')
+    end
+  end
+
+  describe '.fiscal_year' do
+    it 'returns the FY string derived from the module namespace' do
+      expect(klass.fiscal_year).to eq('FY 2024')
+    end
+  end
+
+  describe '.questions' do
+    it 'maps the LSA key to the class itself' do
+      expect(klass.questions).to eq({ 'LSA' => klass })
+    end
+  end
+
+  describe '.table_descriptions' do
+    it 'maps LSA to the human-readable description' do
+      expect(klass.table_descriptions).to eq({ 'LSA' => 'All LSA Data' })
+    end
+  end
+
+  describe '.describe_table' do
+    it 'returns the description for a known table' do
+      expect(klass.describe_table('LSA')).to eq('All LSA Data')
+    end
+
+    it 'returns nil for an unknown table' do
+      expect(klass.describe_table('nonexistent')).to be_nil
+    end
+  end
+
+  describe '.allowed_options' do
+    context 'for a non-HIC report (lsa_scope: 1)' do
+      let(:report) { create_lsa_report(lsa_scope: 1) }
+
+      it 'includes :coc_code, :lsa_scope, :start, and :end' do
+        expect(klass.allowed_options(report)).to include(:coc_code, :lsa_scope, :start, :end)
+      end
+
+      it 'does not include :on' do
+        expect(klass.allowed_options(report)).not_to include(:on)
+      end
+    end
+
+    context 'for a HIC report (lsa_scope: HIC value)' do
+      let(:report) { create_lsa_report(lsa_scope: HudLsa::Fy2026::Report.available_lsa_scopes['HIC']) }
+
+      it 'includes :on' do
+        expect(klass.allowed_options(report)).to include(:on)
+      end
+
+      it 'does not include :start or :end' do
+        opts = klass.allowed_options(report)
+        expect(opts).not_to include(:start)
+        expect(opts).not_to include(:end)
+      end
+    end
+  end
+
+  # -- Instance methods --------------------------------------------------------
+
+  describe '#hic?' do
+    it 'returns false when lsa_scope is 1' do
+      expect(create_lsa_report(lsa_scope: 1)).not_to be_hic
+    end
+
+    it 'returns false when lsa_scope is nil' do
+      expect(create_lsa_report).not_to be_hic
+    end
+
+    it 'returns true when lsa_scope is the HIC integer value' do
+      expect(create_lsa_report(lsa_scope: HudLsa::Fy2026::Report.available_lsa_scopes['HIC'])).to be_hic
+    end
+
+    it 'returns true when lsa_scope is the HIC value as a string (JSONB stores options values as strings)' do
+      expect(create_lsa_report(lsa_scope: HudLsa::Fy2026::Report.available_lsa_scopes['HIC'].to_s)).to be_hic
+    end
+  end
+
+  # -- STI resolution ----------------------------------------------------------
+
+  describe 'STI resolution' do
+    it 'instantiates as Fy2024::Lsa when loaded via HudReports::ReportInstance' do
+      create(:hud_reports_report_instance, type: 'HudLsa::Generators::Fy2024::Lsa', options: {}, question_names: [])
+      result = HudReports::ReportInstance.where(type: 'HudLsa::Generators::Fy2024::Lsa').first
+      expect(result).to be_a(HudLsa::Generators::Fy2024::Lsa)
+    end
+  end
+
+  describe 'generation is disabled' do
+    it 'does not define a local run! method (cannot generate new reports)' do
+      expect(klass.instance_methods(false)).not_to include(:run!)
+    end
+  end
+end

--- a/spec/models/reports/lsa/legacy_stubs_spec.rb
+++ b/spec/models/reports/lsa/legacy_stubs_spec.rb
@@ -1,0 +1,67 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Reports::Lsa legacy FY stubs', type: :model do
+  # shared_examples defines a reusable block of examples under a name.
+  shared_examples 'an LSA legacy FY stub' do |all_class:, base_class:, report_name:|
+    describe all_class do
+      describe 'class hierarchy' do
+        it 'is a subclass of Report' do
+          expect(all_class.ancestors).to include(Report)
+        end
+
+        it 'has a Base class that is also a subclass of Report' do
+          expect(base_class.ancestors).to include(Report)
+        end
+
+        it 'All inherits from Base' do
+          expect(all_class.ancestors).to include(base_class)
+        end
+      end
+
+      describe '.report_name' do
+        it "returns '#{report_name}'" do
+          expect(base_class.report_name).to eq(report_name)
+        end
+      end
+
+      describe '#report_group_name' do
+        it "returns 'Longitudinal System Analysis '" do
+          expect(all_class.new.report_group_name).to eq('Longitudinal System Analysis ')
+        end
+      end
+
+      describe 'STI round-trip' do
+        it 'is instantiated as the concrete class when loaded through Report' do
+          record = Report.create!(type: all_class.name, name: "#{report_name} test")
+          found = Report.find(record.id)
+          expect(found.class).to eq(all_class)
+        end
+      end
+    end
+  end
+
+  # include_examples runs the shared block inline here, once per call, with
+  # different arguments. Each call produces a full set of examples for that FY.
+  include_examples 'an LSA legacy FY stub',
+                   all_class: Reports::Lsa::Fy2018::All,
+                   base_class: Reports::Lsa::Fy2018::Base,
+                   report_name: 'LSA - FY 2018'
+
+  include_examples 'an LSA legacy FY stub',
+                   all_class: Reports::Lsa::Fy2019::All,
+                   base_class: Reports::Lsa::Fy2019::Base,
+                   report_name: 'LSA - FY 2019'
+
+  include_examples 'an LSA legacy FY stub',
+                   all_class: Reports::Lsa::Fy2021::All,
+                   base_class: Reports::Lsa::Fy2021::Base,
+                   report_name: 'LSA - FY 2021'
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

This change fixes several errors that appeared after #6472 retired the legacy LSA
generators. While the original PR correctly removed the old report generation code,
it didn't leave behind the minimal placeholders that Rails needs to recognize report
records from past fiscal years (FY2018, FY2019, FY2021–2024) stored in the database.
Without those placeholders, loading the LSA report history page caused the app to
crash when it encountered those older records.

In addition to restoring those placeholders, this change corrects two bugs in the
original PR: a database query error caused by a type mismatch when filtering reports
by scope, and a controller issue that prevented older fiscal year reports from loading
alongside the current FY2026 reports. Specs are included to guard against these
regressions going forward.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
