### PR TITLE
remove aws env vars from active storage config

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,8 +8,6 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV.fetch('AWS_ACCESS_KEY_ID', '') %>
-  secret_access_key: <%= ENV.fetch('AWS_SECRET_ACCESS_KEY', '') %>
   region: <%= ENV.fetch('AWS_REGION', 'us-east-1') %>
   bucket: <%= ENV.fetch('ACTIVE_STORAGE_BUCKET', "#{ENV['AWS_CLIENT_NAME']}-#{ENV['AWS_APP_NAME']}-#{Rails.env}-files") %>
   http_open_timeout: 60


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
We believe these keys go stale at some point after boot and cause issues talking to s3