### PR TITLE
Support Project Group-based Table Configuration

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -12870,6 +12870,13 @@ type TableConfig {
 }
 
 type TableConfigLookup {
+  ceClientsConfig(
+    """
+    Optional project group ID to use for detecting the best config. Falls back
+    to global config if not provided, or if no project group config exists.
+    """
+    projectGroupId: ID
+  ): TableConfig
   ceClientsGlobalConfig: TableConfig
   ceClientsUnitGroupConfig(unitGroupId: ID!): TableConfig
 }

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -609,13 +609,7 @@ module Types
       argument :applies_to, HmisSchema::Enums::WorkspaceAppliesTo, required: true
     end
     def workspaces(applies_to:)
-      # future need: limit workspaces depending on users permissions? for CE Referral usage, that would need to check whether
-      # the user can see any referrals to the projects within the project group
-      Hmis::Workspace.
-        active.
-        for_usage(applies_to).
-        where(data_source_id: current_user.hmis_data_source_id).
-        ordered
+      Hmis::Workspace.active.viewable_by(current_user, for_usage: applies_to).ordered
     end
 
     field :table_config_lookup, Types::TableConfigLookup, null: false

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -609,7 +609,13 @@ module Types
       argument :applies_to, HmisSchema::Enums::WorkspaceAppliesTo, required: true
     end
     def workspaces(applies_to:)
-      Hmis::Workspace.active.viewable_by(current_user, for_usage: applies_to).ordered
+      # future need: limit workspaces depending on users permissions? for CE Referral usage, that would need to check whether
+      # the user can see any referrals to the projects within the project group
+      Hmis::Workspace.
+        active.
+        for_usage(applies_to).
+        where(data_source_id: current_user.hmis_data_source_id).
+        ordered
     end
 
     field :table_config_lookup, Types::TableConfigLookup, null: false

--- a/drivers/hmis/app/graphql/types/table_config_lookup.rb
+++ b/drivers/hmis/app/graphql/types/table_config_lookup.rb
@@ -10,22 +10,35 @@ module Types
   class TableConfigLookup < Types::BaseObject
     skip_activity_log
 
+    # field :ce_clients_config, Types::TableConfig, null: true do
+    #   argument :project_group_id, ID, required: false
+    # end
     field :ce_clients_global_config, Types::TableConfig, null: true
     field :ce_clients_unit_group_config, Types::TableConfig, null: true do
       argument :unit_group_id, ID, required: true
+      # argument :project_group_id, ID, required: false
     end
 
-    # Consolidated waitlist uses the global configuration for ce_waitlist
+    # Consolidated waitlist can use project-group configuration when scoped by a workspace.
+    def ce_clients_config(project_group_id: nil)
+      Hmis::TableConfiguration.detect_ce_clients_config(
+        data_source_id: current_user.hmis_data_source_id,
+        project_group_id: project_group_id,
+      )
+    end
+
+    # Backwards-compatible global configuration lookup for ce_waitlist
     def ce_clients_global_config
       Hmis::TableConfiguration.detect_ce_clients_global_config(
         data_source_id: current_user.hmis_data_source_id,
       )
     end
 
-    def ce_clients_unit_group_config(unit_group_id:)
+    def ce_clients_unit_group_config(unit_group_id:, project_group_id: nil)
       Hmis::TableConfiguration.detect_ce_clients_unit_group_config(
         data_source_id: current_user.hmis_data_source_id,
         unit_group_id: unit_group_id,
+        project_group_id: project_group_id,
       )
     end
   end

--- a/drivers/hmis/app/graphql/types/table_config_lookup.rb
+++ b/drivers/hmis/app/graphql/types/table_config_lookup.rb
@@ -10,13 +10,14 @@ module Types
   class TableConfigLookup < Types::BaseObject
     skip_activity_log
 
-    # field :ce_clients_config, Types::TableConfig, null: true do
-    #   argument :project_group_id, ID, required: false
-    # end
+    field :ce_clients_config, Types::TableConfig, null: true do
+      argument :project_group_id, ID, required: false, description: 'Optional project group ID to use for detecting the best config. Falls back to global config if not provided, or if no project group config exists.'
+    end
+
     field :ce_clients_global_config, Types::TableConfig, null: true
+
     field :ce_clients_unit_group_config, Types::TableConfig, null: true do
       argument :unit_group_id, ID, required: true
-      # argument :project_group_id, ID, required: false
     end
 
     # Consolidated waitlist can use project-group configuration when scoped by a workspace.
@@ -34,11 +35,10 @@ module Types
       )
     end
 
-    def ce_clients_unit_group_config(unit_group_id:, project_group_id: nil)
+    def ce_clients_unit_group_config(unit_group_id:)
       Hmis::TableConfiguration.detect_ce_clients_unit_group_config(
         data_source_id: current_user.hmis_data_source_id,
         unit_group_id: unit_group_id,
-        project_group_id: project_group_id,
       )
     end
   end

--- a/drivers/hmis/app/models/hmis/table_configuration.rb
+++ b/drivers/hmis/app/models/hmis/table_configuration.rb
@@ -71,24 +71,24 @@ class Hmis::TableConfiguration < Hmis::HmisBase
       return config if config.present?
     end
 
+    # Fallback to global config (no owner) if project group is not provided, or project group config does not exist.
     Hmis::TableConfiguration.for_ce_clients_table.find_by(data_source_id: data_source_id, owner: nil)
   end
 
   # Detect config to use for CE Eligible Clients table for a given unit group
-  def self.detect_ce_clients_unit_group_config(data_source_id:, unit_group_id:, project_group_id: nil)
+  def self.detect_ce_clients_unit_group_config(data_source_id:, unit_group_id:)
     unit_group = Hmis::UnitGroup.find_by(id: unit_group_id)
     return unless unit_group
-
-    project_group = Hmis::ProjectGroup.find_by(id: project_group_id, data_source_id: data_source_id) if project_group_id.present?
 
     # find applicable configuration for this unit group, preferring more specific owners
     [
       unit_group,
       unit_group.project,
-      project_group || detect_unambiguous_project_group_config_owner(data_source_id: data_source_id, project: unit_group.project),
+      detect_unambiguous_project_group_config_owner(data_source_id: data_source_id, project: unit_group.project),
       unit_group.project&.organization,
       nil,
     ].each do |owner|
+      # Keep nil so the global fallback config is checked.
       next if owner.blank? && !owner.nil?
 
       found = Hmis::TableConfiguration.for_ce_clients_table.
@@ -108,6 +108,8 @@ class Hmis::TableConfiguration < Hmis::HmisBase
       merge(Hmis::TableConfiguration.for_ce_clients_table.where(data_source_id: data_source_id)).
       distinct
 
+    # todo @martha - this returns nil and then the above loop will return the global config, skipping org config.
+    # test for that and fix the bug
     configured_project_groups.one? ? configured_project_groups.first : nil
   end
 

--- a/drivers/hmis/app/models/hmis/table_configuration.rb
+++ b/drivers/hmis/app/models/hmis/table_configuration.rb
@@ -81,16 +81,18 @@ class Hmis::TableConfiguration < Hmis::HmisBase
     return unless unit_group
 
     # find applicable configuration for this unit group, preferring more specific owners
-    [
+    owners = [
       unit_group,
       unit_group.project,
       detect_unambiguous_project_group_config_owner(data_source_id: data_source_id, project: unit_group.project),
       unit_group.project&.organization,
-      nil,
-    ].each do |owner|
-      # Keep nil so the global fallback config is checked.
-      next if owner.blank? && !owner.nil?
+    ].reject(&:blank?)
 
+    # Global fallback config (nil owner) should only be checked last
+    # (avoids prematurely returning the global config early if no project group config exists)
+    owners << nil
+
+    owners.each do |owner|
       found = Hmis::TableConfiguration.for_ce_clients_table.
         where(data_source_id: data_source_id).
         find_by(owner: owner)
