### PR TITLE
Extend AC HMIS AHA score fetching to parse MH-AHA and VisionLink scores

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/fetch_aha_score.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/fetch_aha_score.rb
@@ -35,10 +35,18 @@ module Mutations
 
       aha = HmisExternalApis::AcHmis::Aha.new
       begin
-        result = aha.fetch_score(client, lookup_catalyst: lookup_catalyst, lookup_reason: lookup_reason)
+        results = aha.fetch_score(
+          client,
+          lookup_catalyst: lookup_catalyst,
+          lookup_reason: lookup_reason,
+          requested_generators: [:aha],
+        )
+        result = results[:aha]
       rescue HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError => _e
         return { score: -1, aha_failed_reason: 'NO_MCI_UNIQUE_ID' }
       end
+
+      raise HmisExternalApis::AcHmis::Aha::Error, 'Response does not contain AHA score' unless result
 
       {
         score: result.score,

--- a/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
+++ b/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
     end
 
+    context 'when response does not contain AHA score' do
+      it 'returns server error' do
+        allow(stub_aha).to receive(:fetch_score).with(
+          c1,
+          lookup_catalyst: nil,
+          lookup_reason: nil,
+          requested_generators: [:aha],
+        ).and_return({ aha: nil })
+
+        expect_gql_error(
+          post_graphql(client_id: c1.id) { mutation },
+          message: 'Response does not contain AHA score',
+        )
+      end
+    end
+
     context 'when client has no MCI unique ID' do
       let!(:client_without_mci) { create(:hmis_hud_client, data_source: ds1, user: u1) }
 

--- a/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
+++ b/drivers/hmis/spec/requests/ac_hmis/fetch_aha_score_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     context 'when client has MCI unique ID' do
       let(:aha_result) do
-        OpenStruct.new(
+        HmisExternalApis::AcHmis::AhaScores::AhaResult.new(
           score: 8,
           mci_quality_indicator: 0,
           dw_client_id: mci_unique_id.value,
@@ -73,7 +73,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
 
       it 'returns AHA score successfully' do
-        allow(stub_aha).to receive(:fetch_score).with(c1, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other']).and_return(aha_result)
+        allow(stub_aha).to receive(:fetch_score).with(
+          c1,
+          lookup_catalyst: 'OCS Staff',
+          lookup_reason: ['Other'],
+          requested_generators: [:aha],
+        ).and_return({ aha: aha_result })
 
         perform_mutation(client_id: c1.id, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other']) do |data, errors|
           expect(errors).to be_empty
@@ -86,13 +91,18 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       end
 
       it 'handles AHA score of -1' do
-        aha_result_neg_one = OpenStruct.new(
+        aha_result_neg_one = HmisExternalApis::AcHmis::AhaScores::AhaResult.new(
           score: -1,
           mci_quality_indicator: 1,
           dw_client_id: mci_unique_id.value,
           generator: 'AHA',
         )
-        allow(stub_aha).to receive(:fetch_score).with(c1, lookup_catalyst: nil, lookup_reason: nil).and_return(aha_result_neg_one)
+        allow(stub_aha).to receive(:fetch_score).with(
+          c1,
+          lookup_catalyst: nil,
+          lookup_reason: nil,
+          requested_generators: [:aha],
+        ).and_return({ aha: aha_result_neg_one })
 
         perform_mutation(client_id: c1.id) do |data, errors|
           expect(errors).to be_empty
@@ -107,8 +117,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let!(:client_without_mci) { create(:hmis_hud_client, data_source: ds1, user: u1) }
 
       it 'returns score -1 with NO_MCI_UNIQUE_ID reason' do
-        allow(stub_aha).to receive(:fetch_score).with(client_without_mci, lookup_catalyst: nil, lookup_reason: nil).
-          and_raise(HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError)
+        allow(stub_aha).to receive(:fetch_score).with(
+          client_without_mci,
+          lookup_catalyst: nil,
+          lookup_reason: nil,
+          requested_generators: [:aha],
+        ).and_raise(HmisExternalApis::AcHmis::Aha::NoMciUniqueIdError)
 
         perform_mutation(client_id: client_without_mci.id) do |data, errors|
           expect(errors).to be_empty

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -282,11 +282,6 @@ module HmisExternalApis::AcHmis
         parsed_by_generator[generator_key].compact.max_by(&:score)
       end
 
-      # If no AHA score is found and only AHA was requested, raise an error.
-      # This maintains previous behavior of this class.
-      # (Not yet clear on whether MH-AHA or VisionLink should raise if missing when they are requested.)
-      raise(Error, 'Response does not contain AHA score') if requested_generators == [:aha] && results[:aha].blank?
-
       results
     end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -50,15 +50,32 @@ module HmisExternalApis::AcHmis
     ].freeze
 
     SYSTEM_ID = 'ac_hmis_aha'
-    AHA_GENERATOR = 'AHA'
-    VALID_AHA_SCORES = [-1, *(1..10)].freeze # AHA can be -1 or 1..10, but not zero. (Note that 'MH-AHA' generator appears to support zero as a score.)
+    # Internal symbol keys map to the generator string returned by the Scores API.
+    # Use normalize_generator to match API/request values case-insensitively.
+    GENERATORS = {
+      aha: 'AHA',
+      mh_aha: 'MH-AHA',
+      visionlink: 'VisionLink',
+    }.freeze
+    VALID_SCORES = [-1, *(1..10)].freeze # AHA and MH-AHA can be -1 or 1..10, but not zero.
     CONNECTION_TIMEOUT_SECONDS = Rails.env.staging? ? 15 : 10
 
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to AHA')
     # Custom error class for MciUniqueId so the mutation can catch it
     class NoMciUniqueIdError < HmisErrors::ApiError; end
 
-    def fetch_score(client, lookup_catalyst: nil, lookup_reason: nil)
+    # Fetches scores from the external Scores API for an HMIS source client, and any
+    # linked source clients sharing the same destination client.
+    #
+    # @param client [Hmis::Hud::Client] HMIS source client (not a destination/warehouse client)
+    # @param lookup_catalyst [String, nil] optional catalyst submitted to the API when present on the form
+    # @param lookup_reason [Array<String>, nil] optional reasons submitted to the API when present on the form
+    # @param requested_generators [Array<Symbol>] `:aha`, `:mh_aha`, and/or `:visionlink` (default: `[:aha]`)
+    # @return [Hash] keyed by requested generator, with typed result objects (see build_results)
+    #   => { aha: AhaScores::AhaResult(...), mh_aha: AhaScores::MhAhaResult(...), visionlink: AhaScores::VisionLinkResult(...) }
+    def fetch_score(client, lookup_catalyst: nil, lookup_reason: nil, requested_generators: [:aha])
+      raise ArgumentError, "unsupported generators: #{requested_generators.inspect}" unless requested_generators.all? { |key| GENERATORS.key?(key) }
+
       # Collect MCI unique IDs for this client and all source clients with the same destination client
       clients = [client, *client.destination_client&.source_clients&.to_a]
       mci_uniq_ids = clients.compact.uniq.filter_map do |c|
@@ -79,35 +96,10 @@ module HmisExternalApis::AcHmis
       raise NoMciUniqueIdError if client_not_found_response?(result)
 
       data = result.parsed_body&.dig('data')
-      raise(Error, "AHA response missing `data` key. Response body: `#{result.parsed_body}`") unless data
+      raise(Error, "Scores API response missing `data` key. Response body: `#{result.parsed_body}`") unless data
 
-      score_objects = data.flat_map do |response_client|
-        response_client.dig('scores')&.filter_map do |score_obj|
-          score_value = score_obj.dig('score')
-          next unless score_obj.dig('generator') == AHA_GENERATOR # non-AHA scores
-
-          raise(Error, 'Received blank score') if score_value.blank?
-          raise(Error, "Received invalid score: #{score_value.inspect}") unless score_value.is_a?(Numeric) && score_value % 1 == 0 && VALID_AHA_SCORES.include?(score_value.to_i)
-
-          OpenStruct.new(
-            # AHA Score
-            score: score_value.to_i,
-            # This field is a 0/1 flag indicating whether the Alt-AHA should be performed or not. (1 = Alt-AHA is required, 0 = Alt-AHA is not required).
-            mci_quality_indicator: score_obj.dig('metadata', 'alt_aha_flag')&.to_i,
-            # MCI Unique ID that is associated with the AHA score
-            dw_client_id: Array.wrap(response_client.dig('dw_client_id') || response_client.dig('dw_client_id_dw_client_id'))&.first,
-            # Generator is always 'AHA'
-            generator: score_obj.dig('generator'),
-          )
-        end
-      end
-
-      # Find the highest AHA score
-      highest_aha_score = score_objects.compact.max_by(&:score)
-
-      raise(Error, 'Response does not contain AHA score') unless highest_aha_score.present?
-
-      highest_aha_score
+      parsed_by_generator = parse_response_scores(data)
+      build_results(parsed_by_generator, requested_generators)
     end
 
     def self.enabled?
@@ -122,6 +114,180 @@ module HmisExternalApis::AcHmis
 
     def conn
       @conn ||= HmisExternalApis::ApiKeyConnection.new(creds, connection_timeout: CONNECTION_TIMEOUT_SECONDS)
+    end
+
+    def normalize_generator(raw)
+      normalized = raw.to_s.downcase.strip.tr('_', '-')
+      GENERATORS.find do |key, label|
+        key.to_s.tr('_', '-') == normalized || label.downcase == normalized
+      end&.first
+    end
+
+    # Walks the API `data` array (one element per matching client) and collects valid parsed
+    # scores grouped by generator. Each client may return multiple score entries; sibling MCI IDs
+    # may each appear as separate clients. Unknown generators are skipped. Invalid entries are
+    # skipped after logging to Sentry (see parse_score_entry). The highest score per generator is
+    # chosen later in build_results.
+    #
+    # Example API shape:
+    #   data: [
+    #     { 'dw_client_id' => '100000001', 'scores' => [
+    #       { 'score' => 7, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '1' } },
+    #       { 'score' => 5, 'generator' => 'MH-AHA', 'metadata' => { ... } },
+    #     ]},
+    #     { 'dw_client_id' => '100000002', 'scores' => [
+    #       { 'score' => 9, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '0' } },
+    #     ]},
+    #   ]
+    #
+    # Example return value:
+    #   { aha: [AhaResult(score: 7, ...), AhaResult(score: 9, ...)], mh_aha: [MhAhaResult(score: 5, ...)] }
+    def parse_response_scores(data)
+      parsed_by_generator = Hash.new { |hash, key| hash[key] = [] }
+
+      data.each do |response_client|
+        dw_client_id = Array.wrap(
+          response_client.dig('dw_client_id') || response_client.dig('dw_client_id_dw_client_id'),
+        ).first
+
+        response_client.dig('scores')&.each do |score_obj|
+          generator_key = normalize_generator(score_obj['generator'])
+          next unless generator_key
+
+          parsed = parse_score_entry(score_obj, dw_client_id, generator_key)
+          parsed_by_generator[generator_key] << parsed if parsed
+        end
+      end
+
+      parsed_by_generator
+    end
+
+    # Parses a single score entry from the API into a typed result for the given generator.
+    # Returns nil (without raising) when the entry is invalid; logs the failure to Sentry so
+    # other entries and generators can still be returned.
+    #
+    # Example score_obj (AHA):
+    #   { 'score' => 8, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '0' } }
+    #   => AhaScores::AhaResult(score: 8, mci_quality_indicator: 0, dw_client_id: '100000001', generator: 'AHA')
+    #
+    # Example score_obj (VisionLink):
+    #   { 'score' => -999, 'generator' => 'VisionLink', 'metadata' => { 'is_eligible_ra' => false, ... } }
+    #   => AhaScores::VisionLinkResult(score: -999, is_eligible_ra: false, ...)
+    def parse_score_entry(score_obj, dw_client_id, generator_key)
+      case generator_key
+      when :aha then parse_aha_entry(score_obj, dw_client_id)
+      when :mh_aha then parse_mh_aha_entry(score_obj, dw_client_id)
+      when :visionlink then parse_visionlink_entry(score_obj, dw_client_id)
+      end
+    rescue StandardError => e
+      Sentry.capture_message(
+        "AHA received invalid #{GENERATORS.fetch(generator_key)} score entry: #{e.message}",
+      )
+      nil
+    end
+
+    # Parses an AHA generator entry. Score must be an integer in [-1, 1..10] (zero invalid).
+    # Extracts alt_aha_flag from metadata as mci_quality_indicator.
+    #
+    # Example:
+    #   score_obj: { 'score' => 8, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '0' } }
+    #   dw_client_id: '100000001'
+    #   => AhaScores::AhaResult(score: 8, mci_quality_indicator: 0, dw_client_id: '100000001', generator: 'AHA')
+    def parse_aha_entry(score_obj, dw_client_id)
+      score = parse_standard_score(score_obj.dig('score'))
+
+      AhaScores::AhaResult.new(
+        score: score,
+        mci_quality_indicator: score_obj.dig('metadata', 'alt_aha_flag')&.to_i,
+        dw_client_id: dw_client_id,
+        generator: score_obj['generator'],
+      )
+    end
+
+    # Parses an MH-AHA generator entry. Uses the same score validation as AHA ([-1, 1..10]).
+    #
+    # Example:
+    #   score_obj: { 'score' => 5, 'generator' => 'MH-AHA', 'metadata' => { 'row_id' => '123', 'run_id' => 'aha_abc' } }
+    #   dw_client_id: '100000022'
+    #   => AhaScores::MhAhaResult(score: 5, dw_client_id: '100000022', generator: 'MH-AHA')
+    def parse_mh_aha_entry(score_obj, dw_client_id)
+      score = parse_standard_score(score_obj.dig('score'))
+
+      AhaScores::MhAhaResult.new(
+        score: score,
+        dw_client_id: dw_client_id,
+        generator: score_obj['generator'],
+      )
+    end
+
+    # Parses a VisionLink generator entry. Accepts any numeric score (including -999, which means
+    # no score but may still carry eligibility flags). Metadata field types are preserved as returned
+    # by the API (booleans stay boolean, numeric flags stay numeric).
+    #
+    # Example:
+    #   score_obj: {
+    #     'score' => -999,
+    #     'generator' => 'VisionLink',
+    #     'metadata' => {
+    #       'is_eligible_ra' => false, 'currently_unhoused' => false, 'is_eligible_cc' => true,
+    #       'homeless_risk' => 0, 'section_8' => 0, 'city_of_pittsburgh' => 0,
+    #       'subsidized_housing' => 0, 'recent_erap_use' => 0,
+    #     },
+    #   }
+    #   dw_client_id: '100000022'
+    #   => AhaScores::VisionLinkResult(score: -999, is_eligible_ra: false, is_eligible_cc: true, ...)
+    def parse_visionlink_entry(score_obj, dw_client_id)
+      score_value = score_obj.dig('score')
+      raise ArgumentError, 'Received blank score' if score_value.blank?
+      raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric)
+
+      metadata = score_obj['metadata'] || {}
+
+      AhaScores::VisionLinkResult.new(
+        score: score_value,
+        dw_client_id: dw_client_id,
+        generator: score_obj['generator'],
+        is_eligible_ra: metadata['is_eligible_ra'],
+        currently_unhoused: metadata['currently_unhoused'],
+        is_eligible_cc: metadata['is_eligible_cc'],
+        homeless_risk: metadata['homeless_risk'],
+        section_8: metadata['section_8'],
+        city_of_pittsburgh: metadata['city_of_pittsburgh'],
+        subsidized_housing: metadata['subsidized_housing'],
+        recent_erap_use: metadata['recent_erap_use'],
+      )
+    end
+
+    def parse_standard_score(score_value)
+      raise ArgumentError, 'Received blank score' if score_value.blank?
+      raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric) && score_value % 1 == 0 && VALID_SCORES.include?(score_value.to_i)
+
+      score_value.to_i
+    end
+
+    # Selects the highest-scoring parsed entry per requested generator and returns a hash keyed
+    # by generator symbol. Values are typed result objects or nil when that
+    # generator was requested but no valid entries were found in the API response.
+    #
+    # Example return value for requested_generators: [:aha, :mh_aha, :visionlink]
+    #   {
+    #     aha: AhaScores::AhaResult(score: 9, mci_quality_indicator: 0, dw_client_id: '100000002', generator: 'AHA'),
+    #     mh_aha: AhaScores::MhAhaResult(score: 5, dw_client_id: '100000001', generator: 'MH-AHA'),
+    #     visionlink: nil,
+    #   }
+    def build_results(parsed_by_generator, requested_generators)
+      # For each requested generator, select the highest score from the parsed entries.
+      # Returns a hash of generator keys to the best score result for that generator.
+      results = requested_generators.index_with do |generator_key|
+        parsed_by_generator[generator_key].compact.max_by(&:score)
+      end
+
+      # If no AHA score is found and only AHA was requested, raise an error.
+      # This maintains previous behavior of this class.
+      # (Not yet clear on whether MH-AHA or VisionLink should raise if missing when they are requested.)
+      raise(Error, 'Response does not contain AHA score') if requested_generators == [:aha] && results[:aha].blank?
+
+      results
     end
 
     def create_payload(mci_uniq_ids, lookup_catalyst, lookup_reason)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -198,6 +198,7 @@ module HmisExternalApis::AcHmis
 
       AhaScores::AhaResult.new(
         score: score,
+        # This field is a 0/1 flag indicating whether the Alt-AHA should be performed or not. (1 = Alt-AHA is required, 0 = Alt-AHA is not required).
         mci_quality_indicator: score_obj.dig('metadata', 'alt_aha_flag')&.to_i,
         dw_client_id: dw_client_id,
         generator: score_obj['generator'],
@@ -258,6 +259,7 @@ module HmisExternalApis::AcHmis
       )
     end
 
+    # Parse "standard" scores (AHA and MH-AHA) that are integers in [-1, 1..10]
     def parse_standard_score(score_value)
       raise ArgumentError, 'Received blank score' if score_value.blank?
       raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric) && score_value % 1 == 0 && VALID_SCORES.include?(score_value.to_i)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha_scores.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha_scores.rb
@@ -1,0 +1,27 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module HmisExternalApis::AcHmis
+  module AhaScores
+    AhaResult = Data.define(:score, :mci_quality_indicator, :dw_client_id, :generator)
+    MhAhaResult = Data.define(:score, :dw_client_id, :generator)
+    VisionLinkResult = Data.define(
+      :score,
+      :dw_client_id,
+      :generator,
+      :is_eligible_ra,
+      :currently_unhoused,
+      :is_eligible_cc,
+      :homeless_risk,
+      :section_8,
+      :city_of_pittsburgh,
+      :subsidized_housing,
+      :recent_erap_use,
+    )
+  end
+end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -21,12 +21,40 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     allow(aha).to receive(:conn).and_return(mock_connection)
   end
 
-  # Helper methods
-  def score_hash(score:, generator:, alt_aha_flag:)
+  # Helper methods for mocking score values returned by API
+  def score_hash(score:, generator:, alt_aha_flag: nil, metadata: nil)
     {
       'score' => score,
-      'metadata' => { 'alt_aha_flag' => alt_aha_flag },
+      'metadata' => metadata || { 'alt_aha_flag' => alt_aha_flag }.compact,
       'generator' => generator,
+    }
+  end
+
+  def mh_aha_score_hash(score:, generator: 'MH-AHA', metadata: nil)
+    {
+      'score' => score,
+      'metadata' => metadata || { 'row_id' => '1', 'run_id' => 'aha_abc', 'mci_uniq_id' => '100000022' },
+      'generator' => generator,
+    }
+  end
+
+  def visionlink_score_hash(score:, metadata: nil, generator: 'VisionLink')
+    {
+      'score' => score,
+      'generator' => generator,
+      'metadata' => metadata || {
+        'row_id' => '1',
+        'run_id' => 'rental_assistance_abcde',
+        'is_eligible_ra' => false,
+        'currently_unhoused' => false,
+        'is_eligible_cc' => true,
+        'mci_uniq_id' => '100000022',
+        'homeless_risk' => 0,
+        'section_8' => 0,
+        'city_of_pittsburgh' => 0,
+        'subsidized_housing' => 0,
+        'recent_erap_use' => 0,
+      },
     }
   end
 
@@ -92,7 +120,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
           dw_client_id: mci_unique_id.value,
           scores: [
             score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 10, generator: 'MH-AHA', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 10),
           ],
         ),
       )
@@ -101,15 +129,16 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     it 'calls API and returns the highest AHA score, disregarding other generators' do
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
-      result = aha.fetch_score(client)
+      result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(8)
       expect(result.dw_client_id).to eq(mci_unique_id.value)
+      expect(result).to be_a(HmisExternalApis::AcHmis::AhaScores::AhaResult)
     end
 
     it 'calls API with lookup catalyst and reason when provided' do
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
 
-      result = aha.fetch_score(client, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])
+      result = aha.fetch_score(client, lookup_catalyst: 'OCS Staff', lookup_reason: ['Other'])[:aha]
       expect(result.score).to eq(8)
     end
 
@@ -117,7 +146,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       allow(Sentry).to receive(:capture_message)
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
-      result = aha.fetch_score(client, lookup_catalyst: 'random text', lookup_reason: ['not a good reason'])
+      result = aha.fetch_score(client, lookup_catalyst: 'random text', lookup_reason: ['not a good reason'])[:aha]
       expect(result.score).to eq(8)
 
       expect(Sentry).to have_received(:capture_message).with('AHA received unexpected lookup catalyst: random text')
@@ -136,7 +165,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
             score_hash(score: 3, generator: 'AHA', alt_aha_flag: 0),
             score_hash(score: 7, generator: 'AHA', alt_aha_flag: 1),
             score_hash(score: 5, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 10, generator: 'MH-AHA', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 10),
           ],
         ),
       )
