### PR TITLE
fix issues around purging attachments from s3

### DIFF
--- a/app/controllers/clients/files_controller.rb
+++ b/app/controllers/clients/files_controller.rb
@@ -133,9 +133,7 @@ module Clients
       end
 
       begin
-        # Mark file as deleted using the acts_as_paranoid field instead of calling @file.destroy! to prevent hooks from
-        # firing which would cause acts_as_taggable to remove the associated tags
-        @file.update(deleted_at: Time.now)
+        @file.soft_delete
 
         flash[:notice] = 'File was successfully deleted.'
         # Keep various client fields in sync with files if appropriate

--- a/app/controllers/clients/files_controller.rb
+++ b/app/controllers/clients/files_controller.rb
@@ -133,7 +133,7 @@ module Clients
       end
 
       begin
-        @file.soft_delete
+        @file.soft_delete!
 
         flash[:notice] = 'File was successfully deleted.'
         # Keep various client fields in sync with files if appropriate

--- a/app/controllers/clients/vispdats_controller.rb
+++ b/app/controllers/clients/vispdats_controller.rb
@@ -118,7 +118,7 @@ module Clients
     def destroy_file
       set_vispdat
       @file = @vispdat.files.find params[:file_id]
-      @file.soft_delete
+      @file.soft_delete!
       respond_with @vispdat
     end
 

--- a/app/controllers/clients/vispdats_controller.rb
+++ b/app/controllers/clients/vispdats_controller.rb
@@ -118,7 +118,7 @@ module Clients
     def destroy_file
       set_vispdat
       @file = @vispdat.files.find params[:file_id]
-      @file.destroy
+      @file.soft_delete
       respond_with @vispdat
     end
 

--- a/app/jobs/importing/run_daily_imports_job.rb
+++ b/app/jobs/importing/run_daily_imports_job.rb
@@ -186,6 +186,7 @@ module Importing
         # Remove any expired export jobs
         PruneDocumentExportsJob.perform_later
         Health::PruneDocumentExportsJob.perform_later
+        PurgeSoftDeletedClientFilesJob.perform_later
 
         YouthFollowUpsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later
         SystemCohortsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later unless Delayed::Job.queued?('SystemCohortsJob')

--- a/app/jobs/importing/run_daily_imports_job.rb
+++ b/app/jobs/importing/run_daily_imports_job.rb
@@ -186,7 +186,6 @@ module Importing
         # Remove any expired export jobs
         PruneDocumentExportsJob.perform_later
         Health::PruneDocumentExportsJob.perform_later
-        PurgeSoftDeletedClientFilesJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later
 
         YouthFollowUpsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later
         SystemCohortsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later unless Delayed::Job.queued?('SystemCohortsJob')

--- a/app/jobs/importing/run_daily_imports_job.rb
+++ b/app/jobs/importing/run_daily_imports_job.rb
@@ -186,7 +186,7 @@ module Importing
         # Remove any expired export jobs
         PruneDocumentExportsJob.perform_later
         Health::PruneDocumentExportsJob.perform_later
-        PurgeSoftDeletedClientFilesJob.perform_later
+        PurgeSoftDeletedClientFilesJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later
 
         YouthFollowUpsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later
         SystemCohortsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later unless Delayed::Job.queued?('SystemCohortsJob')

--- a/app/jobs/purge_soft_deleted_client_files_job.rb
+++ b/app/jobs/purge_soft_deleted_client_files_job.rb
@@ -26,7 +26,7 @@ class PurgeSoftDeletedClientFilesJob < BaseJob
     with_lock do
       scope = GrdaWarehouse::ClientFile.only_deleted.where(
         GrdaWarehouse::ClientFile.arel_table[:deleted_at].lt(retain_at),
-      )
+      ).with_attached_client_file
 
       scope.find_in_batches(batch_size: batch_size) do |batch|
         batch.each do |file|

