### PR TITLE
2. Replace CarrierWave's PublicFile behavior with explicit code

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -694,7 +694,6 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/RedundantCopDisableDirective:
   Exclude:
     - 'app/controllers/warehouse_reports/missing_values_controller.rb'
-    - 'app/models/grda_warehouse/public_file.rb'
     - 'drivers/claims_reporting/app/models/hl7.rb'
     - 'drivers/hmis_csv_twenty_twenty/app/models/hmis_csv_twenty_twenty/hmis_csv_cleanup/enforce_relationship_to_hoh.rb'
     - 'drivers/hud_twenty_twenty_to_twenty_twenty_two/app/models/hud_twenty_twenty_to_twenty_twenty_two/aggregated_enrollment/update_r7_columns.rb'

--- a/app/controllers/admin/public_files_controller.rb
+++ b/app/controllers/admin/public_files_controller.rb
@@ -19,7 +19,9 @@ module Admin
 
     def create
       file = file_params[:file]
-      @file = file_source.create(file_params.merge(user_id: current_user.id, content: file&.read))
+      content = file&.read
+      content_type = Marcel::MimeType.for(content, name: file&.original_filename) if file
+      @file = file_source.create(file_params.merge(user_id: current_user.id, content: content, content_type: content_type, size: file&.size, file: file&.original_filename))
       if @file.invalid?
         flash[:error] = @file.errors.full_messages.join('; ') + params.inspect.to_s
         redirect_to admin_public_files_path

--- a/app/controllers/public_files_controller.rb
+++ b/app/controllers/public_files_controller.rb
@@ -10,7 +10,7 @@ class PublicFilesController < ApplicationController
   before_action :load_file
 
   def show
-    filename = @file.file&.file&.filename&.to_s || 'file'
+    filename = @file.file || @file.name || 'file'
     send_data(@file.content, type: @file.content_type, filename: filename)
   end
 

--- a/app/models/grda_warehouse/public_file.rb
+++ b/app/models/grda_warehouse/public_file.rb
@@ -9,15 +9,34 @@
 module GrdaWarehouse
   class PublicFile < GrdaWarehouse::File
     include ArelHelper
-    mount_uploader :file, FileUploader
     acts_as_taggable
+
+    CONTENT_TYPE_WHITELIST = IceNine.deep_freeze(
+      [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'application/pdf',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'text/csv',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/octet-stream',
+      ],
+    )
 
     validates_presence_of :name
     validate :file_exists_and_not_too_large
+    validate :content_type_allowed
 
     def file_exists_and_not_too_large
       errors.add :file, 'No uploaded file found' if (content&.size || 0) < 100
       errors.add :file, 'File size should be less than 4 MB' if (content&.size || 0) > 4.megabytes
+    end
+
+    def content_type_allowed
+      errors.add :file, 'File type not allowed' unless CONTENT_TYPE_WHITELIST.include?(content_type)
     end
 
     def self.known_locations
@@ -50,7 +69,7 @@ module GrdaWarehouse
     end
 
     def self.url_for_location location
-      if (id = order(id: :desc).where(name: location).pluck(:id)&.first) # rubocop:disable Style/GuardClause:
+      if (id = order(id: :desc).where(name: location).pluck(:id)&.first)
         Rails.application.routes.url_helpers.public_file_path(id: id)
       end
     end

--- a/app/views/admin/public_files/index.haml
+++ b/app/views/admin/public_files/index.haml
@@ -29,7 +29,7 @@
     %h4 Upload
     = simple_form_for @file, url: admin_public_files_path do |f|
       = f.input :name, collection: @file.class.known_locations.invert, label: false, as: :select_two
-      = f.input :file, label: false
+      = f.input :file, as: :file, label: false
       = f.button :submit, value: 'Upload File'
 
 

--- a/spec/models/grda_warehouse/public_file_spec.rb
+++ b/spec/models/grda_warehouse/public_file_spec.rb
@@ -1,0 +1,42 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::PublicFile, type: :model do
+  def valid_attributes(overrides = {})
+    {
+      name: 'client/hmis_consent',
+      content: 'x' * 200,
+      content_type: 'application/pdf',
+    }.merge(overrides)
+  end
+
+  it 'is valid with an allowed content type and acceptable size' do
+    file = described_class.new(valid_attributes)
+    expect(file).to be_valid
+  end
+
+  it 'is invalid with a disallowed content type' do
+    file = described_class.new(valid_attributes(content_type: 'application/zip'))
+    expect(file).not_to be_valid
+    expect(file.errors[:file]).to include('File type not allowed')
+  end
+
+  it 'is invalid when content is missing' do
+    file = described_class.new(valid_attributes(content: nil))
+    expect(file).not_to be_valid
+    expect(file.errors[:file]).to include('No uploaded file found')
+  end
+
+  it 'is invalid when content exceeds 4 megabytes' do
+    file = described_class.new(valid_attributes(content: 'x' * (4.megabytes + 1)))
+    expect(file).not_to be_valid
+    expect(file.errors[:file]).to include('File size should be less than 4 MB')
+  end
+end

