### PR TITLE
Add HMIS ACL audit history screens

### DIFF
--- a/app/controllers/admin/access_control_audits_controller.rb
+++ b/app/controllers/admin/access_control_audits_controller.rb
@@ -26,7 +26,7 @@ module Admin
     private
 
     def set_variables
-      @access_control = AccessControl.find(params[:access_control_id].to_i)
+      @access_control = AccessControl.with_deleted.find(params[:access_control_id].to_i)
       @history = Audit::Versions.new(@access_control, access_control_component_config)
       @versions = @history.version_array.sort_by(&:created_at).reverse
     end

--- a/app/controllers/admin/collection_audits_controller.rb
+++ b/app/controllers/admin/collection_audits_controller.rb
@@ -26,7 +26,7 @@ module Admin
     private
 
     def set_variables
-      @collection = Collection.find(params[:collection_id].to_i)
+      @collection = Collection.with_deleted.find(params[:collection_id].to_i)
       @history = Audit::Versions.new(@collection, collection_audit_config)
       @versions = @history.version_array.sort_by(&:created_at).reverse
     end

--- a/app/controllers/admin/role_audits_controller.rb
+++ b/app/controllers/admin/role_audits_controller.rb
@@ -26,7 +26,7 @@ module Admin
     private
 
     def set_variables
-      @role = Role.find(params[:role_id].to_i)
+      @role = Role.with_deleted.find(params[:role_id].to_i)
       @history = Audit::Versions.new(@role, role_audit_config)
       @versions = @history.version_array.sort_by(&:created_at).reverse
     end

--- a/app/controllers/admin/user_group_audits_controller.rb
+++ b/app/controllers/admin/user_group_audits_controller.rb
@@ -26,7 +26,7 @@ module Admin
     private
 
     def set_variables
-      @user_group = UserGroup.find(params[:user_group_id].to_i)
+      @user_group = UserGroup.with_deleted.find(params[:user_group_id].to_i)
       @history = Audit::Versions.new(@user_group, user_group_audit_config)
       @versions = @history.version_array.sort_by(&:created_at).reverse
     end

--- a/app/jobs/background_render/hmis_access_controls_audits_job.rb
+++ b/app/jobs/background_render/hmis_access_controls_audits_job.rb
@@ -1,0 +1,29 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class BackgroundRender::HmisAccessControlsAuditsJob < BackgroundRenderJob
+  include HmisAccessControlAuditData
+
+  def render_html(user_id:)
+    current_user = User.find(user_id)
+
+    histories = build_histories
+    data = build_data(histories)
+
+    HmisAdmin::AccessControlsController.render(
+      partial: 'audits_content',
+      assigns: {
+        data: data,
+        current_user: current_user,
+      },
+      locals: {
+        current_user: current_user,
+      },
+    )
+  end
+end

--- a/app/models/grda_warehouse/document_exports/hmis_access_controls_audit_export.rb
+++ b/app/models/grda_warehouse/document_exports/hmis_access_controls_audit_export.rb
@@ -1,0 +1,52 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module GrdaWarehouse::DocumentExports
+  class HmisAccessControlsAuditExport < ::GrdaWarehouse::DocumentExport
+    include ApplicationHelper
+    include HmisAccessControlAuditData
+
+    def authorized?
+      HmisEnforcement.hmis_admin_visible?(user)
+    end
+
+    def regenerate?
+      true
+    end
+
+    def perform
+      with_status_progression do
+        self.filename = "hmis-access-controls-audit-history-#{Date.current.to_fs(:db)}.xlsx"
+        self.file_data = excel_package.to_stream.read
+        self.mime_type = EXCEL_MIME_TYPE
+      end
+    end
+
+    private def excel_package
+      Axlsx::Package.new do |package|
+        wb = package.workbook
+        wb.add_worksheet(name: 'HMIS Access Controls Audit History') do |sheet|
+          title = sheet.styles.add_style(sz: 12, b: true, alignment: { horizontal: :center })
+
+          histories = build_histories
+          histories.each_with_index do |history, header_index|
+            csv_data = generate_audit_csv(history.version_array, history, include_headers: header_index == 0)
+            csv_data.lines.each_with_index do |line, line_index|
+              row = CSV.parse_line(line)
+              if header_index == 0 && line_index == 0
+                sheet.add_row(row, style: title)
+              else
+                sheet.add_row(row)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/drivers/hmis/app/controllers/concerns/hmis_access_control_audit_data.rb
+++ b/drivers/hmis/app/controllers/concerns/hmis_access_control_audit_data.rb
@@ -1,0 +1,40 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisAccessControlAuditData
+  extend ActiveSupport::Concern
+  include HmisAuditHistory
+
+  def hmis_access_control_audit_preloads
+    [
+      :user_group,
+      :role,
+      :access_group,
+      :user_access_controls,
+      { user_group: :user_group_members },
+      { access_group: :group_viewable_entities },
+    ]
+  end
+
+  def build_histories
+    access_controls = Hmis::AccessControl.with_deleted.preload(*hmis_access_control_audit_preloads)
+    Audit::Versions.build_batch(access_controls, hmis_access_control_component_config)
+  end
+
+  def build_data(histories)
+    histories.flat_map do |history|
+      versions = history.version_array
+      history.wrap_display_versions(versions).map do |version|
+        {
+          history: history,
+          version: version,
+        }
+      end
+    end.sort_by { |h| h[:version]&.created_at }.reverse
+  end
+end

--- a/drivers/hmis/app/controllers/concerns/hmis_audit_history.rb
+++ b/drivers/hmis/app/controllers/concerns/hmis_audit_history.rb
@@ -1,0 +1,61 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisAuditHistory
+  extend ActiveSupport::Concern
+  include AuditHistory
+
+  private
+
+  def hmis_access_control_component_config
+    {
+      related_models: [
+        { class: Hmis::UserGroup, association: :user_group },
+        { class: Hmis::Role, association: :role },
+        { class: Hmis::AccessGroup, association: :access_group },
+      ],
+      nested_models: [
+        { class: Hmis::UserGroupMember, parent_association: :user_group, nested_association: :user_group_members },
+        { class: Hmis::GroupViewableEntity, parent_association: :access_group, nested_association: :group_viewable_entities },
+      ],
+      referenced_models: [
+        { class: Hmis::UserAccessControl, association: :user_access_controls },
+      ],
+      excluded_fields: ['updated_at'],
+    }
+  end
+
+  def hmis_group_audit_config
+    {
+      referenced_models: [
+        { class: Hmis::AccessControl, association: :access_controls },
+        { class: Hmis::GroupViewableEntity, association: :group_viewable_entities },
+      ],
+      excluded_fields: ['updated_at'],
+    }
+  end
+
+  def hmis_role_audit_config
+    {
+      referenced_models: [
+        { class: Hmis::AccessControl, association: :access_controls },
+      ],
+      excluded_fields: ['updated_at'],
+    }
+  end
+
+  def hmis_user_group_audit_config
+    {
+      referenced_models: [
+        { class: Hmis::AccessControl, association: :access_controls },
+        { class: Hmis::UserGroupMember, association: :user_group_members },
+      ],
+      excluded_fields: ['updated_at'],
+    }
+  end
+end

--- a/drivers/hmis/app/controllers/hmis_admin/access_control_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/access_control_audits_controller.rb
@@ -1,0 +1,36 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisAdmin::AccessControlAuditsController < ApplicationController
+  include EnforceHmisEnabled
+  include HmisAuditHistory
+
+  before_action :require_hmis_admin_access!
+  before_action :set_variables
+
+  def show
+  end
+
+  def export
+    respond_to do |format|
+      format.csv do
+        send_data generate_audit_csv(@versions, @history),
+                  filename: "hmis-access-control-#{@access_control.id}-audit-history-#{Date.current.to_fs(:db)}.csv"
+      end
+    end
+  end
+
+  private
+
+  def set_variables
+    @access_control = Hmis::AccessControl.with_deleted.find(params[:access_control_id].to_i)
+    @access_control.define_singleton_method(:name) { "Access Control List #{id}" }
+    @history = Audit::Versions.new(@access_control, hmis_access_control_component_config)
+    @versions = @history.version_array.sort_by(&:created_at).reverse
+  end
+end

--- a/drivers/hmis/app/controllers/hmis_admin/access_controls_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/access_controls_controller.rb
@@ -9,9 +9,17 @@
 class HmisAdmin::AccessControlsController < ApplicationController
   include ViewableEntities
   include EnforceHmisEnabled
+  include HmisAccessControlAuditData
+  extend BackgroundRenderAction
 
   before_action :require_hmis_admin_access!
   before_action :set_access_control, only: [:edit, :update, :destroy]
