### PR TITLE
feat: 9147 hopwa-caper-daily-rates

### DIFF
--- a/db/warehouse/migrate/20260522123000_add_total_cost_to_hopwa_caper_enrollments.rb
+++ b/db/warehouse/migrate/20260522123000_add_total_cost_to_hopwa_caper_enrollments.rb
@@ -2,6 +2,6 @@
 
 class AddTotalCostToHopwaCaperEnrollments < ActiveRecord::Migration[7.1]
   def change
-    add_column :hopwa_caper_enrollments, :total_project_cost, :integer
+    add_column :hopwa_caper_enrollments, :total_project_cost, :decimal, precision: 10, scale: 2
   end
 end

--- a/db/warehouse/migrate/20260522123000_add_total_cost_to_hopwa_caper_enrollments.rb
+++ b/db/warehouse/migrate/20260522123000_add_total_cost_to_hopwa_caper_enrollments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTotalCostToHopwaCaperEnrollments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :hopwa_caper_enrollments, :total_project_cost, :integer
+  end
+end

--- a/drivers/hopwa_caper/app/models/hopwa_caper/configuration.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/configuration.rb
@@ -29,6 +29,11 @@ module HopwaCaper
       value_for(:atc_primary_health_contact_field_name)
     end
 
+    # name of the custom data element on funder, for example "funder_daily_rate"
+    def funder_daily_rate_field_name
+      value_for(:funder_daily_rate_field_name)
+    end
+
     protected
 
     PROPERTIES = [
@@ -36,6 +41,7 @@ module HopwaCaper
       :atc_maintained_contact_field_name,
       :atc_housing_plan_field_name,
       :atc_primary_health_contact_field_name,
+      :funder_daily_rate_field_name,
     ].freeze
 
     def values

--- a/drivers/hopwa_caper/app/models/hopwa_caper/drilldown_presenter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/drilldown_presenter.rb
@@ -87,6 +87,7 @@ module HopwaCaper
         Field.new(name: 'ever_prescribed_anti_retroviral_therapy'),
         Field.new(name: 'viral_load_suppression'),
         Field.new(name: 'percent_ami', label: 'Percent AMI', transform: ->(v, _poly) { hud_helper.percent_ami(v) }, not_collected: true),
+        Field.new(name: ':total_project_cost', label: 'Total Funder Cost'),
         Field.new(name: 'atc_maintained_contact', label: 'ATC: Maintained Contact'),
         Field.new(name: 'atc_housing_plan', label: 'ATC: Housing Plan'),
         Field.new(name: 'atc_primary_health_contact', label: 'ATC: Primary Health Contact'),

--- a/drivers/hopwa_caper/app/models/hopwa_caper/drilldown_presenter.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/drilldown_presenter.rb
@@ -87,7 +87,7 @@ module HopwaCaper
         Field.new(name: 'ever_prescribed_anti_retroviral_therapy'),
         Field.new(name: 'viral_load_suppression'),
         Field.new(name: 'percent_ami', label: 'Percent AMI', transform: ->(v, _poly) { hud_helper.percent_ami(v) }, not_collected: true),
-        Field.new(name: ':total_project_cost', label: 'Total Funder Cost'),
+        Field.new(name: 'total_project_cost', label: 'Total Funder Cost'),
         Field.new(name: 'atc_maintained_contact', label: 'ATC: Maintained Contact'),
         Field.new(name: 'atc_housing_plan', label: 'ATC: Housing Plan'),
         Field.new(name: 'atc_primary_health_contact', label: 'ATC: Primary Health Contact'),

--- a/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/enrollment.rb
@@ -79,7 +79,7 @@ module HopwaCaper
       :OtherIncomeSource
     ].freeze
 
-    def self.from_hud_record(enrollment:, report:, client:)
+    def self.from_hud_record(enrollment:, report:, client:, cost_calculator:)
       project = enrollment.project
       # get deterministic order
       hiv_disabilities = enrollment.disabilities.
@@ -102,6 +102,13 @@ module HopwaCaper
         # Only add if no other specific sources are present to maintain logical consistency
         income_benefit_source_types << 'NoIncomeSource' if latest_income_benefit.IncomeFromAnySource == 0 && income_benefit_source_types.empty?
         medical_insurance_types << 'NoInsuranceSource' if latest_income_benefit.InsuranceFromAnySource == 0 && medical_insurance_types.empty?
+      end
+
+      # calculate the total cost from the schedule. Only for HoH
+      if enrollment.relationship_to_hoh == 1
+        last_enrolled_day = enrollment.exit&.exit_date&.-(1)
+        enrolled_range = [enrollment.entry_date, report.start_date].max..[last_enrolled_day, report.end_date].compact.min
+        total_cost = cost_calculator.call(project, enrolled_range).round(2)
       end
 
       exit = enrollment.exit if enrollment.exit&.exit_date&.<= report.end_date
