### PR TITLE
One-off Unit Occupancy exporter

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
@@ -1,0 +1,112 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisExternalApis::AcHmis::Exporters
+  # Exports the full history of unit occupancies, combining hmis_unit_occupancy with hmis_active_ranges.
+  # Join keys: UnitID (UnitExport), EnrollmentID (HMIS CSV export, including deleted enrollments).
+  # It include unit information because the UnitExport currently does not include deleted units.
+  #
+  # Note: this was created as a one-off export (Issue#9037), it's not currently part of the daily export process (DataWarehouseUploadJob).
+  class UnitOccupancyExport
+    include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
+
+    def run!
+      Rails.logger.info 'Generating Unit Occupancy export'
+      write_row(columns)
+      total = unit_occupancies.count
+      Rails.logger.info "There are #{total} unit occupancies to export"
+
+      processed = 0
+      unit_occupancies.find_in_batches do |batch|
+        occupancy_periods = load_occupancy_periods(batch.map(&:id))
+        units = load_units(batch.map(&:unit_id))
+        projects = load_projects(units.values.map(&:project_id))
+
+        batch.each do |unit_occupancy|
+          Rails.logger.info "Processed #{processed} of #{total}" if (processed % 100).zero?
+          processed += 1
+
+          occupancy_period = occupancy_periods[unit_occupancy.id]
+          next unless occupancy_period
+
+          unit = units[unit_occupancy.unit_id]
+          project = unit && projects[unit.project_id]
+          write_row(row_values(unit_occupancy, occupancy_period, unit, project))
+        end
+      end
+    end
+
+    private
+
+    def columns
+      [
+        'UnitOccupancyID', # Unique ID for this occupancy record
+        'UnitID', # Unit identifier; join to Units.csv for active units
+        'UnitTypeName', # Unit type; included here because Units.csv omits deleted units
+        'ProjectID', # Project identifier; included here because Units.csv omits deleted units
+        'ProjectName', # Project name; included here because Units.csv omits deleted units
+        'EnrollmentID', # Enrollment identifier; join to Enrollment.csv
+        'StartDate', # Date the client entered the unit (often the enrollment entry date)
+        'EndDate', # Date the client left the unit (often the exit date), or blank if still active
+        'DateCreated', # When the occupancy record was created
+        'DateUpdated', # When the occupancy record was last updated
+      ]
+    end
+
+    def row_values(unit_occupancy, occupancy_period, unit, project)
+      [
+        unit_occupancy.id,
+        unit_occupancy.unit_id,
+        unit_type_name(unit),
+        project&.id,
+        project&.project_name,
+        unit_occupancy.enrollment_id,
+        occupancy_period.start_date,
+        occupancy_period.end_date,
+        occupancy_period.created_at,
+        occupancy_period.updated_at,
+      ]
+    end
+
+    def unit_type_name(unit)
+      return unless unit
+
+      unit.unit_group&.unit_type&.description || unit.unit_type&.description
+    end
+
+    def unit_occupancies
+      # Note: need to join with arel to get deleted enrollments
+      uo_t = Hmis::UnitOccupancy.arel_table
+      e_t = Hmis::Hud::Enrollment.unscoped.arel_table
+
+      @unit_occupancies ||= Hmis::UnitOccupancy.with_deleted.
+        joins(uo_t.join(e_t).on(uo_t[:enrollment_id].eq(e_t[:id])).join_sources).
+        where(e_t[:data_source_id].eq(data_source.id)).
+        order(uo_t[:unit_id], uo_t[:enrollment_id], uo_t[:id])
+    end
+
+    def load_occupancy_periods(unit_occupancy_ids)
+      Hmis::ActiveRange.with_deleted.
+        where(entity_type: Hmis::UnitOccupancy.name, entity_id: unit_occupancy_ids).
+        index_by(&:entity_id)
+    end
+
+    def load_units(unit_ids)
+      Hmis::Unit.with_deleted.
+        where(id: unit_ids).
+        preload(:unit_type, unit_group: :unit_type).
+        index_by(&:id)
+    end
+
+    def load_projects(project_ids)
+      Hmis::Hud::Project.with_deleted.
+        where(id: project_ids).
+        index_by(&:id)
+    end
+  end
+end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
@@ -9,7 +9,7 @@
 module HmisExternalApis::AcHmis::Exporters
   # Exports the full history of unit occupancies, combining hmis_unit_occupancy with hmis_active_ranges.
   # Join keys: UnitID (UnitExport), EnrollmentID (HMIS CSV export, including deleted enrollments).
