### PR TITLE
Add organization exclusion criteria to HMIS project groups UI

### DIFF
--- a/drivers/hmis/app/views/hmis_admin/project_groups/_form.haml
+++ b/drivers/hmis/app/views/hmis_admin/project_groups/_form.haml
@@ -20,4 +20,5 @@
   %h3 Exclusion Criteria
   = f.simple_fields_for :exclusion_criteria, @project_group.parsed_exclusion_criteria do |ec|
     = ec.input :project_ids, collection: [], as: :select_two, input_html: { multiple: true, data: { 'collection-path' => api_projects_path(selected_project_ids: @project_group.parsed_exclusion_criteria.project_ids, data_source_ids: [ds.id]) }, placeholder: 'Choose Projects'}, label: 'Projects to Exclude', required: false
+    = ec.input :organization_ids, collection: organization_options, as: :grouped_select_two, group_method: :last, input_html: {multiple: true, placeholder: 'Choose Organizations' }, label: 'Organizations to Exclude', required: false
     = ec.input :project_type_numbers, collection: Hmis::ProjectGroupCriteria.available_project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types to Exclude', as: :select_two, required: false

--- a/drivers/hmis/spec/models/hmis/project_group_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_group_spec.rb
@@ -91,5 +91,25 @@ RSpec.describe Hmis::ProjectGroup, type: :model do
         expect(project_group.projects.map(&:id)).to contain_exactly(*expected)
       end
     end
+
+    context 'when exclusion criteria include organization_ids' do
+      let(:project_group) do
+        create(:hmis_project_group,
+               data_source: hmis_ds,
+               inclusion_criteria: {
+                 all_projects_in_data_source: true,
+               }.to_json,
+               exclusion_criteria: {
+                 organization_ids: [o2.id],
+               }.to_json)
+      end
+
+      it 'excludes all projects belonging to the specified organizations' do
+        expected = [p1_o1.id]
+
+        expect(project_group.effective_project_ids).to contain_exactly(*expected)
+        expect(project_group.parsed_exclusion_criteria.effective_project_ids).to contain_exactly(p2_o2.id, p3_o2.id, p4_o2.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Related Issue: https://github.com/open-path/Green-River/issues/9323

Project groups already supported organization IDs in inclusion criteria and in the underlying criteria model, but the admin form had no way to exclude by organization. This adds an organization picker to the exclusion criteria section so admins can exclude all projects belonging to selected organizations.

- Add "Organizations to Exclude" field to the project group admin form
- Add spec coverage for organization-based exclusion in project group evaluation

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)


## Screenshots

<img width="1230" height="1191" alt="Screenshot 2026-06-18 at 4 59 32 PM" src="https://github.com/user-attachments/assets/4974c000-b357-4d4e-97ef-d445281108e3" />
<img width="716" height="449" alt="Screenshot 2026-06-18 at 4 59 22 PM" src="https://github.com/user-attachments/assets/10c7608f-a05a-4139-b390-90fad6915fbd" />
