### PR TITLE
fix: restrict VAMC station DQ check to HoH only

### DIFF
--- a/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
+++ b/drivers/hmis_data_quality_tool/app/models/hmis_data_quality_tool/enrollment.rb
@@ -845,10 +845,14 @@ module HmisDataQualityTool
             !item.target_screen_completed
           },
         },
+        # V6 VAMC Station Number — FY2026 VA Data Guide
+        # Required (R) for: SSVF RRH, SSVF HP, all HCHV, all GPD projects.
+        # Applies to HoH only: "VAMCStation Should not be null when RelationshipToHoH = 1"
+        # Note: HP project type is currently excluded from this check — see follow-up issue.
         vamc_station: {
           title: 'VAMC Station Number is Missing',
           description: 'VAMC Station Number is missing or not collected',
-          required_for: 'HoH and Veteran in ES (E/E), TH, PSH, SO, SH, PH-Housing Only, and RRH',
+          required_for: 'HoH in ES (E/E), TH, PSH, SO, SH, PH-Housing Only, and RRH',
           detail_columns: default_detail_columns + [
             :vamc_station,
           ],
@@ -870,12 +874,13 @@ module HmisDataQualityTool
               HudHelper.util.performance_reporting[:rrh],
             ].flatten.include?(item.project_type)
 
-            # Only hohs or veterans that include the above funder(s) and project type(s)
-            (hoh?(item) || item.veteran == 1) && in_project_types && (funding_sources & item.funders).any?
+            # VA Data Guide: "VAMCStation Should not be null when RelationshipToHoH = 1"
+            # Non-HoH household members (including veterans) are not required to have a VAMC station.
+            hoh?(item) && in_project_types && (funding_sources & item.funders).any?
           },
           limiter: ->(item) {
-            # HoHs or Veterans
-            return false unless hoh?(item) || item.veteran == 1
+            # HoHs
+            return false unless hoh?(item)
 
             # Limit to items with intersecting funders below
             funding_sources = [

--- a/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
+++ b/drivers/hmis_data_quality_tool/spec/models/hmis_data_quality_tool/enrollment_metrics_spec.rb
@@ -1495,5 +1495,86 @@ RSpec.describe HmisDataQualityTool::Report, type: :model do
         end
       end
     end
+
+    describe 'VAMC Station Number' do
+      # Project type 13 = RRH; Funder 33 = VA: SSVF — both required to enter denominator
+      context 'HoH with missing VAMC station' do
+        before do
+          @project = create_project(project_type: 13) # RRH
+          create(:hud_funder, data_source: data_source, ProjectID: @project.ProjectID, Funder: 33)
+          @client = create_client_with_warehouse_link
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            relationship_to_ho_h: 1, # HoH
+          )
+          @enrollment.update(VAMCStation: nil)
+          @report = setup_report([@project.id])
+        end
+
+        it 'flags the enrollment' do
+          expect_result(key: :vamc_station, total: 1, invalid_count: 1)
+        end
+      end
+
+      context 'HoH with valid VAMC station' do
+        before do
+          @project = create_project(project_type: 13) # RRH
+          create(:hud_funder, data_source: data_source, ProjectID: @project.ProjectID, Funder: 33)
+          @client = create_client_with_warehouse_link
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            relationship_to_ho_h: 1, # HoH
+          )
+          # 402 is a valid VAMC station number
+          @enrollment.update(VAMCStation: 402)
+          @report = setup_report([@project.id])
+        end
+
+        it 'does not flag the enrollment' do
+          expect_result(key: :vamc_station, total: 1, invalid_count: 0)
+        end
+      end
+
+      context 'non-HoH veteran with missing VAMC station' do
+        before do
+          @project = create_project(project_type: 13) # RRH
+          create(:hud_funder, data_source: data_source, ProjectID: @project.ProjectID, Funder: 33)
+          @client = create_client_with_warehouse_link(veteran_status: 1) # veteran
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            relationship_to_ho_h: 99, # non-HoH
+          )
+          @enrollment.update(VAMCStation: nil)
+          @report = setup_report([@project.id])
+        end
+
+        it 'does not flag the enrollment' do
+          # total: 0 because non-HoH should not be in the denominator at all
+          expect_result(key: :vamc_station, total: 0, invalid_count: 0)
+        end
+      end
+
+      context 'non-HoH non-veteran with missing VAMC station' do
+        before do
+          @project = create_project(project_type: 13) # RRH
+          create(:hud_funder, data_source: data_source, ProjectID: @project.ProjectID, Funder: 33)
+          @client = create_client_with_warehouse_link
+          @enrollment = create_enrollment(
+            client: @client,
+            project: @project,
+            relationship_to_ho_h: 99, # non-HoH
+          )
+          @enrollment.update(VAMCStation: nil)
+          @report = setup_report([@project.id])
+        end
+
+        it 'does not flag the enrollment' do
+          expect_result(key: :vamc_station, total: 0, invalid_count: 0)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

The HMIS Data Quality Tool was incorrectly flagging veterans who are not the Head of Household (HoH) for a missing VAMC Station Number. Per HUD and VA guidance, this field is only required for the HoH — other household members, including veterans, are not expected to provide it.

This fix removes non-HoH veterans from the check entirely, so they no longer appear in the flagged count or the denominator. The `required_for` label in the report UI has been updated to reflect this. Four new automated tests confirm the corrected behavior.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [X] I have provided testing instructions in this PR or the related issue (or not applicable)

[//]: # NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected
