### PR TITLE
fix: error on report question pages loaded via XHR

### DIFF
--- a/app/controllers/hud_reports/base_controller.rb
+++ b/app/controllers/hud_reports/base_controller.rb
@@ -160,8 +160,13 @@ module HudReports
 
       # use the 'history' action for relative URLs in pagination. This keeps our
       # crude status polling from breaking pagination links (app/views/hud_reports/_list_refresher.haml)
+      #
+      # NB: use path_for_history rather than url_for(action: :history). The history
+      # action only exists on the reports controller (as a collection route), so
+      # url_for would raise ActionController::UrlGenerationError when set_reports runs
+      # under the questions controller, which has no :history route.
       pagy_opts = {}
-      pagy_opts[:request_path] = url_for(action: :history) if request.xhr?
+      pagy_opts[:request_path] = path_for_history if request.xhr?
       @pagy, @reports = pagy(@reports, **pagy_opts)
     end
 

--- a/drivers/hopwa_caper/spec/requests/hopwa_caper/questions_controller_spec.rb
+++ b/drivers/hopwa_caper/spec/requests/hopwa_caper/questions_controller_spec.rb
@@ -1,0 +1,40 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HopwaCaper::QuestionsController, type: :request do
+  generator = HopwaCaper::Generators::Fy2026::Generator
+
+  let!(:user) { create(:user) }
+  let!(:report) do
+    create(
+      :hud_reports_report_instance,
+      user: user,
+      report_name: generator.title,
+      build_for_questions: generator.questions.keys,
+    )
+  end
+
+  before do
+    user.legacy_roles << create(:role, can_view_own_hud_reports: true)
+    sign_in(user)
+  end
+
+  describe 'GET #show' do
+    # XHR requests build pagination links off the reports "history" route, which the
+    # questions controller does not define directly (regression: #6223 UrlGenerationError).
+    generator.questions.keys.each do |question|
+      it "renders question #{question} requested via XHR" do
+        get hud_reports_hopwa_caper_question_path(hopwa_caper_id: report.id, id: question), xhr: true
+
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION


## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
  Report question pages failed when loaded via XHR, because pagination setup called url_for(action: :history) and the questions controller has no :history route. The fix uses the existing path_for_history helper, which resolves to the reports controller's named collection route regardless of the current controller. Adds a request spec covering all HOPWA CAPER question pages under XHR.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

