### PR TITLE
fix: ignore signal exceptions in sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -18,6 +18,9 @@ if sentry_dsn
     config.breadcrumbs_logger = [:active_support_logger, :http_logger]
     # sending all the gems isn't that helpful in practice, it just adds noise
     config.send_modules = false
+    # don't report on errors due to operational events (a pod being told to shut down)
+    # resulting in SIGTERM, SIGINT, etc.
+    config.excluded_exceptions += ['SignalException']
 
     ENV['SENTRY_PERFORMANCE_TRACE_RATE'].presence.yield_self do |base_trace_rate|
       # enable performance monitoring on QA


### PR DESCRIPTION
don't send signal exceptions; cuts down on noise due to normal pod scaling operations.