### PR TITLE
Add documentation and improve dev ex for CE Workflow Templates

### DIFF
--- a/docs/features/hmis/ce-workflow-builders.md
+++ b/docs/features/hmis/ce-workflow-builders.md
@@ -38,7 +38,7 @@ Installation-specific workflow builders follow two different patterns. This read
 
 ### Preferred destroy-and-recreate pattern
 
-Use this pattern for new workflows. See `drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb` as a reference implementation.
+Use this pattern for new workflows. See [`drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb`](../../../drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb) as a reference implementation.
 
 **Why we prefer it:**
 
@@ -67,7 +67,7 @@ end
 
 **Local iteration:** run the rake task repeatedly. Expect referrals to be destroyed.
 
-**Production:** run once at initial setup with `UNSAFE_RUN_IN_PRODUCTION=true`. Do not re-run after go-live (same as the rake comment in [ce_define_workflows.rake](../tasks/ce_define_workflows.rake)).
+**Production:** run once at initial setup with `UNSAFE_RUN_IN_PRODUCTION=true`. Do not re-run after go-live (same as the rake comment in [`ce_define_workflows.rake`](../../../drivers/hmis/lib/tasks/ce_define_workflows.rake)).
 
 **Rake task shape:** prod guard at top; pass `unsafe_run_in_production:` into builder.
 
