### PR TITLE
Limit bar height for outliers

### DIFF
--- a/app/javascript/controllers/metric_threshold_chart_controller.js
+++ b/app/javascript/controllers/metric_threshold_chart_controller.js
@@ -28,6 +28,18 @@ export default class extends Controller {
     const counts = data.map(d => d[1]);
     const entityLabel = this.entityLabelValue || 'Entities';
 
+    const yAxisConfig = {
+      label: {
+        text: `Number of ${entityLabel}`,
+        position: 'outer-middle'
+      },
+      tick: {
+        format: (x) => { return Math.floor(x).toLocaleString('en-US'); }
+      }
+    };
+    const yMax = this.calculateYAxisCap(counts);
+    if (yMax !== null) yAxisConfig.max = yMax;
+
     const chartConfig = {
       bindto: this.chartTarget,
       data: {
@@ -62,15 +74,7 @@ export default class extends Controller {
             }
           }
         },
-        y: {
-          label: {
-            text: `Number of ${entityLabel}`,
-            position: 'outer-middle'
-          },
-          tick: {
-            format: (x) => { return Math.floor(x).toLocaleString('en-US'); }
-          }
-        }
+        y: yAxisConfig
       },
       legend: {
         show: false
@@ -98,6 +102,20 @@ export default class extends Controller {
     this.chart = bb.generate(chartConfig);
     const svg = this.chartTarget.querySelector('svg');
     if (svg) svg.style.overflow = 'visible';
+  }
+
+  calculateYAxisCap(counts) {
+    const nonZero = counts.filter(v => v > 0).sort((a, b) => a - b);
+    if (nonZero.length < 4) return null;
+
+    const max = nonZero[nonZero.length - 1];
+    const q1 = nonZero[Math.floor(nonZero.length * 0.25)];
+    const q3 = nonZero[Math.floor(nonZero.length * 0.75)];
+    const iqr = q3 - q1;
+    const upperFence = q3 + 1.5 * iqr;
+
+    if (max > upperFence) return upperFence * 1.2;
+    return null;
   }
 
   async handleBarClick(d) {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

How it works:
1. Sort all values, find Q1 (25th percentile) and Q3 (75th percentile)
2. IQR = Q3 − Q1
3. "Upper fence" = Q3 + 1.5 × IQR — anything above this is a statistical outlier
4. If the max exceeds the upper fence, cap `axis.y.max` at the upper fence (plus a little headroom, e.g. ×1.2)

This example isn't as bad as some we're seeing in production, but it shows the improvement.
Before:
<img width="1510" height="495" alt="Screenshot 2026-06-03 at 3 53 53 PM" src="https://github.com/user-attachments/assets/5be2b8d2-b2d6-4291-958a-ca7a85df1539" />

After:
<img width="1498" height="458" alt="Screenshot 2026-06-03 at 3 53 21 PM" src="https://github.com/user-attachments/assets/5e99784d-7be3-4154-bb27-0682d203190a" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
