### PR TITLE
Fix HMIS System Test Timezone

### DIFF
--- a/drivers/hmis/spec/system/hmis/timezone_alignment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/timezone_alignment_spec.rb
@@ -1,0 +1,80 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Proves that the headless browser, Ferrum, and Rails all agree on the timezone, so date
+# defaults/comparisons in system tests don't drift by a day when CI runs near the UTC boundary.
+# See spec/support/e2e_tests.rb (env: { 'TZ' => ... }) for the fix these tests guard.
+RSpec.feature 'System test timezone alignment', type: :system do
+  # Read the browser's IANA timezone identifier (what Chromium/ICU resolved it to).
+  def browser_timezone
+    page.evaluate_script('Intl.DateTimeFormat().resolvedOptions().timeZone')
+  end
+
+  # Read the browser's current local date as an ISO 'YYYY-MM-DD' string.
+  def browser_current_date
+    page.evaluate_script("new Date().toLocaleDateString('en-CA')")
+  end
+
+  # The browser's date must equal Rails' current date. Guard against the (vanishingly rare) case
+  # of crossing local midnight between the two reads by accepting either side of the boundary.
+  def expect_browser_date_to_match_rails
+    before_date = Date.current
+    actual = browser_current_date
+    after_date = Date.current
+    expect([before_date.iso8601, after_date.iso8601]).to include(actual)
+  end
+
+  it 'runs the browser in the same timezone as Rails (America/New_York in CI)' do
+    visit '/' # any page will do; we only need a JS context
+
+    # The core, deterministic guard: before the fix the browser resolved to UTC (its container's
+    # system zone) while Rails uses America/New_York, so these identifiers differed on every run.
+    expect(browser_timezone).to eq(Time.zone.tzinfo.identifier)
+
+    expect_browser_date_to_match_rails
+  end
+
+  # Force Rails onto a zone that is currently on a *different calendar date than UTC*, launch a
+  # browser configured for that same zone (via the same TZ-env mechanism as the fix), and prove
+  # the test's "today" follows Rails rather than falling back to UTC.
+  it 'uses the current date from Rails, not UTC, when the two are on different days' do
+    # UTC+14 and UTC-12 are fixed-offset zones (no DST). At any instant at least one of them is on
+    # a different calendar day than UTC, so this test is deterministic regardless of wall-clock.
+    utc_today = Time.now.getutc.to_date
+    zone = ['Pacific/Kiritimati', 'Etc/GMT+12'].find do |z|
+      Time.find_zone!(z).now.to_date != utc_today
+    end
+    expect(zone).to be_present, 'expected one extreme zone to differ from UTC (should always hold)'
+
+    driver_name = :cuprite_tz_probe
+    Capybara.register_driver(driver_name) do |app|
+      Capybara::Cuprite::Driver.new(
+        app,
+        headless: true,
+        browser_path: ENV.fetch('CHROMIUM_PATH', '/usr/bin/chromium'),
+        browser_options: { 'no-sandbox' => nil, 'disable-dev-shm-usage' => nil },
+        env: { 'TZ' => zone }, # same mechanism as the real driver: set the browser's OS timezone
+      )
+    end
+
+    Time.use_zone(zone) do
+      Capybara.using_driver(driver_name) do
+        visit '/'
+
+        # The browser agrees with Rails' current date... (identifier equality is covered by the
+        # first test; here we assert on dates because ICU may canonicalize an Etc/* zone name.)
+        expect_browser_date_to_match_rails
+
+        # ...and that date is genuinely NOT the UTC date, proving we aren't silently on UTC.
+        expect(browser_current_date).not_to eq(Time.now.getutc.to_date.iso8601)
+      end
+    end
+  end
+end

--- a/drivers/hmis/spec/system/hmis/timezone_alignment_spec.rb
+++ b/drivers/hmis/spec/system/hmis/timezone_alignment_spec.rb
@@ -17,7 +17,9 @@ RSpec.feature 'System test timezone alignment', type: :system do
     page.evaluate_script('Intl.DateTimeFormat().resolvedOptions().timeZone')
   end
 