@@ -108,8 +110,6 @@ class Hmis::TableConfiguration < Hmis::HmisBase
       merge(Hmis::TableConfiguration.for_ce_clients_table.where(data_source_id: data_source_id)).
       distinct
 
-    # todo @martha - this returns nil and then the above loop will return the global config, skipping org config.
-    # test for that and fix the bug
     configured_project_groups.one? ? configured_project_groups.first : nil
   end
 

--- a/drivers/hmis/app/models/hmis/table_configuration.rb
+++ b/drivers/hmis/app/models/hmis/table_configuration.rb
@@ -58,21 +58,39 @@ class Hmis::TableConfiguration < Hmis::HmisBase
 
   # Detect config to use for CE Eligible Clients table for a given data source
   def self.detect_ce_clients_global_config(data_source_id:)
+    detect_ce_clients_config(data_source_id: data_source_id)
+  end
+
+  # Detect config to use for CE Eligible Clients table, optionally scoped to a Project Group
+  def self.detect_ce_clients_config(data_source_id:, project_group_id: nil)
+    project_group = Hmis::ProjectGroup.find_by(id: project_group_id, data_source_id: data_source_id) if project_group_id.present?
+    if project_group
+      config = Hmis::TableConfiguration.for_ce_clients_table.
+        where(data_source_id: data_source_id).
+        find_by(owner: project_group)
+      return config if config.present?
+    end
+
     Hmis::TableConfiguration.for_ce_clients_table.find_by(data_source_id: data_source_id, owner: nil)
   end
 
   # Detect config to use for CE Eligible Clients table for a given unit group
-  def self.detect_ce_clients_unit_group_config(data_source_id:, unit_group_id:)
+  def self.detect_ce_clients_unit_group_config(data_source_id:, unit_group_id:, project_group_id: nil)
     unit_group = Hmis::UnitGroup.find_by(id: unit_group_id)
     return unless unit_group
+
+    project_group = Hmis::ProjectGroup.find_by(id: project_group_id, data_source_id: data_source_id) if project_group_id.present?
 
     # find applicable configuration for this unit group, preferring more specific owners
     [
       unit_group,
       unit_group.project,
+      project_group || detect_unambiguous_project_group_config_owner(data_source_id: data_source_id, project: unit_group.project),
       unit_group.project&.organization,
       nil,
     ].each do |owner|
+      next if owner.blank? && !owner.nil?
+
       found = Hmis::TableConfiguration.for_ce_clients_table.
         where(data_source_id: data_source_id).
         find_by(owner: owner)
@@ -80,6 +98,17 @@ class Hmis::TableConfiguration < Hmis::HmisBase
     end
 
     nil # no config found
+  end
+
+  def self.detect_unambiguous_project_group_config_owner(data_source_id:, project:)
+    return unless project
+
+    configured_project_groups = project.project_groups.
+      joins("INNER JOIN #{quoted_table_name} ON #{quoted_table_name}.owner_type = 'Hmis::ProjectGroup' AND #{quoted_table_name}.owner_id = hmis_project_groups.id").
+      merge(Hmis::TableConfiguration.for_ce_clients_table.where(data_source_id: data_source_id)).
+      distinct
+
+    configured_project_groups.one? ? configured_project_groups.first : nil
   end
 
   private

--- a/drivers/hmis/app/models/hmis/table_configuration.rb
+++ b/drivers/hmis/app/models/hmis/table_configuration.rb
@@ -88,8 +88,9 @@ class Hmis::TableConfiguration < Hmis::HmisBase
       unit_group.project&.organization,
     ].reject(&:blank?)
 
-    # Global fallback config (nil owner) should only be checked last
-    # (avoids prematurely returning the global config early if no project group config exists)
+    # Global fallback config (nil owner) should only be checked last.
+    # (Appending here after filtering out blanks above avoids prematurely
+    # returning the global config early if no owner exists at that level, e.g. project group)
     owners << nil
 
     owners.each do |owner|

