### PR TITLE
Move report archival/purge execution into background job

### DIFF
--- a/app/jobs/reports/archive_and_purge_report_job.rb
+++ b/app/jobs/reports/archive_and_purge_report_job.rb
@@ -1,0 +1,40 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Reports
+  class ArchiveAndPurgeReportJob < BaseJob
+    queue_as ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)
+
+    def perform(report_class:, report_id:)
+      # Ensure driver models are loaded so archival registries (HudReportArchival.generator_registry,
+      # Rails.application.config.report_archival_types) are populated. The DJ worker is a separate
+      # process from the rake task and does not call eager_load! on its own when eager_load is false.
+      Rails.application.eager_load! unless Rails.application.config.eager_load
+
+      klass = report_class.safe_constantize
+      unless klass
+        Rails.logger.warn("#{self.class.name}: unknown report class #{report_class.inspect}, skipping")
+        return
+      end
+
+      report = klass.find_by(id: report_id)
+      unless report
+        Rails.logger.warn("#{self.class.name}: #{report_class} ##{report_id} not found, skipping")
+        return
+      end
+
+      result = report.archive_and_purge!
+      unless result[:success]
+        report.update_archival_metadata('purge_failed_at', Time.current.iso8601)
+        raise "#{self.class.name}: failed for #{report_class} ##{report_id}: #{result[:errors].inspect}"
+      end
+
+      Rails.logger.info("#{self.class.name}: completed for #{report_class} ##{report_id}: #{result.inspect}")
+    end
+  end
+end

--- a/app/models/concerns/report_archival.rb
+++ b/app/models/concerns/report_archival.rb
@@ -142,7 +142,7 @@ module ReportArchival
     scoped.unscope(:order).in_batches(of: ARCHIVAL_HARD_DELETE_BATCH_SIZE, load: false) do |batch|
       subquery_sql = batch.select(:id).to_sql
       sql = ActiveRecord::Base.sanitize_sql_array(["DELETE FROM #{table} WHERE id IN (#{subquery_sql})"])
-      deleted_count += model_class.connection.exec_delete(sql, 'ReportArchival Hard Delete', []).to_i
+      deleted_count += model_class.connection.execute(sql).cmd_tuples
     end
 
     deleted_count

--- a/app/services/hud_reports/archive_report_service.rb
+++ b/app/services/hud_reports/archive_report_service.rb
@@ -92,9 +92,9 @@ module HudReports
       Tempfile.create(['hud_archive', '.csv']) do |temp_file|
         CSV.open(temp_file.path, 'wb') do |csv|
           csv << column_names
-          relation.find_in_batches(batch_size: 1_000) do |batch|
-            batch.each do |record|
-              csv << column_names.map { |col| csv_value(record[col], json: json_column_names.include?(col)) }
+          relation.unscope(:order).in_batches(of: 1_000, load: false) do |batch_scope|
+            batch_scope.pluck(*column_names).each do |row|
+              csv << column_names.zip(row).map { |col, value| csv_value(value, json: json_column_names.include?(col)) }
             end
           end
         end

--- a/app/services/hud_reports/purge_archived_report_data_service.rb
+++ b/app/services/hud_reports/purge_archived_report_data_service.rb
@@ -169,7 +169,7 @@ module HudReports
       scoped.unscope(:order).in_batches(of: 1_000, load: false) do |batch|
         subquery_sql = batch.select(:id).to_sql
         sql = ActiveRecord::Base.sanitize_sql_array(["DELETE FROM #{table} WHERE id IN (#{subquery_sql})"])
-        deleted_count += model_class.connection.exec_delete(sql, 'HudReports Hard Delete', []).to_i
+        deleted_count += model_class.connection.execute(sql).cmd_tuples
       end
 
       deleted_count

--- a/app/services/reports/archive_report_service.rb
+++ b/app/services/reports/archive_report_service.rb
@@ -144,13 +144,11 @@ module Reports
       CSV.open(file_path, 'wb') do |csv|
         csv << column_names
 
-        association.find_in_batches(batch_size: 1000) do |batch|
-          batch.each do |record|
-            values = column_names.map do |col|
-              value = record.send(col)
+        association.unscope(:order).in_batches(of: 1_000, load: false) do |batch_scope|
+          batch_scope.pluck(*column_names).each do |row|
+            csv << column_names.zip(row).map do |col, value|
               jsonb_columns.include?(col) && !value.nil? ? value.to_json : value
             end
-            csv << values
           end
         end
       end

--- a/lib/tasks/reports/migrate_to_csv.rake
+++ b/lib/tasks/reports/migrate_to_csv.rake
@@ -10,7 +10,7 @@ namespace :reports do
     task :archive_and_purge_simple_reports, [:dry_run] => :environment do |_t, args|
       dry_run = ['true', '1'].include?(args[:dry_run])
 