+
+  background_render_action(:render_audits, ::BackgroundRender::HmisAccessControlsAuditsJob) do
+    {
+      user_id: current_user.id,
+    }
+  end
 
   def index
     @access_controls = access_control_scope.
@@ -47,6 +55,12 @@ class HmisAdmin::AccessControlsController < ApplicationController
     redirect_to({ action: :index }, notice: 'Access Control List removed.')
   end
 
+  def audits
+    @excel_export = GrdaWarehouse::DocumentExports::HmisAccessControlsAuditExport.new
+    # Processing is backgrounded unless render_inline is set to 1
+    @data = data if params[:render_inline] == '1'
+  end
+
   private def access_control_scope
     Hmis::AccessControl
   end
@@ -61,7 +75,13 @@ class HmisAdmin::AccessControlsController < ApplicationController
 
   private def set_access_control
     @access_control = access_control_scope.find(params[:id].to_i)
-    # Set a name to be used by the user_members_table partial
     @access_control.define_singleton_method(:name) { "Access Control List #{id}" }
+  end
+
+  private def data
+    @data ||= begin
+      histories = build_histories
+      build_data(histories)
+    end
   end
 end

--- a/drivers/hmis/app/controllers/hmis_admin/group_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/group_audits_controller.rb
@@ -1,0 +1,35 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisAdmin::GroupAuditsController < ApplicationController
+  include EnforceHmisEnabled
+  include HmisAuditHistory
+
+  before_action :require_hmis_admin_access!
+  before_action :set_variables
+
+  def show
+  end
+
+  def export
+    respond_to do |format|
+      format.csv do
+        send_data generate_audit_csv(@versions, @history),
+                  filename: "#{@group.name.parameterize}-audit-history-#{Date.current.to_fs(:db)}.csv"
+      end
+    end
+  end
+
+  private
+
+  def set_variables
+    @group = Hmis::AccessGroup.find(params[:group_id].to_i)
+    @history = Audit::Versions.new(@group, hmis_group_audit_config)
+    @versions = @history.version_array.sort_by(&:created_at).reverse
+  end
+end

--- a/drivers/hmis/app/controllers/hmis_admin/group_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/group_audits_controller.rb
@@ -28,7 +28,7 @@ class HmisAdmin::GroupAuditsController < ApplicationController
   private
 
   def set_variables
-    @group = Hmis::AccessGroup.find(params[:group_id].to_i)
+    @group = Hmis::AccessGroup.with_deleted.find(params[:group_id].to_i)
     @history = Audit::Versions.new(@group, hmis_group_audit_config)
     @versions = @history.version_array.sort_by(&:created_at).reverse
   end

--- a/drivers/hmis/app/controllers/hmis_admin/role_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/role_audits_controller.rb
@@ -28,7 +28,7 @@ class HmisAdmin::RoleAuditsController < ApplicationController
   private
 
   def set_variables
-    @role = Hmis::Role.find(params[:role_id].to_i)
+    @role = Hmis::Role.with_deleted.find(params[:role_id].to_i)
     @history = Audit::Versions.new(@role, hmis_role_audit_config)
     @versions = @history.version_array.sort_by(&:created_at).reverse
   end

--- a/drivers/hmis/app/controllers/hmis_admin/role_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/role_audits_controller.rb
@@ -1,0 +1,35 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisAdmin::RoleAuditsController < ApplicationController
+  include EnforceHmisEnabled
+  include HmisAuditHistory
+
+  before_action :require_hmis_admin_access!
+  before_action :set_variables
+
+  def show
+  end
+
+  def export
+    respond_to do |format|
+      format.csv do
+        send_data generate_audit_csv(@versions, @history),
+                  filename: "#{@role.name.parameterize}-audit-history-#{Date.current.to_fs(:db)}.csv"
+      end
+    end
+  end
+
+  private
+
+  def set_variables
+    @role = Hmis::Role.find(params[:role_id].to_i)
+    @history = Audit::Versions.new(@role, hmis_role_audit_config)
+    @versions = @history.version_array.sort_by(&:created_at).reverse
+  end
+end

--- a/drivers/hmis/app/controllers/hmis_admin/user_group_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/user_group_audits_controller.rb
@@ -28,7 +28,7 @@ class HmisAdmin::UserGroupAuditsController < ApplicationController
   private
 
   def set_variables
