### PR TITLE
HMIS Simulation Engine - Concurrent Enrollments

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/concurrent_enrollment_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/concurrent_enrollment_builder.rb
@@ -1,0 +1,98 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates concurrent (overlapping) enrollments for a client alongside their
+    # primary enrollment. Typical use cases: Street Outreach contacts, Services Only
+    # case management that runs parallel to housing enrollments.
+    #
+    # For each slot (0..count-1):
+    #   - Picks a project from projects_config weighted by selection_weight
+    #   - Creates Hmis::Hud::Enrollment in that project
+    #   - Samples the duration distribution → sets exit_on on the state record
+    #   - Creates HmisSimulation::ConcurrentEnrollment state record
+    class ConcurrentEnrollmentBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      def initialize(client:, date:, projects_config:, count:, coc_code:, data_source:, user_id:, rng_seed:)
+        @client   = client
+        @date     = date
+        @projects = (projects_config || []).map(&:deep_stringify_keys)
+        @count    = count.to_i
+        @coc_code = coc_code
+        @ds       = data_source
+        @uid      = user_id
+        @rng_seed = rng_seed
+      end
+
+      def build!
+        return if @count.zero? || @projects.empty?
+
+        @count.times do |slot|
+          proj_cfg = pick_project(slot)
+          next unless proj_cfg
+
+          project = find_project(proj_cfg['name'])
+          next unless project
+
+          enrollment = create_enrollment(project)
+          duration   = sample_duration(proj_cfg, slot)
+
+          ConcurrentEnrollment.create!(
+            data_source_id: @ds.id,
+            hud_client_id: @client.id,
+            hud_enrollment_id: enrollment.id,
+            project_name: proj_cfg['name'],
+            exit_on: @date + duration,
+          )
+        end
+      end
+
+      private
+
+      def pick_project(slot)
+        return @projects.first if @projects.size == 1
+
+        weights = @projects.each_with_object({}) { |p, h| h[p['name']] = p['selection_weight'].to_f }
+        cfg = { 'distribution' => 'weighted', 'weights' => weights }
+        name = Distribution.sample(cfg, rng: Random.new(@rng_seed + slot))
+        @projects.find { |p| p['name'] == name }
+      end
+
+      def find_project(name)
+        Hmis::Hud::Project.find_by(data_source_id: @ds.id, ProjectName: name)
+      end
+
+      def create_enrollment(project)
+        Hmis::Hud::Enrollment.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @date.to_datetime,
+          DateUpdated: @date.to_datetime,
+          EnrollmentID: FakeIdentifier.uuid,
+          PersonalID: @client.PersonalID,
+          project_pk: project.id,
+          HouseholdID: FakeIdentifier.uuid,
+          EntryDate: @date,
+          RelationshipToHoH: 1,
+          DisablingCondition: 99,
+          LivingSituation: 116,
+          EnrollmentCoC: @coc_code,
+        )
+      end
+
+      def sample_duration(proj_cfg, slot)
+        duration_cfg = proj_cfg['duration'] || { 'distribution' => 'constant', 'value' => 30 }
+        raw = Distribution.sample(duration_cfg.deep_stringify_keys, rng: Random.new(@rng_seed + slot + 100))
+        [raw.ceil, 1].max
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -50,6 +50,7 @@ module HmisSimulation
           spawn_clients(date: date)
           tick_primary(date: date)
           tick_annual_collections(date: date)
