### PR TITLE
Upgrade oauth2, remove oauth 1.1.0 transitive gmail dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'omniauth', '~> 2.1'
 gem 'omniauth-oauth2', '~> 1.7.3'
 gem 'omniauth-rails_csrf_protection', '~> 1.0.1'
 gem 'faraday', '~> 2.2'
-gem 'oauth2'
+gem 'oauth2', '>= 2.0.22'
 
 gem 'pretender'
 gem 'rqrcode'
@@ -159,7 +159,7 @@ gem 'htmlentities'
 # ETO API related
 gem 'rest-client', '~> 2.0'
 gem 'curb', '~> 1.0.9', require: false # pinning to 1.0.9 to keep webmock happy
-gem 'gmail', require: false
+# gem 'gmail', require: false
 # gem 'savon'
 # gem 'qaaws', require: false, git: 'https://github.com/greenriver/eis-ruby-qaaws.git', branch: 'master'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     attr_encrypted (4.2.0)
       encryptor (~> 3.0.0)
     attribute_normalizer (1.2.0)
+    auth-sanitizer (0.2.1)
+      version_gem (~> 1.1, >= 1.1.10)
     authtrail (0.7.0)
       railties (>= 7.1)
       warden
@@ -514,11 +516,6 @@ GEM
       ffi (~> 1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    gmail (0.7.1)
-      gmail_xoauth (>= 0.3.0)
-      mail (>= 2.2.1)
-    gmail_xoauth (0.4.3)
-      oauth (>= 0.3.6)
     gpgme (2.0.25)
       mini_portile2 (~> 2.7)
     graphiql-rails (1.10.5)
@@ -689,20 +686,15 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    oauth (1.1.0)
-      oauth-tty (~> 1.0, >= 1.0.1)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
-    oauth-tty (1.0.5)
-      version_gem (~> 1.1, >= 1.1.1)
-    oauth2 (2.0.17)
+    oauth2 (2.0.22)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.5)
+      version_gem (~> 1.1, >= 1.1.11)
     observer (0.1.2)
     oj (3.16.11)
       bigdecimal (>= 3.0)
@@ -995,7 +987,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
     slack-notifier (2.4.0)
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.5)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     soundex (0.1.2)
@@ -1065,7 +1057,7 @@ GEM
       simpleidn
     vcr (6.3.1)
       base64
-    version_gem (1.1.9)
+    version_gem (1.1.11)
     virtus (2.0.0)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -1219,7 +1211,6 @@ DEPENDENCIES
   fx
   geocoder
   get_process_mem
-  gmail
   gpgme
   graphiql-rails
   graphql (~> 2.5.4)
@@ -1260,7 +1251,7 @@ DEPENDENCIES
   net-sftp
   net-ssh (~> 7)
   nokogiri
-  oauth2
+  oauth2 (>= 2.0.22)
   observer
   oj
   omniauth (~> 2.1)
@@ -1390,6 +1381,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   attr_encrypted (4.2.0) sha256=7e5c80159e6e38ed40dc4e2e65c4f57234fe1f376bddc40c8b773bfb9b81ad51
   attribute_normalizer (1.2.0) sha256=580df3f316d7f0a2cc068fd655377f4769848643328d0c6c6c685ea98ac181c4
+  auth-sanitizer (0.2.1) sha256=917dcf01f7589b06c26726afe90568cf2fb29d37a1f94facfc664f11967cc577
   authtrail (0.7.0) sha256=b209a3752f961e7efa4e3f900f7df50ec4f9dacf4a89bf4260a784e1ea1bef30
   autoprefixer-rails (10.4.21.0) sha256=71b48caf850fc25275abd96f0b1fdd51c82e1c9b99cd30085cacb05da9c70235
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
@@ -1528,8 +1520,6 @@ CHECKSUMS
   geocoder (1.8.5) sha256=caf44f5ee5a4fd9a346db6295dd9cdf015b76567d2f5fcb626c1acd04839f6bf
   get_process_mem (1.0.0) sha256=d54024f3bcbf776a4d6e0155ec2b21bc3ba44e2fd158c4c00c80aa8a36e0b4aa
   globalid (1.2.1) sha256=70bf76711871f843dbba72beb8613229a49429d1866828476f9c9d6ccc327ce9
