### PR TITLE
Log to sentry when API shape is unexpected

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -178,7 +178,7 @@ module HmisExternalApis::AcHmis
 
         unless dw_client_id
           Sentry.capture_message(
-            "AHA score API response received no dw_client_id or dw_client_id_dw_client_id. HmisExternalApis::ExternalRequestLog #{external_request_log_id}",
+            "AHA score API response received no dw_client_id or dw_client_id_dw_client_id. HmisExternalApis::ExternalRequestLog #{external_request_log_id || 'unknown'}",
           )
         end
 

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -99,7 +99,7 @@ module HmisExternalApis::AcHmis
       data = result.parsed_body&.dig('data')
       raise(Error, "Scores API response missing `data` key. Response body: `#{result.parsed_body}`") unless data
 
-      parsed_by_generator = parse_response_scores(data, requested_generators)
+      parsed_by_generator = parse_response_scores(data, requested_generators, external_request_log_id: result.request_log&.id)
       build_results(parsed_by_generator, requested_generators)
     end
 
@@ -138,25 +138,49 @@ module HmisExternalApis::AcHmis
     # do not trigger validation errors or Sentry noise.
     #
     # Example API shape:
-    #   data: [
-    #     { 'dw_client_id' => '100000001', 'scores' => [
-    #       { 'score' => 7, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '1' } },
-    #       { 'score' => 5, 'generator' => 'MH-AHA', 'metadata' => { ... } },
-    #     ]},
-    #     { 'dw_client_id' => '100000002', 'scores' => [
-    #       { 'score' => 9, 'generator' => 'AHA', 'metadata' => { 'alt_aha_flag' => '0' } },
-    #     ]},
+    # {
+    #   "result": "success",
+    #   "message": "Returning client with score.",
+    #   "data": [
+    #     {
+    #       "public_id": "...",
+    #       "id": ...,
+    #       "dw_client_id_dw_client_id": ["100000001"],
+    #       "scores": [
+    #         {
+    #           "score": 7.0,
+    #           "generator": "AHA",
+    #           "metadata": {"alt_aha_flag": "0"},
+    #           ...
+    #         },
+    #         {
+    #           "score": 5.0,
+    #           "generator": "MH-AHA",
+    #           "metadata": {},
+    #           ...
+    #         }
+    #       ]
+    #     }
     #   ]
+    # }
     #
     # Example return value:
     #   { aha: [AhaResult(score: 7, ...), AhaResult(score: 9, ...)], mh_aha: [MhAhaResult(score: 5, ...)] }
-    def parse_response_scores(data, requested_generators)
+    #
+    # accepts external_request_log_id for logging to Sentry
+    def parse_response_scores(data, requested_generators, external_request_log_id: nil)
       parsed_by_generator = Hash.new { |hash, key| hash[key] = [] }
 
       data.each do |response_client|
         dw_client_id = Array.wrap(
           response_client.dig('dw_client_id') || response_client.dig('dw_client_id_dw_client_id'),
         ).first
+
+        unless dw_client_id
+          Sentry.capture_message(
+            "AHA score API response received no dw_client_id or dw_client_id_dw_client_id. HmisExternalApis::ExternalRequestLog #{external_request_log_id}",
+          )
+        end
 
         response_client.dig('scores')&.each do |score_obj|
           generator_key = normalize_generator(score_obj['generator'])

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -58,12 +58,13 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
     }
   end
 
-  def mock_api_response(*client_data_hashes)
+  def mock_api_response(*client_data_hashes, request_log: nil)
     double(
       'response',
       error: false,
       http_status: 200,
       parsed_body: { 'data' => client_data_hashes },
+      request_log: request_log,
     )
   end
 
@@ -622,6 +623,36 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       result = aha.fetch_score(client)[:aha]
       expect(result.score).to eq(8)
       expect(Sentry).not_to have_received(:capture_message)
+    end
+  end
+
+  context 'when response is missing dw_client_id' do
+    let!(:mci_unique_id) { create(:mci_unique_id_external_id, source: client, remote_credential: remote_credential) }
+
+    it 'logs the external request log ID to Sentry' do
+      allow(Sentry).to receive(:capture_message)
+      request_log = instance_double(HmisExternalApis::ExternalRequestLog, id: 123)
+      response = mock_api_response(
+        {
+          'id' => 456,
+          'scores' => [
+            {
+              'score' => 10.0,
+              'generator' => 'AHA',
+              'metadata' => {
+                'alt_aha_flag' => '0',
+              },
+            },
+          ],
+        },
+        request_log: request_log,
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      aha.fetch_score(client)
+
+      expect(Sentry).to have_received(:capture_message).
+        with(/AHA score API response received no dw_client_id or dw_client_id_dw_client_id. HmisExternalApis::ExternalRequestLog 123/)
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- Update code-comment documentation of external API expected shape
- Log to sentry if expected field is missing from API response
- See linked ticket for more details

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Log improvement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
