### PR TITLE
Add notes field to project groups

### DIFF
--- a/app/controllers/project_groups_controller.rb
+++ b/app/controllers/project_groups_controller.rb
@@ -37,7 +37,7 @@ class ProjectGroupsController < ApplicationController
     begin
       @project_group = project_group_source.new
       project_group_source.transaction do
-        @project_group.assign_attributes(name: group_params[:name])
+        @project_group.assign_attributes(name: group_params[:name], notes: group_params[:notes])
         filter = ::Filters::HudFilterBase.new(user_id: current_user.id, project_type_numbers: []).update(filter_params.merge(coc_codes: []))
         filter.coc_codes = []
         @project_group.options = filter.to_h
@@ -75,7 +75,7 @@ class ProjectGroupsController < ApplicationController
   def update
     begin
       project_group_source.transaction do
-        @project_group.assign_attributes(name: group_params[:name])
+        @project_group.assign_attributes(name: group_params[:name], notes: group_params[:notes])
         filter = ::Filters::HudFilterBase.new(user_id: current_user.id, project_type_numbers: []).update(filter_params)
         filter.coc_codes = []
         @project_group.options = filter.to_h
@@ -156,6 +156,7 @@ class ProjectGroupsController < ApplicationController
     params.require(:filters).
       permit(
         :name,
+        :notes,
       )
   end
 

--- a/app/models/grda_warehouse/project_group.rb
+++ b/app/models/grda_warehouse/project_group.rb
@@ -199,6 +199,16 @@ module GrdaWarehouse
       save_filter!
     end
 
+    def markdown_notes
+      return '' if notes.blank?
+
+      # Notes are user-entered content, so filter_html: true is required to strip raw HTML
+      # tags and prevent XSS. Do not switch to TranslatedHtml or remove filter_html — those
+      # are only safe for developer/admin-authored content.
+      renderer = Redcarpet::Render::HTML.new(filter_html: true)
+      Redcarpet::Markdown.new(renderer).render(notes).html_safe
+    end
+
     def any_contacts?
       contacts.any? || organization_contacts.any?
     end

--- a/app/views/project_groups/_form.haml
+++ b/app/views/project_groups/_form.haml
@@ -3,6 +3,7 @@
 
 .form-inputs.well
   = f.input :name
+  = f.input :notes, as: :text
 
 %h3 Inclusion Criteria
 .form-inputs.well

--- a/app/views/project_groups/download.xlsx.axlsx
+++ b/app/views/project_groups/download.xlsx.axlsx
@@ -11,6 +11,7 @@ wb.add_worksheet(name: 'Project Groups') do |sheet|
     'Data Sources',
     'Created',
     'Last Updated',
+    'Notes',
   ]
   sheet.add_row(columns, style: title)
   @project_groups.each do |group|
@@ -23,7 +24,8 @@ wb.add_worksheet(name: 'Project Groups') do |sheet|
       group.filter.chosen(:data_source_ids)&.join(', '),
       group.created_at,
       group.updated_at,
+      group.notes,
     ]
-    sheet.add_row(row, style: [data_cell] * 6) # Don't add style to the date columns
+    sheet.add_row(row, style: [data_cell] * 6 + [nil, nil, data_cell]) # nil preserves Axlsx default date formatting for Created/Last Updated
   end
 end

--- a/app/views/project_groups/index.haml
+++ b/app/views/project_groups/index.haml
@@ -37,6 +37,7 @@
             %th Name
             %th Project Count
             %th Universe
+            %th Notes
         %tbody
           - @project_groups.each do |group|
             %tr
@@ -49,6 +50,7 @@
               %th= group.projects.count
               %td.reports.report-parameters-all
                 = group.describe_filter_as_html
+              %td= group.notes
     .form-actions
       = f.button :submit, "Delete Selected Groups", id: :deleteMultipleButton, data: {confirm: "Are you sure you want to delete the selected project groups?"}
 

--- a/app/views/project_groups/index.haml
+++ b/app/views/project_groups/index.haml
@@ -50,7 +50,7 @@
               %th= group.projects.count
               %td.reports.report-parameters-all
                 = group.describe_filter_as_html
-              %td= group.notes
+              %td= group.markdown_notes
     .form-actions
       = f.button :submit, "Delete Selected Groups", id: :deleteMultipleButton, data: {confirm: "Are you sure you want to delete the selected project groups?"}
 

--- a/db/views/analytics_project_groups_v02.sql
+++ b/db/views/analytics_project_groups_v02.sql
@@ -1,0 +1,9 @@
+SELECT id,
+    name,
+    notes,
+    created_at,
+    updated_at,
+    deleted_at,
+    options
+   FROM project_groups
+  WHERE (deleted_at IS NULL)