-      puts "Archiving (if needed) and purging database data for eligible SimpleReports (grace period expired)#{dry_run ? ' (DRY RUN)' : ''}..."
+      puts "Enqueueing archival and purge jobs for eligible SimpleReports (grace period expired)#{dry_run ? ' (DRY RUN)' : ''}..."
       puts ''
 
       # Ensure models are loaded so report types are registered
@@ -25,91 +25,34 @@ namespace :reports do
         next
       end
 
-      # Filter at database level:
-      # - Must be one of the configured archival types
-      # - Must have completed_at
-      # - Must not be purged yet (purged_at is null) and must have purge_eligible_at <= now OR (purge_eligible_at doesn't exist AND completed_at + grace_period_days <= now)
       reports_to_process = SimpleReports::ReportInstance.
         of_types(archival_types).
         completed.
         purge_eligible(grace_period_days, now).
-        order(updated_at: :asc)
+        order(updated_at: :asc).
+        limit(20)
 
-      puts "Found #{reports_to_process.count} SimpleReports eligible for archival and purging (grace period expired)"
+      count = reports_to_process.count
+      puts "Found #{count} SimpleReports eligible for archival and purging (grace period expired)"
       puts ''
 
-      if reports_to_process.empty?
+      if count.zero?
         puts 'No SimpleReports eligible for archival and purging at this time.'
       else
-        reports_to_process = reports_to_process.limit(20)
-        puts "Processing #{reports_to_process.count} reports"
-
-        success_count = 0
-        failure_count = 0
-        errors = []
-
         reports_to_process.each do |report|
           if dry_run
-            puts "DRY RUN: Would archive and purge SimpleReport ##{report.id} (#{report.class.name})"
-            success_count += 1
+            puts "DRY RUN: Would enqueue archival for SimpleReport ##{report.id} (#{report.class.name})"
           else
-            result = report.archive_and_purge!
-
-            if result[:success]
-              success_count += 1
-              puts "SimpleReport ##{report.id} (#{report.class.name}) - Archived and purged:"
-              result[:deleted_counts]&.each do |model, count|
-                puts "  #{model}: #{count} records"
-              end
-            else
-              failure_count += 1
-              error_msg = "SimpleReport #{report.class.name} ##{report.id}: #{result[:errors].join(', ')}"
-              errors << error_msg
-              Rails.logger.error(error_msg)
-              report.update_archival_metadata('purge_failed_at', Time.current.iso8601)
-              report.update_archival_metadata('purge_failure_reason', result[:errors].join(', '))
-              Sentry.capture_exception_with_info(
-                StandardError.new(error_msg),
-                "Failed to archive and purge SimpleReport #{report.class.name} ##{report.id}",
-                {
-                  report_id: report.id,
-                  report_class: report.class.name,
-                  errors: result[:errors],
-                },
-              )
-              puts "SimpleReport ##{report.id} - Failed: #{error_msg}"
-            end
-          end
-        rescue StandardError => e
-          failure_count += 1
-          error_msg = "Error processing SimpleReport ##{report.id}: #{e.message}"
-          errors << error_msg
-          Rails.logger.error("#{error_msg}\n#{e.backtrace.first(5).join("\n")}")
-          Sentry.capture_exception_with_info(
-            e,
-            "Error processing archival and purge task for SimpleReport ##{report.id}",
-            {
-              report_id: report.id,
+            Reports::ArchiveAndPurgeReportJob.perform_later(
               report_class: report.class.name,
-            },
-          )
-          puts "SimpleReport ##{report.id} - Error: #{error_msg}"
-        ensure
-          GC.start # release report objects between iterations to reduce peak memory
+              report_id: report.id,
+            )
+            puts "Enqueued SimpleReport ##{report.id} (#{report.class.name})"
+          end
         end
 
         puts ''
-        puts "SimpleReports archive and purge#{dry_run ? ' (DRY RUN)' : ''} complete:"
-        puts "  Success: #{success_count}"
-        puts "  Failures: #{failure_count}"
-
-        if errors.any?
-          puts ''
-          puts 'Errors:'
-          errors.each do |error|
-            puts "  - #{error}"
-          end
-        end
+        puts "SimpleReports#{dry_run ? ' (DRY RUN)' : ''}: #{dry_run ? 'would enqueue' : 'enqueued'} #{count} jobs"
       end
     end
 
@@ -117,7 +60,7 @@ namespace :reports do
     task :archive_and_purge_hud_reports, [:dry_run] => :environment do |_t, args|
       dry_run = ['true', '1'].include?(args[:dry_run])
 