--- a/app/jobs/purge_soft_deleted_client_files_job.rb
+++ b/app/jobs/purge_soft_deleted_client_files_job.rb
@@ -16,11 +16,15 @@
 class PurgeSoftDeletedClientFilesJob < BaseJob
   queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
 
-  RETENTION_PERIOD = 30.days
-
   # @param retain_at [DateTime] Records deleted before this time will be purged
   # @param batch_size [Integer] Number of records to process per batch
-  def perform(retain_at: RETENTION_PERIOD.ago, batch_size: 1_000)
+  def perform(retain_at: nil, max_deleted: nil, batch_size: 1_000)
+    config = SoftDeleteRetentionConfiguration.new
+    return 0 unless config.enabled?
+
+    retain_at ||= config.retain_at
+    max_deleted ||= config.max_deleted_per_run
+
     total = 0
 
     with_lock do
@@ -28,12 +32,11 @@ class PurgeSoftDeletedClientFilesJob < BaseJob
         GrdaWarehouse::ClientFile.arel_table[:deleted_at].lt(retain_at),
       ).with_attached_client_file
 
-      scope.find_in_batches(batch_size: batch_size) do |batch|
-        batch.each do |file|
-          file.client_file.purge if file.client_file.attached?
-          file.really_destroy!
-          total += 1
-        end
+      scope.find_each(batch_size: batch_size) do |file|
+        file.client_file.purge if file.client_file.attached?
+        file.really_destroy!
+        total += 1
+        break if total >= max_deleted
       end
     end
 

--- a/app/jobs/purge_soft_deleted_client_files_job.rb
+++ b/app/jobs/purge_soft_deleted_client_files_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Purge soft-deleted ClientFile records whose retention window has expired.
+# For each record: purges the ActiveStorage blob from S3, then hard-deletes
+# the database record (including taggings).
+#
+# ClientFile uses `soft_delete` (sets deleted_at without firing destroy
+# callbacks) to preserve taggings for restorability. This job is the
+# counterpart that cleans up once the restore window has passed.
+class PurgeSoftDeletedClientFilesJob < BaseJob
+  queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+
+  RETENTION_PERIOD = 30.days
+
+  # @param retain_at [DateTime] Records deleted before this time will be purged
+  # @param batch_size [Integer] Number of records to process per batch
+  def perform(retain_at: RETENTION_PERIOD.ago, batch_size: 1_000)
+    total = 0
+
+    with_lock do
+      scope = GrdaWarehouse::ClientFile.only_deleted.where(
+        GrdaWarehouse::ClientFile.arel_table[:deleted_at].lt(retain_at),
+      )
+
+      scope.find_in_batches(batch_size: batch_size) do |batch|
+        batch.each do |file|
+          file.client_file.purge if file.client_file.attached?
+          file.really_destroy!
+          total += 1
+        end
+      end
+    end
+
+    Rails.logger.info "PurgeSoftDeletedClientFilesJob: purged #{total} records"
+    total
+  end
+
+  private
+
+  def with_lock(&block)
+    GrdaWarehouseBase.with_advisory_lock('PurgeSoftDeletedClientFilesJob', timeout_seconds: 0, &block)
+  end
+end

--- a/app/jobs/purge_soft_deleted_client_files_job.rb
+++ b/app/jobs/purge_soft_deleted_client_files_job.rb
@@ -30,13 +30,12 @@ class PurgeSoftDeletedClientFilesJob < BaseJob
     with_lock do
       scope = GrdaWarehouse::ClientFile.only_deleted.where(
         GrdaWarehouse::ClientFile.arel_table[:deleted_at].lt(retain_at),
-      ).with_attached_client_file
+      ).with_attached_client_file.limit(max_deleted)
 
       scope.find_each(batch_size: batch_size) do |file|
         file.client_file.purge if file.client_file.attached?
         file.really_destroy!
         total += 1
-        break if total >= max_deleted
       end
     end
 

--- a/app/jobs/purge_soft_deleted_records_job.rb
+++ b/app/jobs/purge_soft_deleted_records_job.rb
@@ -21,8 +21,14 @@ class PurgeSoftDeletedRecordsJob < BaseJob
   # @param dry_run [Boolean] When true, only counts records that would be deleted (default: true)
   #
   # @return [Integer] Total number of records deleted
-  def perform(retain_at: 1.year.ago, max_deleted: 10_000_000, models: warehouse_models, dry_run: true)
+  def perform(retain_at: nil, max_deleted: nil, models: warehouse_models, dry_run: true)
     raise 'all models must be paranoid' unless models.all?(&:paranoid?)
+
+    config = SoftDeleteRetentionConfiguration.new
+    return 0 unless config.enabled?
+
+    retain_at ||= config.retain_at
+    max_deleted ||= config.max_deleted_per_run
 
     Rails.logger.info "Purging soft-deleted records (#{dry_run ? 'dry run' : 'live run'})"
 

--- a/app/models/concerns/client_file_base.rb
+++ b/app/models/concerns/client_file_base.rb
@@ -19,15 +19,17 @@ module ClientFileBase
     # dependent: false prevents soft-deletes (via acts_as_paranoid) from enqueuing
     # ActiveStorage::PurgeJob, which would delete the S3 blob while the DB record
     # is still restorable and may have pending AnalyzeJobs.
+    # S3 blobs are cleaned up later by PurgeSoftDeletedClientFilesJob.
+    # Use soft_delete/soft_delete! instead of .destroy (see below).
     has_one_attached :client_file, dependent: false
 
     # Use instead of .destroy to soft-delete without side effects.
     # acts_as_paranoid's .destroy runs :destroy callbacks, which triggers
     # acts_as_taggable's `dependent: :destroy` on the taggings association,
     # hard-deleting the join rows. That makes tag-based restore impossible.
-    def soft_delete
-      update(deleted_at: Time.current)
-    end
+    # S3 blobs are cleaned up later by PurgeSoftDeletedClientFilesJob.
+    def soft_delete = update(deleted_at: Time.current)
+    def soft_delete! = update!(deleted_at: Time.current)
 
     # The file_exists_and_not_too_large validation checks that the client_file exists, so we can rely on that and only validate presence of name if the file has a client_file attachment.
     # This avoids an awkward double-error "Name can't be blank" if the file is not uploaded or has expired.

--- a/app/models/concerns/client_file_base.rb
+++ b/app/models/concerns/client_file_base.rb
@@ -16,7 +16,18 @@ module ClientFileBase
     pii_attr :name, as: :full_name
     pii_attr :client_file, as: :attached_file
 
-    has_one_attached :client_file
+    # dependent: false prevents soft-deletes (via acts_as_paranoid) from enqueuing
+    # ActiveStorage::PurgeJob, which would delete the S3 blob while the DB record
+    # is still restorable and may have pending AnalyzeJobs.
+    has_one_attached :client_file, dependent: false
+
+    # Use instead of .destroy to soft-delete without side effects.
+    # acts_as_paranoid's .destroy runs :destroy callbacks, which triggers
+    # acts_as_taggable's `dependent: :destroy` on the taggings association,
+    # hard-deleting the join rows. That makes tag-based restore impossible.
+    def soft_delete
+      update(deleted_at: Time.current)
+    end
 
     # The file_exists_and_not_too_large validation checks that the client_file exists, so we can rely on that and only validate presence of name if the file has a client_file attachment.
     # This avoids an awkward double-error "Name can't be blank" if the file is not uploaded or has expired.

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -98,7 +98,7 @@ module ClientImageConsumer
       self.class.transaction do
         # Hard-delete ephemeral cache records (no reason to soft-delete or restore).
         # Purge blobs first so S3 objects aren't orphaned.
