### PR TITLE
Return Not Found for deleted form definitions and ce rules

### DIFF
--- a/drivers/hmis/app/graphql/schema.graphql
+++ b/drivers/hmis/app/graphql/schema.graphql
@@ -10387,7 +10387,7 @@ type Query {
   Custom assessment form definitions for use in CE match rule management.
   """
   ceMatchCustomAssessmentForms: [FormDefinition!]!
-  ceMatchRule(id: ID!): CeMatchRule!
+  ceMatchRule(id: ID!): CeMatchRule
 
   """
   Coordinated Entry Match Rules in the current data source.

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -440,7 +440,9 @@ module Types
       # NOTE: this query is only used for form management. It probably should
       # not be used for the application, because there is no project context passed
       # to the definition.
-      definition = Hmis::Form::Definition.in_data_source(current_user.hmis_data_source_id).find(id)
+      definition = Hmis::Form::Definition.in_data_source(current_user.hmis_data_source_id).find_by(id: id)
+      return nil unless definition # return nil (Not Found) if the definition is not found, e.g. this was a draft that got deleted
+
       access_denied! unless policy_for(definition, policy_type: :form_definition).can_configure_form?
 
       definition

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -696,12 +696,14 @@ module Types
       Hmis::Unit.viewable_by(current_user).find_by(id: id)
     end
 
-    field :ce_match_rule, HmisSchema::CeMatchRule, null: false do
+    field :ce_match_rule, HmisSchema::CeMatchRule, null: true do
       argument :id, ID, required: true
     end
     def ce_match_rule(id:)
       rule = Hmis::Ce::Match::Rule.find_by(id: id)
-      access_denied! unless rule && policy_for(rule, policy_type: :ce_match_rule).can_view?
+      return nil unless rule # not found (instead of raising)
+
+      access_denied! unless policy_for(rule, policy_type: :ce_match_rule).can_view?
 
       rule
     end

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -701,7 +701,7 @@ module Types
     end
     def ce_match_rule(id:)
       rule = Hmis::Ce::Match::Rule.find_by(id: id)
-      return nil unless rule # not found (instead of raising)
+      return nil unless rule # return nil (Not Found) if rule is not found, e.g. this rule was deleted
 
       access_denied! unless policy_for(rule, policy_type: :ce_match_rule).can_view?
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/query_type.rb
@@ -443,9 +443,7 @@ module Types
       # not be used for the application, because there is no project context passed
       # to the definition.
       definition = Hmis::Form::Definition.in_data_source(current_user.hmis_data_source_id).find_by(id: id)
-      return nil unless definition # return nil (Not Found) if the definition is not found, e.g. this was a draft that got deleted
-
-      access_denied! unless policy_for(definition, policy_type: :form_definition).can_configure_form?
+      return nil unless definition && policy_for(definition, policy_type: :form_definition).can_configure_form?
 
       definition
     end
@@ -701,9 +699,7 @@ module Types
     end
     def ce_match_rule(id:)
       rule = Hmis::Ce::Match::Rule.find_by(id: id)
-      return nil unless rule # return nil (Not Found) if rule is not found, e.g. this rule was deleted
-
-      access_denied! unless policy_for(rule, policy_type: :ce_match_rule).can_view?
+      return nil unless rule && policy_for(rule, policy_type: :ce_match_rule).can_view?
 
       rule
     end

--- a/drivers/hmis/spec/requests/hmis/ce/ce_match_rules_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_match_rules_spec.rb
@@ -180,6 +180,9 @@ RSpec.describe 'CE Match Rules queries', type: :request do
     remove_permissions(access_control, :can_administrate_coordinated_entry)
 
     expect_access_denied(post_graphql(filters: { global: true }) { rules_query })
-    expect_access_denied(post_graphql(id: global_rule.id) { rule_query })
+
+    # not access denied; returns nil (showing not found in the UI)
+    _, result = post_graphql(id: global_rule.id) { rule_query }
+    expect(result.dig('data', 'ceMatchRule')).to be_nil
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Reduce sentry noise and improve UX when user tries to re-open the URL (by id) for: 
- a form definition that no longer exists
- a CE match rule that no longer exists

https://greenriver.slack.com/archives/C050HQ86GBF/p1784810551602479
https://greenriver.slack.com/archives/C0610D9HSSH/p1784924964160909?thread_ts=1783345604.351399&cid=C0610D9HSSH

Related frontend PR (schema update only): https://github.com/greenriver/hmis-frontend/pull/1546

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Minor ux improvement

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

