### PR TITLE
Update `AssessmentAccess` and deprecate unused fields

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -312,9 +312,9 @@ type AssessmentAccess {
   """
   Whether the user can delete this assessment
   """
-  canDelete: Boolean!
-  canDeleteAssessments: Boolean! @deprecated(reason: "Use assessment.access.canDelete")
-  canDeleteEnrollments: Boolean! @deprecated(reason: "Use assessment.access.canDelete")
+  canDeleteAssessment: Boolean!
+  canDeleteAssessments: Boolean! @deprecated(reason: "Use assessment.access.canDeleteAssessment")
+  canDeleteEnrollments: Boolean! @deprecated(reason: "Use assessment.access.canDeleteAssessment")
   canEditEnrollments: Boolean! @deprecated(reason: "Use enrollment.access.canEditEnrollments for enrollment edit checks")
   id: ID!
 }

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -309,9 +309,12 @@ type Assessment {
 }
 
 type AssessmentAccess {
+  """
+  Whether the user can delete this assessment
+  """
   canDeleteAssessments: Boolean!
-  canDeleteEnrollments: Boolean!
-  canEditEnrollments: Boolean!
+  canDeleteEnrollments: Boolean! @deprecated(reason: "Use assessment.access.canDeleteAssessments for delete checks")
+  canEditEnrollments: Boolean! @deprecated(reason: "Use enrollment.access.canEditEnrollments for enrollment edit checks")
   id: ID!
 }
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -312,8 +312,9 @@ type AssessmentAccess {
   """
   Whether the user can delete this assessment
   """
-  canDeleteAssessments: Boolean!
-  canDeleteEnrollments: Boolean! @deprecated(reason: "Use assessment.access.canDeleteAssessments for delete checks")
+  canDelete: Boolean!
+  canDeleteAssessments: Boolean! @deprecated(reason: "Use assessment.access.canDelete")
+  canDeleteEnrollments: Boolean! @deprecated(reason: "Use assessment.access.canDelete")
   canEditEnrollments: Boolean! @deprecated(reason: "Use enrollment.access.canEditEnrollments for enrollment edit checks")
   id: ID!
 }

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -44,11 +44,11 @@ module Types
     access_field do
       define_method(:assessment_policy) { @assessment_policy ||= policy_for(object, policy_type: :hmis_custom_assessment) }
 
-      # Indicates whether the user can delete THIS assessment. (Keeps the name "can_delete_assessments" for backwards compatibility)
-      bool_field(:can_delete_assessments, description: 'Whether the user can delete this assessment') { assessment_policy.can_delete? }
+      bool_field(:can_delete, description: 'Whether the user can delete this assessment') { assessment_policy.can_delete? }
 
       can :edit_enrollments, deprecation_reason: 'Use enrollment.access.canEditEnrollments for enrollment edit checks'
-      can :delete_enrollments, deprecation_reason: 'Use assessment.access.canDeleteAssessments for delete checks'
+      can :delete_enrollments, deprecation_reason: 'Use assessment.access.canDelete'
+      can :delete_assessments, deprecation_reason: 'Use assessment.access.canDelete'
     end
     # Related records that were created by this Assessment, if applicable
     field :ce_assessment, Types::HmisSchema::CeAssessment, null: true

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -42,9 +42,13 @@ module Types
     field :client, HmisSchema::Client, null: false
     field :in_progress, Boolean, null: false
     access_field do
-      can :edit_enrollments
-      can :delete_enrollments
-      can :delete_assessments
+      define_method(:assessment_policy) { @assessment_policy ||= policy_for(object, policy_type: :hmis_custom_assessment) }
+
+      # Indicates whether the user can delete THIS assessment. (Keeps the name "can_delete_assessments" for backwards compatibility)
+      bool_field(:can_delete_assessments, description: 'Whether the user can delete this assessment') { assessment_policy.can_delete? }
+
+      can :edit_enrollments, deprecation_reason: 'Use enrollment.access.canEditEnrollments for enrollment edit checks'
+      can :delete_enrollments, deprecation_reason: 'Use assessment.access.canDeleteAssessments for delete checks'
     end
     # Related records that were created by this Assessment, if applicable
     field :ce_assessment, Types::HmisSchema::CeAssessment, null: true

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -44,11 +44,11 @@ module Types
     access_field do
       define_method(:assessment_policy) { @assessment_policy ||= policy_for(object, policy_type: :hmis_custom_assessment) }
 
-      bool_field(:can_delete, description: 'Whether the user can delete this assessment') { assessment_policy.can_delete? }
+      bool_field(:can_delete_assessment, description: 'Whether the user can delete this assessment') { assessment_policy.can_delete? }
 
       can :edit_enrollments, deprecation_reason: 'Use enrollment.access.canEditEnrollments for enrollment edit checks'
-      can :delete_enrollments, deprecation_reason: 'Use assessment.access.canDelete'
-      can :delete_assessments, deprecation_reason: 'Use assessment.access.canDelete'
+      can :delete_enrollments, deprecation_reason: 'Use assessment.access.canDeleteAssessment'
+      can :delete_assessments, deprecation_reason: 'Use assessment.access.canDeleteAssessment'
     end
     # Related records that were created by this Assessment, if applicable
     field :ce_assessment, Types::HmisSchema::CeAssessment, null: true

--- a/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             id
             access {
               id
-              canDeleteAssessments
+              canDelete
             }
           }
         }
@@ -34,13 +34,13 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       expect(response.status).to eq(200), result.inspect
       expect(result.dig('data', 'assessment', 'access')).to include(
         'id' => assessment.id.to_s,
-        'canDeleteAssessments' => can_delete,
+        'canDelete' => can_delete,
       )
     end
 
     let(:view_permissions) { [:can_view_enrollment_details, :can_view_project] }
 
-    it 'resolves canDeleteAssessments from the assessment policy (WIP + can_edit_enrollments)' do
+    it 'resolves canDelete from the assessment policy (WIP + can_edit_enrollments)' do
       create_access_control(hmis_user, p1, with_permission: [:can_edit_enrollments, *view_permissions])
       assessment = create(:hmis_wip_custom_assessment, data_source: ds1, enrollment: e1, client: c1)
 

--- a/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
@@ -22,36 +22,36 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             id
             access {
               id
-              canDelete
+              canDeleteAssessment
             }
           }
         }
       GRAPHQL
     end
 
-    def expect_assessment_access!(assessment:, can_delete:)
+    def expect_assessment_access!(assessment:, can_delete_assessment:)
       response, result = post_graphql(id: assessment.id.to_s) { access_query }
       expect(response.status).to eq(200), result.inspect
       expect(result.dig('data', 'assessment', 'access')).to include(
         'id' => assessment.id.to_s,
-        'canDelete' => can_delete,
+        'canDeleteAssessment' => can_delete_assessment,
       )
     end
 
     let(:view_permissions) { [:can_view_enrollment_details, :can_view_project] }
 
-    it 'resolves canDelete from the assessment policy (WIP + can_edit_enrollments)' do
+    it 'resolves canDeleteAssessment from the assessment policy (WIP + can_edit_enrollments)' do
       create_access_control(hmis_user, p1, with_permission: [:can_edit_enrollments, *view_permissions])
       assessment = create(:hmis_wip_custom_assessment, data_source: ds1, enrollment: e1, client: c1)
 
-      expect_assessment_access!(assessment: assessment, can_delete: true)
+      expect_assessment_access!(assessment: assessment, can_delete_assessment: true)
     end
 
     it 'returns false when the policy denies delete' do
       create_access_control(hmis_user, p1, with_permission: [*view_permissions])
       assessment = create(:hmis_custom_assessment, data_source: ds1, enrollment: e1, client: c1)
 
-      expect_assessment_access!(assessment: assessment, can_delete: false)
+      expect_assessment_access!(assessment: assessment, can_delete_assessment: false)
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/assessment_access_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../login_and_permissions'
+require_relative '../../../support/hmis_base_setup'
+
+# Tests Assessment.access schema fields are wired up correctly.
+# See hmis_custom_assessment_policy_spec.rb for full policy coverage.
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let(:c1) { create :hmis_hud_client, data_source: ds1 }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+
+  before(:each) { hmis_login(user) }
+
+  describe 'assessment access' do
+    let(:access_query) do
+      <<~GRAPHQL
+        query AssessmentAccess($id: ID!) {
+          assessment(id: $id) {
+            id
+            access {
+              id
+              canDeleteAssessments
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def expect_assessment_access!(assessment:, can_delete:)
+      response, result = post_graphql(id: assessment.id.to_s) { access_query }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'assessment', 'access')).to include(
+        'id' => assessment.id.to_s,
+        'canDeleteAssessments' => can_delete,
+      )
+    end
+
+    let(:view_permissions) { [:can_view_enrollment_details, :can_view_project] }
+
+    it 'resolves canDeleteAssessments from the assessment policy (WIP + can_edit_enrollments)' do
+      create_access_control(hmis_user, p1, with_permission: [:can_edit_enrollments, *view_permissions])
+      assessment = create(:hmis_wip_custom_assessment, data_source: ds1, enrollment: e1, client: c1)
+
+      expect_assessment_access!(assessment: assessment, can_delete: true)
+    end
+
+    it 'returns false when the policy denies delete' do
+      create_access_control(hmis_user, p1, with_permission: [*view_permissions])
+      assessment = create(:hmis_custom_assessment, data_source: ds1, enrollment: e1, client: c1)
+
+      expect_assessment_access!(assessment: assessment, can_delete: false)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
- On the `Assessment.access` schema object, add a new field `can_delete` that delegates to the policy.
- **Why a new field instead of reusing the old `can_delete_assessments`**: 
  - I got tripped up thinking through whether that strategy would be fully backwards compatible, if the old frontend, expecting raw permissions, ran against the new backend code, which delegates to the policy. 
  - I couldn't come up with a concrete combination of permissions that would lead to a logical error. But I feel much more confident in the backwards compatibility if we just resolve a new permission.
  - Added bonus: naming-wise, the singular `canDelete` instead of plural `canDeleteAssessments` makes much more sense since this field is answering the question, "can the user delete THIS assessment?"
- Deprecate the other `Assessment.access` fields. (See linked frontend PR description https://github.com/greenriver/hmis-frontend/pull/1471)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
