### PR TITLE
Fix nondeterministic sorting issues in dw exports

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/client_export.rb
@@ -32,9 +32,9 @@ module HmisExternalApis::AcHmis::Exporters
         client_values = [warehouse_id]
 
         # If the client has multiple MCI IDs, it doesn't matter which one we send
-        external_id_values = [client.ac_hmis_mci_ids&.first&.value]
+        external_id_values = [client.ac_hmis_mci_ids.max_by { |mci| [mci.updated_at, mci.id] }&.value]
 
-        best_address = client.addresses.to_a.max_by(&:DateUpdated)
+        best_address = client.addresses.to_a.max_by { |addr| [addr.date_updated, addr.id] }
 
         address_values = address_columns.map do |col|
           best_address&.send(col)

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/pathways_export.rb
@@ -33,7 +33,7 @@ module HmisExternalApis::AcHmis::Exporters
       # Iterate through each Destination Client that has Source Client(s) with any Pathway values
       pathway_client_warehouse_id_to_client_ids.each do |warehouse_id, client_ids|
         # Find the pathway CDE that was most recently updated for this destination client
-        most_recent_pathway_cde = client_ids.map { |id| pathways_by_client_id[id] }.flatten.max_by(&:date_updated)
+        most_recent_pathway_cde = client_ids.map { |id| pathways_by_client_id[id] }.flatten.max_by { |cde| [cde.date_updated, cde.id] }
 
         # Collect all pathways for the source client that most recently had any pathway updated.
         # This makes it so that we don't mix-and-match pathways values from different source clients.

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/client_export_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::ClientExport, type: :model d
   let!(:ds) { create(:hmis_primary_data_source) }
   let!(:client) { create(:hmis_hud_client_with_warehouse_client, data_source: ds, DateCreated: today) }
   let(:subject) { HmisExternalApis::AcHmis::Exporters::ClientExport.new }
+  let!(:mci_cred) { create(:ac_hmis_mci_credential) }
   let(:output) do
     subject.output.rewind
     subject.output.read
@@ -39,10 +40,20 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::ClientExport, type: :model d
   end
 
   it 'includes MCIID' do
-    mci = create(:mci_external_id, source: client)
+    mci = create(:mci_external_id, source: client, remote_credential: mci_cred)
     irrelevant = create(:mci_unique_id_external_id, source: client)
     subject.run!
     expect(output).to include(mci.value)
     expect(output).to_not include(irrelevant.value)
+  end
+
+  it 'includes most recently updated MCI ID when client has multiple' do
+    older_mci = create(:mci_external_id, source: client, remote_credential: mci_cred)
+    newer_mci = create(:mci_external_id, source: client, remote_credential: mci_cred)
+    older_mci.update_column(:updated_at, 2.days.ago)
+    newer_mci.update_column(:updated_at, 1.day.ago)
+    subject.run!
+    expect(output).to include(newer_mci.value)
+    expect(output).to_not include(older_mci.value)
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9331

Fixes identified MCI sorting issue, and a few other nondeterministic sorts in the DW exports.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
