### PR TITLE
fix: cop to stop disable_ddl_transaction

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_mode:
   merge:
     - Exclude
 
+require:
+  - ./lib/rubocop/cop/migrations/disable_ddl_transaction
+
 AllCops:
   SuggestExtensions: false
   Exclude:
@@ -272,3 +275,8 @@ Style/ExplicitBlockArgument:
   Enabled: false
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
+
+Migrations/DisableDdlTransaction:
+  Enabled: true
+  Include:
+    - "db/**/migrate/*.rb"

--- a/lib/rubocop/cop/migrations/disable_ddl_transaction.rb
+++ b/lib/rubocop/cop/migrations/disable_ddl_transaction.rb
@@ -23,7 +23,8 @@ module RuboCop
               'through (e.g. a lock timeout on a concurrent index build) leaves earlier statements committed ' \
               'without the migration being recorded, breaking retries on the next deploy. Prefer a plain, ' \
               'transactional add_index when the table is new/small. If concurrent index creation is genuinely ' \
-              'needed, isolate it in its own migration and disable this cop with a comment explaining why.'
+              'transactional add_index when the table is new/small. If concurrent index creation is genuinely ' \
+              'needed, isolate it in its own migration and add `rubocop:disable Migrations/DisableDdlTransaction` with a comment explaining why.'
 
         def on_send(node)
           return unless node.method?(:disable_ddl_transaction!)

--- a/lib/rubocop/cop/migrations/disable_ddl_transaction.rb
+++ b/lib/rubocop/cop/migrations/disable_ddl_transaction.rb
@@ -1,0 +1,36 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Migrations
+      # Flags any use of `disable_ddl_transaction!` in a migration.
+      #
+      # It drops the migration's wrapping transaction, so if any statement
+      # after it fails (most commonly a lock timeout on a concurrent index
+      # build), earlier statements in the migration stay committed, but the
+      # migration is never recorded as run. A retry then re-runs those
+      # earlier statements (e.g. PG::DuplicateColumn on a repeated
+      # add_column) and cancels the rest of the deploy.
+      #
+      class DisableDdlTransaction < RuboCop::Cop::Base
+        MSG = '`disable_ddl_transaction!` removes the migration\'s wrapping transaction, so a failure partway ' \
+              'through (e.g. a lock timeout on a concurrent index build) leaves earlier statements committed ' \
+              'without the migration being recorded, breaking retries on the next deploy. Prefer a plain, ' \
+              'transactional add_index when the table is new/small. If concurrent index creation is genuinely ' \
+              'needed, isolate it in its own migration and disable this cop with a comment explaining why.'
+
+        def on_send(node)
+          return unless node.method?(:disable_ddl_transaction!)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Bans use of `disable_ddl_transaction`

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
