### PR TITLE
feat: 9357 superset-idp-seam

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -317,7 +317,7 @@ jobs:
           AWS_ACCESS_KEY_ID: local_access_key
           AWS_SECRET_ACCESS_KEY: local_secret_key
         run: |
-          AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/models/user_auth_method_spec.rb drivers/hmis/spec/models/hmis/user_auth_method_spec.rb spec/models/idp/jwt_helper_spec.rb spec/models/concerns/idp/jwt_user_spec.rb spec/controllers/concerns/idp/jwt_current_user_spec.rb spec/requests/idp/warehouse_jwt_wiring_spec.rb spec/services/idp/service_factory_spec.rb spec/models/idp/service_config_spec.rb drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+          AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/models/user_auth_method_spec.rb drivers/hmis/spec/models/hmis/user_auth_method_spec.rb spec/models/idp/jwt_helper_spec.rb spec/models/concerns/idp/jwt_user_spec.rb spec/controllers/concerns/idp/jwt_current_user_spec.rb spec/requests/idp/warehouse_jwt_wiring_spec.rb spec/services/idp/service_factory_spec.rb spec/models/idp/service_config_spec.rb drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb spec/requests/api/superset_jwt_wiring_spec.rb
 
       - name: Run logging tests
         if: matrix.test_group.logging || needs.determine_matrix.outputs.logging == 'true'

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -16,13 +16,12 @@ module ApplicationCable
 
     protected def find_verified_user
       if AuthMethod.jwt?
+        # Resolves without provisioning: a WebSocket frame must not cause side effects
+        # (see Idp::JwtHelper.active_user_from_token).
         access_token = request.headers['HTTP_X_FORWARDED_ACCESS_TOKEN']
-        jwt_helper = Idp::JwtHelper.new(access_token: access_token)
-        if jwt_helper.valid?
-          # Do not provision a new user (find_from_jwt). A WebSocket frame must not cause side effects.
-          user = User.find_from_jwt(jwt_helper)
-          return user if user&.active?
-        end
+        user = Idp::JwtHelper.active_user_from_token(access_token)
+        return user if user
+
         reject_unauthorized_connection
       elsif (verified_user = env["warden"].user)
         verified_user

--- a/app/controllers/api/bearer_token_controller.rb
+++ b/app/controllers/api/bearer_token_controller.rb
@@ -33,16 +33,13 @@ module Api
       token = extract_bearer_token
       return head :unauthorized unless token.present?
 
-      jwt_helper = Idp::JwtHelper.new(access_token: token)
-      unless jwt_helper.valid?
-        Rails.logger.warn "#{self.class.name}: invalid or expired JWT token"
-        return head :unauthorized
-      end
-
       # Read-only lookup: this is a machine-to-machine identity query, not a login, so it must not
       # provision a user or learn an Authentication Source (see connection.rb#find_verified_user).
-      @current_user = User.find_from_jwt(jwt_helper)
-      return head(:unauthorized) unless @current_user&.active?
+      @current_user = Idp::JwtHelper.active_user_from_token(token)
+      unless @current_user
+        Rails.logger.warn "#{self.class.name}: invalid/expired JWT token or inactive user"
+        return head :unauthorized
+      end
     end
 
     def extract_bearer_token

--- a/app/controllers/api/bearer_token_controller.rb
+++ b/app/controllers/api/bearer_token_controller.rb
@@ -15,8 +15,7 @@ module Api
   # compose_activity/log_activity, 2FA, ...). Those filters key off current_user, and several of
   # them redirect_to a setup page when the user has outstanding onboarding. A server-to-server
   # caller carrying a live end-user token would then receive a 302 to an HTML page instead of the
-  # JSON it asked for (and the redirect-follower would silently fall back to default behavior), and
-  # every call would write an activity-log row. Riding a clean ActionController::Base — the same
+  # JSON it asked for, and every call would write an activity-log row. Riding a clean ActionController::Base — the same
   # choice Hmis::BaseController and SystemStatusController make — keeps this path to just the token
   # check below. See Api::SupersetController.
   class BearerTokenController < ActionController::Base

--- a/app/controllers/api/bearer_token_controller.rb
+++ b/app/controllers/api/bearer_token_controller.rb
@@ -1,0 +1,66 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Api
+  # Lean base for machine-to-machine JSON endpoints that authenticate with a bearer JWT
+  # (`Authorization: Bearer <token>`), such as Superset's role lookup.
+  #
+  # It deliberately does NOT inherit from ApplicationController. That controller's filter chain is
+  # built for an interactive browser session (require_training!, require_compliance_agreement!,
+  # compose_activity/log_activity, 2FA, ...). Those filters key off current_user, and several of
+  # them redirect_to a setup page when the user has outstanding onboarding. A server-to-server
+  # caller carrying a live end-user token would then receive a 302 to an HTML page instead of the
+  # JSON it asked for (and the redirect-follower would silently fall back to default behavior), and
+  # every call would write an activity-log row. Riding a clean ActionController::Base — the same
+  # choice Hmis::BaseController and SystemStatusController make — keeps this path to just the token
+  # check below. See Api::SupersetController.
+  class BearerTokenController < ActionController::Base
+    include LogRagePayloadBehavior
+
+    # Token-authenticated, session-less API: there is no form or cookie to forge against.
+    skip_forgery_protection
+
+    before_action :authenticate_via_jwt!
+
+    private
+
+    def authenticate_via_jwt!
+      token = extract_bearer_token
+      return head :unauthorized unless token.present?
+
+      jwt_helper = Idp::JwtHelper.new(access_token: token)
+      unless jwt_helper.valid?
+        Rails.logger.warn "#{self.class.name}: invalid or expired JWT token"
+        return head :unauthorized
+      end
+
+      # Read-only lookup: this is a machine-to-machine identity query, not a login, so it must not
+      # provision a user or learn an Authentication Source (see connection.rb#find_verified_user).
+      @current_user = User.find_from_jwt(jwt_helper)
+      return head(:unauthorized) unless @current_user&.active?
+    end
+
+    def extract_bearer_token
+      auth_header = request.headers['Authorization']
+      return nil unless auth_header.present?
+
+      # Only accept the Bearer scheme; anything else (Basic, a bare token, a malformed header) is
+      # not a token we should try to validate.
+      match = auth_header.match(/\ABearer\s+(?<token>\S.*)\z/i)
+      match && match[:token]
+    end
+
+    attr_reader :current_user
+
+    # Lograge: attribute the request to the resolved user (parity with the other base controllers).
+    def append_info_to_payload(payload)
+      super
+      payload[:user_id] = current_user&.id
+    end
+  end
+end

