### PR TITLE
Add standard referral workflow forms to client env

### DIFF
--- a/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
@@ -5,7 +5,7 @@ This directory contains utilities and workflow definitions for the Standard Refe
 
 This workflow is intended as an out-of-the-box baseline for QA, staging, demo, and new client onboarding. It can be customized per customer as needed. It includes CE team initial review, provider decision, enrollment, placement confirmation, and decline review.
 
-*Forms* associated with this workflow are seeded in all environments, since they live in the `default/ce_referral_steps/` form directory, due to the JSON form `seed_all` step. They are unused in environments where the  *workflow template* hasn't been seeded, which is manual.
+*Forms* associated with this workflow need to be added to the desired installation's form directory, e.g. `drivers/hmis/lib/form_data/{env}/ce_referral_steps/`. (They cannot be added to the `default` env because they will fail in multi-HMIS installations. See #9035)
 
 ### Usage
 These workflows are generated and updated using the `CeWorkflows::Standard::WorkflowBuilder` utility class and the `ce_define_standard_workflows` rake task. See usage comments on the rake task.

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_confirm_placement.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_confirm_placement.json
@@ -1,0 +1,13 @@
+{
+  "item": [
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "notes",
+      "mapping": {
+        "custom_field_key": "standard_confirm_placement_notes"
+      },
+      "required": false
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_initial_review.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_initial_review.json
@@ -1,0 +1,54 @@
+{
+  "item": [
+    {
+      "text": "Decision",
+      "type": "CHOICE",
+      "link_id": "decision",
+      "mapping": {
+        "custom_field_key": "standard_initial_review_decision"
+      },
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "continue", "label": "Continue" },
+        { "code": "decline", "label": "Decline" }
+      ]
+    },
+    {
+      "text": "Decline Reason",
+      "type": "CHOICE",
+      "link_id": "decline_reason",
+      "mapping": {
+        "custom_field_key": "standard_initial_review_decline_reason"
+      },
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "hmis_user_error", "label": "HMIS user error" },
+        { "code": "inability_to_complete_intake", "label": "Inability to complete intake" },
+        { "code": "ineligible", "label": "Does not meet eligibility criteria" },
+        { "code": "client_not_interested", "label": "No longer interested in this program" },
+        { "code": "not_experiencing_homelessness", "label": "No longer experiencing homelessness" },
+        { "code": "vacancy_no_longer_available", "label": "Estimated vacancy no longer available" },
+        { "code": "enrolled_declined_hmis_data_entry", "label": "Enrolled, but declined HMIS data entry" }
+      ],
+      "enable_when": [
+        {
+          "operator": "EQUAL",
+          "question": "decision",
+          "answer_code": "decline"
+        }
+      ],
+      "enable_behavior": "ALL"
+    },
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "notes",
+      "mapping": {
+        "custom_field_key": "standard_initial_review_notes"
+      },
+      "required": false
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_provider_decision.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_provider_decision.json
@@ -1,0 +1,92 @@
+{
+  "item": [
+    {
+      "text": "Interview date",
+      "type": "DATE",
+      "link_id": "interview_date",
+      "mapping": {
+        "custom_field_key": "standard_provider_decision_interview_date"
+      },
+      "required": false
+    },
+    {
+      "text": "Client response",
+      "type": "CHOICE",
+      "link_id": "client_response",
+      "mapping": {
+        "custom_field_key": "standard_provider_decision_client_response"
+      },
+      "required": false,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "interested", "label": "Interested" },
+        { "code": "not_interested", "label": "Not interested" },
+        { "code": "unable_to_contact", "label": "Unable to contact" }
+      ]
+    },
+    {
+      "text": "Decision",
+      "type": "CHOICE",
+      "link_id": "decision",
+      "mapping": {
+        "custom_field_key": "standard_provider_decision_decision"
+      },
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "accept", "label": "Accept" },
+        { "code": "decline", "label": "Decline" }
+      ]
+    },
+    {
+      "text": "The client will be added to the project as Incomplete. Please complete and submit the Intake Assessment to finalize enrollment.",
+      "type": "DISPLAY",
+      "link_id": "enroll_message",
+      "component": "ALERT_INFO",
+      "enable_when": [
+        {
+          "operator": "EQUAL",
+          "question": "decision",
+          "answer_code": "accept"
+        }
+      ],
+      "enable_behavior": "ALL"
+    },
+    {
+      "text": "Decline Reason",
+      "type": "CHOICE",
+      "link_id": "decline_reason",
+      "mapping": {
+        "custom_field_key": "standard_provider_decision_decline_reason"
+      },
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "hmis_user_error", "label": "HMIS user error" },
+        { "code": "inability_to_complete_intake", "label": "Inability to complete intake" },
+        { "code": "ineligible", "label": "Does not meet eligibility criteria" },
+        { "code": "client_not_interested", "label": "No longer interested in this program" },
+        { "code": "not_experiencing_homelessness", "label": "No longer experiencing homelessness" },
+        { "code": "vacancy_no_longer_available", "label": "Estimated vacancy no longer available" },
+        { "code": "enrolled_declined_hmis_data_entry", "label": "Enrolled, but declined HMIS data entry" }
+      ],
+      "enable_when": [
+        {
+          "operator": "EQUAL",
+          "question": "decision",
+          "answer_code": "decline"
+        }
+      ],
+      "enable_behavior": "ALL"
+    },
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "notes",
+      "mapping": {
+        "custom_field_key": "standard_provider_decision_notes"
+      },
+      "required": false
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_review_decline.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/standard_review_decline.json
@@ -1,0 +1,27 @@
+{
+  "item": [
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "notes",
+      "mapping": {
+        "custom_field_key": "standard_review_decline_notes"
+      },
+      "required": false
+    },
+    {
+      "text": "Decision",
+      "type": "CHOICE",
+      "link_id": "decision",
+      "mapping": {
+        "custom_field_key": "standard_review_decline_decision"
+      },
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "pick_list_options": [
+        { "code": "approve_decline", "label": "Approve Decline" },
+        { "code": "return_to_provider", "label": "Return to Provider Decision" }
+      ]
+    }
+  ]
+}

--- a/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
+++ b/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
@@ -13,6 +13,9 @@ namespace :ce_define_standard_workflows do
   #   rails driver:hmis:ce_define_standard_workflows:create                   # expects sole HMIS data source
   # Creates/updates draft templates. Idempotent; if the template already exists as draft, it will be updated.
   # Optional: PUBLISH=true, FORCE_RECREATE=true (non-production only; destroys existing template/form data)
+  #
+  # NOTE: This task will fail if the installation's form directory does not contain the required forms.
+  # Copy the forms from drivers/hmis/lib/form_data/demo/ce_referral_steps/ to the installation's directory.
   task :create, [:data_source_id] => :environment do |_, args|
     raise unless HmisEnforcement.hmis_enabled?
     raise 'FORCE_RECREATE destroys data and should not be run in production' if ENV['FORCE_RECREATE'] && Rails.env.production?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- Add CE referral workflow forms to the relevant client environment
- Update documentation

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New config/setup

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
