### PR TITLE
[#7654] PATH Report - ACL filters

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -90,22 +90,21 @@ module Api
     end
 
     private def project_types
-      return HudHelper.util.project_types.keys unless project_params[:project_types].present? || project_params[:project_type_ids].present?
+      # Strip blanks before the presence check: a serialized empty array
+      # (`project_types[]=`) arrives as [""], which must mean "no type
+      # restriction" rather than "no types match".
+      requested_types = project_params[:project_types]&.select(&:present?)
+      requested_type_ids = project_params[:project_type_ids]&.select(&:present?)
+      return HudHelper.util.project_types.keys unless requested_types.present? || requested_type_ids.present?
 
       @project_types ||= begin
         types = []
 
         project_type_to_id = HudHelper.util.performance_reporting.merge(HudHelper.util.residential_project_type_numbers_by_code)
-        if project_params[:project_types].present?
-          project_params[:project_types]&.select(&:present?)&.map(&:to_sym)&.each do |type|
-            types += project_type_to_id[type]
-          end
+        requested_types&.map(&:to_sym)&.each do |type|
+          types += project_type_to_id[type]
         end
-        if project_params[:project_type_ids].present?
-          types += project_params[:project_type_ids]&.
-            select(&:present?)&.
-            map(&:to_i)
-        end
+        types += requested_type_ids.map(&:to_i) if requested_type_ids.present?
         types
       end
     end

--- a/app/models/filters/filter_base.rb
+++ b/app/models/filters/filter_base.rb
@@ -456,7 +456,10 @@ module Filters
         opts[label(:sub_population, labels)] = chosen_sub_population
         opts[label(:data_sources, labels)] = data_source_names if data_source_ids.any?
         opts[label(:organizations, labels)] = organization_names if organization_ids.any?
-        opts[label(:projects, labels)] = project_names(project_ids) if project_ids.any?
+        # Show the actual (e.g. CoC/funder-narrowed) project set the report will
+        # run against, not the raw picks, so this agrees with both the live
+        # "N Projects Included" count on the new-report page and the report run itself.
+        opts[label(:projects, labels)] = project_names(effective_project_ids) if project_ids.any?
         opts[label(:project_groups, labels)] = project_groups if project_group_ids.any?
         opts[label(:funders, labels)] = funder_names if funder_ids.any?
         opts[label(:funder_others, labels)] = funder_others if funder_others.any?
@@ -827,24 +830,24 @@ module Filters
       HudHelper.util.project_type_group_titles.select { |k, _| k.in?(default_project_type_codes) }.invert.freeze
     end
 
-    def project_options_for_select(user:, ids: nil)
-      all_project_scope.options_for_select(user: user, ids: ids)
+    def project_options_for_select(user:, ids: nil, permission: :can_view_assigned_reports)
+      all_project_scope.options_for_select(user: user, ids: ids, permission: permission)
     end
 
-    def organization_options_for_select(user:, ids: nil)
-      all_organizations_scope.distinct.options_for_select(user: user, ids: ids)
+    def organization_options_for_select(user:, ids: nil, permission: :can_view_assigned_reports)
+      all_organizations_scope.distinct.options_for_select(user: user, ids: ids, permission: permission)
     end
 
-    def data_source_options_for_select(user:, ids: nil)
-      all_data_sources_scope.options_for_select(user: user, ids: ids)
+    def data_source_options_for_select(user:, ids: nil, permission: :can_view_assigned_reports)
+      all_data_sources_scope.options_for_select(user: user, ids: ids, permission: permission)
     end
 
-    def funder_options_for_select(user:, funder_codes: nil)
-      all_funders_scope.options_for_select(user: user, funder_codes: funder_codes)
+    def funder_options_for_select(user:, funder_codes: nil, permission: :can_view_assigned_reports)
+      all_funders_scope.options_for_select(user: user, funder_codes: funder_codes, permission: permission)
     end
 
-    def funder_other_options_for_select(user:)
-      all_funders_scope.options_for_select_other(user: user)
+    def funder_other_options_for_select(user:, permission: :can_view_assigned_reports)
+      all_funders_scope.options_for_select_other(user: user, permission: permission)
     end
 
     def coc_code_options_for_select(user:, permission: :can_view_assigned_reports)
@@ -1055,7 +1058,10 @@ module Filters
       @available_coc_codes ||= begin
         return GrdaWarehouse::Hud::ProjectCoc.distinct.pluck(GrdaWarehouse::Hud::ProjectCoc.coc_code_coalesce) if user.system_user?
 
-        GrdaWarehouse::Lookups::CocCode.viewable_by(user).distinct.pluck(:coc_code)
+        # Must match the permission used to populate the coc_codes select
+        # (coc_code_options_for_select) or submitted codes get silently
+        # filtered out here and validation fails with "can't be blank".
+        GrdaWarehouse::Lookups::CocCode.viewable_by(user, permission: :can_view_assigned_reports).distinct.pluck(:coc_code)
       end
     end
 
@@ -1361,9 +1367,12 @@ module Filters
     def chosen_projects
       return nil unless project_ids.reject(&:blank?).present?
 
+      # Use effective_project_ids (not the raw picks) so this agrees with both
+      # the live "N Projects Included" count on the new-report page and the
+      # report run itself, both of which narrow by CoC/funder/etc.
       # OK to use non-confidentialized ProjectName because confidential projects
       # are only select-able if user has permission to view their names
-      GrdaWarehouse::Hud::Project.where(id: project_ids).pluck(:ProjectName)
+      GrdaWarehouse::Hud::Project.where(id: effective_project_ids).pluck(:ProjectName)
     end
 
     def chosen_excluded_projects

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -593,9 +593,9 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     end
   end
 
-  def self.options_for_select(user:, ids: nil)
+  def self.options_for_select(user:, ids: nil, permission: :can_view_projects)
     # don't cache this, it's a class method
-    scope = viewable_by(user)
+    scope = viewable_by(user, permission: permission)
     scope = scope.where(id: ids) if ids.present?
     scope.distinct.
       order(name: :asc).

--- a/app/models/grda_warehouse/hud/funder.rb
+++ b/app/models/grda_warehouse/hud/funder.rb
@@ -83,8 +83,8 @@ module GrdaWarehouse::Hud
       "#{self.StartDate} - #{self.EndDate}"
     end
 
-    def self.options_for_select(user:, funder_codes: nil)
-      scope = viewable_by(user)
+    def self.options_for_select(user:, funder_codes: nil, permission: :can_view_projects)
+      scope = viewable_by(user, permission: permission)
       scope = scope.where(Funder: funder_codes) if funder_codes.present?
       scope.distinct.
         order(Funder: :asc).
@@ -97,8 +97,8 @@ module GrdaWarehouse::Hud
         end
     end
 
-    def self.options_for_select_other(user:)
-      viewable_by(user).
+    def self.options_for_select_other(user:, permission: :can_view_projects)
+      viewable_by(user, permission: permission).
         distinct.
         order(OtherFunder: :asc).
         pluck(:OtherFunder).

--- a/app/models/grda_warehouse/hud/organization.rb
+++ b/app/models/grda_warehouse/hud/organization.rb
@@ -342,11 +342,11 @@ module GrdaWarehouse::Hud
       confidential_organization_ids.include?([organization_id, data_source_id])
     end
 
-    def self.options_for_select(user:, ids: nil)
+    def self.options_for_select(user:, ids: nil, permission: :can_view_projects)
       # don't cache this, it's a class method
       @options = begin
         options = {}
-        scope = viewable_by(user)
+        scope = viewable_by(user, permission: permission)
         scope = scope.where(confidential: false) unless user.can_view_confidential_project_names?
         scope = scope.where(id: ids) if ids.present?
         scope.joins(:data_source).

--- a/app/models/grda_warehouse/hud/project.rb
+++ b/app/models/grda_warehouse/hud/project.rb
@@ -954,11 +954,11 @@ module GrdaWarehouse::Hud
       )
     end
 
