### PR TITLE
fix: GHSA-3h96-34p3-xm76 graphql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
       mini_portile2 (~> 2.7)
     graphiql-rails (1.10.5)
       railties
-    graphql (2.5.12)
+    graphql (2.5.26)
       base64
       fiber-storage
       logger
@@ -1541,7 +1541,7 @@ CHECKSUMS
   gmail_xoauth (0.4.3) sha256=eda5f59bd60564a6e8dd091a896ab221e8457472ab422d5d1282931ac7ae45fb
   gpgme (2.0.25) sha256=9242408b28720513145deb6150f25f5fe5149f3728ebaea635050cc3fc84dc34
   graphiql-rails (1.10.5) sha256=d911486eeac01e125d403a61c04f634cccaff9f8ecee5dc4efce3e7aa11bf5d3
-  graphql (2.5.12) sha256=acab2c42ac319bf123bc08ad6384de9236b44cf90cb99f2edaeba4c52b4c7d98
+  graphql (2.5.26) sha256=be3a148cc9ae52056d38f45cf9864a621a12fe138c027e324b0841dc19979576
   grover (1.2.3) sha256=84d4c5d0d3e225da4e6059f6d3376044a1890ab49ea7b41bf40d71b14490bfd7
   haml (6.3.0) sha256=8e6eb87d869639e348852009e74a2a1663d79663ed7e7dbcb38beb1f12bcdd97
   haml-rails (2.1.0) sha256=273ba0189e2f82ce4b2385019dd9138884017e3103cc2eaebeee7f45186f59ea


### PR DESCRIPTION
No CVE yet. Fixes GHSA-3h96-34p3-xm76 in graphql