-    @user_group = Hmis::UserGroup.find(params[:user_group_id].to_i)
+    @user_group = Hmis::UserGroup.with_deleted.find(params[:user_group_id].to_i)
     @history = Audit::Versions.new(@user_group, hmis_user_group_audit_config)
     @versions = @history.version_array.sort_by(&:created_at).reverse
   end

--- a/drivers/hmis/app/controllers/hmis_admin/user_group_audits_controller.rb
+++ b/drivers/hmis/app/controllers/hmis_admin/user_group_audits_controller.rb
@@ -1,0 +1,35 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class HmisAdmin::UserGroupAuditsController < ApplicationController
+  include EnforceHmisEnabled
+  include HmisAuditHistory
+
+  before_action :require_hmis_admin_access!
+  before_action :set_variables
+
+  def show
+  end
+
+  def export
+    respond_to do |format|
+      format.csv do
+        send_data generate_audit_csv(@versions, @history),
+                  filename: "#{@user_group.name.parameterize}-audit-history-#{Date.current.to_fs(:db)}.csv"
+      end
+    end
+  end
+
+  private
+
+  def set_variables
+    @user_group = Hmis::UserGroup.find(params[:user_group_id].to_i)
+    @history = Audit::Versions.new(@user_group, hmis_user_group_audit_config)
+    @versions = @history.version_array.sort_by(&:created_at).reverse
+  end
+end

--- a/drivers/hmis/app/models/hmis/access_control.rb
+++ b/drivers/hmis/app/models/hmis/access_control.rb
@@ -17,6 +17,39 @@ class Hmis::AccessControl < ApplicationRecord
   belongs_to :role, class_name: 'Hmis::Role'
   belongs_to :user_group, class_name: '::Hmis::UserGroup', required: false, inverse_of: :access_controls
   has_many :users, through: :user_group
+  has_many :user_access_controls, class_name: 'Hmis::UserAccessControl', inverse_of: :access_control, dependent: :destroy
+
+  def entity_name
+    "#{role&.name || 'missing role'} x #{access_group&.name || 'missing collection'} x #{user_group&.name || 'missing user group'}"
+  end
+
+  def self.describe_changes(version, changes, excluded_fields = [])
+    case version.event
+    when 'create'
+      ['Created access control']
+    when 'destroy'
+      ['Deleted access control']
+    else
+      filtered = (changes || {}).reject { |field, _| excluded_fields.include?(field.to_s) }
+      filtered.map do |field, (from_id, to_id)|
+        from_name = resolve_fk_name(field, from_id)
+        to_name = resolve_fk_name(field, to_id)
+        "Changed #{field.humanize.titleize}: from #{from_name} to #{to_name}"
+      end.presence || ['Updated access control']
+    end
+  end
+
+  def self.resolve_fk_name(field, id)
+    return 'none' if id.nil?
+
+    klass = case field.to_s
+    when 'role_id' then Hmis::Role
+    when 'user_group_id' then Hmis::UserGroup
+    when 'access_group_id' then Hmis::AccessGroup
+    end
+    klass ? (klass.with_deleted.find_by(id: id)&.name || "ID #{id}") : id.to_s
+  end
+  private_class_method :resolve_fk_name
 
   scope :ordered, -> do
     joins(:user_group, :role, :access_group).

--- a/drivers/hmis/app/models/hmis/access_group.rb
+++ b/drivers/hmis/app/models/hmis/access_group.rb
@@ -12,6 +12,7 @@
 class Hmis::AccessGroup < ApplicationRecord
   self.table_name = :hmis_access_groups
   include HmisEnabled
+  include HistoryDescriptions
 
   acts_as_paranoid
   has_paper_trail

--- a/drivers/hmis/app/models/hmis/group_viewable_entity.rb
+++ b/drivers/hmis/app/models/hmis/group_viewable_entity.rb
@@ -76,5 +76,47 @@ module Hmis
     def access_group
       collection
     end
