### PR TITLE
fix: move HUD report attachment declarations to HudReportArchival

### DIFF
--- a/app/models/concerns/hud_report_archival.rb
+++ b/app/models/concerns/hud_report_archival.rb
@@ -43,6 +43,40 @@ module HudReportArchival
     has_one_attached :report_cells_csv
     has_one_attached :universe_members_csv
 
+    # APR / CAPER / CE-APR
+    has_one_attached :apr_clients_csv
+    has_one_attached :apr_living_situations_csv
+    has_one_attached :apr_ce_assessments_csv
+    has_one_attached :apr_ce_events_csv
+
+    # DQ
+    has_one_attached :dq_clients_csv
+    has_one_attached :dq_living_situations_csv
+
+    # HIC
+    has_one_attached :hic_projects_csv
+    has_one_attached :hic_project_cocs_csv
+    has_one_attached :hic_inventories_csv
+    has_one_attached :hic_organizations_csv
+    has_one_attached :hic_funders_csv
+
+    # LSA
+    has_one_attached :lsa_summary_results_csv
+
+    # PATH
+    has_one_attached :path_clients_csv
+
+    # PIT
+    has_one_attached :pit_clients_csv
+
+    # SPM
+    has_one_attached :spm_clients_csv
+    has_one_attached :spm_enrollments_csv
+    has_one_attached :spm_enrollment_links_csv
+    has_one_attached :spm_episodes_csv
+    has_one_attached :spm_returns_csv
+    has_one_attached :spm_bed_nights_csv
+
     scope :purge_eligible, ->(grace_period_days, now = Time.current) do
       sanitized_days = grace_period_days.to_i
 

--- a/drivers/hud_apr/app/models/hud_apr/archival.rb
+++ b/drivers/hud_apr/app/models/hud_apr/archival.rb
@@ -11,13 +11,6 @@ module HudApr
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :apr_clients_csv
-        has_one_attached :apr_living_situations_csv
-        has_one_attached :apr_ce_assessments_csv
-        has_one_attached :apr_ce_events_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
 

--- a/drivers/hud_data_quality_report/app/models/hud_data_quality_report/archival.rb
+++ b/drivers/hud_data_quality_report/app/models/hud_data_quality_report/archival.rb
@@ -11,11 +11,6 @@ module HudDataQualityReport
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :dq_clients_csv
-        has_one_attached :dq_living_situations_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
 

--- a/drivers/hud_hic/app/models/hud_hic/archival.rb
+++ b/drivers/hud_hic/app/models/hud_hic/archival.rb
@@ -11,14 +11,6 @@ module HudHic
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :hic_projects_csv
-        has_one_attached :hic_project_cocs_csv
-        has_one_attached :hic_inventories_csv
-        has_one_attached :hic_organizations_csv
-        has_one_attached :hic_funders_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
 

--- a/drivers/hud_lsa/app/models/hud_lsa/archival.rb
+++ b/drivers/hud_lsa/app/models/hud_lsa/archival.rb
@@ -11,10 +11,6 @@ module HudLsa
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :lsa_summary_results_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
   end

--- a/drivers/hud_path_report/app/models/hud_path_report/archival.rb
+++ b/drivers/hud_path_report/app/models/hud_path_report/archival.rb
@@ -11,10 +11,6 @@ module HudPathReport
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :path_clients_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
 

--- a/drivers/hud_pit/app/models/hud_pit/archival.rb
+++ b/drivers/hud_pit/app/models/hud_pit/archival.rb
@@ -11,10 +11,6 @@ module HudPit
     extend ActiveSupport::Concern
 
     included do
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :pit_clients_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/archival.rb
@@ -11,17 +11,6 @@ module HudSpmReport
     extend ActiveSupport::Concern
 
     included do
