### PR TITLE
feat: 8458 ServiceConfig as single source of truth

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -321,6 +321,7 @@ jobs:
             drivers/hmis/spec/models/hmis/user_auth_method_spec.rb
             spec/models/idp/jwt_helper_spec.rb
             spec/models/concerns/idp/jwt_user_spec.rb
+            spec/models/concerns/idp/support_spec.rb
             spec/controllers/concerns/idp/jwt_current_user_spec.rb
             spec/requests/idp/warehouse_jwt_wiring_spec.rb
             spec/services/idp/service_factory_spec.rb

--- a/app/controllers/admin/idp_service_configs_controller.rb
+++ b/app/controllers/admin/idp_service_configs_controller.rb
@@ -72,6 +72,9 @@ module Admin
         :client_id,
         :keycloak_realm,
         :okta_org_id,
+        :browser_url,
+        :account_client_id,
+        :manage_users,
         :active,
       )
     end

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -46,7 +46,9 @@ module Idp::Support
 
   # Whether the JWT-arm admin surface should offer the "Force Password Reset" action
   def idp_password_management_enabled?
-    primary_idp.present?
+    idp_service.supports_user_management?
+  rescue Idp::ServiceError
+    false
   end
 
   # Under JWT credentials are IdP-managed, so admins cannot re-confirm
@@ -76,6 +78,7 @@ module Idp::Support
   # provisioned account off to its owner without the admin setting a credential.
   def idp_send_account_setup_email!
     return false unless primary_idp
+    return false unless idp_service.supports_user_creation?
 
     idp_service.send_execute_actions_email(user_id: idp_connector_user_id!, actions: ['UPDATE_PASSWORD', 'VERIFY_EMAIL'])
   end
@@ -91,6 +94,18 @@ module Idp::Support
 
   private
 
+  # Unlike the render-time predicates above, this deliberately does not rescue Idp::ServiceError. A
+  # deactivated or removed config resolves to a NullService (returns false) and the local write still
+  # proceeds — the local `active` flag is what admits the user here. But a config we can't build
+  # (blank client_id, unregistered provider) means an IdP holds this account and we can't reach it,
+  # so the raise aborts the write rather than letting local state diverge. Deactivate the
+  # Idp::ServiceConfig to fall back to the NullService case.
+  def idp_user_management_available?
+    return false unless primary_idp
+
+    idp_service.supports_user_management?
+  end
+
   def primary_auth_source
     return @primary_auth_source if defined?(@primary_auth_source)
 
@@ -104,7 +119,16 @@ module Idp::Support
   # The user's stable id within the upstream IdP for its primary connector.
   def idp_connector_user_id!
     id = primary_auth_source&.connector_user_id
-    raise Idp::ServiceError.new('No IdP identity on file for this user', operation: :connector_user_id) if id.blank?
+    if id.blank?
+      raise Idp::ServiceError.new(
+        'No IdP identity on file for this user',
+        operation: :connector_user_id,
+        # Local data rather than an IdP fault, so the same answer comes back on retry. Callers that
+        # treat transient errors as connector-wide — Idp::SyncUserFromIdpJob's cooldown — would
+        # otherwise let one user's missing row stop the connector for everyone on it.
+        transient: false,
+      )
+    end
 
     id
   end

--- a/app/models/idp/service_config.rb
+++ b/app/models/idp/service_config.rb
@@ -19,6 +19,14 @@ module Idp
   #
   # Each provider's service translates these columns into its own config keys in
   # .from_config.
+  #
+  # manage_users:
+  #   Whether we have admin/manage-API access to this IdP. True (the default) is an
+  #   IdP we operate; false is authenticate-only — a customer-operated Keycloak, or a
+  #   service account that connects but lacks the manage-users role.
+  # browser_url / account_client_id:
+  #   Per-realm browser origin and account OIDC client for self-service deep-links.
+  #   Seeded once from ENV; the row is authoritative thereafter (no request-time ENV).
   class ServiceConfig < ApplicationRecord
     self.table_name = 'idp_service_configs'
     acts_as_paranoid
@@ -31,8 +39,46 @@ module Idp
     validates :api_url, presence: true
     validates :service_token, presence: true
     validate :validate_provider
+    # Active-only: for_connector builds from .active rows, so a blank-key row only breaks
+    # once active. Scoping here lets us park an inactive, half-filled draft and finish it
+    # before turning it on.
+    validate :validate_provider_config, if: :active?
 
     scope :active, -> { where(active: true) }
+
+    # Materialize the Keycloak config row from ENV once, so the row is the single source of
+    # truth at request time (Idp::ServiceFactory no longer reads KEYCLOAK_*). Runs on every
+    # deploy via SeedMaker, so it must be idempotent and must never clobber a UI credential edit.
+    #
+    # Create-only (find_or_create_by, no update block): ENV is a one-time bootstrap; after the
+    # row exists, credential rotation is a UI/DB operation and a re-seed must not overwrite it.
+    # with_deleted keys the lookup so a soft-deleted row is found (not resurrected) and a
+    # deactivated (active: false) row is left untouched, preserving the off-switch across re-seeds.
+    def self.bootstrap_from_env
+      return unless AuthMethod.jwt?
+
+      # Require all four core build keys, not just API_URL+SECRET: validate_provider_config rejects
+      # an active row missing realm/client_id, so a partial ENV would make create raise
+      # RecordInvalid and break the deploy. Missing keys stay a no-op (external IdPs have no
+      # KEYCLOAK_* at all).
+      return unless ENV['KEYCLOAK_API_URL'].present? &&
+        ENV['KEYCLOAK_REALM'].present? &&
+        ENV['KEYCLOAK_SERVICE_CLIENT_ID'].present? &&
+        ENV['KEYCLOAK_SERVICE_CLIENT_SECRET'].present?
+
+      connector_id = ENV.fetch('KEYCLOAK_CONNECTOR_ID', 'keycloak')
+
+      with_deleted.find_or_create_by(connector_id: connector_id) do |config|
+        config.provider = 'keycloak'
+        config.name = 'Keycloak (seeded from ENV)'
+        config.api_url = ENV['KEYCLOAK_API_URL']
+        config.keycloak_realm = ENV['KEYCLOAK_REALM']
+        config.client_id = ENV['KEYCLOAK_SERVICE_CLIENT_ID']
+        config.service_token = ENV['KEYCLOAK_SERVICE_CLIENT_SECRET']
+        config.browser_url = ENV['KEYCLOAK_PUBLIC_URL']
+        config.account_client_id = ENV['KEYCLOAK_ACCOUNT_CLIENT_ID']
+      end
+    end
 
     # @return [Class] the service class for this provider (e.g. Idp::KeycloakService)
     def service_class
@@ -55,6 +101,14 @@ module Idp
       return if Idp::ServiceFactory.services.key?(provider.to_s)
 
       errors.add(:provider, "unknown provider: #{provider}")
+    end
+
+    # Each provider's .from_config reads a specific set of these columns; without them an
+    # active row saves cleanly then raises Idp::ServiceError at every service build.
+    def validate_provider_config
+      return unless Idp::ServiceFactory.services.key?(provider.to_s) # validate_provider handles unknown
+
+      service_class.validate_config(self)
     end
   end
 end

--- a/app/services/idp/conflict_error.rb
+++ b/app/services/idp/conflict_error.rb
@@ -1,0 +1,15 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Idp
+  # The write collides with an account the IdP already holds — under email-as-username realms,
+  # the address belongs to somebody else there. Unlike the rest of ServiceError, this is ordinary
+  # bad input rather than a broken service, so callers put it on the form instead of paging.
+  class ConflictError < ServiceError
+  end
+end

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -13,15 +13,23 @@ require 'json'
 module Idp
   # Keycloak IDP service over the Admin REST API.
   #
-  # Authenticates via OAuth2 client_credentials. Initialized with a config hash
-  # (from Idp::ServiceConfig) or falls back to ENV. Required config keys: api_url,
-  # realm, client_id, client_secret. There is no realm default — a blank realm
-  # raises, so it must be configured explicitly (DB config or KEYCLOAK_REALM).
+  # Authenticates via OAuth2 client_credentials. Built from an Idp::ServiceConfig
+  # row (seeded from ENV) via .from_config. Required config keys: api_url, realm,
+  # client_id, client_secret; validate_config! raises when any is blank.
   class KeycloakService < Service
     UPDATABLE_ATTRIBUTES = [:first_name, :last_name, :email].freeze
 
+    # Most calls are on a request path, so the default budget is short enough that a hung Keycloak
+    # fails the request rather than holding the thread.
+    OPEN_TIMEOUT_SECONDS = 2
+    IO_TIMEOUT_SECONDS = 3
+
+    # For the two calls that move more than a status code: the paginated user listing (#each_user)
+    # and the bulk user import (#partial_import). Requested at the call site.
+    BULK_IO_TIMEOUT_SECONDS = 30
+
     def initialize(config: nil)
-      super(config: config || default_config)
+      super(config: config || {})
       validate_config!
       @cached_token = nil
       @token_expires_at = nil
@@ -33,7 +41,17 @@ module Idp
             client_id: config.client_id,
             client_secret: config.service_token,
             realm: config.keycloak_realm,
+            manage_users: config.manage_users,
+            browser_url: config.browser_url,
+            account_client_id: config.account_client_id,
           })
+    end
+
+    # api_url/service_token are validated globally on the record; keycloak_realm and
+    # client_id are the columns .from_config additionally needs to build a usable service.
+    def self.validate_config(record)
+      record.errors.add(:keycloak_realm, :blank) if record.keycloak_realm.blank?
+      record.errors.add(:client_id, :blank) if record.client_id.blank?
     end
 
     # @return [Hash] { success: Boolean, connector_user_id: String|nil }
@@ -62,23 +80,34 @@ module Idp
       unknown = attributes.keys - UPDATABLE_ATTRIBUTES
       raise ArgumentError, "Unknown attributes: #{unknown.join(', ')}" if unknown.any?
 
+      # A blank name here is an intentional clear, not a missing field: callers pass exactly the
+      # changes they made locally (Idp::Support#idp_update_profile!). Include each field whenever
+      # it is present in the hash
       patch = {}
-      patch['firstName'] = attributes[:first_name] if attributes[:first_name]
-      patch['lastName'] = attributes[:last_name] if attributes[:last_name]
+      patch['firstName'] = attributes[:first_name] if attributes.key?(:first_name)
+      patch['lastName'] = attributes[:last_name] if attributes.key?(:last_name)
 
-      email_changed = attributes[:email].present?
+      email_changed = attributes.key?(:email)
       if email_changed
-        # We treat username and email as one field even though Keycloak stores them
-        # separately; create_user seeds username from email, so keep them in lockstep here too.
+        # The realm runs email-as-username, so Keycloak keeps username in step with email
+        # on its own — we only send the email.
         patch['email'] = attributes[:email]
-        patch['username'] = attributes[:email]
         patch['emailVerified'] = false
       end
 
       return true if patch.empty?
 
       result = put_full_user(user_id: user_id, patch: patch, operation: :update_user, failure: 'Failed to update user')
-      send_execute_actions_email(user_id: user_id, actions: ['VERIFY_EMAIL']) if email_changed
+      if email_changed
+        # Keycloak already holds the new address, so a mail failure must not fail the update: the
+        # caller would roll its local write back and leave the two out of step in the other
+        # direction, with no retry that could close the gap.
+        begin
+          send_execute_actions_email(user_id: user_id, actions: ['VERIFY_EMAIL'])
+        rescue ServiceError => e
+          Sentry.capture_exception_with_info(e, "Updated #{user_id} in #{idp_name}, but couldn't send the address verification email")
+        end
+      end
       result
     end
 
@@ -121,7 +150,7 @@ module Idp
 
       first = 0
       loop do
-        response = make_request(:get, "/admin/realms/#{realm}/users?first=#{first}&max=#{page_size}")
+        response = make_request(:get, "/admin/realms/#{realm}/users?first=#{first}&max=#{page_size}", io_timeout: BULK_IO_TIMEOUT_SECONDS)
         users = handle_response(response, operation: :each_user, failure: 'Failed to list users') do |resp|
           JSON.parse(resp.body)
         end
@@ -143,6 +172,8 @@ module Idp
           "User not found: #{user_id}",
           idp_name: idp_name,
           operation: :get_user,
+          # The account is gone over there; the same 404 comes back until the link is repaired here.
+          transient: false,
         )
       end
 
@@ -171,19 +202,19 @@ module Idp
     end
 
     def supports_user_management?
-      true
+      manage_users?
     end
 
     def supports_profile_updates?
-      true
+      manage_users?
     end
 
     def supports_user_creation?
-      true
+      manage_users?
     end
 
     def supports_account_backfill?
-      true
+      manage_users?
     end
 
     # Deep-link to the Keycloak Account Console for this realm, where end users
@@ -251,18 +282,9 @@ module Idp
       }
     end
 
-    def logout_url(post_logout_redirect_uri:, client_id: nil)
-      return post_logout_redirect_uri unless api_url.present?
-
-      params = { post_logout_redirect_uri: post_logout_redirect_uri }
-      params[:client_id] = client_id if client_id.present?
-
-      "#{api_url}/realms/#{realm}/protocol/openid-connect/logout?#{params.to_query}"
-    end
-
     # Used by the migration tooling; remove once Devise account data has been migrated.
     def partial_import(import_data)
-      make_request(:post, "/admin/realms/#{realm}/partialImport", body: import_data)
+      make_request(:post, "/admin/realms/#{realm}/partialImport", body: import_data, io_timeout: BULK_IO_TIMEOUT_SECONDS)
     end
 
     # Used by the migration tooling; remove once Devise account data has been migrated.
@@ -305,6 +327,31 @@ module Idp
       config[:api_url]
     end
 
+    # Whether this realm's service account has admin/manage-API access. Defaults to true so a config
+    # built without the key (or a direct .new for tests) stays admin-managed; false is authenticate-only.
+    def manage_users?
+      config.fetch(:manage_users, true)
+    end
+
+    # Base URL for links we hand to a browser instead of fetching ourselves. Same host as the
+    # Admin API except in dev, where containers talk to Keycloak directly but the browser goes
+    # through Traefik, and the deep-links need the origin that owns the SSO session cookies.
+    #
+    # Per-realm on the Idp::ServiceConfig row (seeded once from KEYCLOAK_PUBLIC_URL); the DB is the
+    # single source of truth at request time. Falls back to api_url when unset — the browser origin
+    # only differs from the API origin behind a split-network deployment.
+    def browser_url
+      return nil if api_url.blank?
+
+      config[:browser_url].presence || api_url
+    end
+
+    # The OIDC client an application-initiated action (AIA) runs under. Per-realm on the config row
+    # (seeded from KEYCLOAK_ACCOUNT_CLIENT_ID); defaults to Keycloak's built-in 'account' client.
+    def account_client_id
+      config[:account_client_id].presence || 'account'
+    end
+
     def realm
       config[:realm]
     end
@@ -329,11 +376,14 @@ module Idp
       @cached_token
     end
 
-    def build_http(uri)
+    # `io_timeout` overrides the read and write budget for a caller that needs longer than the
+    # default — see BULK_IO_TIMEOUT_SECONDS.
+    def build_http(uri, io_timeout: IO_TIMEOUT_SECONDS)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == 'https'
-      http.open_timeout = 10
-      http.read_timeout = 30
+      http.open_timeout = OPEN_TIMEOUT_SECONDS
+      http.read_timeout = io_timeout
+      http.write_timeout = io_timeout
       http
     end
 
