### PR TITLE
8458-l1-jwt-auth-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ gem 'devise-two-factor', '~> 4.1.1'
 gem 'rack-cors'
 gem 'doorkeeper'
 
+gem 'jwt', '~> 3.1' # Validates IdP-issued JWT access tokens
 gem 'omniauth', '~> 2.1'
 gem 'omniauth-oauth2', '~> 1.7.3'
 gem 'omniauth-rails_csrf_protection', '~> 1.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1238,6 +1238,7 @@ DEPENDENCIES
   jsbundling-rails (~> 1.1)
   json
   json_schemer (~> 2.4.0)
+  jwt (~> 3.1)
   k8s-ruby!
   kaminari
   kiba

--- a/app/models/jwt_helper.rb
+++ b/app/models/jwt_helper.rb
@@ -1,0 +1,201 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'net/http'
+require 'memery'
+
+class JwtHelper
+  include Memery
+  attr_reader :access_token
+
+  REQUIRED_ENV_KEYS = ['IDP_AUD', 'ISS_URL', 'JWKS_URL', 'JWT_ALGORITHM'].freeze
+
+  def initialize(access_token:)
+    @access_token = access_token
+  end
+
+  def token?
+    access_token.present?
+  end
+
+  def validate!
+    return false unless token?
+
+    unless public_key
+      Rails.logger.info "Unable to find public key: #{header['kid']}"
+      return false
+    end
+
+    payload
+    true
+  rescue JWT::ExpiredSignature
+    Rails.logger.warn 'Token has expired'
+    false
+  rescue JWT::InvalidIssuerError
+    Rails.logger.error 'Invalid issuer'
+    false
+  rescue JWT::InvalidAudError
+    Rails.logger.error 'Invalid audience'
+    false
+  rescue JWT::DecodeError => e
+    Rails.logger.error "JWT verification failed: #{e.message}"
+    false
+  rescue JSON::ParserError => e
+    Rails.logger.error "JSON verification failed: #{e.message}"
+    false
+  end
+
+  memoize def payload
+    JWT.decode(
+      access_token,
+      public_key,
+      true,
+      {
+        algorithm: algorithm,
+        aud: idp_audiences,
+        iss: ENV.fetch('ISS_URL'),
+        verify_aud: true,
+        verify_iss: true,
+      },
+    )
+  end
+
+  private def idp_audiences
+    ENV.fetch('IDP_AUD').split(',').map(&:strip)
+  end
+
+  def email(forwarded_email)
+    return nil unless payload_email == forwarded_email.to_s.downcase
+
+    payload_email
+  end
+
+  def connector_user_id
+    payload.first.dig('federated_claims', 'user_id')
+  end
+  alias_method :idp_user, :connector_user_id
+
+  def connector_id
+    payload.first.dig('federated_claims', 'connector_id')
+  end
+  alias_method :idp, :connector_id
+
+  memoize def payload_email
+    payload.first['email'].to_s.downcase
+  end
+
+  def last_login_at
+    payload.first['iat']
+  end
+
+  def expiration_time
+    exp = payload.first['exp']
+    return nil unless exp
+
+    Time.zone.at(exp)
+  end
+
+  # Returns the at_hash claim — stable per token, changes on reissue.
+  # Not all IdPs include at_hash in access tokens; callers must handle nil.
+  def session_id
+    payload.first['at_hash']
+  end
+
+  def self.authenticated?(access_token)
+    return false unless access_token.present?
+
+    helper = new(access_token: access_token)
+    helper.token? && helper.validate!
+  end
+
+  # User.find_from_jwt is provided by L1.2 (idp-l1-identity-resolution); inert until then.
+  def self.user_id_from_token(access_token)
+    return nil unless access_token.present?
+
+    helper = new(access_token: access_token)
+    return nil unless helper.token? && helper.validate!
+
+    User.find_from_jwt(helper)&.id
+  end
+
+  def self.assert_boot_config!
+    missing = REQUIRED_ENV_KEYS.select { |key| ENV.fetch(key, '').blank? }
+    raise "Missing JWT configuration: #{missing.join(', ')}" if missing.any?
+  end
+
+  # TODO: this is inconsistent based on the IDP
+  def first_name
+    payload.first['given_name'].presence || payload.first['name'].to_s.strip.split.first&.titleize
+  end
+
+  # TODO: this is inconsistent based on the IDP
+  def last_name
+    raw = payload.first['name'].to_s.strip
+    return '' if raw.blank?
+
+    parts = raw.split
+    return '' if parts.size <= 1
+
+    parts.last.titleize
+  end
+
+  def jwks
+    self.class.jwks
+  end
+
+  class << self
+    def jwks
+      memory_cache.fetch('jwt_helper_jwks', expires_in: 1.hour) do
+        fetch_jwks
+      end
+    end
+
+    def fetch_jwks
+      uri = URI(ENV.fetch('JWKS_URL'))
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 5, read_timeout: 5) do |http|
+        http.get(uri.request_uri).body
+      end
+      JSON.parse(response)
+    end
+
+    def invalidate_jwks_cache!
+      memory_cache.delete('jwt_helper_jwks')
+    end
+
+    def memory_cache
+      @memory_cache ||= ActiveSupport::Cache::MemoryStore.new
+    end
+  end
+
+  memoize private def header
+    JWT.decode(access_token, nil, false, algorithm: algorithm)[1]
+  end
+
+  # Looks up the public key for this token's kid. On a cache miss (key rotation),
+  # busts the JWKS cache and retries once before giving up.
+  private def public_key
+    find_public_key(allow_retry: true)
+  end
+
+  private def find_public_key(allow_retry:)
+    key_data = jwks['keys'].find { |key| key['kid'] == header['kid'] }
+
+    if key_data.nil? && allow_retry
+      self.class.invalidate_jwks_cache!
+      return find_public_key(allow_retry: false)
+    end
+
+    return nil unless key_data
+
+    JWT::JWK.import(key_data).keypair
+  end
+
+  private def algorithm
+    ENV.fetch('JWT_ALGORITHM')
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = 'true'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative '../lib/auth_method'
 require_relative '../lib/util/id_protector'
 require_relative '../lib/util/rails_trusted_proxies_config'
 

