### PR TITLE
fix: 9324 ignore CVE-2026-54171 for now

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -10,3 +10,5 @@ ignore:
   - GHSA-57hq-95w6-v4fc
   - CVE-2026-40295
   - CVE-2026-44587
+  # not exploitable, no patch yet available. See #9324
+  - CVE-2026-54171

--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,6 @@ CVE-2026-41316
 
 # carrierwave's content_type_denylist is not used in our codebase
 CVE-2026-44587
+
+# not exploitable, no patch yet available. See #9324
+CVE-2026-54171


### PR DESCRIPTION
see issue, ignore non-exploitable vuln until a patch is released