### PR TITLE
Restore FY2020 Project associations for Source Data

### DIFF
--- a/drivers/hmis_csv_twenty_twenty/extensions/grda_warehouse/hud/project_extension.rb
+++ b/drivers/hmis_csv_twenty_twenty/extensions/grda_warehouse/hud/project_extension.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+module HmisCsvTwentyTwenty::GrdaWarehouse::Hud
+  module ProjectExtension
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :imported_items_2020, class_name: 'HmisCsvTwentyTwenty::Importer::Project', primary_key: [:ProjectID, :data_source_id], foreign_key: [:ProjectID, :data_source_id]
+      has_many :loaded_items_2020, class_name: 'HmisCsvTwentyTwenty::Loader::Project', primary_key: [:ProjectID, :data_source_id], foreign_key: [:ProjectID, :data_source_id]
+    end
+  end
+end

--- a/spec/models/grda_warehouse/hud/project_source_data_spec.rb
+++ b/spec/models/grda_warehouse/hud/project_source_data_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Hud::Project, 'project CSV driver extensions' do
+  let(:data_source) { create(:source_data_source) }
+  let(:organization) { create(:hud_organization, data_source: data_source) }
+  let(:project) { create(:hud_project, data_source: data_source, organization: organization) }
+  let(:importer_log) { create(:hmis_csv_importer_log, data_source: data_source) }
+
+  describe 'hmis_csv_twenty_twenty extension' do
+    it 'exposes FY2020 import and loader associations' do
+      aggregate_failures do
+        expect(project).to respond_to(:imported_items_2020)
+        expect(project).to respond_to(:loaded_items_2020)
+        expect(project.association(:imported_items_2020).klass).to eq(HmisCsvTwentyTwenty::Importer::Project)
+        expect(project.association(:loaded_items_2020).klass).to eq(HmisCsvTwentyTwenty::Loader::Project)
+      end
+    end
+
+    it 'resolves imported_item_type to 2020 when FY2020 staging rows exist' do
+      HmisCsvTwentyTwenty::Importer::Project.create!(
+        staging_attributes(project, importer_log),
+      )
+
+      expect(project.imported_item_type(importer_log.id)).to eq('2020')
+      expect(project.imported_items_2020.where(importer_log_id: importer_log.id)).to exist
+    end
+  end
+
+  describe 'convert_to_aggregated!' do
+    let(:client) { create(:grda_warehouse_hud_client, data_source: data_source) }
+    let!(:enrollment) do
+      create(
+        :hud_enrollment,
+        data_source: data_source,
+        ProjectID: project.ProjectID,
+        PersonalID: client.PersonalID,
+      )
+    end
+    let!(:exit_record) do
+      create(
+        :hud_exit,
+        data_source: data_source,
+        EnrollmentID: enrollment.EnrollmentID,
+        PersonalID: enrollment.PersonalID,
+      )
+    end
+
+    it 'is defined by the hmis_csv_importer extension, not the FY2020 extension' do
+      file, = project.method(:convert_to_aggregated!).source_location
+
+      aggregate_failures do
+        expect(file).to end_with('hmis_csv_importer/extensions/grda_warehouse/hud/project_extension.rb')
+        expect(
+          HmisCsvTwentyTwenty::GrdaWarehouse::Hud::ProjectExtension.instance_methods(false),
+        ).not_to include(:convert_to_aggregated!)
+      end
+    end
+
+    it 'configures unversioned aggregated enrollment import on the data source' do
+      project.convert_to_aggregated!
+
+      aggregate_failures do
+        expect(project.reload.combine_enrollments).to be true
+        expect(data_source.reload.import_aggregators).to eq(
+          'Enrollment' => ['HmisCsvImporter::Aggregated::CombineEnrollments'],
+        )
+      end
+    end
+
+    it 'copies warehouse enrollments and exits into unversioned aggregate tables' do
+      expect do
+        project.convert_to_aggregated!
+      end.to change(HmisCsvImporter::Aggregated::Enrollment, :count).by(1).
+        and change(HmisCsvImporter::Aggregated::Exit, :count).by(1).
+        and not_change(HmisCsvTwentyTwenty::Aggregated::Enrollment, :count).
+        and not_change(HmisCsvTwentyTwenty::Aggregated::Exit, :count)
+
+      aggregate = HmisCsvImporter::Aggregated::Enrollment.last
+      expect(aggregate.source_type).to eq(enrollment.class.name)
+      expect(aggregate.source_id).to eq(enrollment.id)
+    end
+
+    it 'uses HudHelper.current_version when slicing HUD attributes for aggregates' do
+      version = '2099' # sentinel — not tied to a real FY
+      allow(HudHelper).to receive(:current_version).and_return(version)
+      allow(GrdaWarehouse::Hud::Enrollment).to receive(:hmis_structure).
+        with(version: version).
+        and_return(GrdaWarehouse::Hud::Enrollment.hmis_structure)
+      allow(GrdaWarehouse::Hud::Exit).to receive(:hmis_structure).
+        with(version: version).
+        and_return(GrdaWarehouse::Hud::Exit.hmis_structure)
+
+      project.convert_to_aggregated!
+
+      aggregate_failures do
+        expect(GrdaWarehouse::Hud::Enrollment).to have_received(:hmis_structure).with(version: version)
+        expect(GrdaWarehouse::Hud::Exit).to have_received(:hmis_structure).with(version: version)
+        expect(GrdaWarehouse::Hud::Enrollment).not_to have_received(:hmis_structure).with(version: '2020')
+        expect(GrdaWarehouse::Hud::Exit).not_to have_received(:hmis_structure).with(version: '2020')
+      end
+    end
+
+    it 'cannot be run twice for the same project' do
+      project.convert_to_aggregated!
+
+      expect { project.convert_to_aggregated! }.to raise_error(/can only be run once/)
+    end
+  end
+
+  def staging_attributes(project, importer_log)
+    {
+      ProjectID: project.ProjectID,
+      OrganizationID: project.OrganizationID,
+      ProjectName: project.ProjectName,
+      data_source_id: project.data_source_id,
+      importer_log_id: importer_log.id,
+      pre_processed_at: Time.current,
+      source_id: project.id,
+      source_type: project.class.name,
+    }
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description

- Restores `drivers/hmis_csv_twenty_twenty/extensions/grda_warehouse/hud/project_extension.rb` with only `imported_items_2020` and `loaded_items_2020` on `GrdaWarehouse::Hud::Project`.
- Fixes `NoMethodError` on Source Data when `imported_item_type` falls back to `'2020'`.
- Does **not** restore `convert_to_aggregated!` on the FY2020 extension (that method remains solely on `hmis_csv_importer`, per #5947).
- Adds `spec/models/grda_warehouse/hud/project_source_data_spec.rb` covering FY2020 associations and unversioned `convert_to_aggregated!` regression behavior from #5947.

### Context

The fix addresses [this sentry issue](https://green-river.sentry.io/issues/7512326477/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=b3671a28-615e-4dc8-8f07-929b8f4852d5&project=4503977346662400&referrer=slack). 

The issue manifested when opening HMIS Source Data for a Project on a CSV data source with an import year of 2020.

#5947 deleted the entire FY2020 project extension because it duplicated `convert_to_aggregated!` and overwrote the unversioned `HmisCsvImporter::Aggregated` implementation. The importer extension was never meant to replace FY2020 source-data wiring. Project was the only HUD class that lost `imported_items_2020` in that change.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
