### PR TITLE
Add MC direct referral CE workflow template

### DIFF
--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -32,7 +32,7 @@ module Hmis::Ce
         user: Hmis::Hud::User.from_user(message.user),
         ce_referral: referral,
       )
-      referral.reload # ensure referral.ce_event is accessible after creation, for cases where event result is set immediately
+      referral.reload_ce_event # ensure referral.ce_event is accessible after creation, for cases where event result is set immediately
     end
 
     def set_ce_event_result(message) # rubocop:disable Naming/AccessorMethodName

--- a/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
+++ b/drivers/hmis/app/models/hmis/ce/referral_ce_event_manager.rb
@@ -32,6 +32,7 @@ module Hmis::Ce
         user: Hmis::Hud::User.from_user(message.user),
         ce_referral: referral,
       )
+      referral.reload # ensure referral.ce_event is accessible after creation, for cases where event result is set immediately
     end
 
     def set_ce_event_result(message) # rubocop:disable Naming/AccessorMethodName

--- a/drivers/hmis/lib/ce_workflows/az/README_FOR_AZ_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/az/README_FOR_AZ_CE_WORKFLOWS.md
@@ -1,0 +1,65 @@
+# AZ CE Workflows
+
+## Overview
+This directory contains utilities and workflow definitions specific to the AZ installation of Coordinated Entry (CE) workflows.
+
+### Workflow Templates
+- **MC Direct Referral**: Four sequential tasks (Send Referral → Initial Review → Client Outreach → Provider Outcome), with CE Event create/update and enrollment on accept.
+
+### Usage
+These workflows are generated and updated using the `CeWorkflows::Az::WorkflowBuilder` utility class.
+
+**CAUTION:** Building these workflows deletes existing referrals and opportunities associated with the templates. Do not run in production after the first time.
+
+These workflows expect client-specific forms to be available. The forms live under `form_data/az/ce_referral_steps/`. Load them with:
+
+```bash
+CLIENT=az rails driver:hmis:seed_definitions
+```
+
+or:
+
+```ruby
+HmisUtil::JsonForms.new(env_key: 'az', data_source_id: 1).seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])
+```
+
+Then recreate the template:
+
+```bash
+rails driver:hmis:ce_define_az_workflows
+```
+
+After creating, attach the template on unit groups via `direct_referral_workflow_template_identifier = 'mc_direct_referral'`.
+
+### MC Direct Referral Workflow
+
+```mermaid
+flowchart TD
+  start(["Start Referral"]) --> send["Send Referral\nstatus: Assigned"]
+  send --> review["Initial Review\nstatus: Initial Review"]
+  review --> gw2{"decision"}
+  gw2 -->|"approve"| createEvt["Create CE Event\nno result"]
+  gw2 -->|"provider_rejected"| createEvtDenied["Create CE Event\nresult 3"]
+  gw2 -->|"canceled"| decline(["Decline"])
+  createEvtDenied --> decline
+  createEvt --> outreach["Client Outreach\nstatus: Outreach"]
+  outreach --> gw3{"outcome"}
+  gw3 -->|"intake_scheduled"| providerOut["Provider Outcome\nstatus: Pending Provider Decision"]
+  gw3 -->|"client_rejected"| setRes2["CE Event result 2"]
+  gw3 -->|"provider_rejected"| setRes3["CE Event result 3"]
+  setRes2 --> decline
+  setRes3 --> decline
+  providerOut --> gw4{"decision"}
+  gw4 -->|"approved"| enroll["Create Enrollment"]
+  gw4 -->|"client_rejected"| setRes2b["CE Event result 2"]
+  gw4 -->|"provider_rejected"| setRes3b["CE Event result 3"]
+  enroll --> accept(["Accept"])
+  setRes2b --> decline
+  setRes3b --> decline
+```
+
+#### Updates
+
+**Form definition updates**: Forms are managed in version control under `form_data/az/ce_referral_steps/`. Modify them in source control and re-seed.
+
+**Workflow template updates**: See `CeWorkflows::Az::WorkflowBuilder` and `ce_define_az_workflows.rake`. Each local run deletes and recreates the template and associated referral data.