--- a/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
+++ b/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
@@ -50,7 +50,18 @@ RSpec.describe Hmis::TableConfiguration, type: :model do
   describe '.detect_ce_clients_config' do
     it 'prefers project group configuration when provided' do
       global = create(:hmis_table_configuration_ce_clients, data_source: data_source, columns: [])
-      project_group_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: project_group, columns: [{ 'key' => 'cde.custom_assessment.score', 'type' => 'string', 'label' => 'Score' }])
+      project_group_config = create(
+        :hmis_table_configuration_ce_clients,
+        data_source: data_source,
+        owner: project_group,
+        columns: [
+          {
+            'key' => 'cde.custom_assessment.score',
+            'type' => 'string',
+            'label' => 'Score',
+          },
+        ],
+      )
 
       expect(described_class.detect_ce_clients_config(data_source_id: data_source.id, project_group_id: project_group.id)).to eq(project_group_config)
       expect(described_class.detect_ce_clients_config(data_source_id: data_source.id)).to eq(global)

--- a/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
+++ b/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
@@ -11,6 +11,7 @@ require 'rails_helper'
 RSpec.describe Hmis::TableConfiguration, type: :model do
   let(:data_source) { create(:hmis_data_source) }
   let(:project) { create(:hmis_hud_project, data_source: data_source) }
+  let(:project_group) { create(:hmis_project_group, data_source: data_source, with_projects: [project]) }
 
   describe 'validations' do
     subject { build(:hmis_table_configuration_ce_clients, data_source: data_source) }
@@ -38,6 +39,21 @@ RSpec.describe Hmis::TableConfiguration, type: :model do
       duplicate = build(:hmis_table_configuration_ce_clients, owner: project, data_source: data_source2)
 
       expect(duplicate).to be_valid
+    end
+
+    it 'allows project groups as owners' do
+      config = build(:hmis_table_configuration_ce_clients, owner: project_group, data_source: data_source)
+      expect(config).to be_valid
+    end
+  end
+
+  describe '.detect_ce_clients_config' do
+    it 'prefers project group configuration when provided' do
+      global = create(:hmis_table_configuration_ce_clients, data_source: data_source, columns: [])
+      project_group_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: project_group, columns: [{ 'key' => 'cde.custom_assessment.score', 'type' => 'string', 'label' => 'Score' }])
+
+      expect(described_class.detect_ce_clients_config(data_source_id: data_source.id, project_group_id: project_group.id)).to eq(project_group_config)
+      expect(described_class.detect_ce_clients_config(data_source_id: data_source.id)).to eq(global)
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
+++ b/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
@@ -102,11 +102,11 @@ RSpec.describe Hmis::TableConfiguration, type: :model do
       organization_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: organization)
       create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: project_group)
       create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: other_project_group)
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: nil)
 
       expect(described_class.detect_ce_clients_unit_group_config(data_source_id: data_source.id, unit_group_id: unit_group.id)).to eq(organization_config)
     end
 
-    # todo @martha - this is the bug mentioned in comments on the table config file
     it 'falls back to organization config when no matching project group config exists' do
       create(:hmis_project_group, data_source: data_source, with_projects: [project])
       organization_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: organization)

--- a/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
+++ b/drivers/hmis/spec/models/hmis/table_configuration_spec.rb
@@ -48,23 +48,71 @@ RSpec.describe Hmis::TableConfiguration, type: :model do
   end
 
   describe '.detect_ce_clients_config' do
-    it 'prefers project group configuration when provided' do
-      global = create(:hmis_table_configuration_ce_clients, data_source: data_source, columns: [])
-      project_group_config = create(
-        :hmis_table_configuration_ce_clients,
-        data_source: data_source,
-        owner: project_group,
-        columns: [
-          {
-            'key' => 'cde.custom_assessment.score',
-            'type' => 'string',
-            'label' => 'Score',
-          },
-        ],
-      )
+    let!(:global_config) { create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: nil) }
 
