### PR TITLE
HMIS Simulation Engine - RunnerJob and Scheduling

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -192,6 +192,14 @@ tasks = [
     at: '2:00 am',
     interruptable: true,
   },
+  # HMIS simulation — only runs on servers where ENABLE_HMIS_SIMULATION=true (demo/staging)
+  {
+    task: 'driver:hmis_simulation:run_all',
+    frequency: 1.day,
+    at: '4:30 am',
+    trigger: ENV['ENABLE_HMIS_SIMULATION'] == 'true',
+    interruptable: false,
+  },
 ]
 
 job_type :rake_short, 'cd :path && :environment_variable=:environment bundle exec rake :task --silent #capacity_provider:short-term'

--- a/drivers/hmis_simulation/app/jobs/hmis_simulation/runner_job.rb
+++ b/drivers/hmis_simulation/app/jobs/hmis_simulation/runner_job.rb
@@ -1,0 +1,105 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisSimulation
+  # Nightly job that advances every configured simulation by one or more days.
+  #
+  # Finds all AppConfigProperty records whose key starts with "hmis_simulation/",
+  # derives the start date from last_successful_run_date + 1, and runs the engine
+  # forward through end_date (defaults to today).
+  #
+  # Each simulation is isolated — one failure writes an error RunLog entry but
+  # does not prevent other simulations from running.
+  #
+  # After all simulations complete, queues warehouse service-history processing
+  # so the new HUD records are immediately available in reports.
+  #
+  # Usage (manual):
+  #   HmisSimulation::RunnerJob.perform_later
+  #
+  # Scheduled via: driver:hmis_simulation:run_all rake task (see schedule.rb)
+  class RunnerJob < BaseJob
+    include NotifierConfig
+
+    queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+
+    SIM_KEY_PREFIX = 'hmis_simulation/'
+
+    def perform(end_date: Date.current)
+      setup_notifier('HmisSimulation::RunnerJob')
+
+      config_keys = AppConfigProperty.where('key LIKE ?', "#{SIM_KEY_PREFIX}%").pluck(:key)
+
+      if config_keys.empty?
+        log('No simulation configs found — nothing to run')
+        return
+      end
+
+      log("Found #{config_keys.size} simulation config(s)")
+
+      config_keys.each do |key|
+        advance_simulation(key, end_date: end_date)
+      end
+
+      Hmis::Hud::Enrollment.queue_service_history_processing!
+      log('Service history processing queued')
+    end
+
+    private
+
+    def advance_simulation(key, end_date:)
+      config = HmisSimulation::ConfigLoader.from_app_config(key)
+      data_source_id = config['data_source_id'].to_i
+
+      last_run = HmisSimulation::RunLog.last_successful_run_date(data_source_id)
+      start_date = last_run ? last_run + 1 : end_date
+
+      if start_date > end_date
+        log("Simulation '#{config['name']}' is already current through #{last_run}")
+        return
+      end
+
+      engine = HmisSimulation::Engine.new(config)
+      (start_date..end_date).each do |date|
+        engine.run(date: date)
+      end
+
+      days_run = (end_date - start_date).to_i + 1
+      log("Simulation '#{config['name']}' advanced #{days_run} day(s) through #{end_date}")
+    rescue StandardError => e
+      record_simulation_error(config, end_date, e)
+    end
+
+    def record_simulation_error(config, date, error)
+      data_source_id = config['data_source_id'].to_i
+      warn_msg = "Simulation '#{config['name']}' (data_source_id: #{data_source_id}) failed on #{date}: #{error.message}"
+      log(warn_msg)
+      Sentry.capture_exception(error) if defined?(Sentry)
+
+      existing = HmisSimulation::RunLog.find_by(data_source_id: data_source_id, run_date: date)
+      if existing
+        existing.update!(error_message: error.message, finished_at: Time.current)
+      else
+        HmisSimulation::RunLog.create!(
+          data_source_id: data_source_id,
+          run_date: date,
+          started_at: Time.current,
+          finished_at: Time.current,
+          error_message: error.message,
+        )
+      end
+    rescue StandardError
+      nil
+    end
+
+    def log(message)
+      @notifier&.ping("[HmisSimulation] #{message}")
+      Rails.logger.info("[HmisSimulation] #{message}")
+    end
+  end
+end

--- a/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
+++ b/drivers/hmis_simulation/lib/tasks/hmis_simulation.rake
@@ -35,6 +35,12 @@ task :validate, [:path_or_key] => :environment do |_t, args|
   end
 end
 
+desc 'Enqueue RunnerJob to advance all active simulations (called by cron via schedule.rb)'
+task run_all: :environment do
+  HmisSimulation::RunnerJob.perform_later
+  puts 'HmisSimulation::RunnerJob enqueued'
+end
+
 desc 'Run simulation for a single date (YYYY-MM-DD)'
 task :run, [:key, :date] => :environment do |_t, args|
   key = args[:key]

--- a/drivers/hmis_simulation/spec/jobs/hmis_simulation/runner_job_spec.rb
+++ b/drivers/hmis_simulation/spec/jobs/hmis_simulation/runner_job_spec.rb
@@ -1,0 +1,132 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisSimulation::RunnerJob, type: :job do
+  let!(:data_source) { create(:hmis_data_source) }
+  let(:run_date)     { Date.new(2026, 1, 15) }
+
+  let(:base_config) do
+    {
+      'name' => 'Runner Test CoC',
+      'data_source_id' => data_source.id,
+      'seed' => 77,
+      'coc_codes' => { 'primary' => 'XX-500' },
+      'organizations' => [
+        {
+          'name' => 'Test Org_',
+          'projects' => [
+            { 'name' => 'Test ES_', 'project_type' => 1, 'capacity' => 20 },
+          ],
+        },
+      ],
+      'household_templates' => {
+        'adult_only' => {
+          'hoh' => {
+            'age' => { 'distribution' => 'uniform', 'min' => 25, 'max' => 55 },
+            'gender' => { 'woman' => 0.5, 'man' => 0.5 },
+            'veteran_probability' => 0.0,
+            'race' => { 'white' => 1.0 },
+          },
+        },
+      },
+      'populations' => [
+        { 'name' => 'street', 'label' => 'Street', 'project_ref' => 'Test ES_',
+          'household_templates' => { 'adult_only' => 1 },
+          'entry_point' => 1, 'exit_point' => 0.1 },
+      ],
+      'transitions' => [],
+      'enrollment_config' => {
+        'new_clients_per_month' => { 'distribution' => 'poisson', 'lambda' => 30 },
+      },
+    }
+  end
+
+  let(:config_key) { 'hmis_simulation/runner-test-coc' }
+  let(:config)     { HmisSimulation::ConfigLoader.send(:normalize, base_config) }
+
+  before do
+    User.setup_system_user
+    AppConfigProperty.where(key: config_key).delete_all
+    HmisSimulation::ConfigLoader.upsert_app_config(config_key, config)
+    HmisSimulation::Bootstrapper.new(config).run!
+  end
+
+  after do
+    AppConfigProperty.where(key: config_key).delete_all
+  end
+
+  describe '#perform' do
+    context 'with no prior run logs (first ever run)' do
+      it 'runs the engine for today only when no prior run exists' do
+        travel_to(run_date) do
+          described_class.perform_now(end_date: run_date)
+          expect(HmisSimulation::RunLog.where(data_source_id: data_source.id, run_date: run_date).count).to eq(1)
+        end
+      end
+    end
+
+    context 'catch-up across missed days' do
+      it 'processes all days between last successful run and today' do
+        # Seed a run log for 3 days ago
+        HmisSimulation::RunLog.create!(
+          data_source_id: data_source.id,
+          run_date: run_date - 3,
+          started_at: Time.current,
+          finished_at: Time.current,
+          clients_created: 0,
+        )
+
+        travel_to(run_date) do
+          described_class.perform_now(end_date: run_date)
+          run_dates = HmisSimulation::RunLog.where(data_source_id: data_source.id).pluck(:run_date)
+          expect(run_dates).to include(run_date - 2, run_date - 1, run_date)
+        end
+      end
+    end
+
+    context 'error isolation' do
+      let(:config_key2) { 'hmis_simulation/broken-coc' }
+
+      before do
+        # A second config that references a non-existent data_source_id — engine will raise
+        broken = base_config.merge('name' => 'Broken CoC', 'data_source_id' => 999_999)
+        HmisSimulation::ConfigLoader.upsert_app_config(config_key2, broken)
+      end
+
+      after do
+        AppConfigProperty.where(key: config_key2).delete_all
+      end
+
+      it 'does not raise even when one simulation config fails' do
+        travel_to(run_date) do
+          expect { described_class.perform_now(end_date: run_date) }.not_to raise_error
+        end
+      end
+
+      it 'still runs valid simulations when one config fails' do
+        travel_to(run_date) do
+          described_class.perform_now(end_date: run_date)
+          # The good simulation should have completed
+          expect(HmisSimulation::RunLog.where(data_source_id: data_source.id, run_date: run_date).count).to eq(1)
+        end
+      end
+    end
+
+    context 'idempotency' do
+      it 'does not create duplicate RunLog records on re-run' do
+        travel_to(run_date) do
+          described_class.perform_now(end_date: run_date)
+          described_class.perform_now(end_date: run_date)
+          expect(HmisSimulation::RunLog.where(data_source_id: data_source.id, run_date: run_date).count).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

# HMIS Simulation Engine — Phase 8: RunnerJob + Scheduling

## Summary

Adds the nightly job that drives simulations automatically. `RunnerJob` finds all simulation configs, determines how many days to catch up, advances each simulation independently, and queues warehouse service-history processing so new records appear in reports. A cron entry via `schedule.rb` activates it on servers where `ENABLE_HMIS_SIMULATION=true`.

This is the final operational phase — after this, the simulation runs daily without manual intervention.

## What's in this PR

### `HmisSimulation::RunnerJob`

Inherits from `BaseJob`, queues on `DJ_LONG_QUEUE_NAME` (long-running queue).

**`perform(end_date: Date.current)`**:
1. Queries all `AppConfigProperty` records whose key matches `hmis_simulation/*`
2. For each config key: derives `start_date = last_successful_run_date + 1` (or today if no prior run), then calls `engine.run(date:)` for each date from `start_date` through `end_date`
3. Each simulation is wrapped in its own rescue block — one failure logs the error but does not abort other simulations
4. After all simulations: calls `Hmis::Hud::Enrollment.queue_service_history_processing!`

**Catch-up behavior**: if the job misses a night (server down, deploy, etc.), the next run processes all the missed days in sequence. This also supports weekly scheduling — the job will just catch up the full week of missed ticks.

**Error handling**: if a simulation raises, `record_simulation_error` writes the error message to a `RunLog` record for that date, then continues to the next simulation.

### `run_all` rake task

```bash
bundle exec rake driver:hmis_simulation:run_all
```

Enqueues `RunnerJob.perform_later`. Use this for manual triggers or the cron entry.

### `config/schedule.rb` entry

```ruby
{
  task: 'driver:hmis_simulation:run_all',
  frequency: 1.day,
  at: '4:30 am',
  trigger: ENV['ENABLE_HMIS_SIMULATION'] == 'true',
  interruptable: false,
}
```

Set `ENABLE_HMIS_SIMULATION=true` on demo/staging servers to activate the schedule. Absent on production — this ensures fake data never flows into real environments through the scheduler.

## Complete engineer workflow

```bash
# 1. Copy and edit a sample config (set data_source_id, adjust populations)
cp config/simulations/samples/small_coc.json /path/to/my-coc.json

# 2. Validate
bundle exec rake driver:hmis_simulation:validate[/path/to/my-coc.json]

# 3. Load config into AppConfigProperty
bundle exec rake driver:hmis_simulation:setup_from_file[/path/to/my-coc.json]

# 4. Bootstrap HUD records (orgs, projects, ProjectCoc, Inventory, Funders)
bundle exec rake driver:hmis_simulation:bootstrap[hmis_simulation/demo-coc-small]

# 5. Generate historical data (e.g. past year)
bundle exec rake driver:hmis_simulation:run_range[hmis_simulation/demo-coc-small,2025-06-01,2026-06-04]

# 6. Enable nightly automation (on demo/staging server)
ENABLE_HMIS_SIMULATION=true
# RunnerJob will now advance the simulation daily at 4:30am
```

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