-      # Declare all SPM-specific attachments on ReportInstance (union across all fiscal years).
-      # Repeated class_eval calls for the same attachment name are idempotent in Rails.
-      ::HudReports::ReportInstance.class_eval do
-        has_one_attached :spm_clients_csv
-        has_one_attached :spm_enrollments_csv
-        has_one_attached :spm_enrollment_links_csv
-        has_one_attached :spm_episodes_csv
-        has_one_attached :spm_returns_csv
-        has_one_attached :spm_bed_nights_csv
-      end
-
       ::HudReportArchival.register_archival_generator(title, self)
     end
   end

--- a/spec/models/concerns/hud_report_archival_spec.rb
+++ b/spec/models/concerns/hud_report_archival_spec.rb
@@ -194,6 +194,45 @@ RSpec.describe HudReportArchival, type: :model do
     end
   end
 
+  describe 'attachment declarations' do
+    # These must exist without loading any driver generator — they are declared in HudReportArchival
+    # itself, not via each driver's class_eval. This prevents the class-loading-order bug where
+    # subclasses that snapshot _reflections before a generator is loaded would get AssociationNotFoundError
+    # on destroy.
+    expected_attachments = [
+      :report_cells_csv, :universe_members_csv,
+      :apr_clients_csv, :apr_living_situations_csv, :apr_ce_assessments_csv, :apr_ce_events_csv,
+      :dq_clients_csv, :dq_living_situations_csv,
+      :hic_projects_csv, :hic_project_cocs_csv, :hic_inventories_csv, :hic_organizations_csv, :hic_funders_csv,
+      :lsa_summary_results_csv,
+      :path_clients_csv,
+      :pit_clients_csv,
+      :spm_clients_csv, :spm_enrollments_csv, :spm_enrollment_links_csv, :spm_episodes_csv, :spm_returns_csv, :spm_bed_nights_csv
+    ]
+
+    expected_attachments.each do |name|
+      it "declares #{name} on HudReports::ReportInstance without loading any driver generator" do
+        expect(HudReports::ReportInstance.new).to respond_to(name)
+      end
+    end
+  end
+
+  describe 'destroy regression — subclass with own _reflections' do
+    # Regression for the bug where HmisDataQualityTool::Report (a subclass that defines its own
+    # has_many associations, causing it to snapshot _reflections before driver class_eval calls ran)
+    # raised AssociationNotFoundError on destroy because inherited before_destroy callbacks tried to
+    # look up driver-specific attachment associations not present in the subclass's snapshot.
+    it 'HmisDataQualityTool::Report can be destroyed after APR generators are loaded' do
+      report = HmisDataQualityTool::Report.create!(
+        report_name: 'HMIS Data Quality Tool',
+        user_id: User.system_user.id,
+        question_names: [],
+      )
+      _ = HudApr::Generators::Apr::Fy2026::Generator
+      expect { report.destroy! }.not_to raise_error
+    end
+  end
+
   describe 'purge_eligible scope' do
     let!(:eligible_report) do
       HudReports::ReportInstance.create!(


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

[Sentry Issue](https://green-river.sentry.io/issues/7481459512/?project=4503977346662400)

Fixes an `ActiveRecord::AssociationNotFoundError` crash when destroying
any `HudReports::ReportInstance` subclass (e.g. `HmisDataQualityTool::Report`)
that defines its own associations.

**Root cause:** Each driver's `Archival` concern added `has_one_attached`
associations to `HudReports::ReportInstance` via `class_eval` at generator
load time. Subclasses that had already called `belongs_to`/`has_many`
directly had their own private copy of `_reflections` snapshotted before
those `class_eval` calls ran. ActiveRecord's `before_destroy` callbacks
(inherited from the parent) tried to `association(:apr_clients_csv_attachment)`,
which was missing from the subclass's snapshot, raising the error.

**Fix:** All `has_one_attached` declarations are moved into the `HudReportArchival`
concern, which is included in `HudReports::ReportInstance` at initial class load —
before any subclass is autoloaded. This guarantees every subclass inherits
a complete `_reflections` copy inclusive of all driver attachment slots.
Each driver's `Archival` concern now only calls `register_archival_generator`;
the `class_eval` blocks are removed. Driver-specific archival config
(`archival_csv_config`) is unchanged.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