+
+    def entity_name
+      group_name = collection&.name || 'Unknown Collection'
+      entity_display = case entity_type
+      when 'Hmis::Hud::Project'
+        "Project: #{entity&.ProjectName || entity_id}"
+      when 'Hmis::Hud::Organization'
+        "Organization: #{entity&.OrganizationName || entity_id}"
+      when 'GrdaWarehouse::DataSource'
+        "Data Source: #{entity&.name || entity_id}"
+      when 'Hmis::ProjectGroup'
+        "Project Group: #{entity&.name || entity_id}"
+      else
+        entity&.name || "Entity: #{entity_id}"
+      end
+
+      "Collection: #{group_name} - #{entity_display}"
+    end
+
+    def self.describe_changes(version, _changes, _excluded_fields = [])
+      index = version.event == 'destroy' ? 0 : 1
+
+      entity_name = if version.item
+        version.item.entity_name
+      else
+        object_changes = version.object_changes
+        entity_id = object_changes&.dig('entity_id', index)
+        entity_type = object_changes&.dig('entity_type', index)
+        collection_id = object_changes&.dig('collection_id', index)
+        collection = Hmis::AccessGroup.with_deleted.find_by(id: collection_id)
+        "#{entity_type&.demodulize || 'Entity'} #{entity_id} in #{collection&.name || "Collection #{collection_id}"}"
+      end
+
+      case version.event
+      when 'create'
+        ["Added #{entity_name}"]
+      when 'destroy'
+        ["Removed #{entity_name}"]
+      else
+        ["Updated #{entity_name}"]
+      end
+    end
   end
 end

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -13,6 +13,7 @@ class Hmis::Role < ::ApplicationRecord
   self.table_name = :hmis_roles
   acts_as_paranoid
   has_paper_trail
+  include HistoryDescriptions
 
   has_many :access_controls, class_name: '::Hmis::AccessControl', inverse_of: :role
   has_many :users, through: :access_controls

--- a/drivers/hmis/app/models/hmis/user_access_control.rb
+++ b/drivers/hmis/app/models/hmis/user_access_control.rb
@@ -15,4 +15,31 @@ class Hmis::UserAccessControl < ApplicationRecord
 
   belongs_to :access_control, class_name: '::Hmis::AccessControl'
   belongs_to :user, class_name: 'Hmis::User'
+
+  def entity_name
+    "Access Control #{access_control_id}: #{user&.name || 'Unknown User'}"
+  end
+
+  def self.describe_changes(version, _changes, _excluded_fields = [])
+    object_changes = if version.object_changes.is_a?(String)
+      YAML.safe_load(version.object_changes, permitted_classes: [Time, Date, DateTime])
+    else
+      version.object_changes
+    end
+    user_id = object_changes&.dig('user_id', 1) || object_changes&.dig('user_id', 0)
+    user_name = if user_id
+      Hmis::User.with_deleted.find_by(id: user_id)&.name || "User ID #{user_id}"
+    else
+      'Unknown User'
+    end
+
+    case version.event
+    when 'create'
+      ["Directly assigned user \"#{user_name}\" to access control"]
+    when 'destroy'
+      ["Removed direct user assignment for \"#{user_name}\""]
+    else
+      ['Modified direct user assignment']
+    end
+  end
 end

--- a/drivers/hmis/app/models/hmis/user_group.rb
+++ b/drivers/hmis/app/models/hmis/user_group.rb
@@ -10,6 +10,7 @@ class Hmis::UserGroup < ApplicationRecord
   acts_as_paranoid
   has_paper_trail
   include UserPermissionCache
+  include HistoryDescriptions
 
   has_many :access_controls, inverse_of: :user_group
   has_many :user_group_members, class_name: '::Hmis::UserGroupMember', inverse_of: :user_group

--- a/drivers/hmis/app/models/hmis/user_group_member.rb
+++ b/drivers/hmis/app/models/hmis/user_group_member.rb
@@ -12,4 +12,31 @@ class Hmis::UserGroupMember < ApplicationRecord
 
   belongs_to :user_group, class_name: '::Hmis::UserGroup'
   belongs_to :user, class_name: 'Hmis::User'
+
+  def entity_name
+    "#{user_group&.name || 'Unknown Group'}: #{user&.name || 'Unknown User'}"
+  end
+
+  def self.describe_changes(version, _changes, _excluded_fields = [])
+    object_changes = if version.object_changes.is_a?(String)
+      YAML.safe_load(version.object_changes, permitted_classes: [Time, Date, DateTime])
+    else
+      version.object_changes
+    end
+    user_id = object_changes&.dig('user_id', 1) || object_changes&.dig('user_id', 0)
+    user_name = if user_id
+      Hmis::User.with_deleted.find_by(id: user_id)&.name || "User ID #{user_id}"
+    else
+      'Unknown User'
+    end
+
+    case version.event
+    when 'create'
+      ["Added user \"#{user_name}\" to group"]
+    when 'destroy'
+      ["Removed user \"#{user_name}\" from group"]
+    else
+      ['Modified user group membership']
+    end
+  end
 end

