### PR TITLE
Report Archival ids & jsonb columns

### DIFF
--- a/app/services/reports/archive_report_service.rb
+++ b/app/services/reports/archive_report_service.rb
@@ -137,18 +137,19 @@ module Reports
     end
 
     def generate_csv_to_file(association, _attachment_name, file_path)
-      # Get column names from the association's model class
       model_class = association.klass
       column_names = model_class.column_names
+      jsonb_columns = model_class.columns.select { |c| c.sql_type == 'jsonb' }.map(&:name).to_set
 
-      # Stream CSV directly to file
       CSV.open(file_path, 'wb') do |csv|
         csv << column_names
 
-        # Process in batches to avoid memory issues
         association.find_in_batches(batch_size: 1000) do |batch|
           batch.each do |record|
-            values = column_names.map { |col| record.send(col) }
+            values = column_names.map do |col|
+              value = record.send(col)
+              jsonb_columns.include?(col) && !value.nil? ? value.to_json : value
+            end
             csv << values
           end
         end

--- a/app/services/reports/reload_report_from_csv_service.rb
+++ b/app/services/reports/reload_report_from_csv_service.rb
@@ -67,8 +67,7 @@ module Reports
 
       # Get valid column names for the model
       valid_columns = model_class.column_names.to_set
-      # Exclude id from inserts - let database auto-generate new IDs
-      columns_to_exclude = ['id'].to_set
+      jsonb_columns = model_class.columns.select { |c| c.sql_type == 'jsonb' }.map(&:name).to_set
 
       relation = report.archival_relation_scope(csv_config, association_name, model_class)
 
@@ -87,8 +86,11 @@ module Reports
 
           # Convert CSV row to model attributes
           attributes = row.transform_keys(&:to_s)
-          # Filter to only include valid columns and exclude id
-          filtered_attributes = attributes.select { |key, _| valid_columns.include?(key) && !columns_to_exclude.include?(key) }
+          # Keep all valid columns including id — original IDs must be preserved so that
+          # polymorphic foreign keys (e.g. universe_membership_id in simple_report_universe_members)
+          # continue to resolve after reload. The hard-delete above removed the old rows, so
+          # re-inserting with the same IDs is safe.
+          filtered_attributes = attributes.select { |key, _| valid_columns.include?(key) }
           # Set required fields
           filtered_attributes['report_id'] = report.id if valid_columns.include?('report_id')
           filtered_attributes['deleted_at'] = nil if valid_columns.include?('deleted_at')
@@ -99,17 +101,20 @@ module Reports
           # Convert string values to appropriate types using model
           model_instance = model_class.new
           filtered_attributes.each do |key, value|
-            model_instance.send("#{key}=", value) if model_instance.respond_to?("#{key}=")
-          end
-          final_attributes = model_instance.attributes
-          final_attributes.delete('id')
+            next unless model_instance.respond_to?("#{key}=")
 
-          final_attributes
+            value = JSON.parse(value) if jsonb_columns.include?(key) && value.is_a?(String)
+            model_instance.send("#{key}=", value)
+          end
+          model_instance.attributes
         end
 
         # Insert the processed batch
         insert_batch(model_class, processed_batch, attachment_name)
       end
+
+      # Reset the PK sequence so future inserts don't collide with the restored IDs.
+      model_class.connection.reset_pk_sequence!(model_class.table_name) if model_class.column_names.include?('id')
 
       Rails.logger.info("ReloadReportFromCsvService: Processed #{total_rows} rows from #{attachment_name} for report ##{report.id}")
 

--- a/spec/services/reports/archive_report_service_spec.rb
+++ b/spec/services/reports/archive_report_service_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe Reports::ArchiveReportService, type: :service do
         t.integer :report_id, null: false
         t.string :name
         t.integer :age
+        t.jsonb :metadata
         t.timestamps
       end
     end
+    connection.add_column :test_archive_clients, :metadata, :jsonb unless connection.column_exists?(:test_archive_clients, :metadata)
 
     # Create test projects table
     unless connection.table_exists?(:test_archive_projects)
@@ -359,6 +361,23 @@ RSpec.describe Reports::ArchiveReportService, type: :service do
         # Verify age column is included
         expect(parsed.headers).to include('age')
         expect(parsed.map { |r| r['age'] }).to include('25', '30')
+      end
+    end
+
+    context 'with jsonb columns' do
+      before do
+        test_client_class.where(report_id: report.id).first.update!(metadata: [20, 30])
+      end
+
+      it 'serializes jsonb values as JSON strings in the CSV' do
+        service.archive!
+
+        csv_content = report.clients_csv.first.download
+        parsed = CSV.parse(csv_content, headers: true)
+        row = parsed.find { |r| r['metadata'].present? }
+        expect(row['metadata']).to eq('[20,30]')
+        expect { JSON.parse(row['metadata']) }.not_to raise_error
+        expect(JSON.parse(row['metadata'])).to eq([20, 30])
       end
     end
 

--- a/spec/services/reports/reload_report_from_csv_service_spec.rb
+++ b/spec/services/reports/reload_report_from_csv_service_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe Reports::ReloadReportFromCsvService, type: :service do
         t.integer :report_id, null: false
         t.integer :client_id
         t.integer :reporting_age
+        t.jsonb :metadata
         t.timestamps
       end
     end
+    connection.add_column :test_reload_clients, :metadata, :jsonb unless connection.column_exists?(:test_reload_clients, :metadata)
 
     # Create test projects table
     unless connection.table_exists?(:test_reload_projects)
@@ -239,6 +241,42 @@ RSpec.describe Reports::ReloadReportFromCsvService, type: :service do
         client = test_client_class.find_by(report_id: report.id, client_id: 100)
         expect(client).to be_present
         expect(client.reporting_age).to eq(25)
+      end
+
+      it 'preserves original IDs from the CSV' do
+        service.reload!
+
+        expect(test_client_class.find_by(id: 1)&.client_id).to eq(100)
+        expect(test_client_class.find_by(id: 2)&.client_id).to eq(101)
+      end
+
+      context 'with jsonb columns' do
+        before do
+          clients_csv = CSV.generate do |csv|
+            csv << ['id', 'client_id', 'report_id', 'reporting_age', 'metadata']
+            csv << [1, 100, report.id, 25, [20, 30].to_json]
+            csv << [2, 101, report.id, 30, nil]
+          end
+          report.clients_csv.detach
+          report.clients_csv.attach(
+            io: StringIO.new(clients_csv),
+            filename: 'clients-jsonb.csv',
+            content_type: 'text/csv',
+          )
+        end
+
+        it 'restores jsonb columns as Ruby objects, not strings' do
+          service.reload!
+
+          client = test_client_class.find_by(id: 1)
+          expect(client.metadata).to eq([20, 30])
+          expect(client.metadata).to be_an(Array)
+        end
+
+        it 'handles nil jsonb values without error' do
+          expect { service.reload! }.not_to raise_error
+          expect(test_client_class.find_by(id: 2).metadata).to be_nil
+        end
       end
 
       it 'does not update report updated_at timestamp' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixes two bugs that caused detail pages to show empty results after restoring a purged report from its archival CSV. The reload service was assigning new database IDs to restored records instead of keeping the originals, which silently broke the links between reports and their client lists. It was also mishandling a specific data type (jsonb) when writing to and reading from CSV, causing a database error that prevented the report from reloading at all.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