--- a/drivers/hmis/lib/ce_workflows/az/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/az/workflow_builder.rb
@@ -1,0 +1,195 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Utility for building CE workflow definitions specific to the AZ installation.
+#
+# WARNING! Building these workflows will delete existing referrals and opportunities
+# associated with the workflow templates (unless unsafe_run_in_production is set for
+# initial production setup). Not intended for routine use in production.
+#
+# DeclineReason is intentionally omitted in this first iteration. After further customer
+# discussion we will likely seed ReferralDeclineReason rows for client_rejected,
+# provider_rejected, and canceled; add decline_reason fields on declining step forms; and
+# wire set_referral_decline_reason on complete_step. HUD CE Event referral_result (2/3) is
+# still set on the relevant decline paths — that is independent of DeclineReason.
+module CeWorkflows::Az
+  class WorkflowBuilder
+    FORMS = {
+      send_referral: 'mc_direct_referral_send_referral',
+      initial_review: 'mc_direct_referral_initial_review',
+      client_outreach: 'mc_direct_referral_client_outreach',
+      provider_outcome: 'mc_direct_referral_provider_outcome',
+    }.freeze
+
+    def initialize(data_source, unsafe_run_in_production: false)
+      @data_source = data_source
+      @unsafe_run_in_production = unsafe_run_in_production # flag to allow running in prod ONLY for initial setup
+
+      missing = FORMS.values - Hmis::Form::Definition.
+        in_data_source(@data_source.id).
+        where(role: 'CE_REFERRAL_STEP', identifier: FORMS.values).
+        pluck(:identifier)
+      raise "Missing CE_REFERRAL_STEP forms: #{missing.join(', ')}" if missing.any?
+
+      raise 'This class destroys data and should not be run in production' if Rails.env.production? && !@unsafe_run_in_production
+    end
+
+    def build_mc_direct_referral_workflow
+      identifier = 'mc_direct_referral'
+      template_name = 'Direct Referral'
+      CeWorkflows::Shared::CeBuilderUtils.delete_template_and_associated_data(identifier, data_source: @data_source) unless @unsafe_run_in_production
+
+      puts "Creating workflow definition template '#{identifier}'"
+      template = CeWorkflows::Shared::CeBuilderUtils.create_template(identifier, template_name, @data_source)
+
+      ce_team_swimlane = template.swimlanes.create!(name: 'CE Team')
+      provider_swimlane = template.swimlanes.create!(name: 'Provider')
+
+      assigned_status = Hmis::Ce::CustomReferralStatus.find_or_create_by!(
+        key: 'assigned',
+        data_source: @data_source,
+      ) { |s| s.name = 'Assigned' }
+
+      initial_review_status = Hmis::Ce::CustomReferralStatus.find_or_create_by!(
+        key: 'initial_review',
+        data_source: @data_source,
+      ) { |s| s.name = 'Initial Review' }
+
+      outreach_status = Hmis::Ce::CustomReferralStatus.find_or_create_by!(
+        key: 'outreach',
+        data_source: @data_source,
+      ) { |s| s.name = 'Outreach' }
+
+      pending_provider_decision_status = Hmis::Ce::CustomReferralStatus.find_or_create_by!(
+        key: 'pending_provider_decision',
+        data_source: @data_source,
+      ) { |s| s.name = 'Pending Provider Decision' }
+
+      status_trigger = ->(key) { { event: 'enable_step', message: 'set_custom_referral_status', params: { custom_status_key: key } } }
+
+      start_event = CeWorkflows::Shared::CeBuilderUtils.find_or_create_start_event(template)
+      accept_event = CeWorkflows::Shared::CeBuilderUtils.find_or_create_accept_event(template, update_ce_event: true) # Sets CE Event referral_result to "Successful referral: client accepted"
+      decline_event = CeWorkflows::Shared::CeBuilderUtils.find_or_create_decline_event(template)
+
+      # Task 1: Send Referral
+      send_referral_task = Hmis::WorkflowDefinition::UserTask.create!(
+        name: 'Send Referral',
+        form_definition_identifier: FORMS.fetch(:send_referral),
+        template: template,
+        swimlane: ce_team_swimlane,
+        trigger_config: [status_trigger.call(assigned_status.key)],
+      )
+
+      # Task 2: Initial Review
+      initial_review_task = Hmis::WorkflowDefinition::UserTask.create!(
+        name: 'Initial Review',
+        form_definition_identifier: FORMS.fetch(:initial_review),
+        template: template,
+        swimlane: provider_swimlane,
+        trigger_config: [status_trigger.call(initial_review_status.key)],
+      )
+
+      # Task 3: Client Outreach
+      client_outreach_task = Hmis::WorkflowDefinition::UserTask.create!(
+        name: 'Client Outreach',
+        form_definition_identifier: FORMS.fetch(:client_outreach),
+        template: template,
+        swimlane: provider_swimlane,
+        trigger_config: [status_trigger.call(outreach_status.key)],
+      )
+
+      # Task 4: Provider Outcome
+      provider_outcome_task = Hmis::WorkflowDefinition::UserTask.create!(
+        name: 'Provider Outcome',
+        form_definition_identifier: FORMS.fetch(:provider_outcome),
+        template: template,
+        swimlane: provider_swimlane,
+        trigger_config: [status_trigger.call(pending_provider_decision_status.key)],
+      )
+
+      create_ce_event_task = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Create CE Event',
+        template: template,
+        trigger_config: [
+          { event: 'complete_step', message: 'create_ce_event' },
+        ],
+      )
+
+      create_ce_event_provider_rejected_task = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Create CE Event with result "Unsuccessful referral: provider rejected"',
+        template: template,
+        trigger_config: [
+          { event: 'complete_step', message: 'create_ce_event' },
+          { event: 'complete_step', message: 'set_ce_event_result', params: { referral_result: '3' } }, # Unsuccessful referral: provider rejected
+        ],
+      )
+
+      set_ce_event_client_rejected_task = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Update CE Event with result "Unsuccessful referral: client rejected"',
+        template: template,
+        trigger_config: [
+          { event: 'complete_step', message: 'set_ce_event_result', params: { referral_result: '2' } }, # Unsuccessful referral: client rejected
+        ],
+      )
+
+      set_ce_event_provider_rejected_task = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Update CE Event with result "Unsuccessful referral: provider rejected"',
+        template: template,
+        trigger_config: [
+          { event: 'complete_step', message: 'set_ce_event_result', params: { referral_result: '3' } }, # Unsuccessful referral: provider rejected
+        ],
+      )
+
+      create_enrollment_task = Hmis::WorkflowDefinition::ScriptTask.create!(
+        name: 'Create Enrollment',
+        template: template,
+        trigger_config: [
+          { event: 'complete_step', message: 'create_enrollment' },
+        ],
+      )
+
+      initial_review_gateway = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'initial_review')
+      client_outreach_gateway = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'client_outreach')
+      provider_outcome_gateway = CeWorkflows::Shared::CeBuilderUtils.create_gateway(template, 'provider_outcome')
+
+      # Start → Send Referral → Initial Review → gateway
+      start_event.connect_to!(send_referral_task)
+      send_referral_task.connect_to!(initial_review_task)
+      initial_review_task.connect_to!(initial_review_gateway)
+
+      # Initial Review: approve → create CE event → outreach;
+      # provider_rejected → create CE event w/ result 3 → decline; cancel → decline
+      initial_review_gateway.connect_to!(create_ce_event_task, condition: "initial_review_decision = 'approve'")
+      initial_review_gateway.connect_to!(create_ce_event_provider_rejected_task, condition: "initial_review_decision = 'provider_rejected'")
+      initial_review_gateway.connect_to!(decline_event)
+
+      create_ce_event_task.connect_to!(client_outreach_task)
+      create_ce_event_provider_rejected_task.connect_to!(decline_event)
+
+      # Client Outreach → gateway
+      client_outreach_task.connect_to!(client_outreach_gateway)
+      client_outreach_gateway.connect_to!(set_ce_event_client_rejected_task, condition: "client_outreach_outcome = 'client_rejected'")
+      client_outreach_gateway.connect_to!(set_ce_event_provider_rejected_task, condition: "client_outreach_outcome = 'provider_rejected'")
+      client_outreach_gateway.connect_to!(provider_outcome_task)
+
+      set_ce_event_client_rejected_task.connect_to!(decline_event)
+      set_ce_event_provider_rejected_task.connect_to!(decline_event)
+
+      # Provider Outcome → gateway → enroll/accept or decline (no Confirm Success)
+      provider_outcome_task.connect_to!(provider_outcome_gateway)
+      provider_outcome_gateway.connect_to!(set_ce_event_client_rejected_task, condition: "provider_outcome_decision = 'client_rejected'")
+      provider_outcome_gateway.connect_to!(set_ce_event_provider_rejected_task, condition: "provider_outcome_decision = 'provider_rejected'")
+      provider_outcome_gateway.connect_to!(create_enrollment_task)
+
+      create_enrollment_task.connect_to!(accept_event)
+
+      template.validate!
+      template
+    end
+  end
+end

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_client_outreach.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_client_outreach.json
@@ -1,0 +1,43 @@
+{
+  "item": [
+    {
+      "text": "Date",
+      "type": "DATE",
+      "link_id": "client_outreach_date",
+      "required": true,
+      "initial": [
+        {
+          "initial_behavior": "IF_EMPTY",
+          "value_local_constant": "$today"
+        }
+      ],
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_client_outreach_date"
+      }
+    },
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "client_outreach_notes",
+      "required": true,
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_client_outreach_notes"
+      }
+    },
+    {
+      "text": "Outcome",
+      "type": "CHOICE",
+      "link_id": "client_outreach_outcome",
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_client_outreach_outcome"
+      },
+      "pick_list_options": [
+        { "code": "intake_scheduled", "label": "Intake Scheduled" },
+        { "code": "client_rejected", "label": "Declined - Client Rejected" },
+        { "code": "provider_rejected", "label": "Declined - Provider Rejected" }
+      ]
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_initial_review.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_initial_review.json
@@ -1,0 +1,43 @@
+{
+  "item": [
+    {
+      "text": "Date",
+      "type": "DATE",
+      "link_id": "initial_review_date",
+      "required": true,
+      "initial": [
+        {
+          "initial_behavior": "IF_EMPTY",
+          "value_local_constant": "$today"
+        }
+      ],
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_initial_review_date"
+      }
+    },
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "initial_review_notes",
+      "required": true,
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_initial_review_notes"
+      }
+    },
+    {
+      "text": "Decision",
+      "type": "CHOICE",
+      "link_id": "initial_review_decision",
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_initial_review_decision"
+      },
+      "pick_list_options": [
+        { "code": "approve", "label": "Approve (Continue to Offer)" },
+        { "code": "provider_rejected", "label": "Decline (Provider Rejected)" },
+        { "code": "canceled", "label": "Cancel" }
+      ]
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_provider_outcome.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_provider_outcome.json
@@ -1,0 +1,57 @@
+{
+  "item": [
+    {
+      "text": "Date",
+      "type": "DATE",
+      "link_id": "provider_outcome_date",
+      "required": true,
+      "initial": [
+        {
+          "initial_behavior": "IF_EMPTY",
+          "value_local_constant": "$today"
+        }
+      ],
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_provider_outcome_date"
+      }
+    },
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "provider_outcome_notes",
+      "required": true,
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_provider_outcome_notes"
+      }
+    },
+    {
+      "text": "Decision",
+      "type": "CHOICE",
+      "link_id": "provider_outcome_decision",
+      "required": true,
+      "component": "RADIO_BUTTONS",
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_provider_outcome_decision"
+      },
+      "pick_list_options": [
+        { "code": "approved", "label": "Approved - Client Accepted" },
+        { "code": "client_rejected", "label": "Declined - Client Rejected" },
+        { "code": "provider_rejected", "label": "Declined - Provider Rejected" }
+      ]
+    },
+    {
+      "text": "The client will be added to the project as Incomplete. Please complete and submit the Intake Assessment to finalize enrollment.",
+      "type": "DISPLAY",
+      "link_id": "provider_outcome_enroll_message",
+      "component": "ALERT_INFO",
+      "enable_when": [
+        {
+          "operator": "EQUAL",
+          "question": "provider_outcome_decision",
+          "answer_code": "approved"
+        }
+      ],
+      "enable_behavior": "ALL"
+    }
+  ]
+}