@@ -139,6 +146,7 @@ module HopwaCaper
         rental_subsidy_type: enrollment.rental_subsidy_type,
         viral_load_suppression: hiv_disabilities.any? { |d| d.measured_viral_load&.< 200 },
         ever_prescribed_anti_retroviral_therapy: hiv_disabilities.any? { |d| d.anti_retroviral == 1 },
+        total_project_cost: total_cost || 0,
       )
     end
 

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/generator.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/generator.rb
@@ -114,6 +114,11 @@ module HopwaCaper::Generators::Fy2026
     def build_hopwa_caper_models
       scope = service_history_enrollments.preload(enrollment: [:income_benefits, { client: :destination_client }, :disabilities, :project, :services])
       project_ids = Set.new
+      config = HopwaCaper::Configuration.new
+      cost_calculator = HopwaCaper::ProjectCostCalculator.new(
+        report: report,
+        cded_key: config.funder_daily_rate_field_name,
+      )
       scope.in_batches(of: 100, order: :desc) do |batch|
         enrollment_rows = []
         service_rows = []
@@ -127,7 +132,12 @@ module HopwaCaper::Generators::Fy2026
           client = hud_enrollment&.client&.destination_client
           next unless client
 
-          enrollment_rows << HopwaCaper::Enrollment.from_hud_record(report: report, client: client, enrollment: hud_enrollment)
+          enrollment_rows << HopwaCaper::Enrollment.from_hud_record(
+            report: report,
+            client: client,
+            enrollment: hud_enrollment,
+            cost_calculator: cost_calculator,
+          )
           project_ids.add hud_enrollment.project.id
 
           # Store enrollment context for later custom service lookup

--- a/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_fbh_sheet.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/generators/fy2026/sheets/base_fbh_sheet.rb
@@ -103,7 +103,14 @@ module HopwaCaper::Generators::Fy2026::Sheets
         row.append_cell_members(members: members)
       end
 
-      empty_row(sheet, label: "What were the HOPWA funds expended for #{fbh_activity_label} Facility-Based Housing Leasing Costs for each facility?")
+      facility_row(
+        sheet,
+        label: "What were the HOPWA funds expended for #{fbh_activity_label} Facility-Based Housing Leasing Costs for each facility?",
+      ) do |fac, row|
+        filtered = relevant_enrollments.head_of_household.where(project_id: fac.id)
+        value = filtered.sum { |e| e.total_project_cost.to_i }
+        row.append_cell_members(value: value, members: filtered.as_report_members)
+      end
     end
 
     def facility_operating_expenditures(sheet, fbh_activity_label:)

--- a/drivers/hopwa_caper/app/models/hopwa_caper/project_cost_calculator.rb
+++ b/drivers/hopwa_caper/app/models/hopwa_caper/project_cost_calculator.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module HopwaCaper
+  class ProjectCostCalculator
+    include Memery
+
+    def initialize(report:, cded_key:)
+      @report = report
+      @cdeds_by_data_source_id = cdeds_by_data_source_id(cded_key)
+    end
+
+    # Total cost for a project over the given date range, using the highest
+    # daily rate from any active funder on each day.
+    def call(project, range)
+      schedule = schedule_for(project)
+      return 0 if schedule.empty?
+
+      schedule.sum { |day, cost| range.cover?(day) ? cost : 0 }
+    end
+
+    private
+
+    def cdeds_by_data_source_id(cded_key)
+      return {} unless cded_key
+
+      Hmis::Hud::CustomDataElementDefinition.order(:id).where(key: cded_key).index_by(&:data_source_id)
+    end
+
+    # Day-by-day rate map for a project, memoized per project.
+    # When funders overlap, the highest rate wins for each day.
+    def schedule_for(project)
+      result = {}
+      cded = @cdeds_by_data_source_id[project.data_source_id]
+      return result unless cded
+
+      scope = Hmis::Hud::Funder.where(
+        data_source_id: project.data_source_id,
+        project_id: project.project_id,
+      ).preload(custom_data_elements: :data_element_definition)
+      scope.each do |funder|
+        rate = funder.custom_data_elements.filter { |cde| cde.data_element_definition == cded }.map(&:value).compact.max
+        next unless rate
+
+        # timeline is the intersection of the report period and the funder's active period
+        start_date = [@report.start_date, funder.start_date].compact.max
+        end_date = [@report.end_date, funder.end_date].compact.min
+
+        (start_date..end_date).each do |day|
+          result[day] = [rate, result[day]].compact.max
+        end
+      end
+      result
+    end
+    memoize :schedule_for
+  end
+end

--- a/drivers/hopwa_caper/spec/models/enrollment_spec.rb
+++ b/drivers/hopwa_caper/spec/models/enrollment_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
     create(:hud_enrollment, client: client, project: project, data_source: data_source, entry_date: report_start_date + 1.day)
   end
   let(:report) { create_report([project]) }
