### PR TITLE
HMIS Simulation Engine - Client Generation

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/client_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/client_builder.rb
@@ -1,0 +1,229 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates a single Hmis::Hud::Client record plus a linked
+    # Hmis::Hud::CustomClientName (primary: true).
+    #
+    # All identifiers use FakeIdentifier conventions:
+    #   - PersonalID:  FAKE-prefixed 32-char UUID
+    #   - SSN:         999-prefixed 9-digit string
+    #   - FirstName:   US city name + "_"
+    #   - LastName:    River/water body name + "_"
+    #
+    # Data quality rates are applied probabilistically from data_quality_config.
+    # Randomness is deterministic — identical seed + context_prefix always
+    # produces the same client attributes.
+    #
+    # Usage:
+    #   result = HmisSimulation::Builders::ClientBuilder.new(
+    #     client_config: hoh_config,
+    #     data_quality_config: config['data_quality'],
+    #     data_source: data_source,
+    #     user_id: user_id,
+    #     date: date,
+    #     seed: seed,
+    #     context_prefix: "spawn:#{date}:#{i}:hoh",
+    #   ).build!
+    #   # => { client: Hmis::Hud::Client, custom_name: Hmis::Hud::CustomClientName }
+    class ClientBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      # Gender config key → HUD column name mapping
+      GENDER_MAP = {
+        'woman' => :Woman,
+        'man' => :Man,
+        'non_binary' => :NonBinary,
+        'transgender' => :Transgender,
+        'culturally_specific' => :CulturallySpecific,
+        'different_identity' => :DifferentIdentity,
+        'questioning' => :Questioning,
+      }.freeze
+
+      # Race config key → HUD column name mapping
+      RACE_MAP = {
+        'white' => :White,
+        'black_af_american' => :BlackAfAmerican,
+        'hispanic_latinaeo' => :HispanicLatinaeo,
+        'am_ind_ak_native' => :AmIndAKNative,
+        'asian' => :Asian,
+        'native_hi_pacific' => :NativeHIPacific,
+        'mid_east_n_african' => :MidEastNAfrican,
+      }.freeze
+
+      def initialize(client_config:, data_quality_config:, data_source:, user_id:, date:, seed:, context_prefix:)
+        @cfg    = (client_config || {}).deep_stringify_keys
+        @dq     = (data_quality_config || {}).deep_stringify_keys
+        @ds     = data_source
+        @uid    = user_id
+        @date   = date
+        @seed   = seed
+        @prefix = context_prefix
+      end
+
+      def build!
+        personal_id = FakeIdentifier.uuid
+        first_name, last_name, name_dq = build_name
+        ssn, ssn_dq                   = build_ssn
+        dob, dob_dq                   = build_dob
+
+        client = Hmis::Hud::Client.new(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          PersonalID: personal_id,
+          FirstName: first_name,
+          LastName: last_name,
+          NameDataQuality: name_dq,
+          SSN: ssn,
+          SSNDataQuality: ssn_dq,
+          DOB: dob,
+          DOBDataQuality: dob_dq,
+          VeteranStatus: build_veteran_status,
+        )
+        client.assign_attributes(build_gender_attributes)
+        client.assign_attributes(build_race_attributes)
+        client.save!
+
+        custom_name = Hmis::Hud::CustomClientName.new(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          CustomClientNameID: FakeIdentifier.uuid,
+          PersonalID: personal_id,
+          first: first_name,
+          last: last_name,
+          primary: true,
+          use: :usual,
+          NameDataQuality: name_dq,
+        )
+        custom_name.save!
+
+        { client: client, custom_name: custom_name }
+      end
+
+      private
+
+      def rng(sub_context)
+        Random.new(@seed + "#{@prefix}:#{sub_context}".hash)
+      end
+
+      # -- Name --
+
+      def build_name
+        if roll_rate('missing_name_rate', 'name_missing')
+          [nil, nil, 99]
+        else
+          [FakeIdentifier.first_name(rng: rng('first_name')), FakeIdentifier.last_name(rng: rng('last_name')), 1]
+        end
+      end
+
+      # -- SSN --
+
+      def build_ssn
+        if roll_rate('missing_ssn_rate', 'ssn_missing')
+          [nil, 99]
+        else
+          [FakeIdentifier.ssn, 1]
+        end
+      end
+
+      # -- DOB --
+
+      def build_dob
+        if roll_rate('missing_dob_rate', 'dob_missing')
+          [nil, 99]
+        elsif roll_rate('approximate_dob_rate', 'dob_approximate')
+          birth_year = @date.year - sample_age.to_i
+          [Date.new(birth_year, 1, 1), 2]
+        else
+          [dob_from_age, 1]
+        end
+      end
+
+      def dob_from_age
+        age = sample_age
+        @date - (age * 365.25).round
+      end
+
+      def sample_age
+        age_cfg = @cfg['age'] || { 'distribution' => 'uniform', 'min' => 18, 'max' => 65 }
+        Distribution.sample(age_cfg.deep_stringify_keys, rng: rng('age'))
+      end
+
+      # -- Veteran status --
+
+      def build_veteran_status
+        prob = @cfg['veteran_probability'].to_f
+        age = sample_age
+        return 0 if age < 18
+
+        rng('veteran').rand < prob ? 1 : 0
+      end
+
+      # -- Gender --
+
+      def build_gender_attributes
+        defaults = GENDER_MAP.values.each_with_object({}) { |col, h| h[col] = 0 }
+        gender_cfg = @cfg['gender']
+
+        if gender_cfg.present?
+          valid_weights = gender_cfg.slice(*GENDER_MAP.keys).transform_values(&:to_f)
+          if valid_weights.values.sum.positive?
+            cfg = { 'distribution' => 'weighted', 'weights' => valid_weights }
+            selected = Distribution.sample(cfg, rng: rng('gender'))
+            col = GENDER_MAP[selected]
+            defaults[col] = 1 if col
+            return defaults
+          end
+        end
+
+        # Fallback: pick a random known gender
+        col = GENDER_MAP.values.sample(random: rng('gender_fallback'))
+        defaults[col] = 1
+        defaults
+      end
+
+      # -- Race --
+
+      def build_race_attributes
+        defaults = RACE_MAP.values.each_with_object({}) { |col, h| h[col] = 0 }
+        race_cfg = @cfg['race']
+
+        if race_cfg.present?
+          valid_weights = race_cfg.slice(*RACE_MAP.keys).transform_values(&:to_f)
+          if valid_weights.values.sum.positive?
+            cfg = { 'distribution' => 'weighted', 'weights' => valid_weights }
+            selected = Distribution.sample(cfg, rng: rng('race'))
+            col = RACE_MAP[selected]
+            defaults[col] = 1 if col
+            return defaults
+          end
+        end
+
+        col = RACE_MAP.values.sample(random: rng('race_fallback'))
+        defaults[col] = 1
+        defaults
+      end
+
+      # -- Helpers --
+
+      def roll_rate(config_key, context)
+        rate = @dq[config_key].to_f
+        return false if rate.zero?
+        return true if rate >= 1.0
+
+        rng(context).rand < rate
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/household_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/household_builder.rb
@@ -1,0 +1,119 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates a household: one HoH Client plus any member Clients defined by the
+    # household template. Also creates an HmisSimulation::HouseholdGroup record
+    # that tracks composition for re-enrollment continuity.
+    #
+    # Returns a result hash consumed by the Engine and later by EnrollmentBuilder:
+    #   {
+    #     hoh_id:              bigint,   # Hmis::Hud::Client id for the HoH
+    #     hud_household_id:    string,   # FAKE UUID used as HouseholdID in Enrollment records
+    #     household_group_id:  bigint,   # HmisSimulation::HouseholdGroup id
+    #     member_relationships: [        # empty for single-adult households
+    #       { 'hud_client_id' => N, 'relationship_to_hoh' => N }
+    #     ],
+    #   }
+    class HouseholdBuilder
+      def initialize(
+        household_template:,
+        household_template_name:,
+        data_quality_config:,
+        data_source:,
+        user_id:,
+        date:,
+        seed:,
+        context_prefix:
+      )
+        @template      = (household_template || {}).deep_stringify_keys
+        @template_name = household_template_name
+        @dq            = (data_quality_config || {}).deep_stringify_keys
+        @ds            = data_source
+        @uid           = user_id
+        @date          = date
+        @seed          = seed
+        @prefix        = context_prefix
+      end
+
+      def build!
+        hud_household_id = FakeIdentifier.uuid
+        member_relationships = []
+
+        # Build HoH
+        hoh_result = build_client(@template['hoh'] || {}, "#{@prefix}:hoh")
+        hoh_id     = hoh_result[:client].id
+
+        # Build members
+        (@template['members'] || []).each_with_index do |member_cfg, group_idx|
+          count = member_count(member_cfg, group_idx)
+          count.times do |member_idx|
+            context = "#{@prefix}:member:#{group_idx}:#{member_idx}"
+            member_result = build_client(member_client_config(member_cfg), context)
+            member_relationships << {
+              'hud_client_id' => member_result[:client].id,
+              'relationship_to_hoh' => member_cfg['relationship'].to_i,
+            }
+          end
+        end
+
+        # Persist household group
+        group = HmisSimulation::HouseholdGroup.create!(
+          data_source_id: @ds.id,
+          hoh_client_id: hoh_id,
+          household_template_name: @template_name,
+          member_client_ids: member_relationships,
+        )
+
+        {
+          hoh_id: hoh_id,
+          hud_household_id: hud_household_id,
+          household_group_id: group.id,
+          member_relationships: member_relationships,
+        }
+      end
+
+      private
+
+      def build_client(client_config, context)
+        ClientBuilder.new(
+          client_config: client_config,
+          data_quality_config: @dq,
+          data_source: @ds,
+          user_id: @uid,
+          date: @date,
+          seed: @seed,
+          context_prefix: context,
+        ).build!
+      end
+
+      def member_count(member_cfg, group_idx)
+        count_cfg = member_cfg['count']
+        return 1 unless count_cfg.present?
+
+        rng  = Random.new(@seed + "#{@prefix}:member_count:#{group_idx}".hash)
+        raw  = Distribution.sample(count_cfg.deep_stringify_keys, rng: rng)
+        min  = count_cfg['min'].to_i
+        raw  = [raw.round, min].max if min.positive?
+        max  = count_cfg['max']
+        raw  = [raw, max.to_i].min if max.present?
+        raw.to_i.clamp(1, 10)
+      end
+
+      def member_client_config(member_cfg)
+        {
+          'age' => member_cfg['age'],
+          'gender' => nil,
+          'veteran_probability' => 0.0,
+          'race' => nil,
+        }
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -1,0 +1,150 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  # Drives the simulation forward one calendar day at a time.
+  #
+  # Each call to #run(date:) processes exactly one simulated day:
+  #   1. Spawn new clients (drawn from new_clients_per_month, scaled to daily)
+  #   2. (Phase 4) Process primary enrollment exits and entries
+  #   3. (Phase 5) Annual record collection (IncomeBenefits etc.)
+  #   4. (Phase 6) Concurrent enrollment tick
+  #   5. (Phase 7) Lifecycle enrollment tick
+  #   6. Write RunLog
+  #
+  # Idempotent: re-running the same date is a no-op (detected via RunLog).
+  #
+  # Usage:
+  #   config = HmisSimulation::ConfigLoader.from_app_config('hmis_simulation/demo-coc')
+  #   engine = HmisSimulation::Engine.new(config)
+  #   engine.run(date: Date.current)
+  class Engine
+    def initialize(config)
+      @config = config.deep_stringify_keys
+      @data_source_id = @config['data_source_id'].to_i
+      @seed = @config['seed'].to_i
+    end
+
+    def run(date:)
+      return if already_run?(date)
+
+      log = RunLog.create!(
+        data_source_id: @data_source_id,
+        run_date: date,
+        started_at: Time.current,
+        clients_created: 0,
+      )
+
+      begin
+        Hmis::Hud::Base.transaction do
+          @clients_created = 0
+
+          spawn_clients(date: date)
+
+          log.update!(
+            clients_created: @clients_created,
+            finished_at: Time.current,
+          )
+        end
+      rescue StandardError => e
+        log.update!(error_message: e.message, finished_at: Time.current)
+        raise
+      end
+    end
+
+    private
+
+    def already_run?(date)
+      RunLog.exists?(data_source_id: @data_source_id, run_date: date, error_message: nil)
+    end
+
+    # -- Spawn --
+
+    def spawn_clients(date:)
+      count = daily_new_client_count(date: date)
+      data_source = GrdaWarehouse::DataSource.find(@data_source_id)
+      user_id     = Hmis::Hud::User.system_user(data_source_id: @data_source_id).user_id
+
+      count.times do |i|
+        population = draw_entry_population(date: date, index: i)
+        next unless population
+
+        template_name = draw_household_template(population: population, date: date, index: i)
+        template_cfg  = @config.dig('household_templates', template_name) || {}
+
+        result = Builders::HouseholdBuilder.new(
+          household_template: template_cfg,
+          household_template_name: template_name,
+          data_quality_config: @config['data_quality'] || {},
+          data_source: data_source,
+          user_id: user_id,
+          date: date,
+          seed: @seed,
+          context_prefix: "spawn:#{date}:#{i}",
+        ).build!
+
+        Client.create!(
+          data_source_id: @data_source_id,
+          hud_client_id: result[:hoh_id],
+          household_group_id: result[:household_group_id],
+          current_population: population['name'],
+          entered_current_population_at: date,
+          pending_enrollment_on: date,
+          exited_system: false,
+        )
+
+        @clients_created += 1
+      end
+    end
+
+    def daily_new_client_count(date:)
+      monthly_cfg = @config.dig('enrollment_config', 'new_clients_per_month') ||
+                    { 'distribution' => 'poisson', 'lambda' => 1 }
+      daily_cfg = scale_to_daily(monthly_cfg.deep_stringify_keys)
+      count = Distribution.sample(daily_cfg, rng: rng("spawn_count:#{date}")).to_f
+      [count.ceil, 0].max
+    end
+
+    def scale_to_daily(monthly_cfg)
+      case monthly_cfg['distribution']
+      when 'poisson'
+        monthly_cfg.merge('lambda' => monthly_cfg['lambda'].to_f / 30.0)
+      when 'constant'
+        { 'distribution' => 'poisson', 'lambda' => monthly_cfg['value'].to_f / 30.0 }
+      when 'uniform'
+        monthly_cfg.merge(
+          'min' => monthly_cfg['min'].to_f / 30.0,
+          'max' => monthly_cfg['max'].to_f / 30.0,
+        )
+      else
+        monthly_cfg
+      end
+    end
+
+    def draw_entry_population(date:, index:)
+      populations = @config['populations'] || []
+      candidates  = populations.select { |p| p['entry_point'].to_f.positive? }
+      return nil if candidates.empty?
+
+      weights = candidates.each_with_object({}) { |p, h| h[p['name']] = p['entry_point'].to_f }
+      cfg     = { 'distribution' => 'weighted', 'weights' => weights }
+      name    = Distribution.sample(cfg, rng: rng("population:#{date}:#{index}"))
+      populations.find { |p| p['name'] == name }
+    end
+
+    def draw_household_template(population:, date:, index:)
+      templates = population['household_templates'] || { 'adult_only' => 1.0 }
+      cfg = { 'distribution' => 'weighted', 'weights' => templates }
+      Distribution.sample(cfg, rng: rng("template:#{date}:#{index}"))
+    end
+
+    def rng(context)
+      Random.new(@seed + context.hash)
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/household_group.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/household_group.rb
@@ -9,8 +9,6 @@
 class HmisSimulation::HouseholdGroup < GrdaWarehouseBase
   self.table_name = 'hmis_simulation_household_groups'
 
