### PR TITLE
fix: move money rounding to CSV write phase; restore AR pipeline for HispanicLatinao

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/csv_destination.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/csv_destination.rb
@@ -12,7 +12,10 @@ module HmisCsvTwentyTwentySix::Exporter
 
     def initialize(options)
       @output_file = options[:output_file]
-      @keys = options[:hmis_class].hmis_configuration(version: '2026').keys
+      @config = options[:hmis_class].hmis_configuration(version: '2026')
+      @keys = @config.keys
+      # Cached here so write() can format money/integer fields without re-reading config per row.
+      @rounded_columns = @config.select { |_, m| m[:check].in?([:money, :integer]) }
       @strip_newline_proc = proc do |field|
         field.respond_to?(:gsub) ? field.gsub("\n", '\\n') : field
       end
@@ -24,11 +27,16 @@ module HmisCsvTwentyTwentySix::Exporter
       @csv << options[:destination_class].csv_header_override(@keys)
     end
 
-    # row is a HashWithIndifferentAccess at this point, not an AR object.
-    # See ExportConcern#process for where the conversion happens.
     def write(row)
       @csv ||= CSV.open(@output_file, 'wb', force_quotes: true, write_converters: [@strip_newline_proc])
-      @csv << row.values_at(*@keys)
+      # Build a plain hash from the AR object using spec column names as keys. Rounding is
+      # applied here rather than in ExportConcern#process because AR silently re-casts string
+      # values (e.g. "50.00") back to numeric types on assignment, corrupting the formatted output.
+      hash = @keys.map { |k| [k, row[k]] }.to_h
+      @rounded_columns.each do |k, opts|
+        hash = HmisCsvTwentyTwentySix::Exporter::IncomeBenefit.round_value(hash, hud_field: k, rounding: opts[:check], positive: opts[:positive])
+      end
+      @csv << hash.values_at(*@keys)
     end
 
     def close

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/export_concern.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/export_concern.rb
@@ -136,14 +136,12 @@ module HmisCsvTwentyTwentySix::Exporter::ExportConcern
       keys
     end
 
+    # At this point row is an active record model, if you need to format things that are
+    # incompatible with the native datastructure (Active Record) you need to make the changes
+    # in the csv_destination file ./csv_destination.rb
     def process(row)
       row = assign_export_id(row)
       row = self.class.adjust_keys(row, @options[:export])
-      # Convert to a plain hash so string values set below (e.g. "50.00") are stored as-is.
-      # AR would silently re-cast them back to numeric types on assignment.
-      # Some custom exporters (e.g. CustomDataElement) convert via apply_warehouse_to_export_mappings
-      # inside adjust_keys, so row may already be a Hash at this point.
-      row = row.respond_to?(:attributes) ? row.attributes.with_indifferent_access : row.with_indifferent_access
       row = sanitize_string_fields(row)
       row = enforce_lengths(row)
       row = enforce_rounding(row)

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/fake_data.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/exporter/fake_data.rb
@@ -14,8 +14,6 @@ module HmisCsvTwentyTwentySix::Exporter
       @options = options
     end
 
