### PR TITLE
Add Controller Authorization

### DIFF
--- a/app/controllers/access_controls_controller.rb
+++ b/app/controllers/access_controls_controller.rb
@@ -6,11 +6,12 @@
 
 # frozen_string_literal: true
 
-class AccessControlsController < ApplicationController
+class AccessControlsController < ApplicationControllerV2
   include ViewableEntities
   include ArelHelper
   include AjaxModalRails::Controller
 
+  authorize_with { current_user.can_edit_users? }
   before_action :set_access_control, only: [:show]
 
   def show

--- a/app/controllers/warehouse_reports/inactive_youth_intakes_controller.rb
+++ b/app/controllers/warehouse_reports/inactive_youth_intakes_controller.rb
@@ -8,6 +8,7 @@
 
 module WarehouseReports
   class InactiveYouthIntakesController < ApplicationController
+    include WarehouseReportAuthorization
     include AjaxModalRails::Controller
 
     before_action :set_filter

--- a/drivers/hud_data_quality_report/app/controllers/hud_data_quality_report/legacy_results_controller.rb
+++ b/drivers/hud_data_quality_report/app/controllers/hud_data_quality_report/legacy_results_controller.rb
@@ -7,10 +7,14 @@
 # frozen_string_literal: true
 
 module HudDataQualityReport
-  class LegacyResultsController < ApplicationController
+  class LegacyResultsController < ApplicationControllerV2
+    authorize_with { current_user.can_view_hud_reports? }
+
     def show
       @report = Report.find(params[:legacy_dq_id].to_i)
-      @result = ReportResult.find(params[:id].to_i)
+      # viewable_by narrows to the user's own results unless they can view all HUD
+      # reports; going through @report also keeps a mismatched id pair from resolving.
+      @result = @report.report_results.viewable_by(current_user).find(params[:id].to_i)
       respond_to do |format|
         format.html {} # render the default template
         format.csv do

--- a/drivers/hud_data_quality_report/spec/requests/legacy_results_controller_spec.rb
+++ b/drivers/hud_data_quality_report/spec/requests/legacy_results_controller_spec.rb
@@ -1,0 +1,98 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HudDataQualityReport::LegacyResultsController, type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+
+  let!(:report) { Report.create!(name: 'Legacy DQ', type: 'Reports::DataQuality::Fy2017::Q1') }
+  # ReportResult has no `name` column; `results` is the json payload the CSV is built from.
+  let(:results) { { 'q1' => { 'title' => 'Clients', 'value' => 7 } } }
+  let(:another_user) { create(:user) }
+  let!(:another_users_result) do
+    create(:report_result, report: report, user: another_user, percent_complete: 100, results: results)
+  end
+
+  def sign_in_with(role)
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  def download(report_result)
+    get hud_reports_legacy_dq_legacy_result_path(report, report_result, format: :csv)
+  end
+
+  describe 'GET /hud_reports/legacy_dqs/:legacy_dq_id/legacy_results/:id.csv' do
+    it 'denies a signed-in user with no HUD report permission' do
+      sign_in_with(create(:role, can_view_clients: true))
+
+      download(another_users_result)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(response.body).not_to include('Clients')
+      end
+    end
+
+    it 'allows a user who can view all HUD reports' do
+      sign_in_with(create(:role, can_view_all_hud_reports: true))
+
+      download(another_users_result)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(assigns(:result)).to eq(another_users_result)
+      end
+    end
+
+    context 'when the user can only view their own HUD reports' do
+      before { sign_in_with(create(:role, can_view_own_hud_reports: true)) }
+
+      it "does not serve another user's result" do
+        # ReportResult.viewable_by is what draws the own/all distinction; without it,
+        # holding either HUD report permission exposed every user's saved results.
+        download(another_users_result)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'still serves their own result' do
+        own_result = create(:report_result, report: report, user: user, percent_complete: 100, results: results)
+
+        download(own_result)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(assigns(:result)).to eq(own_result)
+        end
+      end
+    end
+
+    it 'does not serve a result belonging to a different report' do
+      # The id pair comes straight from the url; a result from another report must not
+      # resolve just because both ids exist.
+      sign_in_with(create(:role, can_view_all_hud_reports: true))
+      other_report = Report.create!(name: 'Other Legacy DQ', type: 'Reports::DataQuality::Fy2017::Q2')
+      other_reports_result = create(
+        :report_result,
+        report: other_report,
+        user: user,
+        percent_complete: 100,
+        results: results,
+      )
+
+      download(other_reports_result)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/drivers/hud_data_quality_report/spec/requests/legacy_results_controller_spec.rb
+++ b/drivers/hud_data_quality_report/spec/requests/legacy_results_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe HudDataQualityReport::LegacyResultsController, type: :request do
 
       aggregate_failures do
         expect(response).to have_http_status(:redirect)
