### PR TITLE
Add null/not-null comparators for CE match rules

### DIFF
--- a/drivers/hmis/app/graphql/concerns/manages_ce_match_rules.rb
+++ b/drivers/hmis/app/graphql/concerns/manages_ce_match_rules.rb
@@ -12,16 +12,27 @@ module ManagesCeMatchRules
   # If the rule change will remove more than 25% of the current candidates, warn the user
   IMPACT_WARNING_RATIO = 0.25
 
+  # value must be present for every comparator except these two
+  NULL_COMPARATORS = ['IS_NULL', 'IS_NOT_NULL'].freeze
+
   private
 
   def validate_input(input, expression_required:)
     errors = HmisErrors::Errors.new
-    # If expression is required (create), it's invalid unless exactly one of [expression, structured_expression] is present
-    return errors if expression_required && input.expression.present? ^ input.structured_expression.present?
-    # If expression is not required (update), they can't both be present. Either could be provided, or both could be blank.
-    return errors if !expression_required && (input.expression.blank? || input.structured_expression.blank?)
 
-    errors.add(:expression, :invalid, message: 'Provide exactly one of expression or structuredExpression.')
+    if (input.expression.present? && input.structured_expression.present?) || # Both present - invalid
+      (expression_required && input.expression.blank? && input.structured_expression.blank?) # Neither present - invalid on create
+      errors.add(:expression, :invalid, message: 'Provide exactly one of expression or structuredExpression.')
+    end
+
+    if input.structured_expression.present?
+      input.structured_expression.clauses.each do |clause|
+        is_null_comparator = NULL_COMPARATORS.include?(clause.comparator)
+        errors.add(:expression, :invalid, message: "value must be omitted for #{clause.comparator}") if is_null_comparator && !clause.value.nil?
+        errors.add(:expression, :invalid, message: "value is required for #{clause.comparator}") if !is_null_comparator && clause.value.nil?
+      end
+    end
+
     errors
   end
 

--- a/drivers/hmis/app/graphql/concerns/manages_ce_match_rules.rb
+++ b/drivers/hmis/app/graphql/concerns/manages_ce_match_rules.rb
@@ -12,8 +12,10 @@ module ManagesCeMatchRules
   # If the rule change will remove more than 25% of the current candidates, warn the user
   IMPACT_WARNING_RATIO = 0.25
 
-  # value must be present for every comparator except these two
-  NULL_COMPARATORS = ['IS_NULL', 'IS_NOT_NULL'].freeze
+  # value must be present for every comparator except these two.
+  # Derived from the translator's mapping (which stores symbols) so the two stay in sync;
+  # structured expression input arrives as string enum keys, so compare as strings.
+  NULL_COMPARATORS = Hmis::Ce::Match::Expression::ExpressionTranslator::NULL_COMPARATORS.values.map(&:to_s).freeze
 
   private
 