-    def self.options_for_select(user:, scope: nil, ids: nil)
+    def self.options_for_select(user:, scope: nil, ids: nil, permission: :can_view_projects)
       # don't cache this, it's a class method
       @options = begin
         options = {}
-        project_scope = viewable_by(user)
+        project_scope = viewable_by(user, permission: permission)
         project_scope = project_scope.merge(scope) unless scope.nil?
         project_scope = project_scope.merge(non_confidential) unless user.can_view_confidential_project_names?
         project_scope = project_scope.where(id: ids) if ids.present?

--- a/app/views/hud_reports/_project_filter.haml
+++ b/app/views/hud_reports/_project_filter.haml
@@ -10,7 +10,7 @@
   .col-md-8
     .row
       .col-sm-6
-        = f.input :project_ids, collection: [], as: :grouped_select_two, group_method: :last, input_html: { multiple: true, placeholder: 'Choose Projects', data: { 'filter-projects-target' => 'projects', action: 'change->filter-projects#update', 'collection-path' => api_projects_path(selected_project_ids: @filter.project_ids, **api_projects_parameters), async: "#{Rails.env.development?}" } }, label: 'Projects'
+        = f.input :project_ids, collection: [], as: :grouped_select_two, group_method: :last, input_html: { multiple: true, placeholder: 'Choose Projects', data: { 'filter-projects-target' => 'projects', action: 'change->filter-projects#update', 'collection-path' => api_projects_path(selected_project_ids: @filter.project_ids, permission: :can_view_assigned_reports, **api_projects_parameters), async: "#{Rails.env.development?}" } }, label: 'Projects'
       .col-sm-6
         = f.input :data_source_ids, collection: @filter.data_source_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose Data Sources', data: { 'filter-projects-target' => 'dataSources', action: 'change->filter-projects#update' }}, label: 'Data Sources'
     .row