-  # Read the browser's current local date as an ISO 'YYYY-MM-DD' string.
+  # Read the browser's current local date as an ISO 'YYYY-MM-DD' string. The 'en-CA' locale is a
+  # deliberate idiom for ISO formatting (YYYY-MM-DD) so it matches Ruby's Date#iso8601 below; it is
+  # not about Canada. ('en-US' would give M/D/YYYY and never match.)
   def browser_current_date
     page.evaluate_script("new Date().toLocaleDateString('en-CA')")
   end

--- a/spec/support/e2e_tests.rb
+++ b/spec/support/e2e_tests.rb
@@ -95,7 +95,12 @@ module E2eTests
           logger: FerrumLogger.new,
           inspector: ENV.key?('CHROME_DEBUGGING_PORT'),
           browser_path: ENV.fetch('CHROMIUM_PATH', '/usr/bin/chromium'),
-          timezone_id: 'America/New_York', # Match Rails timezone to avoid date mismatches after midnight UTC
+          # Match the browser's timezone to Rails so date defaults/comparisons don't drift by a
+          # day when CI runs near the UTC date boundary. Ferrum ignores the `timezone_id` option,
+          # so we set TZ in the browser subprocess env (Chromium reads TZ). Without this the
+          # browser falls back to the container's system zone (UTC in CI) while Rails uses
+          # config.time_zone (America/New_York), so evening-Eastern runs render "tomorrow".
+          env: { 'TZ' => Time.zone.tzinfo.identifier },
         }
       end
 

--- a/spec/support/rails_system_setup.rb
+++ b/spec/support/rails_system_setup.rb
@@ -37,6 +37,11 @@ if rails_system_enabled
       timeout: ENV.fetch('FERRUM_DEFAULT_TIMEOUT', 30).to_i,           # Configurable timeout for slow asset loading
       process_timeout: ENV.fetch('FERRUM_PROCESS_TIMEOUT', 60).to_i,   # Configurable process timeout
       pending_connection_errors: false, # Ignore pending connection errors
+      # Match the browser's timezone to Rails so date defaults/comparisons don't drift by a day
+      # when CI runs near the UTC date boundary. Chromium reads TZ from its process env; without
+      # this it falls back to the container's system zone (UTC in CI) while Rails uses
+      # config.time_zone (America/New_York).
+      env: { 'TZ' => Time.zone.tzinfo.identifier },
       browser_options: {
         'no-sandbox' => nil,
         'disable-gpu' => nil,


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Ferrum 0.17 ignores the `timezone_id` option, so headless Chromium ran in the container's system zone (UTC in CI) while Rails uses America/New_York.  Runs near the UTC date boundary rendered dates a day ahead of the server.  Set TZ in the browser subprocess env (which Chromium reads)

Also adds a test `drivers/hmis/spec/system/hmis/timezone_alignment_spec.rb` to prove the browser is running in the same timezone as rails (moving rails to a timezone that would be 1 day off from UTC.)

This should prevent [things like this](https://github.com/greenriver/hmis-warehouse/actions/runs/29667635846/job/88140889959?pr=6716) from creeping in, where when the test suite was run later in the evening in the NY timezone, UTC had already passed midnight and the browser and rails didn't agree on the date.

Notes on why this should work from AI (minimally validated):

Ferrum :env option (the mechanism the fix relies on) — Ferrum README, "Customization" section:
- https://docs.rubycdp.com/docs/ferrum/customization
- It documents exactly: ":env (Hash) - Environment variables you'd like to pass through to the process" — and notably lists no timezone option.

Ferrum source confirming the behavior (v0.17.1, the version we lock):
- Recognized options (no timezone_id): https://github.com/rubycdp/ferrum/blob/v0.17.1/lib/ferrum/browser/options.rb
- :env passed to Process.spawn for the browser subprocess: https://github.com/rubycdp/ferrum/blob/v0.17.1/lib/ferrum/browser/process.rb

TZ environment variable (how Chromium/its ICU picks up the zone) — this is the standard POSIX/glibc TZ variable that the Chromium process inherits from its environment:
- GNU libc manual, "TZ Variable": https://sourceware.org/glibc/manual/latest/html_node/TZ-Variable.html

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

