### PR TITLE
HMIS Simulation Engine - Primary Enrollment Engine

### DIFF
--- a/db/warehouse/migrate/20260604130000_add_next_population_to_hmis_simulation_clients.rb
+++ b/db/warehouse/migrate/20260604130000_add_next_population_to_hmis_simulation_clients.rb
@@ -1,0 +1,16 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddNextPopulationToHmisSimulationClients < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :hmis_simulation_clients, :next_population, :string
+    add_index :hmis_simulation_clients, [:data_source_id, :next_population], algorithm: :concurrently
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/enrollment_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/enrollment_builder.rb
@@ -1,0 +1,91 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates Enrollment records for a household entering a project.
+    # Always creates one enrollment for the HoH. For each household member,
+    # rolls household_cohesion_probability to decide inclusion.
+    #
+    # Returns:
+    #   {
+    #     hoh_enrollment:    Hmis::Hud::Enrollment,
+    #     member_enrollments: [Hmis::Hud::Enrollment],
+    #   }
+    class EnrollmentBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      # rng_seed: pre-computed integer seed for cohesion probability rolls.
+      # Callers derive it as: simulation_seed + "entry:#{date}:#{client_id}".hash
+      def initialize(
+        project:,
+        hud_household_id:,
+        entry_date:,
+        coc_code:,
+        hoh_client:,
+        member_relationships: [],
+        household_cohesion_probability: 1.0,
+        data_source:,
+        user_id:,
+        rng_seed:
+      )
+        @project       = project
+        @household_id  = hud_household_id
+        @entry_date    = entry_date
+        @coc_code      = coc_code
+        @hoh           = hoh_client
+        @members       = member_relationships
+        @cohesion_prob = household_cohesion_probability.to_f
+        @ds            = data_source
+        @uid           = user_id
+        @rng_seed      = rng_seed
+      end
+
+      def build!
+        hoh_enrollment = create_enrollment(@hoh, 1)
+
+        member_enrollments = @members.each_with_index.filter_map do |member, idx|
+          next unless include_member?(idx)
+
+          client = Hmis::Hud::Client.find(member['hud_client_id'])
+          create_enrollment(client, member['relationship_to_hoh'].to_i)
+        end
+
+        { hoh_enrollment: hoh_enrollment, member_enrollments: member_enrollments }
+      end
+
+      private
+
+      def create_enrollment(client, relationship_to_hoh)
+        Hmis::Hud::Enrollment.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @entry_date.to_datetime,
+          DateUpdated: @entry_date.to_datetime,
+          EnrollmentID: FakeIdentifier.uuid,
+          PersonalID: client.PersonalID,
+          project_pk: @project.id,
+          HouseholdID: @household_id,
+          EntryDate: @entry_date,
+          RelationshipToHoH: relationship_to_hoh,
+          DisablingCondition: 99,
+          LivingSituation: 116,
+          EnrollmentCoC: @coc_code,
+        )
+      end
+
+      def include_member?(index)
+        return true if @cohesion_prob >= 1.0
+        return false if @cohesion_prob <= 0.0
+
+        Random.new(@rng_seed + index).rand < @cohesion_prob
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/exit_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/exit_builder.rb
@@ -1,0 +1,53 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates an Exit record for a single Enrollment.
+    # Samples the Destination field from the weighted exit_destinations map.
+    class ExitBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      def initialize(enrollment:, exit_date:, exit_destinations:, data_source:, user_id:, seed:, context_prefix:)
+        @enrollment        = enrollment
+        @exit_date         = exit_date
+        @exit_destinations = exit_destinations
+        @ds                = data_source
+        @uid               = user_id
+        @seed              = seed
+        @prefix            = context_prefix
+      end
+
+      def build!
+        destination = sample_destination
+
+        Hmis::Hud::Exit.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @exit_date.to_datetime,
+          DateUpdated: @exit_date.to_datetime,
+          ExitID: FakeIdentifier.uuid,
+          EnrollmentID: @enrollment.EnrollmentID,
+          PersonalID: @enrollment.PersonalID,
+          ExitDate: @exit_date,
+          Destination: destination,
+        )
+      end
+
+      private
+
+      def sample_destination
+        dests = @exit_destinations.transform_keys(&:to_s)
+        cfg   = { 'distribution' => 'weighted', 'weights' => dests }
+        rng   = Random.new(@seed + "#{@prefix}:destination".hash)
+        Distribution.sample(cfg, rng: rng)
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/service_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/service_builder.rb
@@ -1,0 +1,43 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates Hmis::Hud::Service records.
+    # Currently supports bed nights (RecordType/TypeProvided 200) for ES NBN projects.
+    # Future record types (referrals, PATH services, etc.) can be added as additional
+    # build_* methods following the same pattern.
+    class ServiceBuilder
+      EXPORT_ID    = Bootstrapper::EXPORT_ID
+      BED_NIGHT    = 200
+
+      def initialize(enrollment:, date:, data_source:, user_id:)
+        @enrollment = enrollment
+        @date       = date
+        @ds         = data_source
+        @uid        = user_id
+      end
+
+      def build_bed_night!
+        Hmis::Hud::Service.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          ServicesID: FakeIdentifier.uuid,
+          EnrollmentID: @enrollment.EnrollmentID,
+          PersonalID: @enrollment.PersonalID,
+          DateProvided: @date,
+          RecordType: BED_NIGHT,
+          TypeProvided: BED_NIGHT,
+        )
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/client.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/client.rb
@@ -14,5 +14,5 @@ class HmisSimulation::Client < GrdaWarehouseBase
 
   scope :active, -> { where(exited_system: false) }
   scope :pending_enrollment, ->(date) { where(pending_enrollment_on: date) }