--- a/config/initializers/jwt_auth_config.rb
+++ b/config/initializers/jwt_auth_config.rb
@@ -1,0 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  JwtHelper.assert_boot_config! if AuthMethod.jwt?
+end

--- a/config/initializers/test_jwt_middleware.rb
+++ b/config/initializers/test_jwt_middleware.rb
@@ -1,0 +1,40 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Plumbing for future JWT system/request test support.
+# Not yet wired up — will be used when spec/support/jwt_authentication_helper.rb is implemented.
+#
+# Promotes test_jwt_token cookie to HTTP_X_FORWARDED_ACCESS_TOKEN header,
+# allowing tests to inject JWT tokens via cookies that are read by
+# CurrentUser as if they came from oauth2-proxy.
+# See also: spec/support/jwt_helper_test_extensions.rb (validation bypass for mock tokens)
+if Rails.env.test?
+  class TestJwtMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      cookie_header = env['HTTP_COOKIE']
+      if cookie_header&.include?('test_jwt_token=')
+        cookie_match = cookie_header.match(/test_jwt_token=([^;]+)/)
+        if cookie_match
+          token = cookie_match[1]
+          env['HTTP_X_FORWARDED_ACCESS_TOKEN'] = token
+        end
+      end
+
+      @app.call(env)
+    end
+  end
+
+  Rails.application.config.middleware.insert_before(
+    ActionDispatch::Cookies,
+    TestJwtMiddleware,
+  )
+end

--- a/lib/auth_method.rb
+++ b/lib/auth_method.rb
@@ -1,0 +1,19 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module AuthMethod
+  module_function
+
+  def jwt?
+    ENV.fetch('AUTH_METHOD', 'devise') == 'jwt'
+  end
+
+  def devise?
+    !jwt?
+  end
+end

--- a/spec/lib/auth_method_spec.rb
+++ b/spec/lib/auth_method_spec.rb
@@ -1,0 +1,39 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AuthMethod do
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+  end
+
+  describe '.jwt?' do
+    it 'returns false when AUTH_METHOD is unset (defaults to devise)' do
+      allow(ENV).to receive(:fetch).with('AUTH_METHOD', 'devise').and_return('devise')
+      expect(described_class.jwt?).to be false
+    end
+
+    it 'returns true when AUTH_METHOD is jwt' do
+      allow(ENV).to receive(:fetch).with('AUTH_METHOD', 'devise').and_return('jwt')
+      expect(described_class.jwt?).to be true
+    end
+  end
+
+  describe '.devise?' do
+    it 'returns true when AUTH_METHOD is unset' do
+      allow(ENV).to receive(:fetch).with('AUTH_METHOD', 'devise').and_return('devise')
+      expect(described_class.devise?).to be true
+    end
+
+    it 'returns false when AUTH_METHOD is jwt' do
+      allow(ENV).to receive(:fetch).with('AUTH_METHOD', 'devise').and_return('jwt')
+      expect(described_class.devise?).to be false
+    end
+  end
+end

