### PR TITLE
HMIS Simulation Engine - Foundation

### DIFF
--- a/config/simulations/samples/small_coc.json
+++ b/config/simulations/samples/small_coc.json
@@ -1,0 +1,349 @@
+{
+  "_comment": "Sample simulation config for a small (~500 active clients) CoC. Copy this file, set data_source_id to the target HMIS data source, and adjust populations/projects as needed. Load via: rake driver:hmis_simulation:setup_from_file[path/to/config.json]",
+
+  "name": "Demo CoC (Small)",
+  "data_source_id": 0,
+  "_data_source_id_comment": "REQUIRED: Set this to the ID of the GrdaWarehouse::DataSource with hmis=true for your installation.",
+  "seed": 20250101,
+  "coc_codes": {
+    "primary": "XX-500",
+    "_secondary_comment": "Optional: a small % of projects/enrollments will use this CoC. Remove if not needed.",
+    "secondary": "XX-501"
+  },
+
+  "organizations": [
+    {
+      "name": "Community Action Agency_",
+      "projects": [
+        {
+          "name": "Harbor ES NBN_",
+          "project_type": 1,
+          "capacity": 80,
+          "funders": [{ "funder": 2, "grant_id": "FAKE-ESG-001_" }]
+        },
+        {
+          "name": "Crossroads ES Entry Exit_",
+          "project_type": 0,
+          "capacity": 40
+        },
+        {
+          "name": "Transitional Steps TH_",
+          "project_type": 2,
+          "capacity": 30
+        }
+      ]
+    },
+    {
+      "name": "Pathways Housing Alliance_",
+      "projects": [
+        {
+          "name": "Stable Futures PSH_",
+          "project_type": 3,
+          "capacity": 60,
+          "funders": [{ "funder": 3, "grant_id": "FAKE-CoC-PSH-001_" }]
+        },
+        {
+          "name": "Rapid Rehouse Program_",
+          "project_type": 13,
+          "capacity": 30
+        }
+      ]
+    },
+    {
+      "name": "Street Outreach Coalition_",
+      "projects": [
+        {
+          "name": "Street Outreach Team_",
+          "project_type": 4
+        },
+        {
+          "name": "CE Coordinating Agency_",
+          "project_type": 14
+        },
+        {
+          "name": "Case Management Services_",
+          "project_type": 6
+        }
+      ]
+    }
+  ],
+
+  "household_templates": {
+    "adult_only": {
+      "hoh": {
+        "age": { "distribution": "normal", "mean": 42, "stddev": 12, "min": 18 },
+        "gender": { "woman": 0.35, "man": 0.55, "non_binary": 0.05, "transgender": 0.05 },
+        "veteran_probability": 0.12,
+        "race": {
+          "white": 0.4, "black_af_american": 0.35,
+          "hispanic_latinaeo": 0.15, "other": 0.1
+        }
+      }
+    },
+    "adult_and_child": {
+      "hoh": {
+        "age": { "distribution": "normal", "mean": 32, "stddev": 8, "min": 18 },
+        "gender": { "woman": 0.75, "man": 0.20, "non_binary": 0.05 }
+      },
+      "members": [
+        {
+          "role": "child",
+          "count": { "distribution": "poisson", "lambda": 2, "min": 1, "max": 5 },
+          "age": { "distribution": "uniform", "min": 0, "max": 17 },
+          "relationship": 2
+        }
+      ]
+    },
+    "child_only": {
+      "hoh": { "age": { "distribution": "uniform", "min": 12, "max": 17 } }
+    }
+  },
+
+  "populations": [
+    {
+      "name": "street",
+      "label": "On Street / Unsheltered",
+      "project_ref": "Street Outreach Team_",
+      "household_templates": { "adult_only": 0.7, "adult_and_child": 0.2, "child_only": 0.1 },
+      "_entry_point_comment": "Relative weight — these are normalized internally so you can use any positive numbers.",
+      "entry_point": 5,
+      "exit_point": 0.05
+    },
+    {
+      "name": "es_nbn",
+      "label": "Emergency Shelter (Night-by-Night)",
+      "project_ref": "Harbor ES NBN_",
+      "household_templates": { "adult_only": 0.8, "adult_and_child": 0.15, "child_only": 0.05 },
+      "entry_point": 4,
+      "exit_point": 0.08
+    },
+    {
+      "name": "es_entry_exit",
+      "label": "Emergency Shelter (Entry/Exit)",
+      "project_ref": "Crossroads ES Entry Exit_",
+      "household_templates": { "adult_only": 0.5, "adult_and_child": 0.45, "child_only": 0.05 },
+      "entry_point": 3,
+      "exit_point": 0.08
+    },
+    {
+      "name": "th",
+      "label": "Transitional Housing",
+      "project_ref": "Transitional Steps TH_",
+      "household_templates": { "adult_only": 0.6, "adult_and_child": 0.4 },
+      "entry_point": 0,
+      "exit_point": 0.25
+    },
+    {
+      "name": "psh",
+      "label": "Permanent Supportive Housing",
+      "project_ref": "Stable Futures PSH_",
+      "household_templates": { "adult_only": 0.9, "adult_and_child": 0.1 },
+      "entry_point": 0,
+      "exit_point": 0.5
+    },
+    {
+      "name": "rrh",
+      "label": "Rapid Rehousing",
+      "project_ref": "Rapid Rehouse Program_",
+      "household_templates": { "adult_only": 0.4, "adult_and_child": 0.6 },
+      "entry_point": 0,
+      "exit_point": 0.65
+    }
+  ],
+
+  "transitions": [
+    {
+      "from": "street", "to": "es_nbn",
+      "weight": 6,
+      "timing": { "distribution": "uniform", "min": 1, "max": 14 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 3 },
+      "exit_destinations": { "101": 5, "116": 3, "17": 2 }
+    },
+    {
+      "from": "street", "to": "es_entry_exit",
+      "weight": 4,
+      "timing": { "distribution": "uniform", "min": 1, "max": 21 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 3 },
+      "exit_destinations": { "101": 6, "116": 3, "17": 1 }
+    },
+    {
+      "from": "es_nbn", "to": "street",
+      "weight": 5,
+      "timing": { "distribution": "normal", "mean": 21, "stddev": 14, "min": 1, "max": 180 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 7 },
+      "exit_destinations": { "116": 6, "101": 3, "17": 1 }
+    },
+    {
+      "from": "es_nbn", "to": "th",
+      "weight": 2,
+      "timing": { "distribution": "normal", "mean": 45, "stddev": 20, "min": 7 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 14 },
+      "exit_destinations": { "2": 1 }
+    },
+    {
+      "from": "es_nbn", "to": "psh",
+      "weight": 2,
+      "timing": { "distribution": "normal", "mean": 90, "stddev": 30, "min": 14 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 30 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "es_nbn", "to": "rrh",
+      "weight": 1,
+      "timing": { "distribution": "normal", "mean": 60, "stddev": 20, "min": 7 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 21 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "es_entry_exit", "to": "street",
+      "weight": 4,
+      "timing": { "distribution": "normal", "mean": 30, "stddev": 20, "min": 3 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 7 },
+      "exit_destinations": { "116": 5, "101": 4, "17": 1 }
+    },
+    {
+      "from": "es_entry_exit", "to": "psh",
+      "weight": 2,
+      "timing": { "distribution": "normal", "mean": 90, "stddev": 30, "min": 14 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 30 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "es_entry_exit", "to": "rrh",
+      "weight": 2,
+      "timing": { "distribution": "normal", "mean": 60, "stddev": 20, "min": 7 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 21 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "es_entry_exit", "to": "th",
+      "weight": 2,
+      "timing": { "distribution": "normal", "mean": 45, "stddev": 20, "min": 7 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 14 },
+      "exit_destinations": { "2": 1 }
+    },
+    {
+      "from": "th", "to": "psh",
+      "weight": 3,
+      "timing": { "distribution": "normal", "mean": 365, "stddev": 90, "min": 60 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 21 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "th", "to": "rrh",
+      "weight": 3,
+      "timing": { "distribution": "normal", "mean": 270, "stddev": 60, "min": 60 },
+      "gap_before_entry": { "distribution": "uniform", "min": 1, "max": 14 },
+      "exit_destinations": { "435": 1 }
+    },
+    {
+      "from": "th", "to": "street",
+      "weight": 4,
+      "timing": { "distribution": "normal", "mean": 90, "stddev": 60, "min": 14 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 14 },
+      "exit_destinations": { "116": 5, "101": 3, "17": 2 }
+    },
+    {
+      "from": "psh", "to": "street",
+      "weight": 1,
+      "timing": { "distribution": "normal", "mean": 1095, "stddev": 365, "min": 180 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 30 },
+      "exit_destinations": { "426": 7, "116": 2, "17": 1 }
+    },
+    {
+      "from": "rrh", "to": "street",
+      "weight": 1,
+      "timing": { "distribution": "normal", "mean": 365, "stddev": 120, "min": 90 },
+      "gap_before_entry": { "distribution": "uniform", "min": 0, "max": 14 },
+      "exit_destinations": { "426": 8, "116": 1, "17": 1 }
+    }
+  ],
+
+  "concurrent_enrollments": {
+    "_comment": "Timed enrollments that overlap with the primary track. count_distribution is additional enrollments beyond the primary.",
+    "count_distribution": { "0": 55, "1": 30, "2": 12, "3": 3 },
+    "data_error_rate": 0.01,
+    "projects": [
+      {
+        "name": "Street Outreach Team_",
+        "project_type": 4,
+        "selection_weight": 45,
+        "duration": { "distribution": "uniform", "min": 14, "max": 120 },
+        "gap_before_reentry": { "distribution": "uniform", "min": 0, "max": 30 },
+        "reentry_probability": 0.7
+      },
+      {
+        "name": "Case Management Services_",
+        "project_type": 6,
+        "selection_weight": 30,
+        "duration": { "distribution": "normal", "mean": 90, "stddev": 30, "min": 14 },
+        "gap_before_reentry": { "distribution": "uniform", "min": 14, "max": 60 },
+        "reentry_probability": 0.5
+      }
+    ]
+  },
+
+  "lifecycle_enrollments": [
+    {
+      "_comment": "CE enrollment opens when a client enters an ES or street population, may open a few days before the primary enrollment, and closes on housing move-in, disengagement, or early exit.",
+      "name": "ce",
+      "label": "Coordinated Entry",
+      "project_ref": "CE Coordinating Agency_",
+      "trigger_populations": ["street", "es_nbn", "es_entry_exit"],
+      "trigger_probability": 0.4,
+      "days_before_trigger": { "distribution": "uniform", "min": 0, "max": 14 },
+      "close_conditions": {
+        "housing_move_in": 0.50,
+        "disengagement": {
+          "probability": 0.35,
+          "after_days": { "distribution": "normal", "mean": 365, "stddev": 120, "min": 90 }
+        },
+        "pre_entry_exit": {
+          "probability": 0.15,
+          "after_days": { "distribution": "uniform", "min": 7, "max": 60 }
+        }
+      }
+    }
+  ],
+
+  "enrollment_config": {
+    "_comment": "new_clients_per_month controls how many new clients enter the system each month. Start low and tune up.",
+    "new_clients_per_month": { "distribution": "poisson", "lambda": 15 },
+    "household_cohesion_probability": 0.85,
+    "disabilities": {
+      "disabling_condition_probability": 0.75,
+      "types": {
+        "mental_health": 0.6,
+        "substance_use": 0.5,
+        "chronic_health": 0.35,
+        "physical": 0.25,
+        "developmental": 0.08,
+        "hiv_aids": 0.05
+      }
+    },
+    "income_at_entry": {
+      "no_income_probability": 0.4,
+      "sources": { "ssi": 0.2, "ssdi": 0.15, "earned": 0.1, "ga": 0.2 }
+    },
+    "health_and_dv": {
+      "dv_survivor_probability": 0.2,
+      "currently_fleeing_probability": 0.4,
+      "general_health": { "poor": 0.3, "fair": 0.4, "good": 0.25, "excellent": 0.05 }
+    },
+    "annual_collection": {
+      "_comment": "Controls jitter and miss rate for annually-collected records (IncomeBenefits, etc.).",
+      "miss_rate": 0.005,
+      "timing_jitter": {
+        "distribution": "normal", "mean": 0, "stddev": 30, "min": -90, "max": 90
+      }
+    }
+  },
+
+  "data_quality": {
+    "_comment": "Rates for missing or approximate data. Tune to match realistic data quality issues.",
+    "missing_dob_rate": 0.02,
+    "missing_ssn_rate": 0.05,
+    "missing_name_rate": 0.01,
+    "approximate_dob_rate": 0.03
+  }
+}

--- a/db/warehouse/migrate/20260604120000_create_hmis_simulation_tables.rb
+++ b/db/warehouse/migrate/20260604120000_create_hmis_simulation_tables.rb
@@ -1,0 +1,95 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class CreateHmisSimulationTables < ActiveRecord::Migration[7.2]
+  def change
+    # Tracks clients who "belong together" so household composition is
+    # preserved across re-enrollments. The HoH's SimulatedClient points here;
+    # member client IDs are stored as a JSON array.
+    create_table :hmis_simulation_household_groups do |t|
+      t.bigint  :data_source_id, null: false
+      t.bigint  :hoh_client_id,  null: false
+      t.jsonb   :member_client_ids, null: false, default: []
+      t.string  :household_template_name
+      t.timestamps
+    end
+    add_index :hmis_simulation_household_groups, :data_source_id
+    add_index :hmis_simulation_household_groups, :hoh_client_id
+
+    # One row per simulated client; tracks their current position in the
+    # primary enrollment state machine.
+    create_table :hmis_simulation_clients do |t|
+      t.bigint  :data_source_id,              null: false
+      t.bigint  :hud_client_id,               null: false
+      t.bigint  :household_group_id
+      t.string  :current_population
+      t.date    :entered_current_population_at
+      t.bigint  :hud_enrollment_id
+      t.date    :next_transition_on
+      t.date    :pending_enrollment_on
+      t.boolean :exited_system, null: false, default: false
+      t.timestamps
+    end
+    add_index :hmis_simulation_clients, :data_source_id
+    add_index :hmis_simulation_clients, :hud_client_id
+    add_index :hmis_simulation_clients, :next_transition_on
+    add_index :hmis_simulation_clients, :pending_enrollment_on
+    add_index :hmis_simulation_clients, [:data_source_id, :exited_system]
+
+    # Tracks timed overlapping enrollments (Street Outreach, Services Only,
+    # etc.) that run in parallel with the primary enrollment.
+    create_table :hmis_simulation_concurrent_enrollments do |t|
+      t.bigint  :data_source_id,      null: false
+      t.bigint  :hud_client_id,       null: false
+      t.bigint  :hud_enrollment_id
+      t.string  :project_name
+      t.date    :exit_on
+      t.date    :pending_reentry_on
+      t.timestamps
+    end
+    add_index :hmis_simulation_concurrent_enrollments, :data_source_id
+    add_index :hmis_simulation_concurrent_enrollments, :hud_client_id
+    add_index :hmis_simulation_concurrent_enrollments, :exit_on
+    add_index :hmis_simulation_concurrent_enrollments, :pending_reentry_on
+
+    # Tracks lifecycle enrollments (e.g. Coordinated Entry) that span
+    # multiple primary enrollments and close on a condition rather than a
+    # timer.
+    create_table :hmis_simulation_lifecycle_enrollments do |t|
+      t.bigint  :data_source_id,  null: false
+      t.bigint  :hud_client_id,   null: false
+      t.bigint  :hud_enrollment_id
+      t.string  :lifecycle_name,  null: false
+      t.string  :status,          null: false, default: 'pending_open'
+      t.date    :opens_on
+      t.string  :close_reason
+      t.timestamps
+    end
+    add_index :hmis_simulation_lifecycle_enrollments, :data_source_id
+    add_index :hmis_simulation_lifecycle_enrollments, :hud_client_id
+    add_index :hmis_simulation_lifecycle_enrollments, :opens_on
+    add_index :hmis_simulation_lifecycle_enrollments, [:data_source_id, :status]
+
+    # Audit trail — one row per simulated calendar day per data source.
+    # last_successful_run_date is derived as max(run_date) where error_message is null.
+    create_table :hmis_simulation_run_logs do |t|
+      t.bigint   :data_source_id,       null: false
+      t.date     :run_date,             null: false
+      t.datetime :started_at
+      t.datetime :finished_at
+      t.integer  :clients_created,      default: 0
+      t.integer  :enrollments_opened,   default: 0
+      t.integer  :enrollments_closed,   default: 0
+      t.integer  :services_created,     default: 0
+      t.text     :error_message
+      t.timestamps
+    end
+    add_index :hmis_simulation_run_logs, :data_source_id
+    add_index :hmis_simulation_run_logs, [:data_source_id, :run_date], unique: true
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation.rb
@@ -1,0 +1,13 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  def self.table_name_prefix
+    'hmis_simulation_'
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/client.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/client.rb
@@ -1,0 +1,18 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisSimulation::Client < GrdaWarehouseBase
+  self.table_name = 'hmis_simulation_clients'
+
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+  belongs_to :household_group, class_name: 'HmisSimulation::HouseholdGroup', optional: true
+
+  scope :active, -> { where(exited_system: false) }
+  scope :pending_enrollment, ->(date) { where(pending_enrollment_on: date) }
+  scope :pending_exit, ->(date) { where(next_transition_on: date) }
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/concurrent_enrollment.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/concurrent_enrollment.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisSimulation::ConcurrentEnrollment < GrdaWarehouseBase
+  self.table_name = 'hmis_simulation_concurrent_enrollments'
+
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
+  scope :expiring_on, ->(date) { where(exit_on: date) }
+  scope :pending_reentry_on, ->(date) { where(pending_reentry_on: date) }
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/config_loader.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/config_loader.rb
@@ -1,0 +1,97 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  # Loads simulation configuration from AppConfigProperty or a JSON file,
+  # normalizes relative weights so callers always see values summing to 1.0.
+  #
+  # Usage:
+  #   config = HmisSimulation::ConfigLoader.from_app_config('hmis_simulation/demo-coc')
+  #   config = HmisSimulation::ConfigLoader.from_file('config/simulations/samples/small_coc.json')
+  module ConfigLoader
+    module_function
+
+    def from_app_config(key)
+      record = AppConfigProperty.find_by(key: key)
+      raise KeyError, "AppConfigProperty not found for key: #{key.inspect}" unless record
+
+      normalize(record.value.deep_stringify_keys)
+    end
+
+    def from_file(path)
+      raw = JSON.parse(File.read(path))
+      normalize(raw.deep_stringify_keys)
+    end
+
+    def upsert_app_config(key, config)
+      record = AppConfigProperty.find_or_initialize_by(key: key)
+      record.value = config
+      record.save!
+    end
+
+    # -- private --
+
+    def normalize(config)
+      config = config.deep_dup
+
+      normalize_entry_points!(config)
+      normalize_transition_weights!(config)
+      normalize_exit_destinations!(config)
+      normalize_concurrent_selection_weights!(config)
+
+      config
+    end
+
+    def normalize_entry_points!(config)
+      pops = config['populations']
+      return unless pops.present?
+
+      total = pops.sum { |p| p['entry_point'].to_f }
+      return if total.zero?
+
+      pops.each { |p| p['entry_point'] = p['entry_point'].to_f / total }
+    end
+
+    def normalize_transition_weights!(config)
+      transitions = config['transitions']
+      return unless transitions.present?
+
+      transitions.group_by { |t| t['from'] }.each_value do |group|
+        total = group.sum { |t| t['weight'].to_f }
+        next if total.zero?
+
+        group.each { |t| t['weight'] = t['weight'].to_f / total }
+      end
+    end
+
+    def normalize_exit_destinations!(config)
+      transitions = config['transitions']
+      return unless transitions.present?
+
+      transitions.each do |t|
+        dests = t['exit_destinations']
+        next unless dests.present?
+
+        total = dests.values.sum(&:to_f)
+        next if total.zero?
+
+        t['exit_destinations'] = dests.transform_values { |w| w.to_f / total }
+      end
+    end
+
+    def normalize_concurrent_selection_weights!(config)
+      projects = config.dig('concurrent_enrollments', 'projects')
+      return unless projects.present?
+
+      total = projects.sum { |p| p['selection_weight'].to_f }
+      return if total.zero?
+
+      projects.each { |p| p['selection_weight'] = p['selection_weight'].to_f / total }
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/config_validator.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/config_validator.rb
@@ -1,0 +1,119 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  # Validates the structural integrity of a simulation configuration hash.
+  # Used by the validate rake task and at the start of bootstrap/run to
+  # surface problems before any records are written.
+  #
+  # Usage:
+  #   v = HmisSimulation::ConfigValidator.new(config)
+  #   if v.valid?
+  #     # proceed
+  #   else
+  #     puts v.errors.join("\n")
+  #   end
+  class ConfigValidator
+    attr_reader :errors
+
+    def initialize(config)
+      @config = config.deep_stringify_keys
+      @errors = []
+    end
+
+    def valid?
+      @errors = []
+      validate_top_level
+      validate_project_refs
+      validate_transitions
+      validate_entry_points
+      validate_lifecycle_trigger_populations
+      validate_concurrent_project_refs
+      @errors.empty?
+    end
+
+    private
+
+    def validate_top_level
+      @errors << 'data_source_id must be a positive integer' unless @config['data_source_id'].to_i.positive?
+      @errors << 'seed is required' unless @config.key?('seed')
+      @errors << 'name is required' if @config['name'].blank?
+      @errors << 'coc_codes.primary is required' if @config.dig('coc_codes', 'primary').blank?
+      @errors << 'organizations must be a non-empty array' unless @config['organizations'].is_a?(Array) && @config['organizations'].any?
+      @errors << 'populations must be a non-empty array' unless @config['populations'].is_a?(Array) && @config['populations'].any?
+    end
+
+    def validate_project_refs
+      project_names = all_project_names
+      all_population_names
+
+      @config['populations']&.each do |pop|
+        ref = pop['project_ref']
+        next if ref.blank?
+        next if project_names.include?(ref)
+
+        @errors << "population #{pop['name'].inspect} has project_ref #{ref.inspect} that does not match any project name"
+      end
+    end
+
+    def validate_transitions
+      population_names = all_population_names
+
+      @config['transitions']&.each do |t|
+        from = t['from']
+        to   = t['to']
+
+        @errors << "transition from=#{from.inspect} does not match any defined population" unless population_names.include?(from)
+        @errors << "transition to=#{to.inspect} does not match any defined population" unless population_names.include?(to)
+      end
+    end
+
+    def validate_entry_points
+      pops = @config['populations'] || []
+      return if pops.any? { |p| p['entry_point'].to_f.positive? }
+
+      @errors << 'at least one population must have entry_point > 0'
+    end
+
+    def validate_lifecycle_trigger_populations
+      population_names = all_population_names
+
+      @config['lifecycle_enrollments']&.each do |lc|
+        lc['trigger_populations']&.each do |tp|
+          next if population_names.include?(tp)
+
+          @errors << "lifecycle_enrollment #{lc['name'].inspect} trigger_populations includes #{tp.inspect} which does not match any defined population"
+        end
+
+        ref = lc['project_ref']
+        @errors << "lifecycle_enrollment #{lc['name'].inspect} has project_ref #{ref.inspect} that does not match any project name" if ref.present? && !all_project_names.include?(ref)
+      end
+    end
+
+    def validate_concurrent_project_refs
+      project_names = all_project_names
+
+      @config.dig('concurrent_enrollments', 'projects')&.each do |p|
+        ref = p['name']
+        next if project_names.include?(ref)
+
+        @errors << "concurrent_enrollments project #{ref.inspect} does not match any project name in organizations"
+      end
+    end
+
+    def all_project_names
+      @all_project_names ||= (@config['organizations'] || []).flat_map do |org|
+        (org['projects'] || []).map { |p| p['name'] }
+      end.to_set
+    end
+
+    def all_population_names
+      @all_population_names ||= (@config['populations'] || []).map { |p| p['name'] }.to_set
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/distribution.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/distribution.rb
@@ -1,0 +1,121 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Stateless probability distribution sampler.
+#
+# Uses a caller-supplied RNG so each draw is independent — avoids the
+# butterfly-effect problem where a single extra draw shifts all future
+# results for unrelated entities.
+#
+# Usage:
+#   rng = Random.new(simulation_seed + context_string.hash)
+#   HmisSimulation::Distribution.sample(config, rng: rng)
+#
+# Supported distribution types:
+#   constant  { distribution: constant, value: N }
+#   uniform   { distribution: uniform, min: N, max: N }
+#   normal    { distribution: normal, mean: N, stddev: N, min: N (opt), max: N (opt) }
+#   poisson   { distribution: poisson, lambda: N }
+#   weighted  { distribution: weighted, weights: { key => weight, ... } }
+#             Numeric string keys (e.g. "101") are returned as integers.
+#             Weights are relative — they are normalized internally.
+module HmisSimulation
+  class Distribution
+    # Sample a value from the distribution described by +config+.
+    # +rng+ must be a Random instance.
+    def self.sample(config, rng:)
+      config = config.deep_stringify_keys if config.respond_to?(:deep_stringify_keys)
+      type = config.fetch('distribution') { config.fetch(:distribution) }
+
+      case type.to_s
+      when 'constant'
+        config.fetch('value') { config.fetch(:value) }
+
+      when 'uniform'
+        min = config.fetch('min') { config.fetch(:min) }.to_f
+        max = config.fetch('max') { config.fetch(:max) }.to_f
+        min + rng.rand * (max - min)
+
+      when 'normal'
+        mean   = config.fetch('mean') { config.fetch(:mean) }.to_f
+        stddev = config.fetch('stddev') { config.fetch(:stddev) }.to_f
+        min    = (config['min'] || config[:min])&.to_f
+        max    = (config['max'] || config[:max])&.to_f
+        sample_normal(mean: mean, stddev: stddev, min: min, max: max, rng: rng)
+
+      when 'poisson'
+        lambda_val = config.fetch('lambda') { config.fetch(:lambda) }.to_f
+        sample_poisson(lambda: lambda_val, rng: rng)
+
+      when 'weighted'
+        weights = config.fetch('weights') { config.fetch(:weights) }
+        normalized = normalize_weights(weights)
+        threshold = rng.rand
+        cumulative = 0.0
+        normalized.each do |key, prob|
+          cumulative += prob
+          return coerce_key(key) if threshold < cumulative
+        end
+        coerce_key(normalized.keys.last)
+
+      else
+        raise ArgumentError, "Unknown distribution type: #{type.inspect}"
+      end
+    end
+
+    # Normalize a weights hash so values sum to 1.0.
+    # Raises ArgumentError if all weights are zero.
+    def self.normalize_weights(weights)
+      weights = weights.transform_keys(&:to_s).transform_values(&:to_f)
+      total = weights.values.sum
+      raise ArgumentError, "weights must have at least one positive value (got #{weights.inspect})" if total.zero?
+
+      weights.transform_values { |w| w / total }
+    end
+
+    # -- private helpers --
+
+    def self.sample_normal(mean:, stddev:, min:, max:, rng:)
+      # Box-Muller transform
+      100.times do
+        u1 = rng.rand
+        u2 = rng.rand
+        z  = Math.sqrt(-2.0 * Math.log([u1, Float::EPSILON].max)) * Math.cos(2 * Math::PI * u2)
+        v  = mean + stddev * z
+        next if min && v < min
+        next if max && v > max
+
+        return v
+      end
+      # Fallback: return mean clipped to bounds
+      [[mean, min].compact.max, max].compact.min
+    end
+    private_class_method :sample_normal
+
+    def self.sample_poisson(lambda:, rng:)
+      # Knuth algorithm
+      l = Math.exp(-lambda)
+      k = 0
+      p = 1.0
+      loop do
+        k += 1
+        p *= rng.rand
+        break if p <= l
+      end
+      k - 1
+    end
+    private_class_method :sample_poisson
+
+    def self.coerce_key(key)
+      Integer(key)
+    rescue ArgumentError, TypeError
+      key
+    end
+    private_class_method :coerce_key
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/household_group.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/household_group.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisSimulation::HouseholdGroup < GrdaWarehouseBase
+  self.table_name = 'hmis_simulation_household_groups'
+
+  serialize :member_client_ids, coder: JSON
+
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+  has_many :simulated_clients, class_name: 'HmisSimulation::Client', foreign_key: :household_group_id
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/lifecycle_enrollment.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/lifecycle_enrollment.rb
@@ -1,0 +1,18 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisSimulation::LifecycleEnrollment < GrdaWarehouseBase
+  self.table_name = 'hmis_simulation_lifecycle_enrollments'
+
+  STATUSES = ['pending_open', 'open', 'closed'].freeze
+
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
+  scope :pending_open_on, ->(date) { where(status: 'pending_open', opens_on: date) }
+  scope :open_for_client, ->(client_id) { where(hud_client_id: client_id, status: 'open') }
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/run_log.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/run_log.rb
@@ -1,0 +1,19 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisSimulation::RunLog < GrdaWarehouseBase
+  self.table_name = 'hmis_simulation_run_logs'
+
+  belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
+
+  scope :successful, -> { where(error_message: nil) }
+
+  def self.last_successful_run_date(data_source_id)
+    where(data_source_id: data_source_id).successful.maximum(:run_date)
+  end
+end

--- a/drivers/hmis_simulation/config/initializers/hmis_simulation_feature.rb
+++ b/drivers/hmis_simulation/config/initializers/hmis_simulation_feature.rb
@@ -1,0 +1,14 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# The core app (or other drivers) can check the presence of the
+# HmisSimulation driver with the following code snippet:
+#
+#   do_something if RailsDrivers.loaded.include(:hmis_simulation)
+#
+RailsDrivers.loaded << :hmis_simulation

--- a/drivers/hmis_simulation/lib/hmis_simulation/fake_identifier.rb
+++ b/drivers/hmis_simulation/lib/hmis_simulation/fake_identifier.rb
@@ -1,0 +1,51 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module HmisSimulation
+  # Generates obviously-fake identifiers for simulated HUD records.
+  #
+  # Conventions (all identifiers are recognisably fake at a glance):
+  #   - UUIDs:       FAKE-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  #   - SSNs:        999XXXXXX  (999 prefix is never valid)
+  #   - First names: city name + "_"  (e.g. "Portland_")
+  #   - Last names:  river/water body + "_"  (e.g. "Columbia_")
+  module FakeIdentifier
+    FAKE_NAMES_DIR = File.expand_path('fake_names', __dir__).freeze
+
+    # Generates a 32-character HUD-style ID (no dashes, matching generate_uuid convention)
+    # with a FAKE prefix so it is obviously synthetic at a glance.
+    def self.uuid
+      hex = SecureRandom.uuid.delete('-')
+      "FAKE#{hex[4..]}"
+    end
+
+    def self.ssn
+      "999#{format('%06d', rand(1_000_000))}"
+    end
+
+    def self.first_name
+      "#{cities.sample}_"
+    end
+
+    def self.last_name
+      "#{rivers.sample}_"
+    end
+
+    def self.cities
+      @cities ||= File.readlines(File.join(FAKE_NAMES_DIR, 'cities.txt'), chomp: true).reject(&:blank?)
+    end
+    private_class_method :cities
+
+    def self.rivers
+      @rivers ||= File.readlines(File.join(FAKE_NAMES_DIR, 'rivers.txt'), chomp: true).reject(&:blank?)
+    end
+    private_class_method :rivers
+  end
+end

--- a/drivers/hmis_simulation/lib/hmis_simulation/fake_names/cities.txt
+++ b/drivers/hmis_simulation/lib/hmis_simulation/fake_names/cities.txt
@@ -1,0 +1,219 @@
+Portland
+Denver
+Austin
+Seattle
+Phoenix
+Nashville
+Atlanta
+Boston
+Chicago
+Detroit
+Houston
+Indianapolis
+Jacksonville
+Kansas City
+Louisville
+Memphis
+Milwaukee
+Minneapolis
+New Orleans
+Oklahoma City
+Omaha
+Philadelphia
+Pittsburgh
+Raleigh
+Richmond
+Sacramento
+Salt Lake City
+San Antonio
+San Jose
+Spokane
+Tacoma
+Tampa
+Toledo
+Tucson
+Tulsa
+Wichita
+Albuquerque
+Anchorage
+Baton Rouge
+Birmingham
+Buffalo
+Charlotte
+Cincinnati
+Cleveland
+Colorado Springs
+Columbus
+Dallas
+El Paso
+Fort Worth
+Fresno
+Greensboro
+Honolulu
+Jersey City
+Las Vegas
+Lexington
+Lincoln
+Long Beach
+Los Angeles
+Lubbock
+Madison
+Mesa
+Miami
+Norfolk
+North Las Vegas
+Oakland
+Orlando
+Plano
+Reno
+Santa Ana
+Scottsdale
+Shreveport
+Sioux Falls
+Stockton
+St. Louis
+St. Paul
+Syracuse
+Virginia Beach
+Winston-Salem
+Worcester
+Akron
+Anaheim
+Bakersfield
+Boise
+Chandler
+Chesapeake
+Chula Vista
+Durham
+Fremont
+Garland
+Gilbert
+Glendale
+Henderson
+Hialeah
+Irving
+Laredo
+Laredo
+Lincoln
+Madison
+Modesto
+Montgomery
+North Las Vegas
+Reno
+Rochester
+Riverside
+San Bernardino
+Santa Clarita
+Shreveport
+Springfield
+St. Petersburg
+Tempe
+Yonkers
+Aurora
+Baton Rouge
+Corpus Christi
+Fontana
+Moreno Valley
+Oxnard
+Port Arthur
+Rancho Cucamonga
+Santa Rosa
+Tacoma
+Tallahassee
+Warren
+Wilmington
+Yonkers
+Albany
+Alexandria
+Allentown
+Amarillo
+Anchorage
+Ann Arbor
+Antioch
+Arvada
+Augusta
+Bakersfield
+Beaumont
+Berkeley
+Bridgeport
+Brownsville
+Cape Coral
+Carlsbad
+Carrollton
+Cedar Rapids
+Clarksville
+Clovis
+Columbia
+Concord
+Corona
+Costa Mesa
+Dayton
+Denton
+Des Moines
+Downey
+El Monte
+Elizabeth
+Elk Grove
+Erie
+Escondido
+Eugene
+Evansville
+Fargo
+Flint
+Fort Collins
+Fort Lauderdale
+Gainesville
+Grand Prairie
+Grand Rapids
+Hampton
+Hartford
+Hayward
+Independence
+Irvine
+Jackson
+Joliet
+Killeen
+Knoxville
+Lafayette
+Lakewood
+Lancaster
+Lansing
+Little Rock
+Lowell
+Macon
+Manchester
+McAllen
+Mesquite
+Midland
+Mobile
+Murfreesboro
+Naperville
+Newport News
+Ontario
+Paterson
+Peoria
+Pomona
+Providence
+Provo
+Rancho
+Roseville
+Salem
+Salinas
+Savannah
+Sterling Heights
+Sunnyvale
+Surprise
+Syracuse
+Tempe
+Thousand Oaks
+Torrance
+Vancouver
+Victorville
+Visalia
+Waco
+Waterbury
+West Valley
+Pasadena
+Miramar
+Rockford
+Hayward

--- a/drivers/hmis_simulation/lib/hmis_simulation/fake_names/rivers.txt
+++ b/drivers/hmis_simulation/lib/hmis_simulation/fake_names/rivers.txt
@@ -1,0 +1,162 @@
+Columbia
+Colorado
+Mississippi
+Missouri
+Ohio
+Hudson
+Delaware
+Potomac
+Sacramento
+Snake
+Willamette
+Spokane
+Yakima
+Deschutes
+Rogue
+Klamath
+Trinity
+Feather
+American
+Merced
+Tuolumne
+Kern
+Salinas
+Truckee
+Carson
+Humboldt
+Walker
+Owens
+Santa Ana
+Santa Clara
+San Joaquin
+Stanislaus
+Calaveras
+Cosumnes
+Mokelumne
+Consumnes
+Napa
+Petaluma
+Eel
+Mad
+Trinity
+Klamath
+Smith
+Chetco
+Umpqua
+Siuslaw
+Alsea
+Yaquina
+Siletz
+Nestucca
+Wilson
+Tillamook
+Nehalem
+Lewis
+Cowlitz
+Nisqually
+Puyallup
+Cedar
+Green
+Snoqualmie
+Skykomish
+Sauk
+Skagit
+Nooksack
+Stillaguamish
+Snohomish
+Sammamish
+Duwamish
+Skokomish
+Hoh
+Queets
+Quinault
+Chehalis
+Willapa
+Naselle
+Nemah
+Bear
+Palouse
+Tucannon
+Touchet
+Walla Walla
+Umatilla
+John Day
+Grande Ronde
+Imnaha
+Salmon
+Clearwater
+Boise
+Payette
+Weiser
+Bruneau
+Owyhee
+Malheur
+Powder
+Burnt
+Pine
+Powder
+Lostine
+Wallowa
+Minam
+Catherine
+Whitman
+Tucannon
+Walla
+Nez Perce
+Selway
+Lochsa
+South Fork
+North Fork
+Middle Fork
+Coeur d'Alene
+Kootenai
+Clark Fork
+Bitterroot
+Blackfoot
+Swan
+Flathead
+Sun
+Teton
+Gallatin
+Madison
+Jefferson
+Ruby
+Beaverhead
+Bighole
+Wise
+Bitterroot
+Rock
+Milk
+Marias
+Judith
+Musselshell
+Yellowstone
+Tongue
+Powder
+Little Missouri
+Cannonball
+Heart
+Knife
+Little Knife
+Garrison
+Cherry
+Souris
+James
+Vermillion
+Big Sioux
+Floyd
+Little Sioux
+Boyer
+Platte
+Loup
+Elkhorn
+Niobrara
+White
+Bad
+Cheyenne
+Belle Fourche
+Grand
+Moreau
+Cannonball
+Cedar
+Green

--- a/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
+++ b/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
@@ -1,0 +1,53 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# Tasks are namespaced as driver:hmis_simulation:* by the driver loader.
+# Usage examples:
+#   bundle exec rake driver:hmis_simulation:validate[config/simulations/samples/small_coc.json]
+#   bundle exec rake driver:hmis_simulation:setup_from_file[config/simulations/samples/small_coc.json]
+#   bundle exec rake driver:hmis_simulation:bootstrap[hmis_simulation/demo-coc]
+#   bundle exec rake driver:hmis_simulation:run[hmis_simulation/demo-coc,2026-01-15]
+#   bundle exec rake driver:hmis_simulation:run_range[hmis_simulation/demo-coc,2026-01-01,2026-01-31]
+
+desc 'Validate a simulation config file or AppConfigProperty key'
+task :validate, [:path_or_key] => :environment do |_t, args|
+  path_or_key = args[:path_or_key]
+  raise ArgumentError, 'Usage: rake driver:hmis_simulation:validate[path/to/config.json or hmis_simulation/key]' if path_or_key.blank?
+
+  config = if path_or_key.end_with?('.json')
+    HmisSimulation::ConfigLoader.from_file(path_or_key)
+  else
+    HmisSimulation::ConfigLoader.from_app_config(path_or_key)
+  end
+
+  validator = HmisSimulation::ConfigValidator.new(config)
+  if validator.valid?
+    puts "✓ Config is valid: #{config['name'].inspect} (data_source_id: #{config['data_source_id']})"
+  else
+    warn "✗ Config has #{validator.errors.size} error(s):"
+    validator.errors.each { |e| warn "  - #{e}" }
+    exit 1
+  end
+end
+
+desc 'Load a simulation config JSON file into AppConfigProperty and validate it'
+task :setup_from_file, [:path] => :environment do |_t, args|
+  path = args[:path]
+  raise ArgumentError, 'Usage: rake driver:hmis_simulation:setup_from_file[path/to/config.json]' if path.blank?
+
+  raw = HmisSimulation::ConfigLoader.from_file(path)
+  validator = HmisSimulation::ConfigValidator.new(raw)
+  unless validator.valid?
+    warn "Config has errors — fix before loading:"
+    validator.errors.each { |e| warn "  - #{e}" }
+    exit 1
+  end
+
+  key = "hmis_simulation/#{raw['name'].parameterize}"
+  HmisSimulation::ConfigLoader.upsert_app_config(key, raw)
+  puts "Saved config as AppConfigProperty key: #{key.inspect}"
+  puts "Run bootstrap next: rake driver:hmis_simulation:bootstrap[#{key}]"
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/config_loader_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/config_loader_spec.rb
@@ -1,0 +1,143 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::ConfigLoader do
+  let(:valid_config) do
+    {
+      'name' => 'Test CoC',
+      'data_source_id' => 1,
+      'seed' => 12345,
+      'coc_codes' => { 'primary' => 'XX-500' },
+      'organizations' => [
+        {
+          'name' => 'Test Org_',
+          'projects' => [
+            { 'name' => 'Test ES NBN_', 'project_type' => 1, 'capacity' => 20 },
+            { 'name' => 'Test PSH_', 'project_type' => 3, 'capacity' => 10 },
+          ],
+        },
+      ],
+      'populations' => [
+        {
+          'name' => 'street',
+          'label' => 'Street',
+          'project_ref' => 'Test ES NBN_',
+          'household_templates' => { 'adult_only' => 1.0 },
+          'entry_point' => 1,
+          'exit_point' => 0.1,
+        },
+        {
+          'name' => 'psh',
+          'label' => 'PSH',
+          'project_ref' => 'Test PSH_',
+          'household_templates' => { 'adult_only' => 1.0 },
+          'entry_point' => 0,
+          'exit_point' => 0.5,
+        },
+      ],
+      'transitions' => [
+        {
+          'from' => 'street', 'to' => 'psh',
+          'weight' => 1,
+          'timing' => { 'distribution' => 'constant', 'value' => 30 },
+          'exit_destinations' => { '435' => 1.0 }
+        },
+      ],
+      'enrollment_config' => {
+        'new_clients_per_month' => { 'distribution' => 'constant', 'value' => 5 },
+      },
+    }
+  end
+
+  describe '.from_app_config' do
+    context 'when AppConfigProperty exists' do
+      before do
+        AppConfigProperty.where(key: 'hmis_simulation/test').delete_all
+        AppConfigProperty.create!(key: 'hmis_simulation/test', value: valid_config)
+      end
+
+      it 'loads and returns the config hash' do
+        config = described_class.from_app_config('hmis_simulation/test')
+        expect(config['name']).to eq('Test CoC')
+      end
+    end
+
+    context 'when AppConfigProperty does not exist' do
+      it 'raises KeyError' do
+        expect { described_class.from_app_config('hmis_simulation/missing') }.
+          to raise_error(KeyError, /not found/i)
+      end
+    end
+  end
+
+  describe '.from_file' do
+    it 'parses a JSON file and returns the config hash' do
+      Tempfile.create(['sim_config', '.json']) do |f|
+        f.write(valid_config.to_json)
+        f.flush
+        config = described_class.from_file(f.path)
+        expect(config['name']).to eq('Test CoC')
+      end
+    end
+
+    it 'raises if the file does not exist' do
+      expect { described_class.from_file('/no/such/file.json') }.to raise_error(Errno::ENOENT)
+    end
+  end
+
+  describe 'weight normalization' do
+    it 'normalizes entry_point values to sum to 1.0' do
+      Tempfile.create(['sim', '.json']) do |f|
+        f.write(valid_config.to_json)
+        f.flush
+        config = described_class.from_file(f.path)
+        entry_points = config['populations'].map { |p| p['entry_point'] }
+        expect(entry_points.sum).to be_within(0.001).of(1.0)
+      end
+    end
+
+    it 'normalizes transition weights within each from-population' do
+      Tempfile.create(['sim', '.json']) do |f|
+        f.write(valid_config.to_json)
+        f.flush
+        config = described_class.from_file(f.path)
+        weights = config['transitions'].select { |t| t['from'] == 'street' }.map { |t| t['weight'] }
+        expect(weights.sum).to be_within(0.001).of(1.0)
+      end
+    end
+
+    it 'normalizes exit_destination weights' do
+      Tempfile.create(['sim', '.json']) do |f|
+        f.write(valid_config.to_json)
+        f.flush
+        config = described_class.from_file(f.path)
+        dests = config['transitions'].first['exit_destinations']
+        expect(dests.values.sum).to be_within(0.001).of(1.0)
+      end
+    end
+  end
+
+  describe 'AppConfigProperty upsert' do
+    it 'creates the record if it does not exist' do
+      AppConfigProperty.where(key: 'hmis_simulation/upsert_test').delete_all
+      described_class.upsert_app_config('hmis_simulation/upsert_test', valid_config)
+      expect(AppConfigProperty.find_by(key: 'hmis_simulation/upsert_test')).not_to be_nil
+    end
+
+    it 'updates the record if it already exists' do
+      AppConfigProperty.where(key: 'hmis_simulation/upsert_test').delete_all
+      described_class.upsert_app_config('hmis_simulation/upsert_test', valid_config)
+      updated = valid_config.merge('name' => 'Updated')
+      described_class.upsert_app_config('hmis_simulation/upsert_test', updated)
+      record = AppConfigProperty.find_by(key: 'hmis_simulation/upsert_test')
+      expect(record.value['name']).to eq('Updated')
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/config_validator_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/config_validator_spec.rb
@@ -1,0 +1,147 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::ConfigValidator do
+  let(:valid_config) do
+    {
+      'name' => 'Test',
+      'data_source_id' => 1,
+      'seed' => 99,
+      'coc_codes' => { 'primary' => 'XX-500' },
+      'organizations' => [
+        {
+          'name' => 'Org_',
+          'projects' => [
+            { 'name' => 'ES NBN_', 'project_type' => 1 },
+            { 'name' => 'PSH_', 'project_type' => 3 },
+            { 'name' => 'SO_', 'project_type' => 4 },
+          ],
+        },
+      ],
+      'populations' => [
+        { 'name' => 'street', 'label' => 'Street', 'project_ref' => 'SO_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 1, 'exit_point' => 0.1 },
+        { 'name' => 'psh', 'label' => 'PSH', 'project_ref' => 'PSH_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 0, 'exit_point' => 0.5 },
+      ],
+      'transitions' => [
+        { 'from' => 'street', 'to' => 'psh', 'weight' => 1,
+          'timing' => { 'distribution' => 'constant', 'value' => 30 },
+          'exit_destinations' => { '435' => 1 } },
+      ],
+      'enrollment_config' => {
+        'new_clients_per_month' => { 'distribution' => 'constant', 'value' => 5 },
+      },
+    }
+  end
+
+  subject(:validator) { described_class.new(valid_config) }
+
+  describe '#valid?' do
+    it 'returns true for a valid config' do
+      expect(validator).to be_valid
+    end
+
+    it 'returns false and populates errors when config is invalid' do
+      bad = valid_config.merge('data_source_id' => nil)
+      v = described_class.new(bad)
+      expect(v).not_to be_valid
+      expect(v.errors).not_to be_empty
+    end
+  end
+
+  describe 'data_source_id' do
+    it 'is required and must be a positive integer' do
+      v = described_class.new(valid_config.merge('data_source_id' => nil))
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/data_source_id/i)
+    end
+  end
+
+  describe 'seed' do
+    it 'is required' do
+      v = described_class.new(valid_config.except('seed'))
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/seed/i)
+    end
+  end
+
+  describe 'project_ref resolution' do
+    it 'errors when a population project_ref does not match any project name' do
+      config = valid_config.deep_dup
+      config['populations'].first['project_ref'] = 'No Such Project_'
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/project_ref/i)
+    end
+  end
+
+  describe 'transition population references' do
+    it 'errors when a transition from population does not exist' do
+      config = valid_config.deep_dup
+      config['transitions'].first['from'] = 'nonexistent'
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/transition.*nonexistent|nonexistent.*transition/i)
+    end
+
+    it 'errors when a transition to population does not exist' do
+      config = valid_config.deep_dup
+      config['transitions'].first['to'] = 'nonexistent'
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+    end
+  end
+
+  describe 'entry_point weights' do
+    it 'errors when no population has entry_point > 0' do
+      config = valid_config.deep_dup
+      config['populations'].each { |p| p['entry_point'] = 0 }
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/entry_point/i)
+    end
+  end
+
+  describe 'lifecycle enrollment trigger_populations' do
+    it 'errors when a trigger_population does not name a defined population' do
+      config = valid_config.deep_dup
+      config['lifecycle_enrollments'] = [
+        {
+          'name' => 'ce', 'project_ref' => 'ES NBN_',
+          'trigger_populations' => ['ghost_population'],
+          'trigger_probability' => 0.4,
+          'close_conditions' => { 'housing_move_in' => 1.0 }
+        },
+      ]
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/ghost_population/i)
+    end
+  end
+
+  describe 'concurrent enrollment project_refs' do
+    it 'errors when a concurrent project name does not exist' do
+      config = valid_config.deep_dup
+      config['concurrent_enrollments'] = {
+        'count_distribution' => { '0' => 1 },
+        'projects' => [
+          { 'name' => 'Missing Project_', 'project_type' => 4, 'selection_weight' => 1,
+            'duration' => { 'distribution' => 'constant', 'value' => 30 } },
+        ],
+      }
+      v = described_class.new(config)
+      expect(v).not_to be_valid
+      expect(v.errors.join).to match(/Missing Project_/i)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/distribution_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/distribution_spec.rb
@@ -1,0 +1,126 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Distribution do
+  let(:seed) { 42 }
+
+  def rng(context)
+    Random.new(seed + context.hash)
+  end
+
+  describe '.sample' do
+    context 'constant distribution' do
+      let(:config) { { 'distribution' => 'constant', 'value' => 7 } }
+
+      it 'always returns the configured value' do
+        results = 10.times.map { described_class.sample(config, rng: rng('ctx')) }
+        expect(results.uniq).to eq([7])
+      end
+    end
+
+    context 'uniform distribution' do
+      let(:config) { { 'distribution' => 'uniform', 'min' => 5, 'max' => 10 } }
+
+      it 'returns values within [min, max]' do
+        results = 100.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.min).to be >= 5
+        expect(results.max).to be <= 10
+      end
+    end
+
+    context 'normal distribution' do
+      let(:config) { { 'distribution' => 'normal', 'mean' => 50, 'stddev' => 10, 'min' => 20, 'max' => 80 } }
+
+      it 'returns values within [min, max]' do
+        results = 200.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.min).to be >= 20
+        expect(results.max).to be <= 80
+      end
+
+      it 'clusters around the mean' do
+        results = 500.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.sum.to_f / results.size).to be_within(5).of(50)
+      end
+    end
+
+    context 'normal distribution without min/max' do
+      let(:config) { { 'distribution' => 'normal', 'mean' => 30, 'stddev' => 5 } }
+
+      it 'returns numeric values' do
+        result = described_class.sample(config, rng: rng('ctx'))
+        expect(result).to be_a(Numeric)
+      end
+    end
+
+    context 'poisson distribution' do
+      let(:config) { { 'distribution' => 'poisson', 'lambda' => 8 } }
+
+      it 'returns non-negative integers' do
+        results = 100.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results).to all(be_a(Integer))
+        expect(results).to all(be >= 0)
+      end
+
+      it 'has mean approximately equal to lambda' do
+        results = 500.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.sum.to_f / results.size).to be_within(1.5).of(8)
+      end
+    end
+
+    context 'weighted distribution' do
+      let(:config) { { 'distribution' => 'weighted', 'weights' => { 'a' => 3, 'b' => 1 } } }
+
+      it 'returns only defined keys' do
+        results = 100.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.uniq.sort).to eq(['a', 'b'])
+      end
+
+      it 'selects proportionally to weights' do
+        results = 1000.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        ratio = results.count('a').to_f / results.count('b')
+        expect(ratio).to be_within(0.5).of(3.0)
+      end
+    end
+
+    context 'weighted distribution with numeric keys' do
+      let(:config) { { 'distribution' => 'weighted', 'weights' => { '101' => 0.5, '116' => 0.3, '17' => 0.2 } } }
+
+      it 'returns integer versions of numeric string keys' do
+        results = 100.times.map { |i| described_class.sample(config, rng: rng("ctx#{i}")) }
+        expect(results.uniq.sort).to eq([17, 101, 116])
+      end
+    end
+
+    context 'unknown distribution type' do
+      let(:config) { { 'distribution' => 'magic' } }
+
+      it 'raises ArgumentError' do
+        expect { described_class.sample(config, rng: rng('ctx')) }.to raise_error(ArgumentError, /unknown distribution/i)
+      end
+    end
+  end
+
+  describe '.normalize_weights' do
+    it 'converts absolute values to probabilities summing to 1.0' do
+      normalized = described_class.normalize_weights({ 'a' => 3, 'b' => 1 })
+      expect(normalized['a']).to be_within(0.001).of(0.75)
+      expect(normalized['b']).to be_within(0.001).of(0.25)
+    end
+
+    it 'handles already-normalized values' do
+      normalized = described_class.normalize_weights({ 'x' => 0.6, 'y' => 0.4 })
+      expect(normalized['x']).to be_within(0.001).of(0.6)
+    end
+
+    it 'raises ArgumentError when all weights are zero' do
+      expect { described_class.normalize_weights({ 'a' => 0, 'b' => 0 }) }.to raise_error(ArgumentError, /weights/i)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/fake_identifier_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/fake_identifier_spec.rb
@@ -1,0 +1,77 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::FakeIdentifier do
+  describe '.uuid' do
+    it 'starts with FAKE' do
+      expect(described_class.uuid).to start_with('FAKE')
+    end
+
+    it 'is 32 characters total (matching HUD generate_uuid convention — no dashes)' do
+      expect(described_class.uuid.length).to eq(32)
+    end
+
+    it 'generates unique values' do
+      ids = 20.times.map { described_class.uuid }
+      expect(ids.uniq.length).to eq(20)
+    end
+
+    it 'has FAKE prefix followed by 28 lowercase hex characters' do
+      expect(described_class.uuid).to match(/\AFAKE[0-9a-f]{28}\z/)
+    end
+  end
+
+  describe '.ssn' do
+    it 'starts with 999' do
+      expect(described_class.ssn).to start_with('999')
+    end
+
+    it 'is 9 digits total' do
+      expect(described_class.ssn).to match(/\A999\d{6}\z/)
+    end
+
+    it 'generates varied values' do
+      ssns = 20.times.map { described_class.ssn }
+      expect(ssns.uniq.length).to be > 1
+    end
+  end
+
+  describe '.first_name' do
+    it 'ends with underscore' do
+      expect(described_class.first_name).to end_with('_')
+    end
+
+    it 'returns a non-empty string before the underscore' do
+      name = described_class.first_name
+      expect(name.chomp('_')).not_to be_empty
+    end
+
+    it 'draws from the city list' do
+      names = 50.times.map { described_class.first_name }
+      expect(names.uniq.length).to be > 1
+    end
+  end
+
+  describe '.last_name' do
+    it 'ends with underscore' do
+      expect(described_class.last_name).to end_with('_')
+    end
+
+    it 'returns a non-empty string before the underscore' do
+      name = described_class.last_name
+      expect(name.chomp('_')).not_to be_empty
+    end
+
+    it 'draws from the river/water body list' do
+      names = 50.times.map { described_class.last_name }
+      expect(names.uniq.length).to be > 1
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 1: Foundation

