### PR TITLE
Disable dba:unbloat scheduled task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -174,12 +174,13 @@ tasks = [
     at: '11:00am',
     interruptable: true,
   },
-  {
-    task: 'dba:unbloat',
-    frequency: :sunday,
-    at: '2:00 am',
-    interruptable: true,
-  },
+  # Disable this task so it doesn't run on production while we adjust it to better handle extremely large tables.
+  # {
+  #   task: 'dba:unbloat',
+  #   frequency: :sunday,
+  #   at: '2:00 am',
+  #   interruptable: true,
+  # },
   {
     task: 'driver:hmis_csv_importer:cleanup:expire_and_delete',
     frequency: 1.day,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

Disables the `dba:unbloat` cron task by commenting it out in `config/schedule.rb`. The task runs `pg_repack` weekly (Sunday at 2am) to reclaim dead tuple bloat, but it lacks any guardrails on table size. Two tables totaling ~700GB were identified in its run queue, creating real risk of exhausting RDS free space.

This is a targeted hotfix to prevent the task from running again this Sunday while we implement a proper fix (e.g., skip tables exceeding a configurable size or free-space percentage threshold). The `dba:dry_run` task is unaffected and continues to run daily.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