-    # row is a HashWithIndifferentAccess at this point, not an AR object.
-    # See ExportConcern#process for where the conversion happens.
     def process(row)
       export = @options[:export]
       return row unless export.faked_pii

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/client_overrides_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/client_overrides_spec.rb
@@ -1,0 +1,67 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisCsvTwentyTwentySix::Exporter::Client::Overrides, type: :model do
+  let(:client) { GrdaWarehouse::Hud::Client.new }
+  let(:export) { GrdaWarehouse::HmisExport.new(hash_status: 1) }
+  let(:race_fields) { HudHelper.util('2026').race_fields - [:RaceNone] }
+
+  describe '.enforce_required_fields' do
+    it 'defaults nil race fields to 0' do
+      race_fields.each { |f| client[f] = nil }
+      described_class.enforce_required_fields(client)
+      race_fields.each do |field|
+        expect(client[field]).to eq(0), "expected #{field} to be 0, got #{client[field].inspect}"
+      end
+    end
+
+    it 'does not overwrite existing values' do
+      client[:HispanicLatinaeo] = 1
+      client[:White] = 0
+      described_class.enforce_required_fields(client)
+      expect(client[:HispanicLatinaeo]).to eq(1)
+      expect(client[:White]).to eq(0)
+    end
+  end
+
+  describe '.enforce_race_none' do
+    it 'sets RaceNone to 99 when all race flags are 0' do
+      race_fields.each { |f| client[f] = 0 }
+      described_class.enforce_race_none(client)
+      expect(client.RaceNone).to eq(99)
+    end
+
+    it 'leaves RaceNone nil when at least one race flag is 1' do
+      race_fields.each { |f| client[f] = 0 }
+      client[:HispanicLatinaeo] = 1
+      described_class.enforce_race_none(client)
+      expect(client.RaceNone).to be_nil
+    end
+  end
+
+  describe '.apply_overrides' do
+    it 'defaults all-nil race fields to 0 and sets RaceNone to 99' do
+      race_fields.each { |f| client[f] = nil }
+      described_class.apply_overrides(client, export: export)
+      race_fields.each do |field|
+        expect(client[field]).to eq(0), "expected #{field} to be 0"
+      end
+      expect(client.RaceNone).to eq(99)
+    end
+
+    it 'preserves a race flag of 1 and does not set RaceNone to 99' do
+      race_fields.each { |f| client[f] = 0 }
+      client[:HispanicLatinaeo] = 1
+      described_class.apply_overrides(client, export: export)
+      expect(client[:HispanicLatinaeo]).to eq(1)
+      expect(client.RaceNone).to be_nil
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_tests.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/single_enrollment_tests.rb
@@ -62,6 +62,15 @@ RSpec.shared_context '2026 single-enrollment tests', shared_context: :metadata d
       csv = CSV.read(ExportHelper2026.csv_file_path(ExportHelper2026.client_class), headers: true)
       expect(csv.first['PersonalID']).to eq ExportHelper2026.clients.first.destination_client.id.to_s
     end
+    it 'exports HispanicLatinao as 0 when source data is nil' do
+      # HUD renamed HispanicLatinaeo -> HispanicLatinao in FY2026. The DB column keeps the old name
+      # but alias_attribute on the AR model makes row[:HispanicLatinao] transparently read it.
+      # enforce_required_fields defaults nil race fields to 0.
+      # A blank here causes a NOT NULL violation in the LSA SQL Server import.
+      csv = CSV.read(ExportHelper2026.csv_file_path(ExportHelper2026.client_class), headers: true)
+      expect(csv.headers).to include('HispanicLatinao')
+      expect(csv.first['HispanicLatinao']).to eq('0')
+    end
   end
   ExportHelper2026.enrollment_related_items.each do |items, klass|
     describe "when exporting #{items}" do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

This fixes a data export pipeline issue introduced in #6488 that caused the `HispanicLatinao` column to be blank in FY2026 HMIS CSV exports, which triggers NOT NULL violations when the LSA imports that data into SQL Server.

The root cause: #6488 converted ActiveRecord objects to plain hashes early in the export pipeline to prevent money values (e.g. `50.00`) from being silently re-cast back to numbers. That conversion used database column names, but the FY2026 HUD spec renamed `HispanicLatinaeo` → `HispanicLatinao`. The Rails `alias_attribute` that bridges those two names only works on the AR object — once converted to a hash, the lookup key mismatched and the column came out nil.

The fix moves money/integer rounding to the CSV write step (`CsvDestination#write`), where it operates on a fresh hash that's not subject to AR re-casting. The AR object now flows through the full transform pipeline unchanged, so the `alias_attribute` remains active and `HispanicLatinao` resolves correctly.

Also adds unit tests for `Client::Overrides` race field logic and an integration test verifying the `HispanicLatinao` value appears correctly in exported CSV.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