--- a/app/views/project_groups/_form.haml
+++ b/app/views/project_groups/_form.haml
@@ -12,11 +12,11 @@
 
   = f.input :project_ids, collection: [], as: :select_two, input_html: { multiple: true, data: { 'collection-path' => api_projects_path(selected_project_ids: @project_group.filter.project_ids) }, placeholder: 'Choose Projects'}, label: 'Projects'
 
-  = f.input :organization_ids, collection: @project_group.filter.organization_options_for_select(user: current_user), as: :grouped_select_two, group_method: :last, input_html: {multiple: true, placeholder: 'Choose Organizations' }, label: 'Organizations', required: false
+  = f.input :organization_ids, collection: @project_group.filter.organization_options_for_select(user: current_user, permission: :can_view_projects), as: :grouped_select_two, group_method: :last, input_html: {multiple: true, placeholder: 'Choose Organizations' }, label: 'Organizations', required: false
 
   = f.input :project_type_numbers, collection: @project_group.filter.available_project_type_numbers, input_html: { multiple: true, placeholder: 'Choose Project Types' }, label: 'Project Types', as: :select_two
 
-  = f.input :data_source_ids, collection: @project_group.filter.data_source_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, placeholder: 'Choose Data Sources' }, label: 'Data Sources'
+  = f.input :data_source_ids, collection: @project_group.filter.data_source_options_for_select(user: current_user, permission: :can_view_projects), as: :select_two, input_html: {multiple: true, placeholder: 'Choose Data Sources' }, label: 'Data Sources'
 %h3 Exclusion Criteria
 .form-inputs.well
   %p Choices below will remove from the selection of included projects.

--- a/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
+++ b/drivers/hud_path_report/app/views/hud_path_report/shared/_report_form.haml
@@ -20,7 +20,7 @@
         %div{ class: coc_cols }
           = f.input :coc_codes, collection: @filter.coc_code_options_for_select(user: current_user), as: :select_two, input_html: {multiple: true, data: {'filter-projects-target' => 'cocCodes', 'action': 'change->filter-projects#update'}}, label: 'CoC Codes', hint: default_coc_code
         = f.input :funder_ids, as: :hidden, input_html: { value: [path_funder_code], data: {'filter-projects-target' => 'funderIds'} }
-      = render 'hud_reports/project_filter', f: f, api_projects_parameters: { project_types: @filter.default_project_type_codes, funder_codes: [path_funder_code] }, alert: alert
+      = render 'hud_reports/project_filter', f: f, api_projects_parameters: { project_types: @filter.path_project_types, funder_codes: [path_funder_code] }, alert: alert
 
   - content_for :filter_actions do
     = f.button :submit, value: 'Queue Report', data: { 'filter-projects-target' => 'submitButton' }