@@ -356,6 +406,8 @@ module Idp
           "Failed to obtain access token: #{response.code}",
           idp_name: idp_name,
           operation: :access_token,
+          # Refused credentials are an ops fix; no retry outlasts them.
+          transient: transient_status?(response.code.to_i),
         )
       end
 
@@ -363,9 +415,9 @@ module Idp
     end
 
     # Make an authenticated request to the Keycloak Admin API, retrying once on 401.
-    def make_request(method, path, body: nil, token_retried: false)
+    def make_request(method, path, body: nil, io_timeout: IO_TIMEOUT_SECONDS, token_retried: false)
       uri = URI("#{api_url}#{path}")
-      http = build_http(uri)
+      http = build_http(uri, io_timeout: io_timeout)
 
       request_class =
         case method
@@ -386,7 +438,7 @@ module Idp
       if response.code.to_i == 401 && !token_retried
         @cached_token = nil
         @token_expires_at = nil
-        return make_request(method, path, body: body, token_retried: true)
+        return make_request(method, path, body: body, io_timeout: io_timeout, token_retried: true)
       end
 
       response
@@ -394,23 +446,48 @@ module Idp
 
     # Interpret a Keycloak Admin API response: yield the response on 2xx and
     # return the block's value, otherwise raise a ServiceError tagged with the
-    # operation. `failure` is the verb used in the 4xx message.
+    # operation. `failure` names the call in every message, 5xx included — an
+    # operator reading Sentry needs to know which one it was. 409 gets the
+    # ConflictError subclass so callers can tell "this email is taken over there"
+    # from "the connector is broken".
     def handle_response(response, operation:, failure:)
-      case response.code.to_i
+      code = response.code.to_i
+      case code
       when 200..299
         yield(response)
+      when 409
+        raise ConflictError.new(
+          "#{failure}: #{error_message_from(response)}",
+          idp_name: idp_name,
+          operation: operation,
+          # The address belongs to another account over there until somebody changes it.
+          transient: false,
+        )
       when 400..499
         raise ServiceError.new(
           "#{failure}: #{error_message_from(response)}",
           idp_name: idp_name,
           operation: operation,
+          transient: transient_status?(code),
         )
       else
         raise ServiceError.new(
-          "Unexpected response from Keycloak: #{response.code}",
+          "#{failure}: unexpected response from Keycloak (#{code})",
           idp_name: idp_name,
           operation: operation,
         )
+      end
+    end
+
+    # A 4xx means Keycloak answered and will keep giving the same answer until somebody changes
+    # something — there or in our config — so neither a job retry nor the sync cooldown buys
+    # anything (Idp::SyncUserFromIdpJob branches on this). 408 and 429 are the exceptions: they
+    # invite the caller back. 5xx and transport failures stay transient.
+    def transient_status?(code)
+      case code
+      when 408, 429 then true
+      when 400..499 then false
+      else true
       end
     end
 
@@ -434,17 +511,6 @@ module Idp
       response = make_request(:put, "/admin/realms/#{realm}/users/#{user_id}", body: current.merge(patch))
 
       handle_response(response, operation: operation, failure: failure) { true }
-    end
-
-    protected
-
-    def default_config
-      {
-        api_url: ENV['KEYCLOAK_API_URL'],
-        realm: ENV['KEYCLOAK_REALM'],
-        client_id: ENV['KEYCLOAK_SERVICE_CLIENT_ID'],
-        client_secret: ENV['KEYCLOAK_SERVICE_CLIENT_SECRET'],
-      }
     end
   end
 end

--- a/app/services/idp/null_service.rb
+++ b/app/services/idp/null_service.rb
@@ -19,35 +19,35 @@ module Idp
     end
 
     def create_user(**)
-      raise ServiceError.new('User management not supported', idp_name: idp_name, operation: :create_user)
+      raise ServiceError.new('User management not supported', idp_name: idp_name, operation: :create_user, transient: false)
     end
 
     def update_user(**)
-      raise ServiceError.new('Profile updates not supported', idp_name: idp_name, operation: :update_user)
+      raise ServiceError.new('Profile updates not supported', idp_name: idp_name, operation: :update_user, transient: false)
     end
 
     def get_user(**)
-      raise ServiceError.new('User lookup not supported', idp_name: idp_name, operation: :get_user)
+      raise ServiceError.new('User lookup not supported', idp_name: idp_name, operation: :get_user, transient: false)
     end
 
     def find_user_by_email(**)
-      raise ServiceError.new('User lookup not supported', idp_name: idp_name, operation: :find_user_by_email)
+      raise ServiceError.new('User lookup not supported', idp_name: idp_name, operation: :find_user_by_email, transient: false)
     end
 
     def send_execute_actions_email(**)
-      raise ServiceError.new('Account setup email not supported', idp_name: idp_name, operation: :send_execute_actions_email)
+      raise ServiceError.new('Account setup email not supported', idp_name: idp_name, operation: :send_execute_actions_email, transient: false)
     end
 
     def reactivate_user(**)
-      raise ServiceError.new('User reactivation not supported', idp_name: idp_name, operation: :reactivate_user)
+      raise ServiceError.new('User reactivation not supported', idp_name: idp_name, operation: :reactivate_user, transient: false)
     end
 
     def deactivate_user(**)
-      raise ServiceError.new('User deactivation not supported', idp_name: idp_name, operation: :deactivate_user)
+      raise ServiceError.new('User deactivation not supported', idp_name: idp_name, operation: :deactivate_user, transient: false)
     end
 
     def set_required_action(**)
-      raise ServiceError.new('Required actions not supported', idp_name: idp_name, operation: :set_required_action)
+      raise ServiceError.new('Required actions not supported', idp_name: idp_name, operation: :set_required_action, transient: false)
     end
 
     def idp_name

--- a/app/services/idp/service.rb
+++ b/app/services/idp/service.rb
@@ -23,6 +23,12 @@ module Idp
       raise NotImplementedError, "#{name} must implement .from_config"
     end
 
+    # Validate that a persisted Idp::ServiceConfig carries every column this service's
+    # .from_config needs, adding errors to the record for any that are missing. Base is a
+    # no-op — providers with required columns override.
+    def self.validate_config(record)
+    end
+
     # @return [Hash] { success: Boolean, connector_user_id: String|nil }
     def create_user(email:, first_name:, last_name:, phone: nil)
       raise NotImplementedError, "#{self.class.name} must implement #create_user"

--- a/app/services/idp/service_error.rb
+++ b/app/services/idp/service_error.rb
@@ -10,10 +10,17 @@ module Idp
   class ServiceError < StandardError
     attr_reader :idp_name, :operation
 
-    def initialize(message, idp_name: nil, operation: nil)
+    # transient: false when the IdP answered fine and keeps giving the same answer until an operator
+    # changes something there. Neither a retry nor the sync job's cooldown helps with those.
+    def initialize(message, idp_name: nil, operation: nil, transient: true)
       super(message)
       @idp_name = idp_name
       @operation = operation
+      @transient = transient
+    end
+
+    def transient?
+      @transient
     end
   end
 end

--- a/app/services/idp/service_factory.rb
+++ b/app/services/idp/service_factory.rb
@@ -7,11 +7,8 @@
 # frozen_string_literal: true
 
 module Idp
-  # Registry mapping a connector_id to its Idp::Service implementation.
-  #
-  # for_connector is fail-soft: a blank connector returns a NullService, and a
-  # DB-backed Idp::ServiceConfig is preferred over a registered class so ops can
-  # manage credentials in the UI. Only a registered-but-unknown id raises.
+  # Registry of Idp::Service implementations by provider, and resolver from a
+  # connector_id to a configured service (see #for_connector).
   class ServiceFactory
     class << self
       def services
@@ -26,30 +23,17 @@ module Idp
         services[provider.to_s] = service_class
       end
 
-      # Get an IDP service instance for the given connector_id (the auth-proxy
-      # routing key). Prefers an active Idp::ServiceConfig record; with no config,
-      # falls back to a registered service class — which only resolves when the
-      # connector_id happens to equal a provider key (the single-realm/ENV path).
+      # Resolve a connector_id (the auth-proxy routing key) to its service. The active
+      # Idp::ServiceConfig row is the single source of truth; there is no ENV fallback.
       #
-      # Fail-soft: an unknown connector returns a NullService rather than raising.
-      # Authentication never consults this method (UserProvisioner works off the
-      # JWT alone), so a valid token from a connector with no config must still
-      # degrade to "no management" on capability checks instead of crashing the
-      # request — see Idp::Support#idp_service.
+      # Degrades to a NullService instead of raising: a valid token from a connector with no active
+      # config must still pass the capability checks in Idp::Support#idp_service without crashing the
+      # request (authentication itself works off the JWT alone, never this method).
       def for_connector(connector_id)
         return Idp::NullService.new(connector_id) unless connector_id.present?
 
-        # Prefer DB-managed credentials. Guarded so the factory is usable before
-        # the idp_service_configs table exists (e.g. during its own migration).
-        config_record = Idp::ServiceConfig.active.find_by(connector_id: connector_id) if defined?(Idp::ServiceConfig)
-        return config_record.to_service if config_record
-
-        # No managed config: treat connector_id as a provider key for ENV defaults.
-        service_class = services[connector_id.to_s]
-        return service_class.new if service_class
-
-        # Unknown connector: authenticated but unconfigured. Degrade gracefully.
-        Idp::NullService.new(connector_id)
+        active_config = Idp::ServiceConfig.active.find_by(connector_id: connector_id)
+        active_config ? active_config.to_service : Idp::NullService.new(connector_id)
       end
 
       # @return [Array<String>] registered provider keys (IDP types)

--- a/app/views/admin/idp_service_configs/_form.haml
+++ b/app/views/admin/idp_service_configs/_form.haml
@@ -11,6 +11,9 @@
         = f.input :keycloak_realm, as: :string, hint: 'Keycloak realm (required for Keycloak; no default)'
         = f.input :service_token, as: :password, input_html: { value: @idp_service_config.service_token }, hint: 'Service account token/password.'
         = f.input :okta_org_id, label: 'Okta Org ID', hint: 'Org identifier in Okta (optional)'
+        = f.input :browser_url, label: 'Browser URL', hint: 'Public origin for self-service deep-links (Keycloak; defaults to the API URL when blank)'
+        = f.input :account_client_id, label: 'Account client ID', hint: "OIDC client an application-initiated action runs under (Keycloak; defaults to 'account')"
+        = f.input :manage_users, label: 'Manage users', as: :boolean, hint: 'On when this service account has admin access to manage users in the IdP. Turn off for an authenticate-only IdP (e.g. a customer-operated Keycloak); management actions are then hidden instead of failing at the API.'
         = f.input :active, label: 'Active', hint: 'Only active configurations will be used'
 
       .form_actions

--- a/app/views/admin/idp_service_configs/_list.haml
+++ b/app/views/admin/idp_service_configs/_list.haml
@@ -6,6 +6,7 @@
         %th Provider
         %th Connector ID
         %th API URL
+        %th Manage users
         %th Active
         %th
     %tbody
@@ -16,6 +17,7 @@
           %td= config.provider
           %td= config.connector_id
           %td= truncate(config.api_url, length: 50)
+          %td= checkmark(config.manage_users)
           %td= checkmark(config.active)
           %td
             :ruby

--- a/db/migrate/20260803120000_add_idp_service_config_capability_columns.rb
+++ b/db/migrate/20260803120000_add_idp_service_config_capability_columns.rb
@@ -1,0 +1,22 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Columns that let the DB row be the single source of truth for an IdP connector,
+# so ENV is read only once at seed time (see Idp::ServiceConfig.bootstrap_from_env).
+#
+# - manage_users:      whether we have admin/manage-API access to this realm. Default
+#                      true keeps existing rows admin-managed; false is authenticate-only.
+# - browser_url:       public origin for the account console / AIA deep-links, per realm.
+# - account_client_id: OIDC client an application-initiated action runs under.
+class AddIdpServiceConfigCapabilityColumns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :idp_service_configs, :manage_users, :boolean, default: true, null: false
+    add_column :idp_service_configs, :browser_url, :string
+    add_column :idp_service_configs, :account_client_id, :string
+  end
+end

--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -429,6 +429,7 @@ class SeedMaker
 
   def run_all
     ensure_db_triggers_and_functions
+    Idp::ServiceConfig.bootstrap_from_env
     setup_fake_user if Rails.env.development?
     setup_fake_health_data
     maintain_data_sources

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1150,7 +1150,10 @@ CREATE TABLE public.idp_service_configs (
     active boolean DEFAULT true NOT NULL,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    manage_users boolean DEFAULT true NOT NULL,
+    browser_url character varying,
+    account_client_id character varying
 );
 
 
@@ -4257,6 +4260,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260803120000'),
 ('20260724120000'),
 ('20260715120000'),
 ('20260620000000'),

--- a/docker/auth/keycloak-credentials.env
+++ b/docker/auth/keycloak-credentials.env
@@ -1,5 +1,10 @@
 KEYCLOAK_API_URL=http://op-keycloak.dev.test:8080
+# Where the browser reaches Keycloak: Traefik, not the container address above.
+KEYCLOAK_PUBLIC_URL=https://op-keycloak.dev.test
 KEYCLOAK_REALM=openpath
+# The client account deep-links run under. Its Base URL in Keycloak is where the user lands after
+# confirming a new address from the new mailbox, which is the only control we have over that leg.
+KEYCLOAK_ACCOUNT_CLIENT_ID=warehouse-account
 KEYCLOAK_IDP_CLIENT_ID=dex-connector
 KEYCLOAK_IDP_CLIENT_SECRET=dex-connector-secret-dev
 KEYCLOAK_SERVICE_CLIENT_ID=rails-service-account

--- a/docs/developer/keycloak-idp.md
+++ b/docs/developer/keycloak-idp.md
@@ -1,7 +1,6 @@
 # Keycloak IDP Integration (dev stack)
 
-The opt-in local Docker Compose stack that reproduces the production auth chain. Application wiring
-(JWT validation, identity resolution, `Idp::Service`, user-migration tasks) lands in later branches.
+The opt-in local Docker Compose stack that reproduces the production auth chain.
 
 ```
 User → OAuth2-Proxy → Dex (OIDC broker) → Keycloak → Rails (JWT headers)
@@ -57,69 +56,87 @@ Then log into the Keycloak admin console at `https://op-keycloak.dev.test` (`adm
 
 ## Service config (Admin API credentials)
 
-`Idp::KeycloakService` (`app/services/idp/keycloak_service.rb`) talks to the Keycloak **Admin
-REST API** — creating/updating users, profile edits, the migration tooling. It authenticates with
-the OAuth2 `client_credentials` grant using the **`rails-service-account`** client (a *service
-account*, not the `dex-connector` browser client). That client needs the `realm-management` roles
-(`manage-users`, `view-users`, `query-users`, `manage-realm`); `realm-import.json` grants them on
-first import.
+`Idp::KeycloakService` talks to the Keycloak **Admin REST API** using the OAuth2
+`client_credentials` grant on the **`rails-service-account`** client (a *service account*, not the
+`dex-connector` browser client). That client needs the `realm-management` roles `manage-users`,
+`view-users`, `query-users` and `manage-realm`; `realm-import.json` grants them on first import.
 
-`Idp::KeycloakService` needs four values — `api_url`, `realm`, `client_id`, `client_secret`. There
-are two ways to supply them; the DB-managed config wins when both are present (see
-`Idp::ServiceFactory.for_connector`).
+The `Idp::ServiceConfig` row is the **single source of truth** at request time. ENV is read **once**,
+at deploy, to seed that row (see *Seeding from ENV* below); there is no request-time ENV fallback, so a
+connector with no active row degrades to an unmanaged `NullService` rather than silently reading ENV.
 
