### PR TITLE
Work around deadlocks without adjusting production code

### DIFF
--- a/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
+++ b/drivers/hmis_simulation/app/models/hmis_simulation/engine.rb
@@ -23,6 +23,7 @@ module HmisSimulation
   #
   # Idempotent: re-running the same date is a no-op (detected via RunLog).
   # Recoverable: a previously failed date's RunLog is overwritten on retry.
+  # Deadlocks (e.g. CE change-marker contention) retry the rolled-back day a few times.
   #
   # Usage:
   #   config = HmisSimulation::ConfigLoader.from_app_config('hmis_simulation/demo-coc')
@@ -36,6 +37,10 @@ module HmisSimulation
       record_miss_rate = (@config.dig('data_quality', 'record_miss_rate') || 0).to_f
       @schedule = Schedule.new(seed: @seed, record_miss_rate: record_miss_rate)
     end
+
+    # CE dirty-marking during the day-long transaction can deadlock with
+    # ProcessClientsJob on hmis_ce_change_markers; retry the rolled-back day.
+    DEADLOCK_RETRIES = 3
 
     def run(date:)
       HmisSimulation.ensure_not_production!
@@ -78,7 +83,9 @@ module HmisSimulation
       )
       log.save!
 
+      attempts = 0
       begin
+        attempts += 1
         Hmis::Hud::Base.transaction do
           @clients_created     = 0
           @enrollments_opened  = 0
@@ -103,6 +110,17 @@ module HmisSimulation
             finished_at: Time.current,
           )
         end
+      rescue ActiveRecord::Deadlocked => e
+        if attempts < DEADLOCK_RETRIES
+          Rails.logger.warn(
+            "[HmisSimulation] Deadlock on #{date} (attempt #{attempts}/#{DEADLOCK_RETRIES}), retrying: #{e.message}",
+          )
+          sleep(0.25 * attempts)
+          retry
+        end
+
+        log.update!(error_message: e.message, finished_at: Time.current)
+        raise
       rescue StandardError => e
         log.update!(error_message: e.message, finished_at: Time.current)
         raise

--- a/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
+++ b/drivers/hmis_simulation/spec/models/hmis_simulation/engine_spec.rb
@@ -123,6 +123,32 @@ RSpec.describe HmisSimulation::Engine do
       expect(log.clients_created).to be > 0
     end
 
+    it 'retries the day when a deadlock occurs' do
+      calls = 0
+      allow(Kernel).to receive(:sleep)
+      allow(engine).to receive(:spawn_clients).and_wrap_original do |method, **kwargs|
+        calls += 1
+        raise ActiveRecord::Deadlocked, 'PG::TRDeadlockDetected: deadlock detected' if calls == 1
+
+        method.call(**kwargs)
+      end
+
+      engine.run(date: run_date)
+      expect(calls).to eq(2)
+      log = HmisSimulation::RunLog.find_by(data_source_id: data_source.id, run_date: run_date)
+      expect(log.error_message).to be_nil
+    end
+
+    it 'records the error after exhausting deadlock retries' do
+      allow(engine).to receive(:spawn_clients).
+        and_raise(ActiveRecord::Deadlocked, 'PG::TRDeadlockDetected: deadlock detected')
+      allow(Kernel).to receive(:sleep)
+
+      expect { engine.run(date: run_date) }.to raise_error(ActiveRecord::Deadlocked)
+      log = HmisSimulation::RunLog.find_by(data_source_id: data_source.id, run_date: run_date)
+      expect(log.error_message).to include('deadlock detected')
+    end
+
     context 'when run twice on the same date' do
       it 'is idempotent — no duplicate clients or log entries' do
         engine.run(date: run_date)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adds a work-around to re-try the simulation day up to 3 times when it hits a deadlock.  This happens if the `Hmis::Ce::ProcessClientsJob` is running at the same time the simulator is generating data for a day with the same client.  Simulator data is written in a transaction for the full-day, and this seems to happen every for every 5-10 days as `Hmis::Ce::ProcessClientsJob` runs every few minutes.  Re-running is safe and generally succeeds. 

We could take a few different, more targeted, approaches, but given that this is only simulation data, I'm hesitant to mess with code that is tested and working.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Work around

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