--- a/drivers/hud_path_report/spec/requests/hud_path_report/paths_new_spec.rb
+++ b/drivers/hud_path_report/spec/requests/hud_path_report/paths_new_spec.rb
@@ -1,0 +1,118 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The Annual PATH Report queue form embeds a data-collection-path URL that the
+# project picker POSTs back to /api/projects. That URL must scope projects with
+# the same permission the queued report uses (:can_view_assigned_reports) and
+# restrict to PATH project types and funder — for both permission schemes.
+RSpec.describe 'HudPathReport paths#new project picker', type: :request, exclude_fixpoints: true do
+  include AccessControlSetup
+
+  before(:all) { GrdaWarehouse::Utility.clear! }
+  after(:all) { GrdaWarehouse::Utility.clear! }
+
+  let!(:config) { create(:config) }
+  let!(:data_source) { create(:source_data_source) }
+  let!(:organization) { create(:hud_organization, data_source_id: data_source.id) }
+  let!(:so_path_project) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 4,
+    )
+  end
+  let!(:so_path_funder) do
+    create(
+      :hud_funder,
+      data_source_id: data_source.id,
+      ProjectID: so_path_project.ProjectID,
+      Funder: 21,
+    )
+  end
+  let!(:so_project_without_path_funder) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 4,
+    )
+  end
+  let!(:es_path_funded_project) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 1,
+    )
+  end
+  let!(:es_funder) do
+    create(
+      :hud_funder,
+      data_source_id: data_source.id,
+      ProjectID: es_path_funded_project.ProjectID,
+      Funder: 21,
+    )
+  end
+
+  def picker_query
+    get new_hud_reports_path_path
+    expect(response).to have_http_status(:ok)
+    select = Nokogiri::HTML(response.body).at_css('select[name="filter[project_ids][]"]')
+    expect(select).to be_present
+    Rack::Utils.parse_nested_query(select['data-collection-path'].split('?', 2).last)
+  end
+
+  shared_examples 'PATH picker wiring' do
+    it 'scopes the picker to the permission the report scope uses' do
+      expect(picker_query['permission']).to eq('can_view_assigned_reports')
+    end
+
+    it 'restricts the picker to PATH project types and the PATH funder' do
+      query = picker_query
+      expect(query['project_types']).to eq(['so', 'services_only'])
+      expect(query['funder_codes']).to eq(['21'])
+    end
+
+    it 'returns exactly the PATH-eligible viewable projects when the embedded query is posted back' do
+      # Reproduces what stimulus_select_controller.js does with data-collection-path.
+      post api_projects_path(format: :json), params: picker_query
+      ids = JSON.parse(response.body)['results'].flat_map { |group| group['children'] }.map { |child| child['id'] }
+      expect(ids).to contain_exactly(so_path_project.id)
+    end
+  end
+
+  context 'with an ACL user whose role has can_view_assigned_reports but not can_view_projects' do
+    let(:user) { create(:acl_user) }
+    let(:role) { create(:role, can_view_assigned_reports: true, can_view_all_hud_reports: true) }
+    let(:collection) { create(:collection) }
+
+    before do
+      collection.set_viewables(projects: [so_path_project.id, so_project_without_path_funder.id, es_path_funded_project.id])
+      setup_access_control(user, role, collection)
+      sign_in(user)
+    end
+
+    include_examples 'PATH picker wiring'
+  end
+
+  context 'with a legacy role-based user' do
+    let(:user) { create(:user) }
+    let(:role) { create(:role, can_view_assigned_reports: true, can_view_all_hud_reports: true) }
+
+    before do
+      user.legacy_roles << role
+      user.add_viewable(data_source)
+      sign_in(user)
+    end
+
+    include_examples 'PATH picker wiring'
+  end
+end

--- a/drivers/hud_path_report/spec/requests/hud_path_report/paths_new_spec.rb
+++ b/drivers/hud_path_report/spec/requests/hud_path_report/paths_new_spec.rb
@@ -114,5 +114,15 @@ RSpec.describe 'HudPathReport paths#new project picker', type: :request, exclude
     end
 
     include_examples 'PATH picker wiring'
+
+    it 'still returns the PATH-eligible projects once the role loses can_view_assigned_reports, proving the embedded permission is ignored for legacy users' do
+      role.update!(can_view_assigned_reports: false)
+      query = picker_query
+      expect(query['permission']).to eq('can_view_assigned_reports')
+
+      post api_projects_path(format: :json), params: query
+      ids = JSON.parse(response.body)['results'].flat_map { |group| group['children'] }.map { |child| child['id'] }
+      expect(ids).to contain_exactly(so_path_project.id)
+    end
   end
 end

--- a/spec/models/filters/filter_base_spec.rb
+++ b/spec/models/filters/filter_base_spec.rb
@@ -205,6 +205,96 @@ RSpec.describe Filters::FilterBase, type: :model do
     end
   end
 