--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -1043,6 +1043,8 @@ enum CeMatchRuleComparator {
   GT
   GTE
   INCLUDES
+  IS_NOT_NULL
+  IS_NULL
   LT
   LTE
   NOT_EQ

--- a/drivers/hmis/app/graphql/types/hmis_schema/enums/ce_match_rule_comparator.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/enums/ce_match_rule_comparator.rb
@@ -18,5 +18,7 @@ module Types
     value 'GTE'
     value 'INCLUDES'
     value 'EXCLUDES'
+    value 'IS_NULL'
+    value 'IS_NOT_NULL'
   end
 end

--- a/drivers/hmis/app/models/hmis/ce/match/expression/expression_translator.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/expression_translator.rb
@@ -42,6 +42,16 @@ module Hmis::Ce::Match::Expression
       GT: '>',
       LTE: '<=',
       GTE: '>=',
+      IS_NULL: '=',
+      IS_NOT_NULL: '!=',
+    }.freeze
+
+    # A NULL RHS becomes IS_NULL/IS_NOT_NULL in the structured expression,
+    # because this allows more precision in the API and frontend.
+    # No other comparison node classes are included here, since "field < NULL" etc. aren't meaningful.
+    NULL_COMPARATORS = {
+      Dentaku::AST::Equal => :IS_NULL,
+      Dentaku::AST::NotEqual => :IS_NOT_NULL,
     }.freeze
 
     FUNCTION_COMPARATORS = {
@@ -136,11 +146,17 @@ module Hmis::Ce::Match::Expression
         field_metadata = field_catalog.field_for(field)
         return unless field_metadata
 
-        value = structured_value_for_expression_value(node.right.value, field_metadata)
+        comparator, value = if node.right.is_a?(Dentaku::AST::Nil) && NULL_COMPARATORS.key?(node.class)
+          # If RHS is nil, use the NULL_COMPARATORS mapping to get the structured comparator. Value is always nil.
+          [NULL_COMPARATORS.fetch(node.class), nil]
+        else
+          # Otherwise, use the COMPARATORS mapping to get the structured comparator and value.
+          [COMPARATORS.fetch(node.class), structured_value_for_expression_value(node.right.value, field_metadata)]
+        end
 
         StructuredExpression::Clause.new(
           field: field,
-          comparator: COMPARATORS.fetch(node.class),
+          comparator: comparator,
           value: value,
           # Return field_source and form_definition_identifier as helpers to the frontend
           # for filling in the related dropdowns when editing existing clauses.
@@ -161,7 +177,7 @@ module Hmis::Ce::Match::Expression
       def clause_to_expression(clause, field_catalog:)
         field = quote_field(clause.field)
         comparator = clause.comparator.to_sym
-        expression_value = format_value_for_expression(clause.value, field: field_catalog&.field_for(clause.field))
+        expression_value = format_value_for_expression(clause.value, field: field_catalog&.field_for(clause.field), comparator: comparator)
 
         if FUNCTION_COMPARATORS.value?(comparator)
           # If this is a function like INCLUDES, format as "INCLUDES(foo, 1)"
@@ -183,7 +199,9 @@ module Hmis::Ce::Match::Expression
         end
       end
 
-      def format_value_for_expression(value, field:)
+      def format_value_for_expression(value, field:, comparator:)
+        return 'NULL' if [:IS_NULL, :IS_NOT_NULL].include?(comparator)
+
         value = expression_value_for_structured_value(value, field)
 
         case value

--- a/drivers/hmis/app/models/hmis/ce/match/expression/expression_translator.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/expression_translator.rb
@@ -200,7 +200,7 @@ module Hmis::Ce::Match::Expression
       end
 
       def format_value_for_expression(value, field:, comparator:)
-        return 'NULL' if [:IS_NULL, :IS_NOT_NULL].include?(comparator)
+        return 'NULL' if NULL_COMPARATORS.values.include?(comparator)
 
         value = expression_value_for_structured_value(value, field)
 

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/expression_translator_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/expression_translator_spec.rb
@@ -93,10 +93,16 @@ RSpec.describe Hmis::Ce::Match::Expression::ExpressionTranslator do
       expect(structured.clauses.first).to have_attributes(field: 'open_referral_project_types', comparator: :EXCLUDES, value: Types::HmisSchema::Enums::ProjectType.key_for(1))
     end
 
-    it 'parses EQ with NULL RHS' do
+    it 'parses = NULL as IS_NULL' do
       structured = described_class.to_structured('current_age = NULL')
       expect(structured.clauses.size).to eq(1)
-      expect(structured.clauses.first).to have_attributes(field: 'current_age', comparator: :EQ, value: nil)
+      expect(structured.clauses.first).to have_attributes(field: 'current_age', comparator: :IS_NULL, value: nil)
+    end
+
+    it 'parses != NULL as IS_NOT_NULL' do
+      structured = described_class.to_structured('current_age != NULL')
+      expect(structured.clauses.size).to eq(1)
+      expect(structured.clauses.first).to have_attributes(field: 'current_age', comparator: :IS_NOT_NULL, value: nil)
     end
 
     it 'coerces enum-backed Dentaku literals to frontend enum keys' do
@@ -210,8 +216,15 @@ RSpec.describe Hmis::Ce::Match::Expression::ExpressionTranslator do
       expect(round).to eq(structured)
     end
 
-    it 'preserves structured form when clause value is NULL' do
+    it 'preserves structured form for IS_NULL' do
       original = 'current_age = NULL'
+      structured = described_class.to_structured(original)
+      round = described_class.to_structured(described_class.from_structured(structured))
+      expect(round).to eq(structured)
+    end
+
+    it 'preserves structured form for IS_NOT_NULL' do
+      original = 'current_age != NULL'
       structured = described_class.to_structured(original)
       round = described_class.to_structured(described_class.from_structured(structured))
       expect(round).to eq(structured)

--- a/drivers/hmis/spec/requests/hmis/ce/create_ce_match_rule_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_ce_match_rule_spec.rb
@@ -137,6 +137,21 @@ RSpec.describe 'createCeMatchRule mutation', type: :request do
     expect(result.dig('data', 'createCeMatchRule', 'rule', 'expression')).to eq('current_age = NULL')
   end
 
+  it 'creates a rule from structured expression input with IS_NOT_NULL' do
+    input = base_input.except(:expression).merge(
+      structuredExpression: {
+        operator: 'AND',
+        clauses: [
+          { field: 'current_age', comparator: 'IS_NOT_NULL' },
+        ],
+      },
+    )
+
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'createCeMatchRule', 'rule', 'expression')).to eq('current_age != NULL')
+  end
+
   it 'returns validation errors when value is provided for IS_NOT_NULL' do
     input = base_input.except(:expression).merge(
       structuredExpression: {
@@ -154,6 +169,26 @@ RSpec.describe 'createCeMatchRule mutation', type: :request do
       errors = result.dig('data', 'createCeMatchRule', 'errors')
       expect(errors.first).to include('attribute' => 'expression', 'severity' => 'error')
       expect(errors.first['message']).to include('value must be omitted for IS_NOT_NULL')
+    end.not_to change(Hmis::Ce::Match::Rule, :count)
+  end
+
+  it 'returns validation errors when value is omitted for a non-null comparator' do
+    input = base_input.except(:expression).merge(
+      structuredExpression: {
+        operator: 'AND',
+        clauses: [
+          { field: 'current_age', comparator: 'EQ' },
+        ],
+      },
+    )
+
+    expect do
+      response, result = post_graphql(input: input) { mutation }
+      expect(response.status).to eq(200), result.inspect
+
+      errors = result.dig('data', 'createCeMatchRule', 'errors')
+      expect(errors.first).to include('attribute' => 'expression', 'severity' => 'error')
+      expect(errors.first['message']).to include('value is required for EQ')
     end.not_to change(Hmis::Ce::Match::Rule, :count)
   end
 

--- a/drivers/hmis/spec/requests/hmis/ce/create_ce_match_rule_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/create_ce_match_rule_spec.rb
@@ -122,6 +122,41 @@ RSpec.describe 'createCeMatchRule mutation', type: :request do
     expect(result.dig('data', 'createCeMatchRule', 'rule', 'expression')).to eq('current_age >= 18')
   end
 
+  it 'creates a rule from structured expression input with IS_NULL' do
+    input = base_input.except(:expression).merge(
+      structuredExpression: {
+        operator: 'AND',
+        clauses: [
+          { field: 'current_age', comparator: 'IS_NULL' },
+        ],
+      },
+    )
+
+    response, result = post_graphql(input: input) { mutation }
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'createCeMatchRule', 'rule', 'expression')).to eq('current_age = NULL')
+  end
+
+  it 'returns validation errors when value is provided for IS_NOT_NULL' do
+    input = base_input.except(:expression).merge(
+      structuredExpression: {
+        operator: 'AND',
+        clauses: [
+          { field: 'current_age', comparator: 'IS_NOT_NULL', value: 18 },
+        ],
+      },
+    )
+
+    expect do
+      response, result = post_graphql(input: input) { mutation }
+      expect(response.status).to eq(200), result.inspect
+
+      errors = result.dig('data', 'createCeMatchRule', 'errors')
+      expect(errors.first).to include('attribute' => 'expression', 'severity' => 'error')
+      expect(errors.first['message']).to include('value must be omitted for IS_NOT_NULL')
+    end.not_to change(Hmis::Ce::Match::Rule, :count)
+  end
+
   it 'coerces enum-backed structured expression values' do
     input = base_input.except(:expression).merge(
       structuredExpression: {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
* Add `IS_NULL`/`IS_NOT_NULL` values to the `CeMatchRuleComparator` enum, so a null check is an explicit comparator instead of `EQ`/`NOT_EQ` with `value: null`.
  * **Alternative considered**: Continue to use `EQ`/`NOT_EQ` with `value: null` and update the frontend only to correctly support this in the UI. Advantage: This would have been a frontend-only change with no backend or schema changes. Code sketch: https://github.com/greenriver/hmis-frontend/commit/f24eade6a5133f742f09f6ab8544d6c30061afde
  * **Why not**: Mainly because it requires abandoning the standard `ControlledSelect` pattern for a hand-rolled dropdown that infers UI state from two watched form fields (comparator and value).
* Update `ExpressionTranslator` to parse `field = NULL` / `field != NULL` into `IS_NULL`/`IS_NOT_NULL` clauses, and to serialize them back to `=`/`!=` NULL regardless of `clause.value`. This is translation-only — the stored free-text `expression` column is unchanged, so existing rules with `= NULL`/`!= NULL` continue to work with no data migration.
* Validate in `ManagesCeMatchRules#validate_input` that `value` is omitted for `IS_NULL`/`IS_NOT_NULL` clauses and required for every other comparator.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