-  scope :pending_exit, ->(date) { where(next_transition_on: date) }
+  scope :pending_exit, ->(date) { where(next_transition_on: date).where.not(hud_enrollment_id: nil) }
 end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -42,12 +42,19 @@ module HmisSimulation
 
       begin
         Hmis::Hud::Base.transaction do
-          @clients_created = 0
+          @clients_created     = 0
+          @enrollments_opened  = 0
+          @enrollments_closed  = 0
+          @services_created    = 0
 
           spawn_clients(date: date)
+          tick_primary(date: date)
 
           log.update!(
             clients_created: @clients_created,
+            enrollments_opened: @enrollments_opened,
+            enrollments_closed: @enrollments_closed,
+            services_created: @services_created,
             finished_at: Time.current,
           )
         end
@@ -101,6 +108,193 @@ module HmisSimulation
         @clients_created += 1
       end
     end
+
+    # -- Primary enrollment tick --
+
+    def tick_primary(date:)
+      data_source = GrdaWarehouse::DataSource.find(@data_source_id)
+      user_id     = Hmis::Hud::User.system_user(data_source_id: @data_source_id).user_id
+
+      # Process exits for clients whose enrollment ends today
+      Client.pending_exit(date).where(data_source_id: @data_source_id).find_each do |sim_client|
+        process_primary_exit(sim_client, date, data_source: data_source, user_id: user_id)
+      end
+
+      # Create enrollments for clients entering a program today
+      Client.pending_enrollment(date).where(data_source_id: @data_source_id).find_each do |sim_client|
+        process_primary_entry(sim_client, date, data_source: data_source, user_id: user_id)
+      end
+
+      # Generate bed nights for all active NBN enrollments
+      create_bed_nights(date, data_source: data_source, user_id: user_id)
+    end
+
+    def process_primary_exit(sim_client, date, data_source:, user_id:)
+      enrollment = Hmis::Hud::Enrollment.find(sim_client.hud_enrollment_id)
+      transition = find_transition(sim_client.current_population, sim_client.next_population)
+      exit_dests = transition&.dig('exit_destinations') || { '17' => 1.0 }
+
+      Builders::ExitBuilder.new(
+        enrollment: enrollment,
+        exit_date: date,
+        exit_destinations: exit_dests,
+        data_source: data_source,
+        user_id: user_id,
+        seed: @seed,
+        context_prefix: "exit:#{date}:#{sim_client.id}",
+      ).build!
+
+      @enrollments_closed += 1
+
+      population_cfg = find_population(sim_client.current_population)
+      if roll_exit_point(population_cfg, sim_client)
+        sim_client.update!(
+          exited_system: true,
+          hud_enrollment_id: nil,
+          next_transition_on: nil,
+          next_population: nil,
+        )
+      else
+        next_pop_name = sim_client.next_population || draw_next_population(sim_client.current_population, date, sim_client.id)
+        gap = sample_gap(transition, date, sim_client.id)
+        sim_client.update!(
+          current_population: next_pop_name,
+          entered_current_population_at: date,
+          hud_enrollment_id: nil,
+          next_transition_on: nil,
+          next_population: nil,
+          pending_enrollment_on: date + gap,
+        )
+      end
+    end
+
+    def process_primary_entry(sim_client, date, data_source:, user_id:)
+      population_cfg = find_population(sim_client.current_population)
+      return unless population_cfg
+
+      project_ref = population_cfg['project_ref']
+      project = find_project_by_ref(project_ref, data_source: data_source)
+      return unless project
+
+      hoh_client = Hmis::Hud::Client.find_by(id: sim_client.hud_client_id)
+      return unless hoh_client
+
+      household_group = (HouseholdGroup.find_by(id: sim_client.household_group_id) if sim_client.household_group_id.present?)
+      members = household_group&.member_client_ids || []
+      cohesion = @config.dig('enrollment_config', 'household_cohesion_probability').to_f
+      cohesion = 0.85 if cohesion.zero?
+
+      hud_household_id = FakeIdentifier.uuid
+      result = Builders::EnrollmentBuilder.new(
+        project: project,
+        hud_household_id: hud_household_id,
+        entry_date: date,
+        coc_code: @config.dig('coc_codes', 'primary') || 'XX-500',
+        hoh_client: hoh_client,
+        member_relationships: members,
+        household_cohesion_probability: cohesion,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: @seed + "entry:#{date}:#{sim_client.id}".hash,
+      ).build!
+
+      @enrollments_opened += 1
+
+      # Pre-select the outgoing transition and sample enrollment length
+      next_pop, timing = sample_enrollment_exit(sim_client.current_population, date, sim_client.id)
+
+      sim_client.update!(
+        hud_enrollment_id: result[:hoh_enrollment].id,
+        pending_enrollment_on: nil,
+        next_transition_on: date + timing,
+        next_population: next_pop,
+      )
+    end
+
+    def create_bed_nights(date, data_source:, user_id:)
+      nbn_project_pks = Hmis::Hud::Project.
+        where(data_source_id: @data_source_id, ProjectType: 1).
+        pluck(:id)
+      return if nbn_project_pks.empty?
+
+      active_nbn_enrollments = Hmis::Hud::Enrollment.
+        where(data_source_id: @data_source_id, project_pk: nbn_project_pks).
+        open_on_date(date)
+
+      active_nbn_enrollments.find_each do |enrollment|
+        Builders::ServiceBuilder.new(
+          enrollment: enrollment,
+          date: date,
+          data_source: data_source,
+          user_id: user_id,
+        ).build_bed_night!
+        @services_created += 1
+      end
+    end
+
+    # -- Transition helpers --
+
+    def sample_enrollment_exit(population_name, date, client_id)
+      transitions = outgoing_transitions(population_name)
+      return [population_name, 30] if transitions.empty?
+
+      weights = transitions.each_with_object({}) { |t, h| h[t['to']] = t['weight'].to_f }
+      cfg     = { 'distribution' => 'weighted', 'weights' => weights }
+      next_pop = Distribution.sample(cfg, rng: rng("next_pop:#{date}:#{client_id}"))
+      transition = find_transition(population_name, next_pop)
+      timing_days = if transition
+        Distribution.sample(transition['timing'].deep_stringify_keys, rng: rng("timing:#{date}:#{client_id}")).ceil
+      else
+        30
+      end
+      [next_pop, [timing_days, 1].max]
+    end
+
+    def roll_exit_point(population_cfg, sim_client)
+      prob = population_cfg&.dig('exit_point').to_f
+      return false if prob.zero?
+      return true if prob >= 1.0
+
+      rng("exit_point:#{sim_client.id}").rand < prob
+    end
+
+    def sample_gap(transition, date, client_id)
+      gap_cfg = transition&.dig('gap_before_entry')
+      return 0 unless gap_cfg.present?
+
+      Distribution.sample(gap_cfg.deep_stringify_keys, rng: rng("gap:#{date}:#{client_id}")).ceil.clamp(0, 365)
+    end
+
+    def draw_next_population(from_population, date, client_id)
+      transitions = outgoing_transitions(from_population)
+      return from_population if transitions.empty?
+
+      weights = transitions.each_with_object({}) { |t, h| h[t['to']] = t['weight'].to_f }
+      cfg = { 'distribution' => 'weighted', 'weights' => weights }
+      Distribution.sample(cfg, rng: rng("next_pop_fallback:#{date}:#{client_id}"))
+    end
+
+    def outgoing_transitions(population_name)
+      (@config['transitions'] || []).select { |t| t['from'] == population_name }
+    end
+
+    def find_transition(from, to)
+      return nil unless from.present? && to.present?
+
+      (@config['transitions'] || []).find { |t| t['from'] == from && t['to'] == to }
+    end
+
+    def find_population(name)
+      (@config['populations'] || []).find { |p| p['name'] == name }
+    end
+
+    def find_project_by_ref(project_ref, data_source:)
+      return nil if project_ref.blank?
+
+      Hmis::Hud::Project.find_by(data_source_id: data_source.id, ProjectName: project_ref)
+    end
+
+    # -- Daily count --
 
     def daily_new_client_count(date:)
       monthly_cfg = @config.dig('enrollment_config', 'new_clients_per_month') ||

