### PR TITLE
Resolve GraphQL Enrollment.access from HmisEnrollmentPolicy

### DIFF
--- a/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
+++ b/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
@@ -82,7 +82,7 @@ module GraphqlApplicationHelper
     # Filter to only enrollments the user has permission to see;
     # Filter down to open enrollments in the specified project on the specified date
     enrollments.filter do |en|
-      has_permission = current_permission?(permission: :can_view_enrollment_details, entity: en)
+      has_permission = current_user.policy_for(en, policy_type: :hmis_enrollment).can_view_details?
       has_permission && en.open_on_date?(open_on_date) && en.project_pk.to_s == project_id.to_s
     end.min_by { |e| [e.entry_date, e.id] }
   end

--- a/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
+++ b/drivers/hmis/app/graphql/concerns/graphql_application_helper.rb
@@ -79,6 +79,9 @@ module GraphqlApplicationHelper
     # Load all enrollments for the client
     enrollments = load_ar_association(client, :enrollments_with_exits)
 
+    # Perf optimization: preload project dependencies for enrollments, to avoid N+1 in policy check below
+    current_user.policy_context.preload_project_dependencies(enrollments.map(&:project_pk))
+
     # Filter to only enrollments the user has permission to see;
     # Filter down to open enrollments in the specified project on the specified date
     enrollments.filter do |en|

--- a/drivers/hmis/app/graphql/mutations/delete_current_living_situation.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_current_living_situation.rb
@@ -14,8 +14,7 @@ module Mutations
 
     def resolve(id:)
       current_living_situation = Hmis::Hud::CurrentLivingSituation.viewable_by(current_user).find_by(id: id)
-      access_denied! unless current_living_situation
-      access_denied! unless current_permission?(permission: :can_edit_enrollments, entity: current_living_situation)
+      access_denied! unless current_living_situation && current_user.policy_for(current_living_situation.enrollment, policy_type: :hmis_enrollment).can_edit?
 
       current_living_situation.with_lock do
         # If this CLS is the owner of a FormProcessor, destroy related records (for example clh_location)

--- a/drivers/hmis/app/graphql/mutations/delete_current_living_situation.rb
+++ b/drivers/hmis/app/graphql/mutations/delete_current_living_situation.rb
@@ -14,7 +14,8 @@ module Mutations
 
     def resolve(id:)
       current_living_situation = Hmis::Hud::CurrentLivingSituation.viewable_by(current_user).find_by(id: id)
-      access_denied! unless current_living_situation && current_user.policy_for(current_living_situation.enrollment, policy_type: :hmis_enrollment).can_edit?
+      access_denied! unless current_living_situation
+      access_denied! unless current_user.policy_for(current_living_situation.enrollment, policy_type: :hmis_enrollment).can_edit?
 
       current_living_situation.with_lock do
         # If this CLS is the owner of a FormProcessor, destroy related records (for example clh_location)

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -293,7 +293,13 @@ module Types
       client = load_ar_client_association(object)
       # There is no "viewable_by" check on the enrollments, because this permission
       # grants full access regardless of enrollment/project visibility.
-      load_ar_association(client, :enrollments).where.not(id: object.id).open_including_wip
+      open_enrollments = client.enrollments.where.not(id: object.id).open_including_wip
+
+      # Perf optimization: preload project dependencies for open enrollments, to avoid N+1
+      # when resolving HmisSchema::EnrollmentSummary#can_view_enrollment
+      context[:current_user].policy_context.preload_project_dependencies(open_enrollments.map(&:project_pk))
+
+      open_enrollments
     end
 
     def reminders

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -100,12 +100,14 @@ module Types
     # Override permission requirement for the access object. This is necessary so the frontend
     # knows whether its safe to link to the full enrollment dashboard for a given enrollment.
     access_field permissions: nil do