--- a/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_send_referral.json
+++ b/drivers/hmis/lib/form_data/az/ce_referral_steps/mc_direct_referral_send_referral.json
@@ -1,0 +1,13 @@
+{
+  "item": [
+    {
+      "text": "Notes",
+      "type": "TEXT",
+      "link_id": "send_referral_notes",
+      "required": true,
+      "mapping": {
+        "custom_field_key": "mc_direct_referral_send_referral_notes"
+      }
+    }
+  ]
+}

--- a/drivers/hmis/lib/tasks/ce_define_az_workflows.rake
+++ b/drivers/hmis/lib/tasks/ce_define_az_workflows.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# CE workflow definitions for the AZ installation.
+# CAUTION: Deletes existing referrals and opportunities associated with these templates,
+# so that we don't have to worry about definitions shifting underfoot.
+# This means it should NOT be run in production after the first time!
+# Usage: rails driver:hmis:ce_define_az_workflows
+desc 'Create CE workflow definitions for AZ'
+task ce_define_az_workflows: [:environment] do
+  raise 'This task destroys data and should not be run in production!' if Rails.env.production?
+  raise unless HmisEnforcement.hmis_enabled?
+
+  puts 'Enabling CE in AppConfigProperty'
+  ce_enabled = AppConfigProperty.find_or_initialize_by(key: 'hmis_ce/enabled')
+  ce_enabled.value = true
+  ce_enabled.save! if ce_enabled.changed?
+
+  # Expect one DS in client-specific env. Raise if we find more than one.
+  # This task should be adapted to accept a data source ID if we want to run it in a multi-OP-HMIS environment such as QA.
+  data_source = GrdaWarehouse::DataSource.hmis.sole
+
+  # Keep custom statuses in sync
+  puts 'Ensuring custom statuses are in sync'
+  CeWorkflows::Shared::CeBuilderUtils.create_state_machine_custom_statuses(data_source)
+
+  puts "Creating workflow templates in data source #{data_source.id} (#{data_source.name})"
+
+  templates = []
+  Hmis::Hud::Base.transaction do
+    builder = CeWorkflows::Az::WorkflowBuilder.new(data_source)
+    templates << builder.build_mc_direct_referral_workflow
+  end
+
+  puts 'Generated Mermaid Diagrams:'
+  puts templates.map(&:to_mermaid_diagram).join("\n\n")
+end

--- a/drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb
+++ b/drivers/hmis/spec/models/hmis/ce/referral_ce_event_manager_spec.rb
@@ -339,4 +339,36 @@ RSpec.describe Hmis::Ce::ReferralCeEventManager, type: :model do
       end
     end
   end
+
+  # Matches workflows that create a CE Event and set its result on the same complete_step
+  describe 'create and set result on the same step' do
+    let!(:ce_creation_task) do
+      create(
+        :hmis_workflow_definition_user_task,
+        template: workflow_template,
+        name: 'Create CE event with provider rejected result',
+        swimlane: case_manager_swimlane,
+        trigger_config: [
+          {
+            event: 'complete_step',
+            message: 'create_ce_event',
+          },
+          {
+            event: 'complete_step',
+            message: 'set_ce_event_result',
+            params: { referral_result: '3' },
+          },
+        ],
+      )
+    end
+
+    it 'creates the CE event and sets referral result without error' do
+      expect { submit_current_step }.to change(Hmis::Hud::Event, :count).by(1)
+
+      event = referral.ce_event
+      expect(event).to be_present
+      expect(event.referral_result).to eq(3)
+      expect(event.result_date).to be_present
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9432

Adds a new CE workflow builder and forms for a four-step MC direct referral flow (Send Referral → Initial Review → Client Outreach → Provider Outcome), including CE Event create/update and enrollment on accept.

It is almost certain that we will need to iterate on this workflow within staging before it gets created in production.

Also **updates the engine logic** to reload the referral after CE Event creation, so create + set-result can run on the same script step.

- New WorkflowBuilder with associated rake task (destructive recreate locally)
- Four `mc_direct_referral_*` CE_REFERRAL_STEP forms under `form_data/az`
- `ReferralCeEventManager#create_ce_event` reloads referral so `ce_event` is visible immediately after create


**Local testing completed:** I ran through every branch of the workflow locally, ensuring with each branch that CE Event results were set correctly.

## Type of change
New feature

## Checklist before requesting review
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)