--- a/drivers/hmis/app/views/hmis_admin/access_control_audits/show.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_control_audits/show.haml
@@ -1,0 +1,5 @@
+= render 'admin/audits/shared/layout',
+  entity_type: 'HMIS Access Controls',
+  entity_path: hmis_admin_access_controls_path,
+  export_path: export_hmis_admin_access_control_audit_path(@access_control, format: :csv),
+  item: @access_control

--- a/drivers/hmis/app/views/hmis_admin/access_controls/_audits_content.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/_audits_content.haml
@@ -1,0 +1,1 @@
+= render_paginated_list(scope: @data, item_name: 'audit event', list_partial: 'admin/audits/shared/bulk_data_list')

--- a/drivers/hmis/app/views/hmis_admin/access_controls/audits.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/audits.haml
@@ -1,0 +1,15 @@
+- entity_type = 'HMIS Access Controls'
+- title = "#{entity_type} Audit History"
+- content_for :title, title
+
+= render 'admin/audits/shared/breadcrumbs', entity_type: 'HMIS Access Controls', entity_path: hmis_admin_access_controls_path
+= render_display_title "#{entity_type} Audit History"
+.text-right.mb-3
+  = render 'report_downloads/report_download', export: nil, excel_download_path: nil, excel_export: @excel_export, excel_download_tooltip: 'Download includes all HMIS access control audit history data in Excel format.'
+
+- if params[:render_inline] == '1'
+  = render 'hmis_admin/access_controls/audits_content'
+- else
+  = render 'background_render', url: render_audits_hmis_admin_access_controls_path, fetch_params: {} do
+    .rollup
+      .rollup-container.well

--- a/drivers/hmis/app/views/hmis_admin/access_controls/edit.haml
+++ b/drivers/hmis/app/views/hmis_admin/access_controls/edit.haml
@@ -1,7 +1,12 @@
 = render 'breadcrumbs'
-.o-page
-  .o-page__title
-    %h1 Edit Access Control #{@access_control.id}
+
+.d-flex
+  %h1 Edit Access Control #{@access_control.id}
+  .ml-auto
+    = link_to hmis_admin_access_control_audit_path(@access_control), class: 'btn btn-info mb-3' do
+      %i.fa.fa-history
+      %span.icon-eye
+      History
 = render 'admin/access_controls/description', entity_type: 'HMIS'
 .row
   .col-sm-8

--- a/drivers/hmis/app/views/hmis_admin/group_audits/show.haml
+++ b/drivers/hmis/app/views/hmis_admin/group_audits/show.haml
@@ -1,0 +1,5 @@
+= render 'admin/audits/shared/layout',
+  entity_type: 'HMIS Collection',
+  entity_path: hmis_admin_groups_path,
+  export_path: export_hmis_admin_group_audit_path(@group, format: :csv),
+  item: @group

--- a/drivers/hmis/app/views/hmis_admin/groups/show.haml
+++ b/drivers/hmis/app/views/hmis_admin/groups/show.haml
@@ -5,9 +5,13 @@
   = link_to hmis_admin_groups_path do
     &laquo; Manage Collections
 
-.o-page
-  .o-page__title
-    %h1= content_for :title
+.d-flex
+  %h1= content_for :title
+  .ml-auto
+    = link_to hmis_admin_group_audit_path(@group), class: 'btn btn-info mb-3' do
+      %i.fa.fa-history
+      %span.icon-eye
+      History
 
 .well
   .row

--- a/drivers/hmis/app/views/hmis_admin/role_audits/show.haml
+++ b/drivers/hmis/app/views/hmis_admin/role_audits/show.haml
@@ -1,0 +1,5 @@
+= render 'admin/audits/shared/layout',
+  entity_type: 'HMIS Role',
+  entity_path: hmis_admin_roles_path,
+  export_path: export_hmis_admin_role_audit_path(@role, format: :csv),
+  item: @role

--- a/drivers/hmis/app/views/hmis_admin/roles/edit.haml
+++ b/drivers/hmis/app/views/hmis_admin/roles/edit.haml
@@ -1,5 +1,12 @@
 = render 'breadcrumbs'
 
-%h1 Edit Role: #{@role.name}
+.d-flex
+  %h1 Edit Role: #{@role.name}
+  .ml-auto
+    = link_to hmis_admin_role_audit_path(@role), class: 'btn btn-info mb-3' do
+      %i.fa.fa-history
+      %span.icon-eye
+      History
+
 = simple_form_for @role, as: :role, url: hmis_admin_role_path(@role) do |f|
   = render 'admin/roles/new_form', f: f, submit_text: 'Update Role'