-        expect(response.body).not_to include('Clients')
+        expect(flash[:alert]).to be_present
       end
     end
 

--- a/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
+++ b/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
@@ -8,8 +8,18 @@
 
 module UserDirectoryReport::WarehouseReports
   class UsersController < ApplicationController
+    include WarehouseReportAuthorization
+
     helper_method :nav_link_classes
     helper_method :cas_available?
+
+    # Both actions are the same report, and there is no :index for the concern's default
+    # derivation to use; the seeded definition is registered under the warehouse action's
+    # path (see GrdaWarehouse::WarehouseReports::ReportDefinition).
+    def related_report
+      GrdaWarehouse::WarehouseReports::ReportDefinition.
+        where(url: 'user_directory_report/warehouse_reports/users/warehouse')
+    end
 
     def readonly?
       true

--- a/drivers/user_directory_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_directory_report/spec/requests/users_controller_spec.rb
@@ -11,13 +11,6 @@ require 'rails_helper'
 # User Directory Report: name, email, phone and agency for every user in the directory,
 # in HTML and as an xlsx download, for both the warehouse and (where configured) CAS.
 #
-# This controller was not in the original ts-013 report; it was found by sweeping every
-# controller for a missing gate. It declared no authorization at all, so any signed-in
-# user could read and export the full user directory.
-#
-# Unlike the youth report, there is no second layer here: `_users` scopes only by
-# User.in_directory (active, non-system, not excluded from the directory) and never by
-# current_user. The gate below is the only thing restricting access.
 RSpec.describe UserDirectoryReport::WarehouseReports::UsersController, type: :request do
   include AccessControlSetup
 

--- a/drivers/user_directory_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_directory_report/spec/requests/users_controller_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe UserDirectoryReport::WarehouseReports::UsersController, type: :re
       aggregate_failures do
         expect(response).to have_http_status(:redirect)
         expect(flash[:alert]).to be_present
-        expect(response.body).not_to include('Listing')
       end
     end
 
@@ -75,7 +74,9 @@ RSpec.describe UserDirectoryReport::WarehouseReports::UsersController, type: :re
 
       aggregate_failures do
         expect(response).to have_http_status(:redirect)
-        expect(response.body).not_to include('Listing')
+        # The action sets an attachment disposition when it builds the spreadsheet, so
+        # its absence distinguishes "refused" from "redirected after generating a file".
+        expect(response.headers['Content-Disposition']).to be_blank
       end
     end
 

--- a/drivers/user_directory_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_directory_report/spec/requests/users_controller_spec.rb
@@ -1,0 +1,115 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# User Directory Report: name, email, phone and agency for every user in the directory,
+# in HTML and as an xlsx download, for both the warehouse and (where configured) CAS.
+#
+# This controller was not in the original ts-013 report; it was found by sweeping every
+# controller for a missing gate. It declared no authorization at all, so any signed-in
+# user could read and export the full user directory.
+#
+# Unlike the youth report, there is no second layer here: `_users` scopes only by
+# User.in_directory (active, non-system, not excluded from the directory) and never by
+# current_user. The gate below is the only thing restricting access.
+RSpec.describe UserDirectoryReport::WarehouseReports::UsersController, type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+
+  # Seed the real report definitions rather than fabricating one: the url is what
+  # WarehouseReportAuthorization matches on, and find_by! makes a rename of the seeded
+  # definition fail here instead of silently passing against a stale hardcoded url.
+  # rails_helper only seeds definitions for runs that include HUD report driver examples.
+  before { GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions }
+
+  let(:report_definition) do
+    GrdaWarehouse::WarehouseReports::ReportDefinition.
+      find_by!(url: 'user_directory_report/warehouse_reports/users/warehouse')
+  end
+
+  # A user who should appear in the directory once access is allowed, and whose absence
+  # from an unauthorized response is what we assert on.
+  let!(:listed_user) { create(:acl_user, first_name: 'Directory', last_name: 'Listing') }
+
+  def sign_in_with(role, grant_report: false)
+    collection.set_viewables(reports: [report_definition.id]) if grant_report
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET /user_directory_report/warehouse_reports/users/warehouse' do
+    it 'denies a user who has not been granted this report' do
+      sign_in_with(create(:role, can_view_assigned_reports: true))
+
+      get warehouse_user_directory_report_warehouse_reports_users_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+        expect(response.body).not_to include('Listing')
+      end
+    end
+
+    it 'denies a user with no report permission at all' do
+      sign_in_with(create(:role, can_view_clients: true), grant_report: true)
+
+      get warehouse_user_directory_report_warehouse_reports_users_path
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'denies the xlsx export for a user who has not been granted this report' do
+      # The export is a separate format on the same action; a gate that only covered the
+      # html path would still leak the whole directory as a spreadsheet.
+      sign_in_with(create(:role, can_view_assigned_reports: true))
+
+      get warehouse_user_directory_report_warehouse_reports_users_path(format: :xlsx)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(response.body).not_to include('Listing')
+      end
+    end
+
+    it 'allows a user granted the report, and lists directory users' do
+      sign_in_with(create(:role, can_view_assigned_reports: true), grant_report: true)
+
+      get warehouse_user_directory_report_warehouse_reports_users_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(assigns(:users)).to include(listed_user)
+      end
+    end
+  end
+
+  describe 'GET /user_directory_report/warehouse_reports/users/cas' do
+    it 'denies a user who has not been granted this report' do
+      # The cas action shares the warehouse action's report definition, so the override
+      # of related_report has to cover it too.
+      sign_in_with(create(:role, can_view_assigned_reports: true))
+
+      get cas_user_directory_report_warehouse_reports_users_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    # No allow-path example for #cas: the action raises before it renders whenever CAS is
+    # not configured, which includes the test environment. `cas_available?` is false, so
+    # @users is set to a plain Array and handed to pagy, which needs a relation --
+    # NoMethodError: undefined method 'offset' for an instance of Array. That is a
+    # pre-existing bug in the action (it predates the authorization gate added here) and
+    # is tracked separately; the deny example above is what pins the gate itself.
+  end
+end

