### PR TITLE
[#9401] Threshold Monitoring - email deduplication

### DIFF
--- a/app/jobs/notify_metric_threshold_crossings_job.rb
+++ b/app/jobs/notify_metric_threshold_crossings_job.rb
@@ -56,18 +56,27 @@ class NotifyMetricThresholdCrossingsJob < BaseJob
         user = users_by_id[user_id]
         next unless user&.active?
 
+        # Skip metrics this user was already successfully notified about today. The job is
+        # enqueued once per collector run (including every retry), so without this guard the
+        # same crossing is re-sent on every run. See docs/features/metric-tracking.md.
+        already_notified = GrdaWarehouse::Monitoring::ThresholdNotificationLog.
+          notified_metric_ids_for(user_id: user.id, date: Date.current)
+
+        new_crossings = crossings.reject { |metric_id, _info| already_notified.include?(metric_id) }
+        next if new_crossings.empty?
+
         log = GrdaWarehouse::Monitoring::ThresholdNotificationLog.create!(
           user_id: user.id,
           email_type: 'metric_threshold_crossed',
           sent_at: Time.current,
           details: {
-            'crossings' => build_notification_details(crossings, notification_metric_defs_by_id, notification_data_sources_by_id),
+            'crossings' => build_notification_details(new_crossings, notification_metric_defs_by_id, notification_data_sources_by_id),
           },
         )
         begin
           NotifyUser.metric_threshold_crossed(
             user_id: user.id,
-            crossings: crossings,
+            crossings: new_crossings,
             calculation_date: calculation_date,
           ).deliver_now!
           message = Message.where(

--- a/app/models/grda_warehouse/monitoring/threshold_notification_log.rb
+++ b/app/models/grda_warehouse/monitoring/threshold_notification_log.rb
@@ -24,6 +24,21 @@ module GrdaWarehouse::Monitoring
 
     scope :for_user, ->(user_id) { where(user_id: user_id) }
     scope :recent_first, -> { order(sent_at: :desc) }
+    scope :successfully_delivered, -> { where(delivery_failed: false) }
+    scope :metric_threshold, -> { where(email_type: 'metric_threshold_crossed') }
+    scope :sent_on, ->(date) { where(sent_at: date.all_day) }
+
+    # Integer metric_ids the user was already successfully notified about on `date`.
+    # Used by NotifyMetricThresholdCrossingsJob to avoid re-sending the same crossing.
+    def self.notified_metric_ids_for(user_id:, date:)
+      for_user(user_id).
+        metric_threshold.
+        successfully_delivered.
+        sent_on(date).
+        flat_map(&:crossings).
+        filter_map { |crossing| crossing['metric_id'] }.
+        to_set
+    end
 
     # Backfills ThresholdNotificationLog stubs from historical Message records for all users.
     # Run from the console: GrdaWarehouse::Monitoring::ThresholdNotificationLog.backfill

--- a/spec/jobs/notify_metric_threshold_crossings_job_spec.rb
+++ b/spec/jobs/notify_metric_threshold_crossings_job_spec.rb
@@ -374,6 +374,19 @@ RSpec.describe NotifyMetricThresholdCrossingsJob, type: :job do
       ActionMailer::Base.deliveries.find { |mail| mail.to.include?(user.email) }
     end
 
+    # Persist a real MetricSnapshot the production detection query reads.
+    def persist_csv_snapshot(observation_date:, value:)
+      GrdaWarehouse::Monitoring::MetricSnapshot.create!(
+        metric_definition: csv_metric,
+        entity: data_source,
+        initial_observation_date: observation_date,
+        current_observation_date: observation_date,
+        initial_value: value,
+        current_value: value,
+        calculation_version: '1.0.0',
+      )
+    end
+
     it '(a) does not re-send on a second identical run' do
       user = create(:user, active: true)
       subscribe_csv(user)
@@ -560,6 +573,31 @@ RSpec.describe NotifyMetricThresholdCrossingsJob, type: :job do
         described_class.new.perform(calculation_date)
       end.not_to(change { ActionMailer::Base.deliveries.count })
       expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(2)
+    end
+
+    it '(h) [integration] dedups against real crossing detection, no stub' do
+      # Exercises the real MetricDefinition.threshold_crossings_for_alerts path (no stub_crossings),
+      # proving the guard suppresses a genuine second run and that the detected crossing shape
+      # feeds build_notification_details / the mailer correctly.
+      user = create(:user, active: true)
+      subscribe_csv(user)
+
+      # A baseline snapshot plus a crossing dated on calculation_date is what the detection SQL
+      # looks for (a current snapshot with initial_observation_date == calculation_date and an
+      # earlier snapshot to compare against).
+      persist_csv_snapshot(observation_date: calculation_date - 7.days, value: 1000)
+      persist_csv_snapshot(observation_date: calculation_date, value: 1100)
+
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
+      expect(metric_ids_for(user)).to contain_exactly(csv_metric.id)
+
+      # Second run recomputes the identical real crossing but must not re-send.
+      expect do
+        described_class.new.perform(calculation_date)
+      end.not_to(change { ActionMailer::Base.deliveries.count })
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(1)
     end
   end
 end

--- a/spec/jobs/notify_metric_threshold_crossings_job_spec.rb
+++ b/spec/jobs/notify_metric_threshold_crossings_job_spec.rb
@@ -302,4 +302,264 @@ RSpec.describe NotifyMetricThresholdCrossingsJob, type: :job do
       expect(log.delivery_error).to include('connection refused')
     end
   end
+
+  context 'idempotency / dedup across repeated runs' do
+    let(:csv_alert) { described_class::CSV_IMPORT_ALERT_CODE }
+    # Non-CSV alert codes seeded by AlertDefinition.maintain! (called in the top-level before).
+    let(:days_homeless_alert_code) { 'metric_days_homeless_threshold' }
+    let(:household_alert_code) { 'metric_household_size_threshold' }
+
+    # Metric A: seeded CSV metric (real record, category csv_import)
+    let(:csv_metric) do
+      GrdaWarehouse::Monitoring::MetricDefinition.find_by!(
+        entity_type: 'GrdaWarehouse::DataSource',
+        subtype: 'Client.csv',
+      )
+    end
+    # Metrics B and C: real non-CSV metric definitions so build_notification_details records
+    # their metric_id in the log (a metric with no MetricDefinition row would be skipped).
+    let(:metric_b) { create(:grda_warehouse_monitoring_metric_definition) }
+    let(:metric_c) { create(:grda_warehouse_monitoring_metric_definition) }
+
+    let!(:monitor) do
+      create(
+        :grda_warehouse_import_csv_monitor,
+        data_source: data_source,
+        csv_file_name: 'Client.csv',
+        count_increase_threshold: 50,
+      )
+    end
+
+    def csv_snapshot_info(display_name:)
+      {
+        display_name: display_name,
+        data: [{ entity_id: data_source.id, current_value: 1100, previous_value: 1000 }],
+        total_count: 1,
+        truncated: false,
+        entity_label: 'data source',
+      }
+    end
+
+    def non_csv_snapshot_info(display_name:)
+      {
+        display_name: display_name,
+        data: [{ entity_id: 1, current_value: 200, previous_value: 100 }],
+        total_count: 1,
+        truncated: false,
+        entity_label: 'client',
+      }
+    end
+
+    # Mirrors the ImportCsvMonitor notification-config controller create path
+    # (no reusable model method exists for this subscription).
+    def subscribe_csv(user, on_monitor = monitor)
+      GrdaWarehouse::NotificationConfiguration.create!(
+        source: on_monitor,
+        notification_slug: GrdaWarehouse::ImportCsvMonitor::NOTIFICATION_SLUG,
+        user: user,
+        active: true,
+      )
+    end
+
+    def metric_ids_for(user)
+      GrdaWarehouse::Monitoring::ThresholdNotificationLog.
+        for_user(user.id).
+        order(:id).
+        last.
+        crossings.
+        map { |c| c['metric_id'] }
+    end
+
+    def delivery_to(user)
+      ActionMailer::Base.deliveries.find { |mail| mail.to.include?(user.email) }
+    end
+
+    it '(a) does not re-send on a second identical run' do
+      user = create(:user, active: true)
+      subscribe_csv(user)
+      stub_crossings(csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') })
+
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(1)
+
+      expect do
+        described_class.new.perform(calculation_date)
+      end.not_to(change { ActionMailer::Base.deliveries.count })
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(1)
+    end
+
+    it '(b) sends only the newly-crossed metric on a later run' do
+      user = create(:user, active: true)
+      subscribe_csv(user)
+      user.subscribe_to_system_alert!(days_homeless_alert_code)
+
+      stub_crossings(csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') })
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      stub_crossings(
+        csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') },
+        'metric_days_homeless_threshold' => { metric_b.id => non_csv_snapshot_info(display_name: 'BetaMetric') },
+      )
+      described_class.new.perform(calculation_date)
+
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+      second = ActionMailer::Base.deliveries.last
+      expect(second.body.encoded).to include('BetaMetric')
+      expect(second.body.encoded).not_to include('AlphaMetric')
+      expect(metric_ids_for(user)).to eq([metric_b.id])
+    end
+
+    it '(c) retries a metric whose earlier delivery failed' do
+      user = create(:user, active: true)
+      subscribe_csv(user)
+      stub_crossings(csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') })
+
+      allow_any_instance_of(Mail::Message).to receive(:deliver!).and_raise(SocketError, 'connection refused')
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries).to be_empty
+      first_log = GrdaWarehouse::Monitoring::ThresholdNotificationLog.order(:id).last
+      expect(first_log.delivery_failed).to be true
+
+      allow_any_instance_of(Mail::Message).to receive(:deliver!).and_call_original
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      new_log = GrdaWarehouse::Monitoring::ThresholdNotificationLog.order(:id).last
+      expect(new_log.id).not_to eq(first_log.id)
+      expect(new_log.delivery_failed).to be false
+    end
+
+    it '(d) still notifies a user who first subscribes on a later run' do
+      user1 = create(:user, active: true)
+      user2 = create(:user, active: true)
+      subscribe_csv(user1)
+      subscribe_csv(user2)
+      stub_crossings(csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') })
+
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+      user3 = create(:user, active: true)
+      subscribe_csv(user3)
+      described_class.new.perform(calculation_date)
+
+      expect(ActionMailer::Base.deliveries.count).to eq(3)
+      expect(ActionMailer::Base.deliveries.last.to).to include(user3.email)
+    end
+
+    it '(e) resends on a later day' do
+      user = create(:user, active: true)
+      subscribe_csv(user)
+      stub_crossings(csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') })
+
+      travel_to(Time.zone.local(2026, 7, 21, 8, 0)) do
+        described_class.new.perform(calculation_date)
+      end
+      travel_to(Time.zone.local(2026, 7, 22, 8, 0)) do
+        described_class.new.perform(calculation_date)
+      end
+
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(2)
+    end
+
+    it '(f) dedups per-user and per-metric across multiple users and metrics' do
+      user1 = create(:user, active: true)
+      user2 = create(:user, active: true)
+      [user1, user2].each do |u|
+        subscribe_csv(u)
+        u.subscribe_to_system_alert!(days_homeless_alert_code)
+      end
+
+      a_and_b = {
+        csv_alert => { csv_metric.id => csv_snapshot_info(display_name: 'AlphaMetric') },
+        'metric_days_homeless_threshold' => { metric_b.id => non_csv_snapshot_info(display_name: 'BetaMetric') },
+      }
+      stub_crossings(a_and_b)
+
+      # Run 1: each user gets one email covering both metrics.
+      described_class.new.perform(calculation_date)
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+      ActionMailer::Base.deliveries.each do |mail|
+        expect(mail.body.encoded).to include('AlphaMetric')
+        expect(mail.body.encoded).to include('BetaMetric')
+      end
+      [user1, user2].each do |u|
+        expect(metric_ids_for(u)).to contain_exactly(csv_metric.id, metric_b.id)
+      end
+
+      # Run 2 (identical): full dedup, nothing new.
+      expect do
+        described_class.new.perform(calculation_date)
+      end.not_to(change { ActionMailer::Base.deliveries.count })
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(2)
+
+      # Run 3: add metric C for both users → each is emailed about C only.
+      [user1, user2].each { |u| u.subscribe_to_system_alert!(household_alert_code) }
+      stub_crossings(
+        a_and_b.merge(
+          'metric_household_size_threshold' => { metric_c.id => non_csv_snapshot_info(display_name: 'GammaMetric') },
+        ),
+      )
+      described_class.new.perform(calculation_date)
+
+      expect(ActionMailer::Base.deliveries.count).to eq(4)
+      ActionMailer::Base.deliveries.last(2).each do |mail|
+        expect(mail.body.encoded).to include('GammaMetric')
+        expect(mail.body.encoded).not_to include('AlphaMetric')
+        expect(mail.body.encoded).not_to include('BetaMetric')
+      end
+      [user1, user2].each do |u|
+        expect(metric_ids_for(u)).to eq([metric_c.id])
+      end
+    end
+
+    it "(g) aggregates each user's CSV metrics into one email without leaking across users" do
+      enrollment_monitor = create(
+        :grda_warehouse_import_csv_monitor,
+        data_source: data_source,
+        csv_file_name: 'Enrollment.csv',
+        count_increase_threshold: 50,
+      )
+      enrollment_metric = GrdaWarehouse::Monitoring::MetricDefinition.find_by!(
+        entity_type: 'GrdaWarehouse::DataSource',
+        subtype: 'Enrollment.csv',
+      )
+
+      one_metric_user = create(:user, active: true)
+      two_metric_user = create(:user, active: true)
+      subscribe_csv(one_metric_user)                     # Client.csv only
+      subscribe_csv(two_metric_user)                     # Client.csv
+      subscribe_csv(two_metric_user, enrollment_monitor) # + Enrollment.csv
+
+      stub_crossings(
+        csv_alert => {
+          csv_metric.id => csv_snapshot_info(display_name: 'ClientCsvMetric'),
+          enrollment_metric.id => csv_snapshot_info(display_name: 'EnrollmentCsvMetric'),
+        },
+      )
+
+      described_class.new.perform(calculation_date)
+
+      # One email each, and the second CSV metric does not leak to the user not subscribed to it.
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+      one_metric_body = delivery_to(one_metric_user).body.encoded
+      expect(one_metric_body).to include('ClientCsvMetric')
+      expect(one_metric_body).not_to include('EnrollmentCsvMetric')
+      expect(metric_ids_for(one_metric_user)).to contain_exactly(csv_metric.id)
+
+      two_metric_body = delivery_to(two_metric_user).body.encoded
+      expect(two_metric_body).to include('ClientCsvMetric')
+      expect(two_metric_body).to include('EnrollmentCsvMetric')
+      expect(metric_ids_for(two_metric_user)).to contain_exactly(csv_metric.id, enrollment_metric.id)
+
+      # Re-run: both users fully deduped across all their CSV metrics.
+      expect do
+        described_class.new.perform(calculation_date)
+      end.not_to(change { ActionMailer::Base.deliveries.count })
+      expect(GrdaWarehouse::Monitoring::ThresholdNotificationLog.count).to eq(2)
+    end
+  end
 end

--- a/spec/models/grda_warehouse/monitoring/threshold_notification_log_spec.rb
+++ b/spec/models/grda_warehouse/monitoring/threshold_notification_log_spec.rb
@@ -46,6 +46,74 @@ RSpec.describe GrdaWarehouse::Monitoring::ThresholdNotificationLog, type: :model
       create(:grda_warehouse_monitoring_threshold_notification_log, user_id: other_user.id)
       expect(described_class.for_user(user.id)).to contain_exactly(log)
     end
+
+    it '.successfully_delivered excludes logs marked delivery_failed' do
+      delivered = create(:grda_warehouse_monitoring_threshold_notification_log, delivery_failed: false)
+      create(:grda_warehouse_monitoring_threshold_notification_log, delivery_failed: true)
+      expect(described_class.successfully_delivered).to contain_exactly(delivered)
+    end
+
+    it '.metric_threshold returns only metric_threshold_crossed logs' do
+      metric = create(:grda_warehouse_monitoring_threshold_notification_log, email_type: 'metric_threshold_crossed')
+      create(:grda_warehouse_monitoring_threshold_notification_log, email_type: 'import_processing')
+      expect(described_class.metric_threshold).to contain_exactly(metric)
+    end
+
+    it '.sent_on returns only logs sent on the given date' do
+      today_log = create(:grda_warehouse_monitoring_threshold_notification_log, sent_at: Time.current)
+      create(:grda_warehouse_monitoring_threshold_notification_log, sent_at: 1.day.ago)
+      expect(described_class.sent_on(Date.current)).to contain_exactly(today_log)
+    end
+  end
+
+  describe '.notified_metric_ids_for' do
+    let(:user) { create(:user) }
+
+    def log_with_metrics(metric_ids, **attrs)
+      create(
+        :grda_warehouse_monitoring_threshold_notification_log,
+        {
+          user_id: user.id,
+          email_type: 'metric_threshold_crossed',
+          sent_at: Time.current,
+          delivery_failed: false,
+          details: { 'crossings' => metric_ids.map { |id| { 'metric_id' => id } } },
+        }.merge(attrs),
+      )
+    end
+
+    it 'returns the delivered metric_ids for the user on the date as a Set of Integers' do
+      log_with_metrics([11, 22])
+      result = described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)
+      expect(result).to be_a(Set)
+      expect(result).to contain_exactly(11, 22)
+    end
+
+    it 'excludes logs marked delivery_failed' do
+      log_with_metrics([11], delivery_failed: true)
+      expect(described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)).to be_empty
+    end
+
+    it 'excludes logs belonging to a different user' do
+      other_user = create(:user)
+      log_with_metrics([11], user_id: other_user.id)
+      expect(described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)).to be_empty
+    end
+
+    it 'excludes logs sent on a different day' do
+      log_with_metrics([11], sent_at: 1.day.ago)
+      expect(described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)).to be_empty
+    end
+
+    it 'excludes import_processing logs for the same user and date' do
+      log_with_metrics([11], email_type: 'import_processing')
+      expect(described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)).to be_empty
+    end
+
+    it 'collapses a metric_id repeated across crossing entries into a single value' do
+      log_with_metrics([11, 11, 22])
+      expect(described_class.notified_metric_ids_for(user_id: user.id, date: Date.current)).to contain_exactly(11, 22)
+    end
   end
 
   describe '#metric_threshold_crossed?' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

`NotifyMetricThresholdCrossingsJob` re-sent the same deterministic crossing set on every run, and `CollectClientMetricsJob's` retry loop re-enqueues it  every 5 min until 10 AM, so users received the same alert multiple times in the day if it needed to run multiple times.

This adds an idempotency guard: skip metrics a user was already successfully notified about today, keyed on (`user_id`, `email_type`, `metric_id`, `send-day`)  via `ThresholdNotificationLog.notified_metric_ids_for`.

More throrough testing added.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

