### PR TITLE
Fix bloated index query timeout caused by partition index explosion

### DIFF
--- a/app/models/dba/database_bloat.rb
+++ b/app/models/dba/database_bloat.rb
@@ -32,7 +32,7 @@ class Dba::DatabaseBloat
   MIN_ROWS = ENV.fetch('DBA_MIN_ROWS', 1_000).to_i
 
   # minimum percentage of non-analyzed rows to trigger adjusting autovaccuum
-  MIN_PCT_NOT_ANALZYED = ENV.fetch('DBA_MIN_PCT_NOT_ANALYZED', 4).to_i
+  MIN_PCT_NOT_ANALYZED = ENV.fetch('DBA_MIN_PCT_NOT_ANALYZED', 4).to_i
 
   def initialize(ar_base_class:, dry_run: false)
     self.ar_base_class = ar_base_class
@@ -99,7 +99,7 @@ class Dba::DatabaseBloat
 
   # Autovacuum is tied to autoanalyze
   def adjust_autovacuum_for(row)
-    return unless row['percent_unanalyzed'] > MIN_PCT_NOT_ANALZYED
+    return unless row['percent_unanalyzed'] > MIN_PCT_NOT_ANALYZED
 
     autovacuum_analyze_threshold = (row['autovacuum_analyze_threshold'] / 2).to_i
     autovacuum_analyze_scale_factor = (row['autovacuum_analyze_scale_factor'] / 2).round(2)
@@ -483,7 +483,12 @@ class Dba::DatabaseBloat
                                 FROM pg_catalog.pg_index i
                                 JOIN pg_catalog.pg_class ci ON ci.oid = i.indexrelid
                                 WHERE ci.relam=(SELECT oid FROM pg_am WHERE amname = 'btree')
-                                AND ci.relpages > 0
+                                -- relpages is the number of 8KB disk pages the index occupies. An index's maximum possible
+                                -- bloat equals its total size (relpages * 8192 bytes), so any index below this threshold
+                                -- can never exceed SIZE_CUTOFF bytes of bloat and will never appear in final results.
+                                -- This avoids running expensive per-index statistics for thousands of small indexes
+                                -- (e.g. child partition indexes from hmis_2022_* tables).
+                                AND ci.relpages > #{(SIZE_CUTOFF / 8192.0).ceil}
                             ) AS idx_data
                         ) AS ic
                         JOIN pg_catalog.pg_class ct ON ct.oid = ic.tbloid


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The `bloated_indexes_sql` query scans all indexes to estimate bloat, including thousands of child partition indexes (e.g. `hmis_2022_*`) that can never have significant bloat.

Rather than filtering by schema (which would silently skip real indexes on some installations) or excluding all partition indexes (which would miss large partitions with genuine bloat), the fix pre-filters in the innermost subquery using `relpages` — the number of 8KB disk pages the index occupies. Since an index's maximum possible bloat is its total size (`relpages * 8192` bytes), any index smaller than `SIZE_CUTOFF / 8192` pages (~12,208 at the 100MB default) cannot produce enough bloat to ever appear in final results, so there is no value in computing statistics for it.

Also fixes a typo in the `MIN_PCT_NOT_ANALZYED` constant name (→ `MIN_PCT_NOT_ANALYZED`).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