--- a/spec/requests/admin/public_files_controller_spec.rb
+++ b/spec/requests/admin/public_files_controller_spec.rb
@@ -1,0 +1,77 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::PublicFilesController, type: :request do
+  let!(:user) { create :acl_user }
+  let!(:role) { create :admin_role }
+  let!(:collection) { create :collection }
+
+  before(:each) do
+    setup_access_control(user, role, collection)
+    sign_in user
+  end
+
+  describe 'GET #index' do
+    it 'renders a file upload input for the upload form' do
+      get admin_public_files_path
+      expect(response.body).to include('type="file"')
+    end
+  end
+
+  describe 'POST #create' do
+    let(:pdf_upload) do
+      Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/test.pdf'), 'application/pdf')
+    end
+
+    it 'creates a public file with content, content_type, and size set from the uploaded file' do
+      expect do
+        post admin_public_files_path, params: { grda_warehouse_public_file: { name: 'client/hmis_consent', file: pdf_upload } }
+      end.to change(GrdaWarehouse::PublicFile, :count).by(1)
+
+      file = GrdaWarehouse::PublicFile.last
+      expect(file.content_type).to eq('application/pdf')
+      expect(file.size).to eq(File.size(Rails.root.join('spec/fixtures/files/test.pdf')))
+      expect(file.content).to eq(File.binread(Rails.root.join('spec/fixtures/files/test.pdf')))
+      expect(file.file).to eq('test.pdf')
+      expect(response).to redirect_to(admin_public_files_path)
+    end
+
+    it 'rejects a disallowed content type' do
+      zip_upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/lsa/fy2019/sample_hmis_export.zip'), 'application/zip')
+
+      expect do
+        post admin_public_files_path, params: { grda_warehouse_public_file: { name: 'client/hmis_consent', file: zip_upload } }
+      end.not_to change(GrdaWarehouse::PublicFile, :count)
+
+      expect(response).to redirect_to(admin_public_files_path)
+      expect(flash[:error]).to include('File type not allowed')
+    end
+
+    it 'rejects a file over 4 megabytes' do
+      jpeg_bytes = File.binread(Rails.root.join('spec/fixtures/files/images/test_photo.jpg'))
+      padded_bytes = jpeg_bytes + ("\x00" * (4.megabytes + 1 - jpeg_bytes.bytesize))
+      tempfile = Tempfile.new(['oversized', '.jpg'])
+      tempfile.binmode
+      tempfile.write(padded_bytes)
+      tempfile.rewind
+      oversized_upload = Rack::Test::UploadedFile.new(tempfile.path, 'image/jpeg')
+
+      expect do
+        post admin_public_files_path, params: { grda_warehouse_public_file: { name: 'client/hmis_consent', file: oversized_upload } }
+      end.not_to change(GrdaWarehouse::PublicFile, :count)
+
+      expect(response).to redirect_to(admin_public_files_path)
+      expect(flash[:error]).to include('File size should be less than 4 MB')
+    ensure
+      tempfile&.close
+      tempfile&.unlink
+    end
+  end
+end

--- a/spec/requests/public_files_controller_spec.rb
+++ b/spec/requests/public_files_controller_spec.rb
@@ -1,0 +1,45 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PublicFilesController, type: :request do
+  let!(:user) { create :user }
+
+  before(:each) { sign_in user }
+
+  describe 'GET #show' do
+    it 'downloads using the stored filename when present' do
+      public_file = GrdaWarehouse::PublicFile.create!(
+        name: 'client/hmis_consent',
+        file: 'consent_form.pdf',
+        content: 'x' * 200,
+        content_type: 'application/pdf',
+      )
+
+      get public_file_path(id: public_file.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq('application/pdf')
+      expect(response.headers['Content-Disposition']).to include('consent_form.pdf')
+    end
+
+    it 'falls back to the name when no filename is stored' do
+      public_file = GrdaWarehouse::PublicFile.create!(
+        name: 'client/hmis_consent',
+        content: 'x' * 200,
+        content_type: 'application/pdf',
+      )
+
+      get public_file_path(id: public_file.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['Content-Disposition']).to include('client%2Fhmis_consent')
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Removes `mount_uploader` from `GrdaWarehouse::PublicFile` and replaces the three behaviors CarrierWave was providing on this active upload/download flow, with no intended change in user-facing behavior:

- **Content-type whitelist**: CarrierWave rejected disallowed file types at upload time via `FileUploader#content_type_whitelist`. `PublicFile` gains its own `CONTENT_TYPE_WHITELIST` constant (values copied from `FileUploader::WHITELIST`, plus `application/octet-stream`) and a `content_type_allowed` validation. It's inlined rather than referencing `FileUploader` so this validation has no dependency on the uploader classes a later part of #9043 deletes.
- **Metadata extraction**: `Admin::PublicFilesController#create` now reads the upload once, detects `content_type` via `Marcel::MimeType.for`, and passes `content_type`/`size`/`file` (the real original filename) through explicitly — previously CarrierWave's `extract_file_metadata!` process callback did this automatically.
- **Simple Form's file-input auto-detection**: Simple Form auto-renders CarrierWave-mounted attributes as file pickers. With `mount_uploader` gone, `app/views/admin/public_files/index.haml` needed an explicit `as: :file` to keep rendering a file input instead of a text box — this wasn't called out in the originating issue and was found while implementing.
- **Filename fallback**: `PublicFilesController#show`'s CarrierWave double-accessor pattern (`@file.file&.file&.filename`) is replaced with a plain `@file.file || @file.name || 'file'`, preferring the real filename over the semantic location-key fallback.

No schema changes — `PublicFile` stays on bytea storage (files are capped at 4MB). Added spec coverage for all three touched files, since none existed previously for this model despite it being an active, security-relevant upload path.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

