### PR TITLE
VisionLink external API patch: Display No Eligibility Data if all flags are missing

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -251,8 +251,14 @@ module HmisExternalApis::AcHmis
 
       metadata = score_obj['metadata'] || {}
 
-      # send a message to sentry if any of the expected flags are missing
-      missing_fields = ['is_eligible_ra', 'section_8', 'city_of_pittsburgh', 'subsidized_housing', 'recent_eviction_case'] - metadata.keys
+      expected_fields = ['is_eligible_ra', 'section_8', 'city_of_pittsburgh', 'subsidized_housing', 'recent_eviction_case']
+      missing_fields = expected_fields - metadata.keys
+
+      # Return nil if ALL expected flags are missing, indicating no eligibility data is available.
+      # This is an expected response (accompanied by a score of -1)
+      return nil if missing_fields.size == expected_fields.size
+
+      # If some flags were missing but not all, log to Sentry so we can investigate (unexpected behavior)
       Sentry.capture_message("VisionLink metadata missing fields: #{missing_fields.join(', ')}") if missing_fields.any?
 
       AhaScores::VisionLinkResult.new(

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -476,7 +476,27 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       expect(result.recent_eviction_case).to eq(false)
     end
 
-    it 'logs to Sentry when metadata is missing required keys' do
+    it 'returns nil when all eligibility metadata fields are missing' do
+      allow(Sentry).to receive(:capture_message)
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [
+            visionlink_score_hash(
+              score: -1,
+              metadata: { 'row_id' => '123', 'mci_uniq_id' => mci_unique_id.value },
+            ),
+          ],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
+      expect(result).to be_nil
+      expect(Sentry).not_to have_received(:capture_message)
+    end
+
+    it 'logs to Sentry when some but not all eligibility metadata fields are missing' do
       allow(Sentry).to receive(:capture_message)
       response = mock_api_response(
         client_data(


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Adjust behavior for VisionLink score fetch based on QA using real API behavior

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have added spec tests (or not applicable)
