### PR TITLE
1. Clean up orphaned system collections nightly

### DIFF
--- a/app/jobs/importing/run_daily_imports_job.rb
+++ b/app/jobs/importing/run_daily_imports_job.rb
@@ -191,6 +191,7 @@ module Importing
         SystemCohortsJob.set(priority: BaseJob::BULK_PROCESSING_PRIORITY_10).perform_later unless Delayed::Job.queued?('SystemCohortsJob')
         AccessGroup.delayed_system_group_maintenance
         Collection.delayed_system_group_maintenance
+        GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections.new.delay.run!
         GrdaWarehouse::Cohort.delay.maintain_auto_maintained!
         SyncSyntheticDataJob.perform_later if CasBase.db_exists?
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -560,9 +560,13 @@ class Collection < ApplicationRecord
     @associated_entity_set ||= group_viewable_entities.pluck(:entity_type, :entity_id).sort.to_set
   end
 
+  # UserGroups are matched by source_type/source_id, so we only run that query when both are
+  # present -- otherwise a sourceless Collection would run UserGroup.where(source_type: nil,
+  # source_id: nil), destroying every sourceless UserGroup rather than just this Collection's
+  # own. destroy_all/destroy! soft-delete (acts_as_paranoid), so all of this remains recoverable.
   def destroy_with_associated_records!
     access_controls.destroy_all
-    UserGroup.where(source_type: source_type, source_id: source_id).destroy_all if source_type.present?
+    UserGroup.where(source_type: source_type, source_id: source_id).destroy_all if source_type.present? && source_id.present?
     destroy!
   end
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -560,6 +560,12 @@ class Collection < ApplicationRecord
     @associated_entity_set ||= group_viewable_entities.pluck(:entity_type, :entity_id).sort.to_set
   end
 
+  def destroy_with_associated_records!
+    access_controls.destroy_all
+    UserGroup.where(source_type: source_type, source_id: source_id).destroy_all if source_type.present?
+    destroy!
+  end
+
   def class_name_for_viewable_type(type)
     viewable_types[type]
   end

--- a/app/models/grda_warehouse/tasks/cleanup_orphaned_system_collections.rb
+++ b/app/models/grda_warehouse/tasks/cleanup_orphaned_system_collections.rb
@@ -77,8 +77,9 @@ module GrdaWarehouse::Tasks
       end
     end
 
-    # Collection is primary DB; group_viewable_entities/:entity are warehouse DB.
-    # Per-collection association access (no joins) keeps this cross-DB safe.
+    # Collection is primary DB; group_viewable_entities/:entity are warehouse DB -- separate
+    # connections, so a LEFT OUTER JOIN across them isn't possible. We load each candidate's
+    # entities per-collection instead (see #orphaned? below) and check in Ruby.
     private def orphaned_collections
       Collection.system.where(must_exist: false).select { |collection| orphaned?(collection) }
     end

--- a/app/models/grda_warehouse/tasks/cleanup_orphaned_system_collections.rb
+++ b/app/models/grda_warehouse/tasks/cleanup_orphaned_system_collections.rb
@@ -1,0 +1,95 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module GrdaWarehouse::Tasks
+  # Finds system Collections (Collection.system, excluding must_exist aggregates
+  # like "All Cohorts") that have zero live entities -- either they never had any,
+  # or every entity they pointed to has since been deleted (hard or soft) -- and
+  # destroys them along with their AccessControls and per-source UserGroups.
+  class CleanupOrphanedSystemCollections
+    include MaintenanceTaskInstrumentation
+
+    def initialize(dry_run: false)
+      @dry_run = dry_run
+    end
+
+    def run!
+      # Dry runs shouldn't touch the shared maintenance-task/alerting state.
+      return perform_cleanup if @dry_run
+
+      result = nil
+
+      instrument_as_maintenance_task do |run|
+        result = perform_cleanup
+        run.complete!
+      end
+
+      result
+    end
+
+    private def perform_cleanup
+      candidates = build_candidates
+      destroyed_ids = []
+      failed = []
+
+      candidates.each do |candidate|
+        next if @dry_run
+
+        begin
+          candidate[:collection].destroy_with_associated_records!
+          destroyed_ids << candidate[:id]
+        rescue StandardError => e
+          # One failure shouldn't abort the rest of the run.
+          failed << { id: candidate[:id], error: e.message }
+          Rails.logger.error("CleanupOrphanedSystemCollections: failed to destroy Collection##{candidate[:id]}: #{e.message}")
+        end
+      end
+
+      Rails.logger.info("CleanupOrphanedSystemCollections: found #{candidates.length} candidates, destroyed #{destroyed_ids.length}, failed #{failed.length}, destroyed_ids: #{destroyed_ids.inspect}")
+
+      if failed.any?
+        Sentry.capture_exception_with_info(
+          StandardError.new("CleanupOrphanedSystemCollections: #{failed.size} collection(s) failed to destroy"),
+          info: { failed: failed },
+        )
+      end
+
+      { candidates: candidates, destroyed_ids: destroyed_ids, failed: failed, dry_run: @dry_run }
+    end
+
+    private def build_candidates
+      orphaned_collections.map do |collection|
+        {
+          id: collection.id,
+          name: collection.name,
+          collection_type: collection.collection_type,
+          source_type: collection.source_type,
+          source_id: collection.source_id,
+          entity_rows_count: collection.group_viewable_entities.count,
+          access_controls_count: collection.access_controls.count,
+          collection: collection,
+        }
+      end
+    end
+
+    # Collection is primary DB; group_viewable_entities/:entity are warehouse DB.
+    # Per-collection association access (no joins) keeps this cross-DB safe.
+    private def orphaned_collections
+      Collection.system.where(must_exist: false).select { |collection| orphaned?(collection) }
+    end
+
+    private def orphaned?(collection)
+      gves = collection.group_viewable_entities.includes(:entity).load
+      gves.none? { |gve| gve.entity.present? }
+    rescue NameError
+      # entity_type names a class that's been renamed or removed.
+      Rails.logger.warn("CleanupOrphanedSystemCollections: unrecognized entity_type on Collection##{collection.id}, excluding")
+      false
+    end
+  end
+end

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -1,0 +1,56 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+namespace :collections do
+  desc 'Find and delete system collections with no live entities (never had any, or entities since deleted)'
+  task :cleanup_orphaned_entities, [:dry_run] => :environment do |_task, args|
+    dry_run = ['true', '1'].include?(args[:dry_run])
+
+    puts '=' * 80
+    puts 'Cleanup Orphaned System Collections'
+    puts "Mode: #{dry_run ? 'DRY RUN' : 'LIVE'}"
+    puts '=' * 80
+    puts
+
+    result = GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections.new(dry_run: dry_run).run!
+
+    if result[:candidates].empty?
+      puts 'No orphaned system collections found.'
+    else
+      result[:candidates].each do |candidate|
+        status = if dry_run
+          'would delete'
+        elsif result[:destroyed_ids].include?(candidate[:id])
+          'deleted'
+        else
+          failure = result[:failed].find { |f| f[:id] == candidate[:id] }
+          "ERROR: #{failure && failure[:error]}"
+        end
+
+        puts "Collection ##{candidate[:id]} \"#{candidate[:name]}\" (#{candidate[:collection_type]}) - " \
+          "source: #{candidate[:source_type] || 'none'}##{candidate[:source_id]} " \
+          "[entity rows: #{candidate[:entity_rows_count]}, access_controls: #{candidate[:access_controls_count]}] - #{status}"
+      end
+    end
+
+    puts
+    puts '=' * 80
+    puts 'Summary:'
+    puts "  Total candidates found: #{result[:candidates].size}"
+    if dry_run
+      puts "  Total that would be deleted: #{result[:candidates].size}"
+      puts
+      puts 'To actually delete these, run without dry_run:'
+      puts '  rake collections:cleanup_orphaned_entities'
+    else
+      puts "  Total deleted: #{result[:destroyed_ids].size}"
+      puts "  Total errors: #{result[:failed].size}"
+    end
+    puts '=' * 80
+  end
+end

--- a/spec/jobs/importing/run_daily_imports_job_spec.rb
+++ b/spec/jobs/importing/run_daily_imports_job_spec.rb
@@ -115,16 +115,6 @@ RSpec.describe Importing::RunDailyImportsJob, type: :job do
         end
       end
 
-      it 'runs the orphaned system collections cleanup as a delayed job' do
-        cleanup_task = double('CleanupOrphanedSystemCollections')
-        delayed_proxy = double('delayed_proxy')
-        expect(GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections).to receive(:new).and_return(cleanup_task)
-        expect(cleanup_task).to receive(:delay).and_return(delayed_proxy)
-        expect(delayed_proxy).to receive(:run!)
-
-        job.perform
-      end
-
       it 'sends completion notification' do
         job.perform
 

--- a/spec/jobs/importing/run_daily_imports_job_spec.rb
+++ b/spec/jobs/importing/run_daily_imports_job_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Importing::RunDailyImportsJob, type: :job do
     allow(SystemCohortsJob).to receive(:set).and_return(double(perform_later: true))
     allow(AccessGroup).to receive(:delayed_system_group_maintenance)
     allow(Collection).to receive(:delayed_system_group_maintenance)
+    allow(GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections).to receive(:new).and_return(double(delay: double(run!: true)))
     allow(GrdaWarehouse::Cohort).to receive(:delay).and_return(double(maintain_auto_maintained!: true))
     allow(SyncSyntheticDataJob).to receive(:perform_later)
     allow(CasBase).to receive(:db_exists?).and_return(false)
@@ -112,6 +113,16 @@ RSpec.describe Importing::RunDailyImportsJob, type: :job do
           expect(run.started_at).to be_present
           expect(run.completed_at).to be_present
         end
+      end
+
+      it 'runs the orphaned system collections cleanup as a delayed job' do
+        cleanup_task = double('CleanupOrphanedSystemCollections')
+        delayed_proxy = double('delayed_proxy')
+        expect(GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections).to receive(:new).and_return(cleanup_task)
+        expect(cleanup_task).to receive(:delay).and_return(delayed_proxy)
+        expect(delayed_proxy).to receive(:run!)
+
+        job.perform
       end
 
       it 'sends completion notification' do

--- a/spec/lib/tasks/collections_spec.rb
+++ b/spec/lib/tasks/collections_spec.rb
@@ -1,0 +1,77 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+describe 'collections:cleanup_orphaned_entities' do
+  let(:rake) { Rake::Application.new }
+  let(:task_name) { 'collections:cleanup_orphaned_entities' }
+
+  before do
+    Rake.application = rake
+    Rake::Task.define_task(:environment)
+    Rake.load_rakefile(Rails.root.join('lib/tasks/collections.rake'))
+  end
+
+  after { rake[task_name].reenable }
+
+  it 'defaults to live mode when no arg is given' do
+    expect { Rake::Task[task_name].invoke }.to output(/Mode: LIVE/).to_stdout
+  end
+
+  it 'runs in dry run mode when passed true' do
+    expect { Rake::Task[task_name].invoke('true') }.to output(/Mode: DRY RUN/).to_stdout
+  end
+
+  it 'reports none found when there are no candidates' do
+    expect { Rake::Task[task_name].invoke('true') }.to output(/No orphaned system collections found\./).to_stdout
+  end
+
+  it 'finds and deletes a real orphan end-to-end' do
+    cohort = create(:cohort)
+    collection = cohort.viewable_access_control.collection
+    cohort.really_destroy!
+
+    expect { Rake::Task[task_name].invoke }.to output(/Collection ##{collection.id}.* - deleted/).to_stdout
+    expect(Collection.find_by(id: collection.id)).to be_nil
+  end
+
+  it 'does not delete anything in dry run mode' do
+    cohort = create(:cohort)
+    collection = cohort.viewable_access_control.collection
+    cohort.really_destroy!
+
+    Rake::Task[task_name].invoke('true')
+
+    expect(Collection.find_by(id: collection.id)).to be_present
+  end
+
+  it 'treats "1" the same as "true" for dry run mode' do
+    cohort = create(:cohort)
+    collection = cohort.viewable_access_control.collection
+    cohort.really_destroy!
+
+    Rake::Task[task_name].invoke('1')
+
+    expect(Collection.find_by(id: collection.id)).to be_present
+  end
+
+  it 'reports a per-candidate error and reflects it in the summary when one fails to delete' do
+    cohort = create(:cohort)
+    collection = cohort.viewable_access_control.collection
+    cohort.really_destroy!
+
+    allow_any_instance_of(Collection).to receive(:destroy_with_associated_records!).and_raise(StandardError, 'simulated failure')
+
+    expect { Rake::Task[task_name].invoke }.to output(
+      /Collection ##{collection.id}.*ERROR: simulated failure.*Total deleted: 0.*Total errors: 1/m,
+    ).to_stdout
+    expect(Collection.find_by(id: collection.id)).to be_present
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,0 +1,84 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Collection, type: :model do
+  describe '#destroy_with_associated_records!' do
+    let(:cohort) { create(:cohort) }
+    let(:access_control) { cohort.viewable_access_control }
+    let(:collection) { access_control.collection }
+    let(:viewable_user_group) { cohort.system_viewable_user_group }
+    let(:editable_user_group) { cohort.system_editable_user_group }
+
+    it 'destroys the collection, both its access controls, and both its viewable and editable source user groups' do
+      editable_access_control = cohort.editable_access_control
+      access_control
+      viewable_user_group
+      editable_user_group
+
+      collection.destroy_with_associated_records!
+
+      expect(Collection.find_by(id: collection.id)).to be_nil
+      expect(AccessControl.find_by(id: access_control.id)).to be_nil
+      expect(AccessControl.find_by(id: editable_access_control.id)).to be_nil
+      expect(UserGroup.find_by(id: viewable_user_group.id)).to be_nil
+      expect(UserGroup.find_by(id: editable_user_group.id)).to be_nil
+    end
+
+    it 'does not touch a different source of the same type' do
+      other_cohort = create(:cohort)
+      other_user_group = other_cohort.system_viewable_user_group
+
+      collection.destroy_with_associated_records!
+
+      expect(UserGroup.find_by(id: other_user_group.id)).to be_present
+    end
+
+    it 'soft-deletes the collection and its dependents so they remain recoverable' do
+      editable_access_control = cohort.editable_access_control
+      access_control
+      viewable_user_group
+      editable_user_group
+
+      collection.destroy_with_associated_records!
+
+      # with_deleted.find raises RecordNotFound if a record was hard-deleted,
+      # so these fail if destroy_all is ever swapped for really_destroy!.
+      expect(Collection.with_deleted.find(collection.id)).to be_present
+      expect(AccessControl.with_deleted.find(access_control.id)).to be_present
+      expect(AccessControl.with_deleted.find(editable_access_control.id)).to be_present
+      expect(UserGroup.with_deleted.find(viewable_user_group.id)).to be_present
+      expect(UserGroup.with_deleted.find(editable_user_group.id)).to be_present
+    end
+
+    it 'does not destroy the shared role' do
+      role = cohort.viewable_role
+      access_control
+      collection.destroy_with_associated_records!
+
+      expect(Role.find_by(id: role.id)).to be_present
+    end
+
+    it 'does not error for a collection with no access controls or user groups' do
+      plain_collection = create(:collection)
+
+      expect { plain_collection.destroy_with_associated_records! }.not_to raise_error
+      expect(Collection.find_by(id: plain_collection.id)).to be_nil
+    end
+
+    it 'does not touch unrelated user groups when the collection has no source' do
+      plain_collection = create(:collection)
+      unrelated_user_group = create(:user_group) # ordinary group, no source -- same shape as production data
+
+      plain_collection.destroy_with_associated_records!
+
+      expect(UserGroup.find_by(id: unrelated_user_group.id)).to be_present
+    end
+  end
+end

--- a/spec/models/grda_warehouse/tasks/cleanup_orphaned_system_collections_spec.rb
+++ b/spec/models/grda_warehouse/tasks/cleanup_orphaned_system_collections_spec.rb
@@ -1,0 +1,163 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Tasks::CleanupOrphanedSystemCollections do
+  describe '#run! (candidate detection)' do
+    it 'returns no candidates when there are none' do
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates]).to eq([])
+    end
+
+    it 'flags a collection whose entity was hard-deleted' do
+      cohort = create(:cohort)
+      collection = cohort.viewable_access_control.collection
+      cohort.really_destroy!
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates].map { |c| c[:id] }).to contain_exactly(collection.id)
+    end
+
+    it 'flags a collection whose entity was soft-deleted' do
+      cohort = create(:cohort)
+      collection = cohort.viewable_access_control.collection
+      cohort.destroy
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates].map { |c| c[:id] }).to contain_exactly(collection.id)
+    end
+
+    it 'flags a legacy system collection created with zero entities' do
+      legacy_collection = Collection.create!(name: 'Legacy Orphan', collection_type: 'Projects', system: ['Entities'])
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates].map { |c| c[:id] }).to contain_exactly(legacy_collection.id)
+    end
+
+    it 'does not flag a collection whose entity is still live' do
+      cohort = create(:cohort)
+      cohort.viewable_access_control
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates]).to eq([])
+    end
+
+    it 'does not flag a non-system collection with zero entities' do
+      create(:collection)
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates]).to eq([])
+    end
+
+    it 'does not flag a must_exist aggregate collection regardless of entity count' do
+      Collection.system_collections
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates]).to eq([])
+    end
+
+    it 'excludes (rather than flags) a collection referencing an unrecognized entity_type' do
+      cohort = create(:cohort)
+      collection = cohort.viewable_access_control.collection
+      record = GrdaWarehouse::GroupViewableEntity.new(
+        collection_id: collection.id,
+        entity_type: 'NoSuchClass',
+        entity_id: 999_999,
+        access_group_id: 0,
+      )
+      record.save(validate: false)
+
+      result = described_class.new(dry_run: true).run!
+
+      expect(result[:candidates].map { |c| c[:id] }).not_to include(collection.id)
+    end
+  end
+
+  describe '#run! (dry run vs. live deletion)' do
+    let(:cohort) { create(:cohort) }
+    let(:access_control) { cohort.viewable_access_control }
+    let(:collection) { access_control.collection }
+
+    before do
+      collection
+      cohort.really_destroy!
+    end
+
+    it 'does not delete anything in dry run mode' do
+      described_class.new(dry_run: true).run!
+
+      expect(Collection.find_by(id: collection.id)).to be_present
+    end
+
+    it 'does not record a maintenance task run in dry run mode' do
+      expect { described_class.new(dry_run: true).run! }.
+        not_to change(GrdaWarehouse::Tasks::SystemMaintenanceTaskRun, :count)
+    end
+
+    it 'records a completed maintenance task run in live mode' do
+      expect { described_class.new(dry_run: false).run! }.
+        to change(GrdaWarehouse::Tasks::SystemMaintenanceTaskRun, :count).by(1)
+      expect(GrdaWarehouse::Tasks::SystemMaintenanceTaskRun.last.completed_at).to be_present
+    end
+
+    it 'reports failures to Sentry with the failure count' do
+      allow_any_instance_of(Collection).to receive(:destroy_with_associated_records!).and_raise(StandardError, 'simulated failure')
+
+      expect(Sentry).to receive(:capture_exception_with_info) do |error, *|
+        expect(error).to be_a(StandardError)
+        expect(error.message).to include('1 collection(s) failed to destroy')
+      end
+
+      described_class.new(dry_run: false).run!
+    end
+
+    it 'does not report to Sentry when nothing fails' do
+      expect(Sentry).not_to receive(:capture_exception_with_info)
+
+      described_class.new(dry_run: false).run!
+    end
+
+    it 'deletes the candidate in live mode via the safe, reversible teardown' do
+      result = described_class.new(dry_run: false).run!
+
+      expect(Collection.find_by(id: collection.id)).to be_nil
+      expect(result[:destroyed_ids]).to contain_exactly(collection.id)
+      # Both assertions below only pass if this went through destroy_with_associated_records!,
+      # not a bare destroy! (would skip the AccessControl cleanup) or really_destroy! (irreversible).
+      expect(Collection.with_deleted.find(collection.id)).to be_present
+      expect(AccessControl.find_by(id: access_control.id)).to be_nil
+    end
+
+    it 'continues processing remaining candidates when one fails to delete' do
+      other_cohort = create(:cohort)
+      other_collection = other_cohort.viewable_access_control.collection
+      other_cohort.really_destroy!
+
+      allow_any_instance_of(Collection).to receive(:destroy_with_associated_records!) do |instance|
+        raise StandardError, 'simulated failure' if instance.id == collection.id
+
+        instance.destroy!
+      end
+
+      result = described_class.new(dry_run: false).run!
+
+      expect(result[:failed]).to contain_exactly({ id: collection.id, error: 'simulated failure' })
+      expect(result[:destroyed_ids]).to contain_exactly(other_collection.id)
+      expect(Collection.find_by(id: collection.id)).to be_present # destroy failed, still there
+      expect(Collection.find_by(id: other_collection.id)).to be_nil # destroyed fine
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Cohort, ProjectGroup, and DataSource auto-create a per-entity system Collection (plus AccessControls and UserGroups) via the EntityAccess concern, but nothing removes them when the owning entity is destroyed, leaving orphaned collections that are invisible and undeletable in the admin UI. Add a CleanupOrphanedSystemCollections service that soft deletes system collections with no live entities along with their dependent AccessControls and per-source UserGroups, exposed as the collections:cleanup_orphaned_entities rake task (dry-run capable) and enqueued as a delayed job from the nightly maintenance run.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