-  gmail (0.7.1) sha256=099f9ec0076a11bec00738a1835878c303a3f09e73aaba1733fa8cbe404a70b8
-  gmail_xoauth (0.4.3) sha256=eda5f59bd60564a6e8dd091a896ab221e8457472ab422d5d1282931ac7ae45fb
   gpgme (2.0.25) sha256=9242408b28720513145deb6150f25f5fe5149f3728ebaea635050cc3fc84dc34
   graphiql-rails (1.10.5) sha256=d911486eeac01e125d403a61c04f634cccaff9f8ecee5dc4efce3e7aa11bf5d3
   graphql (2.5.26) sha256=be3a148cc9ae52056d38f45cf9864a621a12fe138c027e324b0841dc19979576
@@ -1613,9 +1603,7 @@ CHECKSUMS
   nio4r (2.7.4) sha256=d95dee68e0bb251b8ff90ac3423a511e3b784124e5db7ff5f4813a220ae73ca9
   nokogiri (1.19.3) sha256=78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8
   nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  oauth (1.1.0) sha256=38902b7f0f5ed91e858d6353f5e1e06b2c16a8aa0fd91984671eab1a1d1cddeb
-  oauth-tty (1.0.5) sha256=34e25c307da4509d4deec266ff3690bbf42e391355f496201c029268862d8b17
-  oauth2 (2.0.17) sha256=c4e182aeabc06dfdafce9a15095c30edc3a1a21fc3c4f0ea49d9295429e79835
+  oauth2 (2.0.22) sha256=8f4669f0c8de69f6db7ed786bda20996eaf0003966b886f1c519efb1a5682fa6
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
   oj (3.16.11) sha256=2aab609d2bc896529bd3c70d737f591c13932a640ba6164a0f7e414efdb052b1
   omniauth (2.1.3) sha256=8d24e2e55c41926c96e4a93fd566bc026dfd6f2c850408748e89945a565956c2
@@ -1735,7 +1723,7 @@ CHECKSUMS
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   slack-notifier (2.4.0) sha256=cd9aba3f5f3e6227f73df1f6a33ac6c127c5fac35b513b86b7ba900cd98d2b00
-  snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
+  snaky_hash (2.0.5) sha256=70e74137d6738aef067950a3bb9a4d2655778be4bc9725efc36e7607feb22cdd
   soundex (0.1.2) sha256=2e888f4d1af22d8556bd514e2faba62f8b775f636f3fac65751af8db668488ac
   spreadsheet (1.3.4) sha256=0aefd6f3dfdc8b43528109f7fbd54db54f85ce5920429413d48305906bc59253
   spring (4.4.0) sha256=ec4e6cf5fb48d96b9ec9a80ebb40f962f2467b651c000693f33c14b6d6c340af
@@ -1772,7 +1760,7 @@ CHECKSUMS
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451
   validates_email_format_of (1.8.2) sha256=e2dfcf3e933547d06c41dacf066c7b07614819439c8780c3a2521ce047052577
   vcr (6.3.1) sha256=37b56e157e720446a3f4d2d39919cabef8cb7b6c45936acffd2ef8229fec03ed
-  version_gem (1.1.9) sha256=0c1a0962ae543c84a00889bb018d9f14d8f8af6029d26b295d98774e3d2eb9a4
+  version_gem (1.1.11) sha256=695df6464862b3dc976b4f6e0e089062517c8137ecd31078d8c378347f959c97
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warning (1.5.0) sha256=0f12c49fea0c06757778eefdcc7771e4fd99308901e3d55c504d87afdd718c53


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
1. Upgrade `oauth2` from `2.0.17` to `2.0.22` to resolve GHSA-pp92-crg2-gfv9
   - https://github.com/ruby-oauth/oauth2/blob/v2.0.22/CHANGELOG.md
2. Remove unused `gmail` dependency (of which `oauth` was a transitive dependency) to resolve GHSA-prq8-7wvh-44qh


Relevant audit results:

> Name: oauth
> Version: 1.1.0
> GHSA: GHSA-prq8-7wvh-44qh
> Criticality: High
> Title: Cross-origin OAuth token-request redirects can expose signed request metadata
> Solution: update to '>= 1.1.6'
> 
> Name: oauth2
> Version: 2.0.17
> GHSA: GHSA-pp92-crg2-gfv9
> Criticality: High
> Title: Protocol-relative redirect Location overrides authority in OAuth2::Client#request, leaking bearer Authorization to attacker host
> Solution: update to '>= 2.0.22'

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
