### PR TITLE
3. Remove CarrierWave from GrdaWarehouse::NonHmisUpload

### DIFF
--- a/app/controllers/non_hmis_uploads_controller.rb
+++ b/app/controllers/non_hmis_uploads_controller.rb
@@ -24,7 +24,7 @@ class NonHmisUploadsController < ApplicationController
 
   def show
     @upload = upload_source.find(params[:id].to_i)
-    filename = @upload.file&.file&.filename&.to_s || 'upload'
+    filename = @upload.file || 'upload'
     send_data(@upload.content, type: @upload.content_type, filename: filename)
   end
 
@@ -45,6 +45,7 @@ class NonHmisUploadsController < ApplicationController
         user_id: current_user.id,
         content_type: file.content_type,
         content: file.read,
+        file: file.original_filename,
       ),
     )
     if @upload.save
@@ -65,7 +66,7 @@ class NonHmisUploadsController < ApplicationController
 
   def upload_params
     params.require(:grda_warehouse_non_hmis_upload).
-      permit(:file, :file_cache)
+      permit(:file)
   end
 
   def data_source_source

--- a/app/models/grda_warehouse/non_hmis_upload.rb
+++ b/app/models/grda_warehouse/non_hmis_upload.rb
@@ -16,9 +16,13 @@ module GrdaWarehouse
 
     belongs_to :delayed_job, optional: true, class_name: '::Delayed::Job'
 
-    mount_uploader :file, ImportUploader
     validates :data_source, presence: true
     validates :file, presence: true, on: :create
+    validate :file_extension_allowed, on: :create
+
+    def file_extension_allowed
+      errors.add :file, 'must be a zip file' unless ::File.extname(file.to_s).downcase == '.zip'
+    end
 
     def status
       if percent_complete&.zero?

--- a/app/views/non_hmis_uploads/index.haml
+++ b/app/views/non_hmis_uploads/index.haml
@@ -23,7 +23,7 @@
         - @uploads.each do |upload|
           %tr
             %td
-              = link_to File.basename(upload.file.to_s), data_source_non_hmis_upload_path(data_source_id: upload.data_source_id, id: upload.id)
+              = link_to upload.file || 'upload', data_source_non_hmis_upload_path(data_source_id: upload.data_source_id, id: upload.id)
             %td= upload.user&.name
             %td= upload.created_at
             %td

--- a/app/views/supplemental_enrollment_datum/_default.haml
+++ b/app/views/supplemental_enrollment_datum/_default.haml
@@ -9,6 +9,5 @@
       = f.error_notification
       .form-inputs
         = f.input :file, as: :file
-        = f.hidden_field :file_cache
       .form-actions
         = f.button :submit, value: 'Upload'

--- a/drivers/supplemental_enrollment_data/app/views/supplemental_enrollment_data/_tpc.haml
+++ b/drivers/supplemental_enrollment_data/app/views/supplemental_enrollment_data/_tpc.haml
@@ -12,6 +12,5 @@
   = f.error_notification
   .form-inputs
     = f.input :file, as: :file
-    = f.hidden_field :file_cache
   .form-actions
     = f.button :submit, value: 'Upload'

--- a/spec/models/grda_warehouse/non_hmis_upload_spec.rb
+++ b/spec/models/grda_warehouse/non_hmis_upload_spec.rb
@@ -1,0 +1,56 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::NonHmisUpload, type: :model do
+  let(:data_source) { create(:source_data_source) }
+
+  def valid_attributes(overrides = {})
+    {
+      data_source: data_source,
+      file: 'export.zip',
+      content: 'x' * 200,
+      content_type: 'application/zip',
+    }.merge(overrides)
+  end
+
+  it 'is valid with a .zip filename' do
+    upload = described_class.new(valid_attributes)
+    expect(upload).to be_valid
+  end
+
+  it 'is valid with an uppercase .ZIP filename' do
+    upload = described_class.new(valid_attributes(file: 'export.ZIP'))
+    expect(upload).to be_valid
+  end
+
+  it 'is invalid with a non-.zip filename' do
+    upload = described_class.new(valid_attributes(file: 'export.csv'))
+    expect(upload).not_to be_valid
+    expect(upload.errors[:file]).to include('must be a zip file')
+  end
+
+  it 'is invalid with a non-.zip filename disguised by a trailing .zip in the name' do
+    upload = described_class.new(valid_attributes(file: 'malware.zip.exe'))
+    expect(upload).not_to be_valid
+    expect(upload.errors[:file]).to include('must be a zip file')
+  end
+
+  it 'is invalid without a file on create' do
+    upload = described_class.new(valid_attributes(file: nil))
+    expect(upload).not_to be_valid
+    expect(upload.errors[:file]).to include("can't be blank")
+  end
+
+  it 'is invalid without a data_source' do
+    upload = described_class.new(valid_attributes(data_source: nil))
+    expect(upload).not_to be_valid
+    expect(upload.errors[:data_source]).to include("can't be blank")
+  end
+end