--- a/spec/models/jwt_helper_spec.rb
+++ b/spec/models/jwt_helper_spec.rb
@@ -1,0 +1,218 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JwtHelper do
+  let(:jwks_url) { 'http://example.com/jwks' }
+  let(:kid) { 'test_kid' }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:jwk) { JWT::JWK.new(rsa_key, kid: kid) }
+  let(:jwks_hash) { JSON.parse({ 'keys' => [jwk.export] }.to_json) }
+  let(:payload) do
+    {
+      'email' => 'TEST@EXAMPLE.COM',
+      'aud' => 'test_aud',
+      'iss' => 'test_iss',
+      'iat' => Time.now.to_i,
+      'name' => '  John   Quincy   Adams  ',
+      'federated_claims' => {
+        'connector_id' => 'keycloak',
+        'user_id' => 'kc-123',
+      },
+    }
+  end
+  let(:access_token) { JWT.encode(payload, rsa_key, 'RS256', { kid: kid }) }
+  let(:helper) { described_class.new(access_token: access_token) }
+
+  before do
+    JwtHelper.memory_cache.clear
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('JWKS_URL').and_return(jwks_url)
+    allow(ENV).to receive(:fetch).with('IDP_AUD').and_return('test_aud')
+    allow(ENV).to receive(:fetch).with('ISS_URL').and_return('test_iss')
+    allow(ENV).to receive(:fetch).with('JWT_ALGORITHM').and_return('RS256')
+
+    allow(described_class).to receive(:fetch_jwks).and_return(jwks_hash)
+  end
+
+  describe '#token?' do
+    it 'returns true when access_token is present' do
+      expect(helper.token?).to be true
+    end
+
+    it 'returns false when access_token is nil' do
+      nil_helper = described_class.new(access_token: nil)
+      expect(nil_helper.token?).to be false
+    end
+  end
+
+  describe '#validate!' do
+    it 'returns true if token is valid' do
+      expect(helper.validate!).to be true
+    end
+
+    it 'returns false if public key is missing' do
+      bad_token = JWT.encode(payload, rsa_key, 'RS256', { kid: 'wrong_kid' })
+      bad_helper = described_class.new(access_token: bad_token)
+      expect(bad_helper.validate!).to be false
+    end
+
+    it 'returns false if token is expired' do
+      expired_payload = payload.merge('exp' => Time.now.to_i - 3600)
+      expired_token = JWT.encode(expired_payload, rsa_key, 'RS256', { kid: kid })
+      expired_helper = described_class.new(access_token: expired_token)
+      expect(expired_helper.validate!).to be false
+    end
+
+    it 'returns false if issuer is invalid' do
+      bad_iss_payload = payload.merge('iss' => 'wrong_iss')
+      bad_iss_token = JWT.encode(bad_iss_payload, rsa_key, 'RS256', { kid: kid })
+      bad_iss_helper = described_class.new(access_token: bad_iss_token)
+      expect(bad_iss_helper.validate!).to be false
+    end
+
+    it 'returns false if audience is invalid' do
+      bad_aud_payload = payload.merge('aud' => 'wrong_aud')
+      bad_aud_token = JWT.encode(bad_aud_payload, rsa_key, 'RS256', { kid: kid })
+      bad_aud_helper = described_class.new(access_token: bad_aud_token)
+      expect(bad_aud_helper.validate!).to be false
+    end
+
+    it 'rejects a mismatched audience when IDP_AUD is blank (fail-closed)' do
+      allow(ENV).to receive(:fetch).with('IDP_AUD').and_return('')
+      bad_aud_payload = payload.merge('aud' => 'wrong_aud')
+      bad_aud_token = JWT.encode(bad_aud_payload, rsa_key, 'RS256', { kid: kid })
+      bad_aud_helper = described_class.new(access_token: bad_aud_token)
+      expect(bad_aud_helper.validate!).to be false
+    end
+  end
+
+  describe '#payload' do
+    it 'returns the decoded payload and header' do
+      result_payload, result_header = helper.payload
+      expect(result_payload['email']).to eq('TEST@EXAMPLE.COM')
+      expect(result_header['kid']).to eq(kid)
+    end
+  end
+
+  describe '#payload_email' do
+    it 'returns downcased email from payload' do
+      expect(helper.payload_email).to eq('test@example.com')
+    end
+  end
+
+  describe '#email' do
+    it 'returns the email if it matches the forwarded email (case insensitive)' do
+      expect(helper.email('test@example.com')).to eq('test@example.com')
+      expect(helper.email('TEST@EXAMPLE.COM')).to eq('test@example.com')
+    end
+
+    it 'returns nil if it does not match' do
+      expect(helper.email('wrong@example.com')).to be_nil
+    end
+  end
+
+  describe '#connector_user_id' do
+    it 'reads user_id from federated_claims' do
+      expect(helper.connector_user_id).to eq('kc-123')
+    end
+
+    it 'returns nil when federated_claims is absent' do
+      no_claims_payload = payload.except('federated_claims')
+      token = JWT.encode(no_claims_payload, rsa_key, 'RS256', { kid: kid })
+      h = described_class.new(access_token: token)
+      expect(h.connector_user_id).to be_nil
+    end
+  end
+
+  describe '#connector_id' do
+    it 'reads connector_id from federated_claims' do
+      expect(helper.connector_id).to eq('keycloak')
+    end
+
+    it 'returns nil when federated_claims is absent' do
+      no_claims_payload = payload.except('federated_claims')
+      token = JWT.encode(no_claims_payload, rsa_key, 'RS256', { kid: kid })
+      h = described_class.new(access_token: token)
+      expect(h.connector_id).to be_nil
+    end
+  end
+
+  describe 'name parsing' do
+    it '#first_name returns the titleized first part' do
+      expect(helper.first_name).to eq('John')
+    end
+
+    it '#last_name returns the titleized last part' do
+      expect(helper.last_name).to eq('Adams')
+    end
+
+    it '#last_name returns empty string if only one name exists' do
+      single_name_payload = payload.merge('name' => 'Cher')
+      single_name_token = JWT.encode(single_name_payload, rsa_key, 'RS256', { kid: kid })
+      single_name_helper = described_class.new(access_token: single_name_token)
+      expect(single_name_helper.last_name).to eq('')
+    end
+  end
+
+  describe '.assert_boot_config!' do
+    before do
+      allow(ENV).to receive(:fetch).with('IDP_AUD', '').and_return('test_aud')
+      allow(ENV).to receive(:fetch).with('ISS_URL', '').and_return('test_iss')
+      allow(ENV).to receive(:fetch).with('JWKS_URL', '').and_return(jwks_url)
+      allow(ENV).to receive(:fetch).with('JWT_ALGORITHM', '').and_return('RS256')
+    end
+
+    it 'passes when all required env keys are present' do
+      expect { described_class.assert_boot_config! }.not_to raise_error
+    end
+
+    it 'raises naming the missing key when one is absent' do
+      allow(ENV).to receive(:fetch).with('IDP_AUD', '').and_return('')
+      expect { described_class.assert_boot_config! }.to raise_error(RuntimeError, /IDP_AUD/)
+    end
+  end
+
+  describe 'JWKS key rotation' do
+    let(:new_rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+    let(:new_kid) { 'rotated_kid' }
+    let(:new_jwk) { JWT::JWK.new(new_rsa_key, kid: new_kid) }
+    let(:rotated_jwks_hash) { JSON.parse({ 'keys' => [jwk.export, new_jwk.export] }.to_json) }
+    let(:rotated_token) { JWT.encode(payload, new_rsa_key, 'RS256', { kid: new_kid }) }
+
+    it 're-fetches JWKS when a new kid appears after key rotation' do
+      call_count = 0
+      allow(described_class).to receive(:fetch_jwks) do
+        call_count += 1
+        if call_count == 1
+          jwks_hash
+        else
+          rotated_jwks_hash
+        end
+      end
+
+      # Warm the cache with the original keyset (missing the rotated kid)
+      described_class.new(access_token: access_token).validate!
+
+      # Now validate a token signed with the rotated key
+      rotated_helper = described_class.new(access_token: rotated_token)
+      expect(rotated_helper.validate!).to be true
+      expect(call_count).to eq(2)
+    end
+
+    it 'returns false after one retry for a genuinely unknown kid' do
+      unknown_key = OpenSSL::PKey::RSA.generate(2048)
+      unknown_token = JWT.encode(payload, unknown_key, 'RS256', { kid: 'never_in_jwks' })
+      unknown_helper = described_class.new(access_token: unknown_token)
+
+      expect(described_class).to receive(:fetch_jwks).twice.and_return(jwks_hash)
+      expect(unknown_helper.validate!).to be false
+    end
+  end
+end

--- a/spec/support/jwt_helper_test_extensions.rb
+++ b/spec/support/jwt_helper_test_extensions.rb
@@ -1,0 +1,65 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Plumbing for future JWT system/request test support.
+# Not yet wired up — will be used when spec/support/jwt_authentication_helper.rb is implemented.
+#
+# Prepended to JwtHelper only when running tests, keeping production code
+# free of test-specific logic.
+# See also: config/initializers/test_jwt_middleware.rb (cookie-to-header transport)
+#
+# Mock tokens follow the format: "mock-jwt-token-{user_id}-{random_hex}"
+module JwtHelperTestExtensions
+  # Override validate! to bypass cryptographic validation for mock tokens
+  def validate!
+    return false unless token?
+
+    # In system tests, allow mock tokens to bypass validation
+    return true if access_token.start_with?('mock-jwt-token-')
+
+    # Call original implementation for real tokens
+    super
+  end
+
+  # Override payload to return mock payload for mock tokens
+  def payload
+    # For mock tokens in system tests, return mock payload
+    if access_token.start_with?('mock-jwt-token-')
+      user_id, email = extract_mock_token_data
+      now = Time.current.to_i
+      return [
+        {
+          'email' => email || 'test@example.com',
+          'federated_claims' => {
+            'connector_id' => 'test',
+            'user_id' => user_id,
+          },
+          'iat' => now,
+          'exp' => now + 3600, # 1 hour expiration for system tests
+        },
+        {},
+      ]
+    end
+
+    # Call original implementation for real tokens
+    super
+  end
+
+  private
+
+  # Extracts user ID and email from mock token format: "mock-jwt-token-{user_id}-{random_hex}"
+  def extract_mock_token_data
+    match = access_token.match(/\Amock-jwt-token-(?<user_id>\d+)-/)
+    user_id = match[:user_id]
+    user = User.find_by(id: user_id)
+    [user_id, user&.email]
+  end
+end
+
+# Prepend test extensions when running any tests (controller specs, request specs, system tests)
+JwtHelper.prepend(JwtHelperTestExtensions) if Rails.env.test?


### PR DESCRIPTION
## *Merging this PR*

* use the squash-merge strategy for PRs targeting `main`

### Description

Add JWT token-validation primitive and boot-time auth-method switch as inert, additive infrastructure for the IdP migration.

* **Auth Method Switch**: New `AuthMethod` module (`lib/auth_method.rb`) reads `AUTH_METHOD` env var at boot, defaulting to `devise` — merging this branch is a no-op for all existing deployments
* **JWT Validation**: New `JwtHelper` model validates IdP-issued JWT access tokens (signature, audience, issuer, expiry) with fail-closed semantics — missing `federated_claims` returns `nil` instead of fabricating a connector identity
* **Boot-time Config Assertion**: New `jwt_auth_config` initializer calls `JwtHelper.assert_boot_config!` when `AUTH_METHOD=jwt`, failing fast on missing `IDP_AUD`/`ISS_URL`/`JWKS_URL`/`JWT_ALGORITHM` 
* **JWKS Key Rotation**: `JwtHelper` retries JWKS fetch once on unknown `kid`
* **Test Infrastructure**: Test-only mock-token middleware and `JwtHelperTestExtensions` prepend allow later branches to authenticate in specs without real crypto
* **Dependencies**: Added `jwt` gem (~> 3.1)
* **Specs**: Full coverage for `AuthMethod`, `JwtHelper` validation/fail-closed/key-rotation behavior, and boot config assertion

### Type of Change

New feature

## Checklist before requesting review

* [x] I have performed a self-review of my code
* [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
* [x] I have updated the documentation (or not applicable)
* [x] I have added spec tests (or not applicable)
* [ ] I have provided testing instructions in this PR or the related issue (or not applicable)