### PR TITLE
fix: correct Q22c average to exclude clients with >730 days to move-in

### DIFF
--- a/app/models/concerns/hud_reports/start_to_move_in_question.rb
+++ b/app/models/concerns/hud_reports/start_to_move_in_question.rb
@@ -15,7 +15,6 @@ module HudReports::StartToMoveInQuestion
 
   # Upper bound matches the largest bucket row in the spec ("366 to 730 days (1-2 Yrs)").
   # Totals and the average use this same cap so all rows cover the same universe.
-  # APR/CAPER spec (dev/datalab/apr_caper_2026.md): Q22c rows 2-10, row 11, row 12.
   MAX_DAYS_TO_MOVE_IN = 730
 
   def start_to_move_in_question(question:, members:, populations: sub_populations)

--- a/app/models/concerns/hud_reports/start_to_move_in_question.rb
+++ b/app/models/concerns/hud_reports/start_to_move_in_question.rb
@@ -13,6 +13,11 @@
 module HudReports::StartToMoveInQuestion
   extend ActiveSupport::Concern
 
+  # Upper bound matches the largest bucket row in the spec ("366 to 730 days (1-2 Yrs)").
+  # Totals and the average use this same cap so all rows cover the same universe.
+  # APR/CAPER spec (dev/datalab/apr_caper_2026.md): Q22c rows 2-10, row 11, row 12.
+  MAX_DAYS_TO_MOVE_IN = 730
+
   def start_to_move_in_question(question:, members:, populations: sub_populations)
     # PSH/RRH w/ move in date
     # OR project type 7 (other) with Funder 35 (Pay for Success)
@@ -37,10 +42,12 @@ module HudReports::StartToMoveInQuestion
             case row_cond
             when :average
               value = 0
-              scope = relevant_members.where(col_cond).where(a_t[:hoh_move_in_date].between(@report.start_date..@report.end_date))
-              # treat null values as having 0 time in this case
-              stay_lengths = scope.pluck(a_t[:time_to_move_in]).map { |len| len || 0 }
-              value = (stay_lengths.sum(0.0) / stay_lengths.count).round if stay_lengths.any? # using round since this is an average number of days
+              # Make sure totals only include time to move in dates within the ranges being reported on
+              scope = relevant_members.where(col_cond).
+                where(a_t[:hoh_move_in_date].between(@report.start_date..@report.end_date)).
+                where(a_t[:time_to_move_in].between(0..MAX_DAYS_TO_MOVE_IN))
+              stay_lengths = scope.pluck(a_t[:time_to_move_in])
+              value = (stay_lengths.sum(0.0) / stay_lengths.count).round if stay_lengths.any?
               row.append_cell_value(value: value)
             else
               scope = relevant_members.where(col_cond).where(row_cond)
@@ -69,15 +76,12 @@ module HudReports::StartToMoveInQuestion
       cond = lengths.fetch(label).and(a_t[:hoh_move_in_date].between(@report.start_date..@report.end_date))
       [label, cond]
     end
-    # This is the largest amount of days being reported on so we can set a limit in the total.
-    max_days_in_query = 730
-
     # Make sure totals only include time to move in dates within the ranges being reported on
     ret.merge(
-      'Total (persons moved into housing)' => a_t[:hoh_move_in_date].between(@report.start_date..@report.end_date).and(a_t[:time_to_move_in].between(0..max_days_in_query)),
+      'Total (persons moved into housing)' => a_t[:hoh_move_in_date].between(@report.start_date..@report.end_date).and(a_t[:time_to_move_in].between(0..MAX_DAYS_TO_MOVE_IN)),
       'Average length of time to housing' => :average,
       'Persons who were exited without move-in' => a_t[:hoh_move_in_date].eq(nil),
-      'Total persons' => a_t[:time_to_move_in].between(0..max_days_in_query).or(a_t[:hoh_move_in_date].eq(nil)),
+      'Total persons' => a_t[:time_to_move_in].between(0..MAX_DAYS_TO_MOVE_IN).or(a_t[:hoh_move_in_date].eq(nil)),
     ).freeze
   end
 end