@@ -144,7 +173,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
 
     it 'returns the highest AHA score and preserves all fields including metadata' do
-      result = aha.fetch_score(client)
+      result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(7) # Highest AHA score (not 10, which is MH-AHA)
       expect(result.generator).to eq('AHA')
       expect(result.mci_quality_indicator).to eq(1) # From the highest AHA score
@@ -166,7 +195,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
 
     it 'returns all fields including generator and metadata when score is -1' do
-      result = aha.fetch_score(client)
+      result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(-1)
       expect(result.generator).to eq('AHA')
       expect(result.mci_quality_indicator).to eq(1)
@@ -198,7 +227,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
 
     it 'calls API with comma-separated list of all sibling MCI IDs' do
-      result = aha.fetch_score(client)
+      result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(9) # Returns the highest score
       expect(result.mci_quality_indicator).to eq(1)
     end
@@ -233,7 +262,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
           scores: [
             score_hash(score: 2, generator: 'AHA', alt_aha_flag: 1),
             score_hash(score: 6, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 10, generator: 'MH-AHA', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 10),
           ],
         ),
         client_data(
@@ -245,7 +274,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
 
     it 'returns the highest AHA score across all siblings' do
-      result = aha.fetch_score(client)
+      result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(9) # Highest AHA score across all clients (not 10 which is MH-AHA)
       expect(result.generator).to eq('AHA')
       expect(result.mci_quality_indicator).to eq(1) # From the highest scoring AHA entry
@@ -260,7 +289,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       response = mock_api_response(
         client_data(
           dw_client_id: mci_unique_id.value,
-          scores: [score_hash(score: 10, generator: 'MH-AHA', alt_aha_flag: 0)],
+          scores: [mh_aha_score_hash(score: 10)],
         ),
       )
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
@@ -275,7 +304,8 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
 
     [-2, 0, 1.5, 11, 'str'].each do |invalid_score|
-      it "raises Error with message about invalid AHA score (#{invalid_score})" do
+      it "logs to Sentry and raises when sole AHA requested (#{invalid_score})" do
+        allow(Sentry).to receive(:capture_message)
         response = mock_api_response(
           client_data(
             dw_client_id: mci_unique_id.value,
@@ -284,8 +314,230 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         )
         setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
-        expect { aha.fetch_score(client) }.to raise_error(HmisErrors::ApiError, /Received invalid score/)
+        expect { aha.fetch_score(client) }.to raise_error(HmisErrors::ApiError, /does not contain AHA score/)
+        expect(Sentry).to have_received(:capture_message).with(/AHA received invalid AHA score entry/)
       end
+    end
+  end
+
+  context 'when generators are case-insensitive' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    before do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            score_hash(score: 5, generator: 'aha', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 7, generator: 'mh-aha'),
+            visionlink_score_hash(score: 3.5, generator: 'VISIONLINK'),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+    end
+
+    it 'parses mixed-case generator values' do
+      results = aha.fetch_score(client, requested_generators: [:aha, :mh_aha, :visionlink])
+
+      expect(results[:aha].score).to eq(5)
+      expect(results[:mh_aha].score).to eq(7)
+      expect(results[:visionlink].score).to eq(3.5)
+    end
+  end
+
+  context 'when requesting MH-AHA scores' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'returns the highest MH-AHA score across entries' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            mh_aha_score_hash(score: 3),
+            mh_aha_score_hash(score: 7),
+            score_hash(score: 9, generator: 'AHA', alt_aha_flag: 0),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:mh_aha])
+      expect(results[:mh_aha].score).to eq(7)
+      expect(results[:mh_aha]).to be_a(HmisExternalApis::AcHmis::AhaScores::MhAhaResult)
+    end
+
+    it 'returns the highest AHA and MH-AHA scores across clients' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            mh_aha_score_hash(score: 7),
+            score_hash(score: 3, generator: 'AHA', alt_aha_flag: 0),
+          ],
+        ),
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            mh_aha_score_hash(score: 2),
+            score_hash(score: 9, generator: 'AHA', alt_aha_flag: 0),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:mh_aha, :aha])
+      expect(results[:mh_aha].score).to eq(7) # highest across clients (2,7)
+      expect(results[:aha].score).to eq(9) # highest across clients (3,9)
+    end
+
+    it 'returns nil when MH-AHA is missing but AHA is requested' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0)],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:aha, :mh_aha])
+      expect(results[:aha].score).to eq(8)
+      expect(results[:mh_aha]).to be_nil
+    end
+
+    [-2, 0, 11, 'str'].each do |invalid_score|
+      it "skips invalid MH-AHA score (#{invalid_score}) and logs to Sentry" do
+        allow(Sentry).to receive(:capture_message)
+        response = mock_api_response(
+          client_data(
+            dw_client_id: mci_unique_id.value,
+            scores: [
+              mh_aha_score_hash(score: invalid_score),
+              mh_aha_score_hash(score: 6),
+            ],
+          ),
+        )
+        setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+        results = aha.fetch_score(client, requested_generators: [:mh_aha])
+        expect(results[:mh_aha].score).to eq(6)
+        expect(Sentry).to have_received(:capture_message).with(/AHA received invalid MH-AHA score entry/)
+      end
+    end
+  end
+
+  context 'when requesting VisionLink scores' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'returns typed VisionLink metadata with a numeric score' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [visionlink_score_hash(score: 4.25)],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
+      expect(result.score).to eq(4.25)
+      expect(result.is_eligible_ra).to eq(false)
+      expect(result.is_eligible_cc).to eq(true)
+      expect(result.homeless_risk).to eq(0)
+      expect(result).to be_a(HmisExternalApis::AcHmis::AhaScores::VisionLinkResult)
+    end
+
+    it 'returns -999 score with flags when no real score exists' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [visionlink_score_hash(score: -999)],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
+      expect(result.score).to eq(-999)
+      expect(result.is_eligible_ra).to eq(false)
+      expect(result.is_eligible_cc).to eq(true)
+    end
+
+    it 'prefers the highest score when both -999 and a real score are present' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            visionlink_score_hash(score: -999),
+            visionlink_score_hash(score: 3.5),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
+      expect(result.score).to eq(3.5)
+    end
+  end
+
+  context 'when requesting multiple generators' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'returns populated keys and nil for missing requested generators' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 5),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:aha, :mh_aha, :visionlink])
+      expect(results[:aha].score).to eq(8)
+      expect(results[:mh_aha].score).to eq(5)
+      expect(results[:visionlink]).to be_nil
+    end
+
+    it 'returns MH-AHA when AHA entry is invalid' do
+      allow(Sentry).to receive(:capture_message)
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            score_hash(score: 0, generator: 'AHA', alt_aha_flag: 0),
+            mh_aha_score_hash(score: 6),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:aha, :mh_aha])
+      expect(results[:aha]).to be_nil
+      expect(results[:mh_aha].score).to eq(6)
+      expect(Sentry).to have_received(:capture_message).with(/AHA received invalid AHA score entry/)
+    end
+  end
+
+  context 'when response contains unknown generators' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'ignores unknown generators silently' do
+      allow(Sentry).to receive(:capture_message)
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+            score_hash(score: 99, generator: 'UnknownGenerator', alt_aha_flag: 0),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client)[:aha]
+      expect(result.score).to eq(8)
+      expect(Sentry).not_to have_received(:capture_message)
     end
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -282,29 +282,11 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     end
   end
 
