### PR TITLE
Add alias and nil-default specs for HispanicLatinaeo/HispanicLatinao

### DIFF
--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/client_overrides_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/exporter/client_overrides_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe HmisCsvTwentyTwentySix::Exporter::Client::Overrides, type: :model
       expect(client[:HispanicLatinaeo]).to eq(1)
       expect(client[:White]).to eq(0)
     end
+
+    it 'HispanicLatinao (FY2026 name) reflects HispanicLatinaeo (DB column) via alias' do
+      # alias_attribute bridges the DB column name to the FY2026 spec name so the CSV
+      # export can read the value without a separate rename step.
+      expect(client[:HispanicLatinao]).to be nil
+      expect(client[:HispanicLatinaeo]).to be nil
+      client[:HispanicLatinaeo] = 0
+      expect(client[:HispanicLatinao]).to eq(0)
+      expect(client[:HispanicLatinaeo]).to eq(0)
+      client[:HispanicLatinaeo] = 1
+      expect(client[:HispanicLatinao]).to eq(1)
+      expect(client[:HispanicLatinaeo]).to eq(1)
+      client[:HispanicLatinaeo] = nil
+      expect(client[:HispanicLatinao]).to be nil
+      expect(client[:HispanicLatinaeo]).to be nil
+    end
   end
 
   describe '.enforce_race_none' do
@@ -62,6 +78,14 @@ RSpec.describe HmisCsvTwentyTwentySix::Exporter::Client::Overrides, type: :model
       described_class.apply_overrides(client, export: export)
       expect(client[:HispanicLatinaeo]).to eq(1)
       expect(client.RaceNone).to be_nil
+    end
+
+    it 'defaults nil HispanicLatinaeo to 0, readable via both column names' do
+      # If HispanicLatinaeo is nil, both column names read as 0 after overrides are applied.
+      client[:HispanicLatinaeo] = nil
+      described_class.apply_overrides(client, export: export)
+      expect(client[:HispanicLatinaeo]).to eq(0)
+      expect(client[:HispanicLatinao]).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds two specs to `client_overrides_spec.rb` addressing review feedback on #6553.

The first test directly exercises the `alias_attribute` that bridges `HispanicLatinaeo` (the DB column, unchanged for backward compatibility) to `HispanicLatinao` (the FY2026 HUD spec name). It verifies that assigning via either name is reflected by both, including nil round-trips.

The second test covers the nil-default path end-to-end through `apply_overrides`: when `HispanicLatinaeo` is nil, `enforce_required_fields` defaults it to `0`, and that value is readable under both the DB column name and the FY2026 spec name. This is the regression scenario that caused NOT NULL violations in the LSA SQL Server import.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record) 
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