+  let(:cost_calculator) { ->(_project, _range) { 0 } }
 
   describe '.from_hud_record' do
     context 'with income_benefits records' do
@@ -67,6 +68,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           # Should use latest_income_benefit values only
@@ -110,6 +112,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           # Should only use within_range_benefit
@@ -138,6 +141,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.medical_insurance_types).to contain_exactly('NoInsuranceSource')
@@ -151,6 +155,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.medical_insurance_types).to be_empty
@@ -180,6 +185,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.hiv_positive).to be(true)
@@ -208,6 +214,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.hiv_positive).to be(false)
@@ -249,6 +256,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.hiv_positive).to be(true)
@@ -263,6 +271,7 @@ RSpec.describe HopwaCaper::Enrollment, type: :model do
             enrollment: hud_enrollment,
             report: report,
             client: client,
+            cost_calculator: cost_calculator,
           )
 
           expect(enrollment.hiv_positive).to be(false)

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/generator_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Generator, type: :model do
       atc_maintained_contact_field_name: maintained_key,
       atc_housing_plan_field_name: housing_plan_key,
       atc_primary_health_contact_field_name: primary_health_key,
+      funder_daily_rate_field_name: nil,
     )
   end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_access_to_care_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::AccessToCareSheet, type: 
       atc_maintained_contact_field_name: maintained_key,
       atc_housing_plan_field_name: housing_plan_key,
       atc_primary_health_contact_field_name: primary_health_key,
+      funder_daily_rate_field_name: nil,
     )
   end
 

--- a/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
+++ b/drivers/hopwa_caper/spec/models/generators/fy2026/hopwa_caper_p_fbh_spec.rb
@@ -33,7 +33,144 @@ RSpec.describe HopwaCaper::Generators::Fy2026::Sheets::PFbhSheet, type: :model d
   it 'reports leasing support correctly' do
     _, rows = run_and_extract_rows([project], 'Q10')
     expect(rows.fetch("How many households received #{activity_label} Facility-Based Housing Leasing support for each facility?")).to eq(1)
