### PR TITLE
Navigate to new /referrals in system tests

### DIFF
--- a/drivers/hmis/spec/system/hmis/ac_hmis/ac_ce_referral_workflows_spec.rb
+++ b/drivers/hmis/spec/system/hmis/ac_hmis/ac_ce_referral_workflows_spec.rb
@@ -304,8 +304,8 @@ RSpec.feature 'AC CE Referral Workflows', type: :system do
 
     # Shared method for progressing the referral through the initial steps and assigning the provider
     def ce_staff_complete_initial_steps
-      # Navigate to admin referrals page and click into the referral
-      visit '/admin/referrals/'
+      # Navigate to referrals page and click into the referral
+      visit '/referrals/'
       expect(page).to have_content('Alice A')
       expect(page).to have_content('Matching In Progress')
       click_link 'Alice A'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
In system tests, navigate directly to the new route `/referrals`, instead of navigating to the old `/admin/referrals` route, which was still working with a redirect.

Follow up to https://github.com/open-path/Green-River/issues/9157

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
