### PR TITLE
HMIS Simulation Engine - Bootstrapper

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/bootstrapper.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/bootstrapper.rb
@@ -1,0 +1,176 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  # Creates or updates the HMIS records that provide the structural scaffolding
+  # a simulation needs: organizations, projects, ProjectCoc, Inventory, and
+  # Funder records. All operations are idempotent — running twice produces the
+  # same set of records.
+  #
+  # Usage:
+  #   config = HmisSimulation::ConfigLoader.from_app_config('hmis_simulation/demo-coc')
+  #   HmisSimulation::Bootstrapper.new(config).run!
+  class Bootstrapper
+    EXPORT_ID = 'HMIS_SIMULATION'
+    GEOCODE   = '000000'
+    OPERATING_START_DATE = Date.new(2020, 1, 1)
+
+    # Project types that do not require Inventory records (SO, SSO, Other,
+    # Day Shelter, HP, CE — matches HudUtility2026#project_types_without_inventory)
+    NON_RESIDENTIAL_PROJECT_TYPES = [4, 6, 7, 11, 12, 14].freeze
+
+    def initialize(config)
+      @config = config.deep_stringify_keys
+    end
+
+    def run!
+      validate!
+
+      data_source = GrdaWarehouse::DataSource.find(@config['data_source_id'])
+      user_id     = Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+      primary_coc = @config.dig('coc_codes', 'primary')
+
+      Hmis::Hud::Base.transaction do
+        @config['organizations'].each do |org_cfg|
+          org = find_or_create_organization(org_cfg, data_source: data_source, user_id: user_id)
+
+          org_cfg['projects'].each do |proj_cfg|
+            project = find_or_create_project(proj_cfg, org: org, data_source: data_source, user_id: user_id)
+            find_or_create_project_coc(project, coc_code: primary_coc, data_source: data_source, user_id: user_id)
+
+            find_or_create_inventory(project, proj_cfg, coc_code: primary_coc, data_source: data_source, user_id: user_id) unless NON_RESIDENTIAL_PROJECT_TYPES.include?(project.ProjectType)
+
+            (proj_cfg['funders'] || []).each do |funder_cfg|
+              find_or_create_funder(funder_cfg, project: project, data_source: data_source, user_id: user_id)
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    def validate!
+      validator = ConfigValidator.new(@config)
+      return if validator.valid?
+
+      raise ConfigError, "Simulation config is invalid:\n#{validator.errors.join("\n")}"
+    end
+
+    def hud_attrs(data_source:, user_id:)
+      {
+        data_source_id: data_source.id,
+        UserID: user_id,
+        ExportID: EXPORT_ID,
+        DateCreated: Time.current,
+        DateUpdated: Time.current,
+      }
+    end
+
+    def find_or_create_organization(org_cfg, data_source:, user_id:)
+      Hmis::Hud::Organization.find_or_initialize_by(
+        data_source_id: data_source.id,
+        OrganizationName: org_cfg['name'],
+      ).tap do |org|
+        next unless org.new_record?
+
+        org.assign_attributes(
+          **hud_attrs(data_source: data_source, user_id: user_id),
+          OrganizationID: FakeIdentifier.uuid,
+          VictimServiceProvider: false,
+        )
+        org.save!
+      end
+    end
+
+    def find_or_create_project(proj_cfg, org:, data_source:, user_id:)
+      Hmis::Hud::Project.find_or_initialize_by(
+        data_source_id: data_source.id,
+        ProjectName: proj_cfg['name'],
+      ).tap do |project|
+        next unless project.new_record?
+
+        project.assign_attributes(
+          **hud_attrs(data_source: data_source, user_id: user_id),
+          ProjectID: FakeIdentifier.uuid,
+          OrganizationID: org.OrganizationID,
+          organization: org,
+          ProjectType: proj_cfg['project_type'],
+          OperatingStartDate: OPERATING_START_DATE,
+          ContinuumProject: 0,
+          HMISParticipatingProject: 1,
+        )
+        project.save!
+      end
+    end
+
+    def find_or_create_project_coc(project, coc_code:, data_source:, user_id:)
+      Hmis::Hud::ProjectCoc.find_or_initialize_by(
+        data_source_id: data_source.id,
+        ProjectID: project.ProjectID,
+        CoCCode: coc_code,
+      ).tap do |coc|
+        next unless coc.new_record?
+
+        coc.assign_attributes(
+          **hud_attrs(data_source: data_source, user_id: user_id),
+          ProjectCoCID: FakeIdentifier.uuid,
+          ProjectID: project.ProjectID,
+          Geocode: GEOCODE,
+        )
+        coc.save!
+      end
+    end
+
+    def find_or_create_inventory(project, proj_cfg, coc_code:, data_source:, user_id:)
+      Hmis::Hud::Inventory.find_or_initialize_by(
+        data_source_id: data_source.id,
+        ProjectID: project.ProjectID,
+        CoCCode: coc_code,
+      ).tap do |inv|
+        next unless inv.new_record?
+
+        capacity = proj_cfg['capacity'].to_i.then { |c| c.positive? ? c : 10 }
+        inv.assign_attributes(
+          **hud_attrs(data_source: data_source, user_id: user_id),
+          InventoryID: FakeIdentifier.uuid,
+          ProjectID: project.ProjectID,
+          CoCCode: coc_code,
+          HouseholdType: 1,
+          BedInventory: capacity,
+          UnitInventory: capacity,
+          InventoryStartDate: OPERATING_START_DATE,
+        )
+        inv.save!
+      end
+    end
+
+    def find_or_create_funder(funder_cfg, project:, data_source:, user_id:)
+      funder_code = funder_cfg['funder'].to_i
+      grant_id    = funder_cfg['grant_id'].to_s
+
+      Hmis::Hud::Funder.find_or_initialize_by(
+        data_source_id: data_source.id,
+        ProjectID: project.ProjectID,
+        Funder: funder_code,
+      ).tap do |funder|
+        next unless funder.new_record?
+
+        funder.assign_attributes(
+          **hud_attrs(data_source: data_source, user_id: user_id),
+          FunderID: FakeIdentifier.uuid,
+          ProjectID: project.ProjectID,
+          Funder: funder_code,
+          GrantID: grant_id,
+          StartDate: OPERATING_START_DATE,
+        )
+        funder.save!
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/config_error.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/config_error.rb
@@ -1,0 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  class ConfigError < StandardError; end
+end

