### PR TITLE
Handle archived SPM data in Longitudinal SPM report

### DIFF
--- a/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
+++ b/drivers/longitudinal_spm/app/models/longitudinal_spm/report.rb
@@ -138,6 +138,13 @@ module LongitudinalSpm
       end
     end
 
+    # The backing SPMs whose data has been archived and purged from the database. Their
+    # results are still available here, but the metadata that holds the row and column
+    # labels is gone until the SPM data is restored.
+    def purged_spms
+      @purged_spms ||= spms.order(start_date: :asc).select { |spm| spm.hud_spm.purged? }
+    end
+
     def spm_describe(measure_or_table, cell = nil, row_col = :row)
       return spm_generator.describe_table(measure_or_table) if cell.blank?
 
@@ -146,6 +153,12 @@ module LongitudinalSpm
       return '' if spms.first&.hud_spm&.report_name == 'System Performance Measures - FY 2020'
 
       @sample_spm ||= spms.first.hud_spm # Just find one of the SPMs so we can get metadata
+
+      # A purged SPM keeps its completed state, but its report cells (and the metadata holding
+      # the row and column labels) are gone. Check before calling answer, which uses
+      # first_or_create and would write empty cells back into the purged SPM.
+      return '' if @sample_spm.purged?
+
       # Sometimes we get into a weird state where the SPMs didn't run, return so we don't throw errors
       return '' unless @sample_spm.completed?
 

--- a/drivers/longitudinal_spm/app/views/longitudinal_spm/warehouse_reports/reports/show.haml
+++ b/drivers/longitudinal_spm/app/views/longitudinal_spm/warehouse_reports/reports/show.haml
@@ -5,6 +5,13 @@
 %p.mb-2= @report.description
 %p= "Created by #{@report.user.name_with_email} on #{@report.completed_at&.to_date}"
 
+- if @report.purged_spms.any?
+  .alert.alert--flex.alert-warning
+    %i.alert__icon.icon-warning
+    %p.mb-0
+      One or more of the underlying SPM reports has been archived. The archived report(s) must be restored before the data in this report is available.
+
+
 .well.report-listing.warehouse-reports__completed.d-flex.justify-content-between
   .pl-0.w-50
     %h3 Universe
@@ -12,58 +19,61 @@
   .ml-auto
     - if can_view_all_hud_reports? || can_view_own_hud_reports?
       %h3 SPM Reports
+      - purged_spm_ids = @report.purged_spms.map(&:id).to_set
       - @report.spms.order(start_date: :asc).each do |spm|
         .ml-auto
           = link_to "#{spm.start_date} - #{spm.end_date}", hud_reports_spm_path(spm.spm_id), target: :_blank, class: 'btn btn-sm btn-secondary mb-2'
+          - if purged_spm_ids.include?(spm.id)
+            %span.badge.text-bg-warning.mr-2 Archived
 