-### Option A — DB-managed `Idp::ServiceConfig` (preferred)
+### DB-managed `Idp::ServiceConfig`
 
-Credentials live in the `idp_service_configs` table and are managed in the admin UI at
-**`/admin/idp_service_configs`** (New → provider `keycloak`). One row per realm. The columns map to
-the service's config keys in `KeycloakService.from_config`:
+Managed in the admin UI at **`/admin/idp_service_configs`** (New → provider `keycloak`), one row per
+realm. Dev values:
 
-| `Idp::ServiceConfig` column | Maps to service key | Dev value |
-| --- | --- | --- |
-| `provider` | (selects the service class) | `keycloak` |
-| `connector_id` | the auth-proxy routing key in the JWT — must match the connector that issued the token | `keycloak` |
-| `name` | display label only | e.g. `Keycloak (dev)` |
-| `api_url` | `api_url` | `http://op-keycloak.dev.test:8080` |
-| `keycloak_realm` | `realm` | `openpath` |
-| `client_id` | `client_id` | `rails-service-account` |
-| `service_token` (encrypted) | `client_secret` | `rails-service-account-secret-dev` |
+| Column | Dev value |
+| --- | --- |
+| `provider` | `keycloak` |
+| `connector_id` | `keycloak` — the auth-proxy routing key in the JWT; must match the connector that issued the token |
+| `name` | e.g. `Keycloak (dev)` (display only) |
+| `api_url` | `http://op-keycloak.dev.test:8080` |
+| `keycloak_realm` | `openpath` |
+| `client_id` | `rails-service-account` |
+| `service_token` (encrypted, needs `ENCRYPTION_KEY`) | `rails-service-account-secret-dev` |
+| `browser_url` | `https://op-keycloak.dev.test` — public origin for browser deep-links (blank ⇒ `api_url`) |
+| `account_client_id` | `account` — OIDC client for account deep-links (blank ⇒ `account`) |
+| `manage_users` | `true` — see *Manage-users capability* below |
 
-`service_token` is stored `attr_encrypted` (needs `ENCRYPTION_KEY` set). To create one from the
-console instead of the UI:
-
-```ruby
-Idp::ServiceConfig.create!(
-  provider:       'keycloak',
-  connector_id:   'keycloak',
-  name:           'Keycloak (dev)',
-  api_url:        'http://op-keycloak.dev.test:8080',
-  keycloak_realm: 'openpath',
-  client_id:      'rails-service-account',
-  service_token:  'rails-service-account-secret-dev',
-  active:         true,
-)
-```
-
-Verify it end-to-end with the row's `#test` action (the **Test** button in the UI) or
-`config.to_service.test_connection` — a green result means the secret is valid *and* the service
+Verify with the row's **Test** button — a green result means the secret is valid *and* the service
 account has the Admin-API roles.
 
-### Option B — ENV fallback (single realm)
+### Seeding from ENV
 
-With no matching active `ServiceConfig`, the factory falls back to the registered service class,
-which reads ENV (`KeycloakService#default_config`):
+`SeedMaker#seed_idp_service_config` materializes the row from ENV on deploy, so an existing
+ENV-configured install keeps working without a manual UI step:
 
 ```
 KEYCLOAK_API_URL=http://op-keycloak.dev.test:8080
 KEYCLOAK_REALM=openpath
 KEYCLOAK_SERVICE_CLIENT_ID=rails-service-account
 KEYCLOAK_SERVICE_CLIENT_SECRET=rails-service-account-secret-dev
+KEYCLOAK_PUBLIC_URL=https://op-keycloak.dev.test
+KEYCLOAK_ACCOUNT_CLIENT_ID=account
 ```
 