## Summary

Introduces the `hmis_simulation` driver — a new engine for generating obviously-fake HMIS data for demo and staging environments. This phase builds the foundational infrastructure that all later phases depend on: the driver skeleton, probabilistic distribution sampling, fake identifier generation, JSON configuration loading/validation, database state tables, and a sample config.

No HUD records are written yet; that begins in Phase 2 (bootstrapper) and Phase 4 (enrollment engine).

## Context

Demo and staging environments need realistic, recognisably-fake HMIS data that refreshes daily. The existing `GrdaWarehouse::FakeData` class only obfuscates PII on exports from real data — it doesn't generate synthetic data. This driver replaces that workflow for demo/staging use.

Related issue: open-path/Green-River#8210

## What's in this PR

### New driver: `drivers/hmis_simulation`

Follows the native (no-gem) driver pattern documented in `docs/developer/drivers.md`.

### Fake identifier conventions (`lib/hmis_simulation/fake_identifier.rb`)

All generated records are recognisably fake at a glance:

| Field | Convention | Example |
|---|---|---|
| PersonalID, EnrollmentID, etc. | 32-char HUD-style ID with `FAKE` prefix | `FAKE9a3f4b1c9e874fa000000001` |
| SSN | Always starts with `999` | `999421783` |
| FirstName | US city name + `_` | `Portland_` |
| LastName | River/water body name + `_` | `Columbia_` |