--- a/spec/requests/non_hmis_uploads_controller_spec.rb
+++ b/spec/requests/non_hmis_uploads_controller_spec.rb
@@ -1,0 +1,113 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NonHmisUploadsController, type: :request do
+  let(:data_source) { create(:source_data_source) }
+  let(:role) { create(:role, can_upload_dashboard_extras: true) }
+  let(:user) do
+    u = create(:user)
+    u.legacy_roles << role
+    u
+  end
+
+  before do
+    allow(GrdaWarehouse::DataSource).to receive(:viewable_by).with(user).and_return(
+      GrdaWarehouse::DataSource.where(id: data_source.id),
+    )
+    sign_in user
+    Delayed::Job.delete_all
+  end
+
+  after { Delayed::Job.delete_all }
+
+  describe 'authorization' do
+    context 'when the user lacks the upload permission' do
+      let(:role) { create(:role, can_upload_dashboard_extras: false) }
+
+      it 'denies access' do
+        get new_data_source_non_hmis_upload_path(data_source)
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    it 'renders successfully with the default importer' do
+      get new_data_source_non_hmis_upload_path(data_source)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders successfully with the TPC importer' do
+      allow(GrdaWarehouse::Config).to receive(:active_supplemental_enrollment_importer_class).and_return(SupplementalEnrollmentData::Tpc)
+      get new_data_source_non_hmis_upload_path(data_source)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:zip_upload) do
+      Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/lsa/fy2019/sample_hmis_export.zip'), 'application/zip')
+    end
+
+    it 'creates an upload and enqueues the import job' do
+      expect do
+        post data_source_non_hmis_uploads_path(data_source), params: { grda_warehouse_non_hmis_upload: { file: zip_upload } }
+      end.to change(Delayed::Job, :count).by(1)
+
+      upload = GrdaWarehouse::NonHmisUpload.last
+      expect(upload.file).to eq('sample_hmis_export.zip')
+      expect(upload.content_type).to eq('application/zip')
+      expect(upload.content).to eq(File.binread(Rails.root.join('spec/fixtures/files/lsa/fy2019/sample_hmis_export.zip')))
+      expect(flash[:notice]).to eq('Upload queued to start.')
+
+      job = Delayed::Job.last
+      handler = job.payload_object
+      expect(handler).to be_a(Importing::NonHmisJob)
+      expect(handler.instance_variable_get(:@upload).id).to eq(upload.id)
+      expect(handler.instance_variable_get(:@data_source_id)).to eq(data_source.id)
+      expect(upload.reload.delayed_job_id).to eq(job.id)
+    end
+
+    it 'rejects a request with no file attached' do
+      expect do
+        post data_source_non_hmis_uploads_path(data_source), params: { grda_warehouse_non_hmis_upload: { file: nil } }
+      end.not_to change(Delayed::Job, :count)
+
+      expect(flash[:alert]).to eq('You must attach a file in the form.')
+    end
+
+    it 'rejects a non-.zip upload' do
+      pdf_upload = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/files/test.pdf'), 'application/pdf')
+
+      expect do
+        post data_source_non_hmis_uploads_path(data_source), params: { grda_warehouse_non_hmis_upload: { file: pdf_upload } }
+      end.not_to change(Delayed::Job, :count)
+
+      expect(flash[:alert]).to eq('Upload failed to queue, did you attach a file?')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'downloads using the stored filename' do
+      upload = GrdaWarehouse::NonHmisUpload.create!(
+        data_source: data_source,
+        file: 'export.zip',
+        content: 'x' * 200,
+        content_type: 'application/zip',
+      )
+
+      get data_source_non_hmis_upload_path(data_source_id: data_source.id, id: upload.id)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['Content-Disposition']).to include('export.zip')
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Removes CarrierWave's `mount_uploader` from `GrdaWarehouse::NonHmisUpload`, part 3 of 5 in issue #9043's effort to drop the CarrierWave gem (pinned with CVE patches, blocking a framework upgrade) from non-health models.

`NonHmisUpload` backs the supplemental-enrollment-data upload flow (`NonHmisUploadsController`). CarrierWave was already a passenger here — the controller manually writes `content` (bytea) and `content_type`, and `Importing::NonHmisJob` reads from `content` — so its only real contributions were storing the original filename in the `file` varchar column and enforcing a `.zip`-only extension via `ImportUploader`. Both are replaced: `file: file.original_filename` is now set explicitly in the controller's create action, and a new `file_extension_allowed` model validation reproduces the extension check.

Two upload-form partials (`supplemental_enrollment_datum/_default.haml` and the `supplemental_enrollment_data` driver's `_tpc.haml`) each had `= f.hidden_field :file_cache`, a CarrierWave-only virtual attribute. Removing `mount_uploader` without removing this line would break both upload forms with `NoMethodError` — this wasn't called out in the original issue and was caught during design review.

No ActiveStorage migration — this model stays on bytea storage per the issue's guidance (low volume, small files). No behavior change from a user's perspective: the same forms, validations, and download filenames.

Adds first-ever test coverage for this model and controller (13 examples): extension/case-insensitivity/presence validations on the model, and permission-gate, both-partial-render, create/reject, and download-filename coverage on the controller, including job-identity assertions on the enqueued `Importing::NonHmisJob`.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