-In the dev stack these are already provided to the `web` container via
-`docker/auth/keycloak-credentials.env` (loaded through `env_file`), so the service account works
-out of the box — no `.env.development.local` edits needed. This path only resolves when the JWT's
-`connector_id` equals the provider key `keycloak`.
+The dev stack provides these to the `web` container via `docker/auth/keycloak-credentials.env`. Seeding
+is **create-only and idempotent**: it runs on every deploy but never clobbers a later UI edit, never
+resurrects a soft-deleted row, and never reactivates a disabled one. It is gated on the JWT auth method
+and on `KEYCLOAK_API_URL`/`KEYCLOAK_SERVICE_CLIENT_SECRET` being present, so a Devise install or an
+external-IdP customer (no `KEYCLOAK_*`) is a silent no-op. `KEYCLOAK_CONNECTOR_ID` (default `keycloak`)
+sets the row's `connector_id`. After the row exists, credential rotation is a UI/DB operation — ENV is
+not read again.
+
+### Browser URL vs Admin API URL
+
+`api_url` is where Rails calls the Admin API. Anything handed to a *browser* instead uses `browser_url`
+from the row, falling back to `api_url` when blank.
+
+The two only differ in the dev stack: Rails uses the compose network alias
+(`http://op-keycloak.dev.test:8080`), and the browser has to go through Traefik
+(`https://op-keycloak.dev.test`) because the SSO session cookies are `Secure` and belong to that
+origin. Pointing `api_url` at Traefik instead breaks the Admin API, since Traefik serves a
+per-developer self-signed `*.dev.test` cert that only the host keychain trusts
+(`bin/developer/certificates.sh`). Both are seeded from `docker/auth/keycloak-credentials.env`.
+
+`browser_url` is a per-realm column (seeded from `KEYCLOAK_PUBLIC_URL`) rather than a request-time ENV
+read, so multi-realm production can point each realm at its own origin.
+
+`account_client_id` (the row's column, seeded from `KEYCLOAK_ACCOUNT_CLIENT_ID`, default `account`)
+names the client account deep-links run under, which decides where Keycloak returns a user who
+confirmed a new address — see [Where Keycloak sends the user back](#where-keycloak-sends-the-user-back).
+
+### Manage-users capability
+
+`manage_users` records whether this row's service account actually has admin/manage-API access to the
+realm. `true` (the default) is an IdP we operate. `false` is **authenticate-only** — a
+customer-operated Keycloak, or a service account that can sign users in but lacks the `manage-users`
+role. An authenticate-only row still builds a normal `KeycloakService` (so OIDC logout and the
+self-service account console keep working) but answers `false` to every `supports_*?` management
+predicate, so the admin/self-service management surfaces degrade (actions hidden or no-op) instead of
+failing at an Admin API we can't call. A connector with no active row at all resolves to `NullService`,
+which behaves the same way.
 
 > Heads-up: `realm-import.json` is applied only on the **first** import into a fresh `keycloak`
 > database. If your volume predates the `rails-service-account` client (or its roles), the token
@@ -137,9 +154,7 @@ out of the box — no `.env.development.local` edits needed. This path only reso
 - **Linux:** the proxies use `extra_hosts: …:host-gateway`; needs a recent Docker Engine (it resolves
   out of the box on Docker Desktop).
 - **Credentials:** `docker/auth/keycloak-credentials.env` is committed because its values are
-  pre-defined in `realm-import.json` (chosen, not generated). Dev-only — never used in production. It
-  provides `KEYCLOAK_API_URL`, `KEYCLOAK_REALM`, and the `dex-connector` / `rails-service-account`
-  client IDs and secrets.
+  pre-defined in `realm-import.json` (chosen, not generated). Dev-only — never used in production.
 
 ## Related
 

--- a/spec/db/seed_maker_spec.rb
+++ b/spec/db/seed_maker_spec.rb
@@ -1,0 +1,68 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/seed_maker')
+
+RSpec.describe SeedMaker do
+  subject(:seed_maker) { described_class.new }
+
+  # The IdP config is materialized from ENV once, on deploy, through run_all. The full seeding
+  # behavior (idempotency, no-clobber, soft-delete handling) is tested against
+  # Idp::ServiceConfig.bootstrap_from_env; this proves the deploy path actually reaches it and
+  # creates the row, so dropping the step from run_all can't pass unnoticed.
+  describe '#run_all' do
+    let(:keycloak_env) do
+      {
+        'KEYCLOAK_API_URL' => 'http://seed.keycloak:8080',
+        'KEYCLOAK_REALM' => 'seed-realm',
+        'KEYCLOAK_SERVICE_CLIENT_ID' => 'seed-client',
+        'KEYCLOAK_SERVICE_CLIENT_SECRET' => 'seed-secret',
+        'KEYCLOAK_PUBLIC_URL' => 'https://seed.public.test',
+        'KEYCLOAK_ACCOUNT_CLIENT_ID' => 'seed-account',
+      }
+    end
+
+    # Stub only the KEYCLOAK_* keys we read; everything else passes through.
+    def stub_env(values)
+      allow(ENV).to receive(:[]).and_call_original
+      keycloak_env.each_key do |key|
+        allow(ENV).to receive(:[]).with(key).and_return(values[key])
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('KEYCLOAK_CONNECTOR_ID', 'keycloak').
+        and_return(values.fetch('KEYCLOAK_CONNECTOR_ID', 'keycloak'))
+    end
+
+    before do
+      allow(AuthMethod).to receive(:jwt?).and_return(true)
+      stub_env(keycloak_env)
+
+      # Neutralize the unrelated deploy steps: a full run_all loads HMIS data, shapefiles,
+      # translations, etc. — too heavy and brittle to run here. The IdP seed itself runs for real.
+      [
+        :ensure_db_triggers_and_functions, :setup_fake_health_data, :maintain_data_sources, :maintain_health_seeds, :setup_hmis_admin_access, :load_hmis_data, :install_shapes, :maintain_lookups, :maintain_system_groups, :populate_internal_system_choices
+      ].each { |step| allow(seed_maker).to receive(step) }
+
+      allow(GrdaWarehouse::WarehouseReports::ReportDefinition).to receive(:maintain_report_definitions)
+      allow(GrdaWarehouse::Help).to receive(:setup_default_links)
+      allow(GrdaWarehouse::SystemColor).to receive(:ensure_colors)
+      allow(Translation).to receive(:maintain_keys)
+      allow(GrdaWarehouse::Cohorts::CohortColumn).to receive(:maintain!)
+    end
+
+    it 'materializes the IdP service config from ENV' do
+      expect { seed_maker.run_all }.to change(Idp::ServiceConfig, :count).by(1)
+
+      expect(Idp::ServiceConfig.find_by(connector_id: 'keycloak')).to have_attributes(
+        provider: 'keycloak',
+        name: 'Keycloak (seeded from ENV)',
+      )
+    end
+  end
+end

--- a/spec/factories/idp_service_configs.rb
+++ b/spec/factories/idp_service_configs.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
     client_id { 'rails-service-account' }
     keycloak_realm { 'openpath' }
     active { true }
+
+    trait :authenticate_only do
+      manage_users { false }
+    end
   end
 end

--- a/spec/models/concerns/idp/support_spec.rb
+++ b/spec/models/concerns/idp/support_spec.rb
@@ -1,0 +1,224 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Model-layer coverage for the six Idp::Support write ops, driven directly on the User
+# mixin with no controller. The request specs reach these ops only through a controller
+# whose earlier gate is closed for the connector/config combinations exercised here, so
+# the paths with no in-method guard — reconcile on a null-attached user, the setup-email
+# path, and the authenticate-only split — are reachable only from this layer.
+#
+# Each context builds one connector/config combination and lets the real ServiceFactory
+# resolve it, so config→service resolution is exercised, not stubbed. Only the remote
+# Keycloak calls are stubbed, on the memoized service instance (Idp::Support#idp_service
+# caches, so the op reuses what we stub).
+RSpec.describe Idp::Support, type: :model, if: AuthMethod.jwt? do
+  let(:user) { create(:user) }
+  let(:connector_id) { 'test' }
+  let(:connector_user_id) { 'kc-user-1' }
+
+  def link_identity!(cuid: connector_user_id)
+    user.user_authentication_sources.create!(connector_id: connector_id, connector_user_id: cuid)
+    user.update_column(:last_connector_id, connector_id)
+  end
+
+  # reconcile_email! is deliberately excluded from this shared set: alone among the ops it has no
+  # capability gate, so it raises rather than no-ops and diverges per class (see each context).
+  shared_examples 'management ops no-op without raising' do
+    it 'idp_deactivate! returns :unmanaged' do
+      expect(user.idp_deactivate!).to eq(:unmanaged)
+    end
+
+    it 'idp_reactivate! returns :unmanaged' do
+      expect(user.idp_reactivate!).to eq(:unmanaged)
+    end
+
+    it 'idp_force_password_change! returns false' do
+      expect(user.idp_force_password_change!).to be false
+    end
+
+    it 'idp_send_account_setup_email! returns false' do
+      expect(user.idp_send_account_setup_email!).to be false
+    end
+
+    it 'idp_update_profile! returns false' do
+      expect(user.idp_update_profile!(first_name: 'New')).to be false
+    end
+  end
+
+  context 'null-detached (no connector on file)' do
+    it 'resolves to a NullService' do
+      expect(user.idp_service).to be_a(Idp::NullService)
+      expect(user.primary_idp).to be_blank
+    end
+
+    include_examples 'management ops no-op without raising'
+
+    it 'idp_reconcile_email! returns nil (no IdP to adopt from)' do
+      expect(user.idp_reconcile_email!).to be_nil
+    end
+  end
+
+  # null-attached — an auth-source row still names the connector (primary_idp present), but no
+  # active ServiceConfig exists, so the service is a NullService. The ops gate on primary_idp
+  # alone and would reach a raising NullService method if their own capability gate were dropped.
+  context 'null-attached (connector named, config absent)' do
+    before { link_identity! }
+
+    it 'has a present primary_idp but resolves to a NullService' do
+      expect(user.primary_idp).to eq(connector_id)
+      expect(user.idp_service).to be_a(Idp::NullService)
+    end
+
+    include_examples 'management ops no-op without raising'
+
+    # idp_send_account_setup_email! self-gates on supports_user_creation?, so it returns false
+    # rather than reaching the raising NullService#send_execute_actions_email. (Also asserted by
+    # the shared examples above; pinned separately here as the regression it guards.)
+    it 'idp_send_account_setup_email! stays inert instead of reaching the raising NullService method' do
+      expect(user.idp_service).not_to receive(:send_execute_actions_email)
+      expect(user.idp_send_account_setup_email!).to be false
+    end
+
+    # idp_reconcile_email! is the one surviving latent raise — it gates on primary_idp alone and
+    # reaches NullService#get_user, which raises. The controller can never reach this (the
+    # change-email tab gates off when supports_email_self_service? is false), so this model-layer
+    # assertion is the only place it is exercised. Pins that a caller must gate or rescue rather
+    # than call it blind on a null-attached user.
+    it 'idp_reconcile_email! raises Idp::ServiceError (the surviving latent caller-discipline case)' do
+      expect { user.idp_reconcile_email! }.to raise_error(Idp::ServiceError)
+    end
+  end
+
+  # Covered transitively by the request specs; carried here to complete the model-layer matrix and
+  # pin that each op dispatches through to its remote call with the connector_user_id on file.
+  context 'keycloak-on-file, manageable' do
+    let!(:config) { create(:idp_service_config, connector_id: connector_id, manage_users: true) }
+    let(:service) { user.idp_service }
+
+    before { link_identity! }
+
+    it 'resolves to a manageable KeycloakService' do
+      expect(service).to be_a(Idp::KeycloakService)
+      expect(service.supports_user_management?).to be true
+    end
+
+    it 'idp_deactivate! calls deactivate_user and returns :deactivated' do
+      allow(service).to receive(:deactivate_user).and_return(true)
+      expect(user.idp_deactivate!).to eq(:deactivated)
+      expect(service).to have_received(:deactivate_user).with(user_id: connector_user_id)
+    end
+
+    it 'idp_reactivate! calls reactivate_user and returns :reactivated' do
+      allow(service).to receive(:reactivate_user).and_return(true)
+      expect(user.idp_reactivate!).to eq(:reactivated)
+      expect(service).to have_received(:reactivate_user).with(user_id: connector_user_id)
+    end
+
+    it 'idp_force_password_change! requests the UPDATE_PASSWORD action' do
+      allow(service).to receive(:set_required_action).and_return(true)
+      expect(user.idp_force_password_change!).to be true
+      expect(service).to have_received(:set_required_action).with(user_id: connector_user_id, actions: ['UPDATE_PASSWORD'])
+    end
+
+    it 'idp_send_account_setup_email! sends the setup actions email' do
+      allow(service).to receive(:send_execute_actions_email).and_return(true)
+      expect(user.idp_send_account_setup_email!).to be true
+      expect(service).to have_received(:send_execute_actions_email).
+        with(user_id: connector_user_id, actions: ['UPDATE_PASSWORD', 'VERIFY_EMAIL'])
+    end
+
+    it 'idp_update_profile! pushes the edited attributes' do
+      allow(service).to receive(:update_user).and_return(true)
+      expect(user.idp_update_profile!(first_name: 'New')).to be true
+      expect(service).to have_received(:update_user).with(user_id: connector_user_id, attributes: { first_name: 'New' })
+    end
+
+    it 'idp_reconcile_email! leaves the address alone when the IdP matches' do
+      allow(service).to receive(:get_user).and_return('email' => user.email, 'emailVerified' => true)
+      expect(user.idp_reconcile_email!).to be_nil
+    end
+
+    it 'idp_reconcile_email! adopts a verified remote address and returns the previous one' do
+      previous = user.email
+      allow(service).to receive(:get_user).and_return('email' => 'adopted@example.com', 'emailVerified' => true)
+      expect(user.idp_reconcile_email!).to eq(previous)
+      expect(user.reload.email).to eq('adopted@example.com')
+    end
+  end
+
+  # keycloak-on-file, authenticate-only — active config, manage_users:false. Every management
+  # capability reports false so the management ops no-op, but email self-service and session
+  # logout stay live. The email-adopt half (reconcile_email!) has no capability gate, so it still
+  # reaches the admin-API get_user even on this class; the request specs cover that path.
+  context 'keycloak-on-file, authenticate-only (manage_users:false)' do
+    let!(:config) { create(:idp_service_config, connector_id: connector_id, manage_users: false) }
+    let(:service) { user.idp_service }
+
+    before { link_identity! }
+
+    it 'resolves to a KeycloakService with management disabled' do
+      expect(service).to be_a(Idp::KeycloakService)
+      expect(service.supports_user_management?).to be false
+    end
+
+    include_examples 'management ops no-op without raising'
+
+    it 'keeps email self-service and session logout live' do
+      expect(service.supports_email_self_service?).to be true
+      expect(service.supports_session_logout?).to be true
+    end
+
+    it 'idp_reconcile_email! is ungated by capability and still reaches the admin-API get_user' do
+      allow(service).to receive(:get_user).and_return('email' => user.email, 'emailVerified' => true)
+      user.idp_reconcile_email!
+      expect(service).to have_received(:get_user).with(user_id: connector_user_id)
+    end
+  end
+
+  # keycloak-half-linked — active manageable config, but no matching auth-source row, so there is
+  # no connector_user_id on file. The ops split: deactivate/reactivate reach idp_identity_on_file?
+  # first and return :identity_missing (keeping the local flag authoritative); the remaining ops
+  # reach idp_connector_user_id! and raise Idp::ServiceError before any remote call.
+  context 'keycloak-half-linked (config active, no identity row)' do
+    let!(:config) { create(:idp_service_config, connector_id: connector_id, manage_users: true) }
+
+    # primary_idp present via last_connector_id, but no user_authentication_sources row for it.
+    before { user.update_column(:last_connector_id, connector_id) }
+
+    it 'resolves to a manageable KeycloakService with no identity on file' do
+      expect(user.idp_service).to be_a(Idp::KeycloakService)
+      expect(user.primary_idp).to eq(connector_id)
+    end
+
+    it 'idp_deactivate! returns :identity_missing (local flag stays authoritative)' do
+      expect(user.idp_deactivate!).to eq(:identity_missing)
+    end
+
+    it 'idp_reactivate! returns :identity_missing (local flag stays authoritative)' do
+      expect(user.idp_reactivate!).to eq(:identity_missing)
+    end
+
+    it 'idp_force_password_change! raises Idp::ServiceError at idp_connector_user_id!' do
+      expect { user.idp_force_password_change! }.to raise_error(Idp::ServiceError)
+    end
+
+    it 'idp_send_account_setup_email! raises Idp::ServiceError at idp_connector_user_id!' do
+      expect { user.idp_send_account_setup_email! }.to raise_error(Idp::ServiceError)
+    end
+
+    it 'idp_reconcile_email! raises Idp::ServiceError at idp_connector_user_id!' do
+      expect { user.idp_reconcile_email! }.to raise_error(Idp::ServiceError)
+    end
+
+    it 'idp_update_profile! raises Idp::ServiceError at idp_connector_user_id!' do
+      expect { user.idp_update_profile!(first_name: 'New') }.to raise_error(Idp::ServiceError)
+    end
+  end
+end

--- a/spec/models/idp/service_config_spec.rb
+++ b/spec/models/idp/service_config_spec.rb
@@ -29,6 +29,30 @@ RSpec.describe Idp::ServiceConfig, type: :model, if: AuthMethod.jwt? do
       end
     end
 
+    describe 'keycloak build-key validation' do
+      it 'rejects an active keycloak config with a blank client_id' do
+        config = build(:idp_service_config, active: true, client_id: nil)
+        expect(config).not_to be_valid
+        expect(config.errors[:client_id]).to be_present
+      end
+
+      it 'rejects an active keycloak config with a blank keycloak_realm' do
+        config = build(:idp_service_config, active: true, keycloak_realm: nil)
+        expect(config).not_to be_valid
+        expect(config.errors[:keycloak_realm]).to be_present
+      end
+
+      it 'allows an inactive keycloak config with a blank client_id (draft parking)' do
+        config = build(:idp_service_config, active: false, client_id: nil)
+        expect(config).to be_valid
+      end
+
+      it 'allows an inactive keycloak config with a blank keycloak_realm (draft parking)' do
+        config = build(:idp_service_config, active: false, keycloak_realm: nil)
+        expect(config).to be_valid
+      end
+    end
+
     describe 'connector_id uniqueness' do
       let!(:existing) { create(:idp_service_config, connector_id: 'keycloak') }
 
@@ -108,6 +132,34 @@ RSpec.describe Idp::ServiceConfig, type: :model, if: AuthMethod.jwt? do
       expect(service.send(:realm)).to eq('test-realm')
     end
 
+    it 'defaults to a manageable service' do
+      config = create(:idp_service_config, connector_id: 'keycloak')
+
+      expect(config.manage_users).to be true
+      expect(config.to_service.supports_user_management?).to be true
+    end
+
+    it 'builds an authenticate-only service when manage_users is false' do
+      config = create(:idp_service_config, connector_id: 'keycloak', manage_users: false)
+
+      service = config.to_service
+      expect(service).to be_a(Idp::KeycloakService)
+      expect(service.supports_user_management?).to be false
+    end
+
+    it 'carries the per-realm browser fields into the service (DB, not ENV)' do
+      config = create(
+        :idp_service_config,
+        connector_id: 'keycloak',
+        browser_url: 'https://kc.public.test',
+        account_client_id: 'my-account',
+      )
+
+      service = config.to_service
+      expect(service.account_console_url).to eq('https://kc.public.test/realms/openpath/account')
+      expect(service.send(:account_client_id)).to eq('my-account')
+    end
+
     it 'raises ServiceError for an unregistered provider' do
       config = build(:idp_service_config, provider: 'unknown')
       expect { config.to_service }.to raise_error(Idp::ServiceError, /Unknown provider/)
@@ -148,6 +200,137 @@ RSpec.describe Idp::ServiceConfig, type: :model, if: AuthMethod.jwt? do
 
       expect(config.deleted_at).to be_nil
       expect(described_class.find(config.id)).to eq(config)
+    end
+  end
+
+  describe '.bootstrap_from_env' do
+    let(:keycloak_env) do
+      {
+        'KEYCLOAK_API_URL' => 'http://seed.keycloak:8080',
+        'KEYCLOAK_REALM' => 'seed-realm',
+        'KEYCLOAK_SERVICE_CLIENT_ID' => 'seed-client',
+        'KEYCLOAK_SERVICE_CLIENT_SECRET' => 'seed-secret',
+        'KEYCLOAK_PUBLIC_URL' => 'https://seed.public.test',
+        'KEYCLOAK_ACCOUNT_CLIENT_ID' => 'seed-account',
+      }
+    end
+
+    # Stub only the KEYCLOAK_* keys we read; everything else passes through.
+    def stub_env(values)
+      allow(ENV).to receive(:[]).and_call_original
+      keycloak_env.each_key do |key|
+        allow(ENV).to receive(:[]).with(key).and_return(values[key])
+      end
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('KEYCLOAK_CONNECTOR_ID', 'keycloak').
+        and_return(values.fetch('KEYCLOAK_CONNECTOR_ID', 'keycloak'))
+    end
+
+    context 'in JWT mode with core KEYCLOAK_* env present' do
+      before do
+        allow(AuthMethod).to receive(:jwt?).and_return(true)
+        stub_env(keycloak_env)
+      end
+
+      it 'creates one active Idp::ServiceConfig from ENV' do
+        expect { described_class.bootstrap_from_env }.to change(described_class, :count).by(1)
+
+        config = described_class.find_by(connector_id: 'keycloak')
+        expect(config).to have_attributes(
+          provider: 'keycloak',
+          connector_id: 'keycloak',
+          name: 'Keycloak (seeded from ENV)',
+          api_url: 'http://seed.keycloak:8080',
+          keycloak_realm: 'seed-realm',
+          client_id: 'seed-client',
+          browser_url: 'https://seed.public.test',
+          account_client_id: 'seed-account',
+          manage_users: true,
+          active: true,
+        )
+        expect(config.service_token).to eq('seed-secret')
+      end
+
+      it 'uses KEYCLOAK_CONNECTOR_ID as the connector_id when set' do
+        stub_env(keycloak_env.merge('KEYCLOAK_CONNECTOR_ID' => 'realm-a'))
+
+        described_class.bootstrap_from_env
+
+        expect(described_class.find_by(connector_id: 'realm-a')).to be_present
+      end
+    end
+
+    context 'when not in JWT mode' do
+      before do
+        allow(AuthMethod).to receive(:jwt?).and_return(false)
+        stub_env(keycloak_env)
+      end
+
+      it 'is a no-op' do
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+      end
+    end
+
+    context 'when core KEYCLOAK_* env is absent (external IdP)' do
+      before do
+        allow(AuthMethod).to receive(:jwt?).and_return(true)
+        stub_env({}) # every KEYCLOAK_* key nil
+      end
+
+      it 'is a silent no-op and does not raise' do
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+      end
+    end
+
+    context 'with a partial KEYCLOAK_* env (a core build key absent)' do
+      before do
+        allow(AuthMethod).to receive(:jwt?).and_return(true)
+      end
+
+      it 'is a silent no-op when KEYCLOAK_REALM is absent' do
+        stub_env(keycloak_env.merge('KEYCLOAK_REALM' => nil))
+
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+      end
+
+      it 'is a silent no-op when KEYCLOAK_SERVICE_CLIENT_ID is absent' do
+        stub_env(keycloak_env.merge('KEYCLOAK_SERVICE_CLIENT_ID' => nil))
+
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+      end
+    end
+
+    context 're-seeding (runs on every deploy)' do
+      before do
+        allow(AuthMethod).to receive(:jwt?).and_return(true)
+        stub_env(keycloak_env)
+      end
+
+      it 'does not create a second row or clobber a UI credential edit' do
+        described_class.bootstrap_from_env
+        existing = described_class.find_by(connector_id: 'keycloak')
+        existing.update!(api_url: 'http://ui-edited.keycloak:8080')
+
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+        expect(existing.reload.api_url).to eq('http://ui-edited.keycloak:8080')
+      end
+
+      it 'does not resurrect a soft-deleted row' do
+        described_class.bootstrap_from_env
+        described_class.find_by(connector_id: 'keycloak').destroy
+
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+        expect(described_class.find_by(connector_id: 'keycloak')).to be_nil
+        expect(described_class.with_deleted.find_by(connector_id: 'keycloak')).to be_present
+      end
+
+      it 'does not reactivate a deactivated (active: false) row' do
+        described_class.bootstrap_from_env
+        described_class.find_by(connector_id: 'keycloak').update!(active: false)
+
+        expect { described_class.bootstrap_from_env }.not_to change(described_class, :count)
+        expect(described_class.find_by(connector_id: 'keycloak').active).to be(false)
+      end
     end
   end
 end

--- a/spec/services/idp/keycloak_service_spec.rb
+++ b/spec/services/idp/keycloak_service_spec.rb
@@ -6,14 +6,13 @@
 
 # frozen_string_literal: true
 
-require 'webmock/rspec'
-
-RSpec.describe Idp::KeycloakService, type: :model do
+RSpec.describe Idp::KeycloakService do
   let(:api_url) { 'http://keycloak.test:8080' }
   let(:realm) { 'openpath' }
   let(:client_id) { 'rails-service-account' }
   let(:client_secret) { 'test-secret' }
   let(:token_url) { "#{api_url}/realms/#{realm}/protocol/openid-connect/token" }
+  let(:user_id) { 'keycloak-user-id' }
 
   let(:service) do
     described_class.new(
@@ -24,6 +23,38 @@ RSpec.describe Idp::KeycloakService, type: :model do
         client_secret: client_secret,
       },
     )
+  end
+
+  def admin_url(path = '')
+    "#{api_url}/admin/realms/#{realm}#{path}"
+  end
+
+  def user_url(id = user_id)
+    admin_url("/users/#{id}")
+  end
+
+  def actions_url(id = user_id)
+    "#{user_url(id)}/execute-actions-email"
+  end
+
+  # Any request to the connector, for the "it never went out" assertions.
+  def any_api_request
+    /#{Regexp.escape(api_url)}/
+  end
+
+  # The read-modify-write shape every profile write shares: fetch the representation, PUT it back.
+  def stub_read_modify_write(representation:, put_status: 204, put_body: nil)
+    stub_request(:get, user_url).to_return(status: 200, body: representation.to_json)
+    stub_request(:put, user_url).to_return(status: put_status, body: put_body)
+  end
+
+  # Both keys feed fallback chains (#browser_url, #account_client_id) that several examples below
+  # read through, so the unconfigured defaults they assert are only meaningful with the keys
+  # provably absent. KEYCLOAK_PUBLIC_URL in particular is documented for dev, where a developer who
+  # sets it would otherwise turn those examples red over nothing. Contexts that want a value
+  # re-stub ENV themselves.
+  before do
+    stub_const('ENV', ENV.to_h.except('KEYCLOAK_PUBLIC_URL', 'KEYCLOAK_ACCOUNT_CLIENT_ID'))
   end
 
   before do
@@ -43,36 +74,33 @@ RSpec.describe Idp::KeycloakService, type: :model do
 
   describe '#create_user' do
     let(:user_email) { 'test@example.com' }
+    let(:create_url) { admin_url('/users') }
+
+    def create_user(**overrides)
+      service.create_user(**{ email: user_email, first_name: 'John', last_name: 'Doe' }.merge(overrides))
+    end
 
     context 'with valid user data' do
       before do
-        stub_request(:post, "#{api_url}/admin/realms/#{realm}/users").
+        stub_request(:post, create_url).
           to_return(
             status: 201,
-            headers: { 'Location' => "#{api_url}/admin/realms/#{realm}/users/new-user-id" },
+            headers: { 'Location' => "#{create_url}/new-user-id" },
           )
       end
 
       it 'creates user and returns success with user ID' do
-        result = service.create_user(
-          email: user_email,
-          first_name: 'John',
-          last_name: 'Doe',
-        )
+        result = create_user
 
         expect(result[:success]).to be true
         expect(result[:connector_user_id]).to eq('new-user-id')
       end
 
       it 'sends the Keycloak user payload with the expected field mapping' do
-        service.create_user(
-          email: user_email,
-          first_name: 'John',
-          last_name: 'Doe',
-        )
+        create_user
 
         expect(
-          a_request(:post, "#{api_url}/admin/realms/#{realm}/users").
+          a_request(:post, create_url).
             with(
               headers: { 'Authorization' => 'Bearer test-token' },
               body: {
@@ -89,62 +117,68 @@ RSpec.describe Idp::KeycloakService, type: :model do
     end
 
     context 'with a 201 response missing the Location header' do
-      before do
-        stub_request(:post, "#{api_url}/admin/realms/#{realm}/users").
-          to_return(status: 201)
-      end
+      before { stub_request(:post, create_url).to_return(status: 201) }
 
       it 'returns success with a nil connector_user_id rather than raising' do
-        result = service.create_user(
-          email: user_email,
-          first_name: 'John',
-          last_name: 'Doe',
-        )
+        result = create_user
 
         expect(result[:success]).to be true
         expect(result[:connector_user_id]).to be_nil
       end
     end
 
-    context 'with API error response' do
+    # ConflictError, not the plain ServiceError it descends from: the admin controller
+    # rescues the two separately, putting a conflict on the email field and paging on
+    # anything else. Asserting the parent class here would pass either way.
+    context 'when the address already belongs to an account in the realm' do
       before do
-        stub_request(:post, "#{api_url}/admin/realms/#{realm}/users").
-          to_return(
-            status: 409,
-            body: { errorMessage: 'User exists with same username' }.to_json,
-          )
+        stub_request(:post, create_url).
+          to_return(status: 409, body: { errorMessage: 'User exists with same username' }.to_json)
       end
 
-      it 'raises ServiceError' do
-        expect do
-          service.create_user(
-            email: user_email,
-            first_name: 'John',
-            last_name: 'Doe',
-          )
-        end.to raise_error(Idp::ServiceError, /Failed to create user: User exists with same username/)
+      # Non-transient as well as ConflictError: the address stays taken until somebody changes it
+      # over there, and Idp::SyncUserFromIdpJob re-raises transient faults to retry them, so a
+      # retryable conflict would page repeatedly over an answer no retry can change.
+      it 'raises a non-transient ConflictError' do
+        expect { create_user }.
+          to raise_error(Idp::ConflictError, /Failed to create user: User exists with same username/) { |error|
+            expect(error).not_to be_transient
+          }
+      end
+    end
+
+    context 'with a non-conflict API error' do
+      before do
+        stub_request(:post, create_url).
+          to_return(status: 400, body: { errorMessage: 'Invalid email' }.to_json)
+      end
+
+      # The other half of the distinction: a broken write must not arrive as a form problem.
+      it 'raises a bare ServiceError rather than ConflictError' do
+        expect { create_user }.to raise_error(Idp::ServiceError, /Failed to create user: Invalid email/) { |error|
+          expect(error).not_to be_a(Idp::ConflictError)
+        }
       end
     end
   end
 
   describe '#find_user_by_email' do
     let(:email) { 'jane@example.com' }
-    let(:search_url) { "#{api_url}/admin/realms/#{realm}/users" }
+
+    def stub_search(users)
+      stub_request(:get, admin_url('/users')).
+        with(query: { email: email, exact: 'true' }).
+        to_return(status: 200, body: users.to_json)
+    end
 
     it 'queries by exact email and returns the matching representation' do
-      stub_request(:get, search_url).
-        with(query: { email: email, exact: 'true' }).
-        to_return(status: 200, body: [{ id: 'kc-1', email: email }].to_json)
+      stub_search([{ id: 'kc-1', email: email }])
 
-      result = service.find_user_by_email(email: email)
-
-      expect(result['id']).to eq('kc-1')
+      expect(service.find_user_by_email(email: email)['id']).to eq('kc-1')
     end
 
     it 'returns nil when no user matches' do
-      stub_request(:get, search_url).
-        with(query: { email: email, exact: 'true' }).
-        to_return(status: 200, body: [].to_json)
+      stub_search([])
 
       expect(service.find_user_by_email(email: email)).to be_nil
     end
@@ -152,7 +186,6 @@ RSpec.describe Idp::KeycloakService, type: :model do
 
   describe '#send_execute_actions_email' do
     let(:user_id) { 'kc-user-id' }
-    let(:actions_url) { "#{api_url}/admin/realms/#{realm}/users/#{user_id}/execute-actions-email" }
 
     it 'PUTs the required actions and returns true on 204' do
       stub_request(:put, actions_url).to_return(status: 204)
@@ -175,68 +208,49 @@ RSpec.describe Idp::KeycloakService, type: :model do
   end
 
   describe '#update_user' do
-    let(:user_id) { 'keycloak-user-id' }
     let(:current_representation) do
       { id: user_id, username: 'jane', firstName: 'Old', lastName: 'Name', email: 'old@example.com' }
     end
 
     context 'with successful update' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 204)
-      end
+      before { stub_read_modify_write(representation: current_representation) }
 
       it 'returns true and sends the full representation with the mapped attribute merged in' do
-        result = service.update_user(
-          user_id: user_id,
-          attributes: { first_name: 'Jane' },
-        )
+        result = service.update_user(user_id: user_id, attributes: { first_name: 'Jane' })
 
         expect(result).to be true
         expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: current_representation.merge(firstName: 'Jane')),
+          a_request(:put, user_url).with(body: current_representation.merge(firstName: 'Jane')),
         ).to have_been_made
       end
 
-      it 'sets emailVerified to false and syncs username when the email changes, without clearing other fields' do
-        actions_url = "#{api_url}/admin/realms/#{realm}/users/#{user_id}/execute-actions-email"
+      it 'unverifies the address, leaves username for Keycloak to derive, and sends the verification email' do
         stub_request(:put, actions_url).to_return(status: 204)
 
-        service.update_user(
-          user_id: user_id,
-          attributes: { email: 'new@example.com' },
-        )
+        service.update_user(user_id: user_id, attributes: { email: 'new@example.com' })
 
         expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: current_representation.merge(email: 'new@example.com', username: 'new@example.com', emailVerified: false)),