-      puts "Archiving and purging eligible HUD Reports#{dry_run ? ' (DRY RUN)' : ''}..."
+      puts "Enqueueing archival and purge jobs for eligible HUD Reports#{dry_run ? ' (DRY RUN)' : ''}..."
       puts ''
 
       # Ensure models are loaded so report types are registered
@@ -132,90 +75,33 @@ namespace :reports do
         next
       end
 
-      # Filter at database level:
-      # - Must be one of the configured archival types
-      # - Must have completed_at
-      # - Must not be purged yet (purged_at is null) and must have purge_eligible_at <= now OR (purge_eligible_at doesn't exist AND completed_at + grace_period_days <= now)
       reports_to_process = HudReports::ReportInstance.
         where(report_name: registered_names).
         purge_eligible(grace_period_days, now).
-        order(completed_at: :asc)
+        order(completed_at: :asc).
+        limit(20)
 
-      success_count = 0
-      failure_count = 0
-      errors = []
-
-      puts "Found #{reports_to_process.count} HUD Reports eligible for archival and purging (grace period expired)"
+      count = reports_to_process.count
+      puts "Found #{count} HUD Reports eligible for archival and purging (grace period expired)"
       puts ''
 
-      if reports_to_process.empty?
+      if count.zero?
         puts 'No HUD Reports eligible for archival and purging at this time.'
       else
-        reports_to_process = reports_to_process.limit(20)
-        puts "Processing #{reports_to_process.count} reports"
-
         reports_to_process.each do |report|
           if dry_run
-            puts "DRY RUN: Would archive and purge HUD Report ##{report.id} (#{report.report_name})"
-            success_count += 1
+            puts "DRY RUN: Would enqueue archival for HUD Report ##{report.id} (#{report.report_name})"
           else
-            result = report.archive_and_purge!
-
-            if result[:success]
-              success_count += 1
-              puts "HUD Report ##{report.id} (#{report.report_name}) - Archived and purged:"
-              result[:deleted_counts]&.each do |model, count|
-                puts "  #{model}: #{count} records"
-              end
-            else
-              failure_count += 1
-              error_msg = "HUD Report #{report.report_name} ##{report.id}: #{result[:errors].join(', ')}"
-              errors << error_msg
-              Rails.logger.error(error_msg)
-              report.update_archival_metadata('purge_failed_at', Time.current.iso8601)
-              report.update_archival_metadata('purge_failure_reason', result[:errors].join(', '))
-              Sentry.capture_exception_with_info(
-                StandardError.new(error_msg),
-                "Failed to archive and purge HUD Report #{report.report_name} ##{report.id}",
-                {
-                  report_id: report.id,
-                  report_name: report.report_name,
-                  errors: result[:errors],
-                },
-              )
-              puts "HUD Report ##{report.id} - Failed: #{error_msg}"
-            end
-          end
-        rescue StandardError => e
-          failure_count += 1
-          error_msg = "Error processing HUD Report #{report.report_name} ##{report.id}: #{e.message}"
-          errors << error_msg
-          Rails.logger.error("#{error_msg}\n#{e.backtrace.first(5).join("\n")}")
-          Sentry.capture_exception_with_info(
-            e,
-            "Error processing archival and purge task for HUD Report ##{report.id}",
-            {
+            Reports::ArchiveAndPurgeReportJob.perform_later(
+              report_class: report.class.name,
               report_id: report.id,
-              report_name: report.report_name,
-            },
-          )
-          puts "HUD Report ##{report.id} - Error: #{error_msg}"
-        ensure
-          GC.start # release report objects between iterations to reduce peak memory
+            )
+            puts "Enqueued HUD Report ##{report.id} (#{report.report_name})"
+          end
         end
 
         puts ''
-        puts "HUD Reports archive and purge#{dry_run ? ' (DRY RUN)' : ''} complete:"
-        puts "  Success: #{success_count}"
-        puts "  Failures: #{failure_count}"
-
-        if errors.any?
-          puts ''
-          puts 'Errors:'
-          errors.each do |error|
-            puts "  - #{error}"
-          end
-        end
+        puts "HUD Reports#{dry_run ? ' (DRY RUN)' : ''}: #{dry_run ? 'would enqueue' : 'enqueued'} #{count} jobs"
       end
     end
 

