### PR TITLE
Improve ROI "Active" indicator on Releases of Information page

### DIFF
--- a/app/controllers/clients/files_controller.rb
+++ b/app/controllers/clients/files_controller.rb
@@ -103,7 +103,7 @@ module Clients
       else
         not_authorized!
       end
-      @client.invalidate_consent! if attrs[:consent_revoked_at].present? && @client.consent_form_id == @file.id
+      @client.invalidate_consent!(hr_status: GrdaWarehouse::Config.active_consent_class.revoked_consent_string) if attrs[:consent_revoked_at].present? && @client.consent_form_id == @file.id
 
       if attrs.key?(:consent_form_signed_on)
         attrs[:effective_date] = attrs[:consent_form_signed_on]

--- a/app/controllers/clients/releases_controller.rb
+++ b/app/controllers/clients/releases_controller.rb
@@ -97,7 +97,7 @@ module Clients
       else
         not_authorized!
       end
-      @client.invalidate_consent! if attrs[:consent_revoked_at].present? && @client.consent_form_id == @file.id
+      @client.invalidate_consent!(hr_status: GrdaWarehouse::Config.active_consent_class.revoked_consent_string) if attrs[:consent_revoked_at].present? && @client.consent_form_id == @file.id
       # Remove any view caches for this client since permissions may have changed
       @client.clear_view_cache
 

--- a/app/models/grda_warehouse/client_file.rb
+++ b/app/models/grda_warehouse/client_file.rb
@@ -275,8 +275,19 @@ module GrdaWarehouse
       user_id == user.id
     end
 
-    def active_consent_form?
+    def most_recent_consent_form?
       client.consent_form_id == id
+    end
+
+    def calculated_expiration_date
+      case GrdaWarehouse::Hud::Client.release_duration
+      when 'One Year', 'Two Years'
+        consent_form_signed_on&.+(GrdaWarehouse::Hud::Client.consent_validity_period)
+      when 'Use Expiration Date'
+        expiration_date
+      when 'Indefinite'
+        nil
+      end
     end
 
     def consent_form?

--- a/app/models/grda_warehouse/client_file.rb
+++ b/app/models/grda_warehouse/client_file.rb
@@ -282,7 +282,7 @@ module GrdaWarehouse
     def calculated_expiration_date
       case GrdaWarehouse::Hud::Client.release_duration
       when 'One Year', 'Two Years'
-        consent_form_signed_on&.+(GrdaWarehouse::Hud::Client.consent_validity_period)
+        consent_form_signed_on && consent_form_signed_on + GrdaWarehouse::Hud::Client.consent_validity_period
       when 'Use Expiration Date'
         expiration_date
       when 'Indefinite'

--- a/app/models/grda_warehouse/client_file.rb
+++ b/app/models/grda_warehouse/client_file.rb
@@ -275,7 +275,7 @@ module GrdaWarehouse
       user_id == user.id
     end
 
-    def most_recent_consent_form?
+    def active_consent_form?
       client.consent_form_id == id
     end
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1135,6 +1135,14 @@ module GrdaWarehouse::Hud
       clear_view_cache
     end
 
+    def self.bulk_invalidate_consent!(ids, batch_size: 500)
+      return if ids.blank?
+
+      where(id: ids).find_in_batches(batch_size: batch_size) do |batch|
+        batch.each(&:invalidate_consent!)
+      end
+    end
+
     def apply_housing_release_status
       return unless GrdaWarehouse::Config.implied_consent?
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1119,11 +1119,10 @@ module GrdaWarehouse::Hud
       client_files.consent_forms.order(updated_at: :desc)&.first
     end
 
+    # Clear this client's consent fields and invalidate any cached views.
     def invalidate_consent!
-      hr_status = nil
       # If using implied consent, we need to set the housing release status to the current consent type ("Implied Consent")
       hr_status = GrdaWarehouse::Config.active_consent_class.new(client: self).current_consent_type if GrdaWarehouse::Config.implied_consent?
