### PR TITLE
fix: compatability issues in warden proxy

### DIFF
--- a/app/controllers/concerns/idp/current_user.rb
+++ b/app/controllers/concerns/idp/current_user.rb
@@ -17,7 +17,7 @@ module Idp::CurrentUser
 
   included do
     def current_user
-      @current_user ||= authenticated_user_from_jwt(user_class: User)
+      @current_user ||= idp_authenticated_user_from_jwt(user_class: User)
     end
     helper_method :current_user
 
@@ -27,7 +27,7 @@ module Idp::CurrentUser
 
     def authenticate_user!
       # use current_user for memoized resolution to avoid a multiple calls to find_or_create_from_jwt
-      handle_unauthenticated unless current_user
+      idp_handle_unauthenticated unless current_user
     end
 
     def user_signed_in?
@@ -62,7 +62,7 @@ module Idp::CurrentUser
 
     # Absolute expiration timestamp of the current token, for the session-expiry modal.
     def jwt_expires_at
-      jwt_helper = jwt_helper_for_request
+      jwt_helper = idp_jwt_helper_for_request
       return nil unless jwt_helper&.token? && jwt_helper.valid?
 
       jwt_helper.expiration_time
@@ -73,15 +73,15 @@ module Idp::CurrentUser
 
     # In production/development, reads the JWT from the X-Forwarded-Access-Token header
     # (set by oauth2-proxy). In system tests, TestJwtMiddleware promotes a cookie to this header.
-    def jwt_helper_for_request
-      @jwt_helper_for_request ||= begin
+    def idp_jwt_helper_for_request
+      @idp_jwt_helper_for_request ||= begin
         token = request.headers['HTTP_X_FORWARDED_ACCESS_TOKEN']
 
         Idp::JwtHelper.new(access_token: token)
       end
     end
 
-    def validate_impersonation_permissions(true_user, impersonated_user)
+    def idp_validate_impersonation_permissions(true_user, impersonated_user)
       return false unless true_user&.can_impersonate_users?
       return false unless impersonated_user&.impersonateable_by?(true_user)
 
@@ -90,8 +90,8 @@ module Idp::CurrentUser
 
     # Resolve the authenticated user from the JWT, applying impersonation. Generic over
     # user_class so both warehouse (User) and HMIS (Hmis::User) controllers can use it.
-    def authenticated_user_from_jwt(user_class: User)
-      jwt_helper = jwt_helper_for_request
+    def idp_authenticated_user_from_jwt(user_class: User)
+      jwt_helper = idp_jwt_helper_for_request
       return nil unless jwt_helper&.token? && jwt_helper.valid?
 
       # learn: true path — self-gates JIT creation on idp/auto_create_user and learns the
@@ -124,7 +124,7 @@ module Idp::CurrentUser
         true_user = user_class.find_by(id: impersonation_data[:true_user_id])
         impersonated_user = user_class.find_by(id: impersonation_data[:impersonated_user_id])
 
-        return impersonated_user if true_user && impersonated_user && validate_impersonation_permissions(true_user, impersonated_user)
+        return impersonated_user if true_user && impersonated_user && idp_validate_impersonation_permissions(true_user, impersonated_user)
 
         # Clear invalid impersonation
         impersonation_manager.clear
@@ -136,7 +136,7 @@ module Idp::CurrentUser
 
     # Capture the original request URL and redirect to OAuth2-proxy sign-in, preserving the
     # URL via the `rd` query parameter. Override in subclasses for custom behavior (e.g. JSON).