Name lists (`cities.txt`, `rivers.txt`) contain ~200 entries each.

### Distribution sampler (`app/models/hmis_simulation/distribution.rb`)

Stateless probabilistic sampler used throughout the engine. Accepts a caller-supplied `Random` instance so each draw is independent (avoids butterfly-effect drift where a single extra draw shifts all future results for unrelated clients).

Supported types: `constant`, `uniform`, `normal` (with optional min/max clipping), `poisson`, `weighted`. All weight-based distributions normalize internally — configs can use any positive numbers rather than requiring exact sums.

### JSON configuration (`app/models/hmis_simulation/config_loader.rb` + `config_validator.rb`)

Simulation configs are JSON blobs stored in `AppConfigProperty` (key convention: `hmis_simulation/<name>`). Sample files live in `config/simulations/samples/` for engineers to copy and adapt.

`ConfigLoader` reads from `AppConfigProperty` or a file path and normalizes all relative weights (`entry_point`, transition `weight`, `exit_destinations`, concurrent `selection_weight`) so callers always see values summing to 1.0.

`ConfigValidator` checks structural integrity before any records are written: required fields, all `project_ref` values resolve to defined projects, all transition/lifecycle population references resolve, at least one population has `entry_point > 0`. Returns a list of human-readable error messages.