+          a_request(:put, user_url).
+            with(body: current_representation.merge(email: 'new@example.com', emailVerified: false)),
         ).to have_been_made
+        expect(a_request(:put, actions_url).with(body: ['VERIFY_EMAIL'].to_json)).to have_been_made
       end
 
-      it 'sends a verification email when the email changes' do
-        actions_url = "#{api_url}/admin/realms/#{realm}/users/#{user_id}/execute-actions-email"
-        stub_request(:put, actions_url).to_return(status: 204)
+      it 'does not send a verification email when email is unchanged' do
+        service.update_user(user_id: user_id, attributes: { first_name: 'Jane' })
 
-        service.update_user(
-          user_id: user_id,
-          attributes: { email: 'new@example.com' },
-        )
+        expect(WebMock).not_to have_requested(:put, actions_url)
+      end
+
+      # A blank value is a change the caller already committed locally, not an absent one. Returning
+      # true without a request would commit their transaction against a Keycloak still holding the
+      # old name — so both blank forms have to reach the wire rather than be read as "nothing asked".
+      it 'sends a blank or nil value through as a clear' do
+        service.update_user(user_id: user_id, attributes: { first_name: '', last_name: nil })
 
         expect(
-          a_request(:put, actions_url).with(body: ['VERIFY_EMAIL'].to_json),
+          a_request(:put, user_url).with(body: current_representation.merge(firstName: '', lastName: nil)),
         ).to have_been_made
-      end
-
-      it 'does not send a verification email or touch username when email is unchanged' do
-        service.update_user(
-          user_id: user_id,
-          attributes: { first_name: 'Jane' },
-        )
-
-        expect(WebMock).not_to have_requested(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}/execute-actions-email")
       end
 
       it 'carries fields the patch never references (custom attributes, requiredActions) through the merge' do
@@ -244,14 +258,12 @@ RSpec.describe Idp::KeycloakService, type: :model do
           attributes: { department: ['Housing'] },
           requiredActions: ['CONFIGURE_TOTP'],
         )
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: full_representation.to_json)
+        stub_request(:get, user_url).to_return(status: 200, body: full_representation.to_json)
 
         service.update_user(user_id: user_id, attributes: { first_name: 'Jane' })
 
         expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: full_representation.merge(firstName: 'Jane')),
+          a_request(:put, user_url).with(body: full_representation.merge(firstName: 'Jane')),
         ).to have_been_made
       end
     end
@@ -259,327 +271,306 @@ RSpec.describe Idp::KeycloakService, type: :model do
     context 'with unknown attributes' do
       it 'raises ArgumentError' do
         expect do
-          service.update_user(
-            user_id: user_id,
-            attributes: { first_name: 'Jane', phone: '555-1234' },
-          )
+          service.update_user(user_id: user_id, attributes: { first_name: 'Jane', phone: '555-1234' })
         end.to raise_error(ArgumentError, /phone/)
       end
     end
 
+    # The only route to the empty-patch guard now that a blank value counts as a change.
     context 'with empty attributes' do
       it 'returns true without making a request' do
         result = service.update_user(user_id: user_id, attributes: {})
 
         expect(result).to be true
-        expect(WebMock).not_to have_requested(:get, /#{Regexp.escape(api_url)}/)
-        expect(WebMock).not_to have_requested(:put, /#{Regexp.escape(api_url)}/)
+        expect(WebMock).not_to have_requested(:get, any_api_request)
+        expect(WebMock).not_to have_requested(:put, any_api_request)
       end
     end
 
-    context 'with API error' do
+    # The refused-PUT path is in 'a refused write' below; 'does not swallow a failure from the
+    # profile write itself' covers it again with the mail leg in play.
+
+    # The controller's other ConflictError path: the address belongs to another account in
+    # the realm rather than the connector being broken.
+    context 'when the new address is already registered to another account' do
       before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(
-            status: 400,
-            body: { errorMessage: 'Invalid attribute' }.to_json,
-          )
+        stub_read_modify_write(
+          representation: current_representation,
+          put_status: 409,
+          put_body: { errorMessage: 'User exists with same email' }.to_json,
+        )
       end
 
-      it 'raises ServiceError' do
+      it 'raises ConflictError' do
         expect do
-          service.update_user(
-            user_id: user_id,
-            attributes: { first_name: 'Jane' },
-          )
-        end.to raise_error(Idp::ServiceError, /Failed to update user: Invalid attribute/)
+          service.update_user(user_id: user_id, attributes: { email: 'taken@example.com' })
+        end.to raise_error(Idp::ConflictError, /Failed to update user: User exists with same email/)
+      end
+
+      it 'does not send a verification email for a write that never landed' do
+        stub_request(:put, actions_url).to_return(status: 204)
+
+        expect do
+          service.update_user(user_id: user_id, attributes: { email: 'taken@example.com' })
+        end.to raise_error(Idp::ConflictError)
+
+        expect(WebMock).not_to have_requested(:put, actions_url)
+      end
+    end
+
+    # Keycloak holds the new address before the mail goes out, so a delivery failure must not
+    # propagate: the caller would unwind its local write and diverge in the direction no retry
+    # can close.
+    context 'when the verification email cannot be delivered' do
+      before do
+        stub_read_modify_write(representation: current_representation)
+        stub_request(:put, actions_url).
+          to_return(status: 500, body: { errorMessage: 'Failed to send email' }.to_json)
+        allow(Sentry).to receive(:capture_exception_with_info)
+      end
+
+      it 'still reports the update as successful' do
+        expect(service.update_user(user_id: user_id, attributes: { email: 'new@example.com' })).to be true
+      end
+
+      # The profile write itself landing is asserted by the successful-update example above; the mail
+      # leg failing doesn't unwind it, which is what 'still reports the update as successful' shows.
+
+      # Swallowed, not dropped: nobody sees the failure unless it is reported.
+      it 'reports the swallowed delivery failure' do
+        service.update_user(user_id: user_id, attributes: { email: 'new@example.com' })
+
+        expect(Sentry).to have_received(:capture_exception_with_info).
+          with(instance_of(Idp::ServiceError), /couldn't send the address verification email/)
+      end
+
+      # Only the mail leg is forgiven. A failed write still has to reach the caller.
+      it 'does not swallow a failure from the profile write itself' do
+        stub_request(:put, user_url).
+          to_return(status: 400, body: { errorMessage: 'Invalid attribute' }.to_json)
+
+        expect do
+          service.update_user(user_id: user_id, attributes: { email: 'new@example.com' })
+        end.to raise_error(Idp::ServiceError, /Failed to update user/)
       end
     end
 
     context 'when the user cannot be fetched first' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 404)
-      end
+      before { stub_request(:get, user_url).to_return(status: 404) }
 
       it 'raises ServiceError from the GET instead of PUTting a partial body' do
         expect do
           service.update_user(user_id: user_id, attributes: { first_name: 'Jane' })
         end.to raise_error(Idp::ServiceError, /User not found/)
-        expect(WebMock).not_to have_requested(:put, /#{Regexp.escape(api_url)}/)
+        expect(WebMock).not_to have_requested(:put, any_api_request)
       end
     end
   end
 
   describe '#get_user' do
-    let(:user_id) { 'keycloak-user-id' }
+    it 'returns the parsed representation' do
+      stub_request(:get, user_url).
+        to_return(status: 200, body: { id: user_id, username: 'test@example.com' }.to_json)
 
-    context 'with successful response' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(
-            status: 200,
-            body: { id: user_id, username: 'test@example.com' }.to_json,
-          )
-      end
-
-      it 'returns user data' do
-        result = service.get_user(user_id: user_id)
-
-        expect(result).to include('id' => user_id)
-      end
+      expect(service.get_user(user_id: user_id)).to eq('id' => user_id, 'username' => 'test@example.com')
     end
 
-    context 'when user not found' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 404)
-      end
+    it 'raises a non-transient ServiceError when the user is not found' do
+      stub_request(:get, user_url).to_return(status: 404)
 
-      it 'raises ServiceError' do
-        expect do
-          service.get_user(user_id: user_id)
-        end.to raise_error(Idp::ServiceError, /User not found: #{user_id}/)
-      end
+      expect { service.get_user(user_id: user_id) }.
+        to raise_error(Idp::ServiceError, /User not found: #{user_id}/) { |error|
+          # The account is gone over there, so Idp::SyncUserFromIdpJob has to stop rather than retry
+          # this user to its cooldown on a 404 that will never change.
+          expect(error).not_to be_transient
+        }
+    end
+  end
+
+  # Keycloak parks the unconfirmed address in an internal user attribute
+  describe '#pending_email' do
+    # `extra` merges at the top level of the representation, so callers pass `attributes: {...}` to
+    # nest one — the empty case means "a representation with no attributes key at all".
+    def stub_representation(extra)
+      stub_request(:get, user_url).
+        to_return(status: 200, body: { id: user_id, email: 'before@example.com' }.merge(extra).to_json)
+    end
+
+    it 'returns the address awaiting confirmation' do
+      stub_representation(attributes: { 'kc.email.pending' => ['after@example.com'] })
+
+      expect(service.pending_email(user_id: user_id)).to eq('after@example.com')
+    end
+
+    it 'returns nil when no change is in flight' do
+      stub_representation(attributes: { 'someOther' => ['x'] })
+
+      expect(service.pending_email(user_id: user_id)).to be_nil
+    end
+
+    it 'returns nil for a user with no attributes at all' do
+      stub_representation({})
+
+      expect(service.pending_email(user_id: user_id)).to be_nil
     end
   end
 
   describe '#reactivate_user' do
-    let(:user_id) { 'keycloak-user-id' }
     let(:current_representation) { { id: user_id, username: 'test@example.com', firstName: 'Jane' } }
 
-    context 'with successful reactivation' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 204)
-      end
+    before { stub_read_modify_write(representation: current_representation) }
 
-      it 'returns true and enables the user without clearing other fields' do
-        result = service.reactivate_user(user_id: user_id)
+    it 'returns true and enables the user without clearing other fields' do
+      result = service.reactivate_user(user_id: user_id)
 
-        expect(result).to be true
-        expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: current_representation.merge(enabled: true)),
-        ).to have_been_made
-      end
-    end
-
-    context 'with API error' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(
-            status: 404,
-            body: { error: 'User not found' }.to_json,
-          )
-      end
-
-      it 'raises ServiceError' do
-        expect do
-          service.reactivate_user(user_id: user_id)
-        end.to raise_error(Idp::ServiceError, /Failed to reactivate user: User not found/)
-      end
+      expect(result).to be true
+      expect(
+        a_request(:put, user_url).with(body: current_representation.merge(enabled: true)),
+      ).to have_been_made
     end
   end
 
   describe '#deactivate_user' do