-
       update_columns(
         consent_form_id: nil,
         housing_release_status: hr_status,
@@ -1135,11 +1134,25 @@ module GrdaWarehouse::Hud
       clear_view_cache
     end
 
+    # Clear consent fields for multiple clients in batches using a single UPDATE per batch.
+    # @param ids [Array<Integer>] client ids to invalidate
+    # @param batch_size [Integer] number of records per batch
     def self.bulk_invalidate_consent!(ids, batch_size: 500)
       return if ids.blank?
 
-      where(id: ids).find_in_batches(batch_size: batch_size) do |batch|
-        batch.each(&:invalidate_consent!)
+      # If using implied consent, we need to set the housing release status to the current consent type ("Implied Consent")
+      hr_status = GrdaWarehouse::Config.active_consent_class.new(client: new).current_consent_type if GrdaWarehouse::Config.implied_consent?
+
+      ids.each_slice(batch_size) do |slice|
+        clients = where(id: slice)
+        clients.update_all(
+          consent_form_id: nil,
+          housing_release_status: hr_status,
+          consent_form_signed_on: nil,
+          consent_expires_on: nil,
+          consented_coc_codes: [],
+        )
+        clients.each(&:clear_view_cache)
       end
     end
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1120,40 +1120,35 @@ module GrdaWarehouse::Hud
     end
 
     # Clear this client's consent fields and invalidate any cached views.
-    def invalidate_consent!
-      # If using implied consent, we need to set the housing release status to the current consent type ("Implied Consent")
-      hr_status = GrdaWarehouse::Config.active_consent_class.new(client: self).current_consent_type if GrdaWarehouse::Config.implied_consent?
-      update_columns(
+    # This should never be run if there is an active client file indicating a valid consent.
+    # If it does run in this scenario, it will clear out the client data for this consent
+    # and it won't be restored automatically.
+    # @param hr_status [String] the housing release status to set, if overriding the default
+    def invalidate_consent!(hr_status: nil)
+      self.class.invalidate_consent!(id, hr_status: hr_status)
+    end
+
+    # Clear consent fields for one or more clients and invalidate their view caches.
+    # Accepts a single id or an array of ids.
+    # @param ids [Integer, Array<Integer>] client id(s) to invalidate
+    # @param hr_status [String] the housing release status to set, if overriding the default
+    def self.invalidate_consent!(ids, hr_status: nil)
+      ids = Array.wrap(ids)
+      return if ids.blank?
+
+      # Normalize blank to nil; under implied consent, default to the no-consent string
+      hr_status = hr_status.presence
+      hr_status ||= GrdaWarehouse::Config.active_consent_class.no_release_string if GrdaWarehouse::Config.implied_consent?
+
+      where(id: ids).update_all(
         consent_form_id: nil,
         housing_release_status: hr_status,
         consent_form_signed_on: nil,
         consent_expires_on: nil,
         consented_coc_codes: [],
       )
-      # Remove any view caches for this client since permissions may have changed
-      clear_view_cache
-    end
-
-    # Clear consent fields for multiple clients in batches using a single UPDATE per batch.
-    # @param ids [Array<Integer>] client ids to invalidate
-    # @param batch_size [Integer] number of records per batch
-    def self.bulk_invalidate_consent!(ids, batch_size: 500)
-      return if ids.blank?
-
-      # If using implied consent, we need to set the housing release status to the current consent type ("Implied Consent")
-      hr_status = GrdaWarehouse::Config.active_consent_class.new(client: new).current_consent_type if GrdaWarehouse::Config.implied_consent?
-
-      ids.each_slice(batch_size) do |slice|
-        clients = where(id: slice)
-        clients.update_all(
-          consent_form_id: nil,
-          housing_release_status: hr_status,
-          consent_form_signed_on: nil,
-          consent_expires_on: nil,
-          consented_coc_codes: [],
-        )
-        clients.each(&:clear_view_cache)
-      end
+      # Remove any view caches since permissions may have changed
+      ids.each { |id| clear_view_cache(id) }
     end
 
     def apply_housing_release_status

--- a/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
+++ b/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
@@ -58,7 +58,7 @@ module GrdaWarehouse::Tasks
           GrdaWarehouse::ClientRoiAuthorization.where(destination_client: no_roi_status_ids).delete_all
           # Clears stale consent_form_id and related fields on the client record. This is a no-op
           # for clients that never had consent, but necessary for those whose ROI was removed.
-          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(no_roi_status_ids, batch_size: batch_size) if no_roi_status_ids.any?
+          GrdaWarehouse::Hud::Client.invalidate_consent!(no_roi_status_ids) if no_roi_status_ids.any?
         end
 
         # Invalidate consent for clients whose ROI has expired but still have consent_form_id set
@@ -70,7 +70,7 @@ module GrdaWarehouse::Tasks
           merge(GrdaWarehouse::Hud::Client.where.not(consent_form_id: nil))
         expired_scope = expired_scope.where(destination_client_id: client_ids) if client_ids
         expired_client_ids = expired_scope.pluck(:destination_client_id)
-        GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(expired_client_ids, batch_size: batch_size)
+        GrdaWarehouse::Hud::Client.invalidate_consent!(expired_client_ids)
 
         # cleanup orphaned auth records where the client record no-longer exists at all
         orphan_ids = GrdaWarehouse::ClientRoiAuthorization.with_invalid_client.pluck(:id)

--- a/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
+++ b/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
@@ -22,6 +22,12 @@ module GrdaWarehouse::Tasks
       end
     end
 
+    # Rebuild ROI authorization records for destination clients. For each client:
+    #   - upsert a ClientRoiAuthorization if roi_status returns a value
+    #   - delete the authorization and invalidate consent if roi_status returns nil
+    #     (covers both data corrections and clients with no consent of any kind)
+    # After processing all batches, invalidate consent for clients whose authorization
+    # has passed its expiry date, and delete orphaned auth records whose client no longer exists.
     # @param client_ids [Array<Integer>, nil] client ids to rebuild. Rebuild all clients if nil
     # @param batch_size [Integer] number of records to process in each batch
     def _perform(client_ids: nil, batch_size: 500)
@@ -32,10 +38,11 @@ module GrdaWarehouse::Tasks
         scope = scope.where(id: client_ids) unless client_ids.nil?
         scope.find_in_batches(batch_size: batch_size) do |batch|
           values = []
-          missing_ids = []
+          # Clients in this batch that have no current ROI status (e.g. data correction removed their consent)
+          no_roi_status_ids = []
           batch.each do |client|
             result = process_client(client)
-            missing_ids << client.id if result.nil?
+            no_roi_status_ids << client.id if result.nil?
             values << result if result
           end
 
@@ -47,9 +54,11 @@ module GrdaWarehouse::Tasks
             },
           )
 