-  context 'when response does not contain AHA score' do
-    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
-
-    before do
-      response = mock_api_response(
-        client_data(
-          dw_client_id: mci_unique_id.value,
-          scores: [mh_aha_score_hash(score: 10)],
-        ),
-      )
-      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
-    end
-
-    it 'raises Error with message about missing AHA score' do
-      expect { aha.fetch_score(client) }.to raise_error(HmisErrors::ApiError, /does not contain AHA score/)
-    end
-  end
-
   context 'when AHA score is invalid' do
     let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
 
     [-2, 0, 1.5, 11, 'str'].each do |invalid_score|
-      it "logs to Sentry and raises when sole AHA requested (#{invalid_score})" do
+      it "logs to Sentry and returns nil for AHA when sole AHA requested (#{invalid_score})" do
         allow(Sentry).to receive(:capture_message)
         response = mock_api_response(
           client_data(
@@ -314,7 +296,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         )
         setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
-        expect { aha.fetch_score(client) }.to raise_error(HmisErrors::ApiError, /does not contain AHA score/)
+        expect(aha.fetch_score(client)[:aha]).to be_nil
         expect(Sentry).to have_received(:capture_message).with(/AHA received invalid AHA score entry/)
       end
     end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
   end
 
   # Helper methods for mocking score values returned by API
-  def score_hash(score:, generator:, alt_aha_flag: nil, metadata: nil)
+  def aha_score_hash(score:, generator: 'AHA', alt_aha_flag: nil, metadata: nil)
     {
       'score' => score,
       'metadata' => metadata || { 'alt_aha_flag' => alt_aha_flag }.compact,
@@ -38,7 +38,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     }
   end
 
-  def visionlink_score_hash(score:, metadata: nil, generator: 'VisionLink')
+  def visionlink_score_hash(score:, generator: 'VisionLink', metadata: nil)
     {
       'score' => score,
       'generator' => generator,
@@ -119,7 +119,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 8, alt_aha_flag: 0),
             mh_aha_score_hash(score: 10),
           ],
         ),