+  # Regression coverage for a permission mismatch: these *_options_for_select
+  # methods scope through all_project_scope (can_view_assigned_reports), but
+  # each underlying model's own options_for_select used to default its
+  # internal viewable_by call to :can_view_projects, silently ANDing the two
+  # scopes together and returning nothing for a user who only has
+  # can_view_assigned_reports (the normal case for HUD report filter forms).
+  describe 'options for select scoping for an ACL user with only can_view_assigned_reports' do
+    let(:filter) { Filters::FilterBase.new(user_id: user.id) }
+
+    it 'includes the granted data source' do
+      expect(filter.data_source_options_for_select(user: user).map(&:last)).to include(data_source.id)
+    end
+
+    it 'includes the granted organization' do
+      expect(filter.organization_options_for_select(user: user).values.flatten(1).map(&:last)).to include(organization.id)
+    end
+
+    it 'includes a project under the granted data source' do
+      expect(filter.project_options_for_select(user: user).values.flatten(1).map(&:last)).to include(psh_project.id)
+    end
+
+    context 'with a funder on a granted project' do
+      let!(:funder) { create :hud_funder, data_source_id: data_source.id, ProjectID: psh_project.ProjectID, Funder: 21 }
+
+      it 'includes the funder' do
+        expect(filter.funder_options_for_select(user: user).map(&:last)).to include('21')
+      end
+    end
+  end
+
+  # Regression coverage for the same permission mismatch inside
+  # available_coc_codes: a submitted coc_code used to be silently stripped
+  # (falling back to blank) for an ACL user granted only
+  # can_view_assigned_reports, tripping the "CoC codes can't be blank"
+  # validation on report submission even though the code was chosen from the
+  # (correctly scoped) coc_codes select.
+  describe 'coc_codes filtering for an ACL user with only can_view_assigned_reports' do
+    let!(:coc_code_lookup) { create :lookup_coc, coc_code: 'XX-500' }
+    let!(:project_coc) { create :hud_project_coc, data_source_id: data_source.id, ProjectID: psh_project.ProjectID, CoCCode: 'XX-500' }
+
+    it 'retains a coc_code inherited from a project viewable via can_view_assigned_reports' do
+      filter = Filters::HudFilterBase.new(user_id: user.id).update(coc_codes: ['XX-500'])
+      expect(filter.coc_codes).to eq(['XX-500'])
+      expect(filter).to be_valid
+    end
+
+    it 'still strips a coc_code that is not inherited from any viewable project' do
+      filter = Filters::HudFilterBase.new(user_id: user.id).update(coc_codes: ['XX-999'])
+      expect(filter.coc_codes).to be_empty
+      expect(filter).not_to be_valid
+    end
+  end
+
+  # Regression coverage: report summaries must agree with both the live
+  # "N Projects Included" count on the new-report page
+  # (Api::HudFiltersController#index) and the report run itself
+  # (HudReports::ReportInstance), which both use effective_project_ids. Two
+  # independent summary code paths used to display the raw, un-narrowed
+  # project_ids instead: selected_params_for_display (xlsx export summaries)
+  # and chosen_projects (the HTML report list page's "Projects:" line, via
+  # describe_filter_as_html -> describe -> chosen).
+  describe 'selected_params_for_display (xlsx export summaries)' do
+    let!(:coc_code_lookup) { create :lookup_coc, coc_code: 'XX-500' }
+    let!(:psh_project_coc) { create :hud_project_coc, data_source_id: data_source.id, ProjectID: psh_project.ProjectID, CoCCode: 'XX-500' }
+
+    it 'shows only the CoC-narrowed effective projects, not every raw-picked project' do
+      filter = Filters::HudFilterBase.new(user_id: user.id).update(
+        project_ids: [psh_project.id, es_project.id],
+        coc_codes: ['XX-500'],
+      )
+      displayed = filter.selected_params_for_display['Projects']
+      expect(displayed.any? { |name| name.include?(psh_project.ProjectName) }).to eq(true)
+      expect(displayed.any? { |name| name.include?(es_project.ProjectName) }).to eq(false)
+    end
+  end
+
+  describe 'chosen_projects (the HTML report list page "Projects:" line)' do
+    let!(:coc_code_lookup) { create :lookup_coc, coc_code: 'XX-500' }
+    let!(:psh_project_coc) { create :hud_project_coc, data_source_id: data_source.id, ProjectID: psh_project.ProjectID, CoCCode: 'XX-500' }
+
+    it 'shows only the CoC-narrowed effective projects, not every raw-picked project' do
+      filter = Filters::HudFilterBase.new(user_id: user.id).update(
+        project_ids: [psh_project.id, es_project.id],
+        coc_codes: ['XX-500'],
+      )
+      expect(filter.chosen_projects).to include(psh_project.ProjectName)
+      expect(filter.chosen_projects).not_to include(es_project.ProjectName)
+    end
+  end
+
   describe 'defaults regression' do
     it 'evaluates date defaults at instantiation time (dynamic), not class load time (static)' do
       travel_to Date.new(2025, 1, 1)