+          tick_concurrent(date: date)
 
           log.update!(
             clients_created: @clients_created,
@@ -202,6 +203,7 @@ module HmisSimulation
 
       @enrollments_opened += 1
       create_linked_entry_records(result[:hoh_enrollment], date, data_source: data_source, user_id: user_id, sim_client: sim_client)
+      assign_concurrent_enrollments(sim_client, date, data_source: data_source, user_id: user_id)
 
       # Pre-select the outgoing transition and sample enrollment length
       next_pop, timing = sample_enrollment_exit(sim_client.current_population, date, sim_client.id)
@@ -352,6 +354,141 @@ module HmisSimulation
       when 1, 0 then 101  # Emergency shelter
       when 4    then 116  # Street outreach
       end
+    end
+
+    # -- Concurrent enrollment tick --
+
+    def tick_concurrent(date:)
+      concurrent_cfg = @config['concurrent_enrollments']
+      return unless concurrent_cfg.present?
+
+      data_source = GrdaWarehouse::DataSource.find(@data_source_id)
+      user_id     = Hmis::Hud::User.system_user(data_source_id: @data_source_id).user_id
+      coc_code    = @config.dig('coc_codes', 'primary') || 'XX-500'
+
+      # Close expired concurrent enrollments
+      ConcurrentEnrollment.expiring_on(date).where(data_source_id: @data_source_id).find_each do |concurrent_enrollment|
+        close_concurrent_enrollment(concurrent_enrollment, date, data_source: data_source, user_id: user_id,
+                                                                 projects_cfg: concurrent_cfg['projects'] || [])
+      end
+
+      # Open reentries due today
+      ConcurrentEnrollment.pending_reentry_on(date).where(data_source_id: @data_source_id).find_each do |concurrent_enrollment|
+        open_concurrent_reentry(concurrent_enrollment, date, user_id: user_id, coc_code: coc_code,
+                                                             projects_cfg: concurrent_cfg['projects'] || [])
+      end
+    end
+
+    def assign_concurrent_enrollments(sim_client, date, data_source:, user_id:)
+      concurrent_cfg = @config['concurrent_enrollments']
+      return unless concurrent_cfg.present?
+
+      projects_cfg    = concurrent_cfg['projects'] || []
+      count_dist_cfg  = concurrent_cfg['count_distribution'] || { '0' => 1 }
+      data_error_rate = concurrent_cfg['data_error_rate'].to_f
+      coc_code        = @config.dig('coc_codes', 'primary') || 'XX-500'
+
+      normalized_weights = count_dist_cfg.transform_values(&:to_f)
+      cfg    = { 'distribution' => 'weighted', 'weights' => normalized_weights }
+      rng    = Random.new(@seed + "concurrent_count:#{sim_client.id}".hash)
+      count  = Distribution.sample(cfg, rng: rng).to_i
+
+      effective_projects = apply_data_error_rate(projects_cfg, sim_client, data_error_rate)
+
+      Builders::ConcurrentEnrollmentBuilder.new(
+        client: Hmis::Hud::Client.find(sim_client.hud_client_id),
+        date: date,
+        projects_config: effective_projects,
+        count: count,
+        coc_code: coc_code,
+        data_source: data_source,
+        user_id: user_id,
+        rng_seed: @seed + "concurrent:#{sim_client.id}:#{date}".hash,
+      ).build!
+    end
+
+    def close_concurrent_enrollment(concurrent_enrollment, date, data_source:, user_id:, projects_cfg:)
+      enrollment = Hmis::Hud::Enrollment.find_by(id: concurrent_enrollment.hud_enrollment_id)
+      return unless enrollment
+
+      Builders::ExitBuilder.new(
+        enrollment: enrollment,
+        exit_date: date,
+        exit_destinations: { '116' => 1.0 },
+        data_source: data_source,
+        user_id: user_id,
+        seed: @seed,
+        context_prefix: "concurrent_exit:#{concurrent_enrollment.id}:#{date}",
+      ).build!
+
+      proj_cfg = projects_cfg.find { |p| p['name'] == concurrent_enrollment.project_name }
+      reentry  = schedule_concurrent_reentry(concurrent_enrollment, date, proj_cfg)
+
+      concurrent_enrollment.update!(hud_enrollment_id: nil, exit_on: nil, pending_reentry_on: reentry)
+    end
+
+    def open_concurrent_reentry(concurrent_enrollment, date, user_id:, coc_code:, projects_cfg:)
+      proj_cfg = projects_cfg.find { |p| p['name'] == concurrent_enrollment.project_name }
+      return unless proj_cfg
+
+      project = Hmis::Hud::Project.find_by(data_source_id: @data_source_id, ProjectName: concurrent_enrollment.project_name)
+      return unless project
+
+      client = Hmis::Hud::Client.find_by(id: concurrent_enrollment.hud_client_id)
+      return unless client
+
+      enrollment = Hmis::Hud::Enrollment.create!(
+        data_source_id: @data_source_id,
+        UserID: user_id,
+        ExportID: Bootstrapper::EXPORT_ID,
+        DateCreated: date.to_datetime,
+        DateUpdated: date.to_datetime,
+        EnrollmentID: FakeIdentifier.uuid,
+        PersonalID: client.PersonalID,
+        project_pk: project.id,
+        HouseholdID: FakeIdentifier.uuid,
+        EntryDate: date,
+        RelationshipToHoH: 1,
+        DisablingCondition: 99,
+        LivingSituation: 116,
+        EnrollmentCoC: coc_code,
+      )
+
+      duration_cfg = (proj_cfg['duration'] || { 'distribution' => 'constant', 'value' => 30 }).deep_stringify_keys
+      duration = Distribution.sample(duration_cfg, rng: Random.new(@seed + "concurrent_reentry_dur:#{concurrent_enrollment.id}:#{date}".hash)).ceil.clamp(1, 365)
+
+      concurrent_enrollment.update!(hud_enrollment_id: enrollment.id, exit_on: date + duration, pending_reentry_on: nil)
+    end
+
+    def schedule_concurrent_reentry(concurrent_enrollment, exit_date, proj_cfg)
+      return nil unless proj_cfg
+
+      prob = proj_cfg['reentry_probability'].to_f
+      return nil if Random.new(@seed + "reentry_prob:#{concurrent_enrollment.id}".hash).rand >= prob
+
+      gap_cfg  = (proj_cfg['gap_before_reentry'] || { 'distribution' => 'constant', 'value' => 7 }).deep_stringify_keys
+      gap_days = Distribution.sample(gap_cfg, rng: Random.new(@seed + "reentry_gap:#{concurrent_enrollment.id}".hash)).ceil.clamp(0, 365)
+      exit_date + gap_days
+    end
+
+    def apply_data_error_rate(projects_cfg, sim_client, data_error_rate)
+      return projects_cfg if data_error_rate.zero?
+      return projects_cfg unless Random.new(@seed + "data_error:#{sim_client.id}".hash).rand < data_error_rate
+
+      # Data error: introduce an enrollment in a project type matching the primary
+      primary_enrollment = Hmis::Hud::Enrollment.find_by(id: sim_client.hud_enrollment_id)
+      return projects_cfg unless primary_enrollment
+
+      same_type_project = Hmis::Hud::Project.
+        where(data_source_id: @data_source_id, ProjectType: primary_enrollment.project&.ProjectType).
+        where.not(id: primary_enrollment.project_pk).
+        first
+      return projects_cfg unless same_type_project
+
+      error_entry = { 'name' => same_type_project.ProjectName, 'project_type' => same_type_project.ProjectType,
+                      'selection_weight' => 1.0, 'duration' => { 'distribution' => 'constant', 'value' => 30 },
+                      'gap_before_reentry' => { 'distribution' => 'constant', 'value' => 7 }, 'reentry_probability' => 0.0 }
+      [error_entry]
     end
 
     # -- Transition helpers --

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/concurrent_enrollment_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/concurrent_enrollment_builder_spec.rb
@@ -1,0 +1,99 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::ConcurrentEnrollmentBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)    { Date.current - 5 }
+  let(:client)  { create(:hmis_hud_client, data_source: data_source) }
+  let(:so_project) { create(:hmis_hud_project, data_source: data_source, ProjectType: 4) }
+
+  let(:concurrent_projects_config) do
+    [
+      {
+        'name' => so_project.ProjectName,
+        'project_type' => 4,
+        'selection_weight' => 1.0,
+        'duration' => { 'distribution' => 'constant', 'value' => 30 },
+        'gap_before_reentry' => { 'distribution' => 'constant', 'value' => 7 },
+        'reentry_probability' => 0.8,
+      },
+    ]
+  end
+
+  def build(rng_seed: 42)
+    described_class.new(
+      client: client,
+      date: date,
+      projects_config: concurrent_projects_config,
+      count: 1,
+      coc_code: 'XX-500',
+      data_source: data_source,
+      user_id: user_id,
+      rng_seed: rng_seed,
+    ).build!
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::Enrollment for the concurrent project' do
+      expect { build }.to change { Hmis::Hud::Enrollment.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'creates an HmisSimulation::ConcurrentEnrollment state record' do
+      expect { build }.to change { HmisSimulation::ConcurrentEnrollment.where(data_source_id: data_source.id).count }.by(1)
+    end
+
+    it 'uses a FAKE EnrollmentID' do
+      build
+      enrollment = Hmis::Hud::Enrollment.where(data_source: data_source).last
+      expect(enrollment.EnrollmentID).to start_with('FAKE')
+    end
+
+    it 'sets EntryDate to the given date' do
+      build
+      enrollment = Hmis::Hud::Enrollment.where(data_source: data_source).last
+      expect(enrollment.EntryDate).to eq(date)
+    end
+
+    it 'links the state record to the correct client' do
+      build
+      state = HmisSimulation::ConcurrentEnrollment.find_by(
+        data_source_id: data_source.id,
+        hud_client_id: client.id,
+      )
+      expect(state).to be_present
+    end
+
+    it 'sets exit_on based on the duration distribution' do
+      build
+      state = HmisSimulation::ConcurrentEnrollment.where(data_source_id: data_source.id).last
+      expect(state.exit_on).to eq(date + 30)
+    end
+
+    it 'stores the project name on the state record' do
+      build
+      state = HmisSimulation::ConcurrentEnrollment.where(data_source_id: data_source.id).last
+      expect(state.project_name).to eq(so_project.ProjectName)
+    end
+
+    context 'when count is 0' do
+      it 'creates no records' do
+        described_class.new(
+          client: client, date: date, projects_config: concurrent_projects_config,
+          count: 0, coc_code: 'XX-500', data_source: data_source, user_id: user_id, rng_seed: 42
+        ).build!
+        expect(HmisSimulation::ConcurrentEnrollment.where(data_source_id: data_source.id).count).to eq(0)
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -237,6 +237,79 @@ RSpec.describe HmisSimulation::Engine do
       end
     end
 
+    context 'concurrent enrollments' do
+      # Config with concurrent enrollments guaranteed on every client (count=1 always)
+      let(:base_config_with_concurrent) do
+        base_config.deep_dup.tap do |c|
+          c['organizations'].first['projects'] << {
+            'name' => 'Concurrent SO_', 'project_type' => 4
+          }
+          c['concurrent_enrollments'] = {
+            'count_distribution' => { '1' => 1 },
+            'data_error_rate' => 0.0,
+            'projects' => [
+              {
+                'name' => 'Concurrent SO_',
+                'project_type' => 4,
+                'selection_weight' => 1,
+                'duration' => { 'distribution' => 'constant', 'value' => 2 },
+                'gap_before_reentry' => { 'distribution' => 'constant', 'value' => 1 },
+                'reentry_probability' => 1.0,
+              },
+            ],
+          }
+        end
+      end
+      let(:concurrent_config) { HmisSimulation::ConfigLoader.send(:normalize, base_config_with_concurrent) }
+
+      before do
+        HmisSimulation::Bootstrapper.new(concurrent_config).run!
+      end
+
+      it 'assigns concurrent enrollments when a primary enrollment opens' do
+        described_class.new(concurrent_config).run(date: run_date)
+        expect(HmisSimulation::ConcurrentEnrollment.where(data_source_id: data_source.id).count).to be > 0
+      end
+
+      it 'closes concurrent enrollments when exit_on fires' do
+        e = described_class.new(concurrent_config)
+        e.run(date: run_date)
+
+        # concurrent enrollment duration = 2 days, so it expires on run_date + 2
+        e.run(date: run_date + 1)
+        e.run(date: run_date + 2)
+
+        exits = Hmis::Hud::Exit.where(data_source: data_source)
+        # At least some concurrent exits should have been created
+        expect(exits.count).to be > 0
+      end
+
+      it 'schedules reentry when reentry_probability = 1.0' do
+        e = described_class.new(concurrent_config)
+        e.run(date: run_date)
+
+        # Duration=2, so expires on run_date+2
+        e.run(date: run_date + 1)
+        e.run(date: run_date + 2)
+
+        # With reentry_probability=1.0, all expired concurrent enrollments should have pending_reentry_on set
+        expired = HmisSimulation::ConcurrentEnrollment.
+          where(data_source_id: data_source.id).
+          where.not(pending_reentry_on: nil)
+        expect(expired.count).to be > 0
+      end
+
+      it 'opens reentry enrollments when pending_reentry_on fires' do
+        e = described_class.new(concurrent_config)
+        e.run(date: run_date)       # spawns clients, creates concurrent enrollments (exit_on = run_date+2)
+        e.run(date: run_date + 2)   # expires concurrent, schedules reentry on run_date+3
+        enrollment_count = Hmis::Hud::Enrollment.where(data_source: data_source).count
+
+        e.run(date: run_date + 3)   # reentry fires, opens new concurrent enrollment
+        expect(Hmis::Hud::Enrollment.where(data_source: data_source).count).to be > enrollment_count
+      end
+    end
+
     context 'annual collection' do
       it 'creates annual IncomeBenefit records for enrollments near their anniversary' do
         # Create an enrollment that is exactly 365 days old so annual collection fires today


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 6: Concurrent Enrollments

## Summary

Adds support for concurrent (overlapping) enrollments — Street Outreach contacts, Services Only case management, and similar programs that run in parallel with a client's primary housing journey. After this phase, the simulation produces the realistic multi-enrollment patterns that reports like the APR and LSA expect to see.

Builds on Phase 5 (linked record builders, annual collection).

## What's in this PR

### `HmisSimulation::Builders::ConcurrentEnrollmentBuilder`

Creates concurrent enrollments for a single client. For each slot (0..count-1):

1. Picks a project from `concurrent_enrollments.projects` weighted by `selection_weight`
2. Creates `Hmis::Hud::Enrollment` in that project (separate HouseholdID, RelationshipToHoH: 1)
3. Samples the `duration` distribution → computes `exit_on`
4. Creates an `HmisSimulation::ConcurrentEnrollment` state record linking the HUD enrollment to the client

Count is drawn from `count_distribution` (weighted map of "0"→weight, "1"→weight, etc.) and represents *additional* enrollments beyond the primary.

### `Engine#tick_concurrent`

Runs each day after `tick_primary` and `tick_annual_collections`:

**Expire** — find `ConcurrentEnrollment` where `exit_on = date`:
1. Create `Exit` record (destination 116 — place not meant for habitation)
2. Roll `reentry_probability` → if passes, sample `gap_before_reentry` → set `pending_reentry_on`

**Reopen** — find `ConcurrentEnrollment` where `pending_reentry_on = date`:
1. Create new `Hmis::Hud::Enrollment` in the same project
2. Sample new `duration` → set new `exit_on`

### `assign_concurrent_enrollments`

Called from `process_primary_entry` when a client's primary enrollment opens. Rolls `count_distribution`, picks concurrent projects, and calls `ConcurrentEnrollmentBuilder`. Also applies `data_error_rate`: at the configured probability, one concurrent slot is deliberately assigned a project of the same type as the primary enrollment (e.g., two overlapping PSH enrollments), introducing realistic data quality issues for report validation.

## Example config section

```json
"concurrent_enrollments": {
  "count_distribution": { "0": 55, "1": 30, "2": 12, "3": 3 },
  "data_error_rate": 0.01,
  "projects": [
    {
      "name": "Street Outreach Team_",
      "project_type": 4,
      "selection_weight": 45,
      "duration": { "distribution": "uniform", "min": 14, "max": 120 },
      "gap_before_reentry": { "distribution": "uniform", "min": 0, "max": 30 },
      "reentry_probability": 0.7
    }
  ]
}
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
