### PR TITLE
feat: add release tag to system status and non-production header

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           echo $SHA > docker/app/REVISION
           echo $BRANCH > docker/app/GIT_BRANCH
+          git describe --tags --always > docker/app/GIT_RELEASE
           bin/error_if_githash_is_latest.rb base
 
       # https://github.com/docker/metadata-action#images-input

--- a/app/controllers/system_status_controller.rb
+++ b/app/controllers/system_status_controller.rb
@@ -113,6 +113,7 @@ class SystemStatusController < ActionController::Base
       jobs_message: jobs_message,
       revision: Git.revision,
       branch: Git.branch,
+      release: Git.release,
       hostname: `hostname`.chomp,
       cache: cache_message,
       user_count_positive: User.all.any?,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -306,6 +306,8 @@ module ApplicationHelper
   end
 
   def release_info
+    return unless Git.release
+
     content_tag :div, class: 'navbar-text' do
       content_tag :span, Git.release, class: 'label label-warning'
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,6 +305,12 @@ module ApplicationHelper
     end
   end
 
+  def release_info
+    content_tag :div, class: 'navbar-text' do
+      content_tag :span, Git.release, class: 'label label-warning'
+    end
+  end
+
   def git_revision
     Git.revision
   end

--- a/app/views/layouts/_header_warnings.haml
+++ b/app/views/layouts/_header_warnings.haml
@@ -22,8 +22,9 @@
               (EKS)
       .git-branch.ml-4
         = branch_info 
-      .git-branch.ml-4
-        = release_info
+      - if release_info
+        .git-branch.ml-4
+          = release_info
       .git-branch.ml-4
         .navbar-text
           .label.label-info

--- a/app/views/layouts/_header_warnings.haml
+++ b/app/views/layouts/_header_warnings.haml
@@ -21,7 +21,9 @@
             - if ENV['EKS']
               (EKS)
       .git-branch.ml-4
-        = branch_info
+        = branch_info 
+      .git-branch.ml-4
+        = release_info
       .git-branch.ml-4
         .navbar-text
           .label.label-info

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -242,6 +242,7 @@ COPY --chown=app-user:app-user . ./
 COPY --chown=app-user:app-user sample.irbrc ./.irbrc
 COPY --chown=app-user:app-user docker/app/REVISION ./
 COPY --chown=app-user:app-user docker/app/GIT_BRANCH ./
+COPY --chown=app-user:app-user docker/app/GIT_RELEASE ./
 COPY --chown=app-user:app-user docker/app/database.open-path-warehouse.yml ./config/database.yml
 
 # NOTE: The following ENV are required for assets compilation to run, but not actually used

--- a/lib/util/git.rb
+++ b/lib/util/git.rb
@@ -26,4 +26,14 @@ class Git
   rescue StandardError
     'unknown'
   end
+
+  def self.release
+    # Release tags are only meaningful on deployed environments.
+    # Development branches do not have a meaningful release tag.
+    return 'release-DEV' if Rails.env.development?
+
+    File.read("#{Rails.root}/GIT_RELEASE").chomp
+  rescue StandardError
+    'unknown'
+  end
 end

--- a/lib/util/git.rb
+++ b/lib/util/git.rb
@@ -28,9 +28,7 @@ class Git
   end
 
   def self.release
-    # Release tags are only meaningful on deployed environments.
-    # Development branches do not have a meaningful release tag.
-    return 'release-DEV' if Rails.env.development?
+    return nil if Rails.env.development?
 
     File.read("#{Rails.root}/GIT_RELEASE").chomp
   rescue StandardError


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds a `Git.release` helper that reads a `GIT_RELEASE` file baked into the Docker image at build time via `git describe --tags --always`. This gives a human-readable release tag (e.g. `release-2026.05.22`) wherever the existing `Git.revision`/`Git.branch` helpers are used.

Three surfaces are updated:

- **CI (`build_images.yml`)** — writes `GIT_RELEASE` during the Prepare step alongside `REVISION` and `GIT_BRANCH`
- **Dockerfile** — copies `GIT_RELEASE` into the `prod-build` stage
- **`/system_status/details`** — exposes `release` in the JSON payload next to `revision` and `branch`
- **Non-production header bar** — renders the release tag as a yellow `label-warning` badge via the new `release_info` helper; suppressed entirely in development (returns `nil`)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
