### PR TITLE
Disable changing project config type

### DIFF
--- a/drivers/hmis/app/graphql/mutations/update_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_config.rb
@@ -19,9 +19,8 @@ module Mutations
       access_denied! unless policy_for(record, policy_type: :project_config).can_update?
 
       errors = HmisErrors::Errors.new
-      # config_type is intentionally excluded from to_params, so this would not change the persisted STI class.
-      # But changing the config type enables other dependent fields in the form, which are invalid for this config type.
-      # Reject the change outright so the user sees a validation error on config_type instead of hitting a raise.
+      # Config type cannot be changed once set. Frontend prevents it, but return a validation
+      # instead of raising for backwards compatability.
       if input.config_type.present? && input.config_type != record.config_type
         errors.add(:config_type, :invalid, message: 'cannot be changed once set')
         return { project_config: nil, errors: errors.errors }

--- a/drivers/hmis/app/graphql/mutations/update_project_config.rb
+++ b/drivers/hmis/app/graphql/mutations/update_project_config.rb
@@ -17,18 +17,28 @@ module Mutations
     def resolve(id:, input:)
       record = Hmis::ProjectConfig.find(id)
       access_denied! unless policy_for(record, policy_type: :project_config).can_update?
+
+      errors = HmisErrors::Errors.new
+      # config_type is intentionally excluded from to_params, so this would not change the persisted STI class.
+      # But changing the config type enables other dependent fields in the form, which are invalid for this config type.
+      # Reject the change outright so the user sees a validation error on config_type instead of hitting a raise.
+      if input.config_type.present? && input.config_type != record.config_type
+        errors.add(:config_type, :invalid, message: 'cannot be changed once set')
+        return { project_config: nil, errors: errors.errors }
+      end
+
       record.assign_attributes(**input.to_params)
 
       if record.valid?
         record.save!
       else
-        errors = record.errors
+        errors.add_ar_errors(record.errors.errors)
         record = nil
       end
 
       {
         project_config: record,
-        errors: errors,
+        errors: errors.errors,
       }
     end
   end

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -37,6 +37,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
 
   validates :type, inclusion: { in: CONFIG_TYPE_FACTORIES.values }
 
+  validate :validate_config_type_stable_once_set
   validate :validate_config_options_json
   validate :validate_consistent_data_source
 
@@ -125,6 +126,14 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   end
 
   private
+
+  def validate_config_type_stable_once_set
+    # GraphQL update ignores changes to config_type, so this is just an extra guard against other callers.
+    return unless will_save_change_to_type?
+    return if type_was.nil?
+
+    errors.add(:config_type, 'cannot be changed once set')
+  end
 
   def validate_consistent_data_source
     errors.add(:base, 'Data source must be the same as project') if project.present? && data_source != project.data_source

--- a/drivers/hmis/lib/form_data/static/project_config.json
+++ b/drivers/hmis/lib/form_data/static/project_config.json
@@ -8,9 +8,19 @@
       "mapping": {
         "field_name": "configType"
       },
-      "helper_text": "Select the configuration to enable",
+      "helper_text": "Select the type of configuration to create. Config type cannot be changed once set.",
       "component": "DROPDOWN",
-      "required": true
+      "required": true,
+      "disabled_display": "PROTECTED_WITH_VALUE",
+      "enable_behavior": "ALL",
+      "enable_when": [
+        {
+          "local_constant": "$projectConfigId",
+          "operator": "EXISTS",
+          "answer_boolean": false,
+          "_comment": "Only enable this question when creating a new project config"
+        }
+      ]
     },
     {
       "type": "CHOICE",

--- a/drivers/hmis/spec/models/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_config_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Hmis::ProjectConfig, type: :model do
     expect(config).to be_nil
   end
 
+  it 'does not allow config type to change once set' do
+    config = create(:hmis_project_auto_enter_config, project: p1, data_source: ds1)
+    config.type = Hmis::ProjectConfig::AUTO_EXIT_CONFIG
+
+    expect(config).not_to be_valid
+    expect(config.errors[:config_type]).to include('cannot be changed once set')
+  end
+
   describe '.viewable_by' do
     let!(:ds1) { create(:hmis_data_source) }
     let!(:ds2) { create(:hmis_data_source) }

--- a/drivers/hmis/spec/requests/hmis/update_project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/update_project_config_spec.rb
@@ -1,0 +1,61 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'UpdateProjectConfig Mutation', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation UpdateProjectConfig($id: ID!, $input: ProjectConfigInput!) {
+        updateProjectConfig(id: $id, input: $input) {
+          projectConfig {
+            id
+            configType
+            configOptions
+          }
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1) }
+  let!(:project_config) { create(:hmis_project_auto_enter_config, project: p1, data_source: ds1) }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  it 'successfully updates a project config' do
+    auto_exit_config = create(:hmis_project_auto_exit_config, project: p1, data_source: ds1, length_of_absence_days: 30)
+    response, result = post_graphql(id: auto_exit_config.id, input: { length_of_absence_days: 45 }) { mutation }
+
+    expect(response.status).to eq(200), result.inspect
+    expect(JSON.parse(result.dig('data', 'updateProjectConfig', 'projectConfig', 'configOptions'))).to eq('length_of_absence_days' => 45)
+    expect(auto_exit_config.reload.length_of_absence_days).to eq(45)
+  end
+
+  it 'throws an error when the user does not have access' do
+    remove_permissions(access_control, :can_configure_data_collection)
+    expect_access_denied(post_graphql(id: project_config.id, input: { config_type: 'AUTO_ENTER' }) { mutation })
+  end
+
+  it 'returns a validation error when config type changes' do
+    response, result = post_graphql(id: project_config.id, input: { config_type: 'AUTO_EXIT', length_of_absence_days: 30 }) { mutation }
+
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'updateProjectConfig', 'projectConfig')).to be_nil
+    expect(result.dig('data', 'updateProjectConfig', 'errors')).to contain_exactly(
+      a_hash_including('attribute' => 'configType', 'message' => 'cannot be changed once set'),
+    )
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)
- Update the Project Config static json form to disable the Config Type dropdown when editing an existing config.
  - Use a new local constant to determine whether we're editing an existing config. See corresponding frontend PR: https://github.com/greenriver/hmis-frontend/pull/1507
- Add a guard in the `UpdateProjectConfig` mutation, returning a validation error if the user input tries to change the project config.
  - Previously, any changes to the project config type itself would have been ignored (on the [input type](https://github.com/greenriver/hmis-warehouse/blob/ebc54c1f2c0dcf7926de10e394537e8dcd36833b/drivers/hmis/app/graphql/types/hmis_schema/project_config_input.rb#L22-L24)), _but_ the sentry error in the linked ticket arose when the mutation tried saving other fields (such as length_of_absence_days) that were enabled when the project config was changed in the form. With this guard, trying to change the project config type would return a validation error before hitting that raise.
  - Once the disabling logic described above is in place, the user should never hit this guard.
- Add a validation on the `ProjectConfig` model, requiring the config type to be stable once it is set.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
