### PR TITLE
HMIS Simulation Engine - Linked Record Builders

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/cls_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/cls_builder.rb
@@ -1,0 +1,41 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates one Hmis::Hud::CurrentLivingSituation record.
+    # Called at enrollment entry for street/shelter populations, and
+    # periodically for ongoing enrollments (future enhancement).
+    class ClsBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      def initialize(enrollment:, date:, situation_code:, data_source:, user_id:)
+        @enrollment      = enrollment
+        @date            = date
+        @situation_code  = situation_code
+        @ds              = data_source
+        @uid             = user_id
+      end
+
+      def build!
+        Hmis::Hud::CurrentLivingSituation.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          CurrentLivingSitID: FakeIdentifier.uuid,
+          EnrollmentID: @enrollment.EnrollmentID,
+          PersonalID: @enrollment.PersonalID,
+          InformationDate: @date,
+          CurrentLivingSituation: @situation_code,
+        )
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/disability_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/disability_builder.rb
@@ -1,0 +1,87 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates Hmis::Hud::Disability records at enrollment entry.
+    # One record per disability type configured in disability_config.types.
+    #
+    # Returns { disabling_condition: 0|1 } so the caller can update the
+    # enrollment's DisablingCondition field.
+    class DisabilityBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      # Config key → HUD DisabilityType integer
+      TYPE_MAP = {
+        'physical' => 5,
+        'developmental' => 6,
+        'chronic_health' => 7,
+        'hiv_aids' => 8,
+        'mental_health' => 9,
+        'substance_use' => 10,
+      }.freeze
+
+      # Types for which IndefiniteAndImpairs is not applicable (HUD spec)
+      NO_INDEFINITE_TYPES = [6, 8].freeze
+
+      def initialize(enrollment:, date:, disability_config:, data_source:, user_id:, rng_seed:)
+        @enrollment   = enrollment
+        @date         = date
+        @cfg          = (disability_config || {}).deep_stringify_keys
+        @ds           = data_source
+        @uid          = user_id
+        @rng_seed     = rng_seed
+      end
+
+      def build!
+        disabling_condition = roll_disabling_condition
+        types = @cfg['types'] || {}
+
+        types.each_with_index do |(config_key, probability), idx|
+          hud_type = TYPE_MAP[config_key]
+          next unless hud_type
+
+          rng = Random.new(@rng_seed + idx)
+          response = rng.rand < probability.to_f ? 1 : 0
+          indefinite = indefinite_and_impairs(hud_type, disabling_condition, idx)
+
+          Hmis::Hud::Disability.create!(
+            data_source_id: @ds.id,
+            UserID: @uid,
+            ExportID: EXPORT_ID,
+            DateCreated: @date.to_datetime,
+            DateUpdated: @date.to_datetime,
+            DisabilitiesID: FakeIdentifier.uuid,
+            EnrollmentID: @enrollment.EnrollmentID,
+            PersonalID: @enrollment.PersonalID,
+            InformationDate: @date,
+            DisabilityType: hud_type,
+            DisabilityResponse: response,
+            IndefiniteAndImpairs: indefinite,
+            DataCollectionStage: 1,
+          )
+        end
+
+        { disabling_condition: disabling_condition ? 1 : 0 }
+      end
+
+      private
+
+      def roll_disabling_condition
+        prob = @cfg['disabling_condition_probability'].to_f
+        Random.new(@rng_seed + 999).rand < prob
+      end
+
+      def indefinite_and_impairs(hud_type, disabling_condition, idx)
+        return nil if NO_INDEFINITE_TYPES.include?(hud_type)
+
+        disabling_condition ? [0, 1].sample(random: Random.new(@rng_seed + idx + 100)) : 0
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/health_and_dv_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/health_and_dv_builder.rb
@@ -1,0 +1,67 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates one Hmis::Hud::HealthAndDv record at enrollment entry.
+    class HealthAndDvBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      # HUD GeneralHealthStatus values
+      GENERAL_HEALTH = { 'excellent' => 1, 'good' => 2, 'fair' => 3, 'poor' => 4 }.freeze
+
+      def initialize(enrollment:, date:, hdv_config:, data_source:, user_id:, rng_seed:)
+        @enrollment = enrollment
+        @date       = date
+        @cfg        = (hdv_config || {}).deep_stringify_keys
+        @ds         = data_source
+        @uid        = user_id
+        @rng_seed   = rng_seed
+      end
+
+      def build!
+        dv_survivor = roll_probability('dv_survivor_probability', 0)
+        currently_fleeing = dv_survivor == 1 ? roll_probability('currently_fleeing_probability', 1) : 0
+        health_status = sample_general_health
+
+        Hmis::Hud::HealthAndDv.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          HealthAndDVID: FakeIdentifier.uuid,
+          EnrollmentID: @enrollment.EnrollmentID,
+          PersonalID: @enrollment.PersonalID,
+          InformationDate: @date,
+          DataCollectionStage: 1,
+          DomesticViolenceSurvivor: dv_survivor,
+          CurrentlyFleeing: currently_fleeing,
+          GeneralHealthStatus: health_status,
+        )
+      end
+
+      private
+
+      def roll_probability(config_key, rng_offset)
+        prob = @cfg[config_key].to_f
+        Random.new(@rng_seed + rng_offset).rand < prob ? 1 : 0
+      end
+
+      def sample_general_health
+        health_cfg = @cfg['general_health'] || { 'fair' => 1.0 }
+        valid = health_cfg.slice(*GENERAL_HEALTH.keys).transform_values(&:to_f)
+        return 3 if valid.values.sum.zero?
+
+        cfg = { 'distribution' => 'weighted', 'weights' => valid }
+        key = Distribution.sample(cfg, rng: Random.new(@rng_seed + 2))
+        GENERAL_HEALTH[key] || 3
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/income_benefit_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/income_benefit_builder.rb
@@ -1,0 +1,85 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates Hmis::Hud::IncomeBenefit records.
+    # Called at enrollment entry (stage 1), annual assessment (stage 5), and exit (stage 3).
+    #
+    # Config keys (income_at_entry section from simulation config):
+    #   no_income_probability: float — probability client has no income
+    #   sources: hash of source_key => weight (e.g. { "ssi" => 0.2, "earned" => 0.1 })
+    class IncomeBenefitBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      DATA_COLLECTION_STAGES = { entry: 1, update: 2, exit: 3, annual: 5 }.freeze
+
+      # Maps config source keys to HUD field names and typical monthly amounts
+      INCOME_SOURCES = {
+        'ssi' => { field: :SSI, amount_field: :SSIAmount, typical_amount: 943 },
+        'ssdi' => { field: :SSDI, amount_field: :SSDIAmount, typical_amount: 1400 },
+        'earned' => { field: :Earned, amount_field: :EarnedAmount, typical_amount: 1100 },
+        'ga' => { field: :GA, amount_field: :GAAmount, typical_amount: 350 },
+        'tanf' => { field: :TANF, amount_field: :TANFAmount, typical_amount: 500 },
+        'unemployment' => { field: :Unemployment, amount_field: :UnemploymentAmount, typical_amount: 800 },
+      }.freeze
+
+      def initialize(enrollment:, date:, stage:, income_config:, data_source:, user_id:, rng_seed:)
+        @enrollment    = enrollment
+        @date          = date
+        @stage         = stage
+        @income_cfg    = (income_config || {}).deep_stringify_keys
+        @ds            = data_source
+        @uid           = user_id
+        @rng_seed      = rng_seed
+      end
+
+      def build!
+        dcs = DATA_COLLECTION_STAGES.fetch(@stage, 1)
+        attrs = build_income_attributes
+
+        Hmis::Hud::IncomeBenefit.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          IncomeBenefitsID: FakeIdentifier.uuid,
+          EnrollmentID: @enrollment.EnrollmentID,
+          PersonalID: @enrollment.PersonalID,
+          InformationDate: @date,
+          DataCollectionStage: dcs,
+          **attrs,
+        )
+      end
+
+      private
+
+      def build_income_attributes
+        no_income_prob = @income_cfg['no_income_probability'].to_f
+        return { IncomeFromAnySource: 0 } if Random.new(@rng_seed).rand < no_income_prob
+
+        sources = (@income_cfg['sources'] || {}).transform_values(&:to_f)
+        return { IncomeFromAnySource: 0 } if sources.values.sum.zero?
+
+        cfg = { 'distribution' => 'weighted', 'weights' => sources }
+        selected = Distribution.sample(cfg, rng: Random.new(@rng_seed + 1))
+        source = INCOME_SOURCES[selected]
+        return { IncomeFromAnySource: 0 } unless source
+
+        amount = Random.new(@rng_seed + 2).rand(source[:typical_amount] * 0.5..source[:typical_amount] * 1.5).round
+        {
+          IncomeFromAnySource: 1,
+          source[:field] => 1,
+          source[:amount_field] => amount,
+          TotalMonthlyIncome: amount,
+        }
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -49,6 +49,7 @@ module HmisSimulation
 
           spawn_clients(date: date)
           tick_primary(date: date)
