### PR TITLE
Add worktrunk-based development worktree tooling

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,15 @@
+# Worktrunk project config (https://worktrunk.dev). Wires worktree lifecycle
+# events to the scripts in lib/development/scripts/. Project hooks require a
+# one-time approval the first time they run (wt prompts "Allow and remember?");
+# the /worktree-setup skill runs `wt switch --create --yes` to auto-accept.
+#
+# See docs/worktrees.md for the full workflow.
+
+# Blocking. Copies the gitignored env/compose files a fresh worktree lacks from
+# the primary worktree, then rewrites them for isolated databases, a per-worktree
+# domain, compose project name, and traefik router.
+pre-start = "bash lib/development/scripts/worktree_pre_start.sh {{ worktree_path }} {{ branch }} {{ primary_worktree_path }}"
+
+# Blocking, runs in the worktree being removed. Removes the worktree's app
+# containers and drops its `_wt_`-suffixed databases from the shared db container.
+pre-remove = "bash lib/development/scripts/worktree_pre_remove.sh {{ worktree_path }} {{ branch }}"

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ docker-compose.override.yml
 !/.rspec.sample
 !/.trivyignore
 !/.claude_config.json
+# Worktrunk project config (hooks) — track just this one file under .config/
+!/.config
+/.config/*
+!/.config/wt.toml
 
 # Ignore operational files
 package.box

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -154,15 +154,18 @@ services:
     tty: true
     command: bin/rails server -b 0.0.0.0
     labels:
+      # Router name defaults to `op` (main). Worktrees set TRAEFIK_ROUTER_NAME=op-<name>
+      # in .envrc so concurrent worktree web containers get unique traefik routers
+      # (labels merge by append, so the name can't be overridden from the override file).
       - traefik.enable=${TRAEFIK_ENABLED:-false}
-      - traefik.http.routers.op.entrypoints=web
-      - traefik.http.routers.op.rule=Host(`${FQDN:-hmis-warehouse.dev.test}`)
-      - traefik.http.services.op_https.loadbalancer.server.port=3000
-      - traefik.http.routers.op_https.rule=Host(`${FQDN:-hmis-warehouse.dev.test}`)
-      - traefik.http.routers.op_https.tls=true
-      - traefik.http.routers.op_https.entrypoints=web-secure
-      - traefik.http.middlewares.op_https.redirectscheme.scheme=https
-      - traefik.http.routers.op.middlewares=op_https
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}.entrypoints=web
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}.rule=Host(`${FQDN:-hmis-warehouse.dev.test}`)
+      - traefik.http.services.${TRAEFIK_ROUTER_NAME:-op}_https.loadbalancer.server.port=3000
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}_https.rule=Host(`${FQDN:-hmis-warehouse.dev.test}`)
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}_https.tls=true
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}_https.entrypoints=web-secure
+      - traefik.http.middlewares.${TRAEFIK_ROUTER_NAME:-op}_https.redirectscheme.scheme=https
+      - traefik.http.routers.${TRAEFIK_ROUTER_NAME:-op}.middlewares=${TRAEFIK_ROUTER_NAME:-op}_https
     ports:
       - "3000"
       - "9394"

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -1,0 +1,105 @@
+# Development worktrees
+
+Run multiple isolated copies of hmis-warehouse at once — each on its own branch,
+with its own databases and web domain — using [worktrunk](https://worktrunk.dev)
+(`wt`) and this repo's worktree hooks.
+
+Each worktree shares the **one** postgres/redis/minio container stack from the main
+tree but talks to **separate databases** (a `_wt_<name>` suffix), so work in a
+worktree never touches your main development or test databases. Multiple worktree
+web servers can run concurrently, each at `hmis-warehouse-<name>.dev.test`.
+
+## Requirements
+
+- worktrunk installed, with shell integration: `wt config shell install`
+- [direnv](https://direnv.net/) installed and hooked into your shell
+- The main tree's backing services running (worktrees share them):
+  ```sh
+  docker compose -p hmis-warehouse up -d db redis minio
+  ```
+
+## Files involved
+
+| File | Purpose |
+|------|---------|
+| `.config/wt.toml` | worktrunk project hooks (`pre-start`, `pre-remove`) — committed |
+| `lib/development/scripts/worktree_pre_start.sh` | copies gitignored env/compose files into the new worktree, then rewrites them |
+| `lib/development/scripts/update_worktree_env.rb` | isolates DB names, sets the domain/compose-project/traefik-router, disables CAS |
+| `lib/development/scripts/worktree_pre_remove.sh` | drops the worktree's databases and removes its containers |
+| `docker/docker-compose.yml` | `web` traefik router name is parameterized (`${TRAEFIK_ROUTER_NAME:-op}`) so concurrent webs don't collide — committed |
+| `docker-compose.override.yml` | per-worktree copy: adds `.env.test.local` to `spec`, gives `web`/`yarn` unique container names, points cache volumes at the shared `hmis-warehouse_*` volumes (gitignored) |
+
+The `/worktree-setup` and `/worktree-cleanup` Claude Code skills automate the flow
+below; they are personal (user-level) and not shipped in this repo.
+
+## What isolation you get
+
+- **Databases:** dev + test databases are suffixed `_wt_<name>` in the shared
+  `hmis-warehouse-db` container. `bin/db_prep` and `db:setup_test` create them.
+- **Web domain:** `hmis-warehouse-<name>.dev.test` via traefik (per-worktree router).
+- **Compose project:** `hmis-warehouse-<name>` so app containers coexist.
+- **Shared (not isolated):** the `db`/`redis`/`minio` containers, the bundle /
+  node_modules / rails_cache volumes, and the CAS database (disabled in worktrees).
+
+## Manual workflow
+
+```sh
+# 1. Create the worktree (runs the pre-start hook: copies + rewrites env/compose files)
+wt switch --create ea-1234-my-feature --yes
+
+# 2. Allow the worktree's direnv (loads FQDN / COMPOSE_PROJECT_NAME / TRAEFIK_ROUTER_NAME)
+direnv allow
+
+# 3. Create the isolated databases (mirrors bin/setup). --no-deps uses the shared db.
+docker compose run --rm --no-deps shell bundle exec bin/db_prep
+docker compose run --rm --no-deps spec  bundle exec rails db:setup_test
+
+# 4. Run tests against the worktree's test databases
+docker compose run --rm --no-deps spec bundle exec rspec path/to/spec.rb
+
+# 5. (Optional) Start the web app — coexists with other worktrees' webs
+docker compose up -d --no-deps web yarn
+#    → https://hmis-warehouse-ea-1234-my-feature.dev.test
+
+# 6. Tear down when done (runs pre-remove: drops databases, removes containers)
+wt remove ea-1234-my-feature
+```
+
+## Naming
+
+`ea-1234-my-feature` becomes:
+- database suffix `_wt_ea_1234_my_feature`
+- domain `hmis-warehouse-ea-1234-my-feature.dev.test`
+- compose project `hmis-warehouse-ea-1234-my-feature`
+- traefik router `op-ea-1234-my-feature`
+
+Keep names reasonably short — the suffix is appended to each database name (postgres
+identifiers are capped at 63 characters).
+
+## Notes & caveats
+
+- **Backing services are shared singletons** started from the main tree. Always use
+  `--no-deps` for worktree `run`/`up` commands so they attach to those instead of
+  spawning duplicates (which would collide on the fixed container names).
+- **Don't run `bundle install` in two worktrees simultaneously** — the gem cache
+  volume is shared.  It is safe to run them sequentially in the main tree and the worktree.
+- **CAS is disabled in worktrees** (`DATABASE_CAS_DB` / `CAS_DATABASE_DB_TEST` are
+  blanked). Do cross-application work involving boston-cas in the **main** tree.
+- **Redis is shared** (cache only); worktrees reuse the same Redis.
+- **Don't run the full RSpec suite in a worktree at the same time as another suite**
+  (e.g. in the main tree). Databases are isolated, but the postgres *server's* lock
+  table is shared (`max_locks_per_transaction` × `max_connections` ≈ 6400 slots by
+  default). The suite's `before(:suite)` truncates every warehouse table, grabbing
+  thousands of locks; two suites at once can exhaust the table and fail with
+  `PG::OutOfMemory`. Setup (`db_prep`/`db:setup_test`), running the web app, and
+  background jobs are lock-light and fine to run concurrently. To run two full
+  suites at once, raise the lock table in your **local** `docker-compose.override.yml`
+  `db` block (it's gitignored, so this is a per-developer setting):
+  ```yaml
+    db:
+      command: "-c max_locks_per_transaction=256"
+  ```
+  Then recreate the container when no one is mid-test (drops connections; data
+  persists in the volume): `docker compose -p hmis-warehouse up -d db`, and verify
+  with `docker exec -i hmis-warehouse-db psql -U postgres -c "SHOW max_locks_per_transaction;"`.
+  Use a larger value (e.g. 512) if you want 3+ concurrent suites.

--- a/lib/development/scripts/update_worktree_env.rb
+++ b/lib/development/scripts/update_worktree_env.rb
@@ -1,0 +1,171 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Rewrites a freshly-created git worktree's local environment so it uses isolated
+# databases and its own web domain, without touching the main development/test
+# databases. Invoked by lib/development/scripts/worktree_pre_start.sh (the
+# worktrunk pre-start hook).
+#
+# Usage: ruby lib/development/scripts/update_worktree_env.rb <worktree_path> <branch>
+#
+# All edits are idempotent so the script can be re-run on an existing worktree.
+
+worktree_path = ARGV[0]
+branch = ARGV[1]
+
+abort 'usage: update_worktree_env.rb <worktree_path> <branch>' if worktree_path.to_s.empty? || branch.to_s.empty?
+abort "worktree path does not exist: #{worktree_path}" unless File.directory?(worktree_path)
+
+# Two sanitized forms of the branch name:
+#   name_dash  — for domains, compose project, traefik router, container names ([a-z0-9-])
+#   db_suffix  — for postgres database names, appended after `_wt_` ([a-z0-9_], unquoted-safe)
+name_dash = branch.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-+|-+\z/, '')
+db_suffix = branch.downcase.gsub(/[^a-z0-9]+/, '_').gsub(/\A_+|_+\z/, '')
+
+DEV_DB_KEYS = [
+  'DATABASE_APP_DB',
+  'WAREHOUSE_DATABASE_DB',
+  'HEALTH_DATABASE_DB',
+  'REPORTING_DATABASE_DB',
+].freeze
+
+TEST_DB_KEYS = [
+  'DATABASE_APP_DB_TEST',
+  'WAREHOUSE_DATABASE_DB_TEST',
+  'HEALTH_DATABASE_DB_TEST',
+  'REPORTING_DATABASE_DB_TEST',
+].freeze
+
+# Append `_wt_<db_suffix>` to the value of KEY on its `KEY=value` line, unless the
+# value is empty or already suffixed. Only rewrites lines that already exist.
+def append_db_suffix(content, key, suffix)
+  content.gsub(/^(#{Regexp.escape(key)}=)([^\n]*)$/) do
+    prefix = Regexp.last_match(1)
+    value = Regexp.last_match(2).strip
+    next "#{prefix}#{value}" if value.empty? || value.end_with?("_wt_#{suffix}")
+
+    "#{prefix}#{value}_wt_#{suffix}"
+  end
+end
+
+# Set KEY to an explicit value on its existing `KEY=...` line (no-op if absent).
+def set_value(content, key, value)
+  content.gsub(/^(#{Regexp.escape(key)}=)[^\n]*$/, "\\1#{value}")
+end
+
+# Upsert `export KEY=value` in a shell/direnv file (replace if present, else append).
+def upsert_export(content, key, value)
+  line = "export #{key}=#{value}"
+  if content.match?(/^export #{Regexp.escape(key)}=[^\n]*$/)
+    content.gsub(/^export #{Regexp.escape(key)}=[^\n]*$/, line)
+  else
+    content += "\n" unless content.empty? || content.end_with?("\n")
+    "#{content}#{line}\n"
+  end
+end
+
+def rewrite(path)
+  return unless File.file?(path)
+
+  original = File.read(path)
+  updated = yield(original.dup)
+  if updated == original
+    puts "  #{File.basename(path)} already current"
+  else
+    File.write(path, updated)
+    puts "  updated #{File.basename(path)}"
+  end
+end
+
+# --- .env.local (development databases) -------------------------------------
+env_local = File.join(worktree_path, '.env.local')
+rewrite(env_local) do |content|
+  DEV_DB_KEYS.each { |key| content = append_db_suffix(content, key, db_suffix) }
+  # CAS is the external boston-cas database; disable it in worktrees so the
+  # database.yml `cas:` section (guarded by .present?) is dropped entirely.
+  content = set_value(content, 'DATABASE_CAS_DB', '')
+  content
+end
+
+# --- .env.test.local (test databases) --------------------------------------
+# Created from the committed .env.test; the spec service loads it last (added to
+# its env_file in the copied docker-compose.override.yml).
+env_test = File.join(worktree_path, '.env.test')
+env_test_local = File.join(worktree_path, '.env.test.local')
+if File.file?(env_test)
+  File.write(env_test_local, File.read(env_test)) unless File.file?(env_test_local)
+  rewrite(env_test_local) do |content|
+    TEST_DB_KEYS.each { |key| content = append_db_suffix(content, key, db_suffix) }
+    content = set_value(content, 'CAS_DATABASE_DB_TEST', '')
+    content
+  end
+else
+  warn '  WARNING: .env.test not found; skipping .env.test.local'
+end
+
+# --- .envrc (direnv: domain, compose project, traefik router) ---------------
+envrc = File.join(worktree_path, '.envrc')
+rewrite(envrc) do |content|
+  content = upsert_export(content, 'FQDN', "hmis-warehouse-#{name_dash}.dev.test")
+  content = upsert_export(content, 'COMPOSE_PROJECT_NAME', "hmis-warehouse-#{name_dash}")
+  content = upsert_export(content, 'TRAEFIK_ROUTER_NAME', "op-#{name_dash}")
+  content
+end
+
+# --- docker-compose.override.yml -------------------------------------------
+# Per-worktree copy (gitignored). Line-based edits preserve the file's comments
+# (a Psych round-trip would strip them). All edits are idempotent.
+override = File.join(worktree_path, 'docker-compose.override.yml')
+rewrite(override) do |content|
+  lines = content.lines
+
+  # 1. Add `spec` and `yarn` service blocks right after the top-level `services:`
+  #    line (neither exists in the base override, so no duplicate-key risk).
+  #    spec: adds .env.test.local (compose appends it to the base env_file).
+  #    yarn: gives the asset watcher a unique container_name for concurrency.
+  unless content.include?('.env.test.local')
+    idx = lines.index { |l| l.match?(/^services:\s*$/) }
+    if idx
+      block = <<~BLOCK
+        \  spec:
+        \    env_file:
+        \      - .env.test.local
+        \  yarn:
+        \    container_name: hmis-warehouse-yarn-#{name_dash}
+      BLOCK
+      lines.insert(idx + 1, block)
+    end
+  end
+
+  # 2. Give the web service a unique container_name (override replaces the base's
+  #    fixed name). Insert into the existing `web:` block if not already present.
+  unless content.match?(/container_name:\s*hmis-warehouse-web-/)
+    widx = lines.index { |l| l.match?(/^ {2}web:\s*$/) }
+    lines.insert(widx + 1, "    container_name: hmis-warehouse-web-#{name_dash}\n") if widx
+  end
+
+  # 3. Point the shared cache volumes at main's existing (project-prefixed)
+  #    volumes so worktrees reuse them instead of creating empty per-project
+  #    copies. The `hmis-warehouse_` prefix keeps them from colliding with other
+  #    apps' identically-named volumes.
+  {
+    'bundle_bookworm' => 'hmis-warehouse_bundle_bookworm',
+    'node_modules_bookworm' => 'hmis-warehouse_node_modules_bookworm',
+    'rails_cache_bookworm' => 'hmis-warehouse_rails_cache_bookworm',
+  }.each do |vol, external_name|
+    vidx = lines.index { |l| l.match?(/^ {2}#{Regexp.escape(vol)}:\s*$/) }
+    next unless vidx
+    next if lines[vidx + 1].to_s.match?(/^\s+external:\s*true/)
+
+    lines[vidx] = "  #{vol}:\n    external: true\n    name: #{external_name}\n"
+  end
+
+  lines.join
+end
+
+puts "Worktree environment configured for '#{branch}' (db suffix _wt_#{db_suffix}, domain hmis-warehouse-#{name_dash}.dev.test)."

--- a/lib/development/scripts/worktree_pre_remove.sh
+++ b/lib/development/scripts/worktree_pre_remove.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# worktrunk pre-remove hook: tear down a worktree's isolated resources before the
+# worktree directory is deleted. Removes the worktree's app containers and drops
+# its `_wt_`-suffixed databases from the shared postgres container. Shared backing
+# services and the external cache volumes are left untouched.
+#
+# Wired up in .config/wt.toml:
+#   pre-remove = "bash lib/development/scripts/worktree_pre_remove.sh {{ worktree_path }} {{ branch }}"
+#
+# Runs in the worktree being removed (its env files still exist), so exact DB
+# names are read back from .env.local / .env.test.local rather than recomputed.
+
+# Note: no `set -e` — we want to continue past individual drop failures.
+set -uo pipefail
+
+worktree_path="${1:?worktree path required}"
+branch="${2:?branch required}"
+
+name_dash="$(printf '%s' "$branch" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//')"
+project="hmis-warehouse-${name_dash}"
+db_container="hmis-warehouse-db"
+
+# 1. Remove this worktree's app containers (web/yarn/dj). Shared services and the
+#    external cache volumes are not affected (no `-v`).
+if [ -d "$worktree_path" ]; then
+  echo "Removing containers for compose project $project"
+  ( cd "$worktree_path" && docker compose -p "$project" down --remove-orphans ) 2>/dev/null || \
+    echo "  (nothing to remove or compose unavailable)"
+fi
+
+# 2. Drop the worktree's databases from the shared db container.
+if ! docker ps --format '{{.Names}}' | grep -qx "$db_container"; then
+  echo "WARNING: $db_container is not running; cannot drop databases automatically."
+  echo "Once it is up, drop them manually, e.g.:"
+  echo "  docker exec -i $db_container psql -U postgres -c 'DROP DATABASE IF EXISTS <name> WITH (FORCE);'"
+  exit 0
+fi
+
+drop_db() {
+  local dbname="$1"
+  [ -z "$dbname" ] && return 0
+  case "$dbname" in
+    *_wt_*) ;;                                                # only worktree DBs
+    *) echo "  skip (not a _wt_ database): $dbname"; return 0 ;;
+  esac
+  echo "  dropping $dbname"
+  docker exec -i "$db_container" psql -U postgres -tc \
+    "DROP DATABASE IF EXISTS \"$dbname\" WITH (FORCE);" >/dev/null || \
+    echo "  WARNING: failed to drop $dbname"
+}
+
+db_names_from() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  grep -E '^(DATABASE_APP_DB|WAREHOUSE_DATABASE_DB|HEALTH_DATABASE_DB|REPORTING_DATABASE_DB|DATABASE_APP_DB_TEST|WAREHOUSE_DATABASE_DB_TEST|HEALTH_DATABASE_DB_TEST|REPORTING_DATABASE_DB_TEST)=' "$file" \
+    | sed -E 's/^[^=]+=//' | tr -d "\"'"
+}
+
+for f in "$worktree_path/.env.local" "$worktree_path/.env.test.local"; do
+  while IFS= read -r dbname; do
+    drop_db "$dbname"
+  done < <(db_names_from "$f")
+done
+
+echo "Worktree resources for '$branch' cleaned up."

--- a/lib/development/scripts/worktree_pre_remove.sh
+++ b/lib/development/scripts/worktree_pre_remove.sh
@@ -33,7 +33,7 @@ fi
 if ! docker ps --format '{{.Names}}' | grep -qx "$db_container"; then
   echo "WARNING: $db_container is not running; cannot drop databases automatically."
   echo "Once it is up, drop them manually, e.g.:"
-  echo "  docker exec -i $db_container psql -U postgres -c 'DROP DATABASE IF EXISTS <name> WITH (FORCE);'"
+  echo "  docker exec $db_container psql -U postgres -c 'DROP DATABASE IF EXISTS <name> WITH (FORCE);'"
   exit 0
 fi
 
@@ -45,7 +45,12 @@ drop_db() {
     *) echo "  skip (not a _wt_ database): $dbname"; return 0 ;;
   esac
   echo "  dropping $dbname"
-  docker exec -i "$db_container" psql -U postgres -tc \
+  # No `-i`: this is a single non-interactive `-c` command, and `-i` would keep
+  # docker exec's stdin open. Since drop_db is called from a `while read` loop fed
+  # by process substitution (below), an `-i` docker exec inherits that same stdin
+  # and consumes the loop's remaining input after the first call, silently
+  # skipping every subsequent database.
+  docker exec "$db_container" psql -U postgres -tc \
     "DROP DATABASE IF EXISTS \"$dbname\" WITH (FORCE);" >/dev/null || \
     echo "  WARNING: failed to drop $dbname"
 }

--- a/lib/development/scripts/worktree_pre_start.sh
+++ b/lib/development/scripts/worktree_pre_start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# worktrunk pre-start hook: prepare a freshly-created git worktree for isolated
+# development. Copies the gitignored env/compose files a new worktree lacks from
+# the primary worktree, then rewrites them (isolated DB names, per-worktree
+# domain, compose project, traefik router) via update_worktree_env.rb.
+#
+# Wired up in .config/wt.toml:
+#   pre-start = "bash lib/development/scripts/worktree_pre_start.sh {{ worktree_path }} {{ branch }} {{ primary_worktree_path }}"
+#
+# Idempotent: files already present in the worktree are left in place and the
+# Ruby rewrite never double-applies its changes.
+
+set -euo pipefail
+
+worktree_path="${1:?worktree path required}"
+branch="${2:?branch required}"
+primary_path="${3:?primary worktree path required}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Preparing worktree $worktree_path (branch $branch)"
+
+# Files that are gitignored (so absent in a fresh worktree) but required to boot
+# and to isolate the worktree. .env.test and docker-compose.yml are tracked.
+for f in .env.local .env.development.local .envrc docker-compose.override.yml; do
+  if [ ! -f "$primary_path/$f" ]; then
+    echo "  WARNING: $primary_path/$f not found; skipping"
+  elif [ -f "$worktree_path/$f" ]; then
+    echo "  $f already present; leaving as-is"
+  else
+    cp "$primary_path/$f" "$worktree_path/$f"
+    echo "  copied $f"
+  fi
+done
+
+ruby "$script_dir/update_worktree_env.rb" "$worktree_path" "$branch"


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Sets up config for [Worktrunk](https://worktrunk.dev) to help streamline development with git work trees.
* Adds isolated per-worktree databases, domain, and compose project via pre-start/pre-remove hooks
* Parameterizes web traefik router name so concurrent worktree webs coexist

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

