### PR TITLE
fix: CVE-2026-47737 (puma)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,7 @@ gem 'progress_bar', require: false
 
 gem 'slack-notifier'
 
-gem 'puma', '~> 6'
+gem 'puma', '~> 7'
 
 gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -767,7 +767,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pwned (2.4.1)
     racc (1.8.1)
@@ -1283,7 +1283,7 @@ DEPENDENCIES
   progress_bar
   prometheus-client
   pry-rails
-  puma (~> 6)
+  puma (~> 7)
   rack (< 3.2)
   rack-attack
   rack-cors
@@ -1649,7 +1649,7 @@ CHECKSUMS
   pry-rails (0.3.11) sha256=a69e28e24a34d75d1f60bcf241192a54253f8f7ef8a62cba1e75750a9653593d
   psych (5.2.6) sha256=814328aa5dcb6d604d32126a20bc1cbcf05521a5b49dbb1a8b30a07e580f316e
   public_suffix (6.0.2) sha256=bfa7cd5108066f8c9602e0d6d4114999a5df5839a63149d3e8b0f9c1d3558394
-  puma (6.6.1) sha256=b9b56e4a4ea75d1bfa6d9e1972ee2c9f43d0883f011826d914e8e37b3694ea1e
+  puma (7.2.1) sha256=d7bf0e9cabd532e0d401e142cd94e3ac531e993610e2d80e6fbf9c26961414b0
   pwned (2.4.1) sha256=e375b45e1cd78aded2c923737f75e09e64bc66582142c144bd85f4ce1fa0955d
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.1.21) sha256=285c5f228eef30dbd1dc147859a880b71bc44412fea575cc58c28797f2db9777


### PR DESCRIPTION
upgrade puma from 6 to 7

## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
fixes CVE-2026-47737

major version jump in puma. I did not notice any relevant breaking changes in the changelog for 7.0

## Type of change
Dependency update


