### PR TITLE
Use bool_field pattern on FormAccess

### DIFF
--- a/drivers/hmis/app/graphql/types/forms/form_access.rb
+++ b/drivers/hmis/app/graphql/types/forms/form_access.rb
@@ -13,21 +13,11 @@ module Types
 
       included do
         access_field do
-          field :can_manage_form, GraphQL::Types::Boolean, null: false
-          field :can_duplicate_form, GraphQL::Types::Boolean, null: false
-          field :can_publish_form, GraphQL::Types::Boolean, null: false
+          define_method(:policy) { @policy ||= policy_for(object, policy_type: :form_definition) }
 
-          define_method(:can_manage_form) do
-            policy_for(object, policy_type: :form_definition).can_manage_form?
-          end
-
-          define_method(:can_duplicate_form) do
-            policy_for(object, policy_type: :form_definition).can_duplicate?
-          end
-
-          define_method(:can_publish_form) do
-            policy_for(object, policy_type: :form_definition).can_publish?
-          end
+          bool_field(:can_manage_form) { policy.can_manage_form? }
+          bool_field(:can_duplicate_form) { policy.can_duplicate? }
+          bool_field(:can_publish_form) { policy.can_publish? }
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
Update the `FormAccess` schema object, which already used the `FormDefinitionPolicy`, to use the new `bool_field` pattern.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