-      can :view_enrollment_details
-      can :edit_enrollments
-      can :delete_enrollments
-      can :split_households
-      can :audit_enrollments
-      can :view_enrollment_location_map
+      define_method(:policy) { @policy ||= policy_for(object, policy_type: :hmis_enrollment) }
+
+      bool_field(:can_view_enrollment_details) { policy.can_view_details? }
+      bool_field(:can_edit_enrollments) { policy.can_edit? }
+      bool_field(:can_delete_enrollments) { policy.can_delete? }
+      bool_field(:can_split_households) { policy.can_split_household? }
+      bool_field(:can_audit_enrollments) { policy.can_audit? }
+      bool_field(:can_view_enrollment_location_map) { policy.can_view_location_map? }
     end
 
     # FULL ACCESS FIELDS. All fields below this line require `can_view_enrollment_details` perm, because they use the overridden 'field' class method.

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -269,7 +269,7 @@ module Types
 
     # N+1, not performant for queries on collections
     def geolocations
-      return [] unless current_permission?(permission: :can_view_enrollment_location_map, entity: project)
+      return [] unless enrollment_policy.can_view_location_map?
 
       # Must map to warehouse record because locations use polymorphic source with GrdaWarehouse::Hud::Enrollment type
       object.as_warehouse.enrollment_location_histories.valid
@@ -288,7 +288,7 @@ module Types
     # This is different from the "summary_fields" which are governed by a different
     # permission ('can_view_limited_enrollment_details').
     def open_enrollment_summary
-      return [] unless current_permission?(permission: :can_view_open_enrollment_summary, entity: object)
+      return [] unless enrollment_policy.can_view_open_enrollment_summary?
 
       client = load_ar_client_association(object)
       # There is no "viewable_by" check on the enrollments, because this permission
@@ -330,7 +330,7 @@ module Types
 
     # Needed because limited access viewers cannot resolve the project
     def project_name
-      return Hmis::Hud::Project::CONFIDENTIAL_PROJECT_NAME if project&.confidential && !current_permission?(permission: :can_view_enrollment_details, entity: object)
+      return Hmis::Hud::Project::CONFIDENTIAL_PROJECT_NAME if project&.confidential && !enrollment_policy.can_view_details?
 
       project&.project_name
     end
@@ -477,6 +477,12 @@ module Types
       assignments = load_ar_association(object, :staff_assignments)
       # Sort in-memory to avoid n+1. Equivalent of: order(created_at: :desc, id: :desc)
       assignments.to_a.sort_by { |sa| [-sa.created_at.to_i, -sa.id] }
+    end
+
+    private
+
+    def enrollment_policy
+      @enrollment_policy ||= current_user.policy_for(object, policy_type: :hmis_enrollment)
     end
   end
 end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -25,24 +25,13 @@ module Types
       Hmis::Hud::Enrollment.hmis_configuration(version: '2024')
     end
 
-    # check for the most minimal permission needed to resolve this object
-    # (can_view_project AND can_view_enrollment_details) OR can_view_limited_enrollment_details
+    # Check for the most minimal permission needed to resolve this object (full-access or limited-access)
+    # This is a secondary guard against data source leakage, the viewable_by scope is our primary defense.
     def self.authorized?(object, ctx)
       return false unless super
 
-      # current_permission_for_context? checks to prevent data source leakage, but it is a secondary guard;
-      # the viewable_by scope is our primary defense against this.
-      return true if GraphqlPermissionChecker.current_permission_for_context?(ctx, permission: :can_view_limited_enrollment_details, entity: object)
-
-      return false unless GraphqlPermissionChecker.current_permission_for_context?(ctx, permission: :can_view_enrollment_details, entity: object)
-
-      project = if object.association(:project).loaded?
-        object.project
-      else
-        ctx.dataloader.with(Sources::ActiveRecordAssociation, :project).load(object)
-      end
-
-      GraphqlPermissionChecker.current_permission_for_context?(ctx, permission: :can_view_project, entity: project)
+      policy = ctx[:current_user].policy_for(object, policy_type: :hmis_enrollment)
+      policy.can_view_limited? || policy.can_view_details?
     end
 
     # Override the "field" function to perform field-level authorization.

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment.rb
@@ -297,7 +297,7 @@ module Types
 
       # Perf optimization: preload project dependencies for open enrollments, to avoid N+1
       # when resolving HmisSchema::EnrollmentSummary#can_view_enrollment
-      context[:current_user].policy_context.preload_project_dependencies(open_enrollments.map(&:project_pk))
+      current_user.policy_context.preload_project_dependencies(open_enrollments.pluck(:project_pk))
 
       open_enrollments
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/enrollment_summary.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enrollment_summary.rb
@@ -36,7 +36,7 @@ module Types
     end
 
     def can_view_enrollment
-      current_permission?(permission: :can_view_enrollment_details, entity: object)
+      current_user.policy_for(object, policy_type: :hmis_enrollment).can_view_details?
     end
 
     def project

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_clients.rb
@@ -18,6 +18,7 @@ module Types
             null: false,
             description: description,
             after_paginate: ->(nodes, ctx) {
+              # Preload client dependencies to avoid N+1 queries when invoking HmisClientPolicy
               ctx[:current_user].policy_context.preload_client_dependencies(nodes.map(&:id))
             },
           }

--- a/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/has_enrollments.rb
@@ -20,7 +20,16 @@ module Types
           **override_options,
           &block
         )
-          default_field_options = { type: type, null: false, description: description }
+          default_field_options = {
+            type: type,
+            null: false,
+            description: description,
+            after_paginate: ->(nodes, ctx) {
+              # Preload project dependencies to avoid N+1 queries when invoking HmisEnrollmentPolicy
+              # across a set of Enrollments that span multiple projects.
+              ctx[:current_user].policy_context.preload_project_dependencies(nodes.map(&:project_pk))
+            },
+          }
           field_options = default_field_options.merge(override_options)
           field(name, **field_options) do
             argument :sort_order, HmisSchema::EnrollmentSortOption, required: false

--- a/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/referral_posting.rb
@@ -164,14 +164,6 @@ module Types
       load_ar_association(object, :referral)
     end
 
-    # Decided not to add this yet, but leaving comment in case there is a request in the future to link them up.
-    # def source_enrollment
-    #   return unless current_permission?(permission: :can_view_project, entity: enrollment_project)
-    #   return unless current_permission?(permission: :can_view_enrollment_details, entity: enrollment_project)
-
-    #   protected_source_enrollment
-    # end
-
     protected
 
     # Note: The User who can view this referral may not have access to view the referring project.

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
@@ -8,7 +8,18 @@
 
 class Hmis::AuthPolicies::HmisEnrollmentPolicy < Hmis::AuthPolicies::ResourcePolicy
   class Instance < Hmis::AuthPolicies::BasePolicy
-    # TODO: Add policy methods for can_view and can_view_limited and use them in GraphQL queries
+    # Whether the user can view the full enrollment details (grants access to the Enrollment Dashboard).
+    def can_view_details?
+      # Note: "can_view_enrollment_details" requires the "can_view_project" permission as a dependency,
+      # so the user must have both (enforced already by UserContext#project_permissions)
+      project_permissions.include?(:can_view_enrollment_details)
+    end
+
+    # Whether the user can view limited enrollment details (Entry/Exit date, project name, project type, move-in date, last bed night date).
+    # Note: user can have access to view limited enrollment details even if they cannot view the project.
+    def can_view_limited?
+      project_permissions.include?(:can_view_limited_enrollment_details)
+    end
 
     def can_edit?
       project_permissions.include?(:can_edit_enrollments)
@@ -20,10 +31,6 @@ class Hmis::AuthPolicies::HmisEnrollmentPolicy < Hmis::AuthPolicies::ResourcePol
 
       # Otherwise, to delete an active enrollment the user needs "can_delete_enrollments" permission
       project_permissions.include?(:can_delete_enrollments)
-    end
-
-    def can_view_details?
-      project_permissions.include?(:can_view_enrollment_details) # can_view_enrollment_details? requires can_view_project?
     end
 
     def can_create_file?

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
@@ -45,6 +45,14 @@ class Hmis::AuthPolicies::HmisEnrollmentPolicy < Hmis::AuthPolicies::ResourcePol
       project_permissions.include?(:can_view_enrollment_location_map)
     end
 
+    # Whether the user can see a summary of all of this client's other open enrollments on the
+    # Enrollment Details card (linked number that opens a modal). Unlike normal enrollment visibility, this
+    # permission intentionally exposes minimal info for open enrollments at any project, even
+    # projects the user cannot otherwise access (via HmisSchema::EnrollmentSummary type).
+    def can_view_open_enrollment_summary?
+      project_permissions.include?(:can_view_open_enrollment_summary)
+    end
+
     protected
 
     # convenience

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_enrollment_policy.rb
@@ -33,6 +33,18 @@ class Hmis::AuthPolicies::HmisEnrollmentPolicy < Hmis::AuthPolicies::ResourcePol
       project_permissions.include?(:can_manage_any_client_files) || global_permissions.include?(:can_manage_own_client_files)
     end
 
+    def can_split_household?
+      project_permissions.include?(:can_split_households)
+    end
+
+    def can_audit?
+      project_permissions.include?(:can_audit_enrollments)
+    end
+
+    def can_view_location_map?
+      project_permissions.include?(:can_view_enrollment_location_map)
+    end
+
     protected
 
     # convenience

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
@@ -130,6 +130,18 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
     end
   end
 
+  describe '#can_view_open_enrollment_summary?' do
+    it 'returns true if user has can_view_open_enrollment_summary at the enrollment project' do
+      create_access_control(user, project, with_permission: [:can_view_open_enrollment_summary, *view_permissions])
+      expect(policy.can_view_open_enrollment_summary?).to be true
+    end
+
+    it 'returns false if user has no permissions in this project' do
+      create_access_control(user, other_project, with_permission: [:can_view_open_enrollment_summary, *view_permissions])
+      expect(policy.can_view_open_enrollment_summary?).to be false
+    end
+  end
+
   describe '#can_create_file?' do
     it 'returns true when the user has can_manage_any_client_files on the enrollment project' do
       create_access_control(user, project, with_permission: [:can_manage_any_client_files])

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
   let(:enrollment) { create(:hmis_hud_enrollment, project: project, client: client, data_source: data_source) }
   let(:policy) { user.policy_for(enrollment, policy_type: :hmis_enrollment) }
 
+  # Permissions required for viewing an enrollment
+  let(:view_permissions) { [:can_view_enrollment_details, :can_view_project] }
+
   describe '#can_edit?' do
     it 'returns true if user can edit' do