--- a/drivers/hmis/app/views/hmis_admin/user_group_audits/show.haml
+++ b/drivers/hmis/app/views/hmis_admin/user_group_audits/show.haml
@@ -1,0 +1,5 @@
+= render 'admin/audits/shared/layout',
+  entity_type: 'HMIS User Group',
+  entity_path: hmis_admin_user_groups_path,
+  export_path: export_hmis_admin_user_group_audit_path(@user_group, format: :csv),
+  item: @user_group

--- a/drivers/hmis/app/views/hmis_admin/user_groups/edit.haml
+++ b/drivers/hmis/app/views/hmis_admin/user_groups/edit.haml
@@ -6,8 +6,13 @@
     &laquo; Manage User Groups
 
 .o-page
-  .o-page__title
+  .o-page__title.d-flex
     %h1= content_for :title
+    .ml-auto
+      = link_to hmis_admin_user_group_audit_path(@user_group), class: 'btn btn-info mb-3' do
+        %i.fa.fa-history
+        %span.icon-eye
+        History
 = render 'admin/user_groups/description', entity_type: 'HMIS'
 .row
   .col-sm-6

--- a/drivers/hmis/config/routes.rb
+++ b/drivers/hmis/config/routes.rb
@@ -59,16 +59,31 @@ OpenPath::Application.routes.draw do
     namespace :hmis_admin do
       resources :access_overviews, only: [:index]
       resources :roles do
+        resource :audit, only: :show, controller: 'role_audits' do
+          get :export, on: :member
+        end
         patch :batch_update, on: :collection
       end
       resources :groups do
+        resource :audit, only: :show, controller: 'group_audits' do
+          get :export, on: :member
+        end
         get :entities, on: :member
         patch :bulk_entities, on: :member
       end
       resources :user_groups do
+        resource :audit, only: :show, controller: 'user_group_audits' do
+          get :export, on: :member
+        end
         resources :users, only: [:create, :destroy], controller: 'user_groups/users'
       end
-      resources :access_controls
+      resources :access_controls do
+        resource :audit, only: :show, controller: 'access_control_audits' do
+          get :export, on: :member
+        end
+        get :audits, on: :collection
+        post :render_audits, on: :collection
+      end
       resources :users, only: [:index, :edit, :update]
       resources :project_groups, only: [:index, :new, :create, :edit, :update, :show, :destroy]
     end

--- a/drivers/hmis/spec/models/hmis/access_control_spec.rb
+++ b/drivers/hmis/spec/models/hmis/access_control_spec.rb
@@ -87,6 +87,14 @@ RSpec.describe Hmis::AccessControl, type: :model do
     end
   end
 
+  describe 'associations' do
+    it 'has many user_access_controls' do
+      acl = create(:hmis_access_control)
+      uac = create(:hmis_user_access_control, access_control: acl)
+      expect(acl.user_access_controls).to include(uac)
+    end
+  end
+
   describe 'can_access_hmis_data_source? checker' do
     let!(:ds2) { create :hmis_data_source } # add a second data source
     let!(:ds2_organization) { create :hmis_hud_organization, data_source: ds2 }

