### PR TITLE
Add additional authorization check to MCI clearance

### DIFF
--- a/drivers/hmis/app/graphql/mutations/ac_hmis/clear_mci.rb
+++ b/drivers/hmis/app/graphql/mutations/ac_hmis/clear_mci.rb
@@ -19,6 +19,9 @@ module Mutations
     AUTO_CLEAR_THRESHOLD = 97
 
     def resolve(input:)
+      # MCI Clearance is only permitted for users who can create new client records
+      access_denied! unless policy_for(Hmis::Hud::Client, policy_type: :hmis_client).can_create?
+
       errors = HmisErrors::Errors.new
       errors.add :base, :server_error, full_message: 'MCI connection is not configured' unless HmisExternalApis::AcHmis::Mci.enabled?
       return { errors: errors } if errors.any?

--- a/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/clear_mci_spec.rb
@@ -13,6 +13,7 @@ require_relative '../../support/hmis_base_setup'
 RSpec.describe Hmis::GraphqlController, type: :request do
   include_context 'hmis base setup'
 
+  let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients, :can_edit_clients]) }
   let(:stub_mci) { double }
 
   before(:each) do
@@ -156,6 +157,37 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   it 'should catch and resolve errors' do
     allow(stub_mci).to receive(:clearance).and_raise(StandardError, 'Test error')
     expect_gql_error(post_graphql(input: { input: input }) { mutation })
+  end
+
+  context 'when MCI is not configured' do
+    before do
+      GrdaWarehouse::RemoteCredentials::Oauth.where(slug: HmisExternalApis::AcHmis::Mci::SYSTEM_ID).destroy_all
+    end
+
+    it 'returns a server error and does not call MCI' do
+      expect(HmisExternalApis::AcHmis::Mci).not_to receive(:new)
+
+      mutate(input: { input: input }) do |matches, errors|
+        expect(matches).to be_nil
+        expect(errors).to contain_exactly(
+          include(
+            'type' => 'server_error',
+            'fullMessage' => 'MCI connection is not configured',
+          ),
+        )
+      end
+    end
+  end
+
+  describe 'authorization' do
+    context 'when user cannot create clients' do
+      let!(:access_control) { create_access_control(hmis_user, ds1, with_permission: [:can_view_clients]) }
+
+      it 'returns access denied and does not call MCI' do
+        expect(stub_mci).not_to receive(:clearance)
+        expect_access_denied(post_graphql(input: { input: input }) { mutation })
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9089

The `clearMci` mutation previously allowed any authenticated user to submit PII to the external MCI service and receive match results. It now requires global client create permission before performing clearance.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