--- a/db/warehouse/migrate/20260527100000_add_notes_to_project_groups.rb
+++ b/db/warehouse/migrate/20260527100000_add_notes_to_project_groups.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddNotesToProjectGroups < ActiveRecord::Migration[7.2]
+  def change
+    add_column :project_groups, :notes, :text
+  end
+end

--- a/db/warehouse/migrate/20260527100001_update_analytics_project_groups_to_version_2.rb
+++ b/db/warehouse/migrate/20260527100001_update_analytics_project_groups_to_version_2.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2026 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class UpdateAnalyticsProjectGroupsToVersion2 < ActiveRecord::Migration[7.2]
+  def change
+    update_view 'analytics.project_groups', version: 2, revert_to_version: 1
+  end
+end

--- a/spec/models/grda_warehouse/project_group_spec.rb
+++ b/spec/models/grda_warehouse/project_group_spec.rb
@@ -74,4 +74,31 @@ RSpec.describe GrdaWarehouse::ProjectGroup, type: :model do
       expect(updated_collection.name).to eq('New Name')
     end
   end
+
+  describe '#markdown_notes' do
+    subject(:group) { build(:project_group, skip_maintain_system_group: true) }
+
+    it 'renders markdown to html' do
+      group.notes = '**bold**'
+      expect(group.markdown_notes).to include('<strong>bold</strong>')
+    end
+
+    it 'returns empty string for blank notes' do
+      group.notes = nil
+      expect(group.markdown_notes).to eq('')
+      group.notes = ''
+      expect(group.markdown_notes).to eq('')
+    end
+
+    it 'strips script tags to prevent XSS' do
+      group.notes = '<script>alert("xss")</script>'
+      # filter_html removes the tag; text content remains as harmless plain text
+      expect(group.markdown_notes).not_to include('<script>')
+    end
+
+    it 'strips raw html tags' do
+      group.notes = '<b>bold</b>'
+      expect(group.markdown_notes).not_to include('<b>')
+    end
+  end
 end

--- a/spec/requests/project_groups_controller_spec.rb
+++ b/spec/requests/project_groups_controller_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe ProjectGroupsController, type: :request do
       expect(assigns(:project_groups)).to include(project_group)
       expect(assigns(:project_groups)).not_to include(project_group_2)
     end
+
+    it 'displays notes in the response' do
+      create(:project_group, name: 'Notes Group', notes: 'Visible note text')
+      get project_groups_path
+      expect(response.body).to include('Visible note text')
+    end
   end
 
   describe 'POST #create' do
@@ -42,6 +48,7 @@ RSpec.describe ProjectGroupsController, type: :request do
         {
           filters: { # expectation that we end up with only projects 1 and 3
             name: 'Test Project Group',
+            notes: 'Some notes',
             project_ids: [project1.id, project2.id, project3.id].map(&:to_s),
             organization_ids: [organization1.id].map(&:to_s), # projects 1 and 2
             project_type_numbers: ['1', '2'], # projects 1, 2, and 3
@@ -63,6 +70,7 @@ RSpec.describe ProjectGroupsController, type: :request do
 
         # Test that the basic attributes are saved
         expect(project_group.name).to eq('Test Project Group')
+        expect(project_group.notes).to eq('Some notes')
 
         # Test inclusion criteria are saved in the filter
         expect(project_group.filter.project_ids).to match_array([project1.id, project2.id, project3.id])
@@ -89,6 +97,7 @@ RSpec.describe ProjectGroupsController, type: :request do
         {
           filters: {
             name: 'Updated Project Group', # expectation that we end up with only project 4
+            notes: 'Updated notes',
             project_ids: [project1.id, project4.id].map(&:to_s), # projects 1 and 4
             organization_ids: [organization2.id].map(&:to_s), # projects 3 and 4
             project_type_numbers: ['3'], # project 4
@@ -108,6 +117,7 @@ RSpec.describe ProjectGroupsController, type: :request do
 
         # Test that basic attributes are updated
         expect(project_group.name).to eq('Updated Project Group')
+        expect(project_group.notes).to eq('Updated notes')
 
         # Test inclusion criteria are updated in the filter
         expect(project_group.filter.project_ids).to match_array([project1.id, project4.id])


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Project groups now support a free-text **Notes** field. Staff can add
notes when creating or editing a project group, and the notes appear as
a new column in the project groups list. Notes are also included in the
Excel download and exposed in the analytics view for Superset reporting.

A database migration adds the `notes` column to the warehouse
`project_groups` table, and the `analytics.project_groups` view is
bumped to v02 to include it. Note: the superset-sync repo will need
a follow-up change to surface notes in the dbt model and Superset
dataset config before it appears in dashboards.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
