### PR TITLE
5. Fix NoMethodError in AdHocDataSources::UploadsController#download

### DIFF
--- a/app/controllers/ad_hoc_data_sources/uploads_controller.rb
+++ b/app/controllers/ad_hoc_data_sources/uploads_controller.rb
@@ -48,7 +48,7 @@ class AdHocDataSources::UploadsController < ApplicationController
         send_data(@upload.batch_file.download, filename: filename, type: @upload.batch_file.content_type)
       else
         filename = @upload.sanitized_name
-        send_data(@upload.file.read, filename: filename, type: @upload.file.content_type)
+        send_data(@upload.content, filename: filename, type: @upload.content_type)
       end
       return
     end

--- a/spec/requests/ad_hoc_data_sources/uploads_controller_spec.rb
+++ b/spec/requests/ad_hoc_data_sources/uploads_controller_spec.rb
@@ -1,0 +1,87 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdHocDataSources::UploadsController, type: :request do
+  let(:role) { create(:role, can_manage_ad_hoc_data_sources: true) }
+  let(:user) do
+    u = create(:user)
+    u.legacy_roles << role
+    u
+  end
+  let(:data_source) { create(:ad_hoc_data_source) }
+
+  before { sign_in user }
+
+  describe 'GET #download' do
+    it 'downloads using the ActiveStorage attachment when batch_file is present' do
+      upload = create(:ad_hoc_batch_valid, ad_hoc_data_source: data_source)
+
+      get download_ad_hoc_data_source_upload_path(data_source, upload)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['Content-Disposition']).to include('initial_batch.csv')
+      expect(response.content_type).to eq('text/csv')
+      expect(response.body).to eq(File.binread(Rails.root.join('spec/fixtures/files/ad_hoc_batches/initial_batch.csv')))
+    end
+
+    it 'downloads using the legacy content column when no batch_file is attached' do
+      upload = GrdaWarehouse::AdHocBatch.new(
+        description: 'Legacy Batch',
+        ad_hoc_data_source: data_source,
+        content: 'legacy,csv,content',
+        content_type: 'text/csv',
+        file: 'legacy_upload.csv',
+      )
+      upload.save!(validate: false)
+
+      get download_ad_hoc_data_source_upload_path(data_source, upload)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq('legacy,csv,content')
+      expect(response.content_type).to eq('text/csv')
+      expect(response.headers['Content-Disposition']).to include('Legacy Batch')
+    end
+
+    context 'when the user lacks the ad-hoc management permission' do
+      let(:role) { create(:role, can_manage_ad_hoc_data_sources: false, can_manage_own_ad_hoc_data_sources: false) }
+
+      it 'denies access' do
+        upload = create(:ad_hoc_batch_valid, ad_hoc_data_source: data_source)
+
+        get download_ad_hoc_data_source_upload_path(data_source, upload)
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    context 'when the user can only manage their own ad hoc data sources' do
+      let(:role) { create(:role, can_manage_ad_hoc_data_sources: false, can_manage_own_ad_hoc_data_sources: true) }
+      let(:own_data_source) { create(:ad_hoc_data_source, user_id: user.id) }
+      let(:other_users_data_source) { create(:ad_hoc_data_source, user_id: create(:user).id) }
+
+      it 'allows downloading an upload under their own data source' do
+        upload = create(:ad_hoc_batch_valid, ad_hoc_data_source: own_data_source)
+
+        get download_ad_hoc_data_source_upload_path(own_data_source, upload)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'denies downloading an upload under another user\'s data source' do
+        upload = create(:ad_hoc_batch_valid, ad_hoc_data_source: other_users_data_source)
+
+        get download_ad_hoc_data_source_upload_path(other_users_data_source, upload)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fix NoMethodError in AdHocDataSources::UploadsController#download. The legacy fallback for un-migrated AdHocBatch records called
.read/.content_type on the plain varchar `file` column instead of
using the model's own `content`/`content_type` columns, so it always
raised. Pre-existing bug, unrelated to the CarrierWave removal in
this issue, fixed as a final cleanup item (issue #9043, part 5/5).

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

