### PR TITLE
CVE-2026-38969

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -12,3 +12,5 @@ ignore:
   - CVE-2026-44587
   # not exploitable, no patch yet available. See #9324
   - CVE-2026-54171
+  # webrick is only used internally, no patch available yet
+  - CVE-2026-38969

--- a/.trivyignore
+++ b/.trivyignore
@@ -41,3 +41,6 @@ CVE-2026-44587
 
 # not exploitable, no patch yet available. See #9324
 CVE-2026-54171
+
+# webrick is only used internally, no patch available yet
+CVE-2026-38969


### PR DESCRIPTION
ignore CVE-2026-38969

no patch available yet. And it's only used internally for tests/dev