### PR TITLE
fix: don't crash on match with nil client

### DIFF
--- a/app/views/grda_warehouse/client_matches/_client_match.haml
+++ b/app/views/grda_warehouse/client_matches/_client_match.haml
@@ -2,9 +2,11 @@
   match = client_match
   client_a = match.destination_client
   client_b = match.source_client
-  pii_dest = client_a.pii_provider(user: current_user)
-  pii_source = client_b.pii_provider(user: current_user)
-- if client_a.destination_client && client_b.destination_client
+-# client_a/client_b can be nil when the referenced client has been merged away or soft-deleted (DateDeleted default scope), leaving an orphaned match row
+- if client_a && client_b && client_a.destination_client && client_b.destination_client
+  :ruby
+    pii_dest = client_a.pii_provider(user: current_user)
+    pii_source = client_b.pii_provider(user: current_user)
   .c-card--flush
     .client-match{data: {id: match.id}}
       %h6


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Fix crash on bad client reference from client match

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail

