### PR TITLE
Create keycloak groups if they don't exist

### DIFF
--- a/app/services/idp/keycloak/user_importer.rb
+++ b/app/services/idp/keycloak/user_importer.rb
@@ -18,6 +18,13 @@ module Idp
     # Delete this class, and KeycloakService#partial_import, once all account
     # data has been migrated.
     class UserImporter
+      # The Keycloak groups the import references, keyed by the access they map to;
+      # ensured to exist before import.
+      GROUPS = {
+        warehouse: 'warehouse-users',
+        hmis: 'hmis-users',
+      }.freeze
+
       # Users to migrate: confirmed and active.
       #
       # confirmed_at also gates out invited-but-not-accepted users: :invitable
@@ -89,6 +96,21 @@ module Idp
         }
       end
 
+      # Idempotently ensure the groups the import references exist, so partialImport
+      # can resolve each user's group paths. Safe to re-run. Raises Idp::ServiceError
+      # if a group can neither be found nor created.
+      # @return [Hash] { created: [String], existing: [String] }
+      def ensure_groups!
+        result = { created: [], existing: [] }
+        GROUPS.each_value do |name|
+          case service.ensure_group(name)
+          when :created then result[:created] << name
+          when :existing then result[:existing] << name
+          end
+        end
+        result
+      end
+
       # Build the partialImport JSON structure without making an API call.
       def export_users_to_import_format(users, policy:, progress: nil)
         import_payload(users, policy: policy, progress: progress)
@@ -129,8 +151,8 @@ module Idp
         return [] if user.system_user?
 
         groups = []
-        groups << '/warehouse-users' if warehouse_user?(user)
-        groups << '/hmis-users' if Hmis::UserGroupMember.exists?(user_id: user.id)
+        groups << "/#{GROUPS[:warehouse]}" if warehouse_user?(user)
+        groups << "/#{GROUPS[:hmis]}" if Hmis::UserGroupMember.exists?(user_id: user.id)
         groups
       end
 

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -193,6 +193,29 @@ module Idp
       make_request(:post, "/admin/realms/#{realm}/partialImport", body: import_data)
     end
 
+    # Used by the migration tooling; remove once Devise account data has been migrated.
+    # Idempotently ensure a top-level group exists. Keycloak returns 409 when the
+    # group already exists, which we treat as success — so a re-run is a no-op.
+    # @return [Symbol] :created or :existing
+    def ensure_group(name)
+      response = make_request(
+        :post,
+        "/admin/realms/#{realm}/groups",
+        body: { name: name },
+      )
+
+      case response.code.to_i
+      when 201 then :created
+      when 409 then :existing
+      else
+        raise ServiceError.new(
+          "Failed to ensure group #{name}: #{error_message_from(response)}",
+          idp_name: idp_name,
+          operation: :ensure_group,
+        )
+      end
+    end
+
     private
 
     def validate_config!

--- a/lib/tasks/keycloak.rake
+++ b/lib/tasks/keycloak.rake
@@ -54,6 +54,17 @@ namespace :keycloak do
     Time.zone.parse(raw) || (warn("Error: could not parse since: #{raw}") || exit(1))
   end
 
+  # Ensure the groups the import references exist, print the outcome, and abort on failure.
+  def keycloak_ensure_groups(importer)
+    result = importer.ensure_groups!
+    created = result[:created].join(', ').presence || 'none'
+    existing = result[:existing].join(', ').presence || 'none'
+    puts "Ensured Keycloak groups — created: #{created}; existing: #{existing}"
+  rescue Idp::ServiceError => e
+    warn "Error ensuring Keycloak groups: #{e.message}"
+    exit 1
+  end
+
   desc 'Migrate users from Devise to Keycloak in batches'
   task :migrate_users, [:limit, :batch_size, :policy, :since] => :environment do |_t, args|
     limit = args[:limit]&.to_i
@@ -62,6 +73,7 @@ namespace :keycloak do
     since = keycloak_since(args[:since])
 
     importer = keycloak_importer
+    keycloak_ensure_groups(importer)
 
     users_scope = Idp::Keycloak::UserImporter.migration_scope(since: since)
     users_scope = users_scope.limit(limit) if limit
@@ -143,6 +155,7 @@ namespace :keycloak do
     end
 
     importer = keycloak_importer
+    keycloak_ensure_groups(importer)
 
     puts "Importing users from #{file}..."
 
@@ -172,6 +185,7 @@ namespace :keycloak do
     end
 
     importer = keycloak_importer
+    keycloak_ensure_groups(importer)
 
     puts "Importing user: #{user.email}"
     puts "  Name: #{user.first_name} #{user.last_name}"

--- a/spec/services/idp/keycloak/user_importer_spec.rb
+++ b/spec/services/idp/keycloak/user_importer_spec.rb
@@ -483,4 +483,34 @@ RSpec.describe Idp::Keycloak::UserImporter, type: :model do
       end
     end
   end
+
+  describe '#ensure_groups!' do
+    let(:groups_url) { "#{api_url}/admin/realms/#{realm}/groups" }
+
+    it 'creates both required groups and reports them as created' do
+      stub_request(:post, groups_url).
+        with(body: { name: 'warehouse-users' }.to_json).to_return(status: 201)
+      stub_request(:post, groups_url).
+        with(body: { name: 'hmis-users' }.to_json).to_return(status: 201)
+
+      expect(importer.ensure_groups!).to eq(created: ['warehouse-users', 'hmis-users'], existing: [])
+    end
+
+    it 'reports already-present groups as existing' do
+      stub_request(:post, groups_url).
+        with(body: { name: 'warehouse-users' }.to_json).to_return(status: 409)
+      stub_request(:post, groups_url).
+        with(body: { name: 'hmis-users' }.to_json).to_return(status: 201)
+
+      expect(importer.ensure_groups!).to eq(created: ['hmis-users'], existing: ['warehouse-users'])
+    end
+
+    it 'propagates a ServiceError when a group cannot be ensured' do
+      stub_request(:post, groups_url).
+        with(body: { name: 'warehouse-users' }.to_json).
+        to_return(status: 500, body: { errorMessage: 'boom' }.to_json)
+
+      expect { importer.ensure_groups! }.to raise_error(Idp::ServiceError, /boom/)
+    end
+  end
 end

--- a/spec/services/idp/keycloak_service_spec.rb
+++ b/spec/services/idp/keycloak_service_spec.rb
@@ -466,4 +466,32 @@ RSpec.describe Idp::KeycloakService, type: :model do
       end
     end
   end
+
+  describe '#ensure_group' do
+    let(:groups_url) { "#{api_url}/admin/realms/#{realm}/groups" }
+
+    it 'returns :created when Keycloak creates the group' do
+      stub_request(:post, groups_url).
+        with(body: { name: 'warehouse-users' }.to_json).
+        to_return(status: 201)
+
+      expect(service.ensure_group('warehouse-users')).to eq(:created)
+    end
+
+    it 'returns :existing when the group already exists (409)' do
+      stub_request(:post, groups_url).
+        with(body: { name: 'warehouse-users' }.to_json).
+        to_return(status: 409, body: { errorMessage: 'Top level group named warehouse-users already exists.' }.to_json)
+
+      expect(service.ensure_group('warehouse-users')).to eq(:existing)
+    end
+
+    it 'raises ServiceError on an unexpected response' do
+      stub_request(:post, groups_url).
+        to_return(status: 500, body: { errorMessage: 'boom' }.to_json)
+
+      expect { service.ensure_group('warehouse-users') }.
+        to raise_error(Idp::ServiceError, /boom/)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Fixes a migration issue, if the groups don't exist in keycloak before migrating users, the API throws a 500.
* Groups are just a "name" so they are relatively safe to create.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