--- a/drivers/user_permission_report/app/controllers/user_permission_report/warehouse_reports/users_controller.rb
+++ b/drivers/user_permission_report/app/controllers/user_permission_report/warehouse_reports/users_controller.rb
@@ -8,8 +8,17 @@
 
 module UserPermissionReport::WarehouseReports
   class UsersController < ApplicationController
+    include WarehouseReportAuthorization
     include AjaxModalRails::Controller
     before_action :set_group_associations
+
+    # This controller only serves the detail modal for the report index, so authorize
+    # against that report. The concern's default derives the url from this controller's
+    # own :index action, which doesn't exist here.
+    def related_report
+      GrdaWarehouse::WarehouseReports::ReportDefinition.
+        where(url: 'user_permission_report/warehouse_reports/reports')
+    end
 
     def show
       @modal_size = :xl

--- a/drivers/user_permission_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_permission_report/spec/requests/users_controller_spec.rb
@@ -1,0 +1,87 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Serves the "Full Permissions" detail modal for a single user, opened from the User
+# Permission Report index (reports/index.haml:52). It renders that user's complete
+# access control configuration -- every role, collection, and user group.
+#
+# Until core ts-013 this controller declared no authorization, so any signed-in user
+# could read any other user's permission configuration by id, without ever being granted
+# the report the modal belongs to.
+#
+# The report definition must exist and be granted through the user's collection: that is
+# what WarehouseReportAuthorization#report_visible? checks, and this controller overrides
+# related_report because it has no :index action for the concern's default to derive.
+RSpec.describe UserPermissionReport::WarehouseReports::UsersController, type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+
+  # Seed the real report definitions rather than fabricating one: the url is what
+  # WarehouseReportAuthorization matches on, and find_by! makes a rename of the seeded
+  # definition fail here instead of silently passing against a stale hardcoded url.
+  # rails_helper only seeds definitions for runs that include HUD report driver examples.
+  before { GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions }
+
+  let(:report_definition) do
+    GrdaWarehouse::WarehouseReports::ReportDefinition.
+      find_by!(url: 'user_permission_report/warehouse_reports/reports')
+  end
+
+  # The user whose permissions the request is trying to read.
+  let!(:subject_user) { create(:acl_user) }
+  let!(:subject_access_control) do
+    setup_access_control(subject_user, create(:role, can_view_clients: true), create(:collection))
+  end
+
+  # `grant_report: true` puts the report definition in the collection, which is what
+  # report_visible? requires on top of the can_view_assigned_reports permission.
+  def sign_in_with(role, grant_report: false)
+    collection.set_viewables(reports: [report_definition.id]) if grant_report
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET /user_permission_report/warehouse_reports/users/:id' do
+    it 'denies a user who has not been granted this report' do
+      # Holding can_view_assigned_reports is not enough on its own -- the report itself
+      # has to be assigned to one of the user's collections.
+      sign_in_with(create(:role, can_view_assigned_reports: true))
+
+      get user_permission_report_warehouse_reports_user_path(subject_user)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    it 'denies a user with no report permission at all' do
+      sign_in_with(create(:role, can_view_clients: true), grant_report: true)
+
+      get user_permission_report_warehouse_reports_user_path(subject_user)
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'allows a user granted the report, and renders the subject user\'s configuration' do
+      sign_in_with(create(:role, can_view_assigned_reports: true), grant_report: true)
+
+      get user_permission_report_warehouse_reports_user_path(subject_user)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(assigns(:user)).to eq(subject_user)
+        expect(response.body).to include(subject_access_control.role.name)
+      end
+    end
+  end
+end

