### PR TITLE
fix: project-type report filter options bug

### DIFF
--- a/app/controllers/hud_reports/base_controller.rb
+++ b/app/controllers/hud_reports/base_controller.rb
@@ -61,6 +61,7 @@ module HudReports
         generator.new(@report).queue
         redirect_to(path_for_history(filter: @filter.to_h))
       else
+        @filter.default_project_type_codes = generator.default_project_type_codes
         render :new
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
When the form fails validation, the Project Types dropdown is populated with the generator's allowed project type codes

## Type of change
 Bug fix 

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