--- a/drivers/hud_apr/spec/models/fy2026/shared/question_twenty_two_spec.rb
+++ b/drivers/hud_apr/spec/models/fy2026/shared/question_twenty_two_spec.rb
@@ -1,0 +1,113 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../../../../spec/shared_contexts/hud_enrollment_builders'
+
+RSpec.describe HudApr::Generators::Apr::Fy2026::QuestionTwentyTwo, type: :model, exclude_fixpoints: true do
+  include_context 'HUD enrollment builders'
+
+  let(:report_start) { Date.new(2025, 10, 1) }
+  let(:report_end) { Date.new(2026, 9, 30) }
+
+  let(:apr_filter) do
+    Filters::HudFilterBase.new(
+      user: User.setup_system_user,
+      start: report_start,
+      end: report_end,
+      coc_codes: ['MA-500'],
+      enforce_one_year_range: false,
+    )
+  end
+
+  def setup_apr_report(project_ids)
+    filter = apr_filter.dup
+    filter.update(project_ids: project_ids)
+    report = HudReports::ReportInstance.from_filter(
+      filter,
+      HudApr::Generators::Apr::Fy2026::Generator.title,
+      build_for_questions: ['Question 22'],
+    )
+    report.question_names = ['Question 22']
+    report.save!
+    GrdaWarehouse::Tasks::ServiceHistory::Enrollment.find_each(&:rebuild_service_history!)
+    report
+  end
+
+  def run_q22(report)
+    report.started_at ||= Time.current
+    report.save! if report.changed?
+    generator = HudApr::Generators::Apr::Fy2026::Generator.new(report)
+    question = described_class.new(generator, report)
+    question.run_question!
+    report.reload
+  end
+
+  describe 'Q22c: Average length of time to housing' do
+    # Report period: 2025-10-01 to 2026-09-30
+    #
+    # Client 1: 31 days to move-in (entry 2025-10-01, move-in 2025-11-01)
+    # Client 2: 61 days to move-in (entry 2025-10-01, move-in 2025-12-01)
+    # Client 3: 800 days to move-in (entry 2023-08-14, move-in 2025-10-22)
+    #           → exceeds the 730-day max bucket, must NOT inflate the average
+    #
+    # Correct average = (31 + 61) / 2 = 46
+
+    before do
+      psh_project_type = HudHelper.util('2026').project_type_number_from_code(:psh).first
+      @project = create_project(project_type: psh_project_type)
+
+      client1 = create_client_with_warehouse_link(dob: Date.new(1985, 1, 1))
+      create_enrollment(
+        client: client1,
+        project: @project,
+        entry_date: Date.new(2025, 10, 1),
+        move_in_date: Date.new(2025, 11, 1), # 31 days
+        relationship_to_ho_h: 1,
+      )
+
+      client2 = create_client_with_warehouse_link(dob: Date.new(1990, 6, 1))
+      create_enrollment(
+        client: client2,
+        project: @project,
+        entry_date: Date.new(2025, 10, 1),
+        move_in_date: Date.new(2025, 12, 1), # 61 days
+        relationship_to_ho_h: 1,
+      )
+
+      # Client enrolled 800 days before their move-in date — exceeds the 730-day bucket cap.
+      # This client should be excluded from the Row 12 average and Row 11 total.
+      client3 = create_client_with_warehouse_link(dob: Date.new(1975, 3, 15))
+      create_enrollment(
+        client: client3,
+        project: @project,
+        entry_date: Date.new(2023, 8, 14),
+        move_in_date: Date.new(2025, 10, 22), # 800 days after entry
+        relationship_to_ho_h: 1,
+      )
+
+      @report = setup_apr_report([@project.id])
+      run_q22(@report)
+    end
+
+    it 'excludes clients with >730 days from the average (Row 12)' do
+      # (31 + 61) / 2 = 46, not (31 + 61 + 800) / 3 = 297
+      expect(@report.answer(question: 'Q22c', cell: 'B12').summary).to eq(46)
+    end
+
+    it 'excludes clients with >730 days from total persons moved into housing (Row 11)' do
+      expect(@report.answer(question: 'Q22c', cell: 'B11').summary).to eq(2)
+    end
+
+    it 'excludes clients with >730 days from total persons (Row 14)' do
+      # Client 3 has move_in_date (not a leaver without move-in) but time_to_move_in > 730,
+      # so they appear in neither the "moved into housing" nor the "exited without move-in" rows.
+      expect(@report.answer(question: 'Q22c', cell: 'B14').summary).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixes a miscalculation in APR/CAPER Q22c where the "Average length of time
to housing" (Row 12) could show a value much higher than what users would
calculate from the drilldown data.

The average scope was filtering on `hoh_move_in_date` within the report
period but had no upper bound on `time_to_move_in`. Clients enrolled long
before their move-in date was recorded (>730 days) were silently included
in the average even though they appear in no bucket row, no totals row,
and no drilldown. The fix adds the same `0..730` cap used by all other
rows and extracts it as `MAX_DAYS_TO_MOVE_IN = 730`. The `nil → 0`
coercion is also removed since `BETWEEN` excludes NULLs at the SQL layer.

A new unit spec (`question_twenty_two_spec.rb`) explicitly exercises the
>730-day case to prevent regression: three clients (31, 61, and 800 days)
are enrolled, and the spec asserts the average is 46 (not 297), the moved-
into-housing total is 2, and the total-persons count is 2.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