-    # leasing costs aren't reported
+    expect(rows.fetch("What were the HOPWA funds expended for #{activity_label} Facility-Based Housing Leasing Costs for each facility?")).to eq(0)
+  end
+
+  context 'with funder daily rate configured' do
+    let(:daily_rate_key) { 'funder_daily_rate' }
+
+    let!(:daily_rate_definition) do
+      create(
+        :hmis_custom_data_element_definition,
+        key: daily_rate_key,
+        owner_type: 'Hmis::Hud::Funder',
+        field_type: :integer,
+        data_source: data_source,
+      )
+    end
+
+    before do
+      config = instance_double(
+        HopwaCaper::Configuration,
+        atc_tab_enabled?: false,
+        atc_maintained_contact_field_name: nil,
+        atc_housing_plan_field_name: nil,
+        atc_primary_health_contact_field_name: nil,
+        funder_daily_rate_field_name: daily_rate_key,
+      )
+      allow(HopwaCaper::Configuration).to receive(:new).and_return(config)
+
+      hud_funder = project.funders.first
+      hud_funder.update!(start_date: report_start_date, end_date: report_end_date)
+      hmis_funder = Hmis::Hud::Funder.find(hud_funder.id)
+      create(
+        :hmis_custom_data_element,
+        data_element_definition: daily_rate_definition,
+        owner: hmis_funder,
+        value_integer: 10,
+        data_source: data_source,
+      )
+    end
+
+    it 'computes total_project_cost based on enrollment duration and daily rate' do
+      report = create_report([project])
+      run_report(report)
+
+      # hoh_enrollment: entry at report_start_date + 1.day, no exit
+      hoh_record = report.hopwa_caper_enrollments.find_by(enrollment_id: hoh_enrollment.id)
+      hoh_days = (report_end_date - report_start_date).to_i
+      expect(hoh_record.total_project_cost).to eq(hoh_days * 10)
+
+      # exiting_enrollment: entry at report_start_date + 1.day, exit at report_start_date + 2.months
+      exiting_record = report.hopwa_caper_enrollments.find_by(enrollment_id: exiting_enrollment.id)
+      exit_date = report_start_date + 2.months
+      exiting_days = (exit_date - 1.day - report_start_date).to_i
+      expect(exiting_record.total_project_cost).to eq(exiting_days * 10)
+    end
+
+    it 'reports leasing expenditure totals per facility' do
+      _, rows = run_and_extract_rows([project], 'Q10')
+
+      hoh_days = (report_end_date - report_start_date).to_i
+      exit_date = report_start_date + 2.months
+      exiting_days = (exit_date - 1.day - report_start_date).to_i
+      expected_total = (hoh_days + exiting_days) * 10
+
+      expect(rows.fetch("What were the HOPWA funds expended for #{activity_label} Facility-Based Housing Leasing Costs for each facility?")).to eq(expected_total)
+    end
+
+    it 'uses the higher rate when funders overlap' do
+      # Add a second funder active only for the first 3 months at a higher rate
+      second_funder = create(
+        :hud_funder,
+        project: project,
+        ProjectID: project.ProjectID,
+        funder: funder,
+        data_source: data_source,
+        start_date: report_start_date,
+        end_date: report_start_date + 3.months,
+      )
+      hmis_second_funder = Hmis::Hud::Funder.find(second_funder.id)
+      create(
+        :hmis_custom_data_element,
+        data_element_definition: daily_rate_definition,
+        owner: hmis_second_funder,
+        value_integer: 25,
+        data_source: data_source,
+      )
+
+      report = create_report([project])
+      run_report(report)
+
+      # hoh_enrollment: entry at report_start_date + 1.day, no exit
+      # Days in the overlap period get the higher rate (25), remaining days get 10
+      overlap_end = report_start_date + 3.months
+      high_rate_days = (overlap_end - (report_start_date + 1.day)).to_i + 1
+      low_rate_days = (report_end_date - overlap_end).to_i
+      expected = (high_rate_days * 25) + (low_rate_days * 10)
+
+      hoh_record = report.hopwa_caper_enrollments.find_by(enrollment_id: hoh_enrollment.id)
+      expect(hoh_record.total_project_cost).to eq(expected)
+    end
+
+    it 'limits costs to the funder active period when it partially covers the report' do
+      # Narrow the existing funder to only the last 2 months of the report
+      funder_start = report_end_date - 2.months
+      project.funders.first.update!(start_date: funder_start, end_date: report_end_date)
+
+      report = create_report([project])
+      run_report(report)
+
+      # hoh_enrollment: entry at report_start_date + 1.day, no exit
+      # Cost only accrues during the funder's active window
+      hoh_record = report.hopwa_caper_enrollments.find_by(enrollment_id: hoh_enrollment.id)
+      expected_days = (report_end_date - funder_start).to_i + 1
+      expect(hoh_record.total_project_cost).to eq(expected_days * 10)
+
+      # exiting_enrollment: exits at report_start_date + 2.months, well before funder becomes active
+      exiting_record = report.hopwa_caper_enrollments.find_by(enrollment_id: exiting_enrollment.id)
+      expect(exiting_record.total_project_cost).to eq(0)
+    end
+
+    it 'assigns zero cost to non-head-of-household members' do
+      non_hoh_client = create(:hud_client, data_source: data_source)
+      create_hiv_positive_enrollment(
+        client: non_hoh_client,
+        project: project,
+        entry_date: report_start_date + 1.day,
+        household_id: household_id,
+        relationship_to_ho_h: 2,
+      )
+
+      report = create_report([project])
+      run_report(report)
+
+      non_hoh_record = report.hopwa_caper_enrollments.find_by(
+        destination_client_id: GrdaWarehouse::Hud::Client.find(non_hoh_client.id).destination_client.id,
+        relationship_to_hoh: 2,
+      )
+      expect(non_hoh_record.total_project_cost).to eq(0)
+    end
   end
 
   it 'reports income and insurance correctly' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Add configurable daily-rate-based leasing cost computation for HOPWA CAPER facility-based housing sheets.

- **Configuration**: New `funder_daily_rate_field_name` property to identify the custom data element on funders that holds the daily rate
- **ProjectCostSchedule** (new): Builds a per-day cost map for a project by intersecting funder active periods with the report period, taking the max rate when funders overlap
- **Enrollment Model**: Compute `total_project_cost` from the cost schedule during enrollment creation, restricted to heads of household
- **Facility-Based Housing Sheets**: Populate the leasing expenditure row with summed `total_project_cost` per facility, replacing the previously empty row
- **Generator**: Wire `ProjectCostSchedule` into the enrollment build loop
- Add `total_project_cost` integer column to `hopwa_caper_enrollments`
- Test coverage for daily rate cost computation, non-HoH exclusion, and facility-level aggregation

### Type of Change
New feature

### QA Setup

The daily rate is driven by two pieces of configuration that must agree:

1. **HMIS Custom Data Element Definition** on `Hmis::Hud::Funder` — this is the field on each funder record that holds the daily rate. Note the `key` value (e.g. `funder_daily_rate`).

2. **AppConfigProperty** — tells the CAPER generator which CDED key to look up. Create it via Rails console or admin UI (/admin/app_config_properties/new)

```ruby
AppConfigProperty.find_or_create_by!(key: 'hopwa_caper/funder_daily_rate_field_name') do |p|
  p.value = 'funder_daily_rate'
end
```

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

