### PR TITLE
fix: 9368  Pins Chromium to a known-good build 

### DIFF
--- a/.github/workflows/active_record_smoke_test.yml
+++ b/.github/workflows/active_record_smoke_test.yml
@@ -128,7 +128,8 @@ jobs:
         id: container-setup
         uses: ./.github/workflows/container_setup
         with:
-          additional_packages: libpq-dev chromium chromium-common
+          additional_packages: libpq-dev
+          install_chromium: 'true'
 
       - name: 'App setup'
         run: |

--- a/.github/workflows/container_setup/action.yml
+++ b/.github/workflows/container_setup/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Additional packages to install'
     required: false
     default: ''
+  install_chromium:
+    description: 'Install a version-pinned Chromium/chromium-common/chromium-sandbox for headless browser tests (see DSA-6378-1)'
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -94,6 +98,72 @@ runs:
           zlib1g-dev \
           ${{ inputs.additional_packages }}
         apt-get clean
+
+    - name: Install pinned Chromium
+      if: ${{ inputs.install_chromium == 'true' }}
+      shell: bash
+      env:
+        # Debian's bookworm-security chromium package is a rolling apt install with no
+        # version pin, so it silently picks up whatever build is currently published.
+        # DSA-6378-1 (2026-07-05) bumped it to 150.0.7871.46-1~deb12u1, which fails to
+        # launch headless in this container. Pin to the last known-good build via
+        # snapshot.debian.org, since the old .deb is no longer in the live apt index.
+        CHROMIUM_VERSION: 149.0.7827.196-1~deb12u1
+        CHROMIUM_SNAPSHOT_BASE: https://snapshot.debian.org/archive/debian-security/20260626T014759Z/pool/updates/main/c/chromium
+        # snapshot.debian.org addresses every archived file by its SHA1 (see the
+        # "hash" field at https://snapshot.debian.org/mr/package/chromium/<version>/allfiles),
+        # so this is the checksum to verify each download against, not a SHA256.
+        CHROMIUM_SHA1: b7b0674e68b94af0158bfa8c305a46fc07f6f7c5
+        CHROMIUM_COMMON_SHA1: 098ec4a8fe2e76c66f942ad2e2133f75fbd2a13d
+        CHROMIUM_SANDBOX_SHA1: 48701ce3ed3bd9cf6008862fb67d6decc3cc6569
+      run: |
+        retry() {
+          local max_attempts=3
+          local delay=5
+          local attempt=1
+          local exitcode=0
+
+          while (( attempt <= max_attempts ))
+          do
+            if "$@"
+            then
+              exitcode=0
+              break
+            else
+              exitcode=$?
+              echo "Command failed (attempt $attempt/$max_attempts). Retrying in $delay seconds..."
+              sleep $delay
+              attempt=$(( attempt + 1 ))
+              delay=$(( delay * 2 ))
+            fi
+          done
+
+          return $exitcode
+        }
+
+        tmp_dir=$(mktemp -d)
+        for pkg in chromium chromium-common chromium-sandbox; do
+          retry curl -sL --fail -o "$tmp_dir/${pkg}.deb" "$CHROMIUM_SNAPSHOT_BASE/${pkg}_${CHROMIUM_VERSION}_amd64.deb"
+        done
+
+        verify_sha1() {
+          local file=$1
+          local expected=$2
+          local actual
+          actual=$(sha1sum "$file" | cut -d' ' -f1)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "::error::SHA1 mismatch for $file: expected $expected, got $actual"
+            exit 1
+          fi
+        }
+
+        verify_sha1 "$tmp_dir/chromium.deb" "$CHROMIUM_SHA1"
+        verify_sha1 "$tmp_dir/chromium-common.deb" "$CHROMIUM_COMMON_SHA1"
+        verify_sha1 "$tmp_dir/chromium-sandbox.deb" "$CHROMIUM_SANDBOX_SHA1"
+
+        retry apt-get install -y --no-install-recommends "$tmp_dir"/*.deb
+        apt-mark hold chromium chromium-common chromium-sandbox
+        rm -rf "$tmp_dir"
 
     - name: Install AWS CLI
       shell: bash

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -199,7 +199,8 @@ jobs:
         id: container-setup
         uses: ./.github/workflows/container_setup
         with:
-          additional_packages: libpq-dev chromium chromium-common
+          additional_packages: libpq-dev
+          install_chromium: 'true'
 
       - name: "App setup"
         run: |
@@ -357,7 +358,8 @@ jobs:
       - name: "Container Setup"
         uses: ./.github/workflows/container_setup
         with:
-          additional_packages: libpq-dev chromium chromium-common
+          additional_packages: libpq-dev
+          install_chromium: 'true'
 
       - name: "App setup"
         run: |
@@ -433,7 +435,8 @@ jobs:
       - name: "Container Setup"
         uses: ./.github/workflows/container_setup
         with:
-          additional_packages: libpq-dev chromium chromium-common
+          additional_packages: libpq-dev
+          install_chromium: 'true'
 
       - name: "App setup"
         run: |

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -35,6 +35,21 @@ ARG GROUP_ID=10000
 ARG BUNDLER_VERSION=2.7.2
 ARG PG_MAJOR=17
 
+# Debian's bookworm-security chromium package is a rolling apt install with no
+# version pin, so it silently picks up whatever build is currently published.
+# DSA-6378-1 (2026-07-05) bumped it to 150.0.7871.46-1~deb12u1, which fails to
+# launch headless in this image family (see .github/workflows/container_setup
+# for the same issue/fix in CI). Pin to the last known-good build via
+# snapshot.debian.org, since the old .deb is no longer in the live apt index.
+ARG CHROMIUM_VERSION=149.0.7827.196-1~deb12u1
+ARG CHROMIUM_SNAPSHOT_BASE=https://snapshot.debian.org/archive/debian-security/20260626T014759Z/pool/updates/main/c/chromium
+# snapshot.debian.org addresses every archived file by its SHA1 (see the
+# "hash" field at https://snapshot.debian.org/mr/package/chromium/<version>/allfiles),
+# so this is the checksum to verify each download against, not a SHA256.
+ARG CHROMIUM_SHA1=b7b0674e68b94af0158bfa8c305a46fc07f6f7c5
+ARG CHROMIUM_COMMON_SHA1=098ec4a8fe2e76c66f942ad2e2133f75fbd2a13d
+ARG CHROMIUM_SANDBOX_SHA1=48701ce3ed3bd9cf6008862fb67d6decc3cc6569
+
 LABEL "app"=open-path-warehouse
 LABEL "ruby-version"=3.4.9
 
@@ -86,8 +101,6 @@ RUN apt-get update && apt-get upgrade -y \
   awscli \
   bash \
   build-essential \
-  chromium \
-  chromium-common \
   dbus \
   dbus-user-session \
   expect \
@@ -158,6 +171,21 @@ RUN apt-get update && apt-get upgrade -y \
        ln -s /usr/lib/x86_64-linux-gnu/libproj.so /usr/lib/libproj.so.20; \
      fi \
   && npm install -g yarn@1.22.22
+
+# Install a version-pinned Chromium/chromium-common/chromium-sandbox for PDF
+# generation via grover — see the CHROMIUM_* ARGs above for why this can't
+# just be `apt-get install chromium chromium-common`.
+RUN apt-get update \
+  && tmp_dir=$(mktemp -d) \
+  && for pkg in chromium chromium-common chromium-sandbox; do \
+       curl -sL --fail -o "$tmp_dir/${pkg}.deb" "$CHROMIUM_SNAPSHOT_BASE/${pkg}_${CHROMIUM_VERSION}_amd64.deb"; \
+     done \
+  && echo "${CHROMIUM_SHA1}  $tmp_dir/chromium.deb" | sha1sum -c - \
+  && echo "${CHROMIUM_COMMON_SHA1}  $tmp_dir/chromium-common.deb" | sha1sum -c - \
+  && echo "${CHROMIUM_SANDBOX_SHA1}  $tmp_dir/chromium-sandbox.deb" | sha1sum -c - \
+  && apt-get install -y --no-install-recommends "$tmp_dir"/*.deb \
+  && apt-mark hold chromium chromium-common chromium-sandbox \
+  && rm -rf "$tmp_dir" /var/lib/apt/lists/*
 
 # Install custom pg_repack versions
 COPY docker/app/install_pg_repack.sh /usr/local/bin/install_pg_repack.sh


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Pins Chromium to a known-good build in CI and the app image after a Debian security update broke headless launch.

- **CI Container Setup**: Adds an opt-in `install_chromium` input to the shared `container_setup` action that downloads chromium/chromium-common/chromium-sandbox 149.0.7827.196 from snapshot.debian.org, verifies each against its SHA1, installs them, and holds the packages so they can't drift.
- **CI Container Setup**: Removes `chromium`/`chromium-common` from the plain `apt-get` package list, since the live Debian security repo now serves a newer build (150.0.7871.46, from DSA-6378-1) that fails to launch headless.
- **Rails/Active Record Test Workflows**: Switches the three affected jobs from installing chromium via `additional_packages` to the new pinned `install_chromium: 'true'` flag.
- **App Docker Image**: Applies the same version pin, SHA1 verification, and `apt-mark hold` to `docker/app/Dockerfile`, since the production image installs the same unpinned `chromium`/`chromium-common` packages for PDF generation via grover and would otherwise break on the next rebuild.


## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