-          # cleanup auth records for clients that have lost ROI status (but client still exists). This might be due to data correction rather than revocation
-          GrdaWarehouse::ClientRoiAuthorization.where(destination_client: missing_ids).delete_all
-          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(missing_ids, batch_size: batch_size) if missing_ids.any?
+          # Cleanup auth records for clients that have lost ROI status (but client still exists)
+          GrdaWarehouse::ClientRoiAuthorization.where(destination_client: no_roi_status_ids).delete_all
+          # Clears stale consent_form_id and related fields on the client record. This is a no-op
+          # for clients that never had consent, but necessary for those whose ROI was removed.
+          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(no_roi_status_ids, batch_size: batch_size) if no_roi_status_ids.any?
         end
 
         # Invalidate consent for clients whose ROI has expired but still have consent_form_id set
@@ -74,11 +83,14 @@ module GrdaWarehouse::Tasks
 
     protected
 
-    # we only consider building ROI authorizations for destination clients
+    # @return [ActiveRecord::Relation<GrdaWarehouse::Hud::Client>] destination clients only
     def destination_client_scope
       GrdaWarehouse::Hud::Client.destination
     end
 
+    # Build a hash of ROI authorization attributes for a destination client.
+    # @param destination_client [GrdaWarehouse::Hud::Client] a destination client
+    # @return [Hash, nil] authorization attributes for upsert, or nil if the client has no current ROI status
     def process_client(destination_client)
       status = roi_status(destination_client)
 
@@ -90,10 +102,13 @@ module GrdaWarehouse::Tasks
         coc_codes: roi_coc_codes(destination_client),
         starts_at: destination_client.consent_form_signed_on,
         expires_at: roi_expiry_date(destination_client),
-        # maybe add file, other fields
       }
     end
 
+    # Calculate the ROI expiration date for a client based on the configured release duration.
+    # Raises if the duration is time-based and the client has no signature date.
+    # @param client [GrdaWarehouse::Hud::Client]
+    # @return [Date, nil] expiration date, or nil for indefinite releases
     def roi_expiry_date(client)
       case roi_duration
       when 'One Year', 'Two Years'
@@ -109,17 +124,25 @@ module GrdaWarehouse::Tasks
       end
     end
 
+    # @return [String] configured release duration (e.g. 'One Year', 'Two Years', 'Use Expiration Date', 'Indefinite')
     def roi_duration
       GrdaWarehouse::Hud::Client.release_duration
     end
 
+    # @param client [GrdaWarehouse::Hud::Client]
+    # @return [Array<String>, nil] sorted unique CoC codes the client has consented to, or nil if none
     def roi_coc_codes(client)
       result = client.consented_coc_codes&.compact_blank&.presence
       result&.sort&.uniq
     end
 
+    # Determine the ROI authorization status for a client.
+    # Returns nil when no authorization record should be created or kept. This happens when:
+    #   - the signature date is missing and the duration mode requires one to compute validity, or
+    #   - the client has no active, partial, or revoked consent of any kind.
+    # @param client [GrdaWarehouse::Hud::Client]
+    # @return [String, nil] one of the ClientRoiAuthorization status constants, or nil
     def roi_status(client)
-      # skip if the roi is missing a signature date and it's needed to determine the validity period
       return nil if client.consent_form_signed_on.nil? && roi_duration.in?(['One Year', 'Two Years'])
 
       if client.revoked_consent?
@@ -131,6 +154,8 @@ module GrdaWarehouse::Tasks
       end
     end
 
+    # Acquire an advisory lock so only one instance of this task runs at a time.
+    # Skips execution (does not yield) if the lock is already held.
     def with_lock(&block)
       lock_name = self.class.name.demodulize
       GrdaWarehouseBase.with_advisory_lock(lock_name, timeout_seconds: 0, &block)