@@ -162,9 +162,9 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 3, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 7, generator: 'AHA', alt_aha_flag: 1),
-            score_hash(score: 5, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 3, alt_aha_flag: 0),
+            aha_score_hash(score: 7, alt_aha_flag: 1),
+            aha_score_hash(score: 5, alt_aha_flag: 0),
             mh_aha_score_hash(score: 10),
           ],
         ),
@@ -188,7 +188,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       response = mock_api_response(
         client_data(
           dw_client_id: mci_unique_id.value,
-          scores: [score_hash(score: -1, generator: 'AHA', alt_aha_flag: 1)],
+          scores: [aha_score_hash(score: -1, alt_aha_flag: 1)],
         ),
       )
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
@@ -220,8 +220,8 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
 
     before do
       response = mock_api_response(
-        client_data(dw_client_id: mci_unique_id1.value, scores: [score_hash(score: 6, generator: 'AHA', alt_aha_flag: 0)]),
-        client_data(dw_client_id: mci_unique_id2.value, scores: [score_hash(score: 9, generator: 'AHA', alt_aha_flag: 1)]),
+        client_data(dw_client_id: mci_unique_id1.value, scores: [aha_score_hash(score: 6, alt_aha_flag: 0)]),
+        client_data(dw_client_id: mci_unique_id2.value, scores: [aha_score_hash(score: 9, alt_aha_flag: 1)]),
       )
       setup_api_expectation(mci_unique_ids: [mci_unique_id1.value, mci_unique_id2.value], response: response)
     end
