### PR TITLE
Hotfix NoMethodError in HUD report cell drilldowns; add GeneratorBase delegation

### DIFF
--- a/app/models/hud_reports/generator_base.rb
+++ b/app/models/hud_reports/generator_base.rb
@@ -158,6 +158,14 @@ module HudReports
       )
     end
 
+    def self.valid_cell_name(cell_name)
+      ::HudReports::DrilldownContext.valid_cell_name(cell_name)
+    end
+
+    def self.valid_table_name(table_name)
+      ::HudReports::DrilldownContext.valid_table_name(table_name)
+    end
+
     def self.allowed_options(_)
       [
         :start,

--- a/spec/models/hud_reports/drilldown_context_spec.rb
+++ b/spec/models/hud_reports/drilldown_context_spec.rb
@@ -143,6 +143,36 @@ RSpec.describe HudReports::DrilldownContext, type: :model do
     end
   end
 
+  describe 'HudReports::GeneratorBase validation delegation' do
+    describe '.valid_cell_name' do
+      it 'delegates to DrilldownContext and strips safe characters' do
+        expect(TestGenerator.valid_cell_name('A1')).to eq('A1')
+      end
+
+      it 'strips injection characters' do
+        expect(TestGenerator.valid_cell_name('A1; DROP TABLE users')).to eq('A1')
+      end
+
+      it 'returns empty string for nil' do
+        expect(TestGenerator.valid_cell_name(nil)).to eq('')
+      end
+    end
+
+    describe '.valid_table_name' do
+      it 'delegates to DrilldownContext and strips safe characters' do
+        expect(TestGenerator.valid_table_name('5a')).to eq('5a')
+      end
+
+      it 'strips injection characters' do
+        expect(TestGenerator.valid_table_name('5a!')).to eq('5a')
+      end
+
+      it 'returns empty string for nil' do
+        expect(TestGenerator.valid_table_name(nil)).to eq('')
+      end
+    end
+  end
+
   describe '#base_scope' do
     let(:client_scope) { double('ClientScope') }
     let(:report_cell_scope) { double('ReportCellScope') }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixes a `NoMethodError` that has been breaking PATH and DQR cell drilldown pages since PR #6170 merged in January 2026. That PR refactored `CellsController#show` in both `HudPathReport` and `HudDataQualityReport` to call `generator.valid_cell_name` and `generator.valid_table_name` as class methods on the generator, but only added `drilldown_context` to `HudReports::GeneratorBase` — not the two validation methods. APR-family and SPM reports were unaffected because #6170 fully migrated them to `CellDrilldownConcern`, which calls `DrilldownContext` directly and never touches these methods.

Adds `GeneratorBase.valid_cell_name` and `GeneratorBase.valid_table_name` as one-line delegators to `HudReports::DrilldownContext`. Also adds six specs to `drilldown_context_spec.rb` covering valid input, injection stripping, and nil handling via the existing `TestGenerator` fixture.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
