### PR TITLE
Fix bug in project group editor, pass parsed criteria to form

### DIFF
--- a/drivers/hmis/app/views/hmis_admin/project_groups/_form.haml
+++ b/drivers/hmis/app/views/hmis_admin/project_groups/_form.haml
@@ -10,14 +10,14 @@
 
 %div.mb-4
   %h3 Inclusion Criteria
-  = f.simple_fields_for :inclusion_criteria do |ic|
+  = f.simple_fields_for :inclusion_criteria, @project_group.parsed_inclusion_criteria do |ic|
     = ic.input :project_ids, collection: [], as: :select_two, input_html: { multiple: true, data: { 'collection-path' => api_projects_path(selected_project_ids: @project_group.parsed_inclusion_criteria.project_ids, data_source_ids: [ds.id]) }, placeholder: 'Choose Projects'}, label: 'Projects', required: false
-    = ic.input :organization_ids, collection: organization_options, selected: @project_group.parsed_inclusion_criteria.organization_ids, as: :grouped_select_two, group_method: :last, input_html: {multiple: true, placeholder: 'Choose Organizations' }, label: 'Organizations', required: false
-    = ic.input :project_type_numbers, collection: Hmis::ProjectGroupCriteria.available_project_type_numbers, selected: @project_group.parsed_inclusion_criteria.project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types', as: :select_two, required: false
+    = ic.input :organization_ids, collection: organization_options, as: :grouped_select_two, group_method: :last, input_html: {multiple: true, placeholder: 'Choose Organizations' }, label: 'Organizations', required: false
+    = ic.input :project_type_numbers, collection: Hmis::ProjectGroupCriteria.available_project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types', as: :select_two, required: false
     = ic.input :all_projects_in_data_source, as: :boolean, label: 'Include all projects in data source', required: false
 
 %div.mb-4
   %h3 Exclusion Criteria
-  = f.simple_fields_for :exclusion_criteria do |ec|
+  = f.simple_fields_for :exclusion_criteria, @project_group.parsed_exclusion_criteria do |ec|
     = ec.input :project_ids, collection: [], as: :select_two, input_html: { multiple: true, data: { 'collection-path' => api_projects_path(selected_project_ids: @project_group.parsed_exclusion_criteria.project_ids, data_source_ids: [ds.id]) }, placeholder: 'Choose Projects'}, label: 'Projects to Exclude', required: false
-    = ec.input :project_type_numbers, collection: Hmis::ProjectGroupCriteria.available_project_type_numbers, selected: @project_group.parsed_exclusion_criteria.project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types to Exclude', as: :select_two, required: false
+    = ec.input :project_type_numbers, collection: Hmis::ProjectGroupCriteria.available_project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types to Exclude', as: :select_two, required: false


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

Fixes a bug on the HMIS admin project group edit form where **“Include all projects in data source”** appeared unchecked even when the group was configured with that rule. The form bound nested fields to the raw `inclusion_criteria` / `exclusion_criteria` JSON strings instead of `ProjectGroupCriteria` objects, so SimpleForm could not read `all_projects_in_data_source`. Saving without re-checking the box persisted `false`.

Fix: Pass `parsed_inclusion_criteria` and `parsed_exclusion_criteria` into `simple_fields_for`

Thanks Martha for finding this bug during workspaces review!

## Test instructions

- Open a project group with “Include all projects in Data Source” = Yes on the show page; confirm the checkbox is checked on edit.
- Save without changing the checkbox; confirm inclusion rules and project list are unchanged.
- Uncheck the box, save, and confirm membership updates as expected.
- Smoke-test exclusion criteria fields on the same form.


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