-
-- @report.spm_measures.each do |measure, tables|
-  %h2= "#{measure}: #{@report.spm_describe(measure)}"
-  .well
-    - tables.each do |table, cells|
-      - cells.each do |cell|
-        %h3
-          = "Table #{table}:"
-          = @report.spm_describe(table)
-          = @report.spm_describe(table, cell)
-          - project_types = @report.project_types_for_table(table)
-          = "(#{project_types})" if project_types.present?
-        .chart{id: "spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"}
-        = content_for :page_js do
-          :javascript
-            options = {
-              data: {
-                x: 'x',
-                columns: #{@report.chart_data(measure, table, cell).to_json.html_safe},
-                type: 'line',
-              },
-              axis: {
-                x: {
-                  type: 'timeseries',
-                  padding: { right: 15000*60*60*24 },
-                  tick: {
-                    format: '%b %Y'
+- unless @report.purged_spms.any?
+  - @report.spm_measures.each do |measure, tables|
+    %h2= "#{measure}: #{@report.spm_describe(measure)}"
+    .well
+      - tables.each do |table, cells|
+        - cells.each do |cell|
+          %h3
+            = "Table #{table}:"
+            = @report.spm_describe(table)
+            = @report.spm_describe(table, cell)
+            - project_types = @report.project_types_for_table(table)
+            = "(#{project_types})" if project_types.present?
+          .chart{id: "spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"}
+          = content_for :page_js do
+            :javascript
+              options = {
+                data: {
+                  x: 'x',
+                  columns: #{@report.chart_data(measure, table, cell).to_json.html_safe},
+                  type: 'line',
+                },
+                axis: {
+                  x: {
+                    type: 'timeseries',
+                    padding: { right: 15000*60*60*24 },
+                    tick: {
+                      format: '%b %Y'
+                    }
+                  },
+                  y: {
+                    min: 0,
+                    padding: {
+                      top: 5,
+                      bottom: 0
+                    },
+                    tick: {
+                      culling: { max: 5, lines: true }
+                    }
                   }
                 },
-                y: {
-                  min: 0,
-                  padding: {
-                    top: 5,
-                    bottom: 0
-                  },
-                  tick: {
-                    culling: { max: 5, lines: true }
-                  }
-                }
-              },
-              bindto: "\#spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"
-            };
+                bindto: "\#spm_#{table.gsub('.', '_').gsub(' ', '-')}_#{cell}"
+              };
 
-            // Tables 2 and 7 should be 0-100 (and labeled as percentage)
-            if (['Measure 2', 'Measure 7'].includes('#{measure}')) {
-              options.axis.y.max = 100;
-              options.axis.y.min = 0;
-              options.axis.y.tick.format = function(y) { return y + '%' }
-            }
+              // Tables 2 and 7 should be 0-100 (and labeled as percentage)
+              if (['Measure 2', 'Measure 7'].includes('#{measure}')) {
+                options.axis.y.max = 100;
+                options.axis.y.min = 0;
+                options.axis.y.tick.format = function(y) { return y + '%' }
+              }
 
-            bb.generate(options)
+              bb.generate(options)

--- a/drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb
+++ b/drivers/longitudinal_spm/spec/models/longitudinal_spm/report_spec.rb
@@ -26,4 +26,79 @@ RSpec.describe LongitudinalSpm::Report, type: :model do
       expect { report.run_and_save! }.not_to raise_error
     end
   end
+
+  describe 'when the backing SPMs have been archived and purged' do
+    # A purged SPM keeps its state of Completed, but its report_cells (and the metadata
+    # that holds the row and column labels) are gone from the database.
+    let!(:report) { LongitudinalSpm::Report.create!(user_id: user.id) }
+    let!(:hud_spm) do
+      HudReports::ReportInstance.create!(
+        report_name: HudSpmReport.current_generator.title,
+        question_names: ['Measure 1'],
+        user_id: user.id,
+        state: 'Completed',
+        completed_at: Time.current,
+        archival_metadata: { 'purged_at' => Time.current.iso8601 },
+      )
+    end
+    let!(:spm) do
+      LongitudinalSpm::Spm.create!(
+        report_id: report.id,
+        spm_id: hud_spm.id,
+        start_date: '2023-01-01',
+        end_date: '2023-12-31',
+      )
+    end
+
+    it 'returns a blank label instead of raising' do
+      expect(report.spm_describe('1a', 'D2')).to eq('')
+      expect(report.spm_describe('1a', 'D2', :col)).to eq('')
+    end
+
+    it 'does not add report cells back to the purged SPM' do
+      report.spm_describe('1a', 'D2')
+      expect(hud_spm.report_cells.count).to eq(0)
+    end
+
+    it 'identifies the purged SPM so the view can flag it' do
+      expect(report.purged_spms.map(&:id)).to eq([spm.id])
+    end
+  end
+
+  describe 'when the backing SPMs still have their data' do
+    let!(:report) { LongitudinalSpm::Report.create!(user_id: user.id) }
+    let!(:hud_spm) do
+      HudReports::ReportInstance.create!(
+        report_name: HudSpmReport.current_generator.title,
+        question_names: ['Measure 1'],
+        user_id: user.id,
+        state: 'Completed',
+        completed_at: Time.current,
+      )
+    end
+    let!(:spm) do
+      LongitudinalSpm::Spm.create!(
+        report_id: report.id,
+        spm_id: hud_spm.id,
+        start_date: '2023-01-01',
+        end_date: '2023-12-31',
+      )
+    end
+
+    it 'reports no purged SPMs' do
+      expect(report.purged_spms).to be_empty
+    end
+
+    it 'returns the stored label' do
+      hud_spm.report_cells.create!(
+        question: '1a',
+        cell_name: nil,
+        universe: false,
+        # header_row is indexed by column letter, so 'D' lands on index 3
+        metadata: { 'row_labels' => ['Persons in ES', 'Persons in TH'], 'header_row' => ['', 'B', 'C', 'Current'] },
+      )
+      expect(report.spm_describe('1a', 'D2')).to eq('Persons in ES')
+      expect(report.spm_describe('1a', 'D2', :col)).to eq('Current')
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

This change addresses [this Sentry issue](https://green-river.sentry.io/issues/7642503961/?alert_rule_id=14733065&alert_type=issue&environment=staging&notification_uuid=b2132904-0611-4c2d-a618-ebbd9bcb2667&project=4503977346662400&referrer=slack).

Longitudinal SPM reports raised `ActionView::Template::Error (NoMethodError: undefined method '[]' for nil)` on the show page when their backing SPM reports had been archived and purged. Purging removes an SPM's `hud_report_cells` rows but does not change its `state`, which remains `Completed`. `LongitudinalSpm::Report#spm_describe` therefore passed its `completed?` check and called `HudReports::ReportInstance#answer`, which is a `first_or_create` and returned a new cell with `nil` metadata. A side effect was that each page view inserted empty cells into the purged report.

`LongitudinalSpm::Report#purged_spms` is added, and `spm_describe` now returns an empty string if `@sample_spm.purged?` before reaching the `answer` call. `purged?` reads `archival_metadata`, which is already loaded on the report instance, so the check adds no queries.

The show page displays a warning alert when any backing SPM is purged, marks each affected quarter with an `Archived` badge in the SPM Reports list, and omits the measures and charts until the data is restored. Restoration uses the existing per-SPM **Reload Report from Archived Data** action; no routes, controllers, or services were added. Specs cover the purged path (empty label returned, no cells recreated, `purged_spms` contents) and the intact path.


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [x] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