-    let(:user_id) { 'keycloak-user-id' }
     let(:current_representation) { { id: user_id, username: 'test@example.com', firstName: 'Jane' } }
 
-    context 'with successful deactivation' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 204)
-      end
+    before { stub_read_modify_write(representation: current_representation) }
 
-      it 'returns true and disables the user without clearing other fields' do
-        result = service.deactivate_user(user_id: user_id)
+    it 'returns true and disables the user without clearing other fields' do
+      result = service.deactivate_user(user_id: user_id)
 
-        expect(result).to be true
-        expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: current_representation.merge(enabled: false)),
-        ).to have_been_made
-      end
-    end
-
-    context 'with API error' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(
-            status: 404,
-            body: { error: 'User not found' }.to_json,
-          )
-      end
-
-      it 'raises ServiceError' do
-        expect do
-          service.deactivate_user(user_id: user_id)
-        end.to raise_error(Idp::ServiceError, /Failed to deactivate user: User not found/)
-      end
+      expect(result).to be true
+      expect(
+        a_request(:put, user_url).with(body: current_representation.merge(enabled: false)),
+      ).to have_been_made
     end
   end
 
   describe '#set_required_action' do
-    let(:user_id) { 'keycloak-user-id' }
     let(:current_representation) { { id: user_id, username: 'test@example.com', firstName: 'Jane' } }
 
-    context 'with a successful update' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 204)
-      end
+    before { stub_read_modify_write(representation: current_representation) }
 
-      it 'returns true and sets the required actions without clearing other fields' do
-        result = service.set_required_action(user_id: user_id, actions: ['UPDATE_PASSWORD'])
+    it 'returns true and sets the required actions without clearing other fields' do
+      result = service.set_required_action(user_id: user_id, actions: ['UPDATE_PASSWORD'])
 
-        expect(result).to be true
-        expect(
-          a_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-            with(body: current_representation.merge(requiredActions: ['UPDATE_PASSWORD'])),
-        ).to have_been_made
-      end
+      expect(result).to be true
+      expect(
+        a_request(:put, user_url).with(body: current_representation.merge(requiredActions: ['UPDATE_PASSWORD'])),
+      ).to have_been_made
+    end
+  end
+
+  # Every one of these reads the representation back, merges its change in and PUTs the whole thing,
+  # so a refused PUT is one code path. What each has to get right on its own is the failure message —
+  # a caller looking at Sentry needs to know which call it was — and the merged body, which the
+  # per-method success examples above assert.
+  describe 'a refused write' do
+    before do
+      stub_read_modify_write(
+        representation: { id: user_id, username: 'test@example.com' },
+        put_status: 404,
+        put_body: { error: 'User not found' }.to_json,
+      )
     end
 
