### PR TITLE
feat: Improves controller authorization test coverage

### DIFF
--- a/spec/controllers/controller_authorization_spec.rb
+++ b/spec/controllers/controller_authorization_spec.rb
@@ -16,55 +16,93 @@ RSpec.describe 'Controller Authorization', type: :controller do
   let!(:user) { create :user }
   before(:each) do
     sign_in(user)
+  end
 
+  # We don't override handle_unauthorized_error, so the real failure path (redirect +
+  # flash alert) is tested. A `root` route is drawn so my_root_path can resolve.
+  #
+  # Both contexts share the same controller and routes; the only difference is the
+  # authorize_with config, passed in as a block. `guarded_action` is the action the
+  # filter is expected to cover, `open_action` the one it is expected to skip.
+  def setup_test_controller(&authorize_config)
     klass = Class.new(ApplicationControllerV2) do
-      authorize_with(only: :authorized_action) { authorize_me? }
-
-      def unauthorized_action
-        render plain: 'unauthorized success'
+      def root_action
+        render plain: 'root'
       end
 
-      def authorized_action
-        render plain: 'authorized'
+      def guarded_action
+        render plain: 'guarded'
+      end
+
+      def open_action
+        render plain: 'open'
       end
 
       protected
 
       def authorize_me?
-        # override in test
-      end
-
-      def handle_unauthorized_error(_error)
-        head :forbidden
+        # overridden per-example
       end
     end
+    klass.class_eval(&authorize_config)
 
     @controller = klass.new
 
     stub_const('TestAuthController', klass)
     Rails.application.routes.draw do
-      get 'unauthorized_action' => 'test_auth#unauthorized_action'
-      get 'authorized_action' => 'test_auth#authorized_action'
+      root to: 'test_auth#root_action'
+      get 'guarded_action' => 'test_auth#guarded_action'
+      get 'open_action' => 'test_auth#open_action'
     end
   end
 
-  it 'enforces authorization' do
-    allow(@controller).to receive(:authorize_me?).and_return(false)
-    get :authorized_action
-    expect(response).to have_http_status(:forbidden)
+  context 'with authorize_with(only:)' do
+    before(:each) do
+      setup_test_controller { authorize_with(only: :guarded_action) { authorize_me? } }
+    end
+
+    it 'blocks the request and redirects with an alert when the authorization block returns false' do
+      allow(@controller).to receive(:authorize_me?).and_return(false)
+      get :guarded_action
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:alert]).to be_present
+      expect(response.body).not_to include('guarded')
+    end
+
+    it 'allows access and runs the action when the authorization block returns true' do
+      allow(@controller).to receive(:authorize_me?).and_return(true)
+      get :guarded_action
+      expect(response).to have_http_status(:success)
+      expect(response.body).to eq('guarded')
+    end
+
+    it 'raises when an action performs no authorization check' do
+      expect { get :open_action }.to raise_error(AuthorizationNotPerformedError)
+    end
+
+    it 'does not have access to legacy authorization methods' do
+      expect(@controller.respond_to?(:require_can_view_projects!)).to be false
+    end
   end
 
-  it 'allows access when authorized' do
-    allow(@controller).to receive(:authorize_me?).and_return(true)
-    get :authorized_action
-    expect(response).to have_http_status(:success)
-  end
+  context 'with authorize_with(except:)' do
+    before(:each) do
+      setup_test_controller { authorize_with(except: :open_action) { authorize_me? } }
+    end
 
-  it 'raises when authorization is not performed' do
-    expect { get :unauthorized_action }.to raise_error(AuthorizationNotPerformedError)
-  end
+    it 'runs the authorization block for actions that are not excepted' do
+      allow(@controller).to receive(:authorize_me?).and_return(false)
+      get :guarded_action
+      # a redirect (rather than a fail-closed raise) proves the filter ran here
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:alert]).to be_present
+    end
 
-  it 'does not have access to legacy authorization methods' do
-    expect(@controller.respond_to?(:require_can_view_projects!)).to be false
+    it 'skips the authorization block for excepted actions, tripping the fail-closed safety net' do
+      # the excepted action runs no authorization, so the net must raise even though
+      # the block would have authorized
+      allow(@controller).to receive(:authorize_me?).and_return(true)
+      expect { get :open_action }.to raise_error(AuthorizationNotPerformedError)
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
# description
Improves controller authorization test coverage to exercise the real failure path and the except: filter mode.

- Controller Authorization Tests: Drop the head :forbidden stub so failures now assert the production behavior (redirect with flash alert) instead of a test-only response.
- Controller Authorization Tests: Add coverage for authorize_with(except:), verifying the block runs for non-excepted actions and that excepted actions trip the fail-closed AuthorizationNotPerformedError safety net.
 
 
## Checklist before requesting review
 
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
