### PR TITLE
HMIS Simulation Engine - Lifecycle Enrollments

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/enrollment_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/enrollment_builder.rb
@@ -20,6 +20,9 @@ module HmisSimulation
     class EnrollmentBuilder
       EXPORT_ID = Bootstrapper::EXPORT_ID
 
+      # Project types that receive a MoveInDate on enrollment entry
+      PH_PROJECT_TYPES = [3, 9, 10, 13].freeze
+
       # rng_seed: pre-computed integer seed for cohesion probability rolls.
       # Callers derive it as: simulation_seed + "entry:#{date}:#{client_id}".hash
       def initialize(
@@ -73,6 +76,7 @@ module HmisSimulation
           project_pk: @project.id,
           HouseholdID: @household_id,
           EntryDate: @entry_date,
+          MoveInDate: (PH_PROJECT_TYPES.include?(@project.ProjectType) ? @entry_date : nil),
           RelationshipToHoH: relationship_to_hoh,
           DisablingCondition: 99,
           LivingSituation: 116,

--- a/drivers/hmis_simulation/app/models/hmis_simulation/builders/lifecycle_enrollment_builder.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/builders/lifecycle_enrollment_builder.rb
@@ -1,0 +1,60 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  module Builders
+    # Creates the Coordinated Entry (or other lifecycle-type) enrollment and
+    # corresponding HmisSimulation::LifecycleEnrollment state record.
+    #
+    # Lifecycle enrollments are condition-triggered (not timed):
+    #   - Opens when a client enters a trigger_population
+    #   - EntryDate may be backdated by days_before_trigger
+    #   - Closes on housing_move_in, disengagement timeout, or pre_entry_exit
+    class LifecycleEnrollmentBuilder
+      EXPORT_ID = Bootstrapper::EXPORT_ID
+
+      def initialize(client:, lifecycle_name:, ce_project:, opens_on:, coc_code:, data_source:, user_id:)
+        @client         = client
+        @lifecycle_name = lifecycle_name
+        @project        = ce_project
+        @opens_on       = opens_on
+        @coc_code       = coc_code
+        @ds             = data_source
+        @uid            = user_id
+      end
+
+      def build!
+        enrollment = Hmis::Hud::Enrollment.create!(
+          data_source_id: @ds.id,
+          UserID: @uid,
+          ExportID: EXPORT_ID,
+          DateCreated: @opens_on.to_datetime,
+          DateUpdated: @opens_on.to_datetime,
+          EnrollmentID: FakeIdentifier.uuid,
+          PersonalID: @client.PersonalID,
+          project_pk: @project.id,
+          HouseholdID: FakeIdentifier.uuid,
+          EntryDate: @opens_on,
+          RelationshipToHoH: 1,
+          DisablingCondition: 99,
+          LivingSituation: 116,
+          EnrollmentCoC: @coc_code,
+        )
+
+        LifecycleEnrollment.create!(
+          data_source_id: @ds.id,
+          hud_client_id: @client.id,
+          hud_enrollment_id: enrollment.id,
+          lifecycle_name: @lifecycle_name,
+          status: 'open',
+          opens_on: @opens_on,
+        )
+      end
+    end
+  end
+end

--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -51,6 +51,7 @@ module HmisSimulation
           tick_primary(date: date)
           tick_annual_collections(date: date)
           tick_concurrent(date: date)
+          tick_lifecycle(date: date)
 
           log.update!(
             clients_created: @clients_created,
@@ -204,6 +205,7 @@ module HmisSimulation
       @enrollments_opened += 1
       create_linked_entry_records(result[:hoh_enrollment], date, data_source: data_source, user_id: user_id, sim_client: sim_client)
       assign_concurrent_enrollments(sim_client, date, data_source: data_source, user_id: user_id)
+      trigger_lifecycle_enrollments(sim_client, date, data_source: data_source, user_id: user_id)
 
       # Pre-select the outgoing transition and sample enrollment length
       next_pop, timing = sample_enrollment_exit(sim_client.current_population, date, sim_client.id)
@@ -489,6 +491,147 @@ module HmisSimulation
                       'selection_weight' => 1.0, 'duration' => { 'distribution' => 'constant', 'value' => 30 },
                       'gap_before_reentry' => { 'distribution' => 'constant', 'value' => 7 }, 'reentry_probability' => 0.0 }
       [error_entry]
+    end
+
+    # -- Lifecycle enrollment tick (CE) --
+
+    def tick_lifecycle(date:)
+      lifecycle_cfgs = @config['lifecycle_enrollments']
+      return unless lifecycle_cfgs.present?
+
+      data_source = GrdaWarehouse::DataSource.find(@data_source_id)
+      user_id     = Hmis::Hud::User.system_user(data_source_id: @data_source_id).user_id
+
+      LifecycleEnrollment.
+        where(data_source_id: @data_source_id, status: 'open').
+        find_each do |lifecycle_enrollment|
+          process_lifecycle_close_conditions(lifecycle_enrollment, date, data_source: data_source, user_id: user_id, lifecycle_cfgs: lifecycle_cfgs)
+        end
+    end
+
+    def trigger_lifecycle_enrollments(sim_client, entry_date, data_source:, user_id:)
+      lifecycle_cfgs = @config['lifecycle_enrollments']
+      return unless lifecycle_cfgs.present?
+
+      coc_code = @config.dig('coc_codes', 'primary') || 'XX-500'
+
+      lifecycle_cfgs.each_with_index do |lc_cfg, idx|
+        trigger_populations = lc_cfg['trigger_populations'] || []
+        next unless trigger_populations.include?(sim_client.current_population)
+
+        # Skip if this client already has an open lifecycle enrollment of this type
+        next if LifecycleEnrollment.where(
+          data_source_id: @data_source_id,
+          hud_client_id: sim_client.hud_client_id,
+          lifecycle_name: lc_cfg['name'],
+          status: 'open',
+        ).exists?
+
+        rng = Random.new(@seed + "lifecycle_trigger:#{lc_cfg['name']}:#{sim_client.id}:#{idx}".hash)
+        next if rng.rand >= lc_cfg['trigger_probability'].to_f
+
+        gap_cfg   = (lc_cfg['days_before_trigger'] || { 'distribution' => 'constant', 'value' => 0 }).deep_stringify_keys
+        gap_days  = Distribution.sample(gap_cfg, rng: Random.new(@seed + "lifecycle_gap:#{sim_client.id}:#{idx}".hash)).ceil.clamp(0, 365)
+        opens_on  = entry_date - gap_days
+
+        project_ref = lc_cfg['project_ref']
+        ce_project  = Hmis::Hud::Project.find_by(data_source_id: @data_source_id, ProjectName: project_ref)
+        next unless ce_project
+
+        client = Hmis::Hud::Client.find_by(id: sim_client.hud_client_id)
+        next unless client
+
+        Builders::LifecycleEnrollmentBuilder.new(
+          client: client,
+          lifecycle_name: lc_cfg['name'],
+          ce_project: ce_project,
+          opens_on: opens_on,
+          coc_code: coc_code,
+          data_source: data_source,
+          user_id: user_id,
+        ).build!
+      end
+    end
+
+    def process_lifecycle_close_conditions(lifecycle_enrollment, date, data_source:, user_id:, lifecycle_cfgs:)
+      lc_cfg = lifecycle_cfgs.find { |c| c['name'] == lifecycle_enrollment.lifecycle_name }
+      return unless lc_cfg
+
+      close_conditions = lc_cfg['close_conditions'] || {}
+
+      # housing_move_in: check if any primary enrollment for this client has a MoveInDate
+      if check_housing_move_in?(lifecycle_enrollment, close_conditions)
+        close_lifecycle_enrollment(lifecycle_enrollment, date, reason: 'housing_move_in', data_source: data_source, user_id: user_id)
+        return
+      end
+
+      # disengagement: fires after a timeout from opens_on
+      if check_disengagement?(lifecycle_enrollment, date, close_conditions)
+        close_lifecycle_enrollment(lifecycle_enrollment, date, reason: 'disengagement', data_source: data_source, user_id: user_id)
+        return
+      end
+
+      # pre_entry_exit: fires after a shorter timeout, client may not have a primary enrollment
+      return unless check_pre_entry_exit?(lifecycle_enrollment, date, close_conditions)
+
+      close_lifecycle_enrollment(lifecycle_enrollment, date, reason: 'pre_entry_exit', data_source: data_source, user_id: user_id)
+    end
+
+    def check_housing_move_in?(lifecycle_enrollment, close_conditions)
+      return false unless close_conditions.key?('housing_move_in')
+
+      rng = Random.new(@seed + "lc_housing_move_in:#{lifecycle_enrollment.id}".hash)
+      return false if rng.rand >= close_conditions['housing_move_in'].to_f
+
+      Hmis::Hud::Enrollment.
+        where(data_source_id: @data_source_id, PersonalID: hmis_personal_id_for(lifecycle_enrollment)).
+        where.not(MoveInDate: nil).
+        exists?
+    end
+
+    def check_disengagement?(lifecycle_enrollment, date, close_conditions)
+      disengage_cfg = close_conditions['disengagement']
+      return false unless disengage_cfg.present?
+
+      rng = Random.new(@seed + "lc_disengage_prob:#{lifecycle_enrollment.id}".hash)
+      return false if rng.rand >= disengage_cfg['probability'].to_f
+
+      after_days_cfg = (disengage_cfg['after_days'] || { 'distribution' => 'constant', 'value' => 365 }).deep_stringify_keys
+      after_days = Distribution.sample(after_days_cfg, rng: Random.new(@seed + "lc_disengage_days:#{lifecycle_enrollment.id}".hash)).ceil
+      date >= lifecycle_enrollment.opens_on + after_days
+    end
+
+    def check_pre_entry_exit?(lifecycle_enrollment, date, close_conditions)
+      pre_cfg = close_conditions['pre_entry_exit']
+      return false unless pre_cfg.present?
+
+      rng = Random.new(@seed + "lc_pre_exit_prob:#{lifecycle_enrollment.id}".hash)
+      return false if rng.rand >= pre_cfg['probability'].to_f
+
+      after_days_cfg = (pre_cfg['after_days'] || { 'distribution' => 'constant', 'value' => 30 }).deep_stringify_keys
+      after_days = Distribution.sample(after_days_cfg, rng: Random.new(@seed + "lc_pre_exit_days:#{lifecycle_enrollment.id}".hash)).ceil
+      date >= lifecycle_enrollment.opens_on + after_days
+    end
+
+    def close_lifecycle_enrollment(lifecycle_enrollment, date, reason:, data_source:, user_id:)
+      enrollment = Hmis::Hud::Enrollment.find_by(id: lifecycle_enrollment.hud_enrollment_id)
+      if enrollment
+        Builders::ExitBuilder.new(
+          enrollment: enrollment,
+          exit_date: date,
+          exit_destinations: { '116' => 1.0 },
+          data_source: data_source,
+          user_id: user_id,
+          seed: @seed,
+          context_prefix: "lifecycle_exit:#{lifecycle_enrollment.id}:#{date}",
+        ).build!
+      end
+
+      lifecycle_enrollment.update!(status: 'closed', close_reason: reason)
+    end
+
+    def hmis_personal_id_for(lifecycle_enrollment)
+      Hmis::Hud::Client.find_by(id: lifecycle_enrollment.hud_client_id)&.PersonalID
     end
 
     # -- Transition helpers --

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/builders/lifecycle_enrollment_builder_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/builders/lifecycle_enrollment_builder_spec.rb
@@ -1,0 +1,75 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::Builders::LifecycleEnrollmentBuilder do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:user_id) do
+    User.setup_system_user
+    Hmis::Hud::User.system_user(data_source_id: data_source.id).user_id
+  end
+  let(:date)      { Date.current - 5 }
+  let(:opens_on)  { date - 3 }
+  let(:client)    { create(:hmis_hud_client, data_source: data_source) }
+  let(:ce_project) { create(:hmis_hud_project, data_source: data_source, ProjectType: 14) }
+
+  subject(:builder) do
+    described_class.new(
+      client: client,
+      lifecycle_name: 'ce',
+      ce_project: ce_project,
+      opens_on: opens_on,
+      coc_code: 'XX-500',
+      data_source: data_source,
+      user_id: user_id,
+    )
+  end
+
+  describe '#build!' do
+    it 'creates an Hmis::Hud::Enrollment for the CE project' do
+      expect { builder.build! }.to change { Hmis::Hud::Enrollment.where(data_source: data_source).count }.by(1)
+    end
+
+    it 'creates an HmisSimulation::LifecycleEnrollment state record' do
+      expect { builder.build! }.to change { HmisSimulation::LifecycleEnrollment.where(data_source_id: data_source.id).count }.by(1)
+    end
+
+    it 'sets EntryDate to opens_on (backdated)' do
+      builder.build!
+      enrollment = Hmis::Hud::Enrollment.where(data_source: data_source).last
+      expect(enrollment.EntryDate).to eq(opens_on)
+    end
+
+    it 'uses a FAKE EnrollmentID' do
+      builder.build!
+      expect(Hmis::Hud::Enrollment.where(data_source: data_source).last.EnrollmentID).to start_with('FAKE')
+    end
+
+    it 'sets the lifecycle state to open' do
+      builder.build!
+      state = HmisSimulation::LifecycleEnrollment.find_by(
+        data_source_id: data_source.id,
+        hud_client_id: client.id,
+      )
+      expect(state.status).to eq('open')
+    end
+
+    it 'sets lifecycle_name on the state record' do
+      builder.build!
+      state = HmisSimulation::LifecycleEnrollment.find_by(data_source_id: data_source.id, hud_client_id: client.id)
+      expect(state.lifecycle_name).to eq('ce')
+    end
+
+    it 'sets opens_on on the state record' do
+      builder.build!
+      state = HmisSimulation::LifecycleEnrollment.find_by(data_source_id: data_source.id, hud_client_id: client.id)
+      expect(state.opens_on).to eq(opens_on)
+    end
+  end
+end

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -310,6 +310,105 @@ RSpec.describe HmisSimulation::Engine do
       end
     end
 