--- a/drivers/hmis/spec/models/hmis/acl_audit_describe_changes_spec.rb
+++ b/drivers/hmis/spec/models/hmis/acl_audit_describe_changes_spec.rb
@@ -1,0 +1,125 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'HMIS ACL describe_changes', type: :model do
+  def make_version(item, event:, changes:)
+    create(
+      :gr_paper_trail_version,
+      item_type: item.class.sti_name,
+      item_id: item.id,
+      event: event,
+      object_changes: changes.to_yaml,
+    )
+  end
+
+  describe Hmis::UserGroupMember do
+    let!(:user_group) { create(:hmis_user_group) }
+    let!(:hmis_user) { create(:hmis_user) }
+    let!(:member) { Hmis::UserGroupMember.create!(user_group: user_group, user: hmis_user) }
+
+    it 'describes a create as adding a user' do
+      version = make_version(member, event: 'create', changes: { 'user_id' => [nil, hmis_user.id] })
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Added user').and include(hmis_user.name)
+    end
+
+    it 'describes a destroy as removing a user' do
+      version = make_version(member, event: 'destroy', changes: { 'user_id' => [hmis_user.id, nil] })
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Removed user').and include(hmis_user.name)
+    end
+  end
+
+  describe Hmis::UserAccessControl do
+    let!(:access_control) { create(:hmis_access_control) }
+    let!(:hmis_user) { create(:hmis_user) }
+    let!(:uac) { Hmis::UserAccessControl.create!(access_control: access_control, user: hmis_user) }
+
+    it 'describes a create as directly assigning a user' do
+      version = make_version(uac, event: 'create', changes: { 'user_id' => [nil, hmis_user.id] })
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Directly assigned user').and include(hmis_user.name)
+    end
+
+    it 'describes a destroy as removing a direct assignment' do
+      version = make_version(uac, event: 'destroy', changes: { 'user_id' => [hmis_user.id, nil] })
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Removed direct user assignment').and include(hmis_user.name)
+    end
+  end
+
+  describe Hmis::AccessControl do
+    let!(:role1) { create(:hmis_role, name: 'Read Only') }
+    let!(:role2) { create(:hmis_role, name: 'Full Access') }
+    let!(:access_control) { create(:hmis_access_control, role: role1) }
+
+    it 'describes a create event' do
+      version = make_version(access_control, event: 'create', changes: { 'role_id' => [nil, role1.id] })
+      result = described_class.describe_changes(version, {})
+      expect(result).to eq(['Created access control'])
+    end
+
+    it 'describes a destroy event' do
+      version = make_version(access_control, event: 'destroy', changes: { 'role_id' => [role1.id, nil] })
+      result = described_class.describe_changes(version, {})
+      expect(result).to eq(['Deleted access control'])
+    end
+
+    it 'describes a role change by name' do
+      version = make_version(access_control, event: 'update', changes: { 'role_id' => [role1.id, role2.id] })
+      result = described_class.describe_changes(version, { 'role_id' => [role1.id, role2.id] })
+      expect(result.first).to include('Role').and include('Read Only').and include('Full Access')
+    end
+
+    it 'filters excluded fields' do
+      version = make_version(access_control, event: 'update', changes: { 'updated_at' => [1.day.ago, Time.current] })
+      result = described_class.describe_changes(version, { 'updated_at' => [1.day.ago, Time.current] }, ['updated_at'])
+      expect(result).to eq(['Updated access control'])
+    end
+  end
+
+  describe Hmis::GroupViewableEntity do
+    let!(:access_group) { create(:hmis_access_group) }
+    let!(:project) { create(:hmis_hud_project) }
+    let!(:gve) { create(:hmis_group_viewable_entity, collection: access_group, entity: project) }
+
+    it 'describes a create as adding an entity' do
+      version = create(
+        :grda_warehouse_version,
+        item_type: 'Hmis::GroupViewableEntity',
+        item_id: gve.id,
+        event: 'create',
+        object_changes: {
+          'entity_id' => [nil, project.id],
+          'entity_type' => [nil, 'Hmis::Hud::Project'],
+          'collection_id' => [nil, access_group.id],
+        }.to_yaml,
+      )
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Added')
+    end
+
+    it 'describes a destroy as removing an entity' do
+      version = create(
+        :grda_warehouse_version,
+        item_type: 'Hmis::GroupViewableEntity',
+        item_id: gve.id,
+        event: 'destroy',
+        object_changes: {
+          'entity_id' => [project.id, nil],
+          'entity_type' => ['Hmis::Hud::Project', nil],
+          'collection_id' => [access_group.id, nil],
+        }.to_yaml,
+      )
+      result = described_class.describe_changes(version, {})
+      expect(result.first).to include('Removed')
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

HMIS administrators can now view a full audit history for all HMIS access control components. Before this change, the HMIS admin UI had no way to see what changed, who changed it, or when — for Access Controls, Roles, Collections, or User Groups. This feature mirrors the audit history already available in the warehouse admin.

**What hmis administrators can now do:**

- View an aggregate audit history for all HMIS access controls at once, with a background-rendered table and Excel export
- View per-record audit history for any individual Access Control, Role, Collection (Access Group), or User Group via a new **History** button on each admin edit/show page
- Download a CSV of per-record audit history for any individual component
- See human-readable descriptions of what changed — e.g. "Added user Jane Smith to group", "Changed Role: from Read-Only to Full Access", "Added Project: Elm Street Shelter to Collection" — rather than raw database field values

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