--- a/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
+++ b/app/models/grda_warehouse/tasks/generate_client_roi_authorizations_task.rb
@@ -49,7 +49,19 @@ module GrdaWarehouse::Tasks
 
           # cleanup auth records for clients that have lost ROI status (but client still exists). This might be due to data correction rather than revocation
           GrdaWarehouse::ClientRoiAuthorization.where(destination_client: missing_ids).delete_all
+          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(missing_ids, batch_size: batch_size) if missing_ids.any?
         end
+
+        # Invalidate consent for clients whose ROI has expired but still have consent_form_id set
+        expired_scope = GrdaWarehouse::ClientRoiAuthorization.
+          where(status: [GrdaWarehouse::ClientRoiAuthorization::PARTIAL_STATUS, GrdaWarehouse::ClientRoiAuthorization::FULL_STATUS]).
+          where.not(expires_at: nil).
+          where(expires_at: ..Date.current).
+          joins(:destination_client).
+          merge(GrdaWarehouse::Hud::Client.where.not(consent_form_id: nil))
+        expired_scope = expired_scope.where(destination_client_id: client_ids) if client_ids
+        expired_client_ids = expired_scope.pluck(:destination_client_id)
+        GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(expired_client_ids, batch_size: batch_size)
 
         # cleanup orphaned auth records where the client record no-longer exists at all
         orphan_ids = GrdaWarehouse::ClientRoiAuthorization.with_invalid_client.pluck(:id)

--- a/app/models/grda_warehouse/tasks/update_housing_release_statuses.rb
+++ b/app/models/grda_warehouse/tasks/update_housing_release_statuses.rb
@@ -25,7 +25,7 @@ module GrdaWarehouse
         status_groups = {}
 
         clients.each do |client|
-          consent_class = GrdaWarehouse::Config.active_consent_class.new(client: client)
+          consent_class ||= GrdaWarehouse::Config.active_consent_class.new(client: client)
 
           old_status = client.housing_release_status
           new_status = consent_class.current_consent_type

--- a/app/views/clients/files/_consent_badges.haml
+++ b/app/views/clients/files/_consent_badges.haml
@@ -2,7 +2,7 @@
 -# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
 
 .consent-status-badges.mb-2
-  - if file.most_recent_consent_form? && !file.revoked?
+  - if file.active_consent_form? && !file.revoked?
     %span.badge.text-bg-success Active
   - exp = file.calculated_expiration_date
   - if exp

--- a/app/views/clients/files/_consent_badges.haml
+++ b/app/views/clients/files/_consent_badges.haml
@@ -1,0 +1,16 @@
+-# Copyright 2016 - 2025 Green River Data Analysis, LLC
+-# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+
+.consent-status-badges.mb-2
+  - if file.most_recent_consent_form? && !file.revoked?
+    %span.badge.text-bg-success Active
+  - exp = file.calculated_expiration_date
+  - if exp
+    - if exp.past?
+      %span.badge.text-bg-danger Expired #{exp.to_date}
+    - else
+      %span.badge.text-bg-success Expires #{exp.to_date}
+  - else
+    %span.badge.text-bg-secondary No Expiration
+  - if file.revoked?
+    %span.badge.text-bg-warning Revoked #{file.consent_revoked_at.to_date}

--- a/app/views/clients/files/_file_row.haml
+++ b/app/views/clients/files/_file_row.haml
@@ -64,10 +64,15 @@
           %dl
             %dt Consent Type
             %dd= file.consent_type_with_extras
-          - if file.active_consent_form?
-            .active-release.mb-2{data: { 'bs-toggle' => :tooltip, 'bs-title' => 'You will need to refresh the page to see changes to active release forms'}}
-              %i.icon-flag
-              Active
+          - if file.most_recent_consent_form?
+            .mb-2
+              %span.label.label-default Most Recent
+              - exp = file.calculated_expiration_date
+              - if exp
+                - if exp.past?
+                  %span.label.label-danger Expired #{exp.to_date}
+                - else
+                  %span.label.label-success Expires #{exp.to_date}
           - if @consent_editable
             - unless GrdaWarehouse::Config.get(:release_duration) == 'Use Expiration Date'
               = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|

--- a/app/views/clients/files/_file_row.haml
+++ b/app/views/clients/files/_file_row.haml
@@ -64,15 +64,7 @@
           %dl
             %dt Consent Type
             %dd= file.consent_type_with_extras
-          - if file.most_recent_consent_form?
-            .mb-2
-              %span.label.label-default Most Recent
-              - exp = file.calculated_expiration_date
-              - if exp
-                - if exp.past?
-                  %span.label.label-danger Expired #{exp.to_date}
-                - else
-                  %span.label.label-success Expires #{exp.to_date}
+          = render 'clients/files/consent_badges', file: file
           - if @consent_editable
             - unless GrdaWarehouse::Config.get(:release_duration) == 'Use Expiration Date'
               = simple_form_for file, remote: true, url: appropriate_file_path(id: file.id) do |f|