-      expect(described_class.detect_ce_clients_config(data_source_id: data_source.id, project_group_id: project_group.id)).to eq(project_group_config)
-      expect(described_class.detect_ce_clients_config(data_source_id: data_source.id)).to eq(global)
+    it 'falls back to global config when no matching project group config exists' do
+      project_group = create(:hmis_project_group, data_source: data_source)
+
+      expect(described_class.detect_ce_clients_config(data_source_id: data_source.id, project_group_id: project_group.id)).to eq(global_config)
+    end
+
+    context 'when project group config exists' do
+      let!(:project_group_config) do
+        create(
+          :hmis_table_configuration_ce_clients,
+          data_source: data_source,
+          owner: project_group,
+          columns: [
+            {
+              'key' => 'cde.custom_assessment.score',
+              'type' => 'string',
+              'label' => 'Score',
+            },
+          ],
+        )
+      end
+
+      it 'prefers project group configuration when provided' do
+        expect(described_class.detect_ce_clients_config(data_source_id: data_source.id, project_group_id: project_group.id)).to eq(project_group_config)
+      end
+
+      it 'returns the global config when project group id is not provided' do
+        expect(described_class.detect_ce_clients_config(data_source_id: data_source.id)).to eq(global_config)
+      end
+    end
+  end
+
+  describe '.detect_ce_clients_unit_group_config' do
+    let(:organization) { create(:hmis_hud_organization, data_source: data_source) }
+    let(:project) { create(:hmis_hud_project, data_source: data_source, organization: organization) }
+    let(:unit_group) { create(:hmis_unit_group, project: project) }
+
+    it 'uses matching project group config before organization and global configs' do
+      project_group = create(:hmis_project_group, data_source: data_source, with_projects: [project])
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: organization)
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: nil)
+      project_group_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: project_group)
+
+      expect(described_class.detect_ce_clients_unit_group_config(data_source_id: data_source.id, unit_group_id: unit_group.id)).to eq(project_group_config)
+    end
+
+    it 'skips project group configs when multiple configured project groups match' do
+      project_group = create(:hmis_project_group, data_source: data_source, with_projects: [project])
+      other_project_group = create(:hmis_project_group, data_source: data_source, with_projects: [project])
+      organization_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: organization)
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: project_group)
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: other_project_group)
+
+      expect(described_class.detect_ce_clients_unit_group_config(data_source_id: data_source.id, unit_group_id: unit_group.id)).to eq(organization_config)
+    end
+
+    # todo @martha - this is the bug mentioned in comments on the table config file
+    it 'falls back to organization config when no matching project group config exists' do
+      create(:hmis_project_group, data_source: data_source, with_projects: [project])
+      organization_config = create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: organization)
+      create(:hmis_table_configuration_ce_clients, data_source: data_source, owner: nil)
+
+      expect(described_class.detect_ce_clients_unit_group_config(data_source_id: data_source.id, unit_group_id: unit_group.id)).to eq(organization_config)
     end
   end
 

--- a/drivers/hmis/spec/requests/hmis/table_config_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/table_config_lookup_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Hmis::GraphqlController, type: :request do
   end
 
   describe 'TableConfigLookup' do
-    describe 'ceClientsGlobalConfig' do
+    describe 'ceClientsConfig' do
       let(:query) do
         <<~GRAPHQL
