### PR TITLE
1. Remove vestigial CarrierWave mount_uploader from six models

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -139,7 +139,6 @@ Layout/EmptyLinesAroundClassBody:
     - 'app/models/grda_warehouse/cas_vacancy.rb'
     - 'app/models/grda_warehouse/client_merge_history.rb'
     - 'app/models/grda_warehouse/cohort_copier.rb'
-    - 'app/models/grda_warehouse/dashboard_export_file.rb'
     - 'app/models/grda_warehouse/eto_qaaws/subject_response_lookup.rb'
     - 'app/models/grda_warehouse/federal_census_breakdowns/base.rb'
     - 'app/models/grda_warehouse/generate_service_history_batch_log.rb'
@@ -205,7 +204,6 @@ Layout/EmptyLinesAroundClassBody:
     - 'app/models/health/team/pcp_designee.rb'
     - 'app/models/health/team/provider.rb'
     - 'app/models/health/team/representative.rb'
-    - 'app/models/import.rb'
     - 'app/models/program.rb'
     - 'app/models/report_generators/data_quality/fy2017/base.rb'
     - 'app/models/report_results_summaries/ahar/base.rb'
@@ -492,7 +490,6 @@ Layout/SpaceAroundOperators:
     - 'app/models/grda_warehouse/warehouse_reports/confidential_touch_point.rb'
     - 'app/models/grda_warehouse/warehouse_reports/touch_point.rb'
     - 'app/models/health/transaction_acknowledgement.rb'
-    - 'app/models/import.rb'
     - 'app/models/report_result.rb'
     - 'app/models/similarity_metric/experiment/metric_score_histogram.rb'
     - 'app/models/similarity_metric/experiment/score_histogram.rb'
@@ -1045,7 +1042,6 @@ Style/HashSyntax:
 # Configuration parameters: AllowIfModifier.
 Style/IfInsideElse:
   Exclude:
-    - 'app/models/import.rb'
 
 # Offense count: 32
 # This cop supports safe autocorrection (--autocorrect).

--- a/app/models/grda_warehouse/client_file.rb
+++ b/app/models/grda_warehouse/client_file.rb
@@ -16,7 +16,6 @@ module GrdaWarehouse
 
     CONSENT_FORM_TAG_CACHE_KEY = 'consent_form_tagging_ids/tag_ids'
 
-    mount_uploader :file, FileUploader # This is probably no necessary, but added to be safe
     has_paper_trail
     acts_as_taggable
 

--- a/app/models/grda_warehouse/dashboard_export_file.rb
+++ b/app/models/grda_warehouse/dashboard_export_file.rb
@@ -8,7 +8,5 @@
 
 module GrdaWarehouse
   class DashboardExportFile < GrdaWarehouse::File
-    mount_uploader :file, FileUploader # Tells rails to use this uploader for this model.
-
   end
 end

--- a/app/models/grda_warehouse/hmis_export.rb
+++ b/app/models/grda_warehouse/hmis_export.rb
@@ -16,9 +16,6 @@ module GrdaWarehouse
     attr_accessor :enforce_project_date_scope
     # attr_accessor :zip_password
 
-    # attachment via CarrierWave
-    mount_uploader :file, HmisExportUploader
-
     # attachment via ActiveStorage
     has_one_attached :hmis_zip
 

--- a/app/models/grda_warehouse/report_result_file.rb
+++ b/app/models/grda_warehouse/report_result_file.rb
@@ -8,8 +8,6 @@
 
 module GrdaWarehouse
   class ReportResultFile < GrdaWarehouse::File
-    mount_uploader :file, FileUploader
-
     def save_zip_to(path)
       reconstitute_path = ::File.join(path, 'report_result.zip')
       FileUtils.mkdir_p(path) unless ::File.directory?(path)

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -11,9 +11,7 @@ class Import < ApplicationRecord
   include ActionView::Helpers::DateHelper
   acts_as_paranoid
 
-  mount_uploader :file, ImportUploader
   validates :source, presence: true
-  validates :file, presence: true
 
   def status
     if percent_complete == 0
@@ -29,15 +27,12 @@ class Import < ApplicationRecord
 
   def import_time
     if percent_complete == 100
-      seconds = ((completed_at - created_at)/1.minute).round * 60
+      seconds = ((completed_at - created_at) / 1.minute).round * 60
       distance_of_time_in_words(seconds)
+    elsif updated_at < 2.days.ago
+      'failed'
     else
-      if updated_at < 2.days.ago
-        'failed'
-      else
-        'processing...'
-      end
+      'processing...'
     end
   end
-
 end

--- a/drivers/tx_client_reports/app/models/tx_client_reports/research_exports/export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/research_exports/export.rb
@@ -8,7 +8,6 @@
 
 module TxClientReports
   class ResearchExports::Export < GrdaWarehouse::File
-    mount_uploader :file, FileUploader
     belongs_to :user
     belongs_to :file, class_name: 'GrdaWarehouse::File', optional: true
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Removes the unused `mount_uploader` declaration (and one now-dead `validates :file` presence check) from six models where CarrierWave is not on the active read/write path: `GrdaWarehouse::ClientFile`, `GrdaWarehouse::ReportResultFile`, `GrdaWarehouse::DashboardExportFile`, `GrdaWarehouse::HmisExport`, `TxClientReports::ResearchExports::Export`, and `Import`.

None of these models actually use CarrierWave's storage — they write file bytes to a `content` bytea column, use ActiveStorage instead (`HmisExport#hmis_zip`), or have no active upload path at all. Codebase-wide search confirmed no call site anywhere depends on CarrierWave's uploader-object behavior (`.file.url`, `.file.current_path`, etc.) for any of these six models, so removing the macro just lets `file` revert to being the plain varchar column attribute it already is underneath.

One model, `TxClientReports::ResearchExports::Export`, also declares `belongs_to :file, class_name: 'GrdaWarehouse::File'` on the same attribute name — removing `mount_uploader` lets that association take sole ownership of `.file`/`.file=`, which is safe since nothing reads/writes `.file` on this class today.

This is part 1 of a 5-part effort (issue #9043) to remove the CarrierWave gem entirely. The gem itself, its initializer/CVE patches, and the three uploader classes (`FileUploader`, `ImportUploader`, `HmisExportUploader`) must stay for now — they're still used by `GrdaWarehouse::PublicFile` and `GrdaWarehouse::NonHmisUpload` (later parts) and the health namespace (separate effort). No schema changes; the `file` columns are left in place with their existing data, just unread going forward on these six models.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