-        client_files.window.where(name: 'Client Headshot Cache').each do |f|
+        client_files.window.where(name: 'Client Headshot Cache').with_attached_client_file.each do |f|
           f.client_file.purge if f.client_file.attached?
           f.really_destroy!
         end

--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -96,7 +96,13 @@ module ClientImageConsumer
 
       user = ::User.setup_system_user
       self.class.transaction do
-        client_files.window.where(name: 'Client Headshot Cache')&.delete_all
+        # Hard-delete ephemeral cache records (no reason to soft-delete or restore).
+        # Purge blobs first so S3 objects aren't orphaned.
+        client_files.window.where(name: 'Client Headshot Cache').each do |f|
+          f.client_file.purge if f.client_file.attached?
+          f.really_destroy!
+        end
+
         file = GrdaWarehouse::ClientFile.create(
           client_id: id,
           user_id: user.id,

--- a/app/models/soft_delete_retention_configuration.rb
+++ b/app/models/soft_delete_retention_configuration.rb
@@ -16,11 +16,16 @@ class SoftDeleteRetentionConfiguration
   DEFAULT_MAX_DELETED_PER_RUN = 10_000_000
 
   # Whether purging is enabled. Defaults to true in staging, false otherwise.
-  def enabled? = value_for(:enabled)&.to_i == 1 || Rails.env.staging?
+  def enabled?
+    value = value_for(:enabled)
+    return value.to_i == 1 if value.present?
+
+    Rails.env.staging?
+  end
 
   # Number of days to retain soft-deleted records before purging.
   def retention_period_days
-    value_for(:retention_period_days)&.to_i || DEFAULT_RETENTION_PERIOD_DAYS
+    value_for(:retention_period_days)&.to_i.presence || DEFAULT_RETENTION_PERIOD_DAYS
   end
 
   # Convenience timestamp: records deleted before this time are eligible for purging.

--- a/app/models/soft_delete_retention_configuration.rb
+++ b/app/models/soft_delete_retention_configuration.rb
@@ -18,7 +18,7 @@ class SoftDeleteRetentionConfiguration
   # Whether purging is enabled. Defaults to true in staging, false otherwise.
   def enabled?
     value = value_for(:enabled)
-    return value.to_i == 1 if value.present?
+    return ActiveModel::Type::Boolean.new.cast(value) if value.present?
 
     Rails.env.staging?
   end

--- a/app/models/soft_delete_retention_configuration.rb
+++ b/app/models/soft_delete_retention_configuration.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Shared retention configuration for soft-delete purge jobs.
+# Values are managed via AppConfigProperty and editable in the admin UI.
+#
+# @see PurgeSoftDeletedRecordsJob
+# @see PurgeSoftDeletedClientFilesJob
+class SoftDeleteRetentionConfiguration
+  DEFAULT_RETENTION_PERIOD_DAYS = 365
+  DEFAULT_MAX_DELETED_PER_RUN = 10_000_000
+
+  # Whether purging is enabled. Defaults to true in staging, false otherwise.
+  def enabled? = value_for(:enabled)&.to_i == 1 || Rails.env.staging?
+
+  # Number of days to retain soft-deleted records before purging.
+  def retention_period_days
+    value_for(:retention_period_days)&.to_i || DEFAULT_RETENTION_PERIOD_DAYS
+  end
+
+  # Convenience timestamp: records deleted before this time are eligible for purging.
+  def retain_at
+    retention_period_days.days.ago
+  end
+
+  # Safety cap on records deleted in a single job run.
+  def max_deleted_per_run
+    value_for(:max_deleted_per_run)&.to_i || DEFAULT_MAX_DELETED_PER_RUN
+  end
+
+  protected
+
+  PROPERTIES = [
+    :enabled,
+    :retention_period_days,
+    :max_deleted_per_run,
+  ].freeze
+
+  def values
+    @values ||= AppConfigProperty.
+      where(key: PROPERTIES.map { |attr| key_for(attr) }).
+      pluck(:key, :value).
+      to_h
+  end
+
+  def value_for(attr)
+    values[key_for(attr)].presence
+  end
+
+  def key_for(attr)
+    "purge_soft_deleted_records/#{attr}"
+  end
+end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -3,3 +3,12 @@
 silence_warnings do
   OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if Rails.env.development?
 end
+
+# Safety net: if a blob's backing object is gone from S3 by the time the analyze
+# job runs (e.g. soft-deleted record whose purge already fired, or a failed S3
+# upload), discard the job instead of retrying.
+Rails.application.config.after_initialize do
+  ActiveStorage::AnalyzeJob.discard_on(ActiveStorage::FileNotFoundError) do |_job, error|
+    Sentry.capture_exception(error) if Sentry.initialized?
+  end
+end

--- a/db/migrate/20260520213800_rename_purge_soft_deleted_records_config_key.rb
+++ b/db/migrate/20260520213800_rename_purge_soft_deleted_records_config_key.rb
@@ -1,0 +1,20 @@
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Migrate the legacy `purge_soft_deleted_records` AppConfigProperty key
+# to the namespaced `purge_soft_deleted_records/enabled` key used by
+# SoftDeleteRetentionConfiguration.
+class RenamePurgeSoftDeletedRecordsConfigKey < ActiveRecord::Migration[7.2]
+  def up
+    AppConfigProperty.where(key: 'purge_soft_deleted_records').update_all(key: 'purge_soft_deleted_records/enabled')
+  end
+
+  def down
+    AppConfigProperty.where(key: 'purge_soft_deleted_records/enabled').update_all(key: 'purge_soft_deleted_records')
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4234,6 +4234,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260520213800'),
 ('20260207120000'),
 ('20251215205826'),
 ('20251120143000'),

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -356,7 +356,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   def delete_image
-    client_files&.client_photos&.newest_first&.first&.destroy!
+    client_files&.client_photos&.newest_first&.first&.soft_delete
     @image = nil
   end
 

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -356,7 +356,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   end
 
   def delete_image
-    client_files&.client_photos&.newest_first&.first&.soft_delete
+    client_files&.client_photos&.newest_first&.first&.soft_delete!
     @image = nil
   end
 

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -354,7 +354,10 @@ namespace :grda_warehouse do
 
     # Purge old soft-deleted records (guarded by SoftDeleteRetentionConfiguration#enabled?)
     safely_execute do
-      PurgeSoftDeletedRecordsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later(dry_run: false) if DateTime.current.hour == 5
+      if DateTime.current.hour == 5
+        PurgeSoftDeletedRecordsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later(dry_run: false)
+        PurgeSoftDeletedClientFilesJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later
+      end
     end
 
     # Run CSG Engage export if ready

--- a/lib/tasks/grda_warehouse.rake
+++ b/lib/tasks/grda_warehouse.rake
@@ -352,10 +352,9 @@ namespace :grda_warehouse do
       end
     end
 
-    # Purge old soft-deleted records
+    # Purge old soft-deleted records (guarded by SoftDeleteRetentionConfiguration#enabled?)
     safely_execute do
-      enabled = AppConfigProperty.where(key: 'purge_soft_deleted_records', value: '1').any? || Rails.env.staging?
-      PurgeSoftDeletedRecordsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later(dry_run: false) if DateTime.current.hour == 5 && enabled
+      PurgeSoftDeletedRecordsJob.set(priority: BaseJob::MAINTENANCE_PRIORITY_15).perform_later(dry_run: false) if DateTime.current.hour == 5
     end
 
     # Run CSG Engage export if ready

--- a/spec/jobs/purge_soft_deleted_client_files_job_spec.rb
+++ b/spec/jobs/purge_soft_deleted_client_files_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PurgeSoftDeletedClientFilesJob, type: :job do
+  let!(:file_old) { create(:client_file) }
+  let!(:file_recent) { create(:client_file) }
+  let!(:file_active) { create(:client_file) }
+
+  before do
+    file_old.update_columns(deleted_at: 60.days.ago)
+    file_recent.update_columns(deleted_at: 10.days.ago)
+  end
+
+  describe '#perform' do
+    it 'purges only files deleted before the retention window' do
+      expect do
+        described_class.new.perform(retain_at: 30.days.ago)
+      end.to change { GrdaWarehouse::ClientFile.with_deleted.count }.by(-1)
+
+      expect(GrdaWarehouse::ClientFile.with_deleted.exists?(file_old.id)).to be false
+      expect(GrdaWarehouse::ClientFile.with_deleted.exists?(file_recent.id)).to be true
+      expect(GrdaWarehouse::ClientFile.with_deleted.exists?(file_active.id)).to be true
+    end
+
+    it 'preserves active files' do
+      described_class.new.perform(retain_at: 30.days.ago)
+
+      expect(file_active.reload.deleted_at).to be_nil
+    end
+
+    it 'purges ActiveStorage attachments for deleted files' do
+      blob_id = file_old.client_file.blob.id
+
+      described_class.new.perform(retain_at: 30.days.ago)
+
+      expect(ActiveStorage::Blob.exists?(blob_id)).to be false
+    end
+  end
+end

--- a/spec/jobs/purge_soft_deleted_client_files_job_spec.rb
+++ b/spec/jobs/purge_soft_deleted_client_files_job_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PurgeSoftDeletedClientFilesJob, type: :job do
   let!(:file_active) { create(:client_file) }
 
   before do
+    AppConfigProperty.create!(key: 'purge_soft_deleted_records/enabled', value: '1')
     file_old.update_columns(deleted_at: 60.days.ago)
     file_recent.update_columns(deleted_at: 10.days.ago)
   end

--- a/spec/jobs/purge_soft_deleted_records_job_spec.rb
+++ b/spec/jobs/purge_soft_deleted_records_job_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe PurgeSoftDeletedRecordsJob, type: :job do
     create(:hmis_external_api_ac_hmis_referral_household_member, client_id: client_active.id)
   end
 
+  before do
+    AppConfigProperty.create!(key: 'purge_soft_deleted_records/enabled', value: '1')
+  end
+
   describe '#perform' do
     it 'purges only old soft-deleted records' do
       expect do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description

Fix `ActiveStorage::FileNotFoundError` in `AnalyzeJob` caused by `acts_as_paranoid` + `dependent: :purge_later` race condition on client file records. Also closes the S3 orphan gap and consolidates soft-delete logic into a single documented method.

- **ClientFileBase**: Set `has_one_attached :client_file, dependent: false` to prevent soft-deletes from enqueuing `PurgeJob` that deletes S3 blobs while `AnalyzeJob` is still pending. Added `soft_delete` / `soft_delete!` methods to bypass `acts_as_paranoid`'s destroy callbacks, which would otherwise hard-delete `acts_as_taggable` tagging rows.
- **ActiveStorage initializer**: Add `discard_on ActiveStorage::FileNotFoundError` to `AnalyzeJob` to prevent retries for any case where a blob's S3 object is already gone. Reports to Sentry before discarding.
- **FilesController**: Replace inline `update(deleted_at:)` with `soft_delete!`
- **VI-SPDAT controller**: Replace `@file.destroy` with `soft_delete` to match the safe soft-delete pattern
- **HMIS Client `delete_image`**: Replace `destroy!` with `soft_delete!` to preserve taggings
- **Client image cache**: Purge ActiveStorage attachments and hard-delete (`really_destroy!`) ephemeral cache records in one pass, instead of soft-deleting throwaway records
- **PurgeSoftDeletedClientFilesJob**: Not enabled by default. New nightly job that finds client files soft-deleted beyond a retention window, purges their S3 blobs, and hard-deletes the records. 
- **SoftDeleteRetentionConfiguration**: Shared config for purging soft deleted records


## Checklist before requesting review

- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