--- a/spec/models/grda_warehouse/hud/project_string_mutations_spec.rb
+++ b/spec/models/grda_warehouse/hud/project_string_mutations_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe GrdaWarehouse::Hud::Project, type: :model do
         # Test the string mutation from line 967:
         # options[org_name] << [text, project.id]
 
-        allow(described_class).to receive(:viewable_by).with(user).and_return(described_class.where(id: project.id))
+        allow(described_class).to receive(:viewable_by).with(user, permission: :can_view_projects).and_return(described_class.where(id: project.id))
 
         options = described_class.options_for_select(user: user)
 
@@ -157,7 +157,7 @@ RSpec.describe GrdaWarehouse::Hud::Project, type: :model do
       it 'handles multiple projects under same organization' do
         other_project = create(:grda_warehouse_hud_project, organization: organization, data_source: data_source, ProjectName: 'Another Project')
 
-        allow(described_class).to receive(:viewable_by).with(user).and_return(described_class.where(id: [project.id, other_project.id]))
+        allow(described_class).to receive(:viewable_by).with(user, permission: :can_view_projects).and_return(described_class.where(id: [project.id, other_project.id]))
 
         options = described_class.options_for_select(user: user)
 

--- a/spec/requests/api/projects_controller_spec.rb
+++ b/spec/requests/api/projects_controller_spec.rb
@@ -1,0 +1,185 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# First back-end coverage for the project-picker endpoint shared by HUD report
+# filter forms. viewable_by's permission arg is a hard gate for ACL users but
+# ignored for legacy role-based users; these specs pin both behaviors plus the
+# param filters the PATH report form relies on (funder_codes, project_types).
+RSpec.describe Api::ProjectsController, type: :request do
+  include AccessControlSetup
+
+  before(:all) { GrdaWarehouse::Utility.clear! }
+  after(:all) { GrdaWarehouse::Utility.clear! }
+
+  let!(:data_source) { create(:source_data_source) }
+  let!(:organization) { create(:hud_organization, data_source_id: data_source.id) }
+
+  # PATH-eligible: Street Outreach (4) with PATH funder (21)
+  let!(:so_path_project) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 4,
+    )
+  end
+  let!(:so_path_funder) do
+    create(
+      :hud_funder,
+      data_source_id: data_source.id,
+      ProjectID: so_path_project.ProjectID,
+      Funder: 21,
+    )
+  end
+  # Control: PATH type, but no PATH funder
+  let!(:so_project_without_path_funder) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 4,
+    )
+  end
+  # Control: PATH funder, but not a PATH type (ES = 1)
+  let!(:es_path_funded_project) do
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      ProjectType: 1,
+    )
+  end
+  let!(:es_funder) do
+    create(
+      :hud_funder,
+      data_source_id: data_source.id,
+      ProjectID: es_path_funded_project.ProjectID,
+      Funder: 21,
+    )
+  end
+
+  let(:granted_project_ids) { [so_path_project.id, so_project_without_path_funder.id, es_path_funded_project.id] }
+
+  def returned_project_ids
+    JSON.parse(response.body)['results'].flat_map { |group| group['children'] }.map { |child| child['id'] }
+  end
+
+  def post_projects(params = {})
+    post api_projects_path(format: :json), params: params
+  end
+
+  context 'with a legacy role-based user' do
+    let(:user) { create(:user) }
+    let(:role) { create(:role, can_view_assigned_reports: true) }
+
+    before do
+      user.legacy_roles << role
+      user.add_viewable(data_source)
+      sign_in(user)
+    end
+
+    it 'returns projects viewable through entity assignments when no permission is given' do
+      post_projects
+      expect(returned_project_ids).to match_array(granted_project_ids)
+    end
+
+    it 'returns the same projects when a permission is given (legacy branch ignores it)' do
+      post_projects(permission: 'can_view_assigned_reports')
+      expect(returned_project_ids).to match_array(granted_project_ids)
+    end
+  end
+
+  context 'with an ACL user whose role has can_view_assigned_reports but not can_view_projects' do
+    let(:user) { create(:acl_user) }
+    let(:role) { create(:role, can_view_assigned_reports: true) }
+    let(:collection) { create(:collection) }
+    # Excluded row: in no collection; proves results are attributable to the
+    # grant rather than fixture leakage.
+    let!(:ungranted_project) do
+      create(
+        :hud_project,
+        data_source_id: data_source.id,
+        OrganizationID: organization.OrganizationID,
+        ProjectType: 4,
+      )
+    end
+
+    before do
+      collection.set_viewables(projects: granted_project_ids)
+      setup_access_control(user, role, collection)
+      sign_in(user)
+    end
+
+    it 'returns no projects when no permission is given (endpoint defaults to can_view_projects)' do
+      post_projects
+      expect(returned_project_ids).to eq([])
+    end
+
+    it 'returns granted projects when permission=can_view_assigned_reports' do
+      post_projects(permission: 'can_view_assigned_reports')
+      expect(returned_project_ids).to match_array(granted_project_ids)
+      expect(returned_project_ids).not_to include(ungranted_project.id)
+    end
+
+    it 'ignores a permission that is not in the Role.permissions allow-list' do
+      post_projects(permission: 'destroy_all')
+      expect(returned_project_ids).to eq([])
+    end
+
+    context 'filter params as sent by the PATH report form' do
+      it 'limits by funder_codes' do
+        post_projects(permission: 'can_view_assigned_reports', funder_codes: ['21'])
+        expect(returned_project_ids).to contain_exactly(so_path_project.id, es_path_funded_project.id)
+      end
+
+      it 'limits by project_types' do
+        post_projects(permission: 'can_view_assigned_reports', project_types: ['so'])
+        expect(returned_project_ids).to contain_exactly(so_path_project.id, so_project_without_path_funder.id)
+      end
+
+      it 'limits by project_types and funder_codes together' do
+        post_projects(permission: 'can_view_assigned_reports', project_types: ['so', 'services_only'], funder_codes: ['21'])
+        expect(returned_project_ids).to contain_exactly(so_path_project.id)
+      end
+
+      it 'treats a blanks-only project_types array as no type restriction' do
+        # Rack parses a serialized empty array (`project_types[]=`) as [""].
+        post_projects(permission: 'can_view_assigned_reports', project_types: [''])
+        expect(returned_project_ids).to match_array(granted_project_ids)
+      end
+    end
+  end
+
+  context 'with an ACL user whose role has can_view_projects' do
+    let(:user) { create(:acl_user) }
+    let(:role) { create(:role, can_view_projects: true) }
+    let(:collection) { create(:collection) }
+    let!(:ungranted_project) do
+      create(
+        :hud_project,
+        data_source_id: data_source.id,
+        OrganizationID: organization.OrganizationID,
+        ProjectType: 4,
+      )
+    end
+
+    before do
+      collection.set_viewables(projects: granted_project_ids)
+      setup_access_control(user, role, collection)
+      sign_in(user)
+    end
+
+    it 'returns granted projects with the default permission' do
+      post_projects
+      expect(returned_project_ids).to match_array(granted_project_ids)
+      expect(returned_project_ids).not_to include(ungranted_project.id)
+    end
+  end
+end