--- a/app/views/clients/files/update.js.coffee
+++ b/app/views/clients/files/update.js.coffee
@@ -2,6 +2,7 @@
   alert "<%= @file.errors.full_messages.join(', ') %>"
 <% else %>
   $(".client-file-<%= @file.id %>").addClass 'bg-warning-subtle'
+  $(".client-file-<%= @file.id %> .consent-status-badges").html("<%= escape_javascript(render('clients/files/consent_badges', file: @file)) %>")
 
   setTimeout ->
     $(".client-file-<%= @file.id %>").removeClass('bg-warning-subtle')

--- a/spec/models/grda_warehouse/client_file_legacy_spec.rb
+++ b/spec/models/grda_warehouse/client_file_legacy_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
         end
 
         it 'active release is set to the consent form' do
-          expect(file.active_consent_form?).to be true
+          expect(file.most_recent_consent_form?).to be true
         end
 
         describe 'when a new non-consent form is uploaded' do
@@ -84,7 +84,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
           end
 
           it 'active release is still set to the original consent form' do
-            expect(file.active_consent_form?).to be true
+            expect(file.most_recent_consent_form?).to be true
           end
 
           it 'does not change the client consent_form_signed_on' do
@@ -102,7 +102,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
             end
 
             it 'active release is set to the new consent form' do
-              expect(second_file.active_consent_form?).to be true
+              expect(second_file.most_recent_consent_form?).to be true
             end
             describe 'when the new consent form is un-confirmed' do
               before :each do
@@ -113,7 +113,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
               end
 
               it 'the active release remains the same' do
-                expect(second_file.active_consent_form?).to be true
+                expect(second_file.most_recent_consent_form?).to be true
               end
 
               describe 'when the original consent is un-confirmed' do

--- a/spec/models/grda_warehouse/client_file_legacy_spec.rb
+++ b/spec/models/grda_warehouse/client_file_legacy_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
         end
 
         it 'active release is set to the consent form' do
-          expect(file.most_recent_consent_form?).to be true
+          expect(file.active_consent_form?).to be true
         end
 
         describe 'when a new non-consent form is uploaded' do
@@ -84,7 +84,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
           end
 
           it 'active release is still set to the original consent form' do
-            expect(file.most_recent_consent_form?).to be true
+            expect(file.active_consent_form?).to be true
           end
 
           it 'does not change the client consent_form_signed_on' do
@@ -102,7 +102,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
             end
 
             it 'active release is set to the new consent form' do
-              expect(second_file.most_recent_consent_form?).to be true
+              expect(second_file.active_consent_form?).to be true
             end
             describe 'when the new consent form is un-confirmed' do
               before :each do
@@ -113,7 +113,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
               end
 
               it 'the active release remains the same' do
-                expect(second_file.most_recent_consent_form?).to be true
+                expect(second_file.active_consent_form?).to be true
               end
 
               describe 'when the original consent is un-confirmed' do

--- a/spec/models/grda_warehouse/client_file_spec.rb
+++ b/spec/models/grda_warehouse/client_file_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
         end
 
         it 'active release is set to the consent form' do
-          expect(file.most_recent_consent_form?).to be true
+          expect(file.active_consent_form?).to be true
         end
 
         describe 'when a new non-consent form is uploaded' do
@@ -93,7 +93,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
           end
 
           it 'active release is still set to the original consent form' do
-            expect(file.most_recent_consent_form?).to be true
+            expect(file.active_consent_form?).to be true
           end
 
           it 'does not change the client consent_form_signed_on' do
@@ -111,7 +111,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
             end
 
             it 'active release is set to the new consent form' do
-              expect(second_file.most_recent_consent_form?).to be true
+              expect(second_file.active_consent_form?).to be true
             end
             describe 'when the new consent form is un-confirmed' do
               before :each do
@@ -122,7 +122,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
               end
 
               it 'the active release remains the same' do
-                expect(second_file.most_recent_consent_form?).to be true
+                expect(second_file.active_consent_form?).to be true
               end
 
               describe 'when the original consent is un-confirmed' do

--- a/spec/models/grda_warehouse/client_file_spec.rb
+++ b/spec/models/grda_warehouse/client_file_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
         end
 
         it 'active release is set to the consent form' do
-          expect(file.active_consent_form?).to be true
+          expect(file.most_recent_consent_form?).to be true
         end
 
         describe 'when a new non-consent form is uploaded' do
@@ -93,7 +93,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
           end
 
           it 'active release is still set to the original consent form' do
-            expect(file.active_consent_form?).to be true
+            expect(file.most_recent_consent_form?).to be true
           end
 
           it 'does not change the client consent_form_signed_on' do
