### PR TITLE
Allow valid MH-AHA score of 0, don't attempt parsing unrequested generators

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -57,7 +57,8 @@ module HmisExternalApis::AcHmis
       mh_aha: 'MH-AHA',
       visionlink: 'VisionLink',
     }.freeze
-    VALID_SCORES = [-1, *(1..10)].freeze # AHA and MH-AHA can be -1 or 1..10, but not zero.
+    AHA_VALID_SCORES = [-1, *(1..10)].freeze # AHA can be -1 or 1..10, but not zero.
+    MH_AHA_VALID_SCORES = [-1, 0, *(1..10)].freeze # MH-AHA can be -1, 0, or 1..10.
     CONNECTION_TIMEOUT_SECONDS = Rails.env.staging? ? 15 : 10
 
     Error = HmisErrors::ApiError.new(display_message: 'Failed to connect to AHA')
@@ -98,7 +99,7 @@ module HmisExternalApis::AcHmis
       data = result.parsed_body&.dig('data')
       raise(Error, "Scores API response missing `data` key. Response body: `#{result.parsed_body}`") unless data
 
-      parsed_by_generator = parse_response_scores(data)
+      parsed_by_generator = parse_response_scores(data, requested_generators)
       build_results(parsed_by_generator, requested_generators)
     end
 
@@ -133,6 +134,9 @@ module HmisExternalApis::AcHmis
     # skipped after logging to Sentry (see parse_score_entry). The highest score per generator is
     # chosen later in build_results.
     #
+    # Only entries for requested generators are parsed, so unrelated score shapes in the response
+    # do not trigger validation errors or Sentry noise.
+    #
     # Example API shape:
     #   data: [
     #     { 'dw_client_id' => '100000001', 'scores' => [
@@ -146,7 +150,7 @@ module HmisExternalApis::AcHmis
     #
     # Example return value:
     #   { aha: [AhaResult(score: 7, ...), AhaResult(score: 9, ...)], mh_aha: [MhAhaResult(score: 5, ...)] }
-    def parse_response_scores(data)
+    def parse_response_scores(data, requested_generators)
       parsed_by_generator = Hash.new { |hash, key| hash[key] = [] }
 
       data.each do |response_client|
@@ -157,6 +161,7 @@ module HmisExternalApis::AcHmis
         response_client.dig('scores')&.each do |score_obj|
           generator_key = normalize_generator(score_obj['generator'])
           next unless generator_key
+          next unless requested_generators.include?(generator_key) # skip parsing unrequested generator
 
           parsed = parse_score_entry(score_obj, dw_client_id, generator_key)
           parsed_by_generator[generator_key] << parsed if parsed
@@ -198,7 +203,7 @@ module HmisExternalApis::AcHmis
     #   dw_client_id: '100000001'
     #   => AhaScores::AhaResult(score: 8, mci_quality_indicator: 0, dw_client_id: '100000001', generator: 'AHA')
     def parse_aha_entry(score_obj, dw_client_id)
-      score = parse_standard_score(score_obj.dig('score'))
+      score = parse_aha_score(score_obj.dig('score'))
 
       AhaScores::AhaResult.new(
         score: score,
@@ -209,14 +214,14 @@ module HmisExternalApis::AcHmis
       )
     end
 
-    # Parses an MH-AHA generator entry. Uses the same score validation as AHA ([-1, 1..10]).
+    # Parses an MH-AHA generator entry. Score must be an integer in [-1, 0, 1..10].
     #
     # Example:
     #   score_obj: { 'score' => 5, 'generator' => 'MH-AHA', 'metadata' => { 'row_id' => '123', 'run_id' => 'aha_abc' } }
     #   dw_client_id: '100000022'
     #   => AhaScores::MhAhaResult(score: 5, dw_client_id: '100000022', generator: 'MH-AHA')
     def parse_mh_aha_entry(score_obj, dw_client_id)
-      score = parse_standard_score(score_obj.dig('score'))
+      score = parse_mh_aha_score(score_obj.dig('score'))
 
       AhaScores::MhAhaResult.new(
         score: score,
@@ -262,10 +267,16 @@ module HmisExternalApis::AcHmis
       )
     end
 
-    # Parse "standard" scores (AHA and MH-AHA) that are integers in [-1, 1..10]
-    def parse_standard_score(score_value)
+    def parse_aha_score(score_value)
       raise ArgumentError, 'Received blank score' if score_value.blank?
-      raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric) && score_value % 1 == 0 && VALID_SCORES.include?(score_value.to_i)
+      raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric) && score_value % 1 == 0 && AHA_VALID_SCORES.include?(score_value.to_i)
+
+      score_value.to_i
+    end
+
+    def parse_mh_aha_score(score_value)
+      raise ArgumentError, 'Received blank score' if score_value.blank?
+      raise ArgumentError, "Received invalid score: #{score_value.inspect}" unless score_value.is_a?(Numeric) && score_value % 1 == 0 && MH_AHA_VALID_SCORES.include?(score_value.to_i)
 
       score_value.to_i
     end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -395,7 +395,20 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       expect(results[:mh_aha]).to be_nil
     end
 
-    [-2, 0, 11, 'str'].each do |invalid_score|
+    it 'accepts a score of 0' do
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [mh_aha_score_hash(score: 0)],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:mh_aha])
+      expect(results[:mh_aha].score).to eq(0)
+    end
+
+    [-2, 11, 'str'].each do |invalid_score|
       it "skips invalid MH-AHA score (#{invalid_score}) and logs to Sentry" do
         allow(Sentry).to receive(:capture_message)
         response = mock_api_response(
@@ -588,6 +601,29 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
 
       result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(8)
+      expect(Sentry).not_to have_received(:capture_message)
+    end
+  end
+
+  context 'when response contains unrequested generators' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'does not parse or log Sentry for unrequested generators' do
+      allow(Sentry).to receive(:capture_message)
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            aha_score_hash(score: 100, alt_aha_flag: 0), # invalid AHA score
+            mh_aha_score_hash(score: 6),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      results = aha.fetch_score(client, requested_generators: [:mh_aha])
+
+      expect(results[:mh_aha].score).to eq(6)
       expect(Sentry).not_to have_received(:capture_message)
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description

Issue: https://github.com/open-path/Green-River/issues/9300

Hardens Scores API response parsing so each fetch only validates generators that were requested, and splits AHA vs MH-AHA score rules so they can diverge. MH-AHA now accepts a score of `0`, which AHA still rejects.


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