@@ -253,21 +253,21 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id1.value,
           scores: [
-            score_hash(score: 4, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 4, alt_aha_flag: 0),
+            aha_score_hash(score: 8, alt_aha_flag: 0),
           ],
         ),
         client_data(
           dw_client_id: mci_unique_id2.value,
           scores: [
-            score_hash(score: 2, generator: 'AHA', alt_aha_flag: 1),
-            score_hash(score: 6, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 2, alt_aha_flag: 1),
+            aha_score_hash(score: 6, alt_aha_flag: 0),
             mh_aha_score_hash(score: 10),
           ],
         ),
         client_data(
           dw_client_id: mci_unique_id3.value,
-          scores: [score_hash(score: 9, generator: 'AHA', alt_aha_flag: 1)],
+          scores: [aha_score_hash(score: 9, alt_aha_flag: 1)],
         ),
       )
       setup_api_expectation(mci_unique_ids: [mci_unique_id1.value, mci_unique_id2.value, mci_unique_id3.value], response: response)
@@ -309,7 +309,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         response = mock_api_response(
           client_data(
             dw_client_id: mci_unique_id.value,
-            scores: [score_hash(score: invalid_score, generator: 'AHA', alt_aha_flag: 0)],
+            scores: [aha_score_hash(score: invalid_score, alt_aha_flag: 0)],
           ),
         )
         setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