--- a/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
+++ b/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -33,6 +35,16 @@ task :validate, [:path_or_key] => :environment do |_t, args|
   end
 end
 
+desc 'Bootstrap HUD records (orgs, projects, ProjectCoc, Inventory, Funders) from an AppConfigProperty key'
+task :bootstrap, [:key] => :environment do |_t, args|
+  key = args[:key]
+  raise ArgumentError, 'Usage: rake driver:hmis_simulation:bootstrap[hmis_simulation/key]' if key.blank?
+
+  config = HmisSimulation::ConfigLoader.from_app_config(key)
+  HmisSimulation::Bootstrapper.new(config).run!
+  puts "Bootstrap complete for #{config['name'].inspect} (data_source_id: #{config['data_source_id']})"
+end
+
 desc 'Load a simulation config JSON file into AppConfigProperty and validate it'
 task :setup_from_file, [:path] => :environment do |_t, args|
   path = args[:path]
@@ -41,7 +53,7 @@ task :setup_from_file, [:path] => :environment do |_t, args|
   raw = HmisSimulation::ConfigLoader.from_file(path)
   validator = HmisSimulation::ConfigValidator.new(raw)
   unless validator.valid?
-    warn "Config has errors — fix before loading:"
+    warn 'Config has errors — fix before loading:'
     validator.errors.each { |e| warn "  - #{e}" }
     exit 1
   end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/bootstrapper_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/bootstrapper_spec.rb