-      create_access_control(user, project, with_permission: [:can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: [:can_edit_enrollments, *view_permissions])
       expect(policy.can_edit?).to be true
     end
 
@@ -23,34 +26,34 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
     end
 
     it 'returns false if user can view but not edit' do
-      create_access_control(user, project, with_permission: [:can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: view_permissions)
       expect(policy.can_edit?).to be false
     end
 
     it 'returns false if user has no permissions in this project' do
-      create_access_control(user, other_project, with_permission: [:can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, other_project, with_permission: [:can_edit_enrollments, *view_permissions])
       expect(policy.can_edit?).to be false
     end
   end
 
   describe '#can_delete?' do
     it 'returns true if user can delete' do
-      create_access_control(user, project, with_permission: [:can_delete_enrollments, :can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: [:can_delete_enrollments, :can_edit_enrollments, *view_permissions])
       expect(policy.can_delete?).to be true
     end
 
     it 'returns false if user cannot delete' do
-      create_access_control(user, project, with_permission: [:can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: [:can_edit_enrollments, *view_permissions])
       expect(policy.can_delete?).to be false
     end
 
     it 'returns false if user lacks can_edit_enrollments (missing permission requirements)' do
-      create_access_control(user, project, with_permission: [:can_delete_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: [:can_delete_enrollments, *view_permissions])
       expect(policy.can_delete?).to be false
     end
 
     it 'returns false if user has no permissions in this project' do
-      create_access_control(user, other_project, with_permission: [:can_delete_enrollments, :can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+      create_access_control(user, other_project, with_permission: [:can_delete_enrollments, :can_edit_enrollments, *view_permissions])
       expect(policy.can_delete?).to be false
     end
 
@@ -58,7 +61,7 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
       let(:enrollment) { create(:hmis_hud_wip_enrollment, project: project, client: client, data_source: data_source) }
 
       it 'returns true if user can edit' do
-        create_access_control(user, project, with_permission: [:can_edit_enrollments, :can_view_enrollment_details, :can_view_project])
+        create_access_control(user, project, with_permission: [:can_edit_enrollments, *view_permissions])
         expect(policy.can_delete?).to be true
       end
     end
@@ -66,7 +69,7 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
 
   describe '#can_view_details?' do
     it 'returns true if user can view details' do
-      create_access_control(user, project, with_permission: [:can_view_enrollment_details, :can_view_project])
+      create_access_control(user, project, with_permission: view_permissions)
       expect(policy.can_view_details?).to be true
     end
 
@@ -78,6 +81,52 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
     it 'returns false if user lacks can_view_enrollment_details, even if they can_view_limited_enrollment_details' do
       create_access_control(user, project.data_source, with_permission: [:can_view_project, :can_view_limited_enrollment_details])
       expect(policy.can_view_details?).to be false
+    end
+  end
+
+  describe '#can_split_household?' do
+    it 'returns true if user can split households at the enrollment project' do
+      create_access_control(user, project, with_permission: [:can_split_households, *view_permissions])
+      expect(policy.can_split_household?).to be true
+    end
+
+    it 'returns false if user has no permissions in this project' do
+      create_access_control(user, other_project, with_permission: [:can_split_households, *view_permissions])
+      expect(policy.can_split_household?).to be false
+    end
+  end
+
+  describe '#can_audit?' do
+    it 'returns true if user can audit enrollments at the enrollment project' do
+      create_access_control(user, project, with_permission: [:can_audit_enrollments, *view_permissions])
+      expect(policy.can_audit?).to be true
+    end
+
+    it 'returns false if user lacks can_view_project (required for can_audit_enrollments)' do
+      create_access_control(user, project, with_permission: [:can_audit_enrollments, :can_view_enrollment_details])
+      expect(policy.can_audit?).to be false
+    end
+
+    it 'returns false if user has no permissions in this project' do
+      create_access_control(user, other_project, with_permission: [:can_audit_enrollments, *view_permissions])
+      expect(policy.can_audit?).to be false
+    end
+  end
+
+  describe '#can_view_location_map?' do
+    it 'returns true if user can view the enrollment location map at the enrollment project' do
+      create_access_control(user, project, with_permission: [:can_view_enrollment_location_map, *view_permissions])
+      expect(policy.can_view_location_map?).to be true
+    end
+
+    it 'returns false if user lacks can_view_project (required for can_view_enrollment_location_map)' do
+      create_access_control(user, project, with_permission: [:can_view_enrollment_location_map, :can_view_enrollment_details])
+      expect(policy.can_view_location_map?).to be false
+    end
+
+    it 'returns false if user has no permissions in this project' do
+      create_access_control(user, other_project, with_permission: [:can_view_enrollment_location_map, *view_permissions])
+      expect(policy.can_view_location_map?).to be false
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_enrollment_policy_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe Hmis::AuthPolicies::HmisEnrollmentPolicy, type: :model do
     end
   end
 
+  describe '#can_view_limited?' do
+    it 'returns true if user has can_view_limited_enrollment_details at the enrollment project' do
+      create_access_control(user, project, with_permission: [:can_view_limited_enrollment_details])
+      expect(policy.can_view_limited?).to be true
+    end
+
+    it 'returns false if user has no permissions in this project' do
+      create_access_control(user, other_project, with_permission: [:can_view_limited_enrollment_details])
+      expect(policy.can_view_limited?).to be false
+    end
+  end
+
   describe '#can_split_household?' do
     it 'returns true if user can split households at the enrollment project' do
       create_access_control(user, project, with_permission: [:can_split_households, *view_permissions])

--- a/drivers/hmis/spec/requests/hmis/enrollment_access_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/enrollment_access_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+# Tests Enrollment.access schema fields are wired up correctly.
+# See hmis_enrollment_policy_spec.rb for full policy coverage.
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let(:c1) { create :hmis_hud_client, data_source: ds1 }
+  let!(:e1) { create :hmis_hud_enrollment, data_source: ds1, project: p1, client: c1 }
+
+  before(:each) { hmis_login(user) }
+
+  describe 'enrollment access' do
+    let(:access_query) do
+      <<~GRAPHQL
+        query EnrollmentAccess($id: ID!) {
+          enrollment(id: $id) {
+            id
+            access {
+              id
+              canViewEnrollmentDetails
+              canEditEnrollments
+              canDeleteEnrollments
+              canSplitHouseholds
+              canAuditEnrollments
+              canViewEnrollmentLocationMap
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def expect_enrollment_access!(enrollment:, access:)
+      response, result = post_graphql(id: enrollment.id.to_s) { access_query }
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'enrollment', 'access')).to include(
+        'id' => enrollment.id.to_s,
+        **access.stringify_keys,
+      )
+    end
+
+    let(:view_permissions) { [:can_view_enrollment_details, :can_view_project] }
+
+    it 'resolves all access fields from the enrollment policy' do
+      create_access_control(
+        hmis_user,
+        p1,
+        with_permission: [
+          :can_edit_enrollments,
+          :can_delete_enrollments,
+          :can_split_households,
+          :can_audit_enrollments,
+          :can_view_enrollment_location_map,
+          *view_permissions,
+        ],
+      )
+
+      expect_enrollment_access!(
+        enrollment: e1,
+        access: {
+          canViewEnrollmentDetails: true,
+          canEditEnrollments: true,
+          canDeleteEnrollments: true,
+          canSplitHouseholds: true,
+          canAuditEnrollments: true,
+          canViewEnrollmentLocationMap: true,
+        },
+      )
+    end
+
+    context 'with permissions only in a different data source' do
+      let!(:other_data_source) { create :hmis_data_source }
+      let!(:access_control) { create_access_control(hmis_user, p1, with_permission: view_permissions) }
+      let!(:full_access_other_data_source) { create_access_control(hmis_user, other_data_source) }
+
+      it 'returns false for all editable access fields' do
+        expect_enrollment_access!(
+          enrollment: e1,
+          access: {
+            canViewEnrollmentDetails: true,
+            canEditEnrollments: false,
+            canDeleteEnrollments: false,
+            canSplitHouseholds: false,
+            canAuditEnrollments: false,
+            canViewEnrollmentLocationMap: false,
+          },
+        )
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description

Issue: https://github.com/open-path/Green-River/issues/9134

Migrates enrollment authorization checks from legacy `current_permission?` helpers to `HmisEnrollmentPolicy`, continuing the ADR 0006 policy pattern. The GraphQL `Enrollment.access` object and several related resolvers now delegate to policy predicates, with preloading added to avoid N+1 queries when resolving enrollments across multiple projects.

- Expand `HmisEnrollmentPolicy` with `can_split_household?`, `can_audit?`, `can_view_location_map?`, and `can_view_open_enrollment_summary?`
- Rewire `Enrollment.access` to use `bool_field` + memoized policy instead of legacy `can` helpers
- Switch to using policy-based auth for the object-level `authorized?` check. (We already made this switch for other types like Client and Project).
- Switch `EnrollmentSummary#can_view_enrollment`, `geolocations`, `project_name`, `open_enrollment_summary`, `delete_current_living_situation`, and `load_open_enrollment_for_client` to policy checks
- Add `after_paginate` preloading in `HasEnrollments` (and targeted preloads in `open_enrollment_summary` / `load_open_enrollment_for_client`) to batch project permission lookups
- Add specs for new policy methods and GraphQL access field wiring


## Type of change
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