@@ -328,7 +328,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 5, generator: 'aha', alt_aha_flag: 0),
+            aha_score_hash(score: 5, generator: 'aha', alt_aha_flag: 0),
             mh_aha_score_hash(score: 7, generator: 'mh-aha'),
             visionlink_score_hash(score: 3.5, generator: 'VISIONLINK'),
           ],
@@ -356,7 +356,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
           scores: [
             mh_aha_score_hash(score: 3),
             mh_aha_score_hash(score: 7),
-            score_hash(score: 9, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 9, alt_aha_flag: 0),
           ],
         ),
       )
@@ -373,14 +373,14 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
           dw_client_id: mci_unique_id.value,
           scores: [
             mh_aha_score_hash(score: 7),
-            score_hash(score: 3, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 3, alt_aha_flag: 0),
           ],
         ),
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
             mh_aha_score_hash(score: 2),
-            score_hash(score: 9, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 9, alt_aha_flag: 0),
           ],
         ),
       )
@@ -395,7 +395,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       response = mock_api_response(
         client_data(
           dw_client_id: mci_unique_id.value,
-          scores: [score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0)],
+          scores: [aha_score_hash(score: 8, alt_aha_flag: 0)],
         ),
       )
       setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
@@ -486,7 +486,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 8, alt_aha_flag: 0),
             mh_aha_score_hash(score: 5),
           ],
         ),