+          tick_annual_collections(date: date)
 
           log.update!(
             clients_created: @clients_created,
@@ -143,6 +144,7 @@ module HmisSimulation
         seed: @seed,
         context_prefix: "exit:#{date}:#{sim_client.id}",
       ).build!
+      create_linked_exit_records(enrollment, date, data_source: data_source, user_id: user_id)
 
       @enrollments_closed += 1
 
@@ -199,6 +201,7 @@ module HmisSimulation
       ).build!
 
       @enrollments_opened += 1
+      create_linked_entry_records(result[:hoh_enrollment], date, data_source: data_source, user_id: user_id, sim_client: sim_client)
 
       # Pre-select the outgoing transition and sample enrollment length
       next_pop, timing = sample_enrollment_exit(sim_client.current_population, date, sim_client.id)
@@ -229,6 +232,125 @@ module HmisSimulation
           user_id: user_id,
         ).build_bed_night!
         @services_created += 1
+      end
+    end
+
+    # -- Linked record builders (called at enrollment entry/exit) --
+
+    def create_linked_entry_records(enrollment, date, data_source:, user_id:, sim_client:)
+      rng_seed = @seed + "linked:#{enrollment.EnrollmentID}".hash
+      disability_cfg = @config.dig('enrollment_config', 'disabilities') || {}
+      income_cfg     = @config.dig('enrollment_config', 'income_at_entry') || {}
+      hdv_cfg        = @config.dig('enrollment_config', 'health_and_dv') || {}
+
+      disability_result = Builders::DisabilityBuilder.new(
+        enrollment: enrollment,
+        date: date,
+        disability_config: disability_cfg,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: rng_seed,
+      ).build!
+      enrollment.update!(DisablingCondition: disability_result[:disabling_condition])
+
+      Builders::IncomeBenefitBuilder.new(
+        enrollment: enrollment,
+        date: date,
+        stage: :entry,
+        income_config: income_cfg,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: rng_seed + 1,
+      ).build!
+
+      Builders::HealthAndDvBuilder.new(
+        enrollment: enrollment,
+        date: date,
+        hdv_config: hdv_cfg,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: rng_seed + 2,
+      ).build!
+
+      # CLS at entry for street/shelter populations
+      population_cfg = find_population(sim_client.current_population)
+      return unless population_cfg&.dig('project_ref').present?
+
+      project = find_project_by_ref(population_cfg['project_ref'], data_source: data_source)
+      cls_code = cls_situation_code_for(project)
+      return unless cls_code
+
+      Builders::ClsBuilder.new(
+        enrollment: enrollment,
+        date: date,
+        situation_code: cls_code,
+        data_source: data_source,
+        user_id: user_id,
+      ).build!
+    end
+
+    def create_linked_exit_records(enrollment, exit_date, data_source:, user_id:)
+      income_cfg = @config.dig('enrollment_config', 'income_at_entry') || {}
+      Builders::IncomeBenefitBuilder.new(
+        enrollment: enrollment,
+        date: exit_date,
+        stage: :exit,
+        income_config: income_cfg,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: @seed + "exit_income:#{enrollment.EnrollmentID}".hash,
+      ).build!
+    end
+
+    # -- Annual collection tick --
+
+    def tick_annual_collections(date:)
+      annual_cfg = @config.dig('enrollment_config', 'annual_collection') || {}
+      miss_rate  = annual_cfg['miss_rate'].to_f
+      jitter_cfg = annual_cfg['timing_jitter'] || { 'distribution' => 'normal', 'mean' => 0, 'stddev' => 30, 'min' => -90, 'max' => 90 }
+
+      data_source = GrdaWarehouse::DataSource.find(@data_source_id)
+      user_id     = Hmis::Hud::User.system_user(data_source_id: @data_source_id).user_id
+      income_cfg  = @config.dig('enrollment_config', 'income_at_entry') || {}
+
+      Hmis::Hud::Enrollment.
+        where(data_source_id: @data_source_id).
+        open_on_date(date).
+        find_each do |enrollment|
+          next unless annual_collection_due?(enrollment, date, jitter_cfg)
+          next if Random.new(@seed + "annual_miss:#{enrollment.EnrollmentID}:#{date}".hash).rand < miss_rate
+
+          Builders::IncomeBenefitBuilder.new(
+            enrollment: enrollment,
+            date: date,
+            stage: :annual,
+            income_config: income_cfg,
+            data_source: data_source,
+            user_id: user_id,
+            rng_seed: @seed + "annual:#{enrollment.EnrollmentID}:#{date}".hash,
+          ).build!
+        end
+    end
+
+    def annual_collection_due?(enrollment, date, jitter_cfg)
+      days_enrolled = (date - enrollment.EntryDate).to_i
+      return false if days_enrolled < 300
+
+      year_number = (days_enrolled / 365.0).ceil
+      jitter = Distribution.sample(
+        jitter_cfg.deep_stringify_keys,
+        rng: Random.new(@seed + "annual_jitter:#{enrollment.EnrollmentID}:#{year_number}".hash),
+      ).round
+      expected_date = enrollment.EntryDate + (365 * year_number) + jitter
+      date == expected_date
+    end
+
+    def cls_situation_code_for(project)
+      return nil unless project
+
+      case project.ProjectType
+      when 1, 0 then 101  # Emergency shelter
+      when 4    then 116  # Street outreach
       end
     end
 

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/cls_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/cls_builder_spec.rb
@@ -1,0 +1,55 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::ClsBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: date - 30) }
+
+  subject(:builder) do
+    described_class.new(
+      enrollment: enrollment,
+      date: date,
+      situation_code: 116,
+      data_source: data_source,
+      user_id: user_id,
+    )
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::CurrentLivingSituation record' do
+      expect { builder.build! }.to change { Hmis::Hud::CurrentLivingSituation.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'uses a FAKE CurrentLivingSitID' do
+      expect(builder.build!.CurrentLivingSitID).to start_with('FAKE')
+    end
+
+    it 'sets CurrentLivingSituation to the provided code' do
+      expect(builder.build!.CurrentLivingSituation).to eq(116)
+    end
+
+    it 'sets InformationDate to the given date' do
+      expect(builder.build!.InformationDate).to eq(date)
+    end
+
+    it 'links to the correct enrollment and client' do
+      result = builder.build!
+      expect(result.EnrollmentID).to eq(enrollment.EnrollmentID)
+      expect(result.PersonalID).to eq(client.PersonalID)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/disability_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/disability_builder_spec.rb
@@ -1,0 +1,94 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::DisabilityBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: date - 30) }
+
+  let(:disability_config) do
+    {
+      'disabling_condition_probability' => 0.8,
+      'types' => { 'mental_health' => 0.6, 'substance_use' => 0.4, 'physical' => 0.3 },
+    }
+  end
+
+  subject(:builder) do
+    described_class.new(
+      enrollment: enrollment,
+      date: date,
+      disability_config: disability_config,
+      data_source: data_source,
+      user_id: user_id,
+      rng_seed: 42,
+    )
+  end
+
+  describe '#build!' do
+    it 'creates one Disability record per configured type' do
+      expect { builder.build! }.
+        to change { Hmis::Hud::Disability.where(data_source: data_source).count }.
+        by(disability_config['types'].size)
+    end
+
+    it 'uses FAKE DisabilitiesID on each record' do
+      builder.build!
+      Hmis::Hud::Disability.where(data_source: data_source).each do |d|
+        expect(d.DisabilitiesID).to start_with('FAKE')
+      end
+    end
+
+    it 'sets DataCollectionStage to 1 (entry)' do
+      builder.build!
+      Hmis::Hud::Disability.where(data_source: data_source).each do |d|
+        expect(d.DataCollectionStage).to eq(1)
+      end
+    end
+
+    it 'sets IndefiniteAndImpairs to nil for developmental (type 6) and HIV/AIDS (type 8)' do
+      config = disability_config.merge('types' => { 'developmental' => 1.0, 'hiv_aids' => 1.0 })
+      described_class.new(
+        enrollment: enrollment, date: date, disability_config: config,
+        data_source: data_source, user_id: user_id, rng_seed: 42
+      ).build!
+      Hmis::Hud::Disability.where(data_source: data_source).each do |d|
+        expect(d.IndefiniteAndImpairs).to be_nil
+      end
+    end
+
+    it 'sets IndefiniteAndImpairs to 0 or 1 for non-exempt types (mental_health = type 9)' do
+      config = disability_config.merge('types' => { 'mental_health' => 1.0 })
+      described_class.new(
+        enrollment: enrollment, date: date, disability_config: config,
+        data_source: data_source, user_id: user_id, rng_seed: 42
+      ).build!
+      d = Hmis::Hud::Disability.where(data_source: data_source).first
+      expect([0, 1]).to include(d.IndefiniteAndImpairs)
+    end
+
+    it 'returns the DisablingCondition value (0 or 1)' do
+      result = builder.build!
+      expect([0, 1]).to include(result[:disabling_condition])
+    end
+
+    it 'links records to the correct enrollment' do
+      builder.build!
+      Hmis::Hud::Disability.where(data_source: data_source).each do |d|
+        expect(d.EnrollmentID).to eq(enrollment.EnrollmentID)
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/health_and_dv_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/health_and_dv_builder_spec.rb
@@ -1,0 +1,84 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::HealthAndDvBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: date - 30) }
+
+  let(:hdv_config) do
+    {
+      'dv_survivor_probability' => 0.0,
+      'currently_fleeing_probability' => 0.0,
+      'general_health' => { 'poor' => 0.3, 'fair' => 0.4, 'good' => 0.25, 'excellent' => 0.05 },
+    }
+  end
+
+  subject(:builder) do
+    described_class.new(
+      enrollment: enrollment,
+      date: date,
+      hdv_config: hdv_config,
+      data_source: data_source,
+      user_id: user_id,
+      rng_seed: 42,
+    )
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::HealthAndDv record' do
+      expect { builder.build! }.to change { Hmis::Hud::HealthAndDv.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'uses a FAKE HealthAndDVID' do
+      expect(builder.build!.HealthAndDVID).to start_with('FAKE')
+    end
+
+    it 'sets DataCollectionStage to 1 (entry)' do
+      expect(builder.build!.DataCollectionStage).to eq(1)
+    end
+
+    it 'sets InformationDate to the given date' do
+      expect(builder.build!.InformationDate).to eq(date)
+    end
+
+    it 'links to the correct enrollment and client' do
+      result = builder.build!
+      expect(result.EnrollmentID).to eq(enrollment.EnrollmentID)
+      expect(result.PersonalID).to eq(client.PersonalID)
+    end
+
+    context 'with dv_survivor_probability: 1.0' do
+      let(:hdv_config) { super().merge('dv_survivor_probability' => 1.0) }
+
+      it 'sets DomesticViolenceSurvivor to 1' do
+        expect(builder.build!.DomesticViolenceSurvivor).to eq(1)
+      end
+    end
+
+    context 'with dv_survivor_probability: 0.0' do
+      it 'sets DomesticViolenceSurvivor to 0' do
+        expect(builder.build!.DomesticViolenceSurvivor).to eq(0)
+      end
+    end
+
+    it 'sets GeneralHealthStatus to a value from the configured distribution' do
+      result = builder.build!
+      # 1=Excellent, 2=Good, 3=Fair, 4=Poor in HUD
+      expect([1, 2, 3, 4]).to include(result.GeneralHealthStatus)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/income_benefit_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/income_benefit_builder_spec.rb
@@ -1,0 +1,103 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::IncomeBenefitBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)       { Date.current - 1 }
+  let(:client)     { create(:hmis_hud_client, data_source: data_source) }
+  let(:project)    { create(:hmis_hud_project, data_source: data_source) }
+  let(:enrollment) { create(:hmis_hud_enrollment, data_source: data_source, client: client, project: project, EntryDate: date - 30) }
+
+  let(:income_config) do
+    {
+      'no_income_probability' => 0.0,
+      'sources' => { 'ssi' => 0.5, 'earned' => 0.5 },
+    }
+  end
+
+  def build(stage:, config: income_config, rng_seed: 42)
+    described_class.new(
+      enrollment: enrollment,
+      date: date,
+      stage: stage,
+      income_config: config,
+      data_source: data_source,
+      user_id: user_id,
+      rng_seed: rng_seed,
+    ).build!
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::IncomeBenefit record' do
+      expect { build(stage: :entry) }.to change { Hmis::Hud::IncomeBenefit.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'uses a FAKE IncomeBenefitsID' do
+      result = build(stage: :entry)
+      expect(result.IncomeBenefitsID).to start_with('FAKE')
+    end
+
+    it 'sets DataCollectionStage to 1 for entry' do
+      expect(build(stage: :entry).DataCollectionStage).to eq(1)
+    end
+
+    it 'sets DataCollectionStage to 5 for annual' do
+      expect(build(stage: :annual).DataCollectionStage).to eq(5)
+    end
+
+    it 'sets DataCollectionStage to 3 for exit' do
+      expect(build(stage: :exit).DataCollectionStage).to eq(3)
+    end
+
+    it 'sets InformationDate to the given date' do
+      expect(build(stage: :entry).InformationDate).to eq(date)
+    end
+
+    context 'with no_income_probability: 1.0' do
+      let(:income_config) { { 'no_income_probability' => 1.0, 'sources' => {} } }
+
+      it 'sets IncomeFromAnySource to 0' do
+        expect(build(stage: :entry).IncomeFromAnySource).to eq(0)
+      end
+    end
+
+    context 'with no_income_probability: 0.0 and sources configured' do
+      let(:income_config) { { 'no_income_probability' => 0.0, 'sources' => { 'ssi' => 1.0 } } }
+
+      it 'sets IncomeFromAnySource to 1' do
+        expect(build(stage: :entry).IncomeFromAnySource).to eq(1)
+      end
+
+      it 'sets SSI to 1 when ssi is the only source' do
+        expect(build(stage: :entry).SSI).to eq(1)
+      end
+
+      it 'sets a positive TotalMonthlyIncome' do
+        expect(build(stage: :entry).TotalMonthlyIncome.to_f).to be > 0
+      end
+    end
+
+    it 'links to the correct enrollment and client' do
+      result = build(stage: :entry)
+      expect(result.EnrollmentID).to eq(enrollment.EnrollmentID)
+      expect(result.PersonalID).to eq(client.PersonalID)
+    end
+
+    it 'is deterministic — same rng_seed produces same IncomeFromAnySource' do
+      r1 = build(stage: :entry, rng_seed: 99)
+      r2 = build(stage: :entry, rng_seed: 99)
+      expect(r1.IncomeFromAnySource).to eq(r2.IncomeFromAnySource)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe HmisSimulation::Engine do
       ],
       'enrollment_config' => {
         'new_clients_per_month' => { 'distribution' => 'poisson', 'lambda' => 300 },
+        'disabilities' => {
+          'disabling_condition_probability' => 0.8,
+          'types' => { 'mental_health' => 0.7, 'substance_use' => 0.5 },
+        },
+        'income_at_entry' => { 'no_income_probability' => 0.3, 'sources' => { 'ssi' => 1.0 } },
+        'health_and_dv' => { 'dv_survivor_probability' => 0.2, 'general_health' => { 'fair' => 1.0 } },
       },
     }
   end