-  # It include unit information because the UnitExport currently does not include deleted units.
+  # It includes full unit information (UnitTypeName, ProjectID, and ProjectName) because the UnitExport currently does not include deleted units.
   #
   # Note: this was created as a one-off export (Issue#9037), it's not currently part of the daily export process (DataWarehouseUploadJob).
   class UnitOccupancyExport

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export_spec.rb
@@ -1,0 +1,109 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisExternalApis::AcHmis::Exporters::UnitOccupancyExport, type: :model do
+  let!(:ds) { create(:hmis_data_source) }
+  let(:subject) { described_class.new }
+
+  let!(:project) { create :hmis_hud_project, data_source: ds }
+  let!(:unit_type) { create :hmis_unit_type }
+  let!(:unit_group) { create :hmis_unit_group, project: project, unit_type: unit_type }
+  let!(:unit) { create :hmis_unit, project: project, unit_group: unit_group, unit_type: unit_type }
+  let!(:enrollment) { create :hmis_hud_enrollment, data_source: ds, project: project }
+  let!(:unit_occupancy) do
+    create(
+      :hmis_unit_occupancy,
+      unit: unit,
+      enrollment: enrollment,
+      start_date: Date.new(2024, 1, 1),
+      end_date: Date.new(2024, 6, 30),
+    )
+  end
+
+  let(:output) do
+    subject.output.rewind
+    subject.output.read
+  end
+
+  it 'gets unit occupancies' do
+    subject.run!
+    expect(subject.send(:unit_occupancies).length).to eq(1)
+  end
+
+  it 'makes a csv' do
+    subject.run!
+    result = CSV.parse(output, headers: true)
+
+    expect(result.length).to eq(1)
+    expect(result.first['UnitOccupancyID']).to eq(unit_occupancy.id.to_s)
+    expect(result.first['UnitID']).to eq(unit.id.to_s)
+    expect(result.first['UnitTypeName']).to eq(unit_type.description)
+    expect(result.first['ProjectID']).to eq(project.id.to_s)
+    expect(result.first['ProjectName']).to eq(project.project_name)
+    expect(result.first['EnrollmentID']).to eq(enrollment.id.to_s)
+    expect(result.first['StartDate']).to eq('2024-01-01')
+    expect(result.first['EndDate']).to eq('2024-06-30')
+    expect(result.first['DateCreated']).to be_present
+    expect(result.first['DateUpdated']).to be_present
+  end
+
+  context 'when the unit occupancy is still active' do
+    before { unit_occupancy.occupancy_period.update!(end_date: nil) }
+
+    it 'still exports the record' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['UnitOccupancyID']).to eq(unit_occupancy.id.to_s)
+      expect(result.first['StartDate']).to eq('2024-01-01')
+      expect(result.first['EndDate']).to be_nil
+    end
+  end
+
+  context 'when the unit occupancy is soft-deleted' do
+    before { unit_occupancy.destroy! }
+
+    it 'still exports the record' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['UnitOccupancyID']).to eq(unit_occupancy.id.to_s)
+    end
+  end
+
+  context 'when the enrollment is soft-deleted' do
+    before { enrollment.destroy! }
+
+    it 'still exports the record' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['EnrollmentID']).to eq(enrollment.id.to_s)
+    end
+  end
+
+  context 'when the unit is soft-deleted' do
+    before { unit.destroy! }
+
+    it 'still exports the record with unit and project details' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['UnitID']).to eq(unit.id.to_s)
+      expect(result.first['UnitTypeName']).to eq(unit_type.description)
+      expect(result.first['ProjectID']).to eq(project.id.to_s)
+      expect(result.first['ProjectName']).to eq(project.project_name)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

Add AC HMIS unit occupancy export

## Description

Issue: https://github.com/open-path/Green-River/issues/9037

Adds a one-off AC HMIS export of full unit occupancy history, combining `hmis_unit_occupancy` with `hmis_active_ranges`. This is not wired into the daily `DataWarehouseUploadJob`; it is intended to be run manually and shared with the customer. (In the future we may add it to daily upload).

- Adds `UnitOccupancyExport` CSV exporter with occupancy period dates and join keys for `Units.csv` and `Enrollment.csv`
- Includes deleted enrollments, units, and occupancies so historical records remain joinable with the HMIS CSV export (`include_deleted: true`)
- Includes `UnitTypeName`, `ProjectID`, and `ProjectName` on each row, since the daily `Units.csv` export omits deleted units



## Type of change

New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