--- a/app/controllers/api/superset_controller.rb
+++ b/app/controllers/api/superset_controller.rb
@@ -9,10 +9,10 @@
 # Provides user role information for Superset authentication via JWT.
 # This endpoint is used by Superset when configured with oauth2-proxy/dex authentication.
 # Unlike the Doorkeeper-based /oauth/user-data endpoint, this validates JWT tokens from dex.
-# Authentication (bearer token -> read-only user resolution) lives in Api::BearerTokenController;
+# Authentication (bearer token -> read-only user resolution) lives in Idp::JwtApiController;
 # this M2M endpoint must not ride ApplicationController's interactive filter chain.
 module Api
-  class SupersetController < BearerTokenController
+  class SupersetController < Idp::JwtApiController
     def user_roles
       payload = {
         id: current_user.id,

--- a/app/controllers/api/superset_controller.rb
+++ b/app/controllers/api/superset_controller.rb
@@ -7,10 +7,6 @@
 # frozen_string_literal: true
 
 # Provides user role information for Superset authentication via JWT.
-# This endpoint is used by Superset when configured with oauth2-proxy/dex authentication.
-# Unlike the Doorkeeper-based /oauth/user-data endpoint, this validates JWT tokens from dex.
-# Authentication (bearer token -> read-only user resolution) lives in Idp::JwtApiController;
-# this M2M endpoint must not ride ApplicationController's interactive filter chain.
 module Api
   class SupersetController < Idp::JwtApiController
     def user_roles

--- a/app/controllers/api/superset_controller.rb
+++ b/app/controllers/api/superset_controller.rb
@@ -1,0 +1,28 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Provides user role information for Superset authentication via JWT.
+# This endpoint is used by Superset when configured with oauth2-proxy/dex authentication.
+# Unlike the Doorkeeper-based /oauth/user-data endpoint, this validates JWT tokens from dex.
+# Authentication (bearer token -> read-only user resolution) lives in Api::BearerTokenController;
+# this M2M endpoint must not ride ApplicationController's interactive filter chain.
+module Api
+  class SupersetController < BearerTokenController
+    def user_roles
+      payload = {
+        id: current_user.id,
+        first_name: current_user.first_name,
+        last_name: current_user.last_name,
+        email: current_user.email,
+        superset_roles: current_user.superset_roles,
+      }
+
+      render(json: payload)
+    end
+  end
+end

--- a/app/controllers/idp/jwt_api_controller.rb
+++ b/app/controllers/idp/jwt_api_controller.rb
@@ -7,23 +7,14 @@
 # frozen_string_literal: true
 
 module Idp
-  # Lean base for machine-to-machine JSON endpoints that authenticate with an IdP-issued bearer JWT
-  # (`Authorization: Bearer <token>`), such as Superset's role lookup. It lives in the Idp:: seam
-  # alongside its collaborators (Idp::JwtHelper, Idp::JwtAuthentication, Idp::JwtCurrentUser) rather
-  # than under Api:: because its whole behavior is IdP-JWT specific, not transport-generic.
+  # Base for API endpoints that authenticate with an IdP-issued bearer JWT
   #
-  # It deliberately does NOT inherit from ApplicationController. That controller's filter chain is
-  # built for an interactive browser session (require_training!, require_compliance_agreement!,
-  # compose_activity/log_activity, 2FA, ...). Those filters key off current_user, and several of
-  # them redirect_to a setup page when the user has outstanding onboarding. A server-to-server
-  # caller carrying a live end-user token would then receive a 302 to an HTML page instead of the
-  # JSON it asked for, and every call would write an activity-log row. Riding a clean ActionController::Base — the same
-  # choice Hmis::BaseController and SystemStatusController make — keeps this path to just the token
-  # check below. See Api::SupersetController.
+  # It deliberately does NOT inherit from ApplicationController to avoid bad interactions with
+  # request hooks require_training, compliance_agreement, etc.
   class JwtApiController < ActionController::Base
     include LogRagePayloadBehavior
 
-    # Token-authenticated, session-less API: there is no form or cookie to forge against.
+    # Token-authenticated, session-less API
     skip_forgery_protection
 
     before_action :authenticate_via_jwt!
@@ -34,8 +25,7 @@ module Idp
       token = extract_bearer_token
       return head :unauthorized unless token.present?
 
-      # Read-only lookup: this is a machine-to-machine identity query, not a login, so it must not
-      # provision a user or learn an Authentication Source (see connection.rb#find_verified_user).
+      # Read-only lookup: this is a machine-to-machine query; does not provision users
       @current_user = Idp::JwtHelper.active_user_from_token(token)
       unless @current_user
         Rails.logger.warn "#{self.class.name}: invalid/expired JWT token or inactive user"
@@ -47,15 +37,14 @@ module Idp
       auth_header = request.headers['Authorization']
       return nil unless auth_header.present?
 
-      # Only accept the Bearer scheme; anything else (Basic, a bare token, a malformed header) is
-      # not a token we should try to validate.
+      # Only accept the Bearer scheme; reject all else
       match = auth_header.match(/\ABearer\s+(?<token>\S.*)\z/i)
       match && match[:token]
     end
 
     attr_reader :current_user
 
-    # Lograge: attribute the request to the resolved user (parity with the other base controllers).
+    # Lograge: parity with the other base controllers
     def append_info_to_payload(payload)
       super
       payload[:user_id] = current_user&.id

--- a/app/controllers/idp/jwt_api_controller.rb
+++ b/app/controllers/idp/jwt_api_controller.rb
@@ -6,9 +6,11 @@
 
 # frozen_string_literal: true
 
-module Api
-  # Lean base for machine-to-machine JSON endpoints that authenticate with a bearer JWT
-  # (`Authorization: Bearer <token>`), such as Superset's role lookup.
+module Idp
+  # Lean base for machine-to-machine JSON endpoints that authenticate with an IdP-issued bearer JWT
+  # (`Authorization: Bearer <token>`), such as Superset's role lookup. It lives in the Idp:: seam
+  # alongside its collaborators (Idp::JwtHelper, Idp::JwtAuthentication, Idp::JwtCurrentUser) rather
+  # than under Api:: because its whole behavior is IdP-JWT specific, not transport-generic.
   #
   # It deliberately does NOT inherit from ApplicationController. That controller's filter chain is
   # built for an interactive browser session (require_training!, require_compliance_agreement!,
@@ -18,7 +20,7 @@ module Api
   # JSON it asked for, and every call would write an activity-log row. Riding a clean ActionController::Base — the same
   # choice Hmis::BaseController and SystemStatusController make — keeps this path to just the token
   # check below. See Api::SupersetController.
-  class BearerTokenController < ActionController::Base
+  class JwtApiController < ActionController::Base
     include LogRagePayloadBehavior
 
     # Token-authenticated, session-less API: there is no form or cookie to forge against.

--- a/app/controllers/idp/jwt_api_controller.rb
+++ b/app/controllers/idp/jwt_api_controller.rb
@@ -27,10 +27,10 @@ module Idp
 
       # Read-only lookup: this is a machine-to-machine query; does not provision users
       @current_user = Idp::JwtHelper.active_user_from_token(token)
-      unless @current_user
-        Rails.logger.warn "#{self.class.name}: invalid/expired JWT token or inactive user"
-        return head :unauthorized
-      end
+      return if @current_user
+
+      Rails.logger.warn "#{self.class.name}: invalid/expired JWT token or inactive user"
+      return head :unauthorized
     end
 
     def extract_bearer_token

--- a/app/controllers/idp/sessions_controller.rb
+++ b/app/controllers/idp/sessions_controller.rb
@@ -47,7 +47,7 @@ module Idp
       return head(:unauthorized) unless access_token.present?
 
       jwt_helper = Idp::JwtHelper.new(access_token: access_token)
-      # valid? already returns false for a blank token, so it subsumes the token? check.
+      # valid? returns false for a blank token
       return head(:unauthorized) unless jwt_helper.valid?
 
       expiration_time = jwt_helper.expiration_time

--- a/app/controllers/idp/sessions_controller.rb
+++ b/app/controllers/idp/sessions_controller.rb
@@ -47,7 +47,8 @@ module Idp
       return head(:unauthorized) unless access_token.present?
 
       jwt_helper = Idp::JwtHelper.new(access_token: access_token)
-      return head(:unauthorized) unless jwt_helper.token? && jwt_helper.valid?
+      # valid? already returns false for a blank token, so it subsumes the token? check.
+      return head(:unauthorized) unless jwt_helper.valid?
 
       expiration_time = jwt_helper.expiration_time
       return head(:ok) unless expiration_time

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -66,8 +66,8 @@ class Idp::JwtHelper
     Rails.logger.error "JSON verification failed: #{e.message}"
     false
   rescue *NETWORK_ERRORS => e
-    # Couldn't reach JWKS_URL to fetch the signing key. Fail closed (401), but surface it to Sentry:
-    # unlike a bad token, this is an infrastructure problem the caller can't fix.
+    # Couldn't reach JWKS_URL to fetch the signing key. Unlike a bad token, this is an
+    # infrastructure problem the caller can't fix, so surface it to Sentry (we still fail closed).
     Rails.logger.error "JWT verification could not reach JWKS endpoint: #{e.message}"
     Sentry.capture_exception_with_info(e, 'JWT verification could not reach the JWKS endpoint; treating token as invalid')
     false

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -17,6 +17,21 @@ class Idp::JwtHelper
   REQUIRED_ENV_KEYS = ['IDP_AUD', 'ISS_URL', 'JWKS_URL', 'JWT_ALGORITHM'].freeze
   VALID_AUTH_METHODS = [nil, 'devise', 'jwt'].freeze
 
+  # Transport-level failures reaching JWKS_URL. We can't verify the token when the IdP is
+  # unreachable, so we fail closed (treat it as invalid) rather than letting a 500 escape to the
+  # caller. SocketError covers Socket::ResolutionError (a subclass).
+  NETWORK_ERRORS = [
+    SocketError,
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::EHOSTUNREACH,
+    Errno::ETIMEDOUT,
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    OpenSSL::SSL::SSLError,
+    Timeout::Error,
+  ].freeze
+
   def initialize(access_token:)
     @access_token = access_token
   end
@@ -49,6 +64,12 @@ class Idp::JwtHelper
     false
   rescue JSON::ParserError => e
     Rails.logger.error "JSON verification failed: #{e.message}"
+    false
+  rescue *NETWORK_ERRORS => e
+    # Couldn't reach JWKS_URL to fetch the signing key. Fail closed (401), but surface it to Sentry:
+    # unlike a bad token, this is an infrastructure problem the caller can't fix.
+    Rails.logger.error "JWT verification could not reach JWKS endpoint: #{e.message}"
+    Sentry.capture_exception_with_info(e, 'JWT verification could not reach the JWKS endpoint; treating token as invalid')
     false
   end
 

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -18,8 +18,7 @@ class Idp::JwtHelper
   VALID_AUTH_METHODS = [nil, 'devise', 'jwt'].freeze
 
   # Transport-level failures reaching JWKS_URL. We can't verify the token when the IdP is
-  # unreachable, so we fail closed (treat it as invalid) rather than letting a 500 escape to the
-  # caller. SocketError covers Socket::ResolutionError (a subclass).
+  # unreachable, so we fail closed
   NETWORK_ERRORS = [
     SocketError,
     Errno::ECONNREFUSED,
@@ -66,8 +65,6 @@ class Idp::JwtHelper
     Rails.logger.error "JSON verification failed: #{e.message}"
     false
   rescue *NETWORK_ERRORS => e
-    # Couldn't reach JWKS_URL to fetch the signing key. Unlike a bad token, this is an
-    # infrastructure problem the caller can't fix, so surface it to Sentry (we still fail closed).
     Rails.logger.error "JWT verification could not reach JWKS endpoint: #{e.message}"
     Sentry.capture_exception_with_info(e, 'JWT verification could not reach the JWKS endpoint; treating token as invalid')
     false
@@ -146,10 +143,6 @@ class Idp::JwtHelper
   end
 
   # Resolves an active user from a token, without provisioning or any other side effect
-  # (find_from_jwt, not find_or_create_from_jwt). Used by callers that must not mutate state while
-  # authenticating — the ActionCable resolver (a WebSocket frame must not provision) and the
-  # machine-to-machine bearer API (an identity query, not a login). Returns nil for a missing,
-  # invalid, or expired token, an unknown user, or a locally deactivated account.
   def self.active_user_from_token(access_token)
     helper = new(access_token: access_token)
     return nil unless helper.valid?

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -145,6 +145,19 @@ class Idp::JwtHelper
     User.find_from_jwt(helper)&.id
   end
 
+  # Resolves the active User a token identifies, without provisioning or any other side effect
+  # (find_from_jwt, not find_or_create_from_jwt). Used by callers that must not mutate state while
+  # authenticating — the ActionCable resolver (a WebSocket frame must not provision) and the
+  # machine-to-machine bearer API (an identity query, not a login). Returns nil for a missing,
+  # invalid, or expired token, an unknown user, or a locally deactivated account.
+  def self.active_user_from_token(access_token)
+    helper = new(access_token: access_token)
+    return nil unless helper.valid?
+
+    user = User.find_from_jwt(helper)
+    user if user&.active?
+  end
+
   def self.assert_boot_config!
     auth_method = ENV['AUTH_METHOD']
     raise "Invalid AUTH_METHOD: #{auth_method.inspect}" unless VALID_AUTH_METHODS.include?(auth_method)

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -145,7 +145,7 @@ class Idp::JwtHelper
     User.find_from_jwt(helper)&.id
   end
 
-  # Resolves the active User a token identifies, without provisioning or any other side effect
+  # Resolves an active user from a token, without provisioning or any other side effect
   # (find_from_jwt, not find_or_create_from_jwt). Used by callers that must not mutate state while
   # authenticating — the ActionCable resolver (a WebSocket frame must not provision) and the
   # machine-to-machine bearer API (an identity query, not a login). Returns nil for a missing,

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -6,6 +6,8 @@
 
 # frozen_string_literal: true
 
+return unless AuthMethod.devise?
+
 Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (requires ORM extensions installed).
   # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
@@ -16,7 +18,7 @@ Doorkeeper.configure do
     # raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
     # Put your resource owner authentication logic here.
     # Example implementation:
-    #User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+    # User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
     current_user || warden.authenticate!(scope: :user)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -783,6 +783,10 @@ Rails.application.routes.draw do
       put :unfavorite, on: :member
     end
     resources :clients, only: [:show]
+
+    # Superset (the M2M caller, not oauth2-proxy) presents a bearer JWT directly; the mirror image
+    # of the Doorkeeper-gated 'oauth/user-data' route above.
+    get 'superset/user_roles', to: 'superset#user_roles' if AuthMethod.jwt?
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -784,8 +784,9 @@ Rails.application.routes.draw do
     end
     resources :clients, only: [:show]
 
-    # Superset (the M2M caller, not oauth2-proxy) presents a bearer JWT directly; the mirror image
-    # of the Doorkeeper-gated 'oauth/user-data' route above.
+    # Superset (the M2M caller, not oauth2-proxy) presents a bearer JWT directly; the JWT-side
+    # mirror of the Doorkeeper-gated 'oauth/user-data' route declared under AuthMethod.devise? at
+    # the top of this file.
     get 'superset/user_roles', to: 'superset#user_roles' if AuthMethod.jwt?
   end
 

--- a/docker/auth/dev.oauth2-proxy-warehouse.cfg
+++ b/docker/auth/dev.oauth2-proxy-warehouse.cfg
@@ -25,5 +25,6 @@ skip_auth_routes=[
   "^/dev-assets/.*",
   "^/hmis/user\\.json$",  # HMIS user authentication check - backend validates JWT
   "^/hmis/app_settings$",  # HMIS app settings - backend validates JWT
+  "^/api/superset/user_roles$",  # Superset role lookup (M2M) - backend validates JWT
 ]
 skip_provider_button=true

--- a/docs/developer/superset.md
+++ b/docs/developer/superset.md
@@ -1,25 +1,35 @@
 # Developer Setup for Superset
-Superset has become an external dependency for Open Path rather than integrated in the application's docker compose.  The following instructions may help get it running, but are no longer fully accurate, but left here temporarily until updated documentation can be developed.
+Superset is an external dependency for Open Path, not part of this application's docker compose.
+It lives in its own repository, [greenriver/superset-sync](https://github.com/greenriver/superset-sync),
+which owns the Superset image, the `docker-compose.yaml`, and the auth config
+(`docker/superset/superset_config.py`). Run Superset from a checkout of that repo, not from
+`hmis-warehouse`.
 
-If you are running on Apple M1 architecture, this may help get superset up and running. Run the following in your `hmis-warehouse` directory.  This will install an abstraction layer that will allow the amd64 version of superset to run on arm64.
+## Running Superset locally
+
+Follow the "Development Quick Start" in the superset-sync `README.md`; the short version is:
+
+1. In your superset-sync checkout, seed the local env and compose override:
+   ```sh
+   cp .env.local.sample .env.local
+   cp docker-compose.override.sample.yaml docker-compose.override.yaml
+   ```
+2. Point `.env.local` at your warehouse: make sure the shared docker network in the override
+   matches your warehouse's (`nginx-proxy` or `traefik`), and that `WAREHOUSE_DB_URI` has the
+   right warehouse db host/name/creds.
+3. Choose an auth method in `.env.local` (see "Logging in to superset" below): either
+   `SUPERSET_USE_OAUTH2_PROXY=true` (jwt) or `SUPERSET_USE_OAUTH=true` (Doorkeeper/devise).
+4. Load data from the warehouse into dbt/superset, then start it:
+   ```sh
+   bin/local_development.sh init
+   bin/local_development.sh start
+   ```
+
+If you are on Apple silicon, the DBT/Superset images are amd64. Installing binfmt lets them run
+under emulation:
 ```bash
 docker run --privileged --rm tonistiigi/binfmt --install amd64
 ```
-In one terminal start up the Superset container.  It is set to start in the background by default, so you may need to `docker compose down` first
-```sh
-docker compose up superset
-```
-If all goes well, it'll run through the config and you'll end up with a new
-`superset` db on your postgres container.  If it looks like there were any
-errors, open a second terminal and run the following:
-```sh
-docker compose run superset_init_2
-```
-There's an `init.sh` script in `superset/op/` that only runs if
-`superset/op/.did.db.init` doesn't exist. Removing that file will let the
-script run again.
-
-At this point the usual `docker compose up -d` should bring up a functional superset installation at http://superset.hmis-warehouse.dev.test.
 
 ## Logging in to superset
 
@@ -29,8 +39,9 @@ How Superset resolves a warehouse user depends on the warehouse's `AUTH_METHOD`:
   Doorkeeper application as described below. `Superset.available?` reports true once a
   `Doorkeeper::Application` is registered for the Superset host.
 - **`jwt`** — the warehouse sits behind oauth2-proxy/dex, so there is no Doorkeeper application.
-  Superset instead calls `GET /api/superset/user_roles` with the user's bearer JWT
-  (`Authorization: Bearer <token>`); the warehouse validates the token and returns the user's
+  Superset instead calls `GET /api/superset/user_roles`, authenticating with the user's access
+  token that oauth2-proxy forwards as `X-Forwarded-Access-Token` (sent on as
+  `Authorization: Bearer <token>`); the warehouse validates the token and returns the user's
   roles. That route is exposed only under `AUTH_METHOD=jwt` and is listed in
   `skip_auth_routes` in `docker/auth/dev.oauth2-proxy-warehouse.cfg` because the backend does its
   own validation. `Superset.available?` reports true once `SUPERSET_ADMIN_PASS` is configured
@@ -39,8 +50,11 @@ How Superset resolves a warehouse user depends on the warehouse's `AUTH_METHOD`:
 
 ### Devise / Doorkeeper setup
 
-We use oauth2 with the warehouse as the provider. In a pinch, you can just find `AUTH_TYPE` in
-`docker/superset/op/superset_config.py` and comment that line out.
+We use oauth2 with the warehouse as the provider. Which auth path Superset takes is driven by env
+flags in `docker/superset/superset_config.py` (in the superset-sync repo): `SUPERSET_USE_OAUTH=true`
+selects the Doorkeeper provider, and `SUPERSET_USE_OAUTH2_PROXY=true` takes precedence for jwt.
+`AUTH_TYPE` is assigned inside those conditional blocks, so switch methods by setting the flags
+rather than editing `AUTH_TYPE` directly.
 
 The proper way to get things set up is to set up a doorkeeper application and update your environment variables in superset
 

--- a/docs/developer/superset.md
+++ b/docs/developer/superset.md
@@ -23,6 +23,22 @@ At this point the usual `docker compose up -d` should bring up a functional supe
 
 ## Logging in to superset
 
+How Superset resolves a warehouse user depends on the warehouse's `AUTH_METHOD`:
+
+- **`devise`** — Superset uses OAuth2 with the warehouse as the provider (Doorkeeper). Set up a
+  Doorkeeper application as described below. `Superset.available?` reports true once a
+  `Doorkeeper::Application` is registered for the Superset host.
+- **`jwt`** — the warehouse sits behind oauth2-proxy/dex, so there is no Doorkeeper application.
+  Superset instead calls `GET /api/superset/user_roles` with the user's bearer JWT
+  (`Authorization: Bearer <token>`); the warehouse validates the token and returns the user's
+  roles. That route is exposed only under `AUTH_METHOD=jwt` and is listed in
+  `skip_auth_routes` in `docker/auth/dev.oauth2-proxy-warehouse.cfg` because the backend does its
+  own validation. `Superset.available?` reports true once `SUPERSET_ADMIN_PASS` is configured
+  (any non-blank value in development; anything other than the insecure `admin` default elsewhere),
+  which is the credential `Superset::Api` uses for the warehouse→Superset REST calls.
+
+### Devise / Doorkeeper setup
+
 We use oauth2 with the warehouse as the provider. In a pinch, you can just find `AUTH_TYPE` in
 `docker/superset/op/superset_config.py` and comment that line out.
 

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -22,16 +22,32 @@ module Superset
     "#{superset_base_url}/login/The%20Warehouse"
   end
 
-  def self.available?
-    if AuthMethod.jwt?
-      password_set = ENV['SUPERSET_ADMIN_PASS'].present?
-      return password_set if Rails.env.development?
+  # The value SUPERSET_ADMIN_PASS is seeded with in the local/dev images. Outside development a
+  # password still set to this placeholder means Superset was never really configured, so we treat
+  # it as unavailable rather than exposing it with the insecure default.
+  INSECURE_DEFAULT_ADMIN_PASS = 'admin'
 
-      password_set && ENV['SUPERSET_ADMIN_PASS'] != 'admin'
-    else
-      a_t = Doorkeeper::Application.arel_table
-      Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
-    end
+  # "Available" means two different things depending on how the app authenticates, so split on the
+  # AuthMethod seam and let each side say what it needs.
+  def self.available?
+    AuthMethod.jwt? ? admin_password_configured? : doorkeeper_app_registered?
+  end
+
+  # Under JWT, Superset rides the shared admin credential (see Superset::Api), so it's usable only
+  # once that credential is really set: any non-blank value in development, and anything other than
+  # the insecure placeholder everywhere else.
+  def self.admin_password_configured?
+    password = ENV['SUPERSET_ADMIN_PASS']
+    return false if password.blank?
+    return true if Rails.env.development?
+
+    password != INSECURE_DEFAULT_ADMIN_PASS
+  end
+
+  # Under Devise, availability means a Doorkeeper OAuth app is registered for the Superset host.
+  def self.doorkeeper_app_registered?
+    a_t = Doorkeeper::Application.arel_table
+    Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
   end
 
   def self.available_to_user?(user)

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -23,8 +23,15 @@ module Superset
   end
 
   def self.available?
-    a_t = Doorkeeper::Application.arel_table
-    Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
+    if AuthMethod.jwt?
+      password_set = ENV['SUPERSET_ADMIN_PASS'].present?
+      return password_set if Rails.env.development?
+
+      password_set && ENV['SUPERSET_ADMIN_PASS'] != 'admin'
+    else
+      a_t = Doorkeeper::Application.arel_table
+      Doorkeeper::Application.where(a_t[:redirect_uri].matches("%#{superset_base_url}%")).exists?
+    end
   end
 
   def self.available_to_user?(user)

--- a/drivers/superset/app/models/superset.rb
+++ b/drivers/superset/app/models/superset.rb
@@ -27,8 +27,6 @@ module Superset
   # it as unavailable rather than exposing it with the insecure default.
   INSECURE_DEFAULT_ADMIN_PASS = 'admin'
 
-  # "Available" means two different things depending on how the app authenticates, so split on the
-  # AuthMethod seam and let each side say what it needs.
   def self.available?
     AuthMethod.jwt? ? admin_password_configured? : doorkeeper_app_registered?
   end

--- a/drivers/superset/spec/models/superset_spec.rb
+++ b/drivers/superset/spec/models/superset_spec.rb
@@ -17,6 +17,62 @@ RSpec.describe Superset do
     allow(Sentry).to receive(:capture_exception_with_info)
   end
 
+  describe '.available?' do
+    context 'under AuthMethod.jwt?' do
+      before { allow(AuthMethod).to receive(:jwt?).and_return(true) }
+
+      it 'is unavailable when SUPERSET_ADMIN_PASS is unset' do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SUPERSET_ADMIN_PASS').and_return(nil)
+
+        expect(described_class.available?).to eq(false)
+      end
+
+      it 'is available in development as soon as a password is set, even the insecure default' do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SUPERSET_ADMIN_PASS').and_return('admin')
+
+        expect(described_class.available?).to eq(true)
+      end
+
+      it 'is unavailable outside development when the password is still the insecure default' do
+        allow(Rails.env).to receive(:development?).and_return(false)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SUPERSET_ADMIN_PASS').and_return('admin')
+
+        expect(described_class.available?).to eq(false)
+      end
+
+      it 'is available outside development when a non-default password is set' do
+        allow(Rails.env).to receive(:development?).and_return(false)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SUPERSET_ADMIN_PASS').and_return('a-real-password')
+
+        expect(described_class.available?).to eq(true)
+      end
+    end
+
+    context 'under AuthMethod.devise?' do
+      before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
+
+      it 'checks for a Doorkeeper::Application configured for the Superset redirect URI' do
+        a_t = Doorkeeper::Application.arel_table
+        relation = instance_double(ActiveRecord::Relation, exists?: true)
+        allow(Doorkeeper::Application).to receive(:where).with(a_t[:redirect_uri].matches("%#{described_class.superset_base_url}%")).and_return(relation)
+
+        expect(described_class.available?).to eq(true)
+      end
+
+      it 'is unavailable with no matching Doorkeeper::Application' do
+        relation = instance_double(ActiveRecord::Relation, exists?: false)
+        allow(Doorkeeper::Application).to receive(:where).and_return(relation)
+
+        expect(described_class.available?).to eq(false)
+      end
+    end
+  end
+
   describe '.available_superset_roles' do
     context 'when Superset is not configured' do
       before { allow(api).to receive(:available?).and_return(false) }

--- a/drivers/superset/spec/models/superset_spec.rb
+++ b/drivers/superset/spec/models/superset_spec.rb
@@ -13,8 +13,32 @@ RSpec.describe Superset do
 
   before do
     allow(Superset::Api).to receive(:new).and_return(api)
-    allow(Sentry).to receive(:initialized?).and_return(true)
-    allow(Sentry).to receive(:capture_exception_with_info)
+  end
+
+  describe '.superset_base_url' do
+    it 'splices "superset" into the FQDN when SUPERSET_FQDN is unset' do
+      # SUPERSET_FQDN is unset in the test env, so the second fetch falls through to the
+      # spliced default; only FQDN needs stubbing.
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('FQDN', anything).and_return('warehouse.example.org')
+
+      expect(described_class.superset_base_url).to eq('https://warehouse.superset.example.org')
+    end
+
+    it 'uses SUPERSET_FQDN verbatim when set' do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('SUPERSET_FQDN', anything).and_return('dashboards.example.org')
+
+      expect(described_class.superset_base_url).to eq('https://dashboards.example.org')
+    end
+  end
+
+  describe '.warehouse_login_url' do
+    it 'points at the URL-encoded warehouse login provider path' do
+      allow(described_class).to receive(:superset_base_url).and_return('https://superset.example.test')
+
+      expect(described_class.warehouse_login_url).to eq('https://superset.example.test/login/The%20Warehouse')
+    end
   end
 
   describe '.available?' do
@@ -56,20 +80,56 @@ RSpec.describe Superset do
     context 'under AuthMethod.devise?' do
       before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
 
-      it 'checks for a Doorkeeper::Application configured for the Superset redirect URI' do
-        a_t = Doorkeeper::Application.arel_table
-        relation = instance_double(ActiveRecord::Relation, exists?: true)
-        allow(Doorkeeper::Application).to receive(:where).with(a_t[:redirect_uri].matches("%#{described_class.superset_base_url}%")).and_return(relation)
+      it 'is available when a Doorkeeper::Application is registered for the Superset host' do
+        Doorkeeper::Application.create!(
+          name: 'Superset',
+          redirect_uri: "#{described_class.superset_base_url}/oauth/authorize",
+        )
 
         expect(described_class.available?).to eq(true)
       end
 
-      it 'is unavailable with no matching Doorkeeper::Application' do
-        relation = instance_double(ActiveRecord::Relation, exists?: false)
-        allow(Doorkeeper::Application).to receive(:where).and_return(relation)
+      it 'is unavailable when the only registered Doorkeeper::Application points elsewhere' do
+        Doorkeeper::Application.create!(
+          name: 'Unrelated',
+          redirect_uri: 'https://unrelated.example.test/oauth/authorize',
+        )
 
         expect(described_class.available?).to eq(false)
       end
+    end
+  end
+
+  describe '.available_to_user?' do
+    # The report definition the Superset gate keys off of; present in every example so that a
+    # `false` result is attributable to the authorization scope, not to missing data.
+    let!(:report_definition) { create(:op_analytics_report) }
+    let(:user) { create(:acl_user) }
+    let(:role) { create(:role, can_view_assigned_reports: true) }
+    let(:collection) { create(:collection) }
+
+    # Isolate the per-user authorization decision; .available? has its own coverage above.
+    before { allow(described_class).to receive(:available?).and_return(true) }
+
+    it 'is available to a user granted access to the Superset report definition' do
+      setup_access_control(user, role, collection)
+      collection.set_viewables({ reports: [report_definition.id] })
+
+      expect(described_class.available_to_user?(user)).to eq(true)
+    end
+
+    it 'is unavailable to a user who has not been granted the Superset report definition' do
+      # report_definition exists but is granted to no one, so only the viewable_by(user)
+      # guard — not absent data — makes this false.
+      expect(described_class.available_to_user?(user)).to eq(false)
+    end
+
+    it 'is unavailable when Superset itself is unavailable, even for a permitted user' do
+      setup_access_control(user, role, collection)
+      collection.set_viewables({ reports: [report_definition.id] })
+      allow(described_class).to receive(:available?).and_return(false)
+
+      expect(described_class.available_to_user?(user)).to eq(false)
     end
   end
 
@@ -116,23 +176,29 @@ RSpec.describe Superset do
     end
 
     context 'when Superset is configured but API raises HostResolutionError' do
+      let(:error) { Curl::Err::HostResolutionError.new('could not resolve') }
+
       before do
         allow(api).to receive(:available?).and_return(true)
-        allow(api).to receive(:roles).and_raise(Curl::Err::HostResolutionError.new('could not resolve'))
+        allow(api).to receive(:roles).and_raise(error)
       end
 
-      it 'returns default roles' do
+      it 'reports the error and returns default roles' do
+        expect(UnifiedErrorReporter).to receive(:call).with(error, a_string_matching(/Superset roles/))
         expect(described_class.available_superset_roles).to eq(described_class.default_roles)
       end
     end
 
     context 'when Superset is configured but API returns unparseable JSON' do
+      let(:error) { JSON::ParserError.new('unexpected token') }
+
       before do
         allow(api).to receive(:available?).and_return(true)
-        allow(api).to receive(:roles).and_raise(JSON::ParserError.new('unexpected token'))
+        allow(api).to receive(:roles).and_raise(error)
       end
 
-      it 'returns default roles' do
+      it 'reports the error and returns default roles' do
+        expect(UnifiedErrorReporter).to receive(:call).with(error, a_string_matching(/Superset roles/))
         expect(described_class.available_superset_roles).to eq(described_class.default_roles)
       end
     end

--- a/spec/models/idp/jwt_helper_spec.rb
+++ b/spec/models/idp/jwt_helper_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
       bad_aud_helper = described_class.new(access_token: bad_aud_token)
       expect(bad_aud_helper.valid?).to be false
     end
+
+    it 'fails closed (and reports to Sentry) when the JWKS endpoint is unreachable' do
+      allow(described_class).to receive(:fetch_jwks).and_raise(SocketError.new('getaddrinfo: Name or service not known'))
+      expect(Sentry).to receive(:capture_exception_with_info).with(instance_of(SocketError), anything)
+
+      expect(helper.valid?).to be false
+    end
   end
 
   describe '#payload' do

--- a/spec/requests/api/superset_jwt_wiring_spec.rb
+++ b/spec/requests/api/superset_jwt_wiring_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe 'Superset JWT wiring', type: :request do
       # Stub at the Idp::JwtHelper boundary (as the connection.rb/wiring specs do) rather than
       # handing the real class a malformed string: WebMock.allow_net_connect! is on globally, so an
       # unstubbed token would try a real JWKS fetch instead of exercising this controller's 401 path.
-      invalid_helper = instance_double(Idp::JwtHelper, token?: true, valid?: false)
+      # active_user_from_token gates on valid? before touching find_from_jwt, so valid?: false is the
+      # only stub this path exercises.
+      invalid_helper = instance_double(Idp::JwtHelper, valid?: false)
       allow(Idp::JwtHelper).to receive(:new).with(access_token: 'not-a-real-token').and_return(invalid_helper)
 
       get '/api/superset/user_roles', headers: { 'Authorization' => 'Bearer not-a-real-token' }
@@ -49,15 +51,15 @@ RSpec.describe 'Superset JWT wiring', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    it 'returns 401 for an expired (no longer valid) token' do
-      token = sign_in(user)
-      # sign_in stubs Idp::JwtHelper.new to return a single shared double for this token, so the
-      # instance below IS the one the controller resolves. Re-stubbing valid? on it to false makes
-      # an otherwise-good token read as expired.
-      controller_helper = Idp::JwtHelper.new(access_token: token)
-      allow(controller_helper).to receive(:valid?).and_return(false)
+    it 'returns 401 when a valid token resolves to no user' do
+      # Distinct from the invalid-token path: here valid? is true, so active_user_from_token proceeds
+      # to find_from_jwt, which finds nothing. Proves the unresolved-user branch fails closed (401)
+      # rather than crashing on current_user.id (500) or authenticating a nil user.
+      resolvable_helper = instance_double(Idp::JwtHelper, valid?: true)
+      allow(Idp::JwtHelper).to receive(:new).with(access_token: 'orphan-token').and_return(resolvable_helper)
+      allow(User).to receive(:find_from_jwt).with(resolvable_helper).and_return(nil)
 
-      get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
+      get '/api/superset/user_roles', headers: { 'Authorization' => 'Bearer orphan-token' }
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -77,8 +79,10 @@ RSpec.describe 'Superset JWT wiring', type: :request do
     # JSON. Prove those filters are not in the chain, so a user with a pending compliance
     # requirement still gets 200 + JSON.
     it 'still returns the JSON payload when the resolved user has outstanding onboarding' do
-      allow_any_instance_of(User).to receive(:pending_compliance_requirements).and_return([double('requirement')])
       token = sign_in(user)
+      # find_from_jwt resolves current_user to this exact `user` object (see the sign_in helper), so
+      # stub the instance the controller actually holds rather than reaching for allow_any_instance_of.
+      allow(user).to receive(:pending_compliance_requirements).and_return([double('requirement')])
 
       get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
 

--- a/spec/requests/api/superset_jwt_wiring_spec.rb
+++ b/spec/requests/api/superset_jwt_wiring_spec.rb
@@ -1,0 +1,101 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Proves the /api/superset/user_roles route + Api::SupersetController are wired correctly under
+# AUTH_METHOD=jwt: a valid bearer token resolves the user read-only (no provisioning) and returns
+# the role payload Superset needs; the route is entirely absent under Devise, mirroring how
+# /oauth/user-data is absent under JWT (spec/requests/idp/warehouse_jwt_wiring_spec.rb).
+RSpec.describe 'Superset JWT wiring', type: :request do
+  describe 'GET /api/superset/user_roles', if: AuthMethod.jwt? do
+    let(:user) { create(:user, superset_roles: ['Report Runner']) }
+
+    it 'returns the role payload for a valid bearer token' do
+      token = sign_in(user)
+
+      get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        'id' => user.id,
+        'first_name' => user.first_name,
+        'last_name' => user.last_name,
+        'email' => user.email,
+        'superset_roles' => user.superset_roles,
+      )
+    end
+
+    it 'returns 401 with no bearer token' do
+      get '/api/superset/user_roles'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 401 with an invalid token' do
+      # Stub at the Idp::JwtHelper boundary (as the connection.rb/wiring specs do) rather than
+      # handing the real class a malformed string: WebMock.allow_net_connect! is on globally, so an
+      # unstubbed token would try a real JWKS fetch instead of exercising this controller's 401 path.
+      invalid_helper = instance_double(Idp::JwtHelper, token?: true, valid?: false)
+      allow(Idp::JwtHelper).to receive(:new).with(access_token: 'not-a-real-token').and_return(invalid_helper)
+
+      get '/api/superset/user_roles', headers: { 'Authorization' => 'Bearer not-a-real-token' }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 401 for an expired (no longer valid) token' do
+      token = sign_in(user)
+      # sign_in stubs Idp::JwtHelper.new to return a single shared double for this token, so the
+      # instance below IS the one the controller resolves. Re-stubbing valid? on it to false makes
+      # an otherwise-good token read as expired.
+      controller_helper = Idp::JwtHelper.new(access_token: token)
+      allow(controller_helper).to receive(:valid?).and_return(false)
+
+      get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 401 for an inactive user with an otherwise-valid token' do
+      user.update!(active: false)
+      token = sign_in(user)
+
+      get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    # Regression guard: Superset forwards a live end-user token, so the resolved user may have
+    # outstanding onboarding. If this endpoint rode ApplicationController, require_training! /
+    # require_compliance_agreement! would redirect (302 -> HTML) instead of returning the role
+    # JSON. Prove those filters are not in the chain, so a user with a pending compliance
+    # requirement still gets 200 + JSON.
+    it 'still returns the JSON payload when the resolved user has outstanding onboarding' do
+      allow_any_instance_of(User).to receive(:pending_compliance_requirements).and_return([double('requirement')])
+      token = sign_in(user)
+
+      get '/api/superset/user_roles', headers: { 'Authorization' => "Bearer #{token}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include('superset_roles' => user.superset_roles)
+    end
+  end
+
+  describe 'route surface' do
+    it 'mounts /api/superset/user_roles only under JWT' do
+      if AuthMethod.jwt?
+        expect(Rails.application.routes.recognize_path('/api/superset/user_roles', method: :get)).
+          to include(controller: 'api/superset', action: 'user_roles')
+      else
+        expect { Rails.application.routes.recognize_path('/api/superset/user_roles', method: :get) }.
+          to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

### Description

[superset pr](https://github.com/greenriver/superset-sync/pull/617)

Adds a JWT-authenticated `/api/superset/user_roles` endpoint so Superset can look up a user's roles when the warehouse runs under `AUTH_METHOD=jwt` (dex/oauth2-proxy), mirroring the Doorkeeper-gated `oauth/user-data` path used under Devise.

- **Superset Role Endpoint**: New `Api::SupersetController#user_roles` returns the user's id, name, email, and `superset_roles` as JSON for machine-to-machine calls from Superset.
- **Bearer Token Authentication**: New `Api::BearerTokenController` base validates an `Authorization: Bearer <JWT>` header via `Idp::JwtHelper` and resolves the user read-only (`User.find_from_jwt`, no provisioning), rejecting missing/invalid/expired tokens and inactive users with 401. Rides `ActionController::Base` rather than `ApplicationController` to avoid the interactive filter chain (training/compliance/2FA redirects and activity logging) that would break an M2M caller.
- **Routing**: `superset/user_roles` route is mounted only when `AuthMethod.jwt?`. oauth2-proxy config skips auth on this path since the backend validates the JWT.
- **Doorkeeper**: Initializer now short-circuits unless `AuthMethod.devise?`, so Doorkeeper is not configured under JWT.
- **Superset Availability**: `Superset.available?` under JWT keys off `SUPERSET_ADMIN_PASS` (any value in development; a non-default value elsewhere) instead of looking for a matching Doorkeeper application.
- **JWKS Failure Handling**: `Idp::JwtHelper#valid?` now fails closed (returns false, 401) and reports to Sentry when the JWKS endpoint is unreachable, instead of letting a network error surface as a 500.
- **Test Coverage**: Adds request specs for the endpoint's auth paths and route surface, `Superset.available?` specs for both auth methods, and a JWKS-unreachable spec; wires the new request spec into the JWT CI job.

### Type of Change
New feature
## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