@@ -90,4 +90,3 @@ Updates to Workflow Templates fall into two categories. See [https://github.com/
 - **Graph changes** such as new steps, gateways, side effects:
   - We don't yet have an established pattern for handling this in production.
   - The non-preferred draft-idempotent pattern was partly built to handle this, but due to the downsides listed above, we're retiring that pattern and will cross this bridge when we re-encounter it.
-

--- a/docs/features/hmis/ce-workflow-builders.md
+++ b/docs/features/hmis/ce-workflow-builders.md
@@ -65,6 +65,8 @@ end
 ```
 
 **Local iteration:** run the rake task repeatedly. Expect referrals to be destroyed.
+  - Opportunities are destroyed too unless you pass `delete_opportunities: false` to `delete_template_and_associated_data`.
+  - The `delete_opportunities` flag is only read in dev/staging. Production first-time setup skips `delete_template_and_associated_data` entirely (`unsafe_run_in_production: true`), so the value is never used there.
 
 **Production:** run once in Rails with `unsafe_run_in_production: true` (not using the rake task). Do not re-run after go-live.
 

--- a/docs/features/hmis/ce-workflow-builders.md
+++ b/docs/features/hmis/ce-workflow-builders.md
@@ -26,19 +26,18 @@ Installation-specific workflow builders follow two different patterns. This read
 ### Overview of two patterns
 
 
-|                                             | **Preferred: destroy-and-recreate (AC-style)**                        | **Legacy: draft idempotent (PH/Standard-style)**                            |
-| ------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| **Template lifecycle**                      | `delete_template_and_associated_data` → `create_template` (published) | `find_or_create_draft_template` → mutate in place → optional `PUBLISH=true` |
-| **Strategy for changing existing template** | Wipes existing template and starts anew                               | Idempotent on hard-coded version while draft; errors once published         |
-| **Prod setup**                              | One-time via `UNSAFE_RUN_IN_PRODUCTION=true` (builder + rake guard)   | `PUBLISH=true`; no destroy in prod                                          |
-| **Env vars**                                | `UNSAFE_RUN_IN_PRODUCTION` (prod only)                                | `PUBLISH`, `FORCE_RECREATE` (non-prod only)                                 |
+|                                             | **Preferred: destroy-and-recreate (AC-style)**                         | **Legacy: draft idempotent (PH/Standard-style)**                            |
+| ------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Template lifecycle**                      | `delete_template_and_associated_data` → `create_template` (published)  | `find_or_create_draft_template` → mutate in place → optional `PUBLISH=true` |
+| **Strategy for changing existing template** | Wipes existing template and starts anew                                | Idempotent on hard-coded version while draft; errors once published         |
+| **Prod setup**                              | One-time in rails console using `unsafe_run_in_production: true` flag. | `PUBLISH=true`; no destroy in prod                                          |
 
 
 
 
 ### Preferred destroy-and-recreate pattern
 
-Use this pattern for new workflows. See [`drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb`](../../../drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb) as a reference implementation.
+Use this pattern for new workflows. See `[drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb](../../../drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb)` as a reference implementation.
 
 **Why we prefer it:**
 
@@ -67,7 +66,7 @@ end
 
 **Local iteration:** run the rake task repeatedly. Expect referrals to be destroyed.
 
-**Production:** run once at initial setup with `UNSAFE_RUN_IN_PRODUCTION=true`. Do not re-run after go-live (same as the rake comment in [`ce_define_workflows.rake`](../../../drivers/hmis/lib/tasks/ce_define_workflows.rake)).
+**Production:** run once in Rails with `unsafe_run_in_production: true` (not using the rake task). Do not re-run after go-live.
 
 **Rake task shape:** prod guard at top; pass `unsafe_run_in_production:` into builder.
 

--- a/drivers/hmis/app/models/hmis/workflow_definition/template.rb
+++ b/drivers/hmis/app/models/hmis/workflow_definition/template.rb
@@ -20,8 +20,13 @@ module Hmis::WorkflowDefinition
     has_many :flows, class_name: 'Hmis::WorkflowDefinition::Flow', dependent: :destroy
     has_many :instances, class_name: 'Hmis::WorkflowExecution::Instance', dependent: :restrict_with_exception, foreign_key: 'template_id'
     has_many :swimlanes, class_name: 'Hmis::WorkflowDefinition::Swimlane', dependent: :restrict_with_exception, foreign_key: 'template_id'
-    has_many :unit_groups, class_name: 'Hmis::UnitGroup', foreign_key: 'workflow_template_identifier', primary_key: 'identifier', dependent: :nullify
-    has_many :direct_referral_unit_groups, class_name: 'Hmis::UnitGroup', foreign_key: 'direct_referral_workflow_template_identifier', primary_key: 'identifier', dependent: :nullify
+
+    # When the template is deleted, don't nullify the unit groups' template columns workflow_template_identifier and direct_referral_workflow_template_identifier.
+    # This is for ease of iteration in dev, so that you don't have to reset the unit group's template references every time you rebuild the workflow.
+    # It does run the risk of leaving unit groups that refer to nonexistent templates, an acceptable risk that's low in prod since templates are not deleted there.
+    has_many :unit_groups, class_name: 'Hmis::UnitGroup', foreign_key: 'workflow_template_identifier', primary_key: 'identifier'
+    has_many :direct_referral_unit_groups, class_name: 'Hmis::UnitGroup', foreign_key: 'direct_referral_workflow_template_identifier', primary_key: 'identifier'
+
     belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
 
     validates :name, presence: true

--- a/drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
+++ b/drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
@@ -8,47 +8,54 @@ For workflow-specific details (diagrams, form identifiers, rake usage), see the 
 
 ## Two workflow builder patterns
 
-Installation-specific workflow builders follow two different patterns. This readme documents the decision about our preferred pattern.
+Installation-specific workflow builders follow two different patterns. This readme documents the two patterns and our decision about our preferred pattern.
 
 ### Background information and constraints
-- The Workflow Template table supports a draft/publish/retire lifecycle, similar to Form Definitions, supported by the following columns:
+
+- The Workflow Template table supports a draft/publish/retire lifecycle, similar to Form Definitions, with the following columns:
   - `id`: database primary key that uniquely identifies this template version
-  - `version`: integer starting at 0
+  - `version`: integer starting at 0 that increments when a new version of a template is published
   - `identifier`: string identifier such as "housing_workflow" that is shared across versions
   - `status`: "draft" | "published" | "retired"
-- However, this is not in use yet, because draft templates cannot drive real referrals, and we don't yet have admin tools for previewing a draft workflow. For now, you must publish a template to test a workflow, even in dev.
+- However, this lifecycle is not truly in use yet, because draft templates cannot drive real referrals, and we don't yet have admin tools for previewing a draft workflow. For now, you must publish a template to test a workflow, even in dev.
 - `delete_template_and_associated_data` is the most efficient way to iterate on a template in dev, but should NOT be run in prod.
 - Unit groups reference templates by `identifier`, while referrals reference templates by `id`. At runtime, when a referral is created, it gets associated with the most recent published version of the template identifier stored on the unit group.
 
+
+
 ### Overview of two patterns
 
-| | **Preferred: destroy-and-recreate (AC-style)** | **Legacy: draft idempotent (PH/Standard-style)** |
-|---|---|---|
-| **Template lifecycle** | `delete_template_and_associated_data` → `create_template` (published) | `find_or_create_draft_template` → mutate in place → optional `PUBLISH=true` |
-| **Strategy for changing existing template** | Wipes existing template and starts anew | Idempotent on hard-coded version while draft; errors once published |
-| **Prod setup** | One-time via `UNSAFE_RUN_IN_PRODUCTION=true` (builder + rake guard) | `PUBLISH=true`; no destroy in prod |
-| **Env vars** | `UNSAFE_RUN_IN_PRODUCTION` (prod only) | `PUBLISH`, `FORCE_RECREATE` (non-prod) |
+
+|                                             | **Preferred: destroy-and-recreate (AC-style)**                        | **Legacy: draft idempotent (PH/Standard-style)**                            |
+| ------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **Template lifecycle**                      | `delete_template_and_associated_data` → `create_template` (published) | `find_or_create_draft_template` → mutate in place → optional `PUBLISH=true` |
+| **Strategy for changing existing template** | Wipes existing template and starts anew                               | Idempotent on hard-coded version while draft; errors once published         |
+| **Prod setup**                              | One-time via `UNSAFE_RUN_IN_PRODUCTION=true` (builder + rake guard)   | `PUBLISH=true`; no destroy in prod                                          |
+| **Env vars**                                | `UNSAFE_RUN_IN_PRODUCTION` (prod only)                                | `PUBLISH`, `FORCE_RECREATE` (non-prod only)                                 |
+
+
+
 
 ### Preferred destroy-and-recreate pattern
-Use this pattern for new workflows. See the `drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb` as a reference implementation.
+
+Use this pattern for new workflows. See `drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb` as a reference implementation.
 
 **Why we prefer it:**
+
 - Modifying an existing template in place via idempotent `find_or_*` calls accumulates cruft and is harder to reason about than a clean graph build.
-- Draft/publish/retire statuses exist for UI-managed template versioning; our builders bypass that anyway by creating published templates directly.
 - Simpler mental model: "the Ruby code *is* the template definition; re-run the rake task to apply changes."
 
 **Implementation shape**:
 
 ```ruby
 def initialize(data_source, unsafe_run_in_production: false)
-  # validate forms exist
   raise '...' if Rails.env.production? && !unsafe_run_in_production
 end
 
 def build_my_workflow
   identifier = 'my_workflow'
   CeWorkflows::Shared::CeBuilderUtils.delete_template_and_associated_data(
-    identifier, data_source: @data_source, delete_opportunities: ...
+    identifier, data_source: @data_source, delete_opportunities: false
   ) unless @unsafe_run_in_production
 
   template = CeWorkflows::Shared::CeBuilderUtils.create_template(identifier, name, @data_source)
@@ -62,24 +69,25 @@ end
 
 **Production:** run once at initial setup with `UNSAFE_RUN_IN_PRODUCTION=true`. Do not re-run after go-live (same as the rake comment in [ce_define_workflows.rake](../tasks/ce_define_workflows.rake)).
 
-**Rake task shape:** prod guard at top; pass `unsafe_run_in_production:` into builder; no `PUBLISH` / `FORCE_RECREATE` env vars.
+**Rake task shape:** prod guard at top; pass `unsafe_run_in_production:` into builder.
 
 ### Non-preferred draft-idempotent pattern
 
 **Why not preferred:**
+
 - In practice, devs used `FORCE_RECREATE` anyway because drafts can't be used for referrals.
 - Idempotent `connect_if_not_connected`-style guards add complexity and cruft.
-- Implies that we support changing a prod template *without* incrementing the version number, which we see as an anti-pattern.
-
+- Implies that we support changing a prod template *without* incrementing the version number, which we don't want to support.
 
 ## Updates
 
-Updates to Workflow Templates fall into two categories. See https://github.com/open-path/Green-River/issues/8515.
+Updates to Workflow Templates fall into two categories. See [https://github.com/open-path/Green-River/issues/8515](https://github.com/open-path/Green-River/issues/8515).
 
 - **Form field/label changes** such as label changes, adding a question, or adding a pick list option:
   - Edit JSON in `lib/form_data/`.
   - On deploy, forms are re-seeded automatically.
   - No template version bump.
 - **Graph changes** such as new steps, gateways, side effects:
-  - Not yet handled in production.
+  - We don't yet have an established pattern for handling this in production.
   - The non-preferred draft-idempotent pattern was partly built to handle this, but due to the downsides listed above, we're retiring that pattern and will cross this bridge when we re-encounter it.
+

--- a/drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
+++ b/drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
@@ -1,0 +1,85 @@
+# CE Workflow Builders
+
+## Overview
+
+Workflow builders are Rake task dev/setup scripts, not runtime application logic. They create `Hmis::WorkflowDefinition::Template` graphs wired to CE referral forms. Each client/installation may have its own builder under `ce_workflows/{client_key}/`. Eventually we plan to build admin Template management tools and move these out of version control.
+
+For workflow-specific details (diagrams, form identifiers, rake usage), see the per-client README linked from each builder's directory.
+
+## Two workflow builder patterns
+
+Installation-specific workflow builders follow two different patterns. This readme documents the decision about our preferred pattern.
+
+### Background information and constraints
+- The Workflow Template table supports a draft/publish/retire lifecycle, similar to Form Definitions, supported by the following columns:
+  - `id`: database primary key that uniquely identifies this template version
+  - `version`: integer starting at 0
+  - `identifier`: string identifier such as "housing_workflow" that is shared across versions
+  - `status`: "draft" | "published" | "retired"
+- However, this is not in use yet, because draft templates cannot drive real referrals, and we don't yet have admin tools for previewing a draft workflow. For now, you must publish a template to test a workflow, even in dev.
+- `delete_template_and_associated_data` is the most efficient way to iterate on a template in dev, but should NOT be run in prod.
+- Unit groups reference templates by `identifier`, while referrals reference templates by `id`. At runtime, when a referral is created, it gets associated with the most recent published version of the template identifier stored on the unit group.
+
+### Overview of two patterns
+
+| | **Preferred: destroy-and-recreate (AC-style)** | **Legacy: draft idempotent (PH/Standard-style)** |
+|---|---|---|
+| **Template lifecycle** | `delete_template_and_associated_data` → `create_template` (published) | `find_or_create_draft_template` → mutate in place → optional `PUBLISH=true` |
+| **Strategy for changing existing template** | Wipes existing template and starts anew | Idempotent on hard-coded version while draft; errors once published |
+| **Prod setup** | One-time via `UNSAFE_RUN_IN_PRODUCTION=true` (builder + rake guard) | `PUBLISH=true`; no destroy in prod |
+| **Env vars** | `UNSAFE_RUN_IN_PRODUCTION` (prod only) | `PUBLISH`, `FORCE_RECREATE` (non-prod) |
+
+### Preferred destroy-and-recreate pattern
+Use this pattern for new workflows. See the `drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb` as a reference implementation.
+
+**Why we prefer it:**
+- Modifying an existing template in place via idempotent `find_or_*` calls accumulates cruft and is harder to reason about than a clean graph build.
+- Draft/publish/retire statuses exist for UI-managed template versioning; our builders bypass that anyway by creating published templates directly.
+- Simpler mental model: "the Ruby code *is* the template definition; re-run the rake task to apply changes."
+
+**Implementation shape**:
+
+```ruby
+def initialize(data_source, unsafe_run_in_production: false)
+  # validate forms exist
+  raise '...' if Rails.env.production? && !unsafe_run_in_production
+end
+
+def build_my_workflow
+  identifier = 'my_workflow'
+  CeWorkflows::Shared::CeBuilderUtils.delete_template_and_associated_data(
+    identifier, data_source: @data_source, delete_opportunities: ...
+  ) unless @unsafe_run_in_production
+
+  template = CeWorkflows::Shared::CeBuilderUtils.create_template(identifier, name, @data_source)
+  # create! nodes, create_gateway, connect_to!
+  template.validate!
+  template
+end
+```
+
+**Local iteration:** run the rake task repeatedly. Expect referrals to be destroyed.
+
+**Production:** run once at initial setup with `UNSAFE_RUN_IN_PRODUCTION=true`. Do not re-run after go-live (same as the rake comment in [ce_define_workflows.rake](../tasks/ce_define_workflows.rake)).
+
+**Rake task shape:** prod guard at top; pass `unsafe_run_in_production:` into builder; no `PUBLISH` / `FORCE_RECREATE` env vars.
+
+### Non-preferred draft-idempotent pattern
+
+**Why not preferred:**
+- In practice, devs used `FORCE_RECREATE` anyway because drafts can't be used for referrals.
+- Idempotent `connect_if_not_connected`-style guards add complexity and cruft.
+- Implies that we support changing a prod template *without* incrementing the version number, which we see as an anti-pattern.
+
+
+## Updates
+
+Updates to Workflow Templates fall into two categories. See https://github.com/open-path/Green-River/issues/8515.
+
+- **Form field/label changes** such as label changes, adding a question, or adding a pick list option:
+  - Edit JSON in `lib/form_data/`.
+  - On deploy, forms are re-seeded automatically.
+  - No template version bump.
+- **Graph changes** such as new steps, gateways, side effects:
+  - Not yet handled in production.
+  - The non-preferred draft-idempotent pattern was partly built to handle this, but due to the downsides listed above, we're retiring that pattern and will cross this bridge when we re-encounter it.

--- a/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
@@ -1,7 +1,7 @@
 # Ac CE Workflows
 
 ## Overview
-This directory contains utilities and workflow definitions specific to the AC implementation of Coordinated Entry (CE) workflows. See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
+This directory contains utilities and workflow definitions specific to the AC implementation of Coordinated Entry (CE) workflows. See [CE Workflow Builders](../../../../../docs/features/hmis/ce-workflow-builders.md) for general documentation on the CE workflow builder pattern.
 
 ### Workflow Templates
 - **Housing Workflow**: Handles referrals for housing opportunities, including multiple stages of client engagement, provider outcomes, and denial reviews.

--- a/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ac/README_FOR_AC_CE_WORKFLOWS.md
@@ -1,7 +1,7 @@
 # Ac CE Workflows
 
 ## Overview
-This directory contains utilities and workflow definitions specific to the AC implementation of Coordinated Entry (CE) workflows.
+This directory contains utilities and workflow definitions specific to the AC implementation of Coordinated Entry (CE) workflows. See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
 
 ### Workflow Templates
 - **Housing Workflow**: Handles referrals for housing opportunities, including multiple stages of client engagement, provider outcomes, and denial reviews.

--- a/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
@@ -12,6 +12,8 @@
 #
 # WARNING! Building these workflows will delete existing referrals and opportunities associated with the workflow templates.
 # Not intended for use in production.
+#
+# Pattern: destroy-and-recreate (preferred). See ../README_FOR_CE_WORKFLOW_BUILDERS.md.
 module CeWorkflows::Ac
   class WorkflowBuilder
     CE_STEP_FORMS = {

--- a/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ac/workflow_builder.rb
@@ -13,7 +13,7 @@
 # WARNING! Building these workflows will delete existing referrals and opportunities associated with the workflow templates.
 # Not intended for use in production.
 #
-# Pattern: destroy-and-recreate (preferred). See ../README_FOR_CE_WORKFLOW_BUILDERS.md.
+# Pattern: destroy-and-recreate (preferred). @see docs/features/hmis/ce-workflow-builders.md
 module CeWorkflows::Ac
   class WorkflowBuilder
     CE_STEP_FORMS = {

--- a/drivers/hmis/lib/ce_workflows/az/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/az/workflow_builder.rb
@@ -42,7 +42,7 @@ module CeWorkflows::Az
     def build_mc_direct_referral_workflow
       identifier = 'mc_direct_referral'
       template_name = 'Direct Referral'
-      CeWorkflows::Shared::CeBuilderUtils.delete_template_and_associated_data(identifier, data_source: @data_source) unless @unsafe_run_in_production
+      CeWorkflows::Shared::CeBuilderUtils.delete_template_and_associated_data(identifier, data_source: @data_source, delete_opportunities: false) unless @unsafe_run_in_production
 
       puts "Creating workflow definition template '#{identifier}'"
       template = CeWorkflows::Shared::CeBuilderUtils.create_template(identifier, template_name, @data_source)

--- a/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This directory contains utilities and workflow definitions specific to the PH installation of Coordinated Entry (CE) workflows.
-See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
+See [CE Workflow Builders](../../../../../docs/features/hmis/ce-workflow-builders.md) for general documentation on the CE workflow builder pattern.
 
 ### Workflow Templates
 - **Direct Referral Workflows**:

--- a/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/ph/README_FOR_PH_CE_WORKFLOWS.md
@@ -2,6 +2,7 @@
 
 ## Overview
 This directory contains utilities and workflow definitions specific to the PH installation of Coordinated Entry (CE) workflows.
+See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
 
 ### Workflow Templates
 - **Direct Referral Workflows**:
@@ -16,20 +17,3 @@ These workflows are generated and updated using the `CeWorkflows::Ph::WorkflowBu
 
 These workflows expect client-specific forms to be available. The forms can be loaded with `CLIENT=client rails driver:hmis:seed_definitions` or `HmisUtil::JsonForms.new(env_key: 'client', data_source_id: 1).seed_record_form_definitions(roles: [:CE_REFERRAL_STEP])`
 
-#### Updates
-
-Updates to these workflows fall into two categories:
-
-**Form definition updates**: Updates to the form definitions, such as adding a collected field or changing the text on a form label.
-- These forms are "managed in version control", and unversioned (as opposed to the versioned forms that are published using the Form Builder tool). So updates can be made by modifying the form definitions directly in source control.
-- When the release containing those changes is deployed, referral workflows will start to use the new form definitions.
-- In the future, these forms will be moved into the Form Builder so users can manage them.
-
-**Workflow template updates**: Updates to the workflow structure itself, including adding or removing nodes or modifying side effects.
-- See `CeWorkflows::Ph::WorkflowBuilder` and the associated Rake task `ce_define_ph_workflows.rake`.
-- Currently, the code is updated when new versions of the templates are created/published.
-- The `build_` methods hard-code a version number, and are intended to be idempotent on that version number. So when run repeatedly, they don't create new templates, but continue updating the template identifier/version the code refers to.
-- When ready to publish, the rake task can be run with the `PUBLISH=true` env var. (See usage comment)
-- After those workflow template versions have been published, the task will error if you try to run it again.
-- When ready to create a new draft version, manually bump the version number(s) in `CeWorkflows::Ph::WorkflowBuilder`.
-- In the future, template version management will happen through the UI/mutations, similar to form definitions.

--- a/drivers/hmis/lib/ce_workflows/ph/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ph/workflow_builder.rb
@@ -10,7 +10,7 @@
 #
 # This workflow builder uses the non-preferred draft idempotent pattern.
 # Retained for existing PH direct referral workflows, but don't copy this pattern for new workflows.
-# See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the preferred destroy-and-recreate approach.
+# @see docs/features/hmis/ce-workflow-builders.md for the preferred destroy-and-recreate approach.
 module CeWorkflows::Ph
   class WorkflowBuilder
     FORMS = {

--- a/drivers/hmis/lib/ce_workflows/ph/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/ph/workflow_builder.rb
@@ -7,6 +7,10 @@
 # frozen_string_literal: true
 
 # Utility for building CE workflow definitions specific to the PH installation.
+#
+# This workflow builder uses the non-preferred draft idempotent pattern.
+# Retained for existing PH direct referral workflows, but don't copy this pattern for new workflows.
+# See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the preferred destroy-and-recreate approach.
 module CeWorkflows::Ph
   class WorkflowBuilder
     FORMS = {

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -83,11 +83,9 @@ module CeWorkflows::Shared
       templates = Hmis::WorkflowDefinition::Template.where(identifier: template_identifier)
       raise 'Unexpected, found a template with this identifier associated with another data source' if templates.any? { |template| template.data_source_id != data_source.id }
 
-      # Include soft-deleted records; otherwise steps (and their form_processors) are left behind and block
-      # form definition deletion.
-      instances = Hmis::WorkflowExecution::Instance.with_deleted.where(template: templates)
-      steps = Hmis::WorkflowExecution::Step.with_deleted.where(instance: instances)
-      referrals = Hmis::Ce::Referral.with_deleted.where(workflow_instance: instances)
+      instances = Hmis::WorkflowExecution::Instance.where(template: templates)
+      steps = Hmis::WorkflowExecution::Step.where(instance: instances)
+      referrals = Hmis::Ce::Referral.where(workflow_instance: instances)
 
       Hmis::Form::FormProcessor.
         where(owner_type: Hmis::WorkflowExecution::Step.sti_name, owner_id: steps.select(:id)).

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -74,7 +74,7 @@ module CeWorkflows::Shared
       end
     end
 
-    def self.delete_template_and_associated_data(template_identifier, data_source:)
+    def self.delete_template_and_associated_data(template_identifier, data_source:, delete_opportunities: true)
       raise ArgumentError, 'data_source is required' if data_source.blank?
       raise 'This method destroys data and should not be run in production' if Rails.env.production?
 
@@ -83,23 +83,32 @@ module CeWorkflows::Shared
       templates = Hmis::WorkflowDefinition::Template.where(identifier: template_identifier)
       raise 'Unexpected, found a template with this identifier associated with another data source' if templates.any? { |template| template.data_source_id != data_source.id }
 
-      # Find opportunities through unit groups that use this template
-      unit_groups = Hmis::UnitGroup.where(workflow_template_identifier: template_identifier).
-        or(Hmis::UnitGroup.where(direct_referral_workflow_template_identifier: template_identifier)).
-        preload(:project)
-      raise 'Unexpected, found a unit group associated with this template in another data source' if unit_groups.any? { |ug| ug.project.data_source_id != data_source.id }
+      # Include soft-deleted records; otherwise steps (and their form_processors) are left behind and block
+      # form definition deletion.
+      instances = Hmis::WorkflowExecution::Instance.with_deleted.where(template: templates)
+      steps = Hmis::WorkflowExecution::Step.with_deleted.where(instance: instances)
+      referrals = Hmis::Ce::Referral.with_deleted.where(workflow_instance: instances)
 
-      opportunities = Hmis::Ce::Opportunity.joins(:unit).where(hmis_units: { hmis_unit_group_id: unit_groups.select(:id) })
-      instances = Hmis::WorkflowExecution::Instance.where(template: templates)
-      steps = Hmis::WorkflowExecution::Step.where(instance: instances)
-      referrals = Hmis::Ce::Referral.where(workflow_instance: instances)
+      Hmis::Form::FormProcessor.
+        where(owner_type: Hmis::WorkflowExecution::Step.sti_name, owner_id: steps.select(:id)).
+        find_each(&:destroy!)
 
       Hmis::Ce::ReferralNote.where(referral: referrals).find_each(&:destroy!)
       Hmis::Ce::ReferralParticipant.where(referral: referrals).find_each(&:destroy!)
       referrals.find_each(&:destroy!)
 
-      Hmis::Ce::OpportunityCategorization.where(opportunity: opportunities).find_each(&:destroy!)
-      opportunities.find_each(&:destroy!)
+      if delete_opportunities
+        # Find opportunities through unit groups that use this template
+        unit_groups = Hmis::UnitGroup.where(workflow_template_identifier: template_identifier).
+          or(Hmis::UnitGroup.where(direct_referral_workflow_template_identifier: template_identifier)).
+          preload(:project)
+        raise 'Unexpected, found a unit group associated with this template in another data source' if unit_groups.any? { |ug| ug.project.data_source_id != data_source.id }
+
+        opportunities = Hmis::Ce::Opportunity.joins(:unit).where(hmis_units: { hmis_unit_group_id: unit_groups.select(:id) })
+
+        Hmis::Ce::OpportunityCategorization.where(opportunity: opportunities).find_each(&:destroy!)
+        opportunities.find_each(&:destroy!)
+      end
 
       Hmis::WorkflowExecution::AuditEvent.where(instance: instances).find_each(&:destroy!)
       instances.find_each(&:destroy!)
@@ -150,6 +159,7 @@ module CeWorkflows::Shared
       # Temporarily disable the callback that prevents destroying published forms
       Hmis::Form::Definition.skip_callback(:destroy, :before, :can_be_destroyed)
       scope = Hmis::Form::Definition.in_data_source(data_source_id).where(role: 'CE_REFERRAL_STEP', identifier: form_definition_identifiers)
+      Hmis::Form::FormProcessor.where(definition_id: scope.select(:id)).find_each(&:destroy!)
       scope.destroy_all
       Hmis::Form::Definition.set_callback(:destroy, :before, :can_be_destroyed) # re-enable callback
     end

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -83,9 +83,15 @@ module CeWorkflows::Shared
       templates = Hmis::WorkflowDefinition::Template.where(identifier: template_identifier)
       raise 'Unexpected, found a template with this identifier associated with another data source' if templates.any? { |template| template.data_source_id != data_source.id }
 
-      instances = Hmis::WorkflowExecution::Instance.where(template: templates)
-      steps = Hmis::WorkflowExecution::Step.where(instance: instances)
-      referrals = Hmis::Ce::Referral.where(workflow_instance: instances)
+      # Include soft-deleted records; otherwise steps (and their form_processors) are left behind and block
+      # form definition deletion.
+      instances = Hmis::WorkflowExecution::Instance.with_deleted.where(template: templates)
+      steps = Hmis::WorkflowExecution::Step.with_deleted.where(instance: instances)
+      referrals = Hmis::Ce::Referral.with_deleted.where(workflow_instance: instances)
+
+      Hmis::Form::FormProcessor.
+        where(owner_type: Hmis::WorkflowExecution::Step.sti_name, owner_id: steps.select(:id)).
+        find_each(&:destroy!)
 
       Hmis::Ce::ReferralNote.where(referral: referrals).find_each(&:destroy!)
       Hmis::Ce::ReferralParticipant.where(referral: referrals).find_each(&:destroy!)

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -74,6 +74,23 @@ module CeWorkflows::Shared
       end
     end
 
+    # Destroys a workflow template and its associated dev/staging data so the builder can recreate it from scratch.
+    # Should not be run in production and raises an error if you try.
+    #
+    # Always destroys referrals, workflow instances/steps, and the template graph. Optionally destroys
+    # opportunities linked to unit groups that reference this template identifier.
+    #
+    # @param delete_opportunities [Boolean] When true (default), also destroys opportunities on units
+    #   belonging to unit groups whose `workflow_template_identifier` or
+    #   `direct_referral_workflow_template_identifier` matches +template_identifier+. When false,
+    #   opportunities are preserved so local rebuilds don't wipe CE inventory.
+    #
+    #   When set to false, this could potentially lead to opportunities with dangling references
+    #   to non-existent workflow templates.
+    #   But as long as the workflow builder immediately recreates the template
+    #   with the same identifier right after running this method (which is our normal builder pattern),
+    #   the dangling references will not be left dangling.
+    #   Since this is a dev/staging-only method anyway, the risk is low.
     def self.delete_template_and_associated_data(template_identifier, data_source:, delete_opportunities: true)
       raise ArgumentError, 'data_source is required' if data_source.blank?
       raise 'This method destroys data and should not be run in production' if Rails.env.production?
@@ -98,6 +115,8 @@ module CeWorkflows::Shared
       referrals.find_each(&:destroy!)
 
       if delete_opportunities
+        # Optional: wipe opportunities tied to this template via unit groups. Pass
+        # delete_opportunities: false to preserve CE inventory during local iteration.
         # Find opportunities through unit groups that use this template
         unit_groups = Hmis::UnitGroup.where(workflow_template_identifier: template_identifier).
           or(Hmis::UnitGroup.where(direct_referral_workflow_template_identifier: template_identifier)).

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -87,10 +87,6 @@ module CeWorkflows::Shared
       steps = Hmis::WorkflowExecution::Step.where(instance: instances)
       referrals = Hmis::Ce::Referral.where(workflow_instance: instances)
 
-      Hmis::Form::FormProcessor.
-        where(owner_type: Hmis::WorkflowExecution::Step.sti_name, owner_id: steps.select(:id)).
-        find_each(&:destroy!)
-
       Hmis::Ce::ReferralNote.where(referral: referrals).find_each(&:destroy!)
       Hmis::Ce::ReferralParticipant.where(referral: referrals).find_each(&:destroy!)
       referrals.find_each(&:destroy!)

--- a/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
+++ b/drivers/hmis/lib/ce_workflows/shared/ce_builder_utils.rb
@@ -83,8 +83,8 @@ module CeWorkflows::Shared
       templates = Hmis::WorkflowDefinition::Template.where(identifier: template_identifier)
       raise 'Unexpected, found a template with this identifier associated with another data source' if templates.any? { |template| template.data_source_id != data_source.id }
 
-      # Include soft-deleted records; otherwise steps (and their form_processors) are left behind and block
-      # form definition deletion.
+      # Include soft-deleted records. Otherwise steps and their form_processors are left behind and block form definition deletion
+      # (which doesn't happen as part of this method, but can be run separately while iterating on a workflow, using `delete_form_definitions` below).
       instances = Hmis::WorkflowExecution::Instance.with_deleted.where(template: templates)
       steps = Hmis::WorkflowExecution::Step.with_deleted.where(instance: instances)
       referrals = Hmis::Ce::Referral.with_deleted.where(workflow_instance: instances)

--- a/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
@@ -7,24 +7,10 @@ This workflow is intended as an out-of-the-box baseline for QA, staging, demo, a
 
 *Forms* associated with this workflow need to be added to the desired installation's form directory, e.g. `drivers/hmis/lib/form_data/{env}/ce_referral_steps/`. (They cannot be added to the `default` env because they will fail in multi-HMIS installations. See #9035)
 
+See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
+
 ### Usage
 These workflows are generated and updated using the `CeWorkflows::Standard::WorkflowBuilder` utility class and the `ce_define_standard_workflows` rake task. See usage comments on the rake task.
-
-#### Updates
-
-Updates to these workflows fall into two categories:
-
-**Form definition updates**: Updates to the form definitions, such as adding a collected field or changing the text on a form label.
-- These forms are managed in version control under `lib/form_data/default/ce_referral_steps/`.
-- When the release containing those changes is deployed, the updated form definitions will be seeded automatically.
-
-**Workflow template updates**: Updates to the workflow structure itself, including adding or removing nodes or modifying side effects.
-- See `CeWorkflows::Standard::WorkflowBuilder` and `ce_define_standard_workflows.rake`.
-- `build_standard_referral_workflow` hard-codes a version number and is intended to be idempotent on that version number. When run repeatedly, it updates the existing draft rather than creating a new template.
-- When ready to publish, run the rake task with `PUBLISH=true`.
-- After the template version has been published, the task will error if you try to publish again without bumping the version number.
-- When ready to create a new draft version, manually bump the version number in `CeWorkflows::Standard::WorkflowBuilder`.
-- To wipe and rebuild from scratch in a non-production environment, use `FORCE_RECREATE=true` (raises in production).
 
 ### Standard Referral Workflow
 This is a simplified diagram of the standard referral workflow. To see the full generated diagram, run the rake task or Standard WorkflowBuilder.

--- a/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
+++ b/drivers/hmis/lib/ce_workflows/standard/README_FOR_STANDARD_CE_WORKFLOWS.md
@@ -7,7 +7,7 @@ This workflow is intended as an out-of-the-box baseline for QA, staging, demo, a
 
 *Forms* associated with this workflow need to be added to the desired installation's form directory, e.g. `drivers/hmis/lib/form_data/{env}/ce_referral_steps/`. (They cannot be added to the `default` env because they will fail in multi-HMIS installations. See #9035)
 
-See README_FOR_CE_WORKFLOW_BUILDERS.md for general documentation on the CE workflow builder pattern.
+See [CE Workflow Builders](../../../../../docs/features/hmis/ce-workflow-builders.md) for general documentation on the CE workflow builder pattern.
 
 ### Usage
 These workflows are generated and updated using the `CeWorkflows::Standard::WorkflowBuilder` utility class and the `ce_define_standard_workflows` rake task. See usage comments on the rake task.

--- a/drivers/hmis/lib/ce_workflows/standard/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/standard/workflow_builder.rb
@@ -8,6 +8,11 @@
 
 # Utility for building the default Standard Referral CE workflow template.
 # Intended for QA, staging, demo, and as a baseline when onboarding new clients.
+#
+# This workflow builder uses the non-preferred draft idempotent pattern.
+# Retained for existing workflows, but don't copy this pattern for new workflows,
+# and if we do more development on the Standard workflow, we will likely update it.
+# See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the preferred destroy-and-recreate approach.
 module CeWorkflows::Standard
   class WorkflowBuilder
     FORMS = {
@@ -50,7 +55,7 @@ module CeWorkflows::Standard
     # Similar to PH, the standard workflow builder hard-codes its version number,
     # and is intended to be idempotent on that version number.
     # This enables iterating on a template until it is ready to be published.
-    # See README_FOR_STANDARD_CE_WORKFLOWS.md for more details.
+    # See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the pattern, and README_FOR_STANDARD_CE_WORKFLOWS.md for usage.
     def build_standard_referral_workflow
       find_or_create_draft_template(
         identifier: 'standard_referral',

--- a/drivers/hmis/lib/ce_workflows/standard/workflow_builder.rb
+++ b/drivers/hmis/lib/ce_workflows/standard/workflow_builder.rb
@@ -12,7 +12,7 @@
 # This workflow builder uses the non-preferred draft idempotent pattern.
 # Retained for existing workflows, but don't copy this pattern for new workflows,
 # and if we do more development on the Standard workflow, we will likely update it.
-# See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the preferred destroy-and-recreate approach.
+# @see docs/features/hmis/ce-workflow-builders.md for the preferred destroy-and-recreate approach.
 module CeWorkflows::Standard
   class WorkflowBuilder
     FORMS = {
@@ -55,7 +55,7 @@ module CeWorkflows::Standard
     # Similar to PH, the standard workflow builder hard-codes its version number,
     # and is intended to be idempotent on that version number.
     # This enables iterating on a template until it is ready to be published.
-    # See ../README_FOR_CE_WORKFLOW_BUILDERS.md for the pattern, and README_FOR_STANDARD_CE_WORKFLOWS.md for usage.
+    # @see docs/features/hmis/ce-workflow-builders.md for the pattern, and README_FOR_STANDARD_CE_WORKFLOWS.md for usage.
     def build_standard_referral_workflow
       find_or_create_draft_template(
         identifier: 'standard_referral',

--- a/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
+++ b/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
@@ -16,6 +16,9 @@ namespace :ce_define_standard_workflows do
   #
   # NOTE: This task will fail if the installation's form directory does not contain the required forms.
   # Copy the forms from drivers/hmis/lib/form_data/demo/ce_referral_steps/ to the installation's directory.
+  #
+  # This task uses the non-preferred draft idempotent pattern.
+  # See drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
   task :create, [:data_source_id] => :environment do |_, args|
     raise unless HmisEnforcement.hmis_enabled?
     raise 'FORCE_RECREATE destroys data and should not be run in production' if ENV['FORCE_RECREATE'] && Rails.env.production?

--- a/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
+++ b/drivers/hmis/lib/tasks/ce_define_standard_workflows.rake
@@ -18,7 +18,7 @@ namespace :ce_define_standard_workflows do
   # Copy the forms from drivers/hmis/lib/form_data/demo/ce_referral_steps/ to the installation's directory.
   #
   # This task uses the non-preferred draft idempotent pattern.
-  # See drivers/hmis/lib/ce_workflows/README_FOR_CE_WORKFLOW_BUILDERS.md
+  # @see docs/features/hmis/ce-workflow-builders.md
   task :create, [:data_source_id] => :environment do |_, args|
     raise unless HmisEnforcement.hmis_enabled?
     raise 'FORCE_RECREATE destroys data and should not be run in production' if ENV['FORCE_RECREATE'] && Rails.env.production?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- Add `README_FOR_CE_WORKFLOW_BUILDERS.md` documenting the two CE workflow builder patterns and trimming the now-redundant "Updates" sections from the PH/Standard per-client READMEs in favor of a single shared doc.
- Update `delete_template_and_associated_data` and `delete_form_definitions` to include soft-deleted (`with_deleted`) instances/steps/referrals and to destroy associated `Hmis::Form::FormProcessor` rows before destroying steps/form definitions, so repeated local rebuilds don't leave orphaned records that block form definition deletion.
- Add a `delete_opportunities:` option to `delete_template_and_associated_data`. Set it to `false` for the AZ direct referral workflow to test/prove the new option. Rebuilding that template no longer wipes associated opportunities.
- Remove `dependent: :nullify` from `Hmis::WorkflowDefinition::Template#unit_groups` / `#direct_referral_unit_groups` so destroying a template in dev no longer clears unit groups' template identifier references, easing local iteration.
  - Alternative considered: Manually clear the columns in `delete_template_and_associated_data` unless the new `delete_opportunities` option is `false`, in order to maintain the previous behavior except when otherwise specified. I didn't pursue that since I thought it would be more cruft than needed for a low-risk change.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
- Documentation
- Behavior change on template deletion

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

