### PR TITLE
2. Delete system collections when the owning entity is deleted

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -134,7 +134,8 @@ class CohortsController < ApplicationController
   end
 
   def destroy
-    @cohort.destroy unless @cohort.system_cohort
+    destroyed = @cohort.destroy unless @cohort.system_cohort
+    @cohort.remove_system_collections! if destroyed
     redirect_to cohorts_path
   end
 

--- a/app/controllers/project_groups_controller.rb
+++ b/app/controllers/project_groups_controller.rb
@@ -99,10 +99,15 @@ class ProjectGroupsController < ApplicationController
   end
 
   def destroy
+    destroyed = nil
     project_group_source.transaction do
       @project_group.remove_from_group_viewable_entities!
-      @project_group.destroy
+      destroyed = @project_group.destroy
     end
+    # Collection/AccessControl/UserGroup live in the primary database, so this
+    # teardown is NOT covered by the warehouse transaction above — run it only
+    # after the warehouse delete has committed.
+    @project_group.remove_system_collections! if destroyed
     AccessGroup.maintain_system_groups
     respond_with(@project_group, location: project_groups_path)
   end
@@ -111,13 +116,17 @@ class ProjectGroupsController < ApplicationController
     group_ids = params[:selections]&.try(:[], :group)&.reject(&:empty?)&.map(&:to_i)
     redirect_to project_groups_path and return unless group_ids
 
+    destroyed_groups = []
     project_group_source.transaction do
       group_ids.each do |group|
         project_group = project_group_scope.find(group)
         project_group.remove_from_group_viewable_entities!
-        project_group.destroy
+        destroyed = project_group.destroy
+        destroyed_groups << project_group if destroyed
       end
     end
+    # primary-database teardown, outside the warehouse transaction
+    destroyed_groups.each(&:remove_system_collections!)
     AccessGroup.maintain_system_groups
     redirect_to project_groups_path
   end

--- a/app/models/concerns/entity_access.rb
+++ b/app/models/concerns/entity_access.rb
@@ -103,7 +103,7 @@ module EntityAccess
   # +source+ (not +system_collection+, which would create one). Errors are logged
   # and reported, not raised, so teardown never blocks the delete.
   def remove_system_collections!
-    Collection.where(source: self).find_each(&:destroy_with_associated_records!)
+    Collection.system.where(source: self).find_each(&:destroy_with_associated_records!)
   rescue StandardError => e
     Rails.logger.error("EntityAccess#remove_system_collections! failed for #{self.class.sti_name}##{id}: #{e.message}")
     Sentry.capture_exception_with_info(e, info: { source_type: self.class.sti_name, source_id: id })

--- a/app/models/concerns/entity_access.rb
+++ b/app/models/concerns/entity_access.rb
@@ -99,6 +99,16 @@ module EntityAccess
     end
   end
 
+  # Tears down this entity's system collection(s) when it is deleted. Queries by
+  # +source+ (not +system_collection+, which would create one). Errors are logged
+  # and reported, not raised, so teardown never blocks the delete.
+  def remove_system_collections!
+    Collection.where(source: self).find_each(&:destroy_with_associated_records!)
+  rescue StandardError => e
+    Rails.logger.error("EntityAccess#remove_system_collections! failed for #{self.class.sti_name}##{id}: #{e.message}")
+    Sentry.capture_exception_with_info(e, info: { source_type: self.class.sti_name, source_id: id })
+  end
+
   ##
   # Finds or creates a "system" +UserGroup+ that grants viewable access
   # to this entity to users through the `viewable_access_control``.

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -6,7 +6,6 @@
 
 # frozen_string_literal: true
 
-#
 require 'memery'
 
 class GrdaWarehouse::DataSource < GrdaWarehouseBase
@@ -717,6 +716,7 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
   def destroy_dependents!
     organizations.map(&:destroy_dependents!)
     organizations.update_all(DateDeleted: Time.current, source_hash: nil)
+    remove_system_collections!
   end
 
   def client_count

--- a/spec/jobs/delete_item_job_spec.rb
+++ b/spec/jobs/delete_item_job_spec.rb
@@ -1,0 +1,26 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeleteItemJob, type: :job do
+  describe '#perform for a DataSource' do
+    let(:data_source) { create(:grda_warehouse_data_source) }
+
+    it 'destroys the data source and removes its system collection and access control' do
+      access_control = data_source.editable_access_control # data sources support editable only
+      collection = access_control.collection
+
+      described_class.new.perform(item_class: 'GrdaWarehouse::DataSource', item_id: data_source.id)
+
+      expect(GrdaWarehouse::DataSource.find_by(id: data_source.id)).to be_nil
+      expect(Collection.find_by(id: collection.id)).to be_nil
+      expect(AccessControl.find_by(id: access_control.id)).to be_nil
+    end
+  end
+end

--- a/spec/jobs/delete_item_job_spec.rb
+++ b/spec/jobs/delete_item_job_spec.rb
@@ -22,5 +22,16 @@ RSpec.describe DeleteItemJob, type: :job do
       expect(Collection.find_by(id: collection.id)).to be_nil
       expect(AccessControl.find_by(id: access_control.id)).to be_nil
     end
+
+    it 'removes the system collection but leaves non-system collections that also reference the data source' do
+      system_collection = data_source.editable_access_control.collection
+      non_system_collection = create(:collection)
+      non_system_collection.set_viewables(data_sources: [data_source.id])
+
+      described_class.new.perform(item_class: 'GrdaWarehouse::DataSource', item_id: data_source.id)
+
+      expect(Collection.find_by(id: system_collection.id)).to be_nil
+      expect(Collection.find_by(id: non_system_collection.id)).to eq(non_system_collection)
+    end
   end
 end

--- a/spec/models/concerns/entity_access_spec.rb
+++ b/spec/models/concerns/entity_access_spec.rb
@@ -1,0 +1,79 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EntityAccess is a concern; exercise it through a concrete host (Cohort),
+# which supports both viewable and editable access controls.
+RSpec.describe EntityAccess, type: :model do
+  describe '#remove_system_collections!' do
+    let(:cohort) { create(:cohort) }
+
+    it 'soft-deletes the system collection, its access controls, and its source user groups' do
+      viewable_ac = cohort.viewable_access_control
+      editable_ac = cohort.editable_access_control
+      collection = viewable_ac.collection
+      viewable_ug = cohort.system_viewable_user_group
+      editable_ug = cohort.system_editable_user_group
+
+      cohort.remove_system_collections!
+
+      expect(Collection.find_by(id: collection.id)).to be_nil
+      expect(AccessControl.find_by(id: viewable_ac.id)).to be_nil
+      expect(AccessControl.find_by(id: editable_ac.id)).to be_nil
+      expect(UserGroup.find_by(id: viewable_ug.id)).to be_nil
+      expect(UserGroup.find_by(id: editable_ug.id)).to be_nil
+    end
+
+    it 'does not touch the system collection of a different entity of the same type' do
+      cohort.viewable_access_control
+      other_cohort = create(:cohort)
+      other_ac = other_cohort.viewable_access_control
+      other_collection = other_ac.collection
+      other_ug = other_cohort.system_viewable_user_group
+
+      cohort.remove_system_collections!
+
+      # Guards the source scope: a source_type-only (source_id-dropped) query would
+      # sweep every same-type entity's collection, not just this cohort's.
+      expect(Collection.find_by(id: other_collection.id)).to be_present
+      expect(AccessControl.find_by(id: other_ac.id)).to be_present
+      expect(UserGroup.find_by(id: other_ug.id)).to be_present
+    end
+
+    it 'leaves the shared role intact' do
+      role = cohort.viewable_role
+      cohort.viewable_access_control
+
+      cohort.remove_system_collections!
+
+      expect(Role.find_by(id: role.id)).to be_present
+    end
+
+    it 'creates nothing when the entity has no system collection' do
+      cohort # created, but no access control / collection forced
+
+      expect { cohort.remove_system_collections! }.not_to change(Collection, :count)
+      # with_deleted catches the forbidden system_collection path, which would
+      # first_or_initialize + persist a row and then soft-delete it in the same call,
+      # leaving a soft-deleted row invisible to the default scope but visible here.
+      expect(Collection.with_deleted.where(source: cohort)).to be_empty
+    end
+
+    it 'rescues, logs, and reports errors instead of raising' do
+      cohort.viewable_access_control
+      allow_any_instance_of(Collection).to receive(:destroy_with_associated_records!).and_raise(StandardError, 'boom')
+      expect(Sentry).to receive(:capture_exception_with_info) do |error, *|
+        expect(error).to be_a(StandardError)
+        expect(error.message).to eq('boom')
+      end
+
+      expect { cohort.remove_system_collections! }.not_to raise_error
+    end
+  end
+end

--- a/spec/requests/cohorts_controller_spec.rb
+++ b/spec/requests/cohorts_controller_spec.rb
@@ -119,4 +119,34 @@ RSpec.describe CohortsController, type: :request do
       expect(flash[:alert]).to eq('This cohort is manually maintained.')
     end
   end
+
+  describe 'DELETE /cohorts/:id' do
+    let(:user) { create(:acl_user) }
+    let(:cohort) { create(:cohort) }
+    let(:cohort_role) { create(:cohort_manager) }
+    let(:all_cohorts_collection) { Collection.system_collection(:cohorts) }
+
+    before do
+      Collection.maintain_system_groups
+      setup_access_control(user, cohort_role, all_cohorts_collection)
+      sign_in user
+    end
+
+    it "removes the cohort's system collection when the cohort is deleted" do
+      collection = cohort.viewable_access_control.collection
+
+      delete cohort_path(cohort)
+
+      expect(GrdaWarehouse::Cohort.find_by(id: cohort.id)).to be_nil
+      expect(Collection.find_by(id: collection.id)).to be_nil
+    end
+
+    it 'does not delete a system cohort' do
+      system_cohort = create(:cohort, system_cohort: true)
+
+      delete cohort_path(system_cohort)
+
+      expect(GrdaWarehouse::Cohort.find_by(id: system_cohort.id)).to be_present
+    end
+  end
 end

--- a/spec/requests/project_groups_controller_spec.rb
+++ b/spec/requests/project_groups_controller_spec.rb
@@ -141,6 +141,56 @@ RSpec.describe ProjectGroupsController, type: :request do
     end
   end
 
+  describe 'deleting project groups' do
+    it "DELETE #destroy removes the project group's system collection" do
+      collection = project_group.editable_access_control.collection # project groups support editable only
+
+      delete project_group_path(project_group)
+
+      expect(response).to redirect_to(project_groups_path)
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: project_group.id)).to be_nil
+      expect(Collection.find_by(id: collection.id)).to be_nil
+    end
+
+    it "delete_multiple removes each project group's system collection" do
+      collection_1 = project_group.editable_access_control.collection
+      collection_2 = project_group_2.editable_access_control.collection
+
+      post delete_multiple_project_groups_path, params: { selections: { group: [project_group.id.to_s, project_group_2.id.to_s] } }
+
+      expect(response).to redirect_to(project_groups_path)
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: project_group.id)).to be_nil
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: project_group_2.id)).to be_nil
+      expect(Collection.find_by(id: collection_1.id)).to be_nil
+      expect(Collection.find_by(id: collection_2.id)).to be_nil
+    end
+
+    it 'delete_multiple does not delete project groups that were not selected' do
+      selected_collection = project_group.editable_access_control.collection
+      unselected = create(:project_group, name: 'Keep Me')
+      unselected_collection = unselected.editable_access_control.collection
+
+      post delete_multiple_project_groups_path, params: { selections: { group: [project_group.id.to_s] } }
+
+      # selected group is torn down...
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: project_group.id)).to be_nil
+      expect(Collection.find_by(id: selected_collection.id)).to be_nil
+      # ...but an unselected group and its collection survive
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: unselected.id)).to be_present
+      expect(Collection.find_by(id: unselected_collection.id)).to be_present
+    end
+
+    it 'delete_multiple with no selection redirects without deleting anything' do
+      collection = project_group.editable_access_control.collection
+
+      post delete_multiple_project_groups_path
+
+      expect(response).to redirect_to(project_groups_path)
+      expect(GrdaWarehouse::ProjectGroup.find_by(id: project_group.id)).to be_present
+      expect(Collection.find_by(id: collection.id)).to be_present
+    end
+  end
+
   describe 'integration with project filtering' do
     let!(:project_group) { create(:project_group, skip_maintain_system_group: true) }
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

When a cohort, project group, or data source is deleted, the system creates and then no longer needs a set of hidden records that were used to manage who could see or edit that item. Until now those records were left behind when the item was deleted, and they accumulated over time.

This change deletes those records at the same time the item is deleted. The removal happens only after the deletion has completed, and if the removal fails it is recorded and reported without stopping or reversing the deletion the user requested. A separate nightly process, added earlier, continues to run as a backstop.

Deletion behaves the same as before for users. There is no change to how it looks or works; the change only affects the hidden records that are removed behind the scenes.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

