### PR TITLE
Add disability and DV fields to CE match rules

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_field.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_field.rb
@@ -9,8 +9,6 @@
 module Hmis::Ce::Match::Expression
   PsdeField = Data.define(
     :key,
-    :table,
-    :column,
     :value_type,
     :label,
     :description,

--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_map.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_map.rb
@@ -39,8 +39,15 @@ module Hmis::Ce::Match::Expression
       PsdeFieldRegistry[field]&.label || field.to_s.humanize
     end
 
-    def format_for_display(_field, value)
-      value
+    def format_for_display(field, value)
+      return value if value.nil?
+
+      case PsdeFieldRegistry[field]&.value_type
+      when :logical
+        value ? 'Yes' : 'No'
+      else
+        value.to_s # could expand this later if there are dates or other types
+      end
     end
 
     def self.field_key_for(field_key)

--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_registry.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_registry.rb
@@ -20,8 +20,85 @@ module Hmis::Ce::Match::Expression
                    'Selects the most recent row with a valid IncomeFromAnySource (skipping 8/9/99/nil).',
     )
 
+    MENTAL_HEALTH_DISORDER = PsdeField.new(
+      key: 'mental_health_disorder',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'Mental Health Disorder',
+      description: 'Latest response for HUD Mental Health Disorder (HUD Disabilities, DisabilityType 9) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
+    SUBSTANCE_USE_DISORDER = PsdeField.new(
+      key: 'substance_use_disorder',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'Substance Use Disorder',
+      description: 'Latest response for HUD Substance Use Disorder (HUD Disabilities, DisabilityType 10) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful response (skipping 8/9/99/nil): true for Alcohol/Drug/Both (1/2/3), false for No (0).',
+    )
+
+    PHYSICAL_DISABILITY = PsdeField.new(
+      key: 'physical_disability',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'Physical Disability',
+      description: 'Latest response for HUD Physical Disability (HUD Disabilities, DisabilityType 5) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
+    DEVELOPMENTAL_DISABILITY = PsdeField.new(
+      key: 'developmental_disability',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'Developmental Disability',
+      description: 'Latest response for HUD Developmental Disability (HUD Disabilities, DisabilityType 6) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
+    CHRONIC_HEALTH_CONDITION = PsdeField.new(
+      key: 'chronic_health_condition',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'Chronic Health Condition',
+      description: 'Latest response for HUD Chronic Health Condition (HUD Disabilities, DisabilityType 7) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
+    HIV_AIDS = PsdeField.new(
+      key: 'hiv_aids',
+      table: 'Disabilities',
+      column: 'DisabilityResponse',
+      value_type: :logical,
+      label: 'HIV/AIDS',
+      description: 'Latest response for HUD HIV/AIDS (HUD Disabilities, DisabilityType 8) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
+    DOMESTIC_VIOLENCE_SURVIVOR = PsdeField.new(
+      key: 'domestic_violence_survivor',
+      table: 'HealthAndDV',
+      column: 'DomesticViolenceSurvivor',
+      value_type: :logical,
+      label: 'DV Survivor',
+      description: 'Latest response for HUD Domestic Violence Survivor (HUD HealthAndDV) within the configured eligibility scope. ' \
+                   'Selects the most recent row with a meaningful Yes or No value (skipping 8/9/99/nil).',
+    )
+
     ALL = [
       TOTAL_MONTHLY_INCOME,
+      MENTAL_HEALTH_DISORDER,
+      SUBSTANCE_USE_DISORDER,
+      PHYSICAL_DISABILITY,
+      DEVELOPMENTAL_DISABILITY,
+      CHRONIC_HEALTH_CONDITION,
+      HIV_AIDS,
+      DOMESTIC_VIOLENCE_SURVIVOR,
     ].freeze
 
     def self.[](key)

--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_registry.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_field_registry.rb
@@ -8,12 +8,10 @@
 
 module Hmis::Ce::Match::Expression
   # Static registry of HUD table fields exposed as flat psde.* CE match expression keys
-  # (e.g. psde.total_monthly_income). HUD table/column metadata lives on each PsdeField.
+  # (e.g. psde.total_monthly_income).
   class PsdeFieldRegistry
     TOTAL_MONTHLY_INCOME = PsdeField.new(
       key: 'total_monthly_income',
-      table: 'IncomeBenefits',
-      column: 'TotalMonthlyIncome',
       value_type: :numeric,
       label: 'Total Monthly Income',
       description: 'Latest total monthly income from HUD IncomeBenefits within the configured eligibility scope. ' \
@@ -22,8 +20,6 @@ module Hmis::Ce::Match::Expression
 
     MENTAL_HEALTH_DISORDER = PsdeField.new(
       key: 'mental_health_disorder',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'Mental Health Disorder',
       description: 'Latest response for HUD Mental Health Disorder (HUD Disabilities, DisabilityType 9) within the configured eligibility scope. ' \
@@ -32,8 +28,6 @@ module Hmis::Ce::Match::Expression
 
     SUBSTANCE_USE_DISORDER = PsdeField.new(
       key: 'substance_use_disorder',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'Substance Use Disorder',
       description: 'Latest response for HUD Substance Use Disorder (HUD Disabilities, DisabilityType 10) within the configured eligibility scope. ' \
@@ -42,8 +36,6 @@ module Hmis::Ce::Match::Expression
 
     PHYSICAL_DISABILITY = PsdeField.new(
       key: 'physical_disability',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'Physical Disability',
       description: 'Latest response for HUD Physical Disability (HUD Disabilities, DisabilityType 5) within the configured eligibility scope. ' \
@@ -52,8 +44,6 @@ module Hmis::Ce::Match::Expression
 
     DEVELOPMENTAL_DISABILITY = PsdeField.new(
       key: 'developmental_disability',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'Developmental Disability',
       description: 'Latest response for HUD Developmental Disability (HUD Disabilities, DisabilityType 6) within the configured eligibility scope. ' \
@@ -62,8 +52,6 @@ module Hmis::Ce::Match::Expression
 
     CHRONIC_HEALTH_CONDITION = PsdeField.new(
       key: 'chronic_health_condition',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'Chronic Health Condition',
       description: 'Latest response for HUD Chronic Health Condition (HUD Disabilities, DisabilityType 7) within the configured eligibility scope. ' \
@@ -72,8 +60,6 @@ module Hmis::Ce::Match::Expression
 
     HIV_AIDS = PsdeField.new(
       key: 'hiv_aids',
-      table: 'Disabilities',
-      column: 'DisabilityResponse',
       value_type: :logical,
       label: 'HIV/AIDS',
       description: 'Latest response for HUD HIV/AIDS (HUD Disabilities, DisabilityType 8) within the configured eligibility scope. ' \
@@ -82,8 +68,6 @@ module Hmis::Ce::Match::Expression
 
     DOMESTIC_VIOLENCE_SURVIVOR = PsdeField.new(
       key: 'domestic_violence_survivor',
-      table: 'HealthAndDV',
-      column: 'DomesticViolenceSurvivor',
       value_type: :logical,
       label: 'DV Survivor',
       description: 'Latest response for HUD Domestic Violence Survivor (HUD HealthAndDV) within the configured eligibility scope. ' \

--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_value_resolver.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_value_resolver.rb
@@ -11,20 +11,23 @@ module Hmis::Ce::Match::Expression
   class PsdeValueResolver
     include Hmis::Concerns::HmisArelHelper
 
-    # Maps NoYes-disability field keys to their HUD DisabilityType code. Substance use (type 10)
-    # is deliberately excluded here — it has its own method because its meaningful-value set differs
-    # (see #resolve_substance_use_disorder).
+    # HUD DisabilityType codes, keyed by the names used across the warehouse (:physical, :substance, etc.)
+    DISABILITY_TYPE_CODES = GrdaWarehouse::Hud::Disability.disability_types.invert.freeze
+
+    # Maps NoYes-disability field keys to their HUD DisabilityType code. Substance use is deliberately
+    # excluded here — it is dispatched separately in #call because its meaningful-value set differs.
     NO_YES_DISABILITY_TYPES = {
-      PsdeFieldRegistry::PHYSICAL_DISABILITY.key => 5,
-      PsdeFieldRegistry::DEVELOPMENTAL_DISABILITY.key => 6,
-      PsdeFieldRegistry::CHRONIC_HEALTH_CONDITION.key => 7,
-      PsdeFieldRegistry::HIV_AIDS.key => 8,
-      PsdeFieldRegistry::MENTAL_HEALTH_DISORDER.key => 9,
+      PsdeFieldRegistry::PHYSICAL_DISABILITY.key => DISABILITY_TYPE_CODES.fetch(:physical),
+      PsdeFieldRegistry::DEVELOPMENTAL_DISABILITY.key => DISABILITY_TYPE_CODES.fetch(:developmental),
+      PsdeFieldRegistry::CHRONIC_HEALTH_CONDITION.key => DISABILITY_TYPE_CODES.fetch(:chronic),
+      PsdeFieldRegistry::HIV_AIDS.key => DISABILITY_TYPE_CODES.fetch(:hiv),
+      PsdeFieldRegistry::MENTAL_HEALTH_DISORDER.key => DISABILITY_TYPE_CODES.fetch(:mental),
     }.freeze
 
-    # Meaningful raw HUD response code. Anything else — 8/9/99/nil — is skipped as "not meaningful".
-    # 0 is always No for these response sets; #resolve_latest_boolean_response converts 0 => false and
-    # any other meaningful code => true.
+    SUBSTANCE_USE_DISABILITY_TYPE = DISABILITY_TYPE_CODES.fetch(:substance)
+
+    # Meaningful raw HUD response codes from NoYesReasonsForMissingData.
+    # Anything else — 8/9/99/nil — is skipped as "not meaningful".
     NO_YES_RESPONSES = [0, 1].freeze
     SUBSTANCE_RESPONSES = [0, 1, 2, 3].freeze # 1=Alcohol, 2=Drug, 3=Both; all collapse to true
 
@@ -41,7 +44,8 @@ module Hmis::Ce::Match::Expression
       when *NO_YES_DISABILITY_TYPES.keys
         resolve_disability(clients, disability_type: NO_YES_DISABILITY_TYPES.fetch(field.key))
       when PsdeFieldRegistry::SUBSTANCE_USE_DISORDER.key
-        resolve_substance_use_disorder(clients)
+        # Substance use has a distinct 4-value meaningful set: Alcohol (1), Drug (2), and Both (3) all collapse to true.
+        resolve_disability(clients, disability_type: SUBSTANCE_USE_DISABILITY_TYPE, meaningful_values: SUBSTANCE_RESPONSES)
       when PsdeFieldRegistry::DOMESTIC_VIOLENCE_SURVIVOR.key
         resolve_domestic_violence_survivor(clients)
       else
@@ -97,12 +101,6 @@ module Hmis::Ce::Match::Expression
         column: d_t[:DisabilityResponse],
         meaningful_values: meaningful_values,
       )
-    end
-
-    # Substance use (DisabilityType 10) has a distinct 4-value meaningful set.
-    # Alcohol (1), Drug (2), and Both (3) all collapse to true.
-    def resolve_substance_use_disorder(clients)
-      resolve_disability(clients, disability_type: 10, meaningful_values: SUBSTANCE_RESPONSES)
     end
 
     def resolve_domestic_violence_survivor(clients)

--- a/drivers/hmis/app/models/hmis/ce/match/expression/psde_value_resolver.rb
+++ b/drivers/hmis/app/models/hmis/ce/match/expression/psde_value_resolver.rb
@@ -11,6 +11,23 @@ module Hmis::Ce::Match::Expression
   class PsdeValueResolver
     include Hmis::Concerns::HmisArelHelper
 
+    # Maps NoYes-disability field keys to their HUD DisabilityType code. Substance use (type 10)
+    # is deliberately excluded here — it has its own method because its meaningful-value set differs
+    # (see #resolve_substance_use_disorder).
+    NO_YES_DISABILITY_TYPES = {
+      PsdeFieldRegistry::PHYSICAL_DISABILITY.key => 5,
+      PsdeFieldRegistry::DEVELOPMENTAL_DISABILITY.key => 6,
+      PsdeFieldRegistry::CHRONIC_HEALTH_CONDITION.key => 7,
+      PsdeFieldRegistry::HIV_AIDS.key => 8,
+      PsdeFieldRegistry::MENTAL_HEALTH_DISORDER.key => 9,
+    }.freeze
+
+    # Meaningful raw HUD response code. Anything else — 8/9/99/nil — is skipped as "not meaningful".
+    # 0 is always No for these response sets; #resolve_latest_boolean_response converts 0 => false and
+    # any other meaningful code => true.
+    NO_YES_RESPONSES = [0, 1].freeze
+    SUBSTANCE_RESPONSES = [0, 1, 2, 3].freeze # 1=Alcohol, 2=Drug, 3=Both; all collapse to true
+
     def initialize(current_date: Date.current, configuration: Hmis::Ce.configuration)
       @current_date = current_date.to_date
       @configuration = configuration
@@ -21,6 +38,12 @@ module Hmis::Ce::Match::Expression
       case field.key
       when PsdeFieldRegistry::TOTAL_MONTHLY_INCOME.key
         resolve_total_monthly_income(clients)
+      when *NO_YES_DISABILITY_TYPES.keys
+        resolve_disability(clients, disability_type: NO_YES_DISABILITY_TYPES.fetch(field.key))
+      when PsdeFieldRegistry::SUBSTANCE_USE_DISORDER.key
+        resolve_substance_use_disorder(clients)
+      when PsdeFieldRegistry::DOMESTIC_VIOLENCE_SURVIVOR.key
+        resolve_domestic_violence_survivor(clients)
       else
         raise ArgumentError, "Unknown PSDE field \"#{field.key}\""
       end
@@ -64,6 +87,59 @@ module Hmis::Ce::Match::Expression
       result
     end
 
+    # Filter by DisabilityType, then pick the single latest row with a meaningful response.
+    #
+    # @return [Hash{Integer => Boolean, nil}]
+    def resolve_disability(clients, disability_type:, meaningful_values: NO_YES_RESPONSES)
+      resolve_latest_boolean_response(
+        clients,
+        scope: Hmis::Hud::Disability.where(d_t[:DisabilityType].eq(disability_type)),
+        column: d_t[:DisabilityResponse],
+        meaningful_values: meaningful_values,
+      )
+    end
+
+    # Substance use (DisabilityType 10) has a distinct 4-value meaningful set.
+    # Alcohol (1), Drug (2), and Both (3) all collapse to true.
+    def resolve_substance_use_disorder(clients)
+      resolve_disability(clients, disability_type: 10, meaningful_values: SUBSTANCE_RESPONSES)
+    end
+
+    def resolve_domestic_violence_survivor(clients)
+      resolve_latest_boolean_response(
+        clients,
+        scope: Hmis::Hud::HealthAndDv.all,
+        column: hdv_t[:DomesticViolenceSurvivor],
+        meaningful_values: NO_YES_RESPONSES,
+      )
+    end
+
+    # Picks the single latest row with a meaningful response per client, and converts the raw HUD
+    # response code of that row to a real Ruby boolean (0 => false; any other meaningful code => true).
+    # Returns nil when no row has a meaningful response in scope.
+    #
+    # @return [Hash{Integer => Boolean, nil}]
+    def resolve_latest_boolean_response(clients, scope:, column:, meaningful_values:)
+      client_ids = extract_client_ids(clients)
+      return {} if client_ids.empty?
+
+      # Ensure all destination clients are in the hash. Clients with no meaningful rows will have a nil value.
+      result = client_ids.index_with { nil }
+
+      rows = scope.
+        joins(:enrollment).
+        merge(eligibility_scope.call(client_ids)).
+        order(information_date: :desc, date_updated: :desc, id: :desc).
+        pluck(wc_t[:destination_id], column)
+
+      rows.group_by(&:first).each do |client_id, client_rows|
+        selected = client_rows.find { |row| meaningful_values.include?(row[1]) }
+        result[client_id] = !selected[1].zero? if selected # 0 => false; any other meaningful code => true
+      end
+
+      result
+    end
+
     def eligibility_scope
       @eligibility_scope ||= EnrollmentEligibilityScope.new(
         current_date: @current_date,
@@ -74,7 +150,7 @@ module Hmis::Ce::Match::Expression
     # Used to evaluate HUD 1.7 NoYesReasonsForMissingData response code (0/1/8/9/99/nil)
     # Returns true if the response is meaningful (0/1)
     def meaningful_yes_no_response?(value)
-      value.in?([0, 1])
+      value.in?(NO_YES_RESPONSES)
     end
 
     # Yes (1) with a blank MonthlyTotalIncome is invalid data and is skipped, same as 8/9/99/nil on IncomeFromAnySource.

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/psde_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/psde_field_map_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeFieldMap, type: :model do
       expect(field_map.client_query(clients, field_key)).to eq({ destination_client.id => 500.0 })
     end
 
+    it 'resolves a known disability value' do
+      create(
+        :hmis_disability,
+        :skip_validate,
+        enrollment: enrollment,
+        client: client,
+        data_source: hmis_data_source,
+        disability_type: 9,
+        disability_response: 1,
+        information_date: current_date - 1.week,
+        data_collection_stage: 1,
+      )
+
+      expect(field_map.client_query(clients, 'mental_health_disorder')).
+        to eq({ destination_client.id => true })
+    end
+
     it 'raises for unknown fields' do
       expect { field_map.client_query(clients, 'unknown_field') }.
         to raise_error(ArgumentError, /Unknown PSDE field/)
@@ -48,11 +65,27 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeFieldMap, type: :model do
     it 'includes total monthly income' do
       expect(field_map.fields.map(&:key)).to include(field_key)
     end
+
+    it 'includes the disability and health/DV fields' do
+      expect(field_map.fields.map(&:key)).to include(
+        'mental_health_disorder',
+        'substance_use_disorder',
+        'physical_disability',
+        'developmental_disability',
+        'chronic_health_condition',
+        'hiv_aids',
+        'domestic_violence_survivor',
+      )
+    end
   end
 
   describe '#label_for' do
     it 'returns the registry label' do
       expect(field_map.label_for(field_key)).to eq('Total Monthly Income')
+    end
+
+    it 'returns the registry label for a disability field' do
+      expect(field_map.label_for('mental_health_disorder')).to eq('Mental Health Disorder')
     end
   end
 

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/psde_field_map_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/psde_field_map_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeFieldMap, type: :model do
     end
   end
 
+  describe '#format_for_display' do
+    it 'formats logical fields as Yes/No' do
+      expect(field_map.format_for_display('mental_health_disorder', true)).to eq('Yes')
+      expect(field_map.format_for_display('mental_health_disorder', false)).to eq('No')
+    end
+
+    it 'returns nil without formatting' do
+      expect(field_map.format_for_display('mental_health_disorder', nil)).to be_nil
+      expect(field_map.format_for_display(field_key, nil)).to be_nil
+    end
+
+    it 'falls back to string formatting for unknown fields' do
+      expect(field_map.format_for_display('unknown_field', 5)).to eq('5')
+    end
+  end
+
   describe '#arel_field and #joins' do
     it 'returns nil for SQL prefiltering' do
       expect(field_map.arel_field(field_key)).to be_nil

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/psde_value_resolver_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/psde_value_resolver_spec.rb
@@ -263,4 +263,328 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeValueResolver, type: :model do
       expect(resolver.call(clients, field)).to eq({ destination_client.id => 400.0 })
     end
   end
+
+  describe 'disability fields' do
+    def create_disability(**attrs)
+      defaults = {
+        enrollment: enrollment,
+        client: client,
+        data_source: hmis_data_source,
+        data_collection_stage: 1,
+      }
+      create(:hmis_disability, :skip_validate, defaults.merge(attrs))
+    end
+
+    # Common behaviors shared by every NoYes disability field. `field` and `disability_type` are
+    # provided by each including context.
+    shared_examples 'a NoYes disability field' do
+      it 'returns nil for clients with no disability rows in scope' do
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+
+      it 'resolves the latest meaningful Yes (1) response to true' do
+        create_disability(disability_type: disability_type, disability_response: 1, information_date: current_date - 1.week)
+        result = resolver.call(clients, field)
+        expect(result).to eq({ destination_client.id => true })
+      end
+
+      it 'resolves the latest meaningful No (0) response to false' do
+        create_disability(disability_type: disability_type, disability_response: 0, information_date: current_date - 1.week)
+        result = resolver.call(clients, field)
+        expect(result).to eq({ destination_client.id => false })
+      end
+
+      it 'returns nil when only 8/9/99/nil responses exist' do
+        [8, 9, 99, nil].each_with_index do |response, i|
+          create_disability(
+            disability_type: disability_type,
+            disability_response: response,
+            information_date: current_date - (i + 1).days,
+          )
+        end
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+
+      it 'skips 8/9/99/nil and falls back to the prior meaningful row' do
+        create_disability(
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 2.weeks,
+          date_updated: current_date - 2.weeks,
+        )
+        create_disability(
+          disability_type: disability_type,
+          disability_response: 9,
+          information_date: current_date - 1.week,
+          date_updated: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
+      end
+
+      it 'excludes disabilities from exited enrollments when lookback is 0' do
+        exited_enrollment = create(
+          :hmis_hud_enrollment,
+          data_source: hmis_data_source,
+          client: client,
+          EntryDate: current_date - 3.months,
+          exit_date: current_date - 1.month,
+        )
+        create_disability(
+          enrollment: exited_enrollment,
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 6.weeks,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+
+      it 'excludes disabilities from projects outside a configured project group' do
+        out_of_group_project = create(:hmis_hud_project, data_source: hmis_data_source)
+        in_group_project = create(:hmis_hud_project, data_source: hmis_data_source)
+        project_group = create(:hmis_project_group, data_source: hmis_data_source, with_projects: [in_group_project])
+        AppConfigProperty.create!(key: 'hmis_ce/eligibility_project_group_id', value: project_group.id)
+
+        out_of_group_enrollment = create(
+          :hmis_hud_enrollment,
+          data_source: hmis_data_source,
+          client: client,
+          project: out_of_group_project,
+          EntryDate: current_date - 1.month,
+        )
+        create_disability(
+          enrollment: out_of_group_enrollment,
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+
+      it 'aggregates across merged source clients for a destination client' do
+        other_source_client = create(:hmis_hud_client, data_source: hmis_data_source)
+        create(
+          :hmis_warehouse_client,
+          data_source: hmis_data_source,
+          source: other_source_client,
+          destination: destination_client,
+        )
+        other_enrollment = create(
+          :hmis_hud_enrollment,
+          data_source: hmis_data_source,
+          client: other_source_client,
+          EntryDate: current_date - 1.month,
+        )
+        create_disability(
+          disability_type: disability_type,
+          disability_response: 0,
+          information_date: current_date - 2.weeks,
+        )
+        create_disability(
+          enrollment: other_enrollment,
+          client: other_source_client,
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
+      end
+
+      it 'includes disabilities from a non-HMIS source data source linked to the destination client' do
+        non_hmis_data_source = create(:source_data_source)
+        non_hmis_client = create(:hmis_hud_client, data_source: non_hmis_data_source)
+        create(
+          :hmis_warehouse_client,
+          data_source: non_hmis_data_source,
+          source: non_hmis_client,
+          destination: destination_client,
+        )
+        non_hmis_enrollment = create(
+          :hmis_hud_enrollment,
+          data_source: non_hmis_data_source,
+          client: non_hmis_client,
+          EntryDate: current_date - 1.month,
+        )
+        create_disability(
+          enrollment: non_hmis_enrollment,
+          client: non_hmis_client,
+          data_source: non_hmis_data_source,
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
+      end
+    end
+
+    describe 'mental_health_disorder resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::MENTAL_HEALTH_DISORDER }
+      let(:disability_type) { 9 }
+
+      it_behaves_like 'a NoYes disability field'
+    end
+
+    describe 'physical_disability resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::PHYSICAL_DISABILITY }
+      let(:disability_type) { 5 }
+
+      it_behaves_like 'a NoYes disability field'
+    end
+
+    describe 'developmental_disability resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::DEVELOPMENTAL_DISABILITY }
+      let(:disability_type) { 6 }
+
+      it_behaves_like 'a NoYes disability field'
+    end
+
+    describe 'chronic_health_condition resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::CHRONIC_HEALTH_CONDITION }
+      let(:disability_type) { 7 }
+
+      it_behaves_like 'a NoYes disability field'
+    end
+
+    describe 'hiv_aids resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::HIV_AIDS }
+      let(:disability_type) { 8 }
+
+      it_behaves_like 'a NoYes disability field'
+    end
+
+    describe 'substance_use_disorder resolution' do
+      let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::SUBSTANCE_USE_DISORDER }
+
+      [1, 2, 3].each do |code|
+        it "resolves substance code #{code} (Alcohol/Drug/Both) to true" do
+          create_disability(
+            disability_type: 10,
+            disability_response: code,
+            information_date: current_date - 1.week,
+          )
+
+          result = resolver.call(clients, field)
+          expect(result).to eq({ destination_client.id => true })
+          expect(result[destination_client.id]).to be(true)
+        end
+      end
+
+      it 'resolves No (0) to false' do
+        create_disability(
+          disability_type: 10,
+          disability_response: 0,
+          information_date: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => false })
+      end
+
+      it 'skips 8/9/99/nil responses' do
+        [8, 9, 99, nil].each_with_index do |response, i|
+          create_disability(
+            disability_type: 10,
+            disability_response: response,
+            information_date: current_date - (i + 1).days,
+          )
+        end
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+    end
+
+    describe 'disability type independence' do
+      it 'resolves each disability type from its own most-recent rows' do
+        create_disability(
+          disability_type: 9, # mental health
+          disability_response: 1,
+          information_date: current_date - 1.week,
+        )
+        create_disability(
+          disability_type: 5, # physical
+          disability_response: 0,
+          information_date: current_date - 3.days,
+        )
+
+        expect(resolver.call(clients, Hmis::Ce::Match::Expression::PsdeFieldRegistry::MENTAL_HEALTH_DISORDER)).
+          to eq({ destination_client.id => true })
+        expect(resolver.call(clients, Hmis::Ce::Match::Expression::PsdeFieldRegistry::PHYSICAL_DISABILITY)).
+          to eq({ destination_client.id => false })
+      end
+    end
+  end
+
+  describe 'domestic_violence_survivor resolution' do
+    let(:field) { Hmis::Ce::Match::Expression::PsdeFieldRegistry::DOMESTIC_VIOLENCE_SURVIVOR }
+
+    def create_health_and_dv(**attrs)
+      defaults = {
+        enrollment: enrollment,
+        client: client,
+        data_source: hmis_data_source,
+        data_collection_stage: 1,
+      }
+      create(:hmis_health_and_dv, :skip_validate, defaults.merge(attrs))
+    end
+
+    it 'returns nil for clients with no HealthAndDV rows in scope' do
+      expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+    end
+
+    it 'resolves the latest meaningful Yes (1) response to true' do
+      create_health_and_dv(
+        domestic_violence_survivor: 1,
+        information_date: current_date - 1.week,
+      )
+
+      result = resolver.call(clients, field)
+      expect(result).to eq({ destination_client.id => true })
+      expect(result[destination_client.id]).to be(true)
+    end
+
+    it 'resolves the latest meaningful No (0) response to false' do
+      create_health_and_dv(
+        domestic_violence_survivor: 0,
+        information_date: current_date - 1.week,
+      )
+
+      expect(resolver.call(clients, field)).to eq({ destination_client.id => false })
+    end
+
+    it 'skips 8/9/99/nil and falls back to the prior meaningful row' do
+      create_health_and_dv(
+        domestic_violence_survivor: 1,
+        information_date: current_date - 2.weeks,
+        date_updated: current_date - 2.weeks,
+      )
+      create_health_and_dv(
+        domestic_violence_survivor: 99,
+        information_date: current_date - 1.week,
+        date_updated: current_date - 1.week,
+      )
+
+      expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
+    end
+
+    it 'excludes DV rows from exited enrollments when lookback is 0' do
+      exited_enrollment = create(
+        :hmis_hud_enrollment,
+        data_source: hmis_data_source,
+        client: client,
+        EntryDate: current_date - 3.months,
+        exit_date: current_date - 1.month,
+      )
+      create_health_and_dv(
+        enrollment: exited_enrollment,
+        domestic_violence_survivor: 1,
+        information_date: current_date - 6.weeks,
+      )
+
+      expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+    end
+  end
 end

--- a/drivers/hmis/spec/models/hmis/ce/match/expression/psde_value_resolver_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/match/expression/psde_value_resolver_spec.rb
@@ -306,6 +306,31 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeValueResolver, type: :model do
         expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
       end
 
+      # Substance use codes (2/3) are not valid for these types. Note this is stricter than the CAS
+      # path (GrdaWarehouse::Hud::Client#<type>_response), which accepts 0/1/2/3 for every type.
+      it 'returns nil when the only response is a non-HUD code for this disability type' do
+        create_disability(disability_type: disability_type, disability_response: 2, information_date: current_date - 1.week)
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => nil })
+      end
+
+      it 'skips a non-HUD code and falls back to the prior meaningful row' do
+        create_disability(
+          disability_type: disability_type,
+          disability_response: 1,
+          information_date: current_date - 2.weeks,
+          date_updated: current_date - 2.weeks,
+        )
+        create_disability(
+          disability_type: disability_type,
+          disability_response: 2,
+          information_date: current_date - 1.week,
+          date_updated: current_date - 1.week,
+        )
+
+        expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
+      end
+
       it 'skips 8/9/99/nil and falls back to the prior meaningful row' do
         create_disability(
           disability_type: disability_type,
@@ -468,9 +493,7 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeValueResolver, type: :model do
             information_date: current_date - 1.week,
           )
 
-          result = resolver.call(clients, field)
-          expect(result).to eq({ destination_client.id => true })
-          expect(result[destination_client.id]).to be(true)
+          expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
         end
       end
 
@@ -541,9 +564,7 @@ RSpec.describe Hmis::Ce::Match::Expression::PsdeValueResolver, type: :model do
         information_date: current_date - 1.week,
       )
 
-      result = resolver.call(clients, field)
-      expect(result).to eq({ destination_client.id => true })
-      expect(result[destination_client.id]).to be(true)
+      expect(resolver.call(clients, field)).to eq({ destination_client.id => true })
     end
 
     it 'resolves the latest meaningful No (0) response to false' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- Register six HUD `Disabilities` fields and the `HealthAndDV` field DV survivor in the `psde.*` CE match expression namespace
- Extend `PsdeValueResolver` to resolve the latest meaningful response per client for each new field, reusing the existing eligibility-scope, lookback, and project-group logic from `total_monthly_income`
- Handle the distinct response code set for substance use disorder (0/1/2/3) separately from the shared NoYes (0/1) disability fields

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

