### PR TITLE
Hotfix: skip parsing unrequested Scores API generator entries

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -98,7 +98,7 @@ module HmisExternalApis::AcHmis
       data = result.parsed_body&.dig('data')
       raise(Error, "Scores API response missing `data` key. Response body: `#{result.parsed_body}`") unless data
 
-      parsed_by_generator = parse_response_scores(data)
+      parsed_by_generator = parse_response_scores(data, requested_generators)
       build_results(parsed_by_generator, requested_generators)
     end
 
@@ -129,6 +129,9 @@ module HmisExternalApis::AcHmis
     # skipped after logging to Sentry (see parse_score_entry). The highest score per generator is
     # chosen later in build_results.
     #
+    # Only entries for requested generators are parsed, so unrelated score shapes in the response
+    # do not trigger validation errors or Sentry noise.
+    #
     # Example API shape:
     #   data: [
     #     { 'dw_client_id' => '100000001', 'scores' => [
@@ -142,7 +145,7 @@ module HmisExternalApis::AcHmis
     #
     # Example return value:
     #   { aha: [AhaResult(score: 7, ...), AhaResult(score: 9, ...)], mh_aha: [MhAhaResult(score: 5, ...)] }
-    def parse_response_scores(data)
+    def parse_response_scores(data, requested_generators)
       parsed_by_generator = Hash.new { |hash, key| hash[key] = [] }
 
       data.each do |response_client|
@@ -153,6 +156,7 @@ module HmisExternalApis::AcHmis
         response_client.dig('scores')&.each do |score_obj|
           generator_key = normalize_generator(score_obj['generator'])
           next unless generator_key
+          next unless requested_generators.include?(generator_key) # skip parsing unrequested generator
 
           parsed = parse_score_entry(score_obj, dw_client_id, generator_key)
           parsed_by_generator[generator_key] << parsed if parsed

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -522,4 +522,27 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       expect(Sentry).not_to have_received(:capture_message)
     end
   end
+
+  context 'when response contains unrequested generators' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'does not parse or log Sentry for unrequested generators' do
+      allow(Sentry).to receive(:capture_message)
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            aha_score_hash(score: 100, alt_aha_flag: 0), # invalid AHA score
+            mh_aha_score_hash(score: 6),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:mh_aha])
+
+      expect(results[:mh_aha].score).to eq(6)
+      expect(Sentry).not_to have_received(:capture_message)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Hotfix related to issue: https://github.com/open-path/Green-River/issues/9037

When fetching a single score type (e.g. AHA only), the Scores API client was still parsing every generator in the response. That could trigger validation errors and Sentry noise from unrelated entries (while we are still working on nailing down the specs for the new shapes). This hotfix skips parsing for generators that weren’t requested.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

