### PR TITLE
Fix CSS being dropped from inlined PDF stylesheets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,7 +24,7 @@
 // NOTE: as this file is now type scss, we cannot use require, or require_tree, we need to use @import
 @import 'select2/dist/css/select2.min';
 @import 'select2-bootstrap';
-@import 'billboard.js/dist/billboard.min.css';
+@import 'billboard.js/dist/billboard.min';
 @import 'jquery-ui/sortable';
 @import 'jquery-ui/slider';
 @import 'jquery-ui/autocomplete';
@@ -32,7 +32,7 @@
 @import 'leaflet.markercluster/dist/MarkerCluster';
 @import 'leaflet.markercluster/dist/MarkerCluster.Default';
 @import 'beautifymarker/leaflet-beautify-marker-icon';
-@import 'ag-grid-community/styles/ag-theme-balham.min.css';
+@import 'ag-grid-community/styles/ag-theme-balham.min';
 @import 'jquery.minicolors';
 
 // require datatables.net-bs5/css/dataTables.bootstrap5

--- a/app/assets/stylesheets/dashboard_pdf.scss
+++ b/app/assets/stylesheets/dashboard_pdf.scss
@@ -11,7 +11,7 @@
 // NOTE: as this file is now type scss, we cannot use require, or require_tree, we need to use @import
 @import 'select2/dist/css/select2.min';
 @import 'select2-bootstrap';
-@import 'billboard.js/dist/billboard.min.css';
+@import 'billboard.js/dist/billboard.min';
 
 @import 'datatables_bootstrap';
 @import 'application/vendor/icons_embedded'; // Embedded font data for PDFs

--- a/app/assets/stylesheets/health_flex_services_pdf.scss
+++ b/app/assets/stylesheets/health_flex_services_pdf.scss
@@ -10,7 +10,7 @@
 // NOTE: as this file is now type scss, we cannot use require, or require_tree, we need to use @import
 @import 'select2/dist/css/select2.min';
 @import 'select2-bootstrap';
-@import 'billboard.js/dist/billboard.min.css';
+@import 'billboard.js/dist/billboard.min';
 
 @import 'datatables_bootstrap';
 @import 'application/vendor/icons';

--- a/app/assets/stylesheets/modern.scss
+++ b/app/assets/stylesheets/modern.scss
@@ -24,7 +24,7 @@
 // NOTE: as this file is now type scss, we cannot use require, or require_tree, we need to use @import
 @import 'select2/dist/css/select2.min';
 @import 'select2-bootstrap';
-@import 'billboard.js/dist/billboard.min.css';
+@import 'billboard.js/dist/billboard.min';
 @import 'jquery-ui/sortable';
 @import 'jquery-ui/slider';
 @import 'jquery-ui/autocomplete';
@@ -32,7 +32,7 @@
 @import 'leaflet.markercluster/dist/MarkerCluster';
 @import 'leaflet.markercluster/dist/MarkerCluster.Default';
 @import 'beautifymarker/leaflet-beautify-marker-icon';
-@import 'ag-grid-community/styles/ag-theme-balham.min.css';
+@import 'ag-grid-community/styles/ag-theme-balham.min';
 @import 'jquery.minicolors';
 
 // require datatables.net-bs5/css/dataTables.bootstrap5

--- a/app/assets/stylesheets/roi_pdf.scss
+++ b/app/assets/stylesheets/roi_pdf.scss
@@ -10,7 +10,7 @@
 // NOTE: as this file is now type scss, we cannot use require, or require_tree, we need to use @import
 @import 'select2/dist/css/select2.min';
 @import 'select2-bootstrap';
-@import 'billboard.js/dist/billboard.min.css';
+@import 'billboard.js/dist/billboard.min';
 
 @import 'datatables_bootstrap';
 @import 'application/vendor/icons';

--- a/spec/helpers/asset_helper_spec.rb
+++ b/spec/helpers/asset_helper_spec.rb
@@ -1,0 +1,66 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AssetHelper, type: :helper do
+  # read_asset returns nil for a stylesheet it cannot resolve, which would satisfy the
+  # @import assertions below with no css at all. The smallest inlined stylesheet is ~91KB.
+  minimum_size = 50_000
+
+  describe '.wicked_pdf_stylesheet_link_tag' do
+    # Sass does not inline an @import written with an explicit .css extension; it emits
+    # a plain `@import url(...)` instead. A browser resolves that over HTTP, but a
+    # stylesheet inlined into a <style> tag for PDF rendering cannot, so the imported
+    # rules are dropped. Import vendor css without the extension.
+    #
+    # Assertions match against extracts rather than the stylesheet itself to keep
+    # failure output small.
+
+    # Stylesheets named literally in a call to inline_stylesheet_link_tag. The example
+    # below fails if this list drifts from the call sites. layouts/pdf_with_map also
+    # inlines theme/styles/*.scss through a local variable, which cannot be derived
+    # statically; that glob currently matches only a sass partial, which sprockets does
+    # not serve.
+    inlined_for_pdf = ['dashboard_pdf', 'application', 'print', 'roi_pdf', 'health_flex_services_pdf'].freeze
+
+    it 'covers every stylesheet named literally in a call to inline_stylesheet_link_tag' do
+      paths = Dir.glob(Rails.root.join('{app,drivers,lib,config}/**/*.{haml,erb,rb}'))
+      named = paths.flat_map { |path| File.read(path).scan(/inline_stylesheet_link_tag\(?\s*['"]([^'"]+)['"]/) }
+
+      expect(named.flatten.uniq.sort).to eq(inlined_for_pdf.sort)
+    end
+
+    inlined_for_pdf.each do |stylesheet|
+      it "has no unresolved @import in #{stylesheet}.css" do
+        css = described_class.wicked_pdf_stylesheet_link_tag(stylesheet)
+
+        expect(css.bytesize).to be > minimum_size
+        expect(css.scan(/@import\s+url\([^)]*\)/)).to be_empty
+      end
+    end
+
+    # Without `fill: none` billboard.js line series render as filled polygons, and
+    # without a grid stroke the gridlines are invisible. These assert the declarations
+    # rather than the selectors, so dropping a declaration is still a failure.
+    it 'inlines the billboard.js declarations' do
+      css = described_class.wicked_pdf_stylesheet_link_tag('dashboard_pdf')
+
+      expect(css[/\.bb path,\s*\.bb line\s*\{[^}]*fill:\s*none/]).to be_present
+      expect(css[/\.bb-grid line\s*\{[^}]*stroke:/]).to be_present
+    end
+
+    # The theme declares its variables on a grouped selector; there is no bare
+    # `.ag-theme-balham {}` rule.
+    it 'inlines the ag-grid theme declarations' do
+      css = described_class.wicked_pdf_stylesheet_link_tag('application')
+
+      expect(css[/\.ag-theme-balham[^{]*\{[^}]*--ag-balham-active-color:/]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Charts in PDF reports rendered as filled black shapes with no gridlines, most visibly the Monthly Census chart on the sub-population dashboards. Sass does not inline an `@import` written with an explicit `.css` extension; it emits a plain `@import url(...)` in the compiled output instead. A browser resolves that over HTTP, so the on-screen charts were unaffected. The PDF path does not: `AssetHelper.wicked_pdf_stylesheet_link_tag` reads the compiled stylesheet into a `<style>` tag, and the headless browser has no origin from which to fetch the import, so the rules are dropped. The missing rules were `.bb path, .bb line { fill: none }`, which prevents billboard.js line series from painting as filled polygons, and `.bb-grid line`, which supplies the gridline stroke.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

