### PR TITLE
9309 cohort-audit-follow-up fixes from review

### DIFF
--- a/app/models/audit/cohort_access/base.rb
+++ b/app/models/audit/cohort_access/base.rb
@@ -73,7 +73,7 @@ module Audit
           next if system_user_ids.include?(user_id)
 
           user = users_by_id[user_id]
-          next unless user&.deleted_at.nil?
+          next if user.nil? || user.deleted_at.present?
 
           labels = segs.map { |s| path_label(s.via) }.uniq.sort
           UserAccess.new(user: user, path_labels: labels)

--- a/app/models/concerns/gr_paper_trail_version_behavior.rb
+++ b/app/models/concerns/gr_paper_trail_version_behavior.rb
@@ -11,6 +11,7 @@
 module GrPaperTrailVersionBehavior
   extend ActiveSupport::Concern
   include PaperTrail::VersionConcern
+  include PaperTrailSafeColumns
 
   included do
     scope :for_users, -> {

--- a/app/models/concerns/paper_trail_safe_columns.rb
+++ b/app/models/concerns/paper_trail_safe_columns.rb
@@ -1,0 +1,33 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Best-effort accessors for a PaperTrail version's serialized `object` / `object_changes` columns.
+module PaperTrailSafeColumns
+  # Errors that can surface when deserializing an old version's YAML. A record can reference a class
+  # that was defined/permitted when the version was written but is gone now: unsafe_load raises
+  # ArgumentError/NameError/TypeError for a removed constant, safe_load raises Psych::DisallowedClass,
+  # and malformed YAML raises Psych::SyntaxError (both Psych::Exception). Callers doing best-effort
+  # audit display want nil, not an exception.
+  DESERIALIZATION_ERRORS = [Psych::Exception, ArgumentError, NameError, TypeError].freeze
+
+  # Best-effort deserialization of the `object` column; nil (and a log line) instead of raising.
+  def safe_object
+    object
+  rescue *DESERIALIZATION_ERRORS => e
+    Rails.logger.warn("#{self.class.name}#safe_object: failed to load object for version #{id}: #{e.message}")
+    nil
+  end
+
+  # Best-effort deserialization of the `object_changes` column; nil (and a log line) instead of raising.
+  def safe_object_changes
+    object_changes
+  rescue *DESERIALIZATION_ERRORS => e
+    Rails.logger.warn("#{self.class.name}#safe_object_changes: failed to load object_changes for version #{id}: #{e.message}")
+    nil
+  end
+end

--- a/app/models/grda_warehouse/group_viewable_entity.rb
+++ b/app/models/grda_warehouse/group_viewable_entity.rb
@@ -71,17 +71,9 @@ module GrdaWarehouse
       # For update events: use index 1 (new value)
       index = version.event == 'destroy' ? 0 : 1
 
-      # Guard against YAML deserialization failures on old records.
-      obj = begin
-        version.object
-      rescue StandardError
-        nil
-      end
-      obj_changes = begin
-        version.object_changes
-      rescue StandardError
-        nil
-      end
+      # Guard against YAML deserialization failures on old records (see Version#safe_object).
+      obj = version.safe_object
+      obj_changes = version.safe_object_changes
 
       # Get the entity name from the version's item or version data
       entity_name = if version.item
@@ -116,11 +108,12 @@ module GrdaWarehouse
           access_group_id = changes['access_group_id'][index]
           access_group = AccessGroup.with_deleted.find_by(id: access_group_id)
           access_group&.name || "Access Group ID #{access_group_id}"
-        elsif obj&.key?('collection_id')
-          # Fall back to object column if object_changes has no path data
+        elsif obj&.dig('collection_id').present?
+          # Fall back to object column if object_changes has no path data. A GVE's object snapshot
+          # always carries both columns with one nil, so key off the populated value, not the key.
           collection = Collection.with_deleted.find_by(id: obj['collection_id'])
           collection&.name || "Collection ID #{obj['collection_id']}"
-        elsif obj&.key?('access_group_id')
+        elsif obj&.dig('access_group_id').present?
           access_group = AccessGroup.with_deleted.find_by(id: obj['access_group_id'])
           access_group&.name || "Access Group ID #{obj['access_group_id']}"
         else
@@ -152,6 +145,11 @@ module GrdaWarehouse
         else
           klass.find_by(id: entity_id)
         end
+      rescue NameError => e
+        # The stored entity_type references a class that no longer exists; degrade to the id
+        # rather than raising out of the audit render.
+        Rails.logger.warn("GroupViewableEntity.get_entity_display_name: unknown entity_type #{entity_type.inspect}: #{e.message}")
+        return "Entity ID #{entity_id}"
       end
       entity&.name
     end

--- a/app/models/grda_warehouse/version.rb
+++ b/app/models/grda_warehouse/version.rb
@@ -9,6 +9,7 @@
 module GrdaWarehouse
   class Version < GrdaWarehouseBase
     include PaperTrail::VersionConcern
+    include PaperTrailSafeColumns
 
     belongs_to :hmis_client, class_name: 'Hmis::Hud::Client', foreign_key: :client_id, optional: true
     belongs_to :hmis_project, class_name: 'Hmis::Hud::Project', foreign_key: :project_id, optional: true

--- a/spec/models/audit/cohort_access/base_spec.rb
+++ b/spec/models/audit/cohort_access/base_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Audit::CohortAccess::Base do
       travel_to(Time.zone.parse('2025-01-01 12:00:00')) { group.add(system_user) }
       expect(audit.current_access.users.map(&:id)).not_to include(system_user.id)
     end
+
+    it 'excludes and does not raise for a user id with no matching row (e.g. hard-deleted via retention purge)' do
+      purged_user_id = user.id
+      # Hard-delete via delete_all to bypass the model's dependent: :destroy callbacks, so the
+      # AccessGroupMember row (and its active membership) survives, the way a retention purge that
+      # only targets `users` would. (really_destroy! would cascade and remove the membership too.)
+      User.where(id: purged_user_id).delete_all
+
+      expect { audit.current_access }.not_to raise_error
+      expect(audit.current_access.user_accesses.map(&:user)).to all(be_present)
+      expect(audit.current_access.users.map(&:id)).not_to include(purged_user_id)
+    end
   end
 
   describe '#events' do

--- a/spec/models/audit/display_item_spec.rb
+++ b/spec/models/audit/display_item_spec.rb
@@ -1,0 +1,47 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::DisplayItem do
+  describe '#changes' do
+    let(:access_group) { create(:access_group) }
+
+    # An unsaved version whose item no longer resolves (so `version.item` is nil), with the
+    # changeset computation stubbed to fail the way a corrupted/disallowed-class YAML payload would.
+    def broken_changeset_version
+      version = GrdaWarehouse::Version.new(item_type: 'GrdaWarehouse::GroupViewableEntity', item_id: 0, event: 'create')
+      allow(version).to receive(:changes_with_computed_fallback).and_raise(StandardError, 'boom')
+      allow(version).to receive(:anonymous?).and_return(true)
+      allow(version).to receive(:clean_true_user_id).and_return(nil)
+      allow(version).to receive(:clean_user_id).and_return(nil)
+      allow(version).to receive(:whodunnit).and_return(nil)
+      allow(version).to receive(:object).and_return('entity_id' => nil, 'entity_type' => nil, 'access_group_id' => access_group.id)
+      allow(version).to receive(:object_changes).and_return(nil)
+      version
+    end
+
+    it 'falls back to describe_changes without a changeset when the changeset fails to compute' do
+      item = described_class.new(broken_changeset_version, {})
+
+      expect(item.error).to be true
+      expect(item.changes.join).to include(access_group.name)
+    end
+
+    it 'falls back to a generic error message when describe_changes without a changeset also fails' do
+      version = broken_changeset_version
+      allow(version).to receive(:object).and_raise(StandardError, 'boom')
+      allow(version).to receive(:object_changes).and_raise(StandardError, 'boom')
+
+      item = described_class.new(version, {})
+
+      expect(item.error).to be true
+      expect(item.changes).to eq(['Error loading changes'])
+    end
+  end
+end

--- a/spec/models/grda_warehouse/group_viewable_entity_spec.rb
+++ b/spec/models/grda_warehouse/group_viewable_entity_spec.rb
@@ -1,0 +1,81 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::GroupViewableEntity do
+  describe '.describe_changes' do
+    let(:access_group) { create(:access_group) }
+    let(:collection) { create(:collection) }
+
+    # describe_changes reads the version through the best-effort accessors, which return nil when the
+    # underlying YAML can't be deserialized. Model a deserialization failure by passing nil.
+    def version_double(event:, object: nil, object_changes: nil)
+      double('Version', id: 1, event: event, item: nil, safe_object: object, safe_object_changes: object_changes)
+    end
+
+    it 'resolves the access group from the object column when collection_id is a nil-valued key' do
+      # GroupViewableEntity always has both columns in its serialized object; only one is ever
+      # populated. The path resolution must key off presence of a value, not presence of the key.
+      version = version_double(
+        event: 'create',
+        object: { 'entity_id' => nil, 'entity_type' => nil, 'collection_id' => nil, 'access_group_id' => access_group.id },
+      )
+
+      description = described_class.describe_changes(version, nil, [])
+
+      expect(description.join).to include(access_group.name)
+      expect(description.join).not_to include('Collection ID')
+    end
+
+    it 'resolves the collection from the object column when access_group_id is a nil-valued key' do
+      version = version_double(
+        event: 'create',
+        object: { 'entity_id' => nil, 'entity_type' => nil, 'collection_id' => collection.id, 'access_group_id' => nil },
+      )
+
+      description = described_class.describe_changes(version, nil, [])
+
+      expect(description.join).to include(collection.name)
+      expect(description.join).not_to include('Access Group ID')
+    end
+
+    it 'recovers via the object column when object_changes fails to deserialize (safe_object_changes nil)' do
+      version = version_double(
+        event: 'create',
+        object: { 'entity_id' => nil, 'entity_type' => nil, 'access_group_id' => access_group.id },
+        object_changes: nil,
+      )
+
+      result = nil
+      expect { result = described_class.describe_changes(version, nil, []) }.not_to raise_error
+      expect(result.join).to include(access_group.name)
+    end
+
+    it 'falls back to Unknown Entity/Collection when both object and object_changes fail to deserialize' do
+      version = version_double(event: 'update', object: nil, object_changes: nil)
+
+      description = described_class.describe_changes(version, nil, [])
+
+      expect(description.join).to include('Unknown Entity')
+      expect(description.join).to include('Unknown Collection or Group')
+    end
+
+    it 'degrades to the entity id (does not raise) when entity_type references a removed class' do
+      version = version_double(
+        event: 'create',
+        object: { 'entity_id' => 42, 'entity_type' => 'GrdaWarehouse::NoSuchRemovedEntityClass', 'access_group_id' => access_group.id },
+      )
+
+      result = nil
+      expect { result = described_class.describe_changes(version, nil, []) }.not_to raise_error
+      expect(result.join).to include('Entity ID 42')
+      expect(result.join).to include(access_group.name)
+    end
+  end
+end

--- a/spec/models/grda_warehouse/version_spec.rb
+++ b/spec/models/grda_warehouse/version_spec.rb
@@ -1,0 +1,44 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Version do
+  describe '#safe_object / #safe_object_changes' do
+    let(:version) { described_class.new(id: 1) }
+
+    it 'returns the deserialized object when it loads cleanly' do
+      allow(version).to receive(:object).and_return('entity_id' => 5)
+      expect(version.safe_object).to eq('entity_id' => 5)
+    end
+
+    # A removed constant surfaces as ArgumentError under unsafe_load, NameError otherwise, and a
+    # disallowed/unknown class under safe_load as Psych::DisallowedClass (a Psych::Exception).
+    [
+      ArgumentError.new('undefined class/module Foo::Bar'),
+      NameError.new('uninitialized constant Foo::Bar'),
+      Psych::DisallowedClass.new('load', 'Foo::Bar'),
+      Psych::Exception.new('malformed YAML'),
+    ].each do |error|
+      it "returns nil (not raising) when object deserialization raises #{error.class}" do
+        allow(version).to receive(:object).and_raise(error)
+        expect(version.safe_object).to be_nil
+      end
+
+      it "returns nil (not raising) when object_changes deserialization raises #{error.class}" do
+        allow(version).to receive(:object_changes).and_raise(error)
+        expect(version.safe_object_changes).to be_nil
+      end
+    end
+
+    it 're-raises errors that are not deserialization failures' do
+      allow(version).to receive(:object).and_raise(RuntimeError, 'boom')
+      expect { version.safe_object }.to raise_error(RuntimeError, 'boom')
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Hardens audit/history rendering:
* users who were hard-deleted (bypassing dependent: :destroy) 
* PaperTrail versions whose serialized YAML can no longer
  be deserialized (removed classes, disallowed classes)

* extracts a shared PaperTrailSafeColumns concern
* removes stray sql 

## Type of change
Bug fix, cleanup

