### PR TITLE
Add secure files helper for file transfer

### DIFF
--- a/lib/tasks/secure_files.rake
+++ b/lib/tasks/secure_files.rake
@@ -1,0 +1,58 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Developer utility for uploading a file to Secure Files.
+# Uploaded files can be accessed via the warehouse UI (Account => Secure Files).
+# Useful for getting ad-hoc exports, reports, or data dumps into the warehouse
+# without one-off scp file transfers or manual S3 uploads.
+#
+# Only for uploading to your own greenriver account. Out of caution,
+# the task will fail if the user ID provided is not associated with a greenriver account.
+#
+# Examples:
+#   bundle exec rake "secure_files:upload_to_secure_files[/tmp/data.zip,168]"
+#
+namespace :secure_files do
+  desc 'Upload a local file as a SecureFile. Args: filepath, user_id (sender and recipient)'
+  task :upload_to_secure_files, [:filepath, :user_id] => :environment do |_task, args|
+    filepath = args[:filepath]
+    user_id = args[:user_id]
+
+    abort 'Usage: rake "secure_files:upload_to_secure_files[filepath,user_id]"' if filepath.blank? || user_id.blank?
+
+    path = Pathname.new(filepath).expand_path
+    abort "File not found: #{path}" unless path.file?
+
+    user = User.find(user_id)
+
+    # Don't allow uploading to non-greenriver accounts, to prevent accidental data exposure. If sharing externally, download and re-upload to Secure Files interface.
+    raise ArgumentError, "User #{user.id} (#{user.email.inspect}) must have an email containing 'greenriver'" unless user.email&.match?(/greenriver/i)
+
+    secure_file = GrdaWarehouse::SecureFile.create!(
+      sender_id: user.id,
+      recipient_id: user.id,
+      name: path.basename.to_s,
+    )
+
+    content_type = Marcel::MimeType.for(path, name: path.basename.to_s) || 'application/octet-stream'
+
+    File.open(path, 'rb') do |io|
+      secure_file.secure_file.attach(
+        io: io,
+        filename: path.basename.to_s,
+        content_type: content_type,
+      )
+    end
+
+    puts "Created SecureFile id=#{secure_file.id}"
+    puts "  name: #{secure_file.name}"
+    puts "  user: #{user.id} (#{user.email})"
+    puts "  size: #{secure_file.secure_file.byte_size} bytes"
+    puts "  path: #{Rails.application.routes.url_helpers.secure_file_path(secure_file)}"
+  end
+end

--- a/lib/tasks/secure_files.rake
+++ b/lib/tasks/secure_files.rake
@@ -7,7 +7,7 @@
 # frozen_string_literal: true
 
 # Developer utility for uploading a file to Secure Files.
-# Uploaded files can be accessed via the warehouse UI (Account => Secure Files).
+# Uploaded files can be accessed via the warehouse UI (Account => Secure Files) with appropriate permissions.
 # Useful for getting ad-hoc exports, reports, or data dumps into the warehouse
 # without one-off scp file transfers or manual S3 uploads.
 #
@@ -15,7 +15,7 @@
 # the task will fail if the user ID provided is not associated with a greenriver account.
 #
 # Examples:
-#   bundle exec rake "secure_files:upload_to_secure_files[/tmp/data.zip,168]"
+#   bundle exec rake "secure_files:upload_to_secure_files[/tmp/data.zip,1]"
 #
 namespace :secure_files do
   desc 'Upload a local file as a SecureFile. Args: filepath, user_id (sender and recipient)'
@@ -31,7 +31,7 @@ namespace :secure_files do
     user = User.find(user_id)
 
     # Don't allow uploading to non-greenriver accounts, to prevent accidental data exposure. If sharing externally, download and re-upload to Secure Files interface.
-    raise ArgumentError, "User #{user.id} (#{user.email.inspect}) must have an email containing 'greenriver'" unless user.email&.match?(/greenriver/i)
+    raise ArgumentError, "User #{user.id} (#{user.email.inspect}) must have an email containing 'greenriver'" unless user.email&.match?(/@greenriver/i) || Rails.env.development?
 
     secure_file = GrdaWarehouse::SecureFile.create!(
       sender_id: user.id,
@@ -53,6 +53,6 @@ namespace :secure_files do
     puts "  name: #{secure_file.name}"
     puts "  user: #{user.id} (#{user.email})"
     puts "  size: #{secure_file.secure_file.byte_size} bytes"
-    puts "  path: #{Rails.application.routes.url_helpers.secure_file_path(secure_file)}"
+    puts "  url:  https://#{ENV['FQDN']}/secure_files"
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
Dev tool for uploading files to Secure Files.

Built when working on https://github.com/open-path/Green-River/issues/9179, sharing for general dev use.

## How to test
```
bundle exec rake "secure_files:upload_to_secure_files[test.txt,1]"
```
## Type of change
New developer feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
