### PR TITLE
Missing eager load paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -131,7 +131,12 @@ module OpenPath
     Dir[root.join('drivers', '*', 'app')].each do |driver_app|
       driver_app_components.each do |component|
         component_dir = File.join(driver_app, component)
-        config.autoload_paths << component_dir if File.directory?(component_dir)
+        next unless File.directory?(component_dir)
+
+        # autoload_paths: the catalog of where things can be found (lazy-load)
+        config.autoload_paths << component_dir
+        # eager_load_paths: the subset Rails loads proactively at boot time
+        config.eager_load_paths << component_dir
       end
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
in production, this should return the subclasses, having loaded them at boot time
```
HmisCsvValidation::Error.subclasses
=> []
# should return `HmisCsvValidation::NonBlank` and others
```
Eager load is important for ensuring deterministic behavior when code is depends on class introspection.

Real impact: `drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb240` builds its type: list from `Error.subclasses.map(&:name)`. A missing/partial list silently changes importer behavior with no error.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


