### PR TITLE
Add MAX_REPACK_TABLE_SIZE guard to pg_repack

### DIFF
--- a/app/models/dba/database_bloat.rb
+++ b/app/models/dba/database_bloat.rb
@@ -34,6 +34,9 @@ class Dba::DatabaseBloat
   # minimum percentage of non-analyzed rows to trigger adjusting autovaccuum
   MIN_PCT_NOT_ANALYZED = ENV.fetch('DBA_MIN_PCT_NOT_ANALYZED', 4).to_i
 
+  # skip pg_repack on tables larger than this (pg_repack needs roughly table_size of free space)
+  MAX_REPACK_TABLE_SIZE = ENV.fetch('DBA_MAX_REPACK_TABLE_SIZE', 100 * 1024**3).to_i
+
   def initialize(ar_base_class:, dry_run: false)
     self.ar_base_class = ar_base_class
     self.dry_run = dry_run
@@ -140,7 +143,10 @@ class Dba::DatabaseBloat
       # password should be in your .pgpass file
 
       bloated_tables.each.with_index do |row, i|
-        # puts row
+        if row['real_size_bytes'].to_i > MAX_REPACK_TABLE_SIZE
+          Rails.logger.warn("Skipping pg_repack for #{row['tblname']} (#{row['real_size']}): exceeds DBA_MAX_REPACK_TABLE_SIZE limit")
+          next
+        end
 
         # Get the appropriate pg_repack binary for this database version
         db_version = pg_repack_db_version
@@ -171,9 +177,7 @@ class Dba::DatabaseBloat
         cmd = ['bash', '-c', bash_cmd]
 
         Rails.logger.info("Repacking #{row['tblname']} with binary: #{binary}")
-        system(*cmd)
-
-        raise 'running repack failed.' if $?.exitstatus != 0 # rubocop:disable Style/SpecialGlobalVars
+        raise 'running repack failed.' unless run_system_command(*cmd)
 
         adjust_autovacuum_for(row)
 
@@ -256,6 +260,12 @@ class Dba::DatabaseBloat
     else
       identifier
     end
+  end
+
+  # Wraps system() so tests can stub it without hitting the frozen $? object
+  def run_system_command(*cmd)
+    system(*cmd)
+    $?.exitstatus == 0 # rubocop:disable Style/SpecialGlobalVars
   end
 
   # for finding bloat, etc. Harmless things only
@@ -370,6 +380,7 @@ class Dba::DatabaseBloat
         r.schemaname,
         r.tblname,
         pg_size_pretty(r.real_size::bigint) as real_size,
+        r.real_size::bigint as real_size_bytes,
         pg_size_pretty(r.extra_size::bigint) as extra_size,
         round(r.extra_pct) as extra_pct,
         round(r.bloat_pct) as bloat_pct,