@@ -111,7 +111,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
             end
 
             it 'active release is set to the new consent form' do
-              expect(second_file.active_consent_form?).to be true
+              expect(second_file.most_recent_consent_form?).to be true
             end
             describe 'when the new consent form is un-confirmed' do
               before :each do
@@ -122,7 +122,7 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
               end
 
               it 'the active release remains the same' do
-                expect(second_file.active_consent_form?).to be true
+                expect(second_file.most_recent_consent_form?).to be true
               end
 
               describe 'when the original consent is un-confirmed' do
@@ -424,6 +424,77 @@ RSpec.describe GrdaWarehouse::ClientFile, type: :model do
         file.save
 
         expect(file.active_storage_url).to be_nil
+      end
+    end
+  end
+
+  describe '#calculated_expiration_date' do
+    let!(:consent_tag) { create :available_file_tag, consent_form: true, name: 'ROI Calc Test' }
+    let!(:file) { create :client_file, effective_date: Date.current }
+
+    before(:each) do
+      file.tag_list.add(consent_tag.name)
+      file.consent_form_signed_on = 1.month.ago.to_date
+      file.save!
+    end
+
+    context 'when release_duration is Indefinite' do
+      before { allow(GrdaWarehouse::Config).to receive(:get).with(:release_duration).and_return('Indefinite') }
+
+      it 'returns nil' do
+        expect(file.calculated_expiration_date).to be_nil
+      end
+    end
+
+    context 'when release_duration is One Year' do
+      before { allow(GrdaWarehouse::Config).to receive(:get).with(:release_duration).and_return('One Year') }
+
+      it 'returns consent_form_signed_on + 1 year' do
+        expect(file.calculated_expiration_date).to eq(file.consent_form_signed_on + 1.year)
+      end
+
+      context 'when consent_form_signed_on is nil' do
+        before { file.update_column(:consent_form_signed_on, nil) }
+
+        it 'returns nil' do
+          expect(file.calculated_expiration_date).to be_nil
+        end
+      end
+    end
+
+    context 'when release_duration is Two Years' do
+      before { allow(GrdaWarehouse::Config).to receive(:get).with(:release_duration).and_return('Two Years') }
+
+      it 'returns consent_form_signed_on + 2 years' do
+        expect(file.calculated_expiration_date).to eq(file.consent_form_signed_on + 2.years)
+      end
+
+      context 'when consent_form_signed_on is nil' do
+        before { file.update_column(:consent_form_signed_on, nil) }
+
+        it 'returns nil' do
+          expect(file.calculated_expiration_date).to be_nil
+        end
+      end
+    end
+
+    context 'when release_duration is Use Expiration Date' do
+      before { allow(GrdaWarehouse::Config).to receive(:get).with(:release_duration).and_return('Use Expiration Date') }
+
+      context 'when expiration_date is set' do
+        before { file.update_column(:expiration_date, 6.months.from_now.to_date) }
+
+        it "returns the file's expiration_date" do
+          expect(file.calculated_expiration_date).to eq(file.expiration_date)
+        end
+      end
+
+      context 'when expiration_date is nil' do
+        before { file.update_column(:expiration_date, nil) }
+
+        it 'returns nil' do
+          expect(file.calculated_expiration_date).to be_nil
+        end
       end
     end
   end

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -557,25 +557,50 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
     end
 
     describe '.bulk_invalidate_consent!' do
-      before do
-        GrdaWarehouse::Config.delete_all
-        create(:config_b)
-        GrdaWarehouse::Config.invalidate_cache
-      end
-
-      it 'calls invalidate_consent! on each client' do
-        clients = create_list(:grda_warehouse_hud_client, 3)
-        clients.each { |c| create(:client_file_expanded_consent, client: c) }
-
-        clients.each { |c| expect(c.reload.consent_form_id).not_to be_nil }
-
-        GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
-
-        clients.each { |c| expect(c.reload.consent_form_id).to be_nil }
-      end
-
       it 'is a no-op when given an empty array' do
         expect { GrdaWarehouse::Hud::Client.bulk_invalidate_consent!([]) }.not_to raise_error
+      end
+
+      context 'when using explicit consent' do
+        before do
+          GrdaWarehouse::Config.delete_all
+          create(:config_b)
+          GrdaWarehouse::Config.invalidate_cache
+        end
+
+        it 'clears consent fields for each client' do
+          clients = create_list(:grda_warehouse_hud_client, 3)
+          clients.each { |c| create(:client_file_expanded_consent, client: c) }
+
+          clients.each { |c| expect(c.reload.consent_form_id).not_to be_nil }
+
+          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
+
+          clients.each do |c|
+            expect(c.reload.consent_form_id).to be_nil
+            expect(c.reload.housing_release_status).to be_nil
+          end
+        end
+      end
+
+      context 'when using implied consent' do
+        before do
+          GrdaWarehouse::Config.delete_all
+          create(:config_va)
+          GrdaWarehouse::Config.invalidate_cache
+        end
+
+        it 'sets housing_release_status for implied consent on each client' do
+          clients = create_list(:grda_warehouse_hud_client, 3)
+          clients.each { |c| create(:client_file_expanded_consent, client: c) }
+
+          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
+
+          clients.each do |c|
+            expect(c.reload.consent_form_id).to be_nil
+            expect(c.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.no_release_string)
+          end
+        end
       end
     end
   end

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
           GrdaWarehouse::Config.invalidate_cache
         end
 
