### PR TITLE
Fix Boston Scorecard Q5 days-to-lease-up scoring logic

### DIFF
--- a/drivers/boston_project_scorecard/app/models/boston_project_scorecard/project_performance.rb
+++ b/drivers/boston_project_scorecard/app/models/boston_project_scorecard/project_performance.rb
@@ -76,12 +76,20 @@ module BostonProjectScorecard
         0
       end
 
-      # NOTE: if days_to_lease_up_comparison is 0 or blank, points are only given based on
-      # overall days within the current year
+      # 12pts: Current FY average is lower than 90 days, or 5% decrease compared to previous FY
+      # 6pts: Decrease from 5% - 0% compared to previous FY (exclusive of 5 and 0)
+      # 0pts: No change compared to previous FY, increase or current FY average is less than 1 day
+
+      # We are looking to score 12pts IF the average is less than 90 days. This could include a
+      # scenario where the previous FY average is 10 and the current FY average is 85. In this
+      # scenario even if it is an increase, it is still under 90 days and should score 12.
+      # IF current FY is less than 1 day, score 0 pts.
+      # 6pts would only be scored IF decrease from previous to current FY is less than 5% AND average is above 90 days
       def days_to_lease_up_score
+        return 0 if days_to_lease_up < 1
         return 12 if days_to_lease_up < 90
-        return 12 if days_to_lease_up_change.present? && days_to_lease_up_change.round < -5
-        return 6 if days_to_lease_up_change.present? && days_to_lease_up_change.round < -1
+        return 12 if days_to_lease_up_change.present? && days_to_lease_up_change.round <= -5
+        return 6 if days_to_lease_up_change.present? && days_to_lease_up_change.round < 0
 
         0
       end

--- a/drivers/boston_project_scorecard/app/models/boston_project_scorecard/project_performance.rb
+++ b/drivers/boston_project_scorecard/app/models/boston_project_scorecard/project_performance.rb
@@ -84,7 +84,7 @@ module BostonProjectScorecard
       # scenario where the previous FY average is 10 and the current FY average is 85. In this
       # scenario even if it is an increase, it is still under 90 days and should score 12.
       # IF current FY is less than 1 day, score 0 pts.
-      # 6pts would only be scored IF decrease from previous to current FY is less than 5% AND average is above 90 days
+      # 6pts would only be scored IF decrease from previous to current FY is less than 5% AND average is 90 days or more
       def days_to_lease_up_score
         return 0 if days_to_lease_up < 1
         return 12 if days_to_lease_up < 90

--- a/drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb
+++ b/drivers/boston_project_scorecard/spec/models/boston_project_scorecard/report_spec.rb
@@ -512,6 +512,17 @@ RSpec.describe BostonProjectScorecard::Report, type: :model do
       expect(report.increased_other_income_score).to eq(0)
     end
 
+    it 'awards 0 for days_to_lease_up_score when current year is less than 1 day' do
+      report.update!(days_to_lease_up: 0, days_to_lease_up_comparison: nil)
+      expect(report.days_to_lease_up_score).to eq(0)
+
+      report.update!(days_to_lease_up: 0, days_to_lease_up_comparison: 0)
+      expect(report.days_to_lease_up_score).to eq(0)
+
+      report.update!(days_to_lease_up: 0, days_to_lease_up_comparison: 100)
+      expect(report.days_to_lease_up_score).to eq(0)
+    end
+
     it 'awards days_to_lease_up_score based on absolute days when there is no comparison' do
       report.update!(days_to_lease_up: 89, days_to_lease_up_comparison: nil)
       expect(report.days_to_lease_up_score).to eq(12)
@@ -520,14 +531,28 @@ RSpec.describe BostonProjectScorecard::Report, type: :model do
       expect(report.days_to_lease_up_score).to eq(0)
     end
 
+    it 'awards 12 pts when current FY is under 90 days even if it is an increase from prior FY' do
+      report.update!(days_to_lease_up: 85, days_to_lease_up_comparison: 10)
+      expect(report.days_to_lease_up_score).to eq(12)
+    end
+
     it 'awards days_to_lease_up_score based on year-over-year improvement once over 90 days' do
       report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 200) # -50% change
       expect(report.days_to_lease_up_score).to eq(12)
 
-      report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 105) # ~-4.8% change
+      report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 105) # -5% change, exactly at threshold
+      expect(report.days_to_lease_up_score).to eq(12)
+
+      report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 104) # ~-3.8% change
+      expect(report.days_to_lease_up_score).to eq(6)
+
+      report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 101) # ~-1% change
       expect(report.days_to_lease_up_score).to eq(6)
 
       report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 100) # no change
+      expect(report.days_to_lease_up_score).to eq(0)
+
+      report.update!(days_to_lease_up: 100, days_to_lease_up_comparison: 90) # increase
       expect(report.days_to_lease_up_score).to eq(0)
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Updates Q5 ("Reduction in Length of Time Homeless") scoring on the Boston Project Scorecard to match a clarified rubric from the Boston team. Three issues were identified and corrected:

- Programs with a 0-day average days-to-move-in were incorrectly scoring 12 points. They now correctly score 0 points, as the rubric specifies 0 pts for a current-year average of less than 1 day.
- A year-over-year decrease of exactly 5% was falling into the 6-point tier. It now correctly scores 12 points.
- The 6-point tier previously required a greater than 1% decrease. It now applies to any decrease greater than 0% (when the current-year average is 90 days or more).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