--- a/drivers/user_permission_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_permission_report/spec/requests/users_controller_spec.rb
@@ -12,9 +12,6 @@ require 'rails_helper'
 # Permission Report index (reports/index.haml:52). It renders that user's complete
 # access control configuration -- every role, collection, and user group.
 #
-# Until core ts-013 this controller declared no authorization, so any signed-in user
-# could read any other user's permission configuration by id, without ever being granted
-# the report the modal belongs to.
 #
 # The report definition must exist and be granted through the user's collection: that is
 # what WarehouseReportAuthorization#report_visible? checks, and this controller overrides

--- a/spec/requests/access_controls_controller_spec.rb
+++ b/spec/requests/access_controls_controller_spec.rb
@@ -1,0 +1,61 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AccessControlsController, type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+
+  # A second, unrelated access control -- the record the request is trying to read.
+  let!(:audited_access_control) do
+    setup_access_control(create(:acl_user), create(:role, can_view_clients: true), create(:collection))
+  end
+
+  def sign_in_with(role)
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET /access_controls/:id' do
+    it 'denies a signed-in user who cannot edit users' do
+      sign_in_with(create(:role, can_view_clients: true))
+
+      get access_control_path(audited_access_control)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    it 'denies a user whose only elevated permission is an adjacent admin one' do
+      # can_audit_users is deliberately close to, but not, the gate: holding some
+      # user-administration permission must not be enough on its own.
+      sign_in_with(create(:role, can_audit_users: true))
+
+      get access_control_path(audited_access_control)
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'allows a user who can edit users, and renders the record' do
+      sign_in_with(create(:role, can_edit_users: true))
+
+      get access_control_path(audited_access_control)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(assigns(:access_control)).to eq(audited_access_control)
+        expect(response.body).to include(audited_access_control.role.name)
+      end
+    end
+  end
+end

--- a/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
+++ b/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
@@ -8,10 +8,6 @@
 
 require 'rails_helper'
 
-# "Inactive Youth" report: youth with an open intake and no case management activity in
-# the date range. Until core ts-013 this controller declared no authorization, so any
-# signed-in user could open a report they had never been granted.
-#
 # Row-level youth data is separately scoped: every source the report reads goes through
 # GrdaWarehouse::YouthIntake::Entry.visible_by?(filter.user) and its siblings (see
 # GrdaWarehouse::WarehouseReports::Youth::InactiveIntake#intake_source and friends), which

--- a/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
+++ b/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
@@ -74,16 +74,18 @@ RSpec.describe WarehouseReports::InactiveYouthIntakesController, type: :request 
     end
 
     it 'defaults the filter range when none is submitted' do
-      # set_filter runs before the report is built; a regression here would silently
-      # change which youth appear, so pin the documented default (3 full months back
-      # through yesterday).
+      # set_filter computes its default range from the clock: the beginning of the month
+      # three months earlier, through the previous day. The request below runs with time
+      # frozen, so those resolve to the fixed dates asserted there.
       sign_in_with(create(:role, can_view_assigned_reports: true), grant_report: true)
 
-      get warehouse_reports_inactive_youth_intakes_path
+      travel_to Time.zone.local(2025, 6, 15, 12, 0, 0) do
+        get warehouse_reports_inactive_youth_intakes_path
 
-      aggregate_failures do
-        expect(assigns(:filter).start).to eq(3.months.ago.beginning_of_month.to_date)
-        expect(assigns(:filter).end).to eq(1.day.ago.to_date)
+        aggregate_failures do
+          expect(assigns(:filter).start).to eq(Date.new(2025, 3, 1))
+          expect(assigns(:filter).end).to eq(Date.new(2025, 6, 14))
+        end
       end
     end
   end