-        it 'sets housing_release_status to nil when no consent file is present' do
+        it 'sets housing_release_status to nil when consent file is removed' do
           client = create(:grda_warehouse_hud_client)
           consent_file = create(:client_file_expanded_consent, client: client)
           expect(client.reload.housing_release_status).to be_present
@@ -514,10 +514,19 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
           expect(client.reload.housing_release_status).to be_nil
         end
 
-        it 'sets housing_release_status to nil when no consent file is revoked' do
+        it 'sets housing_release_status to nil when consent file is revoked and hr_status is passed' do
           client = create(:grda_warehouse_hud_client)
           consent_file = create(:client_file_expanded_consent, client: client)
-          expect(client.reload.housing_release_status).to be_present
+          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.full_release_string)
+          consent_file.update(consent_revoked_at: Time.current)
+          # revoked_consent_string is "" for explicit consent, which normalizes to nil
+          client.invalidate_consent!(hr_status: GrdaWarehouse::Config.active_consent_class.revoked_consent_string)
+          expect(client.reload.housing_release_status).to be_nil
+        end
+
+        it 'sets housing_release_status to nil when consent file is revoked and hr_status is not passed' do
+          client = create(:grda_warehouse_hud_client)
+          consent_file = create(:client_file_expanded_consent, client: client)
           expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.full_release_string)
           consent_file.update(consent_revoked_at: Time.current)
           client.invalidate_consent!
@@ -543,22 +552,29 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
           expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.no_release_string)
         end
 
-        it 'sets housing_release_status for implied consent when consent file is revoked' do
+        it 'sets housing_release_status to revoked_consent_string when consent file is revoked and hr_status is passed' do
           client = create(:grda_warehouse_hud_client)
           consent_file = create(:client_file_expanded_consent, client: client)
-          expect(client.reload.housing_release_status).to be_present
+          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.full_release_string)
+          consent_file.update(consent_revoked_at: Time.current)
+          client.invalidate_consent!(hr_status: GrdaWarehouse::Config.active_consent_class.revoked_consent_string)
+          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.revoked_consent_string)
+        end
+
+        it 'defaults to no_release_string when consent file is revoked but hr_status is not passed' do
+          client = create(:grda_warehouse_hud_client)
+          consent_file = create(:client_file_expanded_consent, client: client)
           expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.full_release_string)
           consent_file.update(consent_revoked_at: Time.current)
           client.invalidate_consent!
-          expect(client.reload.housing_release_status).to be_present
-          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.revoked_consent_string)
+          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Config.active_consent_class.no_release_string)
         end
       end
     end
 
-    describe '.bulk_invalidate_consent!' do
+    describe '.invalidate_consent!' do
       it 'is a no-op when given an empty array' do
-        expect { GrdaWarehouse::Hud::Client.bulk_invalidate_consent!([]) }.not_to raise_error
+        expect { GrdaWarehouse::Hud::Client.invalidate_consent!([]) }.not_to raise_error
       end
 
       context 'when using explicit consent' do
@@ -574,7 +590,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
 
           clients.each { |c| expect(c.reload.consent_form_id).not_to be_nil }
 
-          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
+          GrdaWarehouse::Hud::Client.invalidate_consent!(clients.map(&:id))
 
           clients.each do |c|
             expect(c.reload.consent_form_id).to be_nil
@@ -594,7 +610,7 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
           clients = create_list(:grda_warehouse_hud_client, 3)
           clients.each { |c| create(:client_file_expanded_consent, client: c) }
 
-          GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
+          GrdaWarehouse::Hud::Client.invalidate_consent!(clients.map(&:id))
 
           clients.each do |c|
             expect(c.reload.consent_form_id).to be_nil

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -555,5 +555,28 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
         end
       end
     end