-          query TableConfigLookup {
+          query TableConfigLookup($projectGroupId: ID) {
             tableConfigLookup {
-              ceClientsGlobalConfig {
+              ceClientsConfig(projectGroupId: $projectGroupId) {
                 columns {
                   key
                   label
@@ -50,7 +50,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
           aggregate_failures 'checking response' do
             expect(response.status).to eq(200), result.inspect
-            config = result.dig('data', 'tableConfigLookup', 'ceClientsGlobalConfig')
+            config = result.dig('data', 'tableConfigLookup', 'ceClientsConfig')
             expect(config).to be_nil
           end
         end
@@ -67,34 +67,86 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           )
         end
 
-        it 'returns the global configuration' do
-          response, result = post_graphql({}) { query }
+        context 'when no project group id is provided' do
+          it 'returns the global configuration' do
+            response, result = post_graphql({}) { query }
 
-          aggregate_failures 'checking response' do
-            expect(response.status).to eq(200), result.inspect
-            config = result.dig('data', 'tableConfigLookup', 'ceClientsGlobalConfig')
-            expect(config).to be_present
+            aggregate_failures 'checking response' do
+              expect(response.status).to eq(200), result.inspect
+              config = result.dig('data', 'tableConfigLookup', 'ceClientsConfig')
+              expect(config).to be_present
 
-            # Check columns
-            expect(config['columns']).to be_present
-            column = config['columns'].first
-            expect(column).to include(
-              'key' => 'cde.custom_assessment.my_household_type',
-              'type' => 'STRING',
-              'label' => 'Household Type',
-            )
+              # Check columns
+              expect(config['columns']).to be_present
+              column = config['columns'].first
+              expect(column).to include(
+                'key' => 'cde.custom_assessment.my_household_type',
+                'type' => 'STRING',
+                'label' => 'Household Type',
+              )
 
-            # Check filters
-            expect(config['filters']).to be_present
-            filter = config['filters'].first
-            expect(filter).to include(
-              'key' => 'cde.custom_assessment.my_household_type',
-              'label' => 'Household Type',
+              # Check filters
+              expect(config['filters']).to be_present
+              filter = config['filters'].first
+              expect(filter).to include(
+                'key' => 'cde.custom_assessment.my_household_type',
+                'label' => 'Household Type',
+              )
+              expect(filter['options']).to contain_exactly(
+                { 'code' => 'Household with children' },
+                { 'code' => 'Household without children' },
+              )
+            end
+          end
+        end
+
+        context 'when a project group config exists' do
+          let!(:project_group) { create(:hmis_project_group, data_source: ds1) }
+          let!(:project_group_config) do
+            create(
+              :hmis_table_configuration_ce_clients,
+              data_source: ds1,
+              owner: project_group,
+              columns: [
+                {
+                  'key' => 'cde.custom_assessment.project_group_score',
+                  'type' => 'string',
+                  'label' => 'Project Group Score',
+                },
+              ],
             )
-            expect(filter['options']).to contain_exactly(
-              { 'code' => 'Household with children' },
-              { 'code' => 'Household without children' },
-            )
+          end
+
+          it 'returns the project group configuration' do
+            response, result = post_graphql({ project_group_id: project_group.id }) { query }
+
+            aggregate_failures 'checking response' do
+              expect(response.status).to eq(200), result.inspect
+              config = result.dig('data', 'tableConfigLookup', 'ceClientsConfig')
+              expect(config['columns'].first).to include(
+                'key' => 'cde.custom_assessment.project_group_score',
+                'type' => 'STRING',
+                'label' => 'Project Group Score',
+              )
+            end
+          end
+        end
+
+        context 'when no project group config exists' do
+          let!(:project_group) { create(:hmis_project_group, data_source: ds1) }
+
+          it 'falls back to the global configuration' do
+            response, result = post_graphql({ project_group_id: project_group.id }) { query }
+
+            aggregate_failures 'checking response' do
+              expect(response.status).to eq(200), result.inspect
+              config = result.dig('data', 'tableConfigLookup', 'ceClientsConfig')
+              expect(config['columns'].first).to include(
+                'key' => 'cde.custom_assessment.my_household_type',
+                'type' => 'STRING',
+                'label' => 'Household Type',
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- Add a project-group-aware `ceClientsConfig` GraphQL lookup for CE clients table configuration.
- Fall back to the global CE clients table configuration when no project group is supplied or configured.
- Prefer a unit group's project-group configuration only when exactly one configured project group contains the unit group's project. Otherwise return the global config (if there is one) rather than choosing arbitrarily

Related hmis-frontend PR: https://github.com/greenriver/hmis-frontend/pull/1526

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