--- a/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
+++ b/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
@@ -35,6 +35,33 @@ task :validate, [:path_or_key] => :environment do |_t, args|
   end
 end
 
+desc 'Run simulation for a single date (YYYY-MM-DD)'
+task :run, [:key, :date] => :environment do |_t, args|
+  key = args[:key]
+  raise ArgumentError, 'Usage: rake driver:hmis_simulation:run[hmis_simulation/key,2026-01-15]' if key.blank?
+
+  date   = Date.parse(args[:date])
+  config = HmisSimulation::ConfigLoader.from_app_config(key)
+  HmisSimulation::Engine.new(config).run(date: date)
+  puts "Run complete for #{date}"
+end
+
+desc 'Run simulation for a date range (YYYY-MM-DD)'
+task :run_range, [:key, :start_date, :end_date] => :environment do |_t, args|
+  key        = args[:key]
+  start_date = Date.parse(args[:start_date])
+  end_date   = Date.parse(args[:end_date])
+  raise ArgumentError, 'Usage: rake driver:hmis_simulation:run_range[key,2026-01-01,2026-01-31]' if key.blank?
+
+  config = HmisSimulation::ConfigLoader.from_app_config(key)
+  engine = HmisSimulation::Engine.new(config)
+  (start_date..end_date).each do |date|
+    engine.run(date: date)
+    puts "  Completed #{date}"
+  end
+  puts "Range complete: #{start_date} – #{end_date}"
+end
+
 desc 'Bootstrap HUD records (orgs, projects, ProjectCoc, Inventory, Funders) from an AppConfigProperty key'
 task :bootstrap, [:key] => :environment do |_t, args|
   key = args[:key]

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/enrollment_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/enrollment_builder_spec.rb
@@ -1,0 +1,109 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::EnrollmentBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date) { Date.new(2026, 2, 1) }
+  let(:project) { create(:hmis_hud_project, data_source: data_source, ProjectType: 1) }
+  let(:hoh_client) { create(:hmis_hud_client, data_source: data_source) }
+  let(:member_client) { create(:hmis_hud_client, data_source: data_source) }
+  let(:hud_household_id) { HmisSimulation::FakeIdentifier.uuid }
+  let(:coc_code) { 'XX-500' }
+
+  def build(member_relationships: [], cohesion_probability: 1.0)
+    described_class.new(
+      project: project,
+      hud_household_id: hud_household_id,
+      entry_date: date,
+      coc_code: coc_code,
+      hoh_client: hoh_client,
+      member_relationships: member_relationships,
+      household_cohesion_probability: cohesion_probability,
+      data_source: data_source,
+      user_id: user_id,
+      rng_seed: 42,
+    ).build!
+  end
+
+  describe '#build!' do
+    context 'with no household members' do
+      it 'creates exactly one Enrollment (for the HoH)' do
+        expect { build }.to change { Hmis::Hud::Enrollment.where(data_source: data_source).count }.by(1)
+      end
+
+      it 'sets RelationshipToHoH to 1 (self) on the HoH enrollment' do
+        result = build
+        expect(result[:hoh_enrollment].RelationshipToHoH).to eq(1)
+      end
+
+      it 'uses a FAKE EnrollmentID on the HoH enrollment' do
+        result = build
+        expect(result[:hoh_enrollment].EnrollmentID).to start_with('FAKE')
+      end
+
+      it 'sets EntryDate to the provided entry_date' do
+        result = build
+        expect(result[:hoh_enrollment].EntryDate).to eq(date)
+      end
+
+      it 'sets the HouseholdID on the enrollment' do
+        result = build
+        expect(result[:hoh_enrollment].HouseholdID).to eq(hud_household_id)
+      end
+
+      it 'links enrollment to the correct project via project_pk' do
+        result = build
+        expect(result[:hoh_enrollment].project_pk).to eq(project.id)
+      end
+
+      it 'returns empty member_enrollments array' do
+        result = build
+        expect(result[:member_enrollments]).to be_empty
+      end
+    end
+
+    context 'with household members and cohesion_probability: 1.0' do
+      let(:members) { [{ 'hud_client_id' => member_client.id, 'relationship_to_hoh' => 2 }] }
+
+      it 'creates 2 enrollments (HoH + member)' do
+        expect { build(member_relationships: members) }.
+          to change { Hmis::Hud::Enrollment.where(data_source: data_source).count }.by(2)
+      end
+
+      it 'sets correct RelationshipToHoH (2) on the member enrollment' do
+        result = build(member_relationships: members)
+        expect(result[:member_enrollments].first.RelationshipToHoH).to eq(2)
+      end
+
+      it 'shares HouseholdID across HoH and member' do
+        result = build(member_relationships: members)
+        expect(result[:member_enrollments].first.HouseholdID).to eq(result[:hoh_enrollment].HouseholdID)
+      end
+    end
+
+    context 'with cohesion_probability: 0.0 (no members included)' do
+      let(:members) { [{ 'hud_client_id' => member_client.id, 'relationship_to_hoh' => 2 }] }
+
+      it 'creates only 1 enrollment (the HoH)' do
+        expect { build(member_relationships: members, cohesion_probability: 0.0) }.
+          to change { Hmis::Hud::Enrollment.where(data_source: data_source).count }.by(1)
+      end
+
+      it 'returns empty member_enrollments array' do
+        result = build(member_relationships: members, cohesion_probability: 0.0)
+        expect(result[:member_enrollments]).to be_empty
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/exit_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/exit_builder_spec.rb
@@ -1,0 +1,75 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::ExitBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:entry_date) { Date.current - 30 }
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: entry_date) }
+
+  subject(:builder) do
+    described_class.new(
+      enrollment: enrollment,
+      exit_date: date,
+      exit_destinations: { '435' => 0.7, '426' => 0.3 },
+      data_source: data_source,
+      user_id: user_id,
+      seed: 42,
+      context_prefix: 'test:exit:0',
+    )
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::Exit record' do
+      expect { builder.build! }.to change { Hmis::Hud::Exit.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'uses a FAKE ExitID' do
+      result = builder.build!
+      expect(result.ExitID).to start_with('FAKE')
+    end
+
+    it 'sets ExitDate to the provided date' do
+      result = builder.build!
+      expect(result.ExitDate).to eq(date)
+    end
+
+    it 'links to the correct enrollment via EnrollmentID' do
+      result = builder.build!
+      expect(result.EnrollmentID).to eq(enrollment.EnrollmentID)
+    end
+
+    it 'sets Destination to one of the weighted values' do
+      result = builder.build!
+      expect([435, 426]).to include(result.Destination)
+    end
+
+    it 'samples destinations proportionally' do
+      destinations = 100.times.map do |i|
+        described_class.new(
+          enrollment: enrollment,
+          exit_date: date,
+          exit_destinations: { '435' => 1, '426' => 0 },
+          data_source: data_source,
+          user_id: user_id,
+          seed: 42,
+          context_prefix: "test:exit:#{i}",
+        ).build!.Destination
+      end
+      expect(destinations.uniq).to eq([435])
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/service_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/service_builder_spec.rb
@@ -1,0 +1,62 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::ServiceBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source, ProjectType: 1) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: date - 1) }
+
+  subject(:builder) do
+    described_class.new(
+      enrollment: enrollment,
+      date: date,
+      data_source: data_source,
+      user_id: user_id,
+    )
+  end
+
+  describe '#build_bed_night!' do
+    it 'creates one Hmis::Hud::Service record' do
+      expect { builder.build_bed_night! }.to change { Hmis::Hud::Service.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'uses a FAKE ServicesID' do
+      result = builder.build_bed_night!
+      expect(result.ServicesID).to start_with('FAKE')
+    end
+
+    it 'sets DateProvided to the given date' do
+      result = builder.build_bed_night!
+      expect(result.DateProvided).to eq(date)
+    end
+
+    it 'sets RecordType to 200 (bed night)' do
+      result = builder.build_bed_night!
+      expect(result.RecordType).to eq(200)
+    end
+
+    it 'sets TypeProvided to 200 (bed night)' do
+      result = builder.build_bed_night!
+      expect(result.TypeProvided).to eq(200)
+    end
+
+    it 'links to the correct enrollment and client' do
+      result = builder.build_bed_night!
+      expect(result.EnrollmentID).to eq(enrollment.EnrollmentID)
+      expect(result.PersonalID).to eq(client.PersonalID)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -137,5 +137,74 @@ RSpec.describe HmisSimulation::Engine do
         expect(logs.pluck(:run_date)).to include(run_date, run_date + 1)
       end
     end
+
+    context 'primary enrollment tick' do
+      it 'creates Enrollment records for spawned clients on the same day' do
+        engine.run(date: run_date)
+        enrolled = sim_clients.where.not(hud_enrollment_id: nil)
+        expect(enrolled.count).to be > 0
+      end
+
+      it 'sets next_transition_on for enrolled clients' do
+        engine.run(date: run_date)
+        enrolled = sim_clients.where.not(hud_enrollment_id: nil)
+        enrolled.each do |sc|
+          expect(sc.next_transition_on).to be_present
+          expect(sc.next_transition_on).to be > run_date
+        end
+      end
+
+      it 'stores next_population on enrolled clients' do
+        engine.run(date: run_date)
+        enrolled = sim_clients.where.not(hud_enrollment_id: nil)
+        population_names = config['populations'].map { |p| p['name'] }
+        enrolled.each do |sc|
+          expect(population_names).to include(sc.next_population)
+        end
+      end
+
+      it 'creates Exit records when next_transition_on fires' do
+        # Use config with 1-day timing so transitions fire the next day
+        fast_config = base_config.deep_dup
+        fast_config['transitions'].each { |t| t['timing'] = { 'distribution' => 'constant', 'value' => 1 } }
+        fast_config['transitions'].each { |t| t['gap_before_entry'] = { 'distribution' => 'constant', 'value' => 0 } }
+        cfg = HmisSimulation::ConfigLoader.send(:normalize, fast_config)
+        HmisSimulation::Bootstrapper.new(cfg).run!
+        e = described_class.new(cfg)
+
+        e.run(date: run_date)
+        Hmis::Hud::Enrollment.where(data_source: data_source).count
+
+        e.run(date: run_date + 1)
+        exit_count = Hmis::Hud::Exit.where(data_source: data_source).count
+        expect(exit_count).to be > 0
+      end
+
+      it 'creates bed-night Service records for NBN project enrollments' do
+        engine.run(date: run_date)
+
+        nbn_project = Hmis::Hud::Project.find_by(data_source: data_source, ProjectName: 'Test ES_')
+        nbn_enrollments = Hmis::Hud::Enrollment.where(
+          data_source: data_source, project_pk: nbn_project.id,
+        )
+
+        if nbn_enrollments.any?
+          services = Hmis::Hud::Service.where(data_source: data_source, RecordType: 200)
+          expect(services.count).to be > 0
+        end
+      end
+
+      it 'clears pending_enrollment_on after creating an enrollment' do
+        engine.run(date: run_date)
+        enrolled = sim_clients.where.not(hud_enrollment_id: nil)
+        expect(enrolled.where.not(pending_enrollment_on: nil).count).to eq(0)
+      end
+
+      it 'updates enrollments_opened in RunLog' do
+        engine.run(date: run_date)
+        log = HmisSimulation::RunLog.find_by(data_source_id: data_source.id, run_date: run_date)
+        expect(log.enrollments_opened).to be > 0
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)


# HMIS Simulation Engine — Phase 4: Primary Enrollment Engine

## Summary

Completes the primary enrollment lifecycle: clients spawned in Phase 3 now get enrolled, follow a realistic stay timeline, exit to appropriate destinations, and re-enroll in the next program after a configurable gap. NBN shelter enrollments generate daily bed-night service records.

Builds on Phase 3 (client/household builders, Engine spawn).

## What's in this PR

### New migration

`20260604130000_add_next_population_to_hmis_simulation_clients` — adds `next_population string` to `hmis_simulation_clients`. When a client is enrolled, the engine pre-selects the outgoing transition (weighted by `weight`) and stores the destination population name here. This ensures the enrollment's length (sampled from that transition's `timing` distribution) is realistic for where the client is headed, and that the correct `exit_destinations` and `gap_before_entry` are used when the enrollment ends.

### `HmisSimulation::Builders::EnrollmentBuilder`

Creates `Hmis::Hud::Enrollment` records for a household entering a project.

- Always creates one enrollment for the HoH (`RelationshipToHoH: 1`)
- For each household member, rolls `household_cohesion_probability` (default 0.85) to decide inclusion; accepted members get the `relationship_to_hoh` stored in the household group
- All enrollments share the same `HouseholdID` (FAKE UUID passed in from the engine)
- Links to the project via `project_pk` (integer FK); `ProjectID` is auto-set by the model's before-validation callback

