### PR TITLE
Fix side menu overlapping page content at mid-range window widths

### DIFF
--- a/app/assets/stylesheets/application/_settings/_variables.scss
+++ b/app/assets/stylesheets/application/_settings/_variables.scss
@@ -14,6 +14,13 @@ $header-height: 60px !default;
 $nav-side-width: 185px !default;
 $nav-side-collapsed-width: 65px !default;
 
+// Breakpoint at and above which the side menu sits on-canvas; below it the menu
+// is a drawer. One per body layout class (ApplicationHelper#body_classes).
+// Used with media-breakpoint-down() in objects/_menu.scss and
+// media-breakpoint-up() in layouts/_main.scss and modules/_header.scss.
+$nav-side-on-canvas-md: lg !default;
+$nav-side-on-canvas-lg: xl !default;
+
 // Footer
 $footer-logo-height: 85px !default;
 $footer-logo-padding: 15px !default;

--- a/app/assets/stylesheets/application/layouts/_main.scss
+++ b/app/assets/stylesheets/application/layouts/_main.scss
@@ -15,15 +15,18 @@
   overflow-x: auto;
 }
 
+// Give back the width the on-canvas menu takes. Must stay in lockstep with the
+// drawer breakpoints in objects/_menu.scss — see $nav-side-on-canvas-* in
+// _settings/_variables.scss.
 .l-content-width-md .l-main__content {
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up($nav-side-on-canvas-md) {
     flex: 0 0 calc(100vw - #{$nav-side-width});
     max-width: calc(100vw - #{$nav-side-width});
   }
 }
 
 .l-content-width-lg .l-main__content {
-  @include media-breakpoint-up(xl) {
+  @include media-breakpoint-up($nav-side-on-canvas-lg) {
     flex: 0 0 calc(100vw - #{$nav-side-width});
     max-width: calc(100vw - #{$nav-side-width});
   }

--- a/app/assets/stylesheets/application/modules/_header.scss
+++ b/app/assets/stylesheets/application/modules/_header.scss
@@ -41,14 +41,16 @@
   align-items: center;
 }
 
+// Hide the drawer toggle once the menu is on-canvas. See $nav-side-on-canvas-*
+// in _settings/_variables.scss.
 .l-content-width-md .c-header-nav__mobile-link {
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up($nav-side-on-canvas-md) {
     display: none;
   }
 }
 
 .l-content-width-lg .c-header-nav__mobile-link {
-  @include media-breakpoint-up(xl) {
+  @include media-breakpoint-up($nav-side-on-canvas-lg) {
     display: none;
   }
 }

--- a/app/assets/stylesheets/application/objects/_menu.scss
+++ b/app/assets/stylesheets/application/objects/_menu.scss
@@ -92,14 +92,16 @@
   padding-top: 0.25rem;
 }
 
+// Below the on-canvas breakpoint the menu is a drawer. See
+// $nav-side-on-canvas-* in _settings/_variables.scss before changing these.
 .l-content-width-md .site-menu {
-  @include media-breakpoint-down(md) {
+  @include media-breakpoint-down($nav-side-on-canvas-md) {
     @include o-menu-drawer;
   }
 }
 
 .l-content-width-lg .site-menu {
-  @include media-breakpoint-down(lg) {
+  @include media-breakpoint-down($nav-side-on-canvas-lg) {
     @include o-menu-drawer;
   }
 }
@@ -134,13 +136,13 @@
 }
 
 .l-content-width-md .o-menu {
-  @include media-breakpoint-down(md) {
+  @include media-breakpoint-down($nav-side-on-canvas-md) {
     @include o-menu-drawer;
   }
 }
 
 .l-content-width-lg .o-menu {
-  @include media-breakpoint-down(lg) {
+  @include media-breakpoint-down($nav-side-on-canvas-lg) {
     @include o-menu-drawer;
   }
 }


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

At certain browser window widths, the navigation menu on the right and the page
content overlapped, pushing the left edge of the page off-screen where it could
not be scrolled into view. On report pages this hid the filter panel entirely, so
users could not see or change report filters without resizing their window.
Making the window smaller or larger both fixed it, which is why it only showed up
at in-between sizes.

The menu has two display modes — a slide-out drawer on narrow screens and a fixed
column on wide ones — and the page content is supposed to narrow by the width of
that column when it appears. The width at which the menu became a fixed column
and the width at which the content narrowed did not match, so in between the two
the menu and content competed for the same space. Both now come from a single
shared setting, so they change together and cannot fall out of step in future.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