--- a/spec/jobs/reports/archive_and_purge_report_job_spec.rb
+++ b/spec/jobs/reports/archive_and_purge_report_job_spec.rb
@@ -1,0 +1,143 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reports::ArchiveAndPurgeReportJob, type: :job do
+  # Simulate a DJ worker process where eager_load is false (the production DJ default)
+  before do
+    allow(Rails.application).to receive(:eager_load!)
+    allow(Rails.application.config).to receive(:eager_load).and_return(false)
+  end
+
+  describe '#perform' do
+    context 'when the report class is unknown' do
+      it 'warns and returns without raising' do
+        allow(Rails.logger).to receive(:warn)
+
+        expect { described_class.new.perform(report_class: 'NonExistent::Report', report_id: 1) }.not_to raise_error
+        expect(Rails.logger).to have_received(:warn).with(match(/unknown report class/))
+      end
+    end
+
+    context 'when the report record is not found' do
+      before do
+        allow(SimpleReports::ReportInstance).to receive(:find_by).with(id: 99).and_return(nil)
+      end
+
+      it 'warns and returns without raising' do
+        allow(Rails.logger).to receive(:warn)
+
+        expect { described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 99) }.not_to raise_error
+        expect(Rails.logger).to have_received(:warn).with(match(/not found/))
+      end
+    end
+
+    describe 'eager_load! guard' do
+      before do
+        report = double('report', id: 42)
+        allow(SimpleReports::ReportInstance).to receive(:find_by).with(id: 42).and_return(report)
+        allow(report).to receive(:archive_and_purge!).and_return({ success: true })
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it 'calls eager_load! when config.eager_load is false' do
+        described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 42)
+
+        expect(Rails.application).to have_received(:eager_load!)
+      end
+
+      it 'skips eager_load! when config.eager_load is true' do
+        allow(Rails.application.config).to receive(:eager_load).and_return(true)
+
+        described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 42)
+
+        expect(Rails.application).not_to have_received(:eager_load!)
+      end
+    end
+
+    context 'with a SimpleReport' do
+      let(:report) { double('report', id: 42) }
+
+      before do
+        allow(SimpleReports::ReportInstance).to receive(:find_by).with(id: 42).and_return(report)
+      end
+
+      context 'when archive_and_purge! succeeds' do
+        before do
+          allow(report).to receive(:archive_and_purge!).and_return({ success: true, deleted_counts: {} })
+          allow(Rails.logger).to receive(:info)
+        end
+
+        it 'calls archive_and_purge! on the report' do
+          described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 42)
+
+          expect(report).to have_received(:archive_and_purge!)
+        end
+      end
+
+      context 'when archive_and_purge! fails' do
+        let(:errors) { ['Failed to archive before purge: S3 upload timeout'] }
+
+        before do
+          allow(report).to receive(:archive_and_purge!).and_return({ success: false, errors: errors })
+          allow(report).to receive(:update_archival_metadata)
+        end
+
+        it 'stamps purge_failed_at with an ISO8601 timestamp' do
+          expect { described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 42) }.
+            to raise_error(RuntimeError)
+
+          expect(report).to have_received(:update_archival_metadata).
+            with('purge_failed_at', match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/))
+        end
+
+        it 'raises with the report class, id, and error details' do
+          expect { described_class.new.perform(report_class: 'SimpleReports::ReportInstance', report_id: 42) }.
+            to raise_error(RuntimeError, match(/SimpleReports::ReportInstance.*42.*S3 upload timeout/))
+        end
+      end
+    end
+
+    context 'with a HUD report' do
+      let(:report) { double('hud_report', id: 7) }
+
+      before do
+        allow(HudReports::ReportInstance).to receive(:find_by).with(id: 7).and_return(report)
+      end
+
+      context 'when archive_and_purge! succeeds' do
+        before do
+          allow(report).to receive(:archive_and_purge!).and_return({ success: true })
+          allow(Rails.logger).to receive(:info)
+        end
+
+        it 'calls archive_and_purge! on the report' do
+          described_class.new.perform(report_class: 'HudReports::ReportInstance', report_id: 7)
+
+          expect(report).to have_received(:archive_and_purge!)
+        end
+      end
+
+      context 'when archive_and_purge! fails' do
+        before do
+          allow(report).to receive(:archive_and_purge!).and_return({ success: false, errors: ['Archive failed'] })
+          allow(report).to receive(:update_archival_metadata)
+        end
+
+        it 'stamps purge_failed_at and raises' do
+          expect { described_class.new.perform(report_class: 'HudReports::ReportInstance', report_id: 7) }.
+            to raise_error(RuntimeError, match(/HudReports::ReportInstance.*7/))
+
+          expect(report).to have_received(:update_archival_metadata).
+            with('purge_failed_at', match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Moves report CSV archival and purge from synchronous rake task execution into a `Reports::ArchiveAndPurgeReportJob` background job. The rake tasks (`reports:csv:archive_and_purge_simple_reports` and `archive_and_purge_hud_reports`) now enqueue one job per report (up to 20 each per nightly run) instead of running all archival synchronously in the rake process.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