@@ -1,0 +1,146 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Bootstrapper do
+  let!(:data_source) { create(:hmis_data_source) }
+
+  let(:base_config) do
+    {
+      'name' => 'Test CoC',
+      'data_source_id' => data_source.id,
+      'seed' => 42,
+      'coc_codes' => { 'primary' => 'XX-500' },
+      'organizations' => [
+        {
+          'name' => 'Test Org_',
+          'projects' => [
+            { 'name' => 'Test ES NBN_', 'project_type' => 1, 'capacity' => 20 },
+            {
+              'name' => 'Test PSH_', 'project_type' => 3, 'capacity' => 10,
+              'funders' => [{ 'funder' => 3, 'grant_id' => 'FAKE-GRANT-001_' }]
+            },
+            { 'name' => 'Test SO_', 'project_type' => 4 },
+            { 'name' => 'Test CE_', 'project_type' => 14 },
+          ],
+        },
+      ],
+      'populations' => [
+        { 'name' => 'street', 'label' => 'Street', 'project_ref' => 'Test SO_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 1, 'exit_point' => 0.1 },
+        { 'name' => 'es', 'label' => 'ES', 'project_ref' => 'Test ES NBN_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 0, 'exit_point' => 0.1 },
+        { 'name' => 'psh', 'label' => 'PSH', 'project_ref' => 'Test PSH_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 0, 'exit_point' => 0.5 },
+      ],
+      'transitions' => [
+        { 'from' => 'street', 'to' => 'es', 'weight' => 1,
+          'timing' => { 'distribution' => 'constant', 'value' => 7 },
+          'exit_destinations' => { '101' => 1 } },
+        { 'from' => 'es', 'to' => 'psh', 'weight' => 1,
+          'timing' => { 'distribution' => 'constant', 'value' => 30 },
+          'exit_destinations' => { '435' => 1 } },
+      ],
+      'lifecycle_enrollments' => [
+        { 'name' => 'ce', 'label' => 'CE', 'project_ref' => 'Test CE_',
+          'trigger_populations' => ['street'],
+          'trigger_probability' => 0.3,
+          'days_before_trigger' => { 'distribution' => 'constant', 'value' => 0 },
+          'close_conditions' => { 'housing_move_in' => 1.0 } },
+      ],
+      'enrollment_config' => {
+        'new_clients_per_month' => { 'distribution' => 'constant', 'value' => 5 },
+      },
+    }
+  end
+
+  # Use a normalized copy so weights sum correctly
+  let(:config) { HmisSimulation::ConfigLoader.send(:normalize, base_config) }
+
+  before { User.setup_system_user }
+
+  subject(:bootstrapper) { described_class.new(config) }
+
+  def ds_scope(klass)
+    klass.where(data_source_id: data_source.id)
+  end
+
+  describe '#run!' do
+    it 'creates the configured organizations' do
+      expect { bootstrapper.run! }.to change { ds_scope(Hmis::Hud::Organization).count }.by(1)
+    end
+
+    it 'creates all configured projects' do
+      expect { bootstrapper.run! }.to change { ds_scope(Hmis::Hud::Project).count }.by(4)
+    end
+
+    it 'creates a ProjectCoc for every project' do
+      bootstrapper.run!
+      project_count = ds_scope(Hmis::Hud::Project).count
+      coc_count = ds_scope(Hmis::Hud::ProjectCoc).count
+      expect(coc_count).to eq(project_count)
+    end
+
+    it 'creates Inventory only for residential project types' do
+      bootstrapper.run!
+      # ES (1) and PSH (3) get inventory; SO (4) and CE (14) do not
+      expect(ds_scope(Hmis::Hud::Inventory).count).to eq(2)
+    end
+
+    it 'creates Funder records when specified in project config' do
+      expect { bootstrapper.run! }.to change { ds_scope(Hmis::Hud::Funder).count }.by(1)
+    end
+
+    it 'assigns FAKE UUIDs to all HUD identifiers' do
+      bootstrapper.run!
+      org = ds_scope(Hmis::Hud::Organization).first
+      expect(org.OrganizationID).to start_with('FAKE')
+      project = ds_scope(Hmis::Hud::Project).first
+      expect(project.ProjectID).to start_with('FAKE')
+    end
+
+    it 'preserves configured project names exactly (including trailing underscore)' do
+      bootstrapper.run!
+      names = ds_scope(Hmis::Hud::Project).pluck(:ProjectName).sort
+      expect(names).to include('Test ES NBN_', 'Test PSH_', 'Test SO_', 'Test CE_')
+    end
+
+    it 'sets the primary CoCCode on all ProjectCoc records' do
+      bootstrapper.run!
+      cocs = ds_scope(Hmis::Hud::ProjectCoc).pluck(:CoCCode).uniq
+      expect(cocs).to include('XX-500')
+    end
+
+    context 'when run twice' do
+      it 'is idempotent — creates no duplicate records' do
+        bootstrapper.run!
+
+        expect { bootstrapper.run! }.
+          to not_change { ds_scope(Hmis::Hud::Organization).count }.
+          and not_change { ds_scope(Hmis::Hud::Project).count }.
+          and not_change { ds_scope(Hmis::Hud::ProjectCoc).count }.
+          and not_change { ds_scope(Hmis::Hud::Inventory).count }.
+          and(not_change { ds_scope(Hmis::Hud::Funder).count })
+      end
+    end
+
+    context 'with invalid config' do
+      it 'raises ConfigError without writing any records' do
+        bad_config = base_config.merge('data_source_id' => nil)
+        bootstrapper = described_class.new(bad_config)
+        expect { bootstrapper.run! }.
+          to raise_error(HmisSimulation::ConfigError).
+          and(not_change { ds_scope(Hmis::Hud::Organization).count })
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 2: Bootstrapper

## Summary

Adds the bootstrapper that reads a simulation JSON config and creates all the HMIS structural scaffolding records needed before the engine can generate client data. All operations are idempotent — running the bootstrapper twice produces the same set of records with no duplicates.

Builds on Phase 1 (driver skeleton, config loading/validation, state tables, fake identifiers).

## What's in this PR

### `HmisSimulation::Bootstrapper`

Reads the normalized config from Phase 1's `ConfigLoader`, validates it via `ConfigValidator`, then creates in order:

1. **`Hmis::Hud::Organization`** — one per entry in `config['organizations']`, keyed by name + data source for idempotency
2. **`Hmis::Hud::Project`** — one per project in each organization, keyed by name + data source
3. **`Hmis::Hud::ProjectCoc`** — one per project, using the primary CoC code from config
4. **`Hmis::Hud::Inventory`** — one per residential project (skipped for non-residential types: SO/4, SSO/6, Other/7, Day Shelter/11, HP/12, CE/14)
5. **`Hmis::Hud::Funder`** — created when `funders` array is present in the project config, keyed by project + funder code

All HUD identifiers (OrganizationID, ProjectID, etc.) use `FakeIdentifier.uuid` (FAKE-prefixed, 32-char, no dashes). Project and organization names are taken directly from config and preserve the trailing `_` canary character.

### `HmisSimulation::ConfigError`

Simple exception class raised by `Bootstrapper#run!` when config validation fails, before any records are written.

### New rake task: `driver:hmis_simulation:bootstrap[key]`

Loads config from `AppConfigProperty` by key and runs the bootstrapper. Combines with the Phase 1 `setup_from_file` task for the full engineer workflow:

```bash
# 1. Validate the sample config file
bundle exec rake driver:hmis_simulation:validate[config/simulations/samples/small_coc.json]

# 2. Load config into AppConfigProperty (edit data_source_id first)
bundle exec rake driver:hmis_simulation:setup_from_file[config/simulations/samples/small_coc.json]

# 3. Bootstrap HUD records
bundle exec rake driver:hmis_simulation:bootstrap[hmis_simulation/demo-coc-small]
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