### Database state tables (migration `20260604120000`)

Five new tables in the warehouse database (all prefixed `hmis_simulation_`):

- **`clients`** — tracks each simulated client's position in the primary enrollment state machine (current population, active enrollment, next transition date, pending enrollment date after a gap, system-exit flag)
- **`household_groups`** — tracks household composition across re-enrollments so members stay together (configurable cohesion probability)
- **`concurrent_enrollments`** — tracks timed overlapping enrollments (Street Outreach, Services Only) independent of the primary track
- **`lifecycle_enrollments`** — tracks Coordinated Entry enrollments that span multiple primary enrollments and close on a condition (housing move-in, disengagement timeout, or pre-entry exit)
- **`run_logs`** — one row per simulated calendar day; `last_successful_run_date` is derived from this table to enable automatic catch-up after missed days or failed runs

### Rake tasks (`lib/tasks/hmis_simulation.rake`)

Namespaced under `driver:hmis_simulation:`:

- `validate[path_or_key]` — validates a config file or AppConfigProperty key; exits 1 with error list on failure
- `setup_from_file[path]` — loads a JSON file into AppConfigProperty after validation

### Sample config (`config/simulations/samples/small_coc.json`)

Fully annotated sample for a small CoC (~500 active clients). Includes organizations, projects across all major project types (ES NBN, ES Entry/Exit, TH, PSH, RRH, SO, CE, SSO), household templates (adult only, adult and child, child only), populations with entry/exit weights, transitions with timing distributions and gap jitter, concurrent enrollments, CE lifecycle enrollment, and data quality rates.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