@@ -505,7 +505,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 0, generator: 'AHA', alt_aha_flag: 0),
+            aha_score_hash(score: 0, alt_aha_flag: 0),
             mh_aha_score_hash(score: 6),
           ],
         ),
@@ -528,8 +528,8 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
         client_data(
           dw_client_id: mci_unique_id.value,
           scores: [
-            score_hash(score: 8, generator: 'AHA', alt_aha_flag: 0),
-            score_hash(score: 99, generator: 'UnknownGenerator', alt_aha_flag: 0),
+            aha_score_hash(score: 8, alt_aha_flag: 0),
+            aha_score_hash(score: 99, generator: 'UnknownGenerator', alt_aha_flag: 0),
           ],
         ),
       )


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9300

The external Scores API returns multiple score generators in a single response, but `HmisExternalApis::AcHmis::Aha` previously parsed only AHA scores. This refactors the integration to support fetching one or more generators in a single API call, laying groundwork for integrating data from MH-AHA and VisionLink responses into assessments.

Summary:
- `fetch_score` accepts `requested_generators:` (`:aha`, `:mh_aha`, `:visionlink`) and returns a hash of typed results via new `AhaScores` structs
- Parses AHA, MH-AHA, and VisionLink entries with case-insensitive generator matching; picks the highest score per generator
- Invalid entries are skipped with a Sentry message; missing requested generators return `nil` without raising
- **`fetchAhaScore` GraphQL mutation is unchanged externally**


## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
