### PR TITLE
fix: 9347 handle edge case

### DIFF
--- a/app/controllers/warehouse_reports/client_lookups_controller.rb
+++ b/app/controllers/warehouse_reports/client_lookups_controller.rb
@@ -11,14 +11,14 @@ module WarehouseReports
     include WarehouseReportAuthorization
 
     def index
-      @filter = ::Filters::FilterBase.new(user_id: current_user.id, enforce_one_year_range: false)
+      @filter = ::Filters::ClientLookup.new(user_id: current_user.id, enforce_one_year_range: false)
       @filter.update(report_params)
       @map_enrollments = map_enrollments?
       respond_to do |format|
         format.html {}
         format.xlsx do
           unless @filter.any_effective_project_ids?
-            message = 'must have at least one Data Source, Organization, or Project selected'
+            message = 'At least one Data Source, Organization, or Project must be selected'
             redirect_to warehouse_reports_client_lookups_path(report: redirect_report_params), alert: message
             next
           end

--- a/app/models/filters/client_lookup.rb
+++ b/app/models/filters/client_lookup.rb
@@ -1,0 +1,18 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Filters
+  class ClientLookup < FilterBase
+    # This report has no CoC picker, so CoC codes must not contribute to project scoping.
+    # Otherwise FilterBase#update's multi-CoC auto-default would expand effective_project_ids
+    # even when the user selected nothing, defeating the guard in ClientLookupsController.
+    def effective_project_ids_from_coc_codes
+      []
+    end
+  end
+end

--- a/spec/requests/warehouse_reports/client_lookups_controller_spec.rb
+++ b/spec/requests/warehouse_reports/client_lookups_controller_spec.rb
@@ -548,6 +548,33 @@ RSpec.describe WarehouseReports::ClientLookupsController, type: :request do
 
       expect(response).to have_http_status(:success)
     end
+
+    # On a multi-CoC installation, FilterBase#update seeds coc_codes from the user's CoC
+    # codes when the form submits none. Filters::ClientLookup overrides
+    # effective_project_ids_from_coc_codes so those codes don't expand the project scope
+    # behind the guard. viewable_project is linked to the granted CoC so that, without the
+    # override, it would satisfy any_effective_project_ids? and skip the redirect.
+    it 'still redirects when the installation is multi-CoC and the user has CoC codes assigned' do
+      create(:config, multi_coc_installation: true)
+      coc = create(:lookup_coc)
+      create(
+        :hud_project_coc,
+        data_source_id: viewable_project.data_source_id,
+        ProjectID: viewable_project.ProjectID,
+        CoCCode: coc.coc_code,
+      )
+      collection.set_viewables(
+        reports: [report_definition.id],
+        projects: [viewable_project.id, confidential_project.id],
+        coc_codes: [coc.id],
+      )
+      create_crosswalk
+
+      get_report(project_ids: [], data_source_ids: [], organization_ids: [])
+
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:alert]).to include('Data Source')
+    end
   end
 
   describe 'client name PII policy (regression guard)' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

### Description

Fixes a filter-guard bypass in the Client PersonalID Lookup report on multi-CoC installations. Adjust language on warning message

### Type of Change
Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have added spec tests (or not applicable)