--- a/spec/requests/api/projects_controller_spec.rb
+++ b/spec/requests/api/projects_controller_spec.rb
@@ -11,7 +11,8 @@ require 'rails_helper'
 # First back-end coverage for the project-picker endpoint shared by HUD report
 # filter forms. viewable_by's permission arg is a hard gate for ACL users but
 # ignored for legacy role-based users; these specs pin both behaviors plus the
-# param filters the PATH report form relies on (funder_codes, project_types).
+# param filters the PATH report form relies on (funder_codes, project_types) and
+# the confidentiality exclusion project_scope applies alongside permission.
 RSpec.describe Api::ProjectsController, type: :request do
   include AccessControlSetup
 
@@ -180,6 +181,78 @@ RSpec.describe Api::ProjectsController, type: :request do
       post_projects
       expect(returned_project_ids).to match_array(granted_project_ids)
       expect(returned_project_ids).not_to include(ungranted_project.id)
+    end
+  end
+
+  context 'confidentiality filtering' do
+    let(:user) { create(:acl_user) }
+    let(:collection) { create(:collection) }
+    # Granted alongside the non-confidential projects, so its absence below is
+    # attributable only to the confidentiality guard, not to a missing grant.
+    let!(:confidential_project) do
+      create(
+        :hud_project,
+        data_source_id: data_source.id,
+        OrganizationID: organization.OrganizationID,
+        ProjectType: 4,
+        confidential: true,
+      )
+    end
+
+    before do
+      collection.set_viewables(projects: granted_project_ids + [confidential_project.id])
+      setup_access_control(user, role, collection)
+      sign_in(user)
+    end
+
+    context 'user lacks can_view_confidential_project_names' do
+      let(:role) { create(:role, can_view_assigned_reports: true, can_view_confidential_project_names: false) }
+
+      it 'excludes the confidential project despite it being granted' do
+        post_projects(permission: 'can_view_assigned_reports')
+        expect(returned_project_ids).to match_array(granted_project_ids)
+        expect(returned_project_ids).not_to include(confidential_project.id)
+      end
+    end
+
+    context 'user has can_report_on_confidential_projects but not can_view_confidential_project_names' do
+      # project_scope applies its own non_confidential merge unless
+      # can_view_confidential_project_names? is true, independently of
+      # viewable_by's internal can_report_on_confidential_projects check.
+      let(:role) do
+        create(
+          :role,
+          can_view_assigned_reports: true,
+          can_view_confidential_project_names: false,
+          can_report_on_confidential_projects: true,
+        )
+      end
+
+      it 'still excludes the confidential project' do
+        post_projects(permission: 'can_view_assigned_reports')
+        expect(returned_project_ids).to match_array(granted_project_ids)
+        expect(returned_project_ids).not_to include(confidential_project.id)
+      end
+    end
+
+    context 'user has can_view_confidential_project_names and can_report_on_confidential_projects' do
+      # viewable_by's own non_confidential filter is independently gated on
+      # can_report_on_confidential_projects (project.rb's viewable_by scope);
+      # both permissions must be granted for a confidential project to surface
+      # through this endpoint.
+      let(:role) do
+        create(
+          :role,
+          can_view_assigned_reports: true,
+          can_view_confidential_project_names: true,
+          can_report_on_confidential_projects: true,
+        )
+      end
+
+      it 'includes the confidential project' do
+        post_projects(permission: 'can_view_assigned_reports')
+        expect(returned_project_ids).to match_array(granted_project_ids + [confidential_project.id])
+      end
     end
   end
 end

