### PR TITLE
fix: 8204-adjust-exits-on-outcomes-report

### DIFF
--- a/app/models/warehouse_report/outcomes/base.rb
+++ b/app/models/warehouse_report/outcomes/base.rb
@@ -268,7 +268,7 @@ class WarehouseReport::Outcomes::Base
     @destinations ||= begin
       @destinations = {}
       destinations = {
-        'returned to shelter' => {},
+        'exited to homelessness' => {},
         'exited to other institution' => {},
         'successful exit to PH' => {},
         'exited to temporary destination' => {},
@@ -315,6 +315,7 @@ class WarehouseReport::Outcomes::Base
   end
 
   def destination_bucket(dest_id)
+    return 'exited to homelessness' if HudHelper.util.homeless_destinations.include?(dest_id)
     return 'exited to other institution' if HudHelper.util.institutional_destinations.include?(dest_id)
     return 'successful exit to PH' if HudHelper.util.permanent_destinations.include?(dest_id)
     return 'exited to temporary destination' if HudHelper.util.temporary_destinations.include?(dest_id)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Description
Fix destination bucketing on the Outcomes report to separately classify homeless exits, which were previously lumped into "other or unknown outcome."

- **Destination Bucketing**: Add `homeless_destinations` check to `destination_bucket` and replace the unused "returned to shelter" bucket label with "exited to homelessness"

### Type of Change
Bug fix



## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
