### PR TITLE
Use new CE rule policy; remove old policy method

### DIFF
--- a/drivers/hmis/app/graphql/types/hmis_schema/root_query_access.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/root_query_access.rb
@@ -46,7 +46,7 @@ module Types
     # can_administrate_coordinated_entry is deprecated, and usages should be replaced by more-specific permission checks that delegate to policies.
     bool_field(:can_administrate_coordinated_entry, deprecation_reason: 'Use policy permission specific to the need, such as canManageCeDefaultContacts or canIndexOpportunities') { ce_referral_policy.can_manage_ce_default_contacts? }
     bool_field(:can_manage_ce_default_contacts) { ce_referral_policy.can_manage_ce_default_contacts? }
-    bool_field(:can_manage_ce_match_rules) { ce_opportunity_policy.can_manage_ce_match_rules? }
+    bool_field(:can_manage_ce_match_rules) { ce_match_rule_policy.can_manage? }
     bool_field(:can_index_opportunities) { ce_opportunity_policy.can_index_opportunities? }
     bool_field(:can_index_eligible_clients) { ce_opportunity_policy.can_index_eligible_clients? }
 
@@ -98,6 +98,10 @@ module Types
 
     def hmis_organization_policy
       @hmis_organization_policy ||= policy_for(Hmis::Hud::Organization, policy_type: :hmis_organization)
+    end
+
+    def ce_match_rule_policy
+      @ce_match_rule_policy ||= policy_for(Hmis::Ce::Match::Rule, policy_type: :ce_match_rule)
     end
 
     def warehouse_user

--- a/drivers/hmis/app/models/hmis/auth_policies/ce_opportunity_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/ce_opportunity_policy.rb
@@ -42,11 +42,6 @@ class Hmis::AuthPolicies::CeOpportunityPolicy < Hmis::AuthPolicies::ResourcePoli
       global_permissions.include?(:can_administrate_coordinated_entry)
     end
 
-    # Whether the user can manage CE match rules in the data source.
-    def can_manage_ce_match_rules?
-      global_permissions.include?(:can_administrate_coordinated_entry)
-    end
-
     protected
 
     def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Ce::Opportunity)

--- a/drivers/hmis/spec/models/hmis/auth_policies/ce_opportunity_policy_spec.rb
+++ b/drivers/hmis/spec/models/hmis/auth_policies/ce_opportunity_policy_spec.rb
@@ -89,19 +89,5 @@ RSpec.describe Hmis::AuthPolicies::CeOpportunityPolicy, type: :model do
         end
       end
     end
-
-    describe '#can_manage_ce_match_rules?' do
-      it 'returns false when user does not have can_administrate_coordinated_entry permission' do
-        expect(policy.can_manage_ce_match_rules?).to be false
-      end
-
-      context 'when user has can_administrate_coordinated_entry permission' do
-        let!(:access_control) { create_access_control(user, data_source, with_permission: [:can_administrate_coordinated_entry]) }
-
-        it 'returns true' do
-          expect(policy.can_manage_ce_match_rules?).to be true
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Now that we have a new dedicated CE Match Rule policy, remove the old `can_manage_ce_match_rules?` method on the Opportunity policy. The CE Match Rule policy is also more robust, because it checks that CE is enabled.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