--- a/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
+++ b/spec/requests/warehouse_reports/inactive_youth_intakes_controller_spec.rb
@@ -1,0 +1,90 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# "Inactive Youth" report: youth with an open intake and no case management activity in
+# the date range. Until core ts-013 this controller declared no authorization, so any
+# signed-in user could open a report they had never been granted.
+#
+# Row-level youth data is separately scoped: every source the report reads goes through
+# GrdaWarehouse::YouthIntake::Entry.visible_by?(filter.user) and its siblings (see
+# GrdaWarehouse::WarehouseReports::Youth::InactiveIntake#intake_source and friends), which
+# return `none` for a user with no youth intake permission. So the gate below controls
+# access to the report, not to the youth data itself -- both layers matter.
+RSpec.describe WarehouseReports::InactiveYouthIntakesController, type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+
+  # Seed the real report definitions rather than fabricating one: the url is what
+  # WarehouseReportAuthorization matches on, and find_by! makes a rename of the seeded
+  # definition fail here instead of silently passing against a stale hardcoded url.
+  # rails_helper only seeds definitions for runs that include HUD report driver examples.
+  before { GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions }
+
+  let(:report_definition) do
+    GrdaWarehouse::WarehouseReports::ReportDefinition.
+      find_by!(url: 'warehouse_reports/inactive_youth_intakes')
+  end
+
+  # `grant_report: true` puts the report definition in the user's collection, which is
+  # what WarehouseReportAuthorization#report_visible? requires on top of the permission.
+  def sign_in_with(role, grant_report: false)
+    collection.set_viewables(reports: [report_definition.id]) if grant_report
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET /warehouse_reports/inactive_youth_intakes' do
+    it 'denies a user who has not been granted this report' do
+      sign_in_with(create(:role, can_view_assigned_reports: true))
+
+      get warehouse_reports_inactive_youth_intakes_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    it 'denies a user with no report permission at all' do
+      sign_in_with(create(:role, can_view_clients: true), grant_report: true)
+
+      get warehouse_reports_inactive_youth_intakes_path
+
+      expect(response).to have_http_status(:redirect)
+    end
+
+    it 'allows a user granted the report' do
+      sign_in_with(create(:role, can_view_assigned_reports: true), grant_report: true)
+
+      get warehouse_reports_inactive_youth_intakes_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(assigns(:report)).to be_present
+      end
+    end
+
+    it 'defaults the filter range when none is submitted' do
+      # set_filter runs before the report is built; a regression here would silently
+      # change which youth appear, so pin the documented default (3 full months back
+      # through yesterday).
+      sign_in_with(create(:role, can_view_assigned_reports: true), grant_report: true)
+
+      get warehouse_reports_inactive_youth_intakes_path
+
+      aggregate_failures do
+        expect(assigns(:filter).start).to eq(3.months.ago.beginning_of_month.to_date)
+        expect(assigns(:filter).end).to eq(1.day.ago.to_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

Adds authorization for controllers identified as missing authorization. 

| Controller | Gate added |
|---|---|
| `AccessControlsController#show` | `can_edit_users?` |
| `HudDataQualityReport::LegacyResultsController#show` | `can_view_hud_reports?` plus `viewable_by` record scoping |
| `UserPermissionReport::WarehouseReports::UsersController#show` | `WarehouseReportAuthorization` |
| `WarehouseReports::InactiveYouthIntakesController#index` | `WarehouseReportAuthorization` |
| `UserDirectoryReport::WarehouseReports::UsersController#warehouse`, `#cas` | `WarehouseReportAuthorization` |


### Why some use V2 and some do not

`AccessControlsController` and `LegacyResultsController` gate on a single permission, so they moved to `ApplicationControllerV2` with `authorize_with`. That also brings in `ensure_authorized`, the after-action that raises when no authorization check ran — the guard that would have caught this whole class of bug.

The three report controllers use `WarehouseReportAuthorization` instead, matching their sibling controllers. Their gate is not a single permission but "holds a report permission **and** has been granted this specific report through a collection," which the concern already implements.

Those three cannot use V2 as it currently stands — the concern depends on methods that V2 subclasses deliberately don't receive. Making the concern V2-compatible would affect the 150 controllers that include it, well beyond the scope of this fix. Using the concern here closes these gaps without touching any of them.

`UserPermissionReport` and `UserDirectoryReport` also override `related_report`, which is required rather than stylistic: neither has an `:index` route, so the concern's default `url_for(action: :index)` raises `ActionController::UrlGenerationError` on every request. `InactiveYouthIntakes` has an `index`, so it needs no override.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

