### PR TITLE
Track purge failures in archival_metadata to prevent retry loops

### DIFF
--- a/app/models/concerns/hud_report_archival.rb
+++ b/app/models/concerns/hud_report_archival.rb
@@ -48,7 +48,8 @@ module HudReportArchival
 
       base = where(state: 'Completed').
         where.not(completed_at: nil).
-        where("archival_metadata->>'purged_at' IS NULL")
+        where("archival_metadata->>'purged_at' IS NULL").
+        where("archival_metadata->>'purge_failed_at' IS NULL")
 
       # Branch 1: an explicit purge_eligible_at was set (e.g. by the rake task)
       by_explicit_date = base.

--- a/app/models/simple_reports/report_instance.rb
+++ b/app/models/simple_reports/report_instance.rb
@@ -29,6 +29,7 @@ module SimpleReports
       # Sanitize grace_period_days to prevent SQL injection
       sanitized_days = grace_period_days.to_i
       where(Arel.sql("archival_metadata->>'purged_at' IS NULL")).
+        where(Arel.sql("archival_metadata->>'purge_failed_at' IS NULL")).
         where(
           Arel.sql(
             "((archival_metadata->>'purge_eligible_at' IS NOT NULL AND (archival_metadata->>'purge_eligible_at')::timestamp <= ?) OR " \

--- a/lib/tasks/reports/migrate_to_csv.rake
+++ b/lib/tasks/reports/migrate_to_csv.rake
@@ -66,6 +66,8 @@ namespace :reports do
               error_msg = "SimpleReport #{report.class.name} ##{report.id}: #{result[:errors].join(', ')}"
               errors << error_msg
               Rails.logger.error(error_msg)
+              report.update_archival_metadata('purge_failed_at', Time.current.iso8601)
+              report.update_archival_metadata('purge_failure_reason', result[:errors].join(', '))
               Sentry.capture_exception_with_info(
                 StandardError.new(error_msg),
                 "Failed to archive and purge SimpleReport #{report.class.name} ##{report.id}",
@@ -168,6 +170,8 @@ namespace :reports do
               error_msg = "HUD Report #{report.report_name} ##{report.id}: #{result[:errors].join(', ')}"
               errors << error_msg
               Rails.logger.error(error_msg)
+              report.update_archival_metadata('purge_failed_at', Time.current.iso8601)
+              report.update_archival_metadata('purge_failure_reason', result[:errors].join(', '))
               Sentry.capture_exception_with_info(
                 StandardError.new(error_msg),
                 "Failed to archive and purge HUD Report #{report.report_name} ##{report.id}",

--- a/spec/models/concerns/hud_report_archival_spec.rb
+++ b/spec/models/concerns/hud_report_archival_spec.rb
@@ -241,5 +241,19 @@ RSpec.describe HudReportArchival, type: :model do
       results = HudReports::ReportInstance.purge_eligible(60, Time.current)
       expect(results).not_to include(ineligible_recent)
     end
+
+    it 'excludes reports that have a recorded purge failure' do
+      failed_report = HudReports::ReportInstance.create!(
+        report_name: 'Test',
+        user_id: User.system_user.id,
+        state: 'Completed',
+        completed_at: 61.days.ago,
+        question_names: [],
+      )
+      failed_report.update_column(:archival_metadata, { 'purge_failed_at' => Time.current.iso8601 })
+
+      results = HudReports::ReportInstance.purge_eligible(60, Time.current)
+      expect(results).not_to include(failed_report)
+    end
   end
 end

--- a/spec/models/concerns/report_archival_spec.rb
+++ b/spec/models/concerns/report_archival_spec.rb
@@ -473,6 +473,60 @@ RSpec.describe ReportArchival, type: :model do
     end
   end
 
+  describe 'purge_eligible scope' do
+    let!(:eligible_report) do
+      SimpleReports::ReportInstance.create!(
+        user_id: User.system_user.id,
+        completed_at: 61.days.ago,
+      )
+    end
+
+    let!(:ineligible_purged) do
+      r = SimpleReports::ReportInstance.create!(
+        user_id: User.system_user.id,
+        completed_at: 61.days.ago,
+      )
+      r.update_column(:archival_metadata, { 'purged_at' => Time.current.iso8601 })
+      r
+    end
+
+    let!(:ineligible_recent) do
+      SimpleReports::ReportInstance.create!(
+        user_id: User.system_user.id,
+        completed_at: 30.days.ago,
+      )
+    end
+
+    let!(:ineligible_failed) do
+      r = SimpleReports::ReportInstance.create!(
+        user_id: User.system_user.id,
+        completed_at: 61.days.ago,
+      )
+      r.update_column(:archival_metadata, { 'purge_failed_at' => Time.current.iso8601 })
+      r
+    end
+
+    it 'includes reports past their grace period that have not been purged or failed' do
+      results = SimpleReports::ReportInstance.purge_eligible(60, Time.current)
+      expect(results).to include(eligible_report)
+    end
+
+    it 'excludes already-purged reports' do
+      results = SimpleReports::ReportInstance.purge_eligible(60, Time.current)
+      expect(results).not_to include(ineligible_purged)
+    end
+
+    it 'excludes reports still within the grace period' do
+      results = SimpleReports::ReportInstance.purge_eligible(60, Time.current)
+      expect(results).not_to include(ineligible_recent)
+    end
+
+    it 'excludes reports that have a recorded purge failure' do
+      results = SimpleReports::ReportInstance.purge_eligible(60, Time.current)
+      expect(results).not_to include(ineligible_failed)
+    end
+  end
+
   describe '#expected_archival_files' do
     it 'returns empty array when not archived' do
       expect(report.expected_archival_files).to eq([])


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

When the `migrate_to_csv` rake task fails to archive or purge a report, it
now writes `purge_failed_at` (ISO8601 timestamp) and `purge_failure_reason`
(joined error messages) into the report's `archival_metadata` JSON column
before sending to Sentry. This applies to both `HudReports::ReportInstance`
and `SimpleReports::ReportInstance`.

The `purge_eligible` scopes on both model classes are updated to filter out
records where `archival_metadata->>'purge_failed_at' IS NOT NULL`, so a
known-failing report is excluded from all future purge runs rather than
being retried indefinitely.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