--- a/spec/requests/project_groups_controller_spec.rb
+++ b/spec/requests/project_groups_controller_spec.rb
@@ -9,6 +9,8 @@
 require 'rails_helper'
 
 RSpec.describe ProjectGroupsController, type: :request do
+  include AccessControlSetup
+
   let!(:user) { create(:user) }
   let!(:project_group) { create(:project_group, name: 'Test Group') }
   let!(:project_group_2) { create(:project_group, name: 'Another Group') }
@@ -221,6 +223,30 @@ RSpec.describe ProjectGroupsController, type: :request do
       # Should now have 2 projects (project2 excluded)
       expect(project_group.projects.count).to eq(2)
       expect(project_group.projects.pluck(:id)).to match_array([project1.id, project3.id])
+    end
+  end
+
+  # Regression coverage: this form is a project-management CRUD context (gated
+  # by can_edit_some_project_groups), not a report-queuing context, so its
+  # Organizations/Data Sources dropdowns must be scoped by can_view_projects,
+  # not the can_view_assigned_reports default used by report filter forms.
+  describe 'GET #new for an ACL user with can_view_projects but not can_view_assigned_reports' do
+    let!(:acl_user) { create(:acl_user) }
+    let!(:project_groups_role) { create(:role, can_edit_project_groups: true, can_view_projects: true) }
+    let!(:collection) { create(:collection) }
+
+    before do
+      collection.set_viewables(data_sources: [data_source.id])
+      setup_access_control(acl_user, project_groups_role, collection)
+      sign_in(acl_user)
+    end
+
+    it 'populates the Organizations and Data Sources dropdowns' do
+      get new_project_group_path
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::HTML(response.body)
+      expect(doc.at_css('select[name="filters[organization_ids][]"]').css('option')).not_to be_empty
+      expect(doc.at_css('select[name="filters[data_source_ids][]"]').css('option')).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Fixes an issue where projects were determined by a different permission when evaluating inclusion in the report from when picking them from the filter picker and the user was using ACLs.
Fixes an issue where the CoC Codes submitted were then incorrectly validated against a different permission and consequently blanked out making it impossible to enqueue a HUD (or similar) report.

These applies to all HUD reports and some Warehouse reports (anything that uses the `*_options_for_select` wrapper methods.)

Fixes the display of projects on HUD and similar reports when shown in a list view, previously it referenced `report.project_ids` which doesn't match the kick-off page, which is the equivalent of `report.effective_project_ids`.  The two now match and use `effective_project_ids`.

Also updates the `*_options_for_select` in the Project Group management screens to use the current `can_edit_projects` permission, which may be incorrect, but is done to keep current behavior.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

