### PR TITLE
Add filter for CE steps assigned to you

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1243,6 +1243,8 @@ type CeReferralAuditEventsPaginated {
 }
 
 input CeReferralFilterOptions {
+  assignedToUser: ID
+  assignedToYou: Boolean
   onCurrentTaskSince: ISO8601Date
   organization: [ID!]
   origin: [CeReferralOrigin!]

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1243,7 +1243,6 @@ type CeReferralAuditEventsPaginated {
 }
 
 input CeReferralFilterOptions {
-  assignedToUser: ID
   assignedToYou: Boolean
   onCurrentTaskSince: ISO8601Date
   organization: [ID!]

--- a/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/ce_referral.rb
@@ -107,6 +107,8 @@ module Types
       arg :on_current_task_since, GraphQL::Types::ISO8601Date # TODO - we will discuss this with design and probably make updates
       arg :origin, [HmisSchema::Enums::CeReferralOrigin]
       arg :search_term, String
+      arg :assigned_to_you, Boolean
+      arg :assigned_to_user, ID
     end
 
     def current_match_values

--- a/drivers/hmis/app/graphql/types/hmis_schema/client.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/client.rb
@@ -88,7 +88,7 @@ module Types
     )
     ce_referrals_field(
       :ce_referrals,
-      filter_args: { omit: [:workflow_template, :on_current_task_since, :search_term], type_name: 'ClientCeReferral' },
+      filter_args: { omit: [:workflow_template, :on_current_task_since, :search_term, :assigned_to_you, :assigned_to_user], type_name: 'ClientCeReferral' },
     )
 
     field :active_enrollment, Types::HmisSchema::Enrollment, null: true do

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_ce_referrals.rb
@@ -41,7 +41,7 @@ module Types
         raise unless Hmis::Ce.configuration.enabled?
 
         scope = scope.viewable_by(user) unless dangerous_skip_permission_check
-        scope = scope.apply_filters(filters) if filters.present?
+        scope = scope.apply_filters(filters, user: user) if filters.present?
         scope = scope.sort_by_option(sort_order) if sort_order.present?
 
         scope

--- a/drivers/hmis/app/graphql/types/hmis_schema/project.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/project.rb
@@ -123,8 +123,8 @@ module Types
     field :unit_groups, Types::HmisSchema::UnitGroup.page_type, null: false
 
     ce_opportunities_field(:ce_opportunities, filter_args: { omit: [:project, :project_group_id, :project_type, :organization, :available_on_date, :workflow_template], type_name: 'ProjectCeOpportunity' })
-    ce_referrals_field(:ce_referrals, filter_args: { omit: [:project, :project_group_id, :project_type, :organization, :on_current_task_since, :workflow_template], type_name: 'ProjectCeReferral' })
-    ce_referrals_field(:outgoing_direct_ce_referrals, filter_args: { omit: [:project_group_id, :on_current_task_since, :workflow_template, :origin], type_name: 'ProjectOutgoingCeReferral' })
+    ce_referrals_field(:ce_referrals, filter_args: { omit: [:project, :project_group_id, :project_type, :organization, :on_current_task_since, :workflow_template, :assigned_to_you, :assigned_to_user], type_name: 'ProjectCeReferral' })
+    ce_referrals_field(:outgoing_direct_ce_referrals, filter_args: { omit: [:project_group_id, :on_current_task_since, :workflow_template, :origin, :assigned_to_you, :assigned_to_user], type_name: 'ProjectOutgoingCeReferral' })
 
     def hud_id
       object.project_id

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -607,7 +607,8 @@ module Types
       resolve_ce_opportunities(Hmis::Ce::Opportunity.viewable_by(current_user), **args)
     end
 
-    ce_referrals_field
+    # Omit assigned_to_user for now. Enabling it will require a frontend change to map the filter to a user picklist
+    ce_referrals_field(filter_args: { omit: [:assigned_to_user], type_name: 'CeReferral' })
     def ce_referrals(**args)
       resolve_ce_referrals(Hmis::Ce::Referral.viewable_by(current_user), **args)
     end

--- a/drivers/hmis/app/models/hmis/ce/referral.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral.rb
@@ -189,8 +189,8 @@ module Hmis::Ce
       end
     end
 
-    def self.apply_filters(input)
-      Hmis::Filter::CeReferralFilter.new(input).filter_scope(self)
+    def self.apply_filters(input, user: nil)
+      Hmis::Filter::CeReferralFilter.new(input, user: user).filter_scope(self)
     end
 
     # Returns IDs of Referrals where there are completed steps assigned to

--- a/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
+++ b/drivers/hmis/app/models/hmis/filter/ce_referral_filter.rb
@@ -9,6 +9,13 @@
 class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
   include ::Hmis::Concerns::HmisArelHelper
 
+  attr_accessor :user
+
+  def initialize(input, user: nil)
+    super(input)
+    self.user = user
+  end
+
   def filter_scope(scope)
     scope = ensure_scope(scope)
     scope.
@@ -21,6 +28,8 @@ class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
       yield_self(&method(:on_current_task_since)).
       yield_self(&method(:with_origin)).
       yield_self(&method(:with_search_term)).
+      yield_self(&method(:assigned_to_current_user)).
+      yield_self(&method(:assigned_to_user)).
       yield_self(&method(:clean_scope))
   end
 
@@ -87,5 +96,24 @@ class Hmis::Filter::CeReferralFilter < Hmis::Filter::BaseFilter
     with_filter(scope, :search_term) do
       scope.matching_search_term(input.search_term)
     end
+  end
+
+  def assigned_to_current_user(scope)
+    with_filter(scope, :assigned_to_you) do
+      next scope unless user
+
+      filter_by_assigned_user(scope, user.id)
+    end
+  end
+
+  def assigned_to_user(scope)
+    with_filter(scope, :assigned_to_user) do
+      filter_by_assigned_user(scope, input.assigned_to_user)
+    end
+  end
+
+  def filter_by_assigned_user(scope, user_id)
+    scope.joins(:current_steps).
+      merge(Hmis::WorkflowExecution::Step.assigned_to(user_id))
   end
 end

--- a/drivers/hmis/spec/models/hmis/filter/ce_referral_filter_spec.rb
+++ b/drivers/hmis/spec/models/hmis/filter/ce_referral_filter_spec.rb
@@ -31,4 +31,35 @@ RSpec.describe Hmis::Filter::CeReferralFilter, type: :model do
       expect(apply_filter(base_scope, project_group_id: -1)).to be_empty
     end
   end
+
+  describe 'assignment filters' do
+    let!(:user_a) { create(:hmis_user, data_source: data_source) }
+    let!(:user_b) { create(:hmis_user, data_source: data_source) }
+    let!(:referral_a) { create(:hmis_ce_referral, data_source: data_source) }
+    let!(:referral_b) { create(:hmis_ce_referral, data_source: data_source) }
+    let!(:referral_c) { create(:hmis_ce_referral, data_source: data_source) }
+    let(:base_scope) { Hmis::Ce::Referral.where(id: [referral_a.id, referral_b.id, referral_c.id]) }
+
+    before do
+      create(:hmis_wfe_step, instance: referral_a.workflow_instance, assignees: [user_a])
+      create(:hmis_wfe_step, instance: referral_b.workflow_instance, assignees: [user_b])
+      create(:hmis_wfe_step, instance: referral_c.workflow_instance, assignees: [user_a], status: 'completed')
+    end
+
+    describe '#assigned_to_user' do
+      it 'returns referrals with an open step assigned to the given user' do
+        input = OpenStruct.new(assigned_to_user: user_a.id)
+        result = described_class.new(input).filter_scope(base_scope)
+        expect(result).to contain_exactly(referral_a)
+      end
+    end
+
+    describe '#assigned_to_current_user' do
+      it 'returns referrals with an open step assigned to the current user when assigned_to_you is true' do
+        input = OpenStruct.new(assigned_to_you: true)
+        result = described_class.new(input, user: user_a).filter_scope(base_scope)
+        expect(result).to contain_exactly(referral_a)
+      end
+    end
+  end
 end

--- a/drivers/hmis/spec/requests/hmis/ce/ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_referrals_spec.rb
@@ -111,6 +111,24 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    context 'when filtering by assigned to current user' do
+      let!(:other_user) { create(:hmis_user, data_source: ds1) }
+      let!(:referral_assigned_to_me) { create(:hmis_ce_referral, project: project, data_source: ds1) }
+      let!(:referral_assigned_to_other) { create(:hmis_ce_referral, project: project, data_source: ds1) }
+      let!(:referral_with_completed_step) { create(:hmis_ce_referral, project: project, data_source: ds1) }
+
+      before do
+        create(:hmis_wfe_step, instance: referral_assigned_to_me.workflow_instance, assignees: [hmis_user])
+        create(:hmis_wfe_step, instance: referral_assigned_to_other.workflow_instance, assignees: [other_user])
+        create(:hmis_wfe_step, instance: referral_with_completed_step.workflow_instance, assignees: [hmis_user], status: 'completed')
+      end
+
+      it 'returns only referrals with an open step assigned to the current user' do
+        referrals = perform_referrals_query(filters: { assignedToYou: true })
+        expect(referrals.map { |r| r['id'] }).to contain_exactly(referral_assigned_to_me.id.to_s)
+      end
+    end
+
     context 'when querying by workflow template' do
       let!(:referral) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_1) }
       let!(:referral2) { create(:hmis_ce_referral, project: project, data_source: ds1, workflow_template: workflow_template_1) }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Add and implement new filters for CeReferrals: `assignedToYou` and `assignedToUser`. 
- Only `assignedToYou` is exposed in the graphql API for now
- It's only exposed on the CeReferral table, not the Client or Project referral tables.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
