### PR TITLE
Memoize HMIS permissions_with_descriptions, centralize requirement resolution on Role

### DIFF
--- a/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/context_loaders/hmis_permission_loader.rb
@@ -30,36 +30,13 @@ module Hmis::AuthPolicies::ContextLoaders
 
     protected
 
+    # Drops permissions whose requirements aren't also granted. Requirements are transitive:
+    # required_permissions_for returns the full chain, so can_edit_enrollments needs
+    # can_view_enrollment_details plus everything that permission requires.
     def apply_permission_requirements(permissions)
-      # support cycle detection for requirement chains
-      visited = Set.new
-
       permissions.delete_if do |permission|
-        !requirements_met?(permission, permissions, visited)
+        !Hmis::Role.required_permissions_for(permission).all? { |required| permissions.include?(required) }
       end
-    end
-
-    # Recursively checks that a permission and all its transitive requirements are satisfied
-    def requirements_met?(permission, permissions, visited)
-      raise 'cycle detected' if visited.include?(permission) # This shouldn't occur
-
-      required = role_config[permission][:requirements]
-
-      return true if required.blank? # No requirements, keep it
-
-      # check that all requirements are satisfied
-      visited.add(permission)
-      result = required.all? do |req|
-        permissions.include?(req) && requirements_met?(req, permissions, visited)
-      end
-      visited.delete(permission)
-
-      result
-    end
-
-    # note, the config is not memoized on Role (as of this time) so memoize here
-    memoize def role_config
-      Hmis::Role.permissions_with_descriptions.freeze
     end
   end
 end

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -131,8 +131,29 @@ class Hmis::Role < ::ApplicationRecord
     @fg_color ||= GrdaWarehouse::SystemColor.new.calculated_foreground_color(bg_color)
   end
 
+  # Returns a list of permissions that are required for a given permission (including the permission itself).
+  # For example, can_edit_enrollments requires can_view_enrollment_details, which in turn requires
+  # can_view_project and can_view_clients.
+  def self.required_permissions_for(permission)
+    config = permissions_with_descriptions
+    resolved = []
+    unresolved = [permission]
+
+    while (perm = unresolved.shift)
+      raise "cycle detected: #{perm} requires #{resolved.join(', ')}" if resolved.include?(perm)
+
+      resolved << perm
+      unresolved.concat(config.fetch(perm) { raise "unknown permission #{perm.inspect}" }[:requirements] || [])
+    end
+
+    resolved
+  end
+
+  # Memoized because permission resolution reads this heavily and it would otherwise be rebuilt on
+  # every call. Values are static; `proc` entries are lambdas that callers evaluate when needed, so
+  # memoizing doesn't capture any runtime state.
   def self.permissions_with_descriptions
-    {
+    @permissions_with_descriptions ||= {
       can_administer_hmis: {
         description: 'Ability to manage permissions and data access for the HMIS. Grants access to HMIS Admin section of the Warehouse.',
         administrative: true,
@@ -575,6 +596,6 @@ class Hmis::Role < ::ApplicationRecord
         category: 'Client Access',
         sub_category: 'Access',
       },
-    }
+    }.freeze
   end
 end

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -134,19 +134,12 @@ class Hmis::Role < ::ApplicationRecord
   # Returns a list of permissions that are required for a given permission (including the permission itself).
   # For example, can_edit_enrollments requires can_view_enrollment_details, which in turn requires
   # can_view_project and can_view_clients.
-  def self.required_permissions_for(permission)
-    config = permissions_with_descriptions
-    resolved = []
-    unresolved = [permission]
+  def self.required_permissions_for(permission, path = [])
+    raise "cycle detected: #{permission} requires #{path.join(', ')}" if path.include?(permission)
 
-    while (perm = unresolved.shift)
-      raise "cycle detected: #{perm} requires #{resolved.join(', ')}" if resolved.include?(perm)
-
-      resolved << perm
-      unresolved.concat(config.fetch(perm) { raise "unknown permission #{perm.inspect}" }[:requirements] || [])
-    end
-
-    resolved
+    config = permissions_with_descriptions.fetch(permission) { raise "unknown permission #{permission.inspect}" }
+    required = (config[:requirements] || []).flat_map { |perm| required_permissions_for(perm, path + [permission]) }
+    ([permission] + required).uniq.sort
   end
 
   # Memoized because permission resolution reads this heavily and it would otherwise be rebuilt on every call.

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -139,7 +139,7 @@ class Hmis::Role < ::ApplicationRecord
 
     config = permissions_with_descriptions.fetch(permission) { raise "unknown permission #{permission.inspect}" }
     required = (config[:requirements] || []).flat_map { |perm| required_permissions_for(perm, path + [permission]) }
-    ([permission] + required).uniq.sort
+    ([permission] + required).uniq
   end
 
   # Memoized because permission resolution reads this heavily and it would otherwise be rebuilt on every call.

--- a/drivers/hmis/app/models/hmis/role.rb
+++ b/drivers/hmis/app/models/hmis/role.rb
@@ -149,9 +149,7 @@ class Hmis::Role < ::ApplicationRecord
     resolved
   end
 
