### PR TITLE
hotfix 9242 roh not populating on project scorecard

### DIFF
--- a/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/measure_two.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/generators/fy2026/measure_two.rb
@@ -37,9 +37,11 @@ module HudSpmReport::Generators::Fy2026
       HudSpmReport::Fy2026::Return.where(report_instance_id: report_instance.id).delete_all
     end
 
+    TABLE_NAME = '2a and 2b'
+
     def run_question!
       tables = [
-        ['2a and 2b', :run_2a_and_b],
+        [TABLE_NAME, :run_2a_and_b],
       ]
 
       @report.start(self.class.question_number, tables.map(&:first))

--- a/drivers/project_scorecard/app/models/project_scorecard/report.rb
+++ b/drivers/project_scorecard/app/models/project_scorecard/report.rb
@@ -391,8 +391,9 @@ module ProjectScorecard
         '7'
       end
 
-      number_of_exits = answer(spm_report(project_ids), '2', 'B' + project_row)
-      number_of_returns = answer(spm_report(project_ids), '2', 'I' + project_row)
+      spm_table = HudSpmReport::Generators::Fy2026::MeasureTwo::TABLE_NAME
+      number_of_exits = answer(spm_report(project_ids), spm_table, 'B' + project_row)
+      number_of_returns = answer(spm_report(project_ids), spm_table, 'I' + project_row)
 
       return nil if number_of_exits.blank? || number_of_exits.zero?
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


### Description

Fixes project scorecard failing to find SPM Measure 2 returns-to-homelessness data due to a mismatched table name lookup.

- **SPM Measure Two**: Extracted table name `'2a and 2b'` into a `TABLE_NAME` constant for external reference, avoiding drift
- **Project Scorecard ROH Scoring**: Replaced hardcoded `'2'` with the constant from `MeasureTwo`, fixing the lookup miss

### Type of Change

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