--- a/spec/models/dba/database_bloat_spec.rb
+++ b/spec/models/dba/database_bloat_spec.rb
@@ -1,0 +1,140 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dba::DatabaseBloat, type: :model do
+  # Bypass ensure_matching_pg_repack_versions! so unit tests don't need a live pg_repack extension
+  subject(:db) do
+    instance = described_class.allocate
+    instance.instance_variable_set(:@ar_base_class, GrdaWarehouseBase)
+    instance.instance_variable_set(:@dry_run, false)
+    instance
+  end
+
+  let(:small_row) do
+    {
+      'tblname' => 'small_table',
+      'schemaname' => 'public',
+      'real_size' => '5 GB',
+      'real_size_bytes' => (5 * 1024**3).to_s,
+      'bloat_size' => 100_000_000,
+      'percent_unanalyzed' => 0,
+    }
+  end
+
+  let(:large_row) do
+    {
+      'tblname' => 'huge_table',
+      'schemaname' => 'public',
+      'real_size' => '350 GB',
+      'real_size_bytes' => (350 * 1024**3).to_s,
+      'bloat_size' => 1_000_000_000,
+      'percent_unanalyzed' => 0,
+    }
+  end
+
+  let(:threshold_row) do
+    {
+      'tblname' => 'exact_threshold_table',
+      'schemaname' => 'public',
+      'real_size' => '100 GB',
+      'real_size_bytes' => described_class::MAX_REPACK_TABLE_SIZE.to_s,
+      'bloat_size' => 500_000_000,
+      'percent_unanalyzed' => 0,
+    }
+  end
+
+  def stub_repack_prerequisites
+    allow(db).to receive(:pg_repack_db_version).and_return('1.5.3')
+    allow(db).to receive(:binary_available_on_container?).and_return(true)
+    allow(db).to receive(:adjust_autovacuum_for)
+    allow(db).to receive(:run_system_command).and_return(true)
+    stub_const('Dba::DatabaseBloat::MAX_PER_RUN', 100)
+  end
+
+  describe '#repack!' do
+    context 'when pg_repack is not supported for the base class' do
+      it 'logs and returns early without processing any tables' do
+        instance = described_class.allocate
+        instance.instance_variable_set(:@ar_base_class, HealthBase)
+        instance.instance_variable_set(:@dry_run, false)
+
+        expect(instance).not_to receive(:bloated_tables)
+        instance.repack!
+      end
+    end
+
+    context 'when a table exceeds MAX_REPACK_TABLE_SIZE' do
+      before do
+        allow(db).to receive(:bloated_tables).and_return([large_row, small_row])
+        stub_repack_prerequisites
+      end
+
+      it 'skips the oversized table with a warning' do
+        expect(Rails.logger).to receive(:warn).with(/Skipping pg_repack.*huge_table.*350 GB/)
+        db.repack!
+      end
+
+      it 'still processes the small table' do
+        allow(Rails.logger).to receive(:warn)
+        expect(db).to receive(:run_system_command).once
+        db.repack!
+      end
+    end
+
+    context 'when a table is exactly at MAX_REPACK_TABLE_SIZE' do
+      before do
+        allow(db).to receive(:bloated_tables).and_return([threshold_row])
+        stub_repack_prerequisites
+      end
+
+      it 'still processes the table (must exceed to skip)' do
+        expect(Rails.logger).not_to receive(:warn).with(/Skipping pg_repack/)
+        expect(db).to receive(:run_system_command).once
+        db.repack!
+      end
+    end
+
+    context 'when all tables are under MAX_REPACK_TABLE_SIZE' do
+      before do
+        allow(db).to receive(:bloated_tables).and_return([small_row])
+        stub_repack_prerequisites
+      end
+
+      it 'processes the table without a skip warning' do
+        expect(Rails.logger).not_to receive(:warn).with(/Skipping pg_repack/)
+        expect(db).to receive(:run_system_command).once
+        db.repack!
+      end
+    end
+
+    context 'when there are no bloated tables' do
+      before { allow(db).to receive(:bloated_tables).and_return([]) }
+
+      it 'does nothing' do
+        expect(db).not_to receive(:run_system_command)
+        db.repack!
+      end
+    end
+  end
+
+  describe '#quote_pg_identifier' do
+    it 'leaves lowercase snake_case identifiers unquoted' do
+      expect(db.send(:quote_pg_identifier, 'my_table')).to eq('my_table')
+    end
+
+    it 'quotes identifiers with uppercase letters' do
+      expect(db.send(:quote_pg_identifier, 'MyTable')).to eq('"MyTable"')
+    end
+
+    it 'quotes identifiers starting with a digit' do
+      expect(db.send(:quote_pg_identifier, '2024_data')).to eq('"2024_data"')
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds a size-based safety guard to `Dba::DatabaseBloat#repack!` that skips any table exceeding `MAX_REPACK_TABLE_SIZE` (default 100 GiB, configurable via `DBA_MAX_REPACK_TABLE_SIZE`). pg_repack works by building a parallel copy of the table, so it requires roughly one full table's worth of free disk space — repacking a 350 GB table on an instance with limited headroom risks filling RDS storage mid-operation.

The change adds `real_size_bytes` as a raw bigint column to the `bloated_tables_sql` query so the guard can compare against an integer threshold rather than parsing a human-readable string. The `system()` call and `$?` exit check are extracted into a private `run_system_command` method to allow RSpec stubbing (frozen `Process::Status` objects can't be proxied directly). A new spec at `spec/models/dba/database_bloat_spec.rb` covers the skip logic, threshold boundary behavior, and supporting methods.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
