### PR TITLE
Keycloak API - ability to skip certification verification

### DIFF
--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -33,6 +33,7 @@ module Idp
             client_id: config.client_id,
             client_secret: config.service_token,
             realm: config.keycloak_realm,
+            skip_ssl_verification: config.skip_ssl_verification,
           })
     end
 
@@ -237,9 +238,18 @@ module Idp
     def build_http(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
+      # Some non-production Keycloak instances use self-signed certificates.
+      # Opt out of verification only when the config explicitly requests it.
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl? && skip_ssl_verification?
       http.open_timeout = 10
       http.read_timeout = 30
       http
+    end
+
+    # When true, TLS certificate verification is disabled for Keycloak requests.
+    # Intended for staging/dev environments with self-signed certificates only.
+    def skip_ssl_verification?
+      ActiveModel::Type::Boolean.new.cast(config[:skip_ssl_verification])
     end
 
     def fetch_token

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -247,7 +247,7 @@ module Idp
     end
 
     # When true, TLS certificate verification is disabled for Keycloak requests.
-    # Intended for staging/dev environments with self-signed certificates only.
+    # Intended for environments where the backend communication is secured with a self-signed certificate.
     def skip_ssl_verification?
       ActiveModel::Type::Boolean.new.cast(config[:skip_ssl_verification])
     end

--- a/db/migrate/20260720000000_add_skip_ssl_verification_to_idp_service_configs.rb
+++ b/db/migrate/20260720000000_add_skip_ssl_verification_to_idp_service_configs.rb
@@ -1,0 +1,15 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Allows an IDP config to opt out of TLS certificate verification, for
+# non-production instances that use self-signed certificates.
+class AddSkipSslVerificationToIdpServiceConfigs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :idp_service_configs, :skip_ssl_verification, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1150,7 +1150,8 @@ CREATE TABLE public.idp_service_configs (
     active boolean DEFAULT true NOT NULL,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    skip_ssl_verification boolean DEFAULT false NOT NULL
 );
 
 
@@ -4250,6 +4251,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260720000000'),
 ('20260715120000'),
 ('20260620000000'),
 ('20260614130000'),

--- a/spec/models/idp/service_config_spec.rb
+++ b/spec/models/idp/service_config_spec.rb
@@ -108,9 +108,21 @@ RSpec.describe Idp::ServiceConfig, type: :model do
       expect(service.send(:realm)).to eq('test-realm')
     end
 
+    it 'passes skip_ssl_verification through to the service config' do
+      config = create(:idp_service_config, provider: 'keycloak', skip_ssl_verification: true)
+
+      expect(config.to_service.config).to include(skip_ssl_verification: true)
+    end
+
     it 'raises ServiceError for an unregistered provider' do
       config = build(:idp_service_config, provider: 'unknown')
       expect { config.to_service }.to raise_error(Idp::ServiceError, /Unknown provider/)
+    end
+  end
+
+  describe 'skip_ssl_verification' do
+    it 'defaults to false so TLS verification stays on unless opted out' do
+      expect(create(:idp_service_config).skip_ssl_verification).to be false
     end
   end
 

--- a/spec/services/idp/keycloak_service_spec.rb
+++ b/spec/services/idp/keycloak_service_spec.rb
@@ -322,10 +322,12 @@ RSpec.describe Idp::KeycloakService, type: :model do
       it 'verifies certificates on HTTPS connections' do
         http = service.send(:build_http, https_uri)
 
-        # build_http leaves verify_mode untouched, so Net::HTTP applies its
-        # secure default (VERIFY_PEER) when the connection is started.
+        # build_http leaves verify_mode nil, so Net::HTTP resolves its secure
+        # default (VERIFY_PEER) when the connection is started. Asserting nil
+        # pins that build_http never touches verify_mode on the default path,
+        # rather than the weaker "not explicitly VERIFY_NONE".
         expect(http.use_ssl?).to be true
-        expect(http.verify_mode).not_to eq(OpenSSL::SSL::VERIFY_NONE)
+        expect(http.verify_mode).to be_nil
       end
     end
 
@@ -369,6 +371,26 @@ RSpec.describe Idp::KeycloakService, type: :model do
       end
     end
 
+    context 'when skip_ssl_verification is the string "false"' do
+      let(:service) do
+        described_class.new(
+          config: {
+            api_url: api_url,
+            realm: realm,
+            client_id: client_id,
+            client_secret: client_secret,
+            skip_ssl_verification: 'false',
+          },
+        )
+      end
+
+      it 'casts the value and leaves certificate verification enabled' do
+        http = service.send(:build_http, https_uri)
+
+        expect(http.verify_mode).to be_nil
+      end
+    end
+
     context 'for a plain HTTP connection' do
       let(:service) do
         described_class.new(
@@ -382,10 +404,13 @@ RSpec.describe Idp::KeycloakService, type: :model do
         )
       end
 
-      it 'does not enable SSL even when verification is skipped' do
+      it 'does not enable SSL or touch verify_mode even when verification is skipped' do
         http = service.send(:build_http, URI("#{api_url}/realms/#{realm}"))
 
+        # The guard is `http.use_ssl? && skip_ssl_verification?`, so a non-TLS
+        # connection must skip the verify_mode assignment entirely.
         expect(http.use_ssl?).to be false
+        expect(http.verify_mode).to be_nil
       end
     end
   end
@@ -462,11 +487,13 @@ RSpec.describe Idp::KeycloakService, type: :model do
   end
 
   describe '.from_config' do
-    # Mirrors the Idp::ServiceConfig reader surface that .from_config consumes
-    # (api_url, client_id, service_token, keycloak_realm) without needing the DB
-    # or encryption key. ServiceConfig's own columns are covered by its spec.
+    # Use a real (unpersisted) Idp::ServiceConfig rather than a stand-in double,
+    # so a divergence between .from_config and the model's actual reader surface
+    # (api_url, client_id, service_token, keycloak_realm, skip_ssl_verification)
+    # is caught here instead of only in production.
     let(:persisted_config) do
-      Struct.new(:api_url, :client_id, :service_token, :keycloak_realm, :skip_ssl_verification, keyword_init: true).new(
+      build(
+        :idp_service_config,
         api_url: 'http://kc.from-config:8080',
         client_id: 'config-client',
         service_token: 'config-secret',

--- a/spec/services/idp/keycloak_service_spec.rb
+++ b/spec/services/idp/keycloak_service_spec.rb
@@ -315,6 +315,81 @@ RSpec.describe Idp::KeycloakService, type: :model do
     end
   end
 
+  describe 'TLS certificate verification' do
+    let(:https_uri) { URI("https://keycloak.test:8443/realms/#{realm}") }
+
+    context 'when skip_ssl_verification is not configured' do
+      it 'verifies certificates on HTTPS connections' do
+        http = service.send(:build_http, https_uri)
+
+        # build_http leaves verify_mode untouched, so Net::HTTP applies its
+        # secure default (VERIFY_PEER) when the connection is started.
+        expect(http.use_ssl?).to be true
+        expect(http.verify_mode).not_to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+
+    context 'when skip_ssl_verification is true' do
+      let(:service) do
+        described_class.new(
+          config: {
+            api_url: api_url,
+            realm: realm,
+            client_id: client_id,
+            client_secret: client_secret,
+            skip_ssl_verification: true,
+          },
+        )
+      end
+
+      it 'disables certificate verification on HTTPS connections' do
+        http = service.send(:build_http, https_uri)
+
+        expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+
+    context 'when skip_ssl_verification is the string "true"' do
+      let(:service) do
+        described_class.new(
+          config: {
+            api_url: api_url,
+            realm: realm,
+            client_id: client_id,
+            client_secret: client_secret,
+            skip_ssl_verification: 'true',
+          },
+        )
+      end
+
+      it 'casts the value and disables certificate verification' do
+        http = service.send(:build_http, https_uri)
+
+        expect(http.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+
+    context 'for a plain HTTP connection' do
+      let(:service) do
+        described_class.new(
+          config: {
+            api_url: api_url,
+            realm: realm,
+            client_id: client_id,
+            client_secret: client_secret,
+            skip_ssl_verification: true,
+          },
+        )
+      end
+
+      it 'does not enable SSL even when verification is skipped' do
+        http = service.send(:build_http, URI("#{api_url}/realms/#{realm}"))
+
+        expect(http.use_ssl?).to be false
+      end
+    end
+  end
+
   describe 'token retry on 401' do
     let(:user_id) { 'keycloak-user-id' }
 
@@ -391,11 +466,12 @@ RSpec.describe Idp::KeycloakService, type: :model do
     # (api_url, client_id, service_token, keycloak_realm) without needing the DB
     # or encryption key. ServiceConfig's own columns are covered by its spec.
     let(:persisted_config) do
-      Struct.new(:api_url, :client_id, :service_token, :keycloak_realm, keyword_init: true).new(
+      Struct.new(:api_url, :client_id, :service_token, :keycloak_realm, :skip_ssl_verification, keyword_init: true).new(
         api_url: 'http://kc.from-config:8080',
         client_id: 'config-client',
         service_token: 'config-secret',
         keycloak_realm: 'config-realm',
+        skip_ssl_verification: true,
       )
     end
 
@@ -407,6 +483,7 @@ RSpec.describe Idp::KeycloakService, type: :model do
         client_id: 'config-client',
         client_secret: 'config-secret',
         realm: 'config-realm',
+        skip_ssl_verification: true,
       )
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adds the ability to skip SSL certificate verification for when the keycloak is hosted with a self-signed certificate

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

