### PR TITLE
Authorize CreateDirectUpload mutation

### DIFF
--- a/drivers/hmis/app/graphql/mutations/create_direct_upload.rb
+++ b/drivers/hmis/app/graphql/mutations/create_direct_upload.rb
@@ -15,6 +15,10 @@ module Mutations
     type Types::Uploads::DirectUploadType
 
     def resolve(input:)
+      # Direct upload only stages a blob in storage. Attaching the blob to a record is authorized
+      # separately (e.g. submitForm, updateClientImage). Additional check here just to be safe.
+      access_denied! unless authorized_for_direct_upload?
+
       blob = ActiveStorage::Blob.create_before_direct_upload!(**input.to_h)
       {
         url: blob.service_url_for_direct_upload,
@@ -23,6 +27,16 @@ module Mutations
         signed_blob_id: blob.signed_id(expires_in: 8.hours),
         filename: input.filename,
       }
+    end
+
+    private
+
+    def authorized_for_direct_upload?
+      # File uploads (assessment attachments, client files, etc.)
+      return true if policy_for(Hmis::File, policy_type: :hmis_file).can_upload_files?
+
+      # Client profile image upload uses updateClientImage, which only requires ability to edit the client
+      policy_for(Hmis::Hud::Client, policy_type: :hmis_client).can_edit?
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_file_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_file_policy.rb
@@ -73,7 +73,13 @@ class Hmis::AuthPolicies::HmisFilePolicy < Hmis::AuthPolicies::ResourcePolicy
         global_permissions.include?(:can_view_any_confidential_client_files)
     end
 
-    # Note, there is no "can_create?" permission on the global HmisFile policy. Use the instance HmisClient policy's can_create_file? instead
+    # Whether the user can upload files.
+    # **NOTE** Do not use this to check whether a file can be uploaded to a specific client;
+    # use the instance HmisClient policy's can_create_file? instead.
+    def can_upload_files?
+      global_permissions.include?(:can_manage_own_client_files) ||
+        global_permissions.include?(:can_manage_any_client_files)
+    end
 
     protected
 

--- a/drivers/hmis/spec/models/hmis/auth_policies/hmis_file_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/hmis_file_policy_spec.rb
@@ -168,5 +168,26 @@ RSpec.describe Hmis::AuthPolicies::HmisFilePolicy, type: :model do
         expect(policy.can_index?).to be false
       end
     end
+
+    describe '#can_upload_files?' do
+      it 'returns false without file upload permissions' do
+        expect(policy.can_upload_files?).to be false
+      end
+
+      it 'returns true when the user has can_manage_own_client_files anywhere in the data source' do
+        create_access_control(user, project, with_permission: [:can_manage_own_client_files])
+        expect(policy.can_upload_files?).to be true
+      end
+
+      it 'returns true when the user has can_manage_any_client_files anywhere in the data source' do
+        create_access_control(user, project, with_permission: [:can_manage_any_client_files])
+        expect(policy.can_upload_files?).to be true
+      end
+
+      it 'returns false when the user can only view files' do
+        create_access_control(user, project, with_permission: [:can_view_clients, :can_view_any_nonconfidential_client_files])
+        expect(policy.can_upload_files?).to be false
+      end
+    end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/create_direct_upload_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/create_direct_upload_spec.rb
@@ -1,0 +1,85 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe Hmis::GraphqlController, type: :request do
+  include_context 'hmis base setup'
+
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_manage_own_client_files]) }
+
+  let(:mutation) do
+    <<~GRAPHQL
+      mutation CreateDirectUpload($input: CreateDirectUploadInput!) {
+        createDirectUpload(input: $input) {
+          signedBlobId
+          filename
+          url
+          headers
+        }
+      }
+    GRAPHQL
+  end
+
+  let(:upload_input) do
+    {
+      filename: 'test.txt',
+      byte_size: 4,
+      checksum: 'dGVzdA==',
+      content_type: 'text/plain',
+    }
+  end
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  def perform_mutation
+    post_graphql(input: { input: upload_input }) { mutation }
+  end
+
+  it 'creates a direct upload when the user can upload files' do
+    response, result = perform_mutation
+
+    aggregate_failures do
+      expect(response.status).to eq(200), result.inspect
+      data = result.dig('data', 'createDirectUpload')
+      expect(data['signedBlobId']).to be_present
+      expect(data['filename']).to eq('test.txt')
+      expect(data['url']).to be_present
+      expect(ActiveStorage::Blob.find_signed(data['signedBlobId'])).to be_present
+    end
+  end
+
+  context 'when the user can edit clients but not upload files' do
+    let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_edit_clients]) }
+
+    it 'allows direct upload for client profile images' do
+      response, result = perform_mutation
+
+      expect(response.status).to eq(200), result.inspect
+      expect(result.dig('data', 'createDirectUpload', 'signedBlobId')).to be_present
+    end
+  end
+
+  context 'when the user lacks upload and edit permissions' do
+    let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients]) }
+
+    it 'denies direct upload' do
+      expect do
+        expect_access_denied(perform_mutation)
+      end.not_to change(ActiveStorage::Blob, :count)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9089

The `createDirectUpload` mutation previously allowed any authenticated user to stage blobs in storage. It now requires file upload or client edit permissions before creating a direct upload. Blob attachment remains separately authorized via `submitForm` and `updateClientImage`.

- Add `HmisFilePolicy#can_upload_files?` for global file upload capability
- Gate `CreateDirectUpload` on `can_upload_files?` or global `can_edit_clients`
- Add request and policy specs


**How to test:** no change in behavior expected. Test normal file upload and uploading client photos

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