+
+    describe '.bulk_invalidate_consent!' do
+      before do
+        GrdaWarehouse::Config.delete_all
+        create(:config_b)
+        GrdaWarehouse::Config.invalidate_cache
+      end
+
+      it 'calls invalidate_consent! on each client' do
+        clients = create_list(:grda_warehouse_hud_client, 3)
+        clients.each { |c| create(:client_file_expanded_consent, client: c) }
+
+        clients.each { |c| expect(c.reload.consent_form_id).not_to be_nil }
+
+        GrdaWarehouse::Hud::Client.bulk_invalidate_consent!(clients.map(&:id))
+
+        clients.each { |c| expect(c.reload.consent_form_id).to be_nil }
+      end
+
+      it 'is a no-op when given an empty array' do
+        expect { GrdaWarehouse::Hud::Client.bulk_invalidate_consent!([]) }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/models/grda_warehouse/tasks/generate_client_roi_authorizations_task_spec.rb
+++ b/spec/models/grda_warehouse/tasks/generate_client_roi_authorizations_task_spec.rb
@@ -76,6 +76,37 @@ RSpec.describe GrdaWarehouse::Tasks::GenerateClientRoiAuthorizationsTask, type: 
         end
       end
     end
+
+    context 'when client loses roi status and has a consent file' do
+      let!(:client_losing_roi) { destination_clients.last }
+
+      before do
+        allow(task).to receive(:roi_status) do |client|
+          client.id == client_losing_roi.id ? nil : 'full_status'
+        end
+        create(:client_file_expanded_consent, client: client_losing_roi)
+      end
+
+      it 'clears consent fields for the missing client' do
+        expect { task.perform(batch_size: batch_size) }.
+          to change { client_losing_roi.reload.consent_form_id }.to(nil)
+      end
+    end
+
+    context 'when a client has an expired ROI auth record' do
+      let!(:client_with_expired_roi) { create(:hud_client, consent_form_signed_on: 2.years.ago) }
+
+      before do
+        allow(task).to receive(:roi_status).and_return(GrdaWarehouse::ClientRoiAuthorization::FULL_STATUS)
+        allow(task).to receive(:roi_expiry_date).and_return(1.year.ago.to_date)
+        create(:client_file_expanded_consent, client: client_with_expired_roi)
+      end
+
+      it 'clears consent fields for the expired client' do
+        expect { task.perform(batch_size: batch_size) }.
+          to change { client_with_expired_roi.reload.consent_form_id }.to(nil)
+      end
+    end
   end
 
   describe '#process_client' do

--- a/spec/models/grda_warehouse/tasks/generate_client_roi_authorizations_task_spec.rb
+++ b/spec/models/grda_warehouse/tasks/generate_client_roi_authorizations_task_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe GrdaWarehouse::Tasks::GenerateClientRoiAuthorizationsTask, type: 
         create(:client_file_expanded_consent, client: client_losing_roi)
       end
 
-      it 'clears consent fields for the missing client' do
+      it 'clears consent fields for client that lost ROI status' do
         expect { task.perform(batch_size: batch_size) }.
           to change { client_losing_roi.reload.consent_form_id }.to(nil)
       end

--- a/spec/models/grda_warehouse/tasks/update_housing_release_statuses_spec.rb
+++ b/spec/models/grda_warehouse/tasks/update_housing_release_statuses_spec.rb
@@ -59,10 +59,12 @@ RSpec.describe GrdaWarehouse::Tasks::UpdateHousingReleaseStatuses, type: :model 
         it 'updates the housing release statuses' do
           service.run!
 
+          no_release_string = config_scenario[:expected_consent_class] == Consent::Implied ? GrdaWarehouse::Hud::Client.no_release_string : nil
+
           # Regular client should become the no_release_string for this consent model
-          expect(client.reload.housing_release_status).to eq(GrdaWarehouse::Hud::Client.no_release_string)
+          expect(client.reload.housing_release_status).to eq(no_release_string)
           # Revoked consent client should become the revoked_consent_string for this consent model
-          expect(revoked_consent_client.reload.housing_release_status).to eq(GrdaWarehouse::Hud::Client.revoked_consent_string)
+          expect(revoked_consent_client.reload.housing_release_status.to_s).to eq(GrdaWarehouse::Hud::Client.revoked_consent_string)
           # Expanded consent client should become the full_release_string for this consent model
           expect(expanded_consent_client.reload.housing_release_status).to eq(GrdaWarehouse::Hud::Client.full_release_string)
           # Partial consent client should become the partial_release_string for this consent model


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The "Active" badge on a client's Releases of Information page was misleading — it only showed which ROI file was uploaded most recently, with no indication of whether that consent was still valid. Staff had no quick way to see at a glance whether a client's ROI had lapsed.

This update replaces the "Active" badge with a set of color-coded status badges: a green **"Active"** badge when the most recent file is current and not revoked, a green **"Expires [date]"** badge when it's still valid, a red **"Expired [date]"** badge when it has lapsed, and a grey **"No Expiration"** badge for indefinite releases. A yellow **"Revoked [date]"** badge is also shown when consent has been revoked. The badges update immediately when a file is confirmed, with no page refresh required.

The nightly ROI authorization task is also updated to clear stale consent data from clients who have lost ROI status or whose authorization records have expired, keeping the displayed status accurate over time.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New Feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
