### PR TITLE
Exclude non-continuum projects from CE APR FY2026 Q4

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/question_four.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/question_four.rb
@@ -19,17 +19,21 @@ module HudApr::Generators::CeApr::Fy2026
       @report.complete(QUESTION_NUMBER)
     end
 
-    # CE APR should only include projects where there are assessments or events within the range
-    # as noted in the spec:
-    # Be sure to include data on all projects with clients and enrollments included on any question in this APR.
+    # Q4 lists all projects in the CE APR report universe (spec step 2: projects in the chosen CoC
+    # with ContinuumProject = 1 and active CE participation). active_project_ids (from the generator)
+    # computes this universe by requiring assessments or events in range; if none qualify, we fall back
+    # to the full report project list. Either way, .continuum_project enforces step 1.a
+    # (ContinuumProject = 1) so non-continuum projects can never appear in Q4.
     private def q4_project_scope
       active_project_ids = @generator.active_project_ids
+      # active_project_ids is empty when no projects have qualifying assessments/events;
+      # fall back to the full report selection so Q4 still lists participating projects.
       active_project_ids = if active_project_ids.blank?
         @report.project_ids
       else
         active_project_ids & @report.project_ids
       end
-      GrdaWarehouse::Hud::Project.where(id: active_project_ids)
+      GrdaWarehouse::Hud::Project.where(id: active_project_ids).continuum_project # step 1.a: ContinuumProject = 1
     end
   end
 end

--- a/drivers/hud_apr/spec/models/fy2026/shared/question_four_spec.rb
+++ b/drivers/hud_apr/spec/models/fy2026/shared/question_four_spec.rb
@@ -122,3 +122,55 @@ RSpec.describe HudApr::Generators::Shared::Fy2026::QuestionFour do
     end
   end
 end
+
+RSpec.describe HudApr::Generators::CeApr::Fy2026::QuestionFour do
+  let(:report) { create(:hud_reports_report_instance) }
+  let!(:data_source) { create(:source_data_source) }
+  let(:generator) { HudApr::Generators::CeApr::Fy2026::Generator.new(report) }
+  let(:question) { described_class.new(generator, report) }
+
+  describe '#q4_project_scope' do
+    context 'when active_project_ids is empty (fallback path)' do
+      before do
+        allow(generator).to receive(:active_project_ids).and_return([])
+      end
+
+      it 'excludes projects where ContinuumProject = 0' do
+        project = create(:grda_warehouse_hud_project, data_source: data_source, ContinuumProject: 0)
+        allow(report).to receive(:project_ids).and_return([project.id])
+
+        result = question.send(:q4_project_scope)
+        expect(result.pluck(:id)).not_to include(project.id)
+      end
+
+      it 'excludes projects where ContinuumProject is nil' do
+        project = create(:grda_warehouse_hud_project, data_source: data_source, ContinuumProject: nil)
+        allow(report).to receive(:project_ids).and_return([project.id])
+
+        result = question.send(:q4_project_scope)
+        expect(result.pluck(:id)).not_to include(project.id)
+      end
+
+      it 'includes projects where ContinuumProject = 1' do
+        project = create(:grda_warehouse_hud_project, data_source: data_source, ContinuumProject: 1)
+        allow(report).to receive(:project_ids).and_return([project.id])
+
+        result = question.send(:q4_project_scope)
+        expect(result.pluck(:id)).to include(project.id)
+      end
+    end
+
+    context 'when active_project_ids is non-empty (normal path)' do
+      it 'excludes projects where ContinuumProject = 0 even when returned by active_project_ids' do
+        non_continuum = create(:grda_warehouse_hud_project, data_source: data_source, ContinuumProject: 0)
+        continuum = create(:grda_warehouse_hud_project, data_source: data_source, ContinuumProject: 1)
+        allow(generator).to receive(:active_project_ids).and_return([non_continuum.id, continuum.id])
+        allow(report).to receive(:project_ids).and_return([non_continuum.id, continuum.id])
+
+        result = question.send(:q4_project_scope)
+        expect(result.pluck(:id)).not_to include(non_continuum.id)
+        expect(result.pluck(:id)).to include(continuum.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

`q4_project_scope` in the FY2026 CE APR `QuestionFour` override had a fallback: when `active_project_ids` returned an empty array (no projects with qualifying CE assessments/events), it fell  back to `@report.project_ids` — the raw user-selected project list — which is not filtered by `ContinuumProject`. This allowed projects with `ContinuumProject = 0` or `NULL` to appear in Q4 with 0 clients.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [X] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

