### PR TITLE
fix: nokogiri depency update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -681,10 +681,10 @@ GEM
     net-ssh (7.3.0)
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.22)
       auth-sanitizer (~> 0.2, >= 0.2.1)
@@ -1599,8 +1599,8 @@ CHECKSUMS
   net-ssh (7.3.0) sha256=172076c4b30ce56fb25a03961b0c4da14e1246426401b0f89cba1a3b54bf3ef0
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
   nio4r (2.7.4) sha256=d95dee68e0bb251b8ff90ac3423a511e3b784124e5db7ff5f4813a220ae73ca9
-  nokogiri (1.19.3) sha256=78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
+  nokogiri (1.19.4) sha256=50c951611c92bca05c51411aef45f1cbc50f2821c4802758c5c6d34696533ab5
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
   oauth2 (2.0.22) sha256=8f4669f0c8de69f6db7ed786bda20996eaf0003966b886f1c519efb1a5682fa6
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
   oj (3.16.11) sha256=2aab609d2bc896529bd3c70d737f591c13932a640ba6164a0f7e414efdb052b1


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
No CVEs for these yet
addresses: GHSA-5prr-v3j2-97mh GHSA-5v8h-3h3q-446p GHSA-8678-w3jw-xfc2 GHSA-9cv2-cfxc-v4v2 GHSA-p67v-3w7g-wjg7 GHSA-phwj-rprq-35pp GHSA-wfpw-mmfh-qq69 GHSA-wjv4-x9w8-wm3h GHSA-5prr-v3j2-97mh GHSA-5v8h-3h3q-446p GHSA-8678-w3jw-xfc2 GHSA-9cv2-cfxc-v4v2 GHSA-p67v-3w7g-wjg7 GHSA-phwj-rprq-35pp GHSA-wfpw-mmfh-qq69 GHSA-wjv4-x9w8-wm3h

## Type of change
Dependency update