+    context 'lifecycle enrollments (CE)' do
+      let(:base_config_with_lifecycle) do
+        base_config.deep_dup.tap do |c|
+          c['organizations'].first['projects'] << { 'name' => 'CE Program_', 'project_type' => 14 }
+          c['lifecycle_enrollments'] = [
+            {
+              'name' => 'ce',
+              'label' => 'Coordinated Entry',
+              'project_ref' => 'CE Program_',
+              'trigger_populations' => ['street'],
+              'trigger_probability' => 1.0,
+              'days_before_trigger' => { 'distribution' => 'constant', 'value' => 0 },
+              'close_conditions' => {
+                'housing_move_in' => 0.5,
+                'disengagement' => {
+                  'probability' => 0.5,
+                  'after_days' => { 'distribution' => 'constant', 'value' => 1 },
+                },
+              },
+            },
+          ]
+        end
+      end
+      let(:lifecycle_config) { HmisSimulation::ConfigLoader.send(:normalize, base_config_with_lifecycle) }
+
+      before do
+        HmisSimulation::Bootstrapper.new(lifecycle_config).run!
+      end
+
+      it 'creates a CE LifecycleEnrollment when client enters a trigger population' do
+        described_class.new(lifecycle_config).run(date: run_date)
+        expect(HmisSimulation::LifecycleEnrollment.where(data_source_id: data_source.id, status: 'open').count).to be > 0
+      end
+
+      it 'does NOT create CE for populations not in trigger_populations' do
+        # Add a non-trigger population and a client in it
+        config = lifecycle_config.deep_dup
+        config['populations'].each { |p| p['entry_point'] = p['name'] == 'psh' ? 1 : 0 }
+        e = described_class.new(config)
+        e.run(date: run_date)
+        # psh is not a trigger_population, so no lifecycle enrollments
+        expect(HmisSimulation::LifecycleEnrollment.where(data_source_id: data_source.id).count).to eq(0)
+      end
+
+      it 'creates a CE HUD Enrollment linked to the CE project' do
+        described_class.new(lifecycle_config).run(date: run_date)
+        ce_project = Hmis::Hud::Project.find_by(data_source: data_source, ProjectName: 'CE Program_')
+        ce_enrollments = Hmis::Hud::Enrollment.where(data_source: data_source, project_pk: ce_project.id)
+        expect(ce_enrollments.count).to be > 0
+      end
+
+      it 'closes CE enrollment when primary enrollment has a MoveInDate (housing_move_in condition)' do
+        # Use a config where ALL CE close via housing_move_in
+        config = lifecycle_config.deep_dup
+        config['lifecycle_enrollments'].first['close_conditions'] = { 'housing_move_in' => 1.0 }
+
+        # And transitions lead to PSH (PH project type that gets MoveInDate)
+        config['transitions'] = [
+          { 'from' => 'street', 'to' => 'psh', 'weight' => 1,
+            'timing' => { 'distribution' => 'constant', 'value' => 1 },
+            'gap_before_entry' => { 'distribution' => 'constant', 'value' => 0 },
+            'exit_destinations' => { '435' => 1 } },
+        ]
+        cfg = HmisSimulation::ConfigLoader.send(:normalize, config)
+        HmisSimulation::Bootstrapper.new(cfg).run!
+        e = described_class.new(cfg)
+
+        e.run(date: run_date)     # spawn + primary enrollment (ES) + CE open
+        e.run(date: run_date + 1) # primary enrollment exits to PSH with MoveInDate
+
+        closed = HmisSimulation::LifecycleEnrollment.where(
+          data_source_id: data_source.id, status: 'closed', close_reason: 'housing_move_in',
+        )
+        expect(closed.count).to be > 0
+      end
+
+      it 'closes CE enrollment after disengagement timeout' do
+        # Config: only disengagement, 1-day timeout, probability=1.0
+        config = lifecycle_config.deep_dup
+        config['lifecycle_enrollments'].first['close_conditions'] = {
+          'disengagement' => {
+            'probability' => 1.0,
+            'after_days' => { 'distribution' => 'constant', 'value' => 1 },
+          },
+        }
+        cfg = HmisSimulation::ConfigLoader.send(:normalize, config)
+        HmisSimulation::Bootstrapper.new(cfg).run!
+        e = described_class.new(cfg)
+
+        e.run(date: run_date)     # CE opens
+        e.run(date: run_date + 1) # disengagement fires (opens_on + 1 = run_date + 1)
+
+        closed = HmisSimulation::LifecycleEnrollment.where(
+          data_source_id: data_source.id, status: 'closed', close_reason: 'disengagement',
+        )
+        expect(closed.count).to be > 0
+      end
+    end
+
     context 'annual collection' do
       it 'creates annual IncomeBenefit records for enrollments near their anniversary' do
         # Create an enrollment that is exactly 365 days old so annual collection fires today


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 7: CE Lifecycle Enrollments

## Summary

Adds Coordinated Entry (CE) lifecycle enrollments — the third and most complex enrollment track. CE enrollments span multiple primary enrollments, open when a client enters a trigger population, and close based on conditions rather than a timer. This phase completes the full enrollment model described in the design spec.

Builds on Phase 6 (concurrent enrollments, full engine tick).

## What's in this PR

### `HmisSimulation::Builders::LifecycleEnrollmentBuilder`

Creates a single CE `Hmis::Hud::Enrollment` (backdated to `opens_on`) and the corresponding `HmisSimulation::LifecycleEnrollment` state record (status: `open`). The builder is intentionally simple — all the trigger/close logic lives in the engine.

### `Engine#trigger_lifecycle_enrollments`

Called from `process_primary_entry` after the primary enrollment opens. For each lifecycle enrollment config:
1. Checks if `current_population` is in `trigger_populations`
2. Skips if client already has an open lifecycle enrollment of this type (prevents duplicates across re-enrollments)
3. Rolls `trigger_probability` — if passes, samples `days_before_trigger`, computes `opens_on = entry_date - gap`, calls `LifecycleEnrollmentBuilder`

The CE enrollment is backdated by `days_before_trigger` days — reflecting that a client may have engaged with CE before entering their first shelter bed.

### `Engine#tick_lifecycle`

Runs daily after `tick_concurrent`. For each open `LifecycleEnrollment`:

**`housing_move_in`**: checks if any HUD enrollment for this client has a non-null `MoveInDate`. The trigger probability from `close_conditions.housing_move_in` determines whether this client is in the "housed via CE" cohort (others may be housed outside CE). First to fire wins.

**`disengagement`**: after `after_days` (drawn deterministically from the configured distribution), closes CE for clients who disengage from the system without being housed.

**`pre_entry_exit`**: after a shorter timeout, closes CE for clients who briefly enrolled and exited CE before entering any housing program.

All timing is deterministic — the expected close date for each condition is derived from the simulation seed and the lifecycle enrollment's ID, so the same seed always produces the same close schedule.

Close conditions are checked in order: housing_move_in → disengagement → pre_entry_exit. Whichever fires first sets `close_reason` and creates an `Exit` record for the CE enrollment.

### `EnrollmentBuilder` update

PH project types (3=PSH, 9=Housing Only, 10=Housing with Services, 13=RRH) now receive `MoveInDate = entry_date` when the enrollment is created. This is what `tick_lifecycle` inspects when checking the `housing_move_in` close condition.

## Three enrollment tracks — complete

| Track | Examples | Opens | Closes |
|---|---|---|---|
| **Primary** | ES → PSH, ES → RRH | On `pending_enrollment_on` | On `next_transition_on`; exit_point or transition |
| **Concurrent** | Street Outreach, Case Mgmt | With primary enrollment | Timer-based; reentry gap |
| **Lifecycle** | Coordinated Entry | On `trigger_population` entry (optionally backdated) | Housing move-in, disengagement timeout, or pre-entry exit |

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