-    context 'with API error' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(status: 200, body: current_representation.to_json)
-        stub_request(:put, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-          to_return(
-            status: 404,
-            body: { error: 'User not found' }.to_json,
-          )
-      end
-
-      it 'raises ServiceError' do
-        expect do
-          service.set_required_action(user_id: user_id, actions: ['UPDATE_PASSWORD'])
-        end.to raise_error(Idp::ServiceError, /Failed to set required actions: User not found/)
+    {
+      'reactivate_user' => [->(s, id) { s.reactivate_user(user_id: id) }, /Failed to reactivate user: User not found/],
+      'deactivate_user' => [->(s, id) { s.deactivate_user(user_id: id) }, /Failed to deactivate user: User not found/],
+      'set_required_action' => [
+        ->(s, id) { s.set_required_action(user_id: id, actions: ['UPDATE_PASSWORD']) },
+        /Failed to set required actions: User not found/,
+      ],
+      'update_user' => [
+        ->(s, id) { s.update_user(user_id: id, attributes: { first_name: 'Jane' }) },
+        /Failed to update user: User not found/,
+      ],
+    }.each do |name, (call, message)|
+      it "raises a non-transient ServiceError naming #{name}" do
+        expect { call.call(service, user_id) }.to raise_error(Idp::ServiceError, message) { |error|
+          # 4xx: Keycloak answered, and it keeps giving the same answer until somebody changes
+          # something there or in our config. Retrying it just burns the job's attempts.
+          expect(error).not_to be_transient
+        }
       end
     end
   end
 
+  # What a struggling Keycloak actually returns, and it takes handle_response's fall-through branch
+  # rather than either 4xx arm. Two things that branch owes the caller, asserted together: the failure
+  # verb (Sentry groups on the operation, but a human reads the message) and the classification, which
+  # points the other way from 4xx because a server having a bad minute is worth coming back to.
+  describe 'a 5xx from the Admin API' do
+    before do
+      stub_read_modify_write(
+        representation: { id: user_id, username: 'test@example.com' },
+        put_status: 502,
+        # Not JSON, because a gateway in front of Keycloak answers with its own page and this branch
+        # reports the status rather than trying to read a message out of the body.
+        put_body: '<html>502 Bad Gateway</html>',
+      )
+    end
+
+    it 'raises a transient ServiceError naming both the call and the status' do
+      expect { service.deactivate_user(user_id: user_id) }.
+        to raise_error(Idp::ServiceError, /Failed to deactivate user: unexpected response from Keycloak \(502\)/) { |error|
+          expect(error).to be_transient
+        }
+    end
+  end
+
+  # A diagnostic an operator reads on the connector config screen, so every failure has to name
+  # something they can act on rather than a status code. It never raises — the return value is the
+  # whole contract.
   describe '#test_connection' do
-    context 'with successful connection' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_return(
-            status: 200,
-            body: { realm: realm }.to_json,
-          )
-      end
+    let(:probe_url) { admin_url('/users?max=1') }
 
-      it 'returns success result' do
-        result = service.test_connection
+    it 'reports success when the Admin API answers' do
+      stub_request(:get, probe_url).to_return(status: 200, body: { realm: realm }.to_json)
 
-        expect(result[:success]).to be true
-        expect(result[:message]).to include('Connection successful')
-      end
+      result = service.test_connection
+
+      expect(result[:success]).to be true
+      expect(result[:message]).to include('Connection successful')
     end
 
-    context 'with authentication failure' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_return(status: 401)
-      end
+    {
+      'the credentials are refused' => [{ status: 401 }, 'Authentication failed'],
+      'the endpoint is not there' => [{ status: 404 }, 'API endpoint not found'],
+      'Keycloak itself errors' => [{ status: 500 }, 'Keycloak server error: 500'],
+      'the connection is refused' => [Errno::ECONNREFUSED, 'Connection refused'],
+      'the host is unreachable' => [Errno::EHOSTUNREACH, 'Host unreachable'],
+      'the connection times out' => [:timeout, 'timeout'],
+    }.each do |scenario, (outcome, message)|
+      it "reports failure naming the cause when #{scenario}" do
+        stub = stub_request(:get, probe_url)
+        case outcome
+        when :timeout then stub.to_timeout
+        when Hash then stub.to_return(**outcome)
+        else stub.to_raise(outcome)
+        end
 
-      it 'returns failure with auth message' do
         result = service.test_connection
 
         expect(result[:success]).to be false
-        expect(result[:message]).to include('Authentication failed')
-      end
-    end
-
-    context 'with endpoint not found' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_return(status: 404)
-      end
-
-      it 'returns failure with an endpoint-not-found message' do
-        result = service.test_connection
-
-        expect(result[:success]).to be false
-        expect(result[:message]).to include('API endpoint not found')
-      end
-    end
-
-    context 'with a Keycloak server error' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_return(status: 500)
-      end
-
-      it 'returns failure with the server error message' do
-        result = service.test_connection
-
-        expect(result[:success]).to be false
-        expect(result[:message]).to include('Keycloak server error: 500')
-      end
-    end
-
-    context 'with connection refused' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_raise(Errno::ECONNREFUSED)
-      end
-
-      it 'returns failure with connection message' do
-        result = service.test_connection
-
-        expect(result[:success]).to be false
-        expect(result[:message]).to include('Connection refused')
-      end
-    end
-
-    context 'with host unreachable' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_raise(Errno::EHOSTUNREACH)
-      end
-
-      it 'returns failure with a host-unreachable message' do
-        result = service.test_connection
-
-        expect(result[:success]).to be false
-        expect(result[:message]).to include('Host unreachable')
-      end
-    end
-
-    context 'with timeout' do
-      before do
-        stub_request(:get, "#{api_url}/admin/realms/#{realm}/users?max=1").
-          to_timeout
-      end
-
-      it 'returns failure with timeout message' do
-        result = service.test_connection
-
-        expect(result[:success]).to be false
-        expect(result[:message]).to include('timeout')
+        expect(result[:message]).to include(message)
       end
     end
   end
 
   describe 'token retry on 401' do
-    let(:user_id) { 'keycloak-user-id' }
+    # Two distinct tokens, so "fresh" is read off the wire rather than inferred from the number of
+    # token round trips: a retry that refetched and then sent the stale bearer again looks identical
+    # from the count alone, and would 401 forever.
+    def stub_token_sequence
+      issued = ['token-1', 'token-2'].map do |token|
+        { status: 200, body: { access_token: token, expires_in: 300 }.to_json, headers: { 'Content-Type' => 'application/json' } }
+      end
+      stub_request(:post, token_url).to_return(*issued)
+    end
 
-    it 'retries once with a fresh token when API returns 401' do
-      stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
+    it 'retries once, carrying the newly issued token' do
+      stub_token_sequence
+      stub_request(:get, user_url).
         to_return(
           { status: 401, body: { error: 'invalid_token' }.to_json },
           { status: 200, body: { id: user_id, username: 'test@example.com' }.to_json },
@@ -588,25 +579,88 @@ RSpec.describe Idp::KeycloakService, type: :model do
       result = service.get_user(user_id: user_id)
 
       expect(result).to include('id' => user_id)
-      expect(a_request(:post, token_url)).to have_been_made.times(2)
+      expect(a_request(:get, user_url).with(headers: { 'Authorization' => 'Bearer token-1' })).to have_been_made.once
+      expect(a_request(:get, user_url).with(headers: { 'Authorization' => 'Bearer token-2' })).to have_been_made.once
     end
 
-    it 'does not retry more than once' do
-      stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
-        to_return(status: 401, body: { error: 'invalid_token' }.to_json)
+    it 'gives up after the one retry rather than looping on a token the realm keeps refusing' do
+      stub_token_sequence
+      stub_request(:get, user_url).to_return(status: 401, body: { error: 'invalid_token' }.to_json)
 
-      expect do
-        service.get_user(user_id: user_id)
-      end.to raise_error(Idp::ServiceError, /Failed to get user/)
+      expect { service.get_user(user_id: user_id) }.to raise_error(Idp::ServiceError, /Failed to get user/)
+      expect(a_request(:get, user_url)).to have_been_made.times(2)
       expect(a_request(:post, token_url)).to have_been_made.times(2)
     end
   end
 
-  describe 'token caching' do
-    let(:user_id) { 'keycloak-user-id' }
+  # Every call goes out behind this exchange, and the token stub these examples inherit matches
+  # any body, so nothing else here would notice the credentials going out wrong.
+  describe 'the client-credentials token exchange' do
+    it 'posts the service account credentials to the realm token endpoint' do
+      stub_request(:get, user_url).to_return(status: 200, body: { id: user_id }.to_json)
 
+      service.get_user(user_id: user_id)
+
+      expect(
+        a_request(:post, token_url).
+          with(
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+            body: {
+              grant_type: 'client_credentials',
+              client_id: client_id,
+              client_secret: client_secret,
+            },
+          ),
+      ).to have_been_made
+    end
+
+    it 'sends the token it was issued, not a blank bearer' do
+      stub_request(:post, token_url).
+        to_return(
+          status: 200,
+          body: { access_token: 'issued-token', expires_in: 300 }.to_json,
+          headers: { 'Content-Type' => 'application/json' },
+        )
+      stub_request(:get, user_url).to_return(status: 200, body: { id: user_id }.to_json)
+
+      service.get_user(user_id: user_id)
+
+      expect(
+        a_request(:get, user_url).with(headers: { 'Authorization' => 'Bearer issued-token' }),
+      ).to have_been_made
+    end
+
+    context 'when the token endpoint rejects the credentials' do
+      before do
+        stub_request(:post, token_url).
+          to_return(status: 401, body: { error: 'invalid_client' }.to_json)
+      end
+
+      it 'raises rather than calling the Admin API unauthenticated' do
+        expect { service.get_user(user_id: user_id) }.
+          to raise_error(Idp::ServiceError, /Failed to obtain access token: 401/)
+
+        expect(WebMock).not_to have_requested(:get, /#{Regexp.escape(admin_url)}/)
+      end
+
+      it 'tags the failure with the operation that produced it, and rules out a retry' do
+        error = begin
+          service.get_user(user_id: user_id)
+        rescue Idp::ServiceError => e
+          e
+        end
+
+        expect(error.operation).to eq(:access_token)
+        expect(error.idp_name).to eq('Keycloak')
+        # Refused credentials are an ops fix; retrying them just multiplies the pages.
+        expect(error).not_to be_transient
+      end
+    end
+  end
+
+  describe 'token caching' do
     before do
-      stub_request(:get, "#{api_url}/admin/realms/#{realm}/users/#{user_id}").
+      stub_request(:get, user_url).
         to_return(status: 200, body: { id: user_id, username: 'test@example.com' }.to_json)
     end
 
@@ -628,146 +682,229 @@ RSpec.describe Idp::KeycloakService, type: :model do
     end
   end
 
-  describe '#idp_name' do
-    it 'returns Keycloak' do
+  # Asserted, not probed (see the comment on #supports_email_self_service?), so these are literals in
+  # the source: one example covering all of them is as much as they can be worth, and what it catches
+  # is an override going missing and the base class's false showing through. There is no companion
+  # "without touching the realm" example because a method that returns a literal cannot make a
+  # request — the source comment is where the probe decision lives. #supports_session_logout? is the
+  # only one that reads config, and it sits with #logout_user_sessions. The false side of every
+  # predicate belongs to Idp::NullService's spec.
+  describe 'the capability surface' do
+    it 'advertises everything the Admin API can do, and names itself for operators' do
       expect(service.idp_name).to eq('Keycloak')
-    end
-  end
-
-  describe '#supports_user_management?' do
-    it 'returns true when fully configured' do
       expect(service.supports_user_management?).to be true
-    end
-  end
-
-  describe '#supports_account_backfill?' do
-    it 'returns true (the backfill runs against Keycloak)' do
+      expect(service.supports_profile_updates?).to be true
+      expect(service.supports_user_creation?).to be true
       expect(service.supports_account_backfill?).to be true
-    end
-
-    it 'defaults to false on a service without a manageable admin API' do
-      expect(Idp::NullService.new('keycloak').supports_account_backfill?).to be false
+      expect(service.supports_email_self_service?).to be true
     end
   end
 
+  # An authenticate-only realm (manage_users: false) — a customer-operated Keycloak, or a service
+  # account without the manage-users role. Management capability tracks the config flag, not the
+  # class, while login and the self-service account console keep working.
+  describe 'capabilities on an authenticate-only realm (manage_users: false)' do
+    let(:service) do
+      described_class.new(
+        config: {
+          api_url: api_url,
+          realm: realm,
+          client_id: client_id,
+          client_secret: client_secret,
+          manage_users: false,
+        },
+      )
+    end
+
+    it 'reports every management capability as false' do
+      expect(service.supports_user_management?).to be false
+      expect(service.supports_profile_updates?).to be false
+      expect(service.supports_user_creation?).to be false
+      expect(service.supports_account_backfill?).to be false
+    end
+
+    it 'still offers self-service email and resolves the account console URL' do
+      expect(service.supports_email_self_service?).to be true
+      expect(service.account_console_url).to eq("#{api_url}/realms/#{realm}/account")
+    end
+  end
+
+  # Also the only reachable "unconfigured connector": the blank-api_url guards in #browser_url and
+  # #supports_session_logout? sit behind this raise, so no service can be constructed in the state
+  # they cover and there are no examples driving them through a mutated config hash. What actually
+  # happens to such a connector belongs to its callers and is covered there — rescued at render time
+  # (spec/requests/idp/account_emails_controller_spec.rb) and turned into a refused sign-out rather
+  # than a silent one (spec/requests/idp/warehouse_jwt_wiring_spec.rb).
   describe 'config validation' do
-    it 'raises on missing api_url' do
-      expect do
-        described_class.new(config: { client_id: 'x', client_secret: 'y' })
-      end.to raise_error(Idp::ServiceError, /api_url/)
-    end
+    let(:complete) { { api_url: 'http://kc:8080', realm: 'r', client_id: 'x', client_secret: 'y' } }
 
-    it 'raises on missing realm (no default)' do
-      expect do
-        described_class.new(config: { api_url: 'http://kc:8080', client_id: 'x', client_secret: 'y' })
-      end.to raise_error(Idp::ServiceError, /realm/)
-    end
-
-    it 'raises on missing client_id' do
-      expect do
-        described_class.new(config: { api_url: 'http://kc:8080', realm: 'r', client_secret: 'y' })
-      end.to raise_error(Idp::ServiceError, /client_id/)
-    end
-
-    it 'raises on missing client_secret' do
-      expect do
-        described_class.new(config: { api_url: 'http://kc:8080', realm: 'r', client_id: 'x' })
-      end.to raise_error(Idp::ServiceError, /client_secret/)
+    # Dropped one at a time rather than checking only the empty config: realm in particular has no
+    # default, and a guard that only fired on a wholly blank config would pass that check while
+    # letting three-quarters-configured connectors through.
+    [:api_url, :realm, :client_id, :client_secret].each do |key|
+      it "raises naming #{key} when it is the only one missing" do
+        expect { described_class.new(config: complete.except(key)) }.
+          to raise_error(Idp::ServiceError, /#{key}/)
+      end
     end
 
     it 'lists all missing keys' do
-      expect do
-        described_class.new(config: {})
-      end.to raise_error(Idp::ServiceError, /api_url, realm, client_id, client_secret/)
+      expect { described_class.new(config: {}) }.
+        to raise_error(Idp::ServiceError, /api_url, realm, client_id, client_secret/)
     end
   end
 
-  describe '.from_config' do
-    # Mirrors the Idp::ServiceConfig reader surface that .from_config consumes
-    # (api_url, client_id, service_token, keycloak_realm) without needing the DB
-    # or encryption key. ServiceConfig's own columns are covered by its spec.
-    let(:persisted_config) do
-      Struct.new(:api_url, :client_id, :service_token, :keycloak_realm, keyword_init: true).new(
-        api_url: 'http://kc.from-config:8080',
-        client_id: 'config-client',
-        service_token: 'config-secret',
-        keycloak_realm: 'config-realm',
-      )
-    end
-
-    it 'translates persisted storage columns into the service config keys' do
-      service = described_class.from_config(persisted_config)
-
-      expect(service.config).to include(
-        api_url: 'http://kc.from-config:8080',
-        client_id: 'config-client',
-        client_secret: 'config-secret',
-        realm: 'config-realm',
-      )
-    end
-  end
-
-  describe '#supports_profile_updates?' do
-    it 'returns true' do
-      expect(service.supports_profile_updates?).to be true
-    end
-  end
+  # No .from_config examples here on purpose: spec/models/idp/service_config_spec.rb asserts the same
+  # four column => config-key mappings against a real persisted Idp::ServiceConfig. Covering it here
+  # would mean faking that reader surface, and a fake can't notice a renamed column — the one failure
+  # this translation actually has.
 
   describe '#account_console_url' do
     it 'builds the Account Console URL for the realm' do
       expect(service.account_console_url).to eq("#{api_url}/realms/#{realm}/account")
     end
+  end
 
-    context 'when API URL is not configured' do
-      before do
-        service.config[:api_url] = nil
+  describe '#account_action_url' do
+    let(:redirect_uri) { 'https://warehouse.test/account/edit' }
+
+    subject(:url) { service.account_action_url(action: 'UPDATE_PASSWORD', redirect_uri: redirect_uri) }
+
+    def query_param(key)
+      Rack::Utils.parse_query(URI(url).query)[key]
+    end
+
+    it 'targets the realm authorize endpoint' do
+      expect(url).to start_with("#{api_url}/realms/#{realm}/protocol/openid-connect/auth?")
+    end
+
+    # client_id here is the unconfigured default: Keycloak's own account client returns the user to
+    # the Keycloak account console rather than here, but it exists on every realm, and a wrong
+    # destination beats a dead link.
+    it 'carries the action, client, redirect, and OIDC params' do
+      expect(Rack::Utils.parse_query(URI(url).query)).to include(
+        'kc_action' => 'UPDATE_PASSWORD',
+        'client_id' => 'account',
+        'redirect_uri' => redirect_uri,
+        'response_type' => 'code',
+        'scope' => 'openid',
+      )
+    end
+
+    # The client's Base URL is where Keycloak sends the user back from an out-of-band confirmation
+    # link, so which client the action runs under decides where an email change lands. It comes off
+    # the config row (a per-realm column seeded from KEYCLOAK_ACCOUNT_CLIENT_ID once), not a
+    # request-time ENV read; the unconfigured fallback to 'account' is asserted by the params example
+    # above.
+    describe 'the client the action runs under' do
+      it 'runs under the account client from the config row' do
+        service.config[:account_client_id] = 'from-config'
+
+        expect(query_param('client_id')).to eq('from-config')
       end
 
-      it 'returns nil' do
-        expect(service.account_console_url).to be_nil
+      it 'ignores KEYCLOAK_ACCOUNT_CLIENT_ID in the environment' do
+        stub_const('ENV', ENV.to_h.merge('KEYCLOAK_ACCOUNT_CLIENT_ID' => 'warehouse-account'))
+
+        expect(query_param('client_id')).to eq('account')
       end
     end
   end
 
-  describe '#logout_url' do
-    it 'generates logout URL with post_logout_redirect_uri' do
-      url = service.logout_url(
-        post_logout_redirect_uri: 'http://example.com/logout',
-      )
+  # Back channel rather than an RP-initiated logout redirect: the app is handed Dex's id_token, not
+  # Keycloak's, so there's no id_token_hint to send. The Admin API doesn't need one.
+  describe '#logout_user_sessions' do
+    let(:logout_path) { admin_url('/users/abc/logout') }
 
-      expect(url).to include("#{api_url}/realms/#{realm}/protocol/openid-connect/logout")
-      expect(url).to include('post_logout_redirect_uri=http')
+    it 'POSTs to the user logout endpoint with the service-account token' do
+      stub_request(:post, logout_path).to_return(status: 204)
+
+      expect(service.logout_user_sessions(user_id: 'abc')).to eq(true)
+      expect(a_request(:post, logout_path).with(headers: { 'Authorization' => 'Bearer test-token' })).to have_been_made
     end
 
-    it 'includes client_id when provided' do
-      url = service.logout_url(
-        post_logout_redirect_uri: 'http://example.com/logout',
-        client_id: 'test-client-123',
+    # The service account can hold manage-users for reads/writes and still be refused here.
+    it 'raises when the service account is not authorized for it' do
+      stub_request(:post, logout_path).to_return(
+        status: 403,
+        body: { errorMessage: 'Forbidden' }.to_json,
+        headers: { 'Content-Type' => 'application/json' },
       )
 
-      expect(url).to include('client_id=test-client-123')
+      expect { service.logout_user_sessions(user_id: 'abc') }.
+        to raise_error(Idp::ServiceError, /Failed to end IDP sessions/)
     end
 
-    context 'when API URL is not configured' do
-      before do
-        service.config[:api_url] = nil
+    it 'raises when the user id is unknown to the realm' do
+      stub_request(:post, logout_path).to_return(status: 404, body: '')
+
+      expect { service.logout_user_sessions(user_id: 'abc') }.
+        to raise_error(Idp::ServiceError, /Failed to end IDP sessions/)
+    end
+
+    # Named rather than `StandardError`: the point is that the socket failure reaches the caller
+    # unconverted (the controller has a rescue for exactly this), and StandardError would also be
+    # satisfied by a NoMethodError from a typo in this spec.
+    it 'raises rather than returning quietly when Keycloak is unreachable' do
+      stub_request(:post, logout_path).to_timeout
+
+      expect { service.logout_user_sessions(user_id: 'abc') }.to raise_error(Timeout::Error)
+    end
+
+    it 'is advertised by the capability predicate' do
+      expect(service.supports_session_logout?).to eq(true)
+    end
+  end
+
+  # Browser links come off the public URL; Admin API calls must not.
+  describe 'the browser-facing URL override' do
+    let(:public_url) { 'https://keycloak.public.test' }
+
+    shared_examples 'honors the browser URL' do
+      it 'builds the account console URL from it' do
+        expect(service.account_console_url).to eq("#{public_url}/realms/#{realm}/account")
       end
 
-      it 'returns the redirect URI as-is' do
-        url = service.logout_url(
-          post_logout_redirect_uri: 'http://example.com/logout',
-        )
+      it 'builds account action deep-links from it' do
+        url = service.account_action_url(action: 'UPDATE_PASSWORD', redirect_uri: 'https://warehouse.test/account/edit')
 
-        expect(url).to eq('http://example.com/logout')
+        expect(url).to start_with("#{public_url}/realms/#{realm}/protocol/openid-connect/auth?")
+      end
+
+      it 'leaves Admin API calls on api_url' do
+        stub_request(:get, user_url('abc')).
+          to_return(status: 200, body: { id: 'abc' }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        service.get_user(user_id: 'abc')
+
+        expect(a_request(:get, user_url('abc'))).to have_been_made
+        expect(a_request(:any, /#{Regexp.escape(public_url)}/)).not_to have_been_made
+      end
+    end
+
+    # browser_url is a per-realm Idp::ServiceConfig column (seeded from ENV once); it is not read from
+    # ENV at request time, so a stray KEYCLOAK_PUBLIC_URL must not leak into a DB-configured service.
+    context 'supplied in the config hash' do
+      before do
+        stub_const('ENV', ENV.to_h.merge('KEYCLOAK_PUBLIC_URL' => 'https://ignored.test'))
+        service.config[:browser_url] = public_url
+      end
+
+      include_examples 'honors the browser URL'
+    end
+
+    context 'not set in config' do
+      before { stub_const('ENV', ENV.to_h.merge('KEYCLOAK_PUBLIC_URL' => 'https://ignored.test')) }
+
+      it 'falls back to api_url, ignoring ENV' do
+        expect(service.account_console_url).to eq("#{api_url}/realms/#{realm}/account")
       end
     end
   end
 
   describe '#each_user' do
-    let(:users_url) { "#{api_url}/admin/realms/#{realm}/users" }
-
     def stub_page(first, max, users)
-      stub_request(:get, users_url).
+      stub_request(:get, admin_url('/users')).
         with(query: { first: first.to_s, max: max.to_s }).
         to_return(
           status: 200,
@@ -777,10 +914,8 @@ RSpec.describe Idp::KeycloakService, type: :model do
     end
 
     it 'pages past the first full page and stops on the final short page' do
-      page1 = Array.new(2) { |i| { 'id' => "id-#{i}", 'email' => "u#{i}@example.com" } }
-      page2 = [{ 'id' => 'id-2', 'email' => 'u2@example.com' }]
-      stub_page(0, 2, page1)
-      stub_page(2, 2, page2)
+      stub_page(0, 2, Array.new(2) { |i| { 'id' => "id-#{i}", 'email' => "u#{i}@example.com" } })
+      stub_page(2, 2, [{ 'id' => 'id-2', 'email' => 'u2@example.com' }])
 
       collected = service.each_user(page_size: 2).to_a
 
@@ -801,8 +936,74 @@ RSpec.describe Idp::KeycloakService, type: :model do
     end
   end
 
+  describe 'HTTP timeouts' do
+    # build_http is private and WebMock stands in for the socket, so record what the service had set
+    # on the connection each request went out on. Keyed by path because a call also fetches a token,
+    # on its own connection with its own budget.
+    let(:sent) { {} }
+
+    before do
+      recorded = sent
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_wrap_original do |original, *args|
+        http = original.receiver
+        (recorded[args.first.path] ||= []) << [http.open_timeout, http.read_timeout, http.write_timeout]
+        original.call(*args)
+      end
+    end
+
+    # One entry per request sent to `path`, oldest first, each [open, read, write].
+    def timeouts_of(path)
+      sent.fetch(path)
+    end
+
+    # Literals rather than the constants themselves: read from the source, these would only confirm
+    # that whatever budget is configured reached the socket, and would say nothing about whether it
+    # is short enough to keep a hung Keycloak off a request thread — the reason the budget exists.
+    # Raising IO_TIMEOUT_SECONDS to 300, or dropping BULK_IO_TIMEOUT_SECONDS to the default, has to
+    # turn something red. [open, read, write].
+    let(:default_timeouts) { [2, 3, 3] }
+    let(:bulk_timeouts) { [2, 30, 30] }
+
+    it 'gives an ordinary call the short defaults' do
+      stub_request(:post, admin_url('/users/user-1/logout')).to_return(status: 204)
+
+      service.logout_user_sessions(user_id: 'user-1')
+
+      expect(timeouts_of("/admin/realms/#{realm}/users/user-1/logout")).to eq([default_timeouts])
+      # The token round trip a call makes on the way is on the default budget too.
+      expect(timeouts_of("/realms/#{realm}/protocol/openid-connect/token")).to eq([default_timeouts])
+    end
+
+    it 'gives a bulk call a longer read and write budget' do
+      stub_request(:post, admin_url('/partialImport')).to_return(status: 200, body: '{}')
+
+      service.partial_import({ users: [] })
+
+      expect(timeouts_of("/admin/realms/#{realm}/partialImport")).to eq([bulk_timeouts])
+    end
+
+    it 'keeps the longer budget on the 401 token retry' do
+      stub_request(:post, admin_url('/partialImport')).
+        to_return({ status: 401 }, { status: 200, body: '{}' })
+
+      service.partial_import({ users: [] })
+
+      expect(timeouts_of("/admin/realms/#{realm}/partialImport")).to eq([bulk_timeouts, bulk_timeouts])
+    end
+
+    it 'gives the paginated user listing the longer budget' do
+      stub_request(:get, admin_url('/users')).
+        with(query: { first: '0', max: '100' }).
+        to_return(status: 200, body: '[]', headers: { 'Content-Type' => 'application/json' })
+
+      service.each_user.to_a
+
+      expect(timeouts_of("/admin/realms/#{realm}/users?first=0&max=100")).to eq([bulk_timeouts])
+    end
+  end
+
   describe '#ensure_group' do
-    let(:groups_url) { "#{api_url}/admin/realms/#{realm}/groups" }
+    let(:groups_url) { admin_url('/groups') }
 
     it 'returns :created when Keycloak creates the group' do
       stub_request(:post, groups_url).

--- a/spec/services/idp/null_service_spec.rb
+++ b/spec/services/idp/null_service_spec.rb
@@ -9,42 +9,41 @@
 RSpec.describe Idp::NullService, type: :model do
   let(:service) { described_class.new }
 
-  describe '#create_user' do
-    it 'raises ServiceError' do
-      expect do
-        service.create_user(
-          email: 'test@example.com',
-          first_name: 'Test',
-          last_name: 'User',
-        )
-      end.to raise_error(Idp::ServiceError, /User management not supported/)
-    end
-  end
+  # Every management method has to raise Idp::ServiceError specifically. Callers rescue that class and
+  # nothing wider, so a method that fell through to Idp::Service and raised NotImplementedError would
+  # escape their soft-failure handling and 500 the request. `operation` is also what tells get_user's
+  # raise apart from find_user_by_email's, since the two share a message.
+  #
+  # send_execute_actions_email has no capability predicate in front of it: Idp::Support#idp_send_account_setup_email!
+  # gates only on primary_idp, so the raise is the sole guard.
+  describe 'management methods' do
+    {
+      create_user: ['User management not supported', { email: 'test@example.com', first_name: 'Test', last_name: 'User' }],
+      update_user: ['Profile updates not supported', { user_id: 'user-123', attributes: { first_name: 'John' } }],
+      get_user: ['User lookup not supported', { user_id: 'user-123' }],
+      find_user_by_email: ['User lookup not supported', { email: 'test@example.com' }],
+      send_execute_actions_email: ['Account setup email not supported', { user_id: 'user-123', actions: ['UPDATE_PASSWORD'] }],
+      reactivate_user: ['User reactivation not supported', { user_id: 'user-123' }],
+      deactivate_user: ['User deactivation not supported', { user_id: 'user-123' }],
+      set_required_action: ['Required actions not supported', { user_id: 'user-123', actions: ['UPDATE_PASSWORD'] }],
+    }.each do |method, (message, args)|
+      describe "##{method}" do
+        it 'raises ServiceError tagged with the operation and the IdP name' do
+          expect { service.public_send(method, **args) }.to raise_error(Idp::ServiceError) do |error|
+            expect(error.message).to eq(message)
+            expect(error.operation).to eq(method)
+            # Admin::Idp::UsersController interpolates this into user-facing form copy.
+            expect(error.idp_name).to eq('Unknown IDP')
+            # A blank/unknown/deactivated connector keeps giving the same answer; no retry helps.
+            expect(error.transient?).to be false
+          end
+        end
 
-  describe '#update_user' do
-    it 'raises ServiceError' do
-      expect do
-        service.update_user(
-          user_id: 'user-123',
-          attributes: { first_name: 'John' },
-        )
-      end.to raise_error(Idp::ServiceError, /Profile updates not supported/)
-    end
-  end
-
-  describe '#get_user' do
-    it 'raises ServiceError' do
-      expect do
-        service.get_user(user_id: 'user-123')
-      end.to raise_error(Idp::ServiceError, /User lookup not supported/)
-    end
-  end
-
-  describe '#reactivate_user' do
-    it 'raises ServiceError' do
-      expect do
-        service.reactivate_user(user_id: 'user-123')
-      end.to raise_error(Idp::ServiceError, /User reactivation not supported/)
+        it 'carries the humanized connector_id as the IdP name when there is one' do
+          expect { described_class.new('keycloak').public_send(method, **args) }.
+            to raise_error(Idp::ServiceError) { |error| expect(error.idp_name).to eq('Keycloak') }
+        end
+      end
     end
   end
 
@@ -59,15 +58,22 @@ RSpec.describe Idp::NullService, type: :model do
     end
   end
 
-  describe '#supports_user_management?' do
-    it 'returns false' do
-      expect(service.supports_user_management?).to be false
-    end
-  end
-
-  describe '#supports_profile_updates?' do
-    it 'returns false' do
-      expect(service.supports_profile_updates?).to be false
+  # These gates keep admin and self-service surfaces from offering an action the null IdP cannot
+  # perform, and NullService inherits the defaults, so flipping one to true in Idp::Service would
+  # otherwise go unnoticed here. supports_user_creation? is what stands between an unconfigured
+  # connector and Idp::AdminUserCreator provisioning against it.
+  describe 'capability predicates' do
+    [
+      :supports_user_management?,
+      :supports_user_creation?,
+      :supports_profile_updates?,
+      :supports_email_self_service?,
+      :supports_account_backfill?,
+      :supports_session_logout?,
+    ].each do |predicate|
+      it "answers false to ##{predicate}" do
+        expect(service.public_send(predicate)).to be false
+      end
     end
   end
 
@@ -93,6 +99,18 @@ RSpec.describe Idp::Service, type: :model do
   describe '#account_console_url' do
     it 'defaults to nil on the base contract' do
       expect(described_class.new.account_console_url).to be_nil
+    end
+  end
+
+  describe '#supports_email_self_service?' do
+    it 'defaults to false on the base contract' do
+      expect(described_class.new.supports_email_self_service?).to be false
+    end
+  end
+
+  describe '#supports_session_logout?' do
+    it 'defaults to false on the base contract' do
+      expect(described_class.new.supports_session_logout?).to be false
     end
   end
 end

--- a/spec/services/idp/service_factory_spec.rb
+++ b/spec/services/idp/service_factory_spec.rb
@@ -8,7 +8,7 @@
 
 RSpec.describe Idp::ServiceFactory, type: :model, if: AuthMethod.jwt? do
   describe '.for_connector' do
-    context 'with database config present' do
+    context 'with an active database config' do
       let!(:config) do
         create(
           :idp_service_config,
@@ -18,52 +18,47 @@ RSpec.describe Idp::ServiceFactory, type: :model, if: AuthMethod.jwt? do
         )
       end
 
-      it 'returns service instance from database config' do
+      it 'returns the managed service instance built from the row' do
         service = described_class.for_connector('keycloak')
 
         expect(service).to be_a(Idp::KeycloakService)
         expect(service.send(:api_url)).to eq('http://test.keycloak:8080')
         expect(service.send(:client_secret)).to eq('test-token')
       end
+    end
 
-      it 'uses database config over ENV variables' do
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with('KEYCLOAK_API_URL').
-          and_return('http://env.keycloak:9090')
+    context 'with an inactive database config' do
+      let!(:inactive_config) do
+        create(:idp_service_config, connector_id: 'keycloak', active: false)
+      end
 
+      # The DB row is the single source of truth, so a deactivated row is an
+      # explicit "turn this connector off" that degrades to unmanaged.
+      it 'returns a NullService carrying the connector_id' do
         service = described_class.for_connector('keycloak')
 
-        # Should use database config, not ENV
-        expect(service.send(:api_url)).to eq('http://test.keycloak:8080')
+        expect(service).to be_a(Idp::NullService)
+        expect(service.connector_id).to eq('keycloak')
+        expect(service.supports_user_management?).to be(false)
       end
     end
 
-    context 'without database config' do
-      before do
-        Idp::ServiceConfig.delete_all
-      end
+    context 'with no database config' do
+      before { Idp::ServiceConfig.delete_all }
 
-      it 'returns service instance from ENV config' do
-        allow_any_instance_of(Idp::KeycloakService).
-          to receive(:default_config).
-          and_return({
-                       api_url: 'http://env.keycloak:8080',
-                       realm: 'env-realm',
-                       client_id: 'env-client',
-                       client_secret: 'env-secret',
-                       org_id: 'env-org',
-                     })
-
-        service = described_class.for_connector('keycloak')
-
-        expect(service).to be_a(Idp::KeycloakService)
-      end
-    end
-
-    context 'with unknown connector' do
       # Fail-soft: a valid JWT from a connector with no config still authenticates
       # (UserProvisioner never calls this), so capability checks must degrade to a
       # NullService rather than raising and crashing the request.
+      it 'returns a NullService carrying the connector_id, without raising' do
+        service = described_class.for_connector('keycloak')
+
+        expect(service).to be_a(Idp::NullService)
+        expect(service.connector_id).to eq('keycloak')
+        expect(service.supports_user_management?).to be(false)
+      end
+    end
+
+    context 'with an unknown connector' do
       it 'returns a NullService carrying the connector_id, without raising' do
         service = described_class.for_connector('unknown_idp')
 
@@ -73,55 +68,34 @@ RSpec.describe Idp::ServiceFactory, type: :model, if: AuthMethod.jwt? do
       end
     end
 
-    context 'with blank connector' do
+    context 'with a blank connector' do
       it 'returns a NullService without raising' do
         expect(described_class.for_connector(nil)).to be_a(Idp::NullService)
         expect(described_class.for_connector('')).to be_a(Idp::NullService)
       end
     end
 
-    context 'with soft-deleted config' do
-      let(:env_config) do
-        { api_url: 'http://env.keycloak:8080', realm: 'env-realm', client_id: 'env-client', client_secret: 'env-secret' }
-      end
-
-      let!(:deleted_config) do
-        config = create(
-          :idp_service_config,
-          connector_id: 'keycloak',
-        )
-        config.destroy
-        config
-      end
-
-      it 'uses ENV config, ignoring deleted database config' do
-        allow_any_instance_of(Idp::KeycloakService).to receive(:default_config).and_return(env_config)
-
-        service = described_class.for_connector('keycloak')
-
-        expect(service).to be_a(Idp::KeycloakService)
-      end
-    end
-
-    context 'with inactive config' do
-      let(:env_config) do
-        { api_url: 'http://env.keycloak:8080', realm: 'env-realm', client_id: 'env-client', client_secret: 'env-secret' }
-      end
-
+    context 'with both an inactive and an active row for the same connector_id' do
+      # Deactivating must not strand a connector: a fresh active row for the same
+      # connector_id restores the managed service via the active scope.
       let!(:inactive_config) do
+        create(:idp_service_config, connector_id: 'keycloak', active: false)
+      end
+
+      let!(:active_config) do
         create(
           :idp_service_config,
           connector_id: 'keycloak',
-          active: false,
+          api_url: 'http://test.keycloak:8080',
+          service_token: 'test-token',
         )
       end
 
-      it 'uses ENV config, ignoring inactive database config' do
-        allow_any_instance_of(Idp::KeycloakService).to receive(:default_config).and_return(env_config)
-
+      it 'prefers the active row and builds the managed service' do
         service = described_class.for_connector('keycloak')
 
         expect(service).to be_a(Idp::KeycloakService)
+        expect(service.config[:api_url]).to eq('http://test.keycloak:8080')
       end
     end
   end

--- a/spec/support/shared_examples/auth_method_user_examples.rb
+++ b/spec/support/shared_examples/auth_method_user_examples.rb
@@ -490,6 +490,30 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
       end
     end
 
+    describe 'idp_password_management_enabled?' do
+      it 'follows idp_service.supports_user_management?: disabled when unlinked (NullService can\'t manage the account)' do
+        # null-attached: primary_idp may be present but the service resolves to a NullService that
+        # reports no management capability, so the Force Password Reset affordance stays disabled.
+        user = model.new
+        expect(user.idp_service.supports_user_management?).to be false
+        expect(user.idp_password_management_enabled?).to be false
+      end
+
+      it 'is true when the linked IdP service can manage the account (e.g. Keycloak)' do
+        user = model.new
+        allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, supports_user_management?: true))
+        expect(user.idp_password_management_enabled?).to be true
+      end
+
+      it 'is locked-safe (false) when the service is unbuildable and raises Idp::ServiceError' do
+        # unbuildable (e.g. misconfigured Keycloak): building the service raises, and the predicate
+        # rescues to disabled rather than rendering an action that would raise on click.
+        user = model.new
+        allow(user).to receive(:idp_service).and_raise(Idp::ServiceError.new('unbuildable', operation: :build))
+        expect(user.idp_password_management_enabled?).to be false
+      end
+    end
+
     describe 'account_expiry_enabled?' do
       it 'is false (the IdP does not honor local expired_at; the admin form hides the field)' do
         expect(model.new.account_expiry_enabled?).to be false


### PR DESCRIPTION
## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Makes the idp_service_configs row the sole source of truth for a connector and adds the error taxonomy (to support for future work in this feature stack).

- Add manage_users/browser_url/account_client_id capability columns; seed the row from ENV once at deploy (create-only, idempotent).
- Drop the request-time ENV fallback from ServiceFactory: an active row or a NullService, nothing else. KeycloakService supports_*? predicates answer from manage_users?, so an authenticate-only realm degrades instead of failing at an Admin API we can't call.
- ServiceError#transient?, Idp::ConflictError for 409s, request-path timeouts with a longer budget for the two bulk calls, and handle_response naming the failed call in 5xx messages.
- Validate keycloak_realm/client_id on active rows only.


Three additions land here without a caller/consumer within this branch — this is deliberate, part of the stacked-split partition, not oversight:

- `app/models/concerns/idp/support.rb:108` — `idp_user_management_available?` (new private): lands here because chunk 1's idp_password_management_enabled? needs the same "is the connector actually manageable" semantics, but its direct callers (idp_deactivate! / idp_reactivate! / idp_force_password_change!) arrive in `8458-idp-4-admin-transactional`. Caller-less here on purpose.
- `app/services/idp/keycloak_service.rb:345` — browser_url: reader lands here (it reads the new browser_url column), but its only consumer — account_console_url switching from api_url to browser_url — is `8458-idp-5-account-profile`. In this chunk `account_console_url` is still the base api_url version, so nothing calls browser_url yet.
- `app/services/idp/keycloak_service.rb:354` — account_client_id: seeded into the config in from_config here, but its only reader — account_action_url — is a `8458-idp-5-account-profile` method. No caller yet.


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill

