### PR TITLE
fix: handle conflicting auth source user ids

### DIFF
--- a/app/services/idp/user_provisioner.rb
+++ b/app/services/idp/user_provisioner.rb
@@ -95,13 +95,43 @@ module Idp
       # belongs to the resolved user — no cross-user case to handle here.)
       return if user.user_authentication_sources.where(connector_identity).exists?
 
-      # First JWT login (resolved by email): establish the link. Any prior
-      # soft-deleted row for this pair is left as inert history — the partial
-      # unique index ignores deleted rows, so a fresh live row inserts cleanly.
-      user.user_authentication_sources.create!(connector_identity)
+      # The validated token carries an id we have no live link for. Any live link
+      # this user holds for the same connector under a *different* id is now stale
+      # (e.g. the upstream account was deleted and recreated with a new subject)
+
+      superseded_ids = nil
+      Idp::UserAuthenticationSource.transaction do
+        stale_links = user.user_authentication_sources.
+          where(connector_id: @connector_id).
+          where.not(connector_user_id: @connector_user_id)
+
+        superseded_ids = stale_links.map(&:connector_user_id)
+        stale_links.destroy_all
+        user.user_authentication_sources.create!(connector_identity)
+      end
+
+      report_identity_disagreement(user, superseded_ids) if superseded_ids.present?
     rescue ActiveRecord::RecordNotUnique
-      # Lost a concurrent first-login race; a live row for this pair now exists.
+      # Lost a concurrent first-login/relink race; a live row for this pair now exists.
       nil
+    end
+
+    def report_identity_disagreement(user, superseded_ids)
+      Rails.logger.warn(
+        "IdP identity disagreement on connector #{@connector_id}: token subject #{@connector_user_id} " \
+        "superseded stale link(s) #{superseded_ids.inspect} for user_id=#{user.id}",
+      )
+
+      Sentry.capture_message(
+        'IdP identity disagreement: token subject did not match the stored authentication source',
+        level: :warning,
+        extra: {
+          user_id: user.id,
+          connector_id: @connector_id,
+          token_connector_user_id: @connector_user_id,
+          superseded_connector_user_ids: superseded_ids,
+        },
+      )
     end
 
     def update_last_connector(user)

--- a/db/migrate/20260724120000_add_unique_live_user_connector_to_user_authentication_sources.rb
+++ b/db/migrate/20260724120000_add_unique_live_user_connector_to_user_authentication_sources.rb
@@ -1,0 +1,20 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# A user may hold only one live identity link per connector.
+#
+class AddUniqueLiveUserConnectorToUserAuthenticationSources < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      add_index :user_authentication_sources, [:user_id, :connector_id],
+                unique: true,
+                name: 'index_user_auth_sources_on_user_connector_live',
+                where: 'deleted_at IS NULL'
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4015,6 +4015,13 @@ CREATE INDEX index_uploads_on_deleted_at ON public.uploads USING btree (deleted_
 
 
 --
+-- Name: index_user_auth_sources_on_user_connector_live; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_user_auth_sources_on_user_connector_live ON public.user_authentication_sources USING btree (user_id, connector_id) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_user_authentication_sources_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4250,6 +4257,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260724120000'),
 ('20260715120000'),
 ('20260620000000'),
 ('20260614130000'),

--- a/spec/models/concerns/idp/jwt_user_spec.rb
+++ b/spec/models/concerns/idp/jwt_user_spec.rb
@@ -156,5 +156,58 @@ RSpec.describe Idp::JwtUser, type: :model, if: AuthMethod.jwt? do
         expect(live.id).not_to eq(deleted.id)
       end
     end
+
+    context 'when the user already has a live link for this connector under a different id' do
+      # e.g. the upstream account was deleted and recreated with a new subject.
+      before do
+        user.user_authentication_sources.create!(
+          connector_id: 'test-idp',
+          connector_user_id: 'ext-user-stale',
+        )
+      end
+
+      it 'supersedes the stale link with the token identity' do
+        result = User.find_or_create_from_jwt(jwt_helper)
+        expect(result).to eq(user)
+
+        live = user.user_authentication_sources.where(connector_id: 'test-idp')
+        expect(live.pluck(:connector_user_id)).to contain_exactly('ext-user-1')
+
+        stale = Idp::UserAuthenticationSource.only_deleted.find_by(connector_id: 'test-idp', connector_user_id: 'ext-user-stale')
+        expect(stale.deleted_at).to be_present
+      end
+
+      it 'leaves a live link for a different connector untouched' do
+        user.user_authentication_sources.create!(connector_id: 'other-idp', connector_user_id: 'ext-user-stale')
+
+        User.find_or_create_from_jwt(jwt_helper)
+
+        expect(user.user_authentication_sources.where(connector_id: 'other-idp', connector_user_id: 'ext-user-stale')).to exist
+      end
+
+      it 'alerts engineering via Sentry that the token disagreed with the stored link' do
+        allow(Sentry).to receive(:initialized?).and_return(true)
+        expect(Sentry).to receive(:capture_message).with(
+          /identity disagreement/,
+          hash_including(
+            level: :warning,
+            extra: hash_including(
+              user_id: user.id,
+              connector_id: 'test-idp',
+              token_connector_user_id: 'ext-user-1',
+              superseded_connector_user_ids: ['ext-user-stale'],
+            ),
+          ),
+        )
+
+        User.find_or_create_from_jwt(jwt_helper)
+      end
+    end
+
+    it 'does not alert on an ordinary first-login link (no disagreement)' do
+      expect(Sentry).not_to receive(:capture_message)
+      User.find_or_create_from_jwt(jwt_helper)
+      expect(user.user_authentication_sources.pluck(:connector_user_id)).to eq(['ext-user-1'])
+    end
   end
 end

--- a/spec/services/idp/keycloak/authentication_source_backfill_spec.rb
+++ b/spec/services/idp/keycloak/authentication_source_backfill_spec.rb
@@ -121,6 +121,25 @@ RSpec.describe Idp::Keycloak::AuthenticationSourceBackfill do
       end
     end
 
+    context 'a user with a live link for this connector under a different id' do
+      # e.g. the Keycloak account was recreated with a new subject
+      let(:keycloak_users) { [{ email: 'recreated@example.com', id: 'kc-new' }] }
+      let!(:user) { create(:user, email: 'recreated@example.com', confirmed_at: Time.current, active: true) }
+
+      before do
+        user.user_authentication_sources.create!(connector_id: connector_id, connector_user_id: 'kc-old')
+      end
+
+      it 'does not crash and leaves the existing link in place' do
+        result = nil
+        expect { result = backfill.call }.not_to raise_error
+
+        expect(result).to have_attributes(total: 1, linked: 0, already: 1)
+        sources = user.reload.user_authentication_sources
+        expect(sources.pluck(:connector_user_id)).to eq(['kc-old'])
+      end
+    end
+
     context 'the system user' do
       let(:keycloak_users) { [{ email: 'noreply@greenriver.com', id: 'kc-sys' }] }
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

### Description

Supersede a user's stale IdP authentication source link when a validated JWT presents a different connector subject id for the same connector.

- **IdP User Provisioner**: When a token carries a connector id with no matching live link, soft-delete any existing live link for that connector under a different id before creating the new link; report the disagreement to the log and Sentry.
- Add a partial unique index enforcing one live authentication source per `(user_id, connector_id)`.
- Add test coverage for supersession, connector isolation, Sentry alerting, and the backfill conflict case.

### Type of Change

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] I added spec tests (or not applicable)