-  serialize :member_client_ids, coder: JSON
-
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   has_many :simulated_clients, class_name: 'HmisSimulation::Client', foreign_key: :household_group_id
 end

--- a/drivers/hmis_simulation/lib/hmis_simulation/fake_identifier.rb
+++ b/drivers/hmis_simulation/lib/hmis_simulation/fake_identifier.rb
@@ -30,12 +30,12 @@ module HmisSimulation
       "999#{format('%06d', rand(1_000_000))}"
     end
 
-    def self.first_name
-      "#{cities.sample}_"
+    def self.first_name(rng: nil)
+      "#{rng ? cities.sample(random: rng) : cities.sample}_"
     end
 
-    def self.last_name
-      "#{rivers.sample}_"
+    def self.last_name(rng: nil)
+      "#{rng ? rivers.sample(random: rng) : rivers.sample}_"
     end
 
     def self.cities

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/client_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/client_builder_spec.rb
@@ -1,0 +1,177 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::ClientBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) { User.setup_system_user.tap { Hmis::Hud::User.system_user(data_source_id: data_source.id) } && Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id }
+  let(:date) { Date.new(2026, 1, 15) }
+  let(:seed) { 42 }
+
+  let(:hoh_config) do
+    {
+      'age' => { 'distribution' => 'normal', 'mean' => 40, 'stddev' => 10, 'min' => 18 },
+      'gender' => { 'woman' => 0.5, 'man' => 0.5 },
+      'veteran_probability' => 0.1,
+      'race' => { 'white' => 0.5, 'black_af_american' => 0.5 },
+    }
+  end
+
+  let(:data_quality_config) { {} }
+
+  subject(:builder) do
+    described_class.new(
+      client_config: hoh_config,
+      data_quality_config: data_quality_config,
+      data_source: data_source,
+      user_id: user_id,
+      date: date,
+      seed: seed,
+      context_prefix: 'test:client:0',
+    )
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::Client record' do
+      expect { builder.build! }.to change { Hmis::Hud::Client.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'creates an Hmis::Hud::CustomClientName record linked to the client' do
+      result = builder.build!
+      expect(result[:custom_name].PersonalID).to eq(result[:client].PersonalID)
+      expect(result[:custom_name].primary).to be true
+    end
+
+    it 'assigns a FAKE PersonalID' do
+      result = builder.build!
+      expect(result[:client].PersonalID).to start_with('FAKE')
+      expect(result[:client].PersonalID.length).to eq(32)
+    end
+
+    it 'assigns a 999-prefixed SSN' do
+      result = builder.build!
+      expect(result[:client].SSN).to start_with('999')
+    end
+
+    it 'assigns city name with trailing underscore as FirstName' do
+      result = builder.build!
+      expect(result[:client].FirstName).to end_with('_')
+      expect(result[:client].FirstName.length).to be > 1
+    end
+
+    it 'assigns river name with trailing underscore as LastName' do
+      result = builder.build!
+      expect(result[:client].LastName).to end_with('_')
+      expect(result[:client].LastName.length).to be > 1
+    end
+
+    it 'sets a DOB consistent with the configured age distribution (min 18)' do
+      result = builder.build!
+      age_on_date = ((date - result[:client].DOB) / 365.25).to_i
+      expect(age_on_date).to be >= 18
+    end
+
+    it 'sets NameDataQuality to 1 (full data) by default' do
+      result = builder.build!
+      expect(result[:client].NameDataQuality).to eq(1)
+    end
+
+    it 'sets DOBDataQuality to 1 (full data) by default' do
+      result = builder.build!
+      expect(result[:client].DOBDataQuality).to eq(1)
+    end
+
+    it 'sets SSNDataQuality to 1 (full data) by default' do
+      result = builder.build!
+      expect(result[:client].SSNDataQuality).to eq(1)
+    end
+
+    context 'with missing_dob_rate: 1.0' do
+      let(:data_quality_config) { { 'missing_dob_rate' => 1.0 } }
+
+      it 'sets DOB to nil and DOBDataQuality to 99' do
+        result = builder.build!
+        expect(result[:client].DOB).to be_nil
+        expect(result[:client].DOBDataQuality).to eq(99)
+      end
+    end
+
+    context 'with approximate_dob_rate: 1.0' do
+      let(:data_quality_config) { { 'approximate_dob_rate' => 1.0 } }
+
+      it 'sets DOB to Jan 1 of birth year and DOBDataQuality to 2' do
+        result = builder.build!
+        expect(result[:client].DOB.month).to eq(1)
+        expect(result[:client].DOB.day).to eq(1)
+        expect(result[:client].DOBDataQuality).to eq(2)
+      end
+    end
+
+    context 'with missing_ssn_rate: 1.0' do
+      let(:data_quality_config) { { 'missing_ssn_rate' => 1.0 } }
+
+      it 'sets SSN to nil and SSNDataQuality to 99' do
+        result = builder.build!
+        expect(result[:client].SSN).to be_nil
+        expect(result[:client].SSNDataQuality).to eq(99)
+      end
+    end
+
+    context 'with missing_name_rate: 1.0' do
+      let(:data_quality_config) { { 'missing_name_rate' => 1.0 } }
+
+      it 'sets FirstName and LastName to nil and NameDataQuality to 99' do
+        result = builder.build!
+        expect(result[:client].FirstName).to be_nil
+        expect(result[:client].LastName).to be_nil
+        expect(result[:client].NameDataQuality).to eq(99)
+      end
+    end
+
+    it 'assigns at least one gender field' do
+      result = builder.build!
+      gender_fields = HudHelper.util.gender_fields.map(&:to_s) - ['GenderNone']
+      any_set = gender_fields.any? { |f| result[:client].send(f) == 1 }
+      expect(any_set).to be true
+    end
+
+    it 'assigns at least one race field' do
+      result = builder.build!
+      race_fields = HudHelper.util.race_fields.map(&:to_s) - ['RaceNone']
+      any_set = race_fields.any? { |f| result[:client].send(f) == 1 }
+      expect(any_set).to be true
+    end
+
+    it 'returns a hash with :client and :custom_name keys' do
+      result = builder.build!
+      expect(result).to include(:client, :custom_name)
+      expect(result[:client]).to be_a(Hmis::Hud::Client)
+      expect(result[:custom_name]).to be_a(Hmis::Hud::CustomClientName)
+    end
+
+    it 'is deterministic — same seed + context produces same name' do
+      r1 = described_class.new(
+        client_config: hoh_config, data_quality_config: {}, data_source: data_source,
+        user_id: user_id, date: date, seed: 99, context_prefix: 'ctx:1'
+      ).build!
+
+      # Different data source to avoid uniqueness constraint on PersonalID
+      ds2 = create(:hmis_data_source)
+      User.setup_system_user
+      uid2 = Hmis::Hud::User.system_user(data_source_id: ds2.id).user_id
+      r2 = described_class.new(
+        client_config: hoh_config, data_quality_config: {}, data_source: ds2,
+        user_id: uid2, date: date, seed: 99, context_prefix: 'ctx:1'
+      ).build!
+
+      expect(r1[:client].FirstName).to eq(r2[:client].FirstName)
+      expect(r1[:client].LastName).to eq(r2[:client].LastName)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/household_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/household_builder_spec.rb
@@ -1,0 +1,140 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::HouseholdBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)  { Date.new(2026, 1, 15) }
+  let(:seed)  { 99 }
+
+  let(:adult_only_template) do
+    {
+      'hoh' => {
+        'age' => { 'distribution' => 'uniform', 'min' => 25, 'max' => 55 },
+        'gender' => { 'woman' => 0.5, 'man' => 0.5 },
+        'veteran_probability' => 0.0,
+        'race' => { 'white' => 1.0 },
+      },
+    }
+  end
+
+  let(:adult_and_child_template) do
+    {
+      'hoh' => {
+        'age' => { 'distribution' => 'uniform', 'min' => 25, 'max' => 40 },
+        'gender' => { 'woman' => 1.0 },
+        'veteran_probability' => 0.0,
+        'race' => { 'white' => 1.0 },
+      },
+      'members' => [
+        {
+          'role' => 'child',
+          'count' => { 'distribution' => 'constant', 'value' => 2 },
+          'age' => { 'distribution' => 'uniform', 'min' => 2, 'max' => 10 },
+          'relationship' => 2,
+        },
+      ],
+    }
+  end
+
+  def build(template, template_name: 'test_template')
+    described_class.new(
+      household_template: template,
+      household_template_name: template_name,
+      data_quality_config: {},
+      data_source: data_source,
+      user_id: user_id,
+      date: date,
+      seed: seed,
+      context_prefix: 'test:hh:0',
+    ).build!
+  end
+
+  describe '#build!' do
+    context 'with adult_only template (no members)' do
+      it 'creates exactly one Client (the HoH)' do
+        expect { build(adult_only_template) }.
+          to change { Hmis::Hud::Client.where(data_source: data_source).count }.by(1)
+      end
+
+      it 'creates an hmis_simulation_household_groups record with no members' do
+        result = build(adult_only_template)
+        group = HmisSimulation::HouseholdGroup.find(result[:household_group_id])
+        expect(group.member_client_ids).to be_empty
+      end
+
+      it 'returns a hud_household_id that is a FAKE UUID' do
+        result = build(adult_only_template)
+        expect(result[:hud_household_id]).to start_with('FAKE')
+        expect(result[:hud_household_id].length).to eq(32)
+      end
+
+      it 'returns an empty member_relationships array' do
+        result = build(adult_only_template)
+        expect(result[:member_relationships]).to be_empty
+      end
+    end
+
+    context 'with adult_and_child template (count: constant 2 children)' do
+      it 'creates 3 Client records (HoH + 2 children)' do
+        expect { build(adult_and_child_template) }.
+          to change { Hmis::Hud::Client.where(data_source: data_source).count }.by(3)
+      end
+
+      it 'creates an hmis_simulation_household_groups record with 2 member entries' do
+        result = build(adult_and_child_template)
+        group = HmisSimulation::HouseholdGroup.find(result[:household_group_id])
+        expect(group.member_client_ids.length).to eq(2)
+      end
+
+      it 'stores relationship_to_hoh for each member' do
+        result = build(adult_and_child_template)
+        group = HmisSimulation::HouseholdGroup.find(result[:household_group_id])
+        relationships = group.member_client_ids.map { |m| m['relationship_to_hoh'] }
+        expect(relationships).to all(eq(2))
+      end
+
+      it 'returns member_relationships with hud_client_id and relationship_to_hoh' do
+        result = build(adult_and_child_template)
+        expect(result[:member_relationships].length).to eq(2)
+        result[:member_relationships].each do |m|
+          expect(m).to include('hud_client_id', 'relationship_to_hoh')
+          expect(m['relationship_to_hoh']).to eq(2)
+        end
+      end
+
+      it 'gives children ages within the configured range' do
+        result = build(adult_and_child_template)
+        member_ids = result[:member_relationships].map { |m| m['hud_client_id'] }
+        members = Hmis::Hud::Client.where(id: member_ids)
+        members.each do |m|
+          age = ((date - m.DOB) / 365.25).to_i
+          expect(age).to be_between(2, 10)
+        end
+      end
+    end
+
+    it 'links household_group to the correct data_source' do
+      result = build(adult_only_template)
+      group = HmisSimulation::HouseholdGroup.find(result[:household_group_id])
+      expect(group.data_source_id).to eq(data_source.id)
+      expect(group.hoh_client_id).to eq(result[:hoh_id])
+    end
+
+    it 'returns the hoh_id matching the created HoH Client record id' do
+      result = build(adult_only_template)
+      client = Hmis::Hud::Client.find(result[:hoh_id])
+      expect(client.PersonalID).to start_with('FAKE')
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -1,0 +1,141 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Engine do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:run_date)     { Date.new(2026, 1, 15) }
+
+  # High lambda so we reliably get clients on every test day.
+  # 300/month = ~10/day via Poisson — virtually never 0 in practice.
+  let(:base_config) do
+    {
+      'name' => 'Engine Test CoC',
+      'data_source_id' => data_source.id,
+      'seed' => 42,
+      'coc_codes' => { 'primary' => 'XX-500' },
+      'organizations' => [
+        {
+          'name' => 'Test Org_',
+          'projects' => [
+            { 'name' => 'Test ES_', 'project_type' => 1, 'capacity' => 50 },
+            { 'name' => 'Test PSH_', 'project_type' => 3, 'capacity' => 30 },
+          ],
+        },
+      ],
+      'household_templates' => {
+        'adult_only' => {
+          'hoh' => {
+            'age' => { 'distribution' => 'uniform', 'min' => 25, 'max' => 55 },
+            'gender' => { 'woman' => 0.5, 'man' => 0.5 },
+            'veteran_probability' => 0.0,
+            'race' => { 'white' => 1.0 },
+          },
+        },
+      },
+      'populations' => [
+        { 'name' => 'street', 'label' => 'Street', 'project_ref' => 'Test ES_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 6, 'exit_point' => 0.1 },
+        { 'name' => 'psh', 'label' => 'PSH', 'project_ref' => 'Test PSH_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 0, 'exit_point' => 0.5 },
+      ],
+      'transitions' => [
+        { 'from' => 'street', 'to' => 'psh', 'weight' => 1,
+          'timing' => { 'distribution' => 'constant', 'value' => 30 },
+          'exit_destinations' => { '435' => 1 } },
+      ],
+      'enrollment_config' => {
+        'new_clients_per_month' => { 'distribution' => 'poisson', 'lambda' => 300 },
+      },
+    }
+  end
+
+  let(:config) { HmisSimulation::ConfigLoader.send(:normalize, base_config) }
+
+  before do
+    User.setup_system_user
+    HmisSimulation::Bootstrapper.new(config).run!
+  end
+
+  subject(:engine) { described_class.new(config) }
+
+  def sim_clients
+    HmisSimulation::Client.where(data_source_id: data_source.id)
+  end
+
+  describe '#run' do
+    it 'creates HmisSimulation::Client state records' do
+      expect { engine.run(date: run_date) }.to change { sim_clients.count }.by_at_least(1)
+    end
+
+    it 'sets pending_enrollment_on to the run date for all spawned clients' do
+      engine.run(date: run_date)
+      expect(sim_clients.where.not(pending_enrollment_on: run_date).count).to eq(0)
+    end
+
+    it 'assigns each spawned client a current_population matching a defined population' do
+      engine.run(date: run_date)
+      population_names = config['populations'].map { |p| p['name'] }
+      sim_clients.pluck(:current_population).each do |pop|
+        expect(population_names).to include(pop)
+      end
+    end
+
+    it 'only assigns entry_point populations (street has entry_point > 0, psh does not)' do
+      engine.run(date: run_date)
+      populations = sim_clients.pluck(:current_population).uniq
+      expect(populations).to include('street')
+      expect(populations).not_to include('psh')
+    end
+
+    it 'sets exited_system: false for all spawned clients' do
+      engine.run(date: run_date)
+      expect(sim_clients.where(exited_system: true).count).to eq(0)
+    end
+
+    it 'writes a RunLog record for the run date' do
+      engine.run(date: run_date)
+      log = HmisSimulation::RunLog.find_by(data_source_id: data_source.id, run_date: run_date)
+      expect(log).to be_present
+      expect(log.error_message).to be_nil
+      expect(log.clients_created).to be > 0
+    end
+
+    context 'when run twice on the same date' do
+      it 'is idempotent — no duplicate clients or log entries' do
+        engine.run(date: run_date)
+        first_count = sim_clients.count
+
+        engine.run(date: run_date)
+        expect(sim_clients.count).to eq(first_count)
+        expect(HmisSimulation::RunLog.where(data_source_id: data_source.id, run_date: run_date).count).to eq(1)
+      end
+    end
+
+    context 'when run across multiple dates' do
+      it 'accumulates clients across days' do
+        engine.run(date: run_date)
+        count_day1 = sim_clients.count
+
+        engine.run(date: run_date + 1)
+        expect(sim_clients.count).to be > count_day1
+      end
+
+      it 'creates separate RunLog records per date' do
+        engine.run(date: run_date)
+        engine.run(date: run_date + 1)
+
+        logs = HmisSimulation::RunLog.where(data_source_id: data_source.id)
+        expect(logs.pluck(:run_date)).to include(run_date, run_date + 1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 3: Client Generation + Engine Spawn

## Summary

Adds the client/household builders and the simulation engine's first operational tick: spawning new clients. After this phase, you can run `engine.run(date:)` and watch `HmisSimulation::Client` state records accumulate with real `Hmis::Hud::Client` and `Hmis::Hud::CustomClientName` records written to the database.

Builds on Phase 1 (driver, config, fake identifiers) and Phase 2 (bootstrapper).

## What's in this PR

### `HmisSimulation::Builders::ClientBuilder`

Creates one `Hmis::Hud::Client` + one linked `Hmis::Hud::CustomClientName` (primary: true) per call.

**Fake identifiers applied:**
- `PersonalID`: FAKE-prefixed 32-char UUID
- `SSN`: 999-prefixed 9-digit string
- `FirstName`: US city name + `_` (deterministic — same seed + context always picks the same city)
- `LastName`: river/water body name + `_` (same determinism)

**Demographics drawn from household template config:**
- Age: sampled from configured distribution → back-calculated to DOB
- Gender: one field set from weighted distribution mapping (`woman`/`man`/`non_binary` etc. → HUD column names)
- Race: one field set from weighted distribution mapping
- Veteran status: sampled from `veteran_probability`; always 0 for age < 18

**Data quality rates applied** (from `data_quality` config):
- `missing_dob_rate` → DOB nil, `DOBDataQuality: 99`
- `approximate_dob_rate` → DOB set to Jan 1 of birth year, `DOBDataQuality: 2`
- `missing_ssn_rate` → SSN nil, `SSNDataQuality: 99`
- `missing_name_rate` → FirstName/LastName nil, `NameDataQuality: 99`

All randomness uses hash-based seeded RNG (`Random.new(seed + context.hash)`) so the same seed + context prefix always produces the same client.

### `HmisSimulation::Builders::HouseholdBuilder`

Creates a complete household: HoH client + any configured member clients. Also creates an `HmisSimulation::HouseholdGroup` record that tracks composition for use by the enrollment builder in Phase 4.

**Return value** (consumed by Engine and later EnrollmentBuilder):
```ruby
{
  hoh_id:               bigint,   # Hmis::Hud::Client id of the head of household
  hud_household_id:     string,   # FAKE UUID — used as HouseholdID in Enrollment records
  household_group_id:   bigint,   # HmisSimulation::HouseholdGroup id
  member_relationships: [         # empty for single-adult households
    { 'hud_client_id' => N, 'relationship_to_hoh' => N }
  ],
}
```

Members are created via ClientBuilder using their own age distribution. Member count is sampled from the configured distribution (e.g. `poisson lambda: 2` for children). Relationship codes (child = 2, partner = 3, etc.) come from the template config and are stored in `household_group.member_client_ids` as JSON for Phase 4 re-enrollment.

Also fixed: removed erroneous `serialize` call from `HouseholdGroup` model — the `member_client_ids` jsonb column handles serialization natively.

### `HmisSimulation::Engine` (spawn phase)

The engine's `run(date:)` method now processes one calendar day:
1. Draws a daily new-client count from `new_clients_per_month`, scaled to daily via Poisson(lambda/30)
2. For each new client: draws entry population (weighted by `entry_point`), draws household template (weighted by `household_templates`), calls `HouseholdBuilder`
3. Creates an `HmisSimulation::Client` state record for the HoH with `pending_enrollment_on: date`
4. Writes a `RunLog` record (idempotency key: `data_source_id + run_date`)

The engine is idempotent: re-running the same date is a no-op. Running successive dates accumulates clients incrementally.

Phases 4–7 (enrollment engine, linked records, concurrent/lifecycle enrollments, nightly job) will be added in subsequent PRs.

Also fixed: `FakeIdentifier.first_name` and `.last_name` now accept an optional `rng:` parameter so name picks are deterministic when a seeded RNG is provided.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