-  # Memoized because permission resolution reads this heavily and it would otherwise be rebuilt on
-  # every call. Values are static; `proc` entries are lambdas that callers evaluate when needed, so
-  # memoizing doesn't capture any runtime state.
+  # Memoized because permission resolution reads this heavily and it would otherwise be rebuilt on every call.
   def self.permissions_with_descriptions
     @permissions_with_descriptions ||= {
       can_administer_hmis: {

--- a/drivers/hmis/spec/models/hmis/role_spec.rb
+++ b/drivers/hmis/spec/models/hmis/role_spec.rb
@@ -11,11 +11,8 @@ require 'rails_helper'
 RSpec.describe Hmis::Role, type: :model do
   # These specs catch a bad config of Hmis::Role.permissions_with_descriptions
   describe '.permissions_with_descriptions config' do
-    let(:requirements) do
-      described_class.permissions_with_descriptions.transform_values { |config| config[:requirements] || [] }
-    end
-
     it 'requirements reference only permissions that exist' do
+      requirements = described_class.permissions_with_descriptions.transform_values { |config| config[:requirements] || [] }
       expect(requirements.values.flatten.uniq - described_class.permissions).to be_empty
     end
 

--- a/drivers/hmis/spec/models/hmis/role_spec.rb
+++ b/drivers/hmis/spec/models/hmis/role_spec.rb
@@ -9,41 +9,39 @@
 require 'rails_helper'
 
 RSpec.describe Hmis::Role, type: :model do
-  # Requirements are resolved recursively when a user's permissions are evaluated
-  # (Hmis::AuthPolicies::ContextLoaders::HmisPermissionLoader), which raises on a cycle.
-  # These specs catch a bad config here rather than on every request that checks permissions.
-  describe 'permission requirements' do
+  # These specs catch a bad config of Hmis::Role.permissions_with_descriptions
+  describe 'permissions_with_descriptions config' do
     let(:requirements) do
       described_class.permissions_with_descriptions.transform_values { |config| config[:requirements] || [] }
     end
 
-    # Permissions reachable by following requirements from the given permission.
-    # Includes the permission itself only when it participates in a cycle.
-    def reachable_requirements(permission)
-      reachable = Set.new
-      unresolved = requirements.fetch(permission).dup
-
-      while (perm = unresolved.shift)
-        next unless reachable.add?(perm)
-
-        unresolved.concat(requirements.fetch(perm, []))
-      end
-
-      reachable
-    end
-
-    def cyclic_permissions
-      requirements.keys.select { |permission| reachable_requirements(permission).include?(permission) }
-    end
-
-    it 'reference only permissions that exist' do
+    it 'requirements reference only permissions that exist' do
       expect(requirements.values.flatten.uniq - described_class.permissions).to be_empty
     end
 
-    it 'contain no cycles' do
-      expect(cyclic_permissions).to be_empty
+    it 'declares no requirement cycles' do
+      closures = described_class.permissions.index_with { |permission| described_class.required_permissions_for(permission) }
+
+      cyclic = closures.select do |permission, closure|
+        (closure - [permission]).any? { |required| closures[required].include?(permission) }
+      end
+
+      expect(cyclic.keys).to be_empty
     end
 
+    it 'declares only direct requirements, not transitive ones' do
+      redundant = described_class.permissions.filter_map do |permission|
+        declared = described_class.permissions_with_descriptions[permission][:requirements] || []
+        implied = declared.flat_map { |req| described_class.required_permissions_for(req) - [req] }
+        overlap = declared & implied
+        [permission, overlap] if overlap.any?
+      end
+
+      expect(redundant).to be_empty
+    end
+  end
+
+  describe '#required_permissions_for' do
     it 'would report a cycle if one were introduced' do
       allow(described_class).to receive(:permissions_with_descriptions).and_return(
         can_view_project: { requirements: [:can_view_clients] },
@@ -51,7 +49,7 @@ RSpec.describe Hmis::Role, type: :model do
         can_administer_hmis: {},
       )
 
-      expect(cyclic_permissions).to contain_exactly(:can_view_project, :can_view_clients)
+      expect { described_class.required_permissions_for(:can_view_project) }.to raise_error(/cycle detected/)
     end
   end
 end

--- a/drivers/hmis/spec/models/hmis/role_spec.rb
+++ b/drivers/hmis/spec/models/hmis/role_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 
 RSpec.describe Hmis::Role, type: :model do
   # These specs catch a bad config of Hmis::Role.permissions_with_descriptions
-  describe 'permissions_with_descriptions config' do
+  describe '.permissions_with_descriptions config' do
     let(:requirements) do
       described_class.permissions_with_descriptions.transform_values { |config| config[:requirements] || [] }
     end
@@ -20,13 +20,7 @@ RSpec.describe Hmis::Role, type: :model do
     end
 
     it 'declares no requirement cycles' do
-      closures = described_class.permissions.index_with { |permission| described_class.required_permissions_for(permission) }
-
-      cyclic = closures.select do |permission, closure|
-        (closure - [permission]).any? { |required| closures[required].include?(permission) }
-      end
-
-      expect(cyclic.keys).to be_empty
+      expect { described_class.permissions.each { |perm| described_class.required_permissions_for(perm) } }.not_to raise_error
     end
 
     it 'declares only direct requirements, not transitive ones' do
@@ -41,7 +35,7 @@ RSpec.describe Hmis::Role, type: :model do
     end
   end
 
-  describe '#required_permissions_for' do
+  describe '.required_permissions_for' do
     it 'would report a cycle if one were introduced' do
       allow(described_class).to receive(:permissions_with_descriptions).and_return(
         can_view_project: { requirements: [:can_view_clients] },


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`


## Description

Follow-up to https://github.com/greenriver/hmis-warehouse/pull/6772

Moves transitive permission-requirement resolution into `Hmis::Role.required_permissions_for`, so the permission loader and specs share one implementation instead of duplicating recursion. Also memoizes `permissions_with_descriptions` and tightens config validation specs (unknown refs, cycles, redundant transitive declarations).

In the future `Hmis::Role.required_permissions_for` can be used to incorporate this into a UI: showing required perms on the Role editor page, and/or showing a validation message when a role has a permission that is missing it's requirements.

## Type of change
Code clean-up

## Checklist before requesting review
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