### `HmisSimulation::Builders::ExitBuilder`

Creates `Hmis::Hud::Exit` for a single enrollment. Samples `Destination` from the weighted `exit_destinations` map on the transition config (e.g. `{ "435" => 1.0 }` for clients moving into PSH).

### `HmisSimulation::Builders::ServiceBuilder`

Creates `Hmis::Hud::Service` records. Currently implements `build_bed_night!` — `RecordType: 200`, `TypeProvided: 200` for ES NBN enrollments. The builder's structure (separate `build_*` methods) makes adding other service types in future phases straightforward.

### `HmisSimulation::Engine#tick_primary`

Daily enrollment processing added to `Engine#run` after `spawn_clients`:

**Exits** (`next_transition_on = date` AND `hud_enrollment_id` present):
1. Create `Exit` record using the pre-selected transition's `exit_destinations`
2. Roll `exit_point` probability from the population config
   - If exits system: mark `exited_system: true`, clear state
   - If continues: update `current_population` to `next_population`, sample `gap_before_entry`, set `pending_enrollment_on`

**Entries** (`pending_enrollment_on = date`):
1. Look up the population's `project_ref` to find the project
2. Call `EnrollmentBuilder` with household group members + cohesion probability
3. Pre-select outgoing transition, sample `timing` → set `next_transition_on` and `next_population`
4. Clear `pending_enrollment_on`

**Bed nights** (after entries): find all active ES NBN enrollments → call `ServiceBuilder#build_bed_night!` for each.

RunLog is updated with `enrollments_opened`, `enrollments_closed`, `services_created` counts in addition to the Phase 3 `clients_created`.

### New rake tasks

```bash
# Run one day
bundle exec rake driver:hmis_simulation:run[hmis_simulation/demo-coc,2026-01-15]

# Run a date range (e.g. to back-fill or test)
bundle exec rake driver:hmis_simulation:run_range[hmis_simulation/demo-coc,2026-01-01,2026-01-31]
```

## Full workflow (end-to-end after all 4 phases)

```bash
# 1. Validate config
bundle exec rake driver:hmis_simulation:validate[config/simulations/samples/small_coc.json]

# 2. Load config into AppConfigProperty
bundle exec rake driver:hmis_simulation:setup_from_file[config/simulations/samples/small_coc.json]

# 3. Create orgs, projects, ProjectCoc, Inventory, Funders
bundle exec rake driver:hmis_simulation:bootstrap[hmis_simulation/demo-coc-small]

# 4. Run 30 days of simulation
bundle exec rake driver:hmis_simulation:run_range[hmis_simulation/demo-coc-small,2026-01-01,2026-01-30]
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
