### PR TITLE
HMIS Data Quality Tool - Employment Records Outside of Report Range

### DIFF
--- a/db/warehouse/migrate/20260521120000_add_employment_event_expected_to_dqt_enrollments.rb
+++ b/db/warehouse/migrate/20260521120000_add_employment_event_expected_to_dqt_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmploymentEventExpectedToDqtEnrollments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :hmis_dqt_enrollments, :employment_event_expected, :boolean
+  end
+end

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -24,10 +24,14 @@ module HmisDataQualityTool
     HOMELESS_LIVING_SITUATIONS = HudHelper.util.homeless_situations(as: :prior)
     INSTITUTIONAL_LIVING_SITUATIONS = HudHelper.util.institutional_situations(as: :prior)
     HOUSED_LIVING_SITUATIONS = HudHelper.util.temporary_situations(as: :prior) + HudHelper.util.permanent_situations(as: :prior)
-    REQUIRED_EMPLOYMENT_STAGES = [
-      HudHelper.util.data_collection_stage('Project entry', true),
-      HudHelper.util.data_collection_stage('Project exit', true),
-    ].freeze
+    # HUD data collection stages at which employment data is required (entry and exit).
+    # Keys are stage integers used to filter EmploymentEducation records.
+    # Values are lambdas that extract the corresponding event date from an enrollment,
+    # used to determine whether that event falls within the report range.
+    REQUIRED_EMPLOYMENT_STAGES = {
+      HudHelper.util.data_collection_stage('Project entry', true) => lambda(&:EntryDate),
+      HudHelper.util.data_collection_stage('Project exit', true) => ->(enrollment) { enrollment.exit&.ExitDate },
+    }.freeze
 
     attr_accessor :report_end_date, :entry_threshold, :exit_threshold, :project_coc_codes
 
