### PR TITLE
fix: prevent race in headshot cache refresh

### DIFF
--- a/app/models/concerns/client_image_consumer.rb
+++ b/app/models/concerns/client_image_consumer.rb
@@ -95,22 +95,27 @@ module ClientImageConsumer
       return unless (image_data || '').length > 100
 
       user = ::User.setup_system_user
-      self.class.transaction do
-        # Hard-delete ephemeral cache records (no reason to soft-delete or restore).
-        # Purge blobs first so S3 objects aren't orphaned.
-        client_files.window.where(name: 'Client Headshot Cache').with_attached_client_file.each do |f|
-          f.client_file.purge if f.client_file.attached?
-          f.really_destroy!
-        end
+      # Concurrent refreshes (e.g. two requests rendering this client's photo at once)
+      # would otherwise race: one purges the other's just-created cache blob before its
+      # AnalyzeJob runs, raising Aws::S3::Errors::NoSuchKey.
+      self.class.with_advisory_lock("client_headshot_cache_#{id}", timeout_seconds: 0) do
+        self.class.transaction do
+          # Hard-delete ephemeral cache records (no reason to soft-delete or restore).
+          # Purge blobs first so S3 objects aren't orphaned.
+          client_files.window.where(name: 'Client Headshot Cache').with_attached_client_file.each do |f|
+            f.client_file.purge if f.client_file.attached?
+            f.really_destroy!
+          end
 
-        file = GrdaWarehouse::ClientFile.create(
-          client_id: id,
-          user_id: user.id,
-          name: 'Client Headshot Cache',
-          visible_in_window: true,
-        )
-        file.client_file.attach(io: StringIO.open(image_data), filename: "client_headshot_cache_#{id}")
-        file.save!
+          file = GrdaWarehouse::ClientFile.create(
+            client_id: id,
+            user_id: user.id,
+            name: 'Client Headshot Cache',
+            visible_in_window: true,
+          )
+          file.client_file.attach(io: StringIO.open(image_data), filename: "client_headshot_cache_#{id}")
+          file.save!
+        end
       end
     end
 


### PR DESCRIPTION

## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
fixes possible race while purging in-flight ActiveStorage blobs.

> ClientImageConsumer#persist_local_client_image_cache (app/models/concerns/client_image_consumer.rb:94-115) refreshes a client's cached ETO headshot with no locking: it purges the old 'Client Headshot Cache' ClientFile, then creates and  attaches a new one, inside a plain DB transaction. When two requests refresh the same client's  photo concurrently 


## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

