### PR TITLE
Fix Git Release Tag Display

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Dockerfile Lint
         shell: bash

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-tags: true
 
       - name: Dockerfile Lint
         shell: bash

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+          fetch-depth: 50
 
       - name: Dockerfile Lint
         shell: bash


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

CI builds were writing a bare commit hash into `GIT_RELEASE` instead of the
expected release tag (e.g. `staging-release-215.2`). The root cause was that
`actions/checkout@v4` defaults to a shallow clone with no tag history, leaving
`git describe --tags --always` nothing to traverse.

The fix sets `fetch-depth: 50` on the checkout step. This gives `git describe`
enough commit ancestry to reach the nearest tag while avoiding a full history
fetch (28k commits). Tag history for this repo shows the largest gap between any
two adjacent tags is 27 commits, making 50 a safe ceiling. The `GIT_RELEASE`
value is surfaced in the non-production header bar and at `/system_status/details`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