@@ -124,6 +128,7 @@ module HmisDataQualityTool
         iraq_ond: { title: 'Iraq (Operation New Dawn)', translator: ->(v) { "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
         military_branch: { title: 'Military Branch', translator: ->(v) { "#{HudHelper.util.military_branch(v)} (#{v})" } },
         discharge_status: { title: 'Discharge Status', translator: ->(v) { "#{HudHelper.util.discharge_status(v)} (#{v})" } },
+        employment_event_expected: { title: 'Employment event in report range?' },
         employed: { title: 'Employed', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
         employment_type: { title: 'Employment Type', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.employment_type(v)} (#{v})" } },
         not_employed_reason: { title: 'Reason Not Employed', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.not_employed_reason(v)} (#{v})" } },
@@ -224,6 +229,7 @@ module HmisDataQualityTool
       # To make the HudReport includes work
       @report = report
       self.report_end_date = report.filter.end_date
+      range = report.filter.start..report.filter.end
 
       client = enrollment.client
       report_item = self.class.new(
@@ -271,10 +277,14 @@ module HmisDataQualityTool
       report_item.iraq_ond = client.IraqOND
       report_item.military_branch = client.MilitaryBranch
       report_item.discharge_status = client.DischargeStatus
-      employment_education = required_employment_education_in_range(enrollment, report.filter.start..report.filter.end)
+      employment_education = required_employment_education_in_range(enrollment, range)
       report_item.employed = employment_education&.Employed
       report_item.employment_type = employment_education&.EmploymentType
       report_item.not_employed_reason = employment_education&.NotEmployedReason
+      report_item.employment_event_expected = REQUIRED_EMPLOYMENT_STAGES.any? do |_stage, date_for|
+        date = date_for.call(enrollment)
+        date.present? && range.cover?(date)
+      end
 
       # HP Targeting Criteria
       report_item.target_screen_required = enrollment.TargetScreenReqd
@@ -425,7 +435,7 @@ module HmisDataQualityTool
     # Pull most recent entry or exit record within range.
     private def required_employment_education_in_range(enrollment, range)
       enrollment.employment_educations.select do |ee|
-        REQUIRED_EMPLOYMENT_STAGES.include?(ee.DataCollectionStage) &&
+        REQUIRED_EMPLOYMENT_STAGES.key?(ee.DataCollectionStage) &&
           ee.InformationDate.present? &&
           range.cover?(ee.InformationDate)
       end.max_by(&:InformationDate)
@@ -1897,8 +1907,9 @@ module HmisDataQualityTool
         employed: {
           title: 'Employed',
           description: 'Employed Status is "Data not collected" (99) or blank',
-          required_for: 'Adults',
+          required_for: 'Adults with an entry or exit in the report range',
           detail_columns: default_detail_columns + [
+            :employment_event_expected,
             :employed,
           ],
           denominator: ->(item) {
@@ -1920,10 +1931,11 @@ module HmisDataQualityTool
               HudHelper.util.performance_reporting[:rrh],
             ].flatten.include?(item.project_type)
 
-            # Only adults that include the above funder(s) and project type(s)
-            adult?(item) && in_project_types && (funding_sources & item.funders).any?
+            # Only adults that include the above funder(s) and project type(s), with an in-range entry or exit
+            adult?(item) && in_project_types && (funding_sources & item.funders).any? && item.employment_event_expected != false
           },
           limiter: ->(item) {
+            return false if item.employment_event_expected == false
             return false unless adult?(item)
 
             # Limit to items with intersecting funders below
@@ -1953,8 +1965,9 @@ module HmisDataQualityTool
         employment_type_matches_status: {
           title: 'Employment Type Matches Employment Status',
           description: 'Employment status and employment type do not match expected results',
-          required_for: 'Adults',
+          required_for: 'Adults with an entry or exit in the report range',
           detail_columns: default_detail_columns + [
+            :employment_event_expected,
             :employed,
             :employment_type,
           ],
@@ -1977,10 +1990,11 @@ module HmisDataQualityTool
               HudHelper.util.performance_reporting[:rrh],
             ].flatten.include?(item.project_type)
 
-            # Only adults that include the above funder(s) and project type(s)
-            adult?(item) && in_project_types && (funding_sources & item.funders).any?
+            # Only adults that include the above funder(s) and project type(s), with an in-range entry or exit
+            adult?(item) && in_project_types && (funding_sources & item.funders).any? && item.employment_event_expected != false
           },
           limiter: ->(item) {
+            return false if item.employment_event_expected == false
             return false unless adult?(item)
 
             # Limit to items with intersecting funders below
@@ -2013,8 +2027,9 @@ module HmisDataQualityTool
         not_employed_reason_matches_status: {
           title: 'Reason Not Employed Matches Employment Status',
           description: 'Employment status and reason not employed do not match expected results',
-          required_for: 'Adults',
+          required_for: 'Adults with an entry or exit in the report range',
           detail_columns: default_detail_columns + [
+            :employment_event_expected,
             :employed,
             :not_employed_reason,
           ],
@@ -2037,10 +2052,11 @@ module HmisDataQualityTool
               HudHelper.util.performance_reporting[:rrh],
             ].flatten.include?(item.project_type)
 
-            # Only adults that include the above funder(s) and project type(s)
-            adult?(item) && in_project_types && (funding_sources & item.funders).any?
+            # Only adults that include the above funder(s) and project type(s), with an in-range entry or exit
+            adult?(item) && in_project_types && (funding_sources & item.funders).any? && item.employment_event_expected != false
           },
           limiter: ->(item) {
+            return false if item.employment_event_expected == false
             return false unless adult?(item)
 
             # Limit to items with intersecting funders below

--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -124,9 +124,9 @@ module HmisDataQualityTool
         iraq_ond: { title: 'Iraq (Operation New Dawn)', translator: ->(v) { "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
         military_branch: { title: 'Military Branch', translator: ->(v) { "#{HudHelper.util.military_branch(v)} (#{v})" } },
         discharge_status: { title: 'Discharge Status', translator: ->(v) { "#{HudHelper.util.discharge_status(v)} (#{v})" } },
-        employed: { title: 'Employed', translator: ->(v) { "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
-        employment_type: { title: 'Employment Type', translator: ->(v) { "#{HudHelper.util.employment_type(v)} (#{v})" } },
-        not_employed_reason: { title: 'Reason Not Employed', translator: ->(v) { "#{HudHelper.util.not_employed_reason(v)} (#{v})" } },
+        employed: { title: 'Employed', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.no_yes_reasons_for_missing_data(v)} (#{v})" } },
+        employment_type: { title: 'Employment Type', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.employment_type(v)} (#{v})" } },
+        not_employed_reason: { title: 'Reason Not Employed', translator: ->(v) { v.nil? ? '' : "#{HudHelper.util.not_employed_reason(v)} (#{v})" } },
       }.freeze
     end
 

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
@@ -1201,7 +1201,7 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
     describe 'Employed' do
       # Guard against HUD list changes: Project entry/exit must resolve to valid data collection stages.
       it 'resolves Project entry and Project exit to valid data collection stage values' do
-        stages = HmisDataQualityTool::Enrollment::REQUIRED_EMPLOYMENT_STAGES
+        stages = HmisDataQualityTool::Enrollment::REQUIRED_EMPLOYMENT_STAGES.keys
         expect(stages).to contain_exactly(1, 3), "Expected stages 1 (Project entry) and 3 (Project exit), got #{stages.inspect}"
       end
 
@@ -1443,6 +1443,55 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         it 'does not populate employed when only non-required (annual) record in range' do
           enrollment_item = HmisDataQualityTool::Enrollment.find_by(enrollment_id: @enrollment.id, report_id: @report.id)
           expect(enrollment_item.employed).to be_nil
+        end
+      end
+
+      context 'with pre-period stayer (entry before report range, no exit)' do
+        before do
+          @project = create_employment_required_project
+          @client = create_client_with_warehouse_link(dob: '1990-01-15'.to_date)
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            entry_date: '2022-07-01'.to_date,
+            exit_date: nil,
+          )
+          create_employment_education(
+            enrollment: @enrollment,
+            information_date: '2022-07-01'.to_date,
+            data_collection_stage: 1,
+            employed: 0,
+            not_employed_reason: 2,
+          )
+          @report = setup_report([@project.id])
+        end
+
+        it 'excludes pre-period stayer from employment check (no qualifying event in range)' do
+          expect_result(key: :employed, total: 0, invalid_count: 0)
+        end
+      end
+
+      context 'with pre-period stayer and invalid employment data (entry before range, no exit)' do
+        before do
+          @project = create_employment_required_project
+          @client = create_client_with_warehouse_link(dob: '1990-01-15'.to_date)
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            entry_date: '2022-07-01'.to_date,
+            exit_date: nil,
+          )
+          create_employment_education(
+            enrollment: @enrollment,
+            information_date: '2022-07-01'.to_date,
+            data_collection_stage: 1,
+            employed: 99,
+          )
+          @report = setup_report([@project.id])
+        end
+
+        it 'excludes pre-period stayer even when employment data is invalid' do
+          expect_result(key: :employed, total: 0, invalid_count: 0)
         end
       end
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The HMIS Data Quality Tool was incorrectly flagging clients as having missing employment data when they had actually entered a program *before* the report period and were still enrolled with no exit — so-called "pre-period stayers." Because their entry happened outside the report date range, no employment record was expected to exist within that range, but the check was including them anyway and counting them as errors.

This change updates all three employment-related DQ checks (Employed, Employment Type Matches Status, and Reason Not Employed Matches Status) so that a client is only evaluated if they have an entry or exit that falls within the report date range. Clients who entered before the report window and are still active are now excluded from the denominator entirely. Reports run before this fix are unaffected — only newly generated reports will reflect the corrected logic.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