-    def handle_unauthenticated
+    def idp_handle_unauthenticated
       original_url = Idp::PostAuthRedirect.new(
         request: request,
         cookies: cookies,

--- a/app/models/idp/warden_proxy.rb
+++ b/app/models/idp/warden_proxy.rb
@@ -22,25 +22,46 @@ class Idp::WardenProxy
     @session = session
   end
 
-  def user(scope: :user)
-    @user if user_scope?(scope)
+  # All public methods mirror Warden::Proxy's positional scope / trailing-options-hash
+  # convention rather than keyword args: Devise and Warden call these positionally (and via
+  # splatted `[strategies..., opts]`), so a `*args` signature is what keeps them compatible.
+  # A bare `*args` also absorbs the keyword `scope:` form Devise uses elsewhere.
+
+  def user(*args)
+    @user if user_scope?(_scope(args))
   end
 
-  def authenticated?(scope: :user)
-    user_scope?(scope) && @user.present?
+  def authenticated?(*args)
+    result = !!user(*args)
+    yield if result && block_given?
+    result
   end
 
-  def authenticate?(scope: :user)
-    authenticated?(scope: scope)
+  def authenticate?(*args)
+    result = !!authenticate(*args)
+    yield if result && block_given?
+    result
   end
 
   # No-op for JWT-based auth; authentication is handled via the token.
-  def authenticate!(scope: :user, **)
-    @user if user_scope?(scope)
+  def authenticate(*args)
+    @user if user_scope?(_scope(args))
   end
 
-  def set_user(user, scope: :user, _store: false, _run_callbacks: false)
-    @user = user if user_scope?(scope)
+  # Real Warden throws :warden on failure so its failure app can redirect to login. There is no
+  # Warden failure app under JWT, and the cutover invariant is that an unauthenticated request
+  # never reaches a proxy-backed gate (the :user gate is handled upstream in Idp::CurrentUser).
+  # So reaching here without a resolved user means a scope is leaning on the proxy as its sole
+  # gate: fail loudly rather than silently authorize. Dial back to returning nil if too aggressive.
+  def authenticate!(*args)
+    user = authenticate(*args)
+    raise Warden::NotAuthenticated, "Idp::WardenProxy#authenticate! got no authenticated user for scope #{_scope(args).inspect}" unless user
+
+    user
+  end
+
+  def set_user(user, *args)
+    @user = user if user_scope?(_scope(args))
   end
 
   # In JWT-based authentication, the session is managed by Rails, not Warden.
@@ -48,7 +69,60 @@ class Idp::WardenProxy
     @session
   end
 
+  # Devise's sign_out(scope) routes here as logout(scope); only clear when the :user scope
+  # (or no scope) is targeted, so signing out a non-:user mapping leaves the real user intact.
+  def logout(*scopes)
+    @user = nil if scopes.empty? || scopes.map(&:to_sym).include?(:user)
+  end
+
+  # Strategy-related machinery has no meaning under JWT (there are no Warden strategies to run
+  # or cache), but Devise's sign_in / sign_out / failure paths still call these on the proxy.
+  # No-ops / nil keep those paths working.
+  def clear_strategies_cache!(*_args)
+  end
+
+  def lock!
+  end
+
+  # Devise's bypass_sign_in writes the user straight to the session serializer (skipping
+  # set_user). Under JWT there is no Warden session store to write to, so hand back a sink
+  # that swallows store/delete and answers fetch with nil.
+  def session_serializer
+    @session_serializer ||= NullSessionSerializer.new
+  end
+
+  def winning_strategy
+    nil
+  end
+
+  def message
+    nil
+  end
+
+  # Parse the scope from Warden's flexible call forms: a positional symbol (`user(:admin)`),
+  # a trailing/only options hash (`user(scope: :admin)` or splatted `[:strategy, {scope:}]`),
+  # or nothing (defaults to :user).
+  private def _scope(args)
+    opts = args.last.is_a?(Hash) ? args.last : {}
+    scope = opts[:scope]
+    scope ||= args.first unless args.first.is_a?(Hash)
+    (scope || :user).to_sym
+  end
+
   private def user_scope?(scope)
-    scope&.to_sym == :user
+    scope == :user
+  end
+
+  # Stand-in for Warden::SessionSerializer; the session is Rails-managed under JWT.
+  class NullSessionSerializer
+    def store(*)
+    end
+
+    def delete(*)
+    end
+
+    def fetch(*)
+      nil
+    end
   end
 end

--- a/app/models/idp/warden_proxy.rb
+++ b/app/models/idp/warden_proxy.rb
@@ -10,7 +10,7 @@
 #
 # Provides a warden-like interface for code that expects warden.user to be available,
 # so existing callers keep working without a real Warden session. Only the :user scope
-# carries a user under JWT; :hmis_user ceases to exist at cutover seam 6.
+# carries a user under JWT.
 #
 # Non-:user scopes answer falsey (matching real Warden) rather than raising: Devise's
 # scope-iterating helpers (e.g. signed_in?) probe authenticate?(scope: :hmis_user) on
@@ -22,10 +22,10 @@ class Idp::WardenProxy
     @session = session
   end
 
-  # All public methods mirror Warden::Proxy's positional scope / trailing-options-hash
-  # convention rather than keyword args: Devise and Warden call these positionally (and via
-  # splatted `[strategies..., opts]`), so a `*args` signature is what keeps them compatible.
-  # A bare `*args` also absorbs the keyword `scope:` form Devise uses elsewhere.
+  # The scope-accepting methods take `*args` rather than a keyword `scope:`, mirroring
+  # Warden::Proxy: Devise and Warden call these positionally and via splatted
+  # `[strategies..., opts]`, and `*args` (parsed by _scope) absorbs all those forms plus the
+  # keyword `scope:` form Devise uses elsewhere.
 
   def user(*args)
     @user if user_scope?(_scope(args))
@@ -43,7 +43,8 @@ class Idp::WardenProxy
     result
   end
 
-  # No-op for JWT-based auth; authentication is handled via the token.
+  # Real Warden runs strategies here; under JWT the token already authenticated us, so there's
+  # nothing to run — just hand back the resolved user (identical to #user).
   def authenticate(*args)
     @user if user_scope?(_scope(args))
   end
@@ -60,6 +61,10 @@ class Idp::WardenProxy
     user
   end
 
+  # Devise's sign_in routes here, so the method must exist. Like logout, it cannot actually
+  # establish a session: the user is established by the JWT upstream (oauth2-proxy / okta), and
+  # current_user is resolved from the token, not from @user. We still set the local copy so
+  # warden.user is consistent within the request when the :user scope is targeted.
   def set_user(user, *args)
     @user = user if user_scope?(_scope(args))
   end
@@ -69,15 +74,19 @@ class Idp::WardenProxy
     @session
   end
 
-  # Devise's sign_out(scope) routes here as logout(scope); only clear when the :user scope
-  # (or no scope) is targeted, so signing out a non-:user mapping leaves the real user intact.
+  # Devise's sign_out / sign_out_all_scopes route here, so the method must exist. But it cannot
+  # actually log anyone out: the JWT lives in the X-Forwarded-Access-Token request header (the
+  # source of truth), not in this proxy, and current_user is resolved from that token, not from
+  # @user. Real sign-out is the redirect to oauth2-proxy's sign-out endpoint in
+  # Users::SessionsController#respond_to_on_destroy. We still clear the local copy so warden.user
+  # is consistent within the request when the :user scope (or no scope) is targeted.
   def logout(*scopes)
     @user = nil if scopes.empty? || scopes.map(&:to_sym).include?(:user)
   end
 
-  # Strategy-related machinery has no meaning under JWT (there are no Warden strategies to run
-  # or cache), but Devise's sign_in / sign_out / failure paths still call these on the proxy.
-  # No-ops / nil keep those paths working.
+  # Warden strategy machinery — with no strategies under JWT there's nothing to cache or lock.
+  # Devise's sign-out path still calls these (sign_out clears the cache, sign_out_all_scopes
+  # locks), so keep them as no-ops.
   def clear_strategies_cache!(*_args)
   end
 
@@ -91,6 +100,8 @@ class Idp::WardenProxy
     @session_serializer ||= NullSessionSerializer.new
   end
 
+  # Also strategy machinery: with no strategies there's no winning strategy and no auth-failure
+  # message. Devise's CSRF-cleanup and failure-app paths read these; nil is the honest answer.
   def winning_strategy
     nil
   end

--- a/spec/controllers/concerns/idp/current_user_spec.rb
+++ b/spec/controllers/concerns/idp/current_user_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Idp::CurrentUser, type: :controller do
       get 'auth' => 'anonymous#auth'
       get 'who' => 'anonymous#who'
     end
-    allow(controller).to receive(:jwt_helper_for_request).and_return(jwt_helper)
+    allow(controller).to receive(:idp_jwt_helper_for_request).and_return(jwt_helper)
   end
 
   let(:jwt_helper) do
@@ -72,7 +72,7 @@ RSpec.describe Idp::CurrentUser, type: :controller do
     end
   end
 
-  describe '#authenticated_user_from_jwt' do
+  describe '#idp_authenticated_user_from_jwt' do
     it 'resolves via find_or_create_from_jwt (the learning call), not find_from_jwt' do
       user = double('User', id: 7)
       expect(User).to receive(:find_or_create_from_jwt).with(jwt_helper).and_return(user)
@@ -103,13 +103,13 @@ RSpec.describe Idp::CurrentUser, type: :controller do
       expect(response.body).to eq('authenticated:5')
     end
 
-    it 'calls handle_unauthenticated when no user resolves' do
+    it 'calls idp_handle_unauthenticated when no user resolves' do
       allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
-      allow(controller).to receive(:handle_unauthenticated)
+      allow(controller).to receive(:idp_handle_unauthenticated)
 
       get :auth
 
-      expect(controller).to have_received(:handle_unauthenticated)
+      expect(controller).to have_received(:idp_handle_unauthenticated)
     end
 
     it 'does not consult active_for_authentication? (access is the IdP decision)' do
@@ -121,7 +121,7 @@ RSpec.describe Idp::CurrentUser, type: :controller do
       expect(response.body).to eq('authenticated:9')
     end
 
-    # Exercises the real handle_unauthenticated wiring (capture + redirect), including the
+    # Exercises the real idp_handle_unauthenticated wiring (capture + redirect), including the
     # real Idp::Oauth2ProxySignInPath builder. No last_connector_id cookie is set here, so
     # only the rd parameter appears.
     it 'captures the original URL and redirects to the oauth2 sign-in path when unauthenticated' do

--- a/spec/models/idp/warden_proxy_spec.rb
+++ b/spec/models/idp/warden_proxy_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe Idp::WardenProxy do
       proxy = described_class.new(nil)
       expect(proxy.user).to be_nil
     end
+
+    # Warden/Devise call positionally (e.g. user(:user)) far more than via scope:.
+    it 'returns the user for a positional :user scope' do
+      proxy = described_class.new(user)
+      expect(proxy.user(:user)).to eq(user)
+    end
+
+    it 'returns nil for a positional :hmis_user scope' do
+      proxy = described_class.new(user)
+      expect(proxy.user(:hmis_user)).to be_nil
+    end
+
+    # Devise splats strategies followed by an options hash: user(:strategy, scope: :user).
+    # This guards that a leading positional strategy is not mistaken for the scope.
+    it 'returns the user for a splatted strategies + scope: :user hash' do
+      proxy = described_class.new(user)
+      expect(proxy.user(:password, :token, scope: :user)).to eq(user)
+    end
   end
 
   describe '#authenticated?' do
@@ -50,6 +68,22 @@ RSpec.describe Idp::WardenProxy do
       proxy = described_class.new(user)
       expect(proxy.authenticated?(scope: :hmis_user)).to be false
     end
+
+    # Devise's helpers pass a block that must run only on successful authentication.
+    it 'yields when authenticated' do
+      proxy = described_class.new(user)
+      expect { |b| proxy.authenticated?(scope: :user, &b) }.to yield_control
+    end
+
+    it 'does not yield when not authenticated' do
+      proxy = described_class.new(nil)
+      expect { |b| proxy.authenticated?(scope: :user, &b) }.not_to yield_control
+    end
+
+    it 'does not yield for a non-user scope even when a user is present' do
+      proxy = described_class.new(user)
+      expect { |b| proxy.authenticated?(scope: :hmis_user, &b) }.not_to yield_control
+    end
   end
 
   describe '#authenticate?' do
@@ -57,12 +91,41 @@ RSpec.describe Idp::WardenProxy do
       expect(described_class.new(user).authenticate?(scope: :user)).to be true
       expect(described_class.new(nil).authenticate?(scope: :user)).to be false
     end
+
+    it 'yields when authentication succeeds' do
+      proxy = described_class.new(user)
+      expect { |b| proxy.authenticate?(scope: :user, &b) }.to yield_control
+    end
+
+    it 'does not yield when authentication fails' do
+      proxy = described_class.new(nil)
+      expect { |b| proxy.authenticate?(scope: :user, &b) }.not_to yield_control
+    end
   end
 
   describe '#authenticate!' do
     it 'returns the current user without performing authentication' do
       proxy = described_class.new(user)
       expect(proxy.authenticate!).to eq(user)
+    end
+
+    # Devise calls authenticate! with splatted strategies and a trailing scope: hash.
+    it 'returns the user for a splatted strategies + scope: :user hash' do
+      proxy = described_class.new(user)
+      expect(proxy.authenticate!(:password, scope: :user)).to eq(user)
+    end
+
+    # authenticate! is the "require a user or halt" gate; under JWT a non-:user scope never
+    # carries a user, so it must fail loudly rather than hand back nil and let the caller treat
+    # "no exception" as success.
+    it 'raises for a non-:user scope' do
+      proxy = described_class.new(user)
+      expect { proxy.authenticate!(:password, scope: :hmis_user) }.to raise_error(Warden::NotAuthenticated)
+    end
+
+    it 'raises when there is no authenticated user for the :user scope' do
+      proxy = described_class.new(nil)
+      expect { proxy.authenticate! }.to raise_error(Warden::NotAuthenticated)
     end
   end
 
@@ -89,6 +152,54 @@ RSpec.describe Idp::WardenProxy do
     it 'returns nil when no session was provided' do
       proxy = described_class.new(user)
       expect(proxy.session).to be_nil
+    end
+  end
+
+  describe '#logout' do
+    it 'clears the user when no scope is given' do
+      proxy = described_class.new(user)
+      proxy.logout
+      expect(proxy.user).to be_nil
+    end
+
+    it 'clears the user when the :user scope is targeted' do
+      proxy = described_class.new(user)
+      proxy.logout(:user)
+      expect(proxy.user).to be_nil
+    end
+
+    it 'leaves the user intact when only a non-:user scope is targeted' do
+      proxy = described_class.new(user)
+      proxy.logout(:hmis_user)
+      expect(proxy.user).to eq(user)
+    end
+
+    it 'clears the user when :user is among several targeted scopes' do
+      proxy = described_class.new(user)
+      proxy.logout(:hmis_user, :user)
+      expect(proxy.user).to be_nil
+    end
+  end
+
+  # These exist solely so Devise's sign_in / sign_out / failure paths don't blow up.
+  # A rename or removal would raise NoMethodError in production auth flows.
+  describe 'Devise compatibility surface' do
+    let(:proxy) { described_class.new(user) }
+
+    it 'returns nil from #winning_strategy' do
+      expect(proxy.winning_strategy).to be_nil
+    end
+
+    it 'returns nil from #message' do
+      expect(proxy.message).to be_nil
+    end
+
+    it 'responds to #lock! without raising' do
+      expect { proxy.lock! }.not_to raise_error
+    end
+
+    it 'responds to #clear_strategies_cache! without raising' do
+      expect { proxy.clear_strategies_cache! }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`



### Description

Fixes Devise/Warden compatibility issues in the JWT-based authentication proxy and avoids method-name collisions when the mixin is included into controllers.

* **Warden Proxy**: Reworked scope-accepting methods (`user`, `authenticated?`, `authenticate?`, `authenticate`, `set_user`) to accept `*args` instead of a keyword `scope:`, matching how Devise and Warden invoke them positionally and via splatted strategy/options forms; added a `_scope` parser to normalize all call forms.
* **Warden Proxy**: Implemented previously missing methods Devise's sign-in/sign-out paths require **—** `logout`, `clear_strategies_cache!`, `lock!`, `session_serializer`, `winning_strategy`, and `message` **—** as JWT-appropriate no-ops, with a `NullSessionSerializer` sink for `bypass_sign_in`.
* **Warden Proxy**: Changed `authenticate!` to raise `Warden::NotAuthenticated` when no user is resolved rather than silently authorizing, since under JWT the `:user` gate is handled upstream and reaching the proxy ungated indicates misuse.
* **Current User Concern**: Prefixed internal helper methods (`authenticated_user_from_jwt`, `jwt_helper_for_request`, `validate_impersonation_permissions`, `handle_unauthenticated`) with `idp_` to prevent collisions with host controllers when the mixin is included.
* **Test coverage**: Added Warden proxy specs covering the new call forms and Devise integration methods; updated current-user specs for the renamed helpers.

### Type of Change

Bug fix


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)