@@ -204,6 +210,62 @@ RSpec.describe HmisSimulation::Engine do
         engine.run(date: run_date)
         log = HmisSimulation::RunLog.find_by(data_source_id: data_source.id, run_date: run_date)
         expect(log.enrollments_opened).to be > 0
+      end
+    end
+
+    context 'linked records at entry' do
+      before { engine.run(date: run_date) }
+
+      it 'creates Disability records for enrolled clients' do
+        expect(Hmis::Hud::Disability.where(data_source: data_source).count).to be > 0
+      end
+
+      it 'creates IncomeBenefit records at entry stage' do
+        count = Hmis::Hud::IncomeBenefit.where(data_source: data_source, DataCollectionStage: 1).count
+        expect(count).to be > 0
+      end
+
+      it 'creates HealthAndDv records for enrolled clients' do
+        expect(Hmis::Hud::HealthAndDv.where(data_source: data_source).count).to be > 0
+      end
+
+      it 'sets DisablingCondition on enrollments to 0 or 1 (updated from 99 default)' do
+        updated = Hmis::Hud::Enrollment.
+          where(data_source: data_source).
+          where.not(DisablingCondition: 99)
+        expect(updated.count).to be > 0
+      end
+    end
+
+    context 'annual collection' do
+      it 'creates annual IncomeBenefit records for enrollments near their anniversary' do
+        # Create an enrollment that is exactly 365 days old so annual collection fires today
+        old_entry = run_date - 365
+        hoh = create(:hmis_hud_client, data_source: data_source)
+        project = Hmis::Hud::Project.find_by(data_source: data_source, ProjectName: 'Test ES_')
+        enrollment = create(
+          :hmis_hud_enrollment,
+          data_source: data_source, client: hoh, project: project,
+          EntryDate: old_entry
+        )
+
+        # Use a config with zero jitter so the anniversary date is deterministic
+        zero_jitter_config = base_config.deep_dup
+        zero_jitter_config['enrollment_config'] ||= {}
+        zero_jitter_config['enrollment_config']['annual_collection'] = {
+          'miss_rate' => 0.0,
+          'timing_jitter' => { 'distribution' => 'constant', 'value' => 0 },
+        }
+        cfg = HmisSimulation::ConfigLoader.send(:normalize, zero_jitter_config)
+        e = described_class.new(cfg)
+        e.run(date: run_date)
+
+        annual = Hmis::Hud::IncomeBenefit.where(
+          data_source: data_source,
+          EnrollmentID: enrollment.EnrollmentID,
+          DataCollectionStage: 5,
+        )
+        expect(annual.count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 5: Linked Record Builders

## Summary

Adds the four linked-record builders that fill in the enrollment-adjacent HMIS data: income/benefits, disabilities, health and domestic violence, and current living situation. Also adds annual assessment collection with configurable jitter and miss rate. After this phase, a simulated enrollment has the full set of HUD records needed for reports like the APR and LSA to produce meaningful output.

Builds on Phase 4 (primary enrollment engine).

## What's in this PR

### `HmisSimulation::Builders::IncomeBenefitBuilder`

Creates `Hmis::Hud::IncomeBenefit` records at three lifecycle stages:
- **Entry** (`DataCollectionStage: 1`) — called when an enrollment opens
- **Annual** (`DataCollectionStage: 5`) — called by `tick_annual_collections`
- **Exit** (`DataCollectionStage: 3`) — called when an enrollment closes

Income determination: if `no_income_probability` fires → `IncomeFromAnySource: 0`. Otherwise, one income source is sampled from the weighted `sources` map (ssi, ssdi, earned, ga, tanf, unemployment) and a plausible monthly amount is generated.

### `HmisSimulation::Builders::DisabilityBuilder`

Creates one `Hmis::Hud::Disability` record per configured disability type at enrollment entry (`DataCollectionStage: 1`). Configured types map to HUD integer codes (mental_health→9, substance_use→10, chronic_health→7, physical→5, developmental→6, hiv_aids→8).

`IndefiniteAndImpairs` is set to nil for developmental (6) and HIV/AIDS (8) per HUD spec; for other types it is 0 or 1 based on the overall disabling condition roll. The builder returns `{ disabling_condition: 0|1 }` which the engine uses to update `Enrollment.DisablingCondition` (correcting the initial 99 placeholder).

### `HmisSimulation::Builders::HealthAndDvBuilder`

Creates one `Hmis::Hud::HealthAndDv` record at enrollment entry. Samples:
- `DomesticViolenceSurvivor` from `dv_survivor_probability`
- `CurrentlyFleeing` from `currently_fleeing_probability` (only if DV survivor)
- `GeneralHealthStatus` from weighted `general_health` distribution (excellent/good/fair/poor → HUD 1/2/3/4)

### `HmisSimulation::Builders::ClsBuilder`

Creates `Hmis::Hud::CurrentLivingSituation` records. Called at enrollment entry for street and shelter populations (ES→101, SO→116). Designed to be called periodically for ongoing enrollments in future phases.

### Annual collection tick (`Engine#tick_annual_collections`)

Runs each day as part of `Engine#run`. For every active enrollment:
1. Determines whether the current date is the expected annual assessment date (entry date + 365n days ± jitter drawn from `annual_collection.timing_jitter`)
2. Rolls `annual_collection.miss_rate` — if true, skips this year's collection
3. Creates an annual `IncomeBenefit` (`DataCollectionStage: 5`)

The jitter and miss rate are both configurable from the simulation JSON config. The expected date is deterministically seeded per enrollment and year number, so the same simulation always produces the same collection schedule.

### Engine wiring

- `process_primary_entry` now calls `create_linked_entry_records` after creating an enrollment, which invokes DisabilityBuilder (and updates `DisablingCondition`), IncomeBenefitBuilder (entry), HealthAndDvBuilder, and ClsBuilder for applicable project types.
- `process_primary_exit` now calls `create_linked_exit_records`, which creates an exit-stage IncomeBenefit.

## Extensibility

The `annual_collection` config key and the `tick_annual_collections` method are designed generically — adding `EmploymentEducation`, `Assessment`, or other annually-collected record types means adding a builder class and a single call inside `tick_annual_collections`. No structural changes needed.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
