### PR TITLE
Add unit occupancy export to nightly upload

### DIFF
--- a/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
+++ b/drivers/hmis_external_apis/app/jobs/hmis_external_apis/ac_hmis/data_warehouse_upload_job.rb
@@ -244,15 +244,22 @@ module HmisExternalApis::AcHmis
     end
 
     def unit_export
-      export = HmisExternalApis::AcHmis::Exporters::UnitExport.new
-      export.run!
+      unit_export = HmisExternalApis::AcHmis::Exporters::UnitExport.new
+      unit_export.run!
+
+      unit_occupancy_export = HmisExternalApis::AcHmis::Exporters::UnitOccupancyExport.new
+      unit_occupancy_export.run!
 
       uploader = Exporters::DataWarehouseUploader.new(
         filename_format: '%Y-%m-%d-units.zip',
         io_streams: [
           OpenStruct.new(
             name: 'Units.csv',
-            io: export.output,
+            io: unit_export.output,
+          ),
+          OpenStruct.new(
+            name: 'UnitOccupancies.csv',
+            io: unit_occupancy_export.output,
           ),
         ],
       )

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_occupancy_export.rb
@@ -11,7 +11,7 @@ module HmisExternalApis::AcHmis::Exporters
   # Join keys: UnitID (UnitExport), EnrollmentID (HMIS CSV export, including deleted enrollments).
   # It includes full unit information (UnitTypeName, ProjectID, and ProjectName) because the UnitExport currently does not include deleted units.
   #
-  # Note: this was created as a one-off export (Issue#9037), it's not currently part of the daily export process (DataWarehouseUploadJob).
+  # Included in the daily units.zip upload alongside Units.csv
   class UnitOccupancyExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9037

Include `UnitOccupancies.csv` in the daily `units.zip` data warehouse upload alongside the existing `Units.csv`. The `UnitOccupancyExport` was previously a one-off export and is now wired into the existing `unit_export` daily job.

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
