### PR TITLE
fix: 8458 JWT request path fails loud, session rotation, real expiry

### DIFF
--- a/app/controllers/api/pings_controller.rb
+++ b/app/controllers/api/pings_controller.rb
@@ -1,0 +1,23 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Monitoring endpoint. Deliberately authenticated rather than public, so an
+# unauthenticated probe can't report healthy.
+module Api
+  class PingsController < ApplicationController
+    def show
+      head :ok
+    end
+
+    # rescue prevents the error from bubbling; 500's are expected to be generated
+    # by monitoring
+    rescue_from 'Idp::UnauthenticatedRequestError' do |_exception|
+      head :internal_server_error
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,6 +41,12 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
+  # Registered separately from authenticate_user! so `skip_before_action :authenticate_user!` doesn't
+  # take it with it: deactivation bars an account from the app, not just from the routes that require
+  # a user, and under JWT the IdP keeps handing that person a valid token. Both auth strategies
+  # respond to it (the Devise arm no-ops; see DeviseCurrentUser).
+  before_action :reject_deactivated_user!
+
   before_action :set_sentry_user
 
   before_action :set_paper_trail_whodunnit

--- a/app/controllers/concerns/devise_current_user.rb
+++ b/app/controllers/concerns/devise_current_user.rb
@@ -98,6 +98,11 @@ module DeviseCurrentUser
     end
     helper_method :current_user_identity
 
+    # When devise is active, a user can't be logged in and inactive, so do nothing.
+    def reject_deactivated_user!
+      nil
+    end
+
     # don't extend the user's session if its an ajax request.
     def skip_timeout
       request.env['devise.skip_trackable'] = true if request.xhr?

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -20,6 +20,8 @@
 module Idp::JwtAuthentication
   extend ActiveSupport::Concern
 
+  SESSION_PRINCIPAL_KEY = :idp_token_holder_id
+
   included do
     helper_method :user_session_expires_at
   end
@@ -33,9 +35,25 @@ module Idp::JwtAuthentication
   def idp_token_holder
     return @idp_token_holder if defined?(@idp_token_holder)
 
-    @idp_token_holder = begin
-      jwt_helper = idp_jwt_helper_for_request
-      jwt_helper&.token? && jwt_helper.valid? ? User.find_or_create_from_jwt(jwt_helper) : nil
+    # Set before the raise below: lograge's append_info_to_payload asks for current_user again on
+    # the way out, and a second raise there escapes lograge.
+    @idp_token_holder = nil
+
+    jwt_helper = idp_jwt_helper_for_request
+    case jwt_helper.invalid_reason
+    when nil
+      @idp_token_holder = User.find_or_create_from_jwt(jwt_helper)
+    when :missing
+      # The normal signed-out case: skip_auth_routes reach Rails with no header at all. Those
+      # actions skip authenticate_user! and render based on current_user, so nil is the answer they
+      # want.
+      nil
+    else
+      # oauth2-proxy had already vouched for this token and we refused it, so our own stack is
+      # misconfigured (wrong OIDC client, an opaque token where we want a JWT, a token that isn't
+      # ours). Redirecting to a proxy that still holds a session would hand back the same token, so
+      # fail loudly instead.
+      raise Idp::ForwardedTokenError, jwt_helper.invalid_reason_details
     end
   end
 
@@ -57,11 +75,28 @@ module Idp::JwtAuthentication
     true
   end
 
-  # Memoized per request. The manager does not cache anything itself (it reads the session
-  # again on every call to #get), so it is fine to reuse one instance for store/get/clear
-  # within a single request.
   def impersonation_manager
-    @impersonation_manager ||= Idp::ImpersonationManager.new(session)
+    Idp::ImpersonationManager.new(session)
+  end
+
+  # Nothing rotates the Rails session under JWT: there is no sign-in event, and oauth2-proxy can
+  # idle out without the app ever seeing a request. Left alone, the next person to sign in on this
+  # browser inherits the previous one's session, including the session.id that PaperTrail,
+  # Hmis::ActivityLog, lograge and Rack::Attack log against.
+  #
+  # Stamped with the user id rather than a token claim because oauth2-proxy refreshes the token
+  # mid-session, which would otherwise reset the session on every refresh.
+  def idp_sync_session_principal!(user_id)
+    stamped = session[SESSION_PRINCIPAL_KEY]
+    # Compared as strings so a session store that stringifies the id can't mismatch on every request
+    # and reset the session continuously.
+    return if stamped.to_s == user_id.to_s
+
+    # No stamp means an anonymous visitor on a page that skips authenticate_user!, so there is no
+    # previous session to clear.
+    reset_session if stamped.present?
+
+    session[SESSION_PRINCIPAL_KEY] = user_id
   end
 
   def idp_authenticated_user_from_jwt(user_class: User)
@@ -70,6 +105,10 @@ module Idp::JwtAuthentication
     # idp_token_holder memoizes this so it only happens once per request.
     authenticated_user = idp_token_holder
     return nil unless authenticated_user
+
+    # Ahead of the active? check on purpose: the principal is known either way, and the deactivated
+    # 403 must not render on the previous user's session.
+    idp_sync_session_principal!(authenticated_user.id)
 
     # A warehouse User that has been deactivated locally (active = false) is not allowed
     # to authenticate, even with a valid IdP token. This matches the check already done in
@@ -91,9 +130,8 @@ module Idp::JwtAuthentication
 
     impersonation_data = impersonation_manager.get
     if impersonation_data && impersonation_data[:impersonated_user_id].present?
-      # Only apply impersonation if the current token belongs to the user who started it.
-      # If it doesn't match the stored true_user, this is a leftover session from an
-      # earlier sign-in on this browser, so it is ignored.
+      # idp_sync_session_principal! above already resets the session on a principal change. Checked
+      # again here because honoring another user's impersonation escalates privileges.
       if impersonation_data[:true_user_id] != authenticated_user.id
         impersonation_manager.clear
         return user
@@ -114,17 +152,18 @@ module Idp::JwtAuthentication
     user
   end
 
+  # Never redirects to sign-in. oauth2-proxy owns that, and both cases below arrive with the proxy
+  # holding a live session, so bouncing them to /oauth2/sign_in would return the same request.
   def idp_handle_unauthenticated
-    original_url = Idp::PostAuthRedirect.new(
-      request: request,
-      cookies: cookies,
-    ).capture
-    # No current_user here (that's why we're unauthenticated), so the connector comes
-    # from the cookie oauth2-proxy set on the last sign-in.
-    redirect_to Idp::Oauth2ProxySignInPath.call(
-      connector_id: cookies[:last_connector_id],
-      redirect_to: original_url,
-    )
+    # No token at all — shouldn't be reachable, and ours to fix if it is, so fail loudly. See
+    # Idp::UnauthenticatedRequestError for how the proxy config and route surface let it happen.
+    raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
+
+    # A valid token whose holder has no warehouse account: Idp::UserProvisioner returns nil when
+    # idp/auto_create_user is off and no row matches, which is routine on a realm shared with other
+    # apps. That is a person who needs an account rather than a misconfiguration, so render a
+    # terminal page in the same shape as idp_handle_deactivated.
+    render(template: 'errors/no_warehouse_account', status: :forbidden)
   end
 
   # Shown to a user whose warehouse account has been deactivated (active = false) while

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -30,6 +30,16 @@ module Idp::JwtCurrentUser
       idp_handle_unauthenticated
     end
 
+    # If a deactivated user reaches the app with a valid JWT, show a warning page instead of
+    # letting them land on the public homepage as we do for unauthenticated users.
+    def reject_deactivated_user!
+      return unless request.format.html?
+      return if current_user
+      return unless idp_token_holder && !idp_token_holder.active?
+
+      idp_handle_deactivated
+    end
+
     def user_signed_in?
       current_user.present?
     end

--- a/app/controllers/idp/sessions_controller.rb
+++ b/app/controllers/idp/sessions_controller.rb
@@ -19,6 +19,10 @@ module Idp
   class SessionsController < ApplicationController
     # sign-in is a redirect to the proxy, so these must not bounce off authenticate_user! first.
     skip_before_action :authenticate_user!, only: [:new, :create]
+    # Same reason, one filter later: reject_deactivated_user! walls off the routes that skip
+    # authenticate_user!, and signing out is the one thing a deactivated user still has to be able to
+    # do — otherwise the link on errors/account_deactivated renders that page right back.
+    skip_before_action :reject_deactivated_user!, only: [:new, :create, :destroy]
 
     # GET/POST users/sign_in — nothing in the JWT flow routes here (Idp::JwtCurrentUser redirects
     # straight to the proxy on an unauthenticated request); this only catches stray hits on the
@@ -47,12 +51,10 @@ module Idp
       return head(:unauthorized) unless access_token.present?
 
       jwt_helper = Idp::JwtHelper.new(access_token: access_token)
-      # valid? returns false for a blank token
+      # Defensive: a token we'd refuse raised in authenticate_user! and never reached this action.
       return head(:unauthorized) unless jwt_helper.valid?
 
       expiration_time = jwt_helper.expiration_time
-      return head(:ok) unless expiration_time
-
       remaining_seconds = [(expiration_time - Time.current).to_i, 0].max
       render(json: { expiration_time: expiration_time.to_i, remaining_seconds: remaining_seconds })
     end

--- a/app/javascript/controllers/inactive_session_modal_controller.js
+++ b/app/javascript/controllers/inactive_session_modal_controller.js
@@ -29,6 +29,9 @@ export default class extends Controller {
   connect() {
     this.initialUserIdValue = this.data.get('initial-user-id-value');
     this.sessionLifetimeSecsValue = parseInt(this.data.get('session-lifetime-secs-value'));
+    // Absolute token expiry in epoch seconds (JWT arm), not a duration; absent → NaN on Devise.
+    this.sessionExpiresAtValue = parseInt(this.data.get('session-expires-at-value'));
+    this.tokenExpiryDriven = !Number.isNaN(this.sessionExpiresAtValue);
     shared.saveValue(UID_KEY, this.initialUserIdValue);
     if (!this.initialUserIdValue) {
       return;
@@ -71,7 +74,7 @@ export default class extends Controller {
     state.userId = shared.getValue(UID_KEY);
     const ts = parseInt(shared.getValue(TS_KEY));
     if (ts) {
-      const expires = ts + this.sessionLifetimeSecsValue;
+      const expires = this.tokenExpiryDriven ? this.sessionExpiresAtValue : ts + this.sessionLifetimeSecsValue;
       const delta = expires - getTimestamp();
       const remaining = delta > 0 ? delta : 0;
       state.remaining = remaining;
@@ -151,17 +154,28 @@ export default class extends Controller {
   handleRenewSession(event) {
     event.preventDefault();
     if (this.state.xhr) return;
-    const success = () => {
+    const success = (data) => {
       this.state.xhr = undefined;
+      this.applyKeepaliveExpiry(data);
       this.hideWarning();
     };
     const error = () => {
       window.location.reload();
     };
+    // No dataType: 'json' — the Devise keepalive returns head :ok with an empty body, which a forced
+    // JSON parse would fail, routing this success through `error` (a page reload).
     this.state.xhr = $.ajax(event.currentTarget.href, {
       method: 'POST',
       success,
       error,
     });
+  }
+
+  applyKeepaliveExpiry(data) {
+    if (!this.tokenExpiryDriven || !data) return;
+    const expiresAt = data.expiration_time || (data.remaining_seconds && getTimestamp() + data.remaining_seconds);
+    if (!expiresAt) return;
+    this.sessionExpiresAtValue = parseInt(expiresAt);
+    this.state.remaining = Number.MAX_VALUE;
   }
 }

--- a/app/models/idp/forwarded_token_error.rb
+++ b/app/models/idp/forwarded_token_error.rb
@@ -1,0 +1,19 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Idp
+  # oauth2-proxy only forwards tokens it has vouched for, so a token we refused is our stack
+  # disagreeing with itself (wrong OIDC client, an opaque token where we want a JWT, a token that
+  # isn't ours) rather than a signed-out user. Uncaught on purpose: the 500 is the point, and
+  # sentry-rails attaches the request context. See Idp::JwtAuthentication for who raises it.
+  class ForwardedTokenError < StandardError
+    def initialize(details)
+      super("oauth2-proxy forwarded a token we refused (#{details.map { |key, value| "#{key}: #{value.inspect}" }.join(', ')})")
+    end
+  end
+end

--- a/app/models/idp/impersonation_manager.rb
+++ b/app/models/idp/impersonation_manager.rb
@@ -11,11 +11,7 @@
 # Stores impersonation state ({ true_user_id, impersonated_user_id }) in the Rails session,
 # replacing pretender's session machinery.
 #
-# NOTE: there is deliberately no session-stamp here. Under this cookie-store implementation
-# any such stamp would live in the same cookie as the payload, be written together with it, and be
-# wiped together with it by reset_session — so it could never diverge and offered no protection.
-# Instead, the guard lives upstream in Idp::JwtAuthentication#idp_authenticated_user_from_jwt,
-# which invalidates impersonation whenever the JWT principal is not the stored true_user.
+# Whose impersonation this is gets policed upstream in Idp::JwtAuthentication, not here.
 class Idp::ImpersonationManager
   attr_reader :session
 

--- a/app/models/idp/jwt_helper.rb
+++ b/app/models/idp/jwt_helper.rb
@@ -17,6 +17,22 @@ class Idp::JwtHelper
   REQUIRED_ENV_KEYS = ['IDP_AUD', 'ISS_URL', 'JWKS_URL', 'JWT_ALGORITHM'].freeze
   VALID_AUTH_METHODS = [nil, 'devise', 'jwt'].freeze
 
+  # :missing is the only one that's routinely legitimate — see skip_auth_routes in the proxy config.
+  INVALID_REASONS = [
+    :missing,
+    :malformed,
+    :bad_signature,
+    :unknown_key,
+    :expired,
+    :invalid_issuer,
+    :invalid_audience,
+    :jwks_unreachable,
+  ].freeze
+
+  # The JWKS endpoint answered, but with something that isn't a keyset: an error status, or a body
+  # we can't use (a proxy's HTML error page, say). Handled alongside NETWORK_ERRORS.
+  class JwksUnavailableError < StandardError; end
+
   # Transport-level failures reaching JWKS_URL. We can't verify the token when the IdP is
   # unreachable, so we fail closed
   NETWORK_ERRORS = [
@@ -40,36 +56,68 @@ class Idp::JwtHelper
   end
 
   def valid?
-    return false unless token?
+    invalid_reason.nil?
+  end
+
+  # Why the token didn't verify, nil when it did. A refused forwarded token means our stack is
+  # broken; a refused bearer token just means a wrong client. valid? can't tell those apart.
+  # Memoized because callers ask more than once and this logs.
+  #
+  # @return [Symbol, nil] one of INVALID_REASONS
+  memoize def invalid_reason
+    return :missing unless token?
+
+    # Header first: a token we can't parse is malformed without fetching a keyset to find out.
+    header
 
     unless public_key
       Rails.logger.info "Unable to find public key: #{header['kid']}"
-      return false
+      return :unknown_key
     end
 
     payload
-    true
+    nil
   rescue JWT::ExpiredSignature
     Rails.logger.warn 'Token has expired'
-    false
+    :expired
   rescue JWT::InvalidIssuerError
-    Rails.logger.error 'Invalid issuer'
-    false
+    Rails.logger.error "Invalid issuer: expected #{expected_issuer.inspect}, token carried #{actual_issuer.inspect}"
+    :invalid_issuer
   rescue JWT::InvalidAudError
-    Rails.logger.error 'Invalid audience'
-    false
+    Rails.logger.error "Invalid audience: expected one of #{expected_audiences.inspect}, token carried #{actual_audience.inspect}"
+    :invalid_audience
+  # Ahead of JWT::DecodeError, which it subclasses.
+  rescue JWT::VerificationError => e
+    Rails.logger.error "JWT signature verification failed: #{e.message}"
+    :bad_signature
   rescue JWT::DecodeError => e
     Rails.logger.error "JWT verification failed: #{e.message}"
-    false
+    :malformed
   rescue JSON::ParserError => e
     Rails.logger.error "JSON verification failed: #{e.message}"
-    false
-  rescue *NETWORK_ERRORS => e
-    Rails.logger.error "JWT verification could not reach JWKS endpoint: #{e.message}"
-    Sentry.capture_exception_with_info(e, 'JWT verification could not reach the JWKS endpoint; treating token as invalid')
-    false
+    :malformed
+  rescue JwksUnavailableError, *NETWORK_ERRORS => e
+    Rails.logger.error "JWT verification could not get a keyset from the JWKS endpoint: #{e.message}"
+    Sentry.capture_exception_with_info(e, 'JWT verification could not get a keyset from the JWKS endpoint; treating token as invalid')
+    :jwks_unreachable
   end
 
+  # Detail for the Sentry `extra`/`info` hash. Never the token itself.
+  def invalid_reason_details
+    reason = invalid_reason
+    details = { reason: reason }
+    case reason
+    when :invalid_issuer
+      details.merge(expected_issuer: expected_issuer, actual_issuer: actual_issuer)
+    when :invalid_audience
+      details.merge(expected_audiences: expected_audiences, actual_audience: actual_audience)
+    else
+      details
+    end
+  end
+
+  # required_claims: ruby-jwt enforces exp only when the claim is present, so a token carrying none
+  # would verify forever — iss/aud don't bound a lifetime. A token without exp is :malformed.
   memoize def payload
     JWT.decode(
       access_token,
@@ -79,6 +127,7 @@ class Idp::JwtHelper
         algorithm: algorithm,
         aud: idp_audiences,
         iss: ENV.fetch('ISS_URL'),
+        required_claims: ['exp'],
         verify_aud: true,
         verify_iss: true,
       },
@@ -87,6 +136,29 @@ class Idp::JwtHelper
 
   private def idp_audiences
     ENV.fetch('IDP_AUD').split(',').map(&:strip)
+  end
+
+  private def expected_issuer
+    ENV.fetch('ISS_URL')
+  end
+
+  private def expected_audiences
+    idp_audiences
+  end
+
+  private def actual_issuer
+    unverified_claims['iss']
+  end
+
+  private def actual_audience
+    unverified_claims['aud']
+  end
+
+  # Error messages only — nothing here has been verified, so don't act on it.
+  private def unverified_claims
+    JWT.decode(access_token, nil, false, algorithm: algorithm).first
+  rescue StandardError
+    {}
   end
 
   # JWT.decode returns [claims, header]; this is the claims half.
@@ -112,11 +184,9 @@ class Idp::JwtHelper
     claims['iat']
   end
 
+  # Never nil for a token that verified: #payload requires the exp claim.
   def expiration_time
-    exp = claims['exp']
-    return nil unless exp
-
-    Time.zone.at(exp)
+    Time.zone.at(claims['exp'])
   end
 
   # Returns the at_hash claim — stable per token, changes on reissue.
@@ -186,12 +256,25 @@ class Idp::JwtHelper
       end
     end
 
+    # Raises rather than returns anything that isn't a keyset: only a raise reaches the fail-closed
+    # rescue in #invalid_reason, and only a raise keeps the bad response out of memory_cache.
     def fetch_jwks
       uri = URI(ENV.fetch('JWKS_URL'))
       response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: 5, read_timeout: 5) do |http|
-        http.get(uri.request_uri).body
+        http.get(uri.request_uri)
       end
-      JSON.parse(response)
+      raise JwksUnavailableError, "JWKS endpoint returned #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      keyset = begin
+        JSON.parse(response.body.to_s)
+      rescue JSON::ParserError => e
+        raise JwksUnavailableError, "JWKS endpoint returned an unparseable body: #{e.message}"
+      end
+      # Well-formed JSON that still isn't a keyset, such as a gateway's {"error": ...}
+      keys = keyset['keys'] if keyset.is_a?(Hash)
+      raise JwksUnavailableError, "JWKS endpoint returned no keys: #{keyset.class}" unless keys.is_a?(Array) && keys.any?
+
+      keyset
     end
 
     def invalidate_jwks_cache!

--- a/app/models/idp/unauthenticated_request_error.rb
+++ b/app/models/idp/unauthenticated_request_error.rb
@@ -1,0 +1,23 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Idp
+  # authenticate_user! ran on a request that carried no forwarded token at all. oauth2-proxy performs
+  # the sign-in redirect itself, and the routes it does pass through unauthenticated (skip_auth_routes)
+  # all declare skip_before_action :authenticate_user!, so this combination shouldn't exist. Either a
+  # route was added to skip_auth_routes without the matching skip_before_action, or something reached
+  # Rails without traversing the proxy.
+  #
+  # Uncaught on purpose: the 500 is the point, and sentry-rails attaches the request context. See
+  # Idp::JwtAuthentication for who raises it.
+  class UnauthenticatedRequestError < StandardError
+    def initialize(path)
+      super("An authenticated route was reached with no forwarded token (#{path})")
+    end
+  end
+end

--- a/app/views/application/_inactive_session_modal.haml
+++ b/app/views/application/_inactive_session_modal.haml
@@ -7,6 +7,11 @@
     },
     reflex_permanent: true
   }
+  # On JWT the session is owned by oauth2-proxy / the forwarded token, so the Devise.timeout_in seed
+  # above doesn't reflect the real expiry; seed the token's actual expiry instead.
+  if AuthMethod.jwt? && current_user.present? && (session_expires_at = user_session_expires_at)
+    root_data[:inactive_session_modal][:session_expires_at_value] = session_expires_at.to_i
+  end
 #inactive-session-modal{data: root_data}
   .session_expiry__content.d-none{data: {'inactive-session-modal-target': 'alert'}}
     .session_expiry__alert-box

--- a/app/views/errors/account_deactivated.html.haml
+++ b/app/views/errors/account_deactivated.html.haml
@@ -1,2 +1,5 @@
 %h1= Translation.translate('Your warehouse account has been deactivated')
 %p= Translation.translate('Your account does not have permission to access the warehouse. Please contact your administrator to for assistance')
+-# See errors/no_warehouse_account for why this link is here rather than left to the layout.
+%p
+  = link_to Translation.translate('Sign out'), destroy_user_session_path, method: :delete, class: 'btn btn-primary'

--- a/app/views/errors/no_warehouse_account.html.haml
+++ b/app/views/errors/no_warehouse_account.html.haml
@@ -1,0 +1,8 @@
+%h1= Translation.translate('You do not have a warehouse account')
+%p= Translation.translate('You signed in successfully, but there is no warehouse account for you yet. Please contact your administrator to request access.')
+-# Without this the page is a dead end: current_user is nil, so the layout drops the site menu that
+-# normally holds Sign Out, and the header offers a Sign In link that goes back to a proxy which
+-# already has a session. Signing out is the only thing left that can help — on a shared computer
+-# it's also the only way to stop the next person inheriting a live IdP session.
+%p
+  = link_to Translation.translate('Sign out'), destroy_user_session_path, method: :delete, class: 'btn btn-primary'

--- a/app/views/root/index.haml
+++ b/app/views/root/index.haml
@@ -3,11 +3,15 @@
 - else
   - title = Translation.translate('Open Path HMIS Warehouse')
   - content_for :title, title
-  %h1= content_for :title
-  .row
-    .col-sm-7
-      %p.home-intro
-        = Translation.translate('Open Path HMIS Warehouse')
+  .d-flex
     - if AuthMethod.devise? && !user_signed_in?
-      .col-sm-5
-        = render '/root/sign_in_form'
+      = render '/root/sign_in_form'
+    -else
+      .mx-auto.well.px-5(style="max-width: 340px")
+        %h1= content_for :title
+        %div(style="margin: 2.5em 0")
+          = link_to new_user_session_path, class: 'btn btn-primary btn-lg d-block' do
+            Sign in to your account
+        %p.m-0
+          %strong Need help?
+          Contact your organization's administrator for assistance.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -785,6 +785,7 @@ Rails.application.routes.draw do
       put :unfavorite, on: :member
     end
     resources :clients, only: [:show]
+    get :ping, to: 'pings#show'
 
     # Superset (the M2M caller, not oauth2-proxy) presents a bearer JWT directly; the JWT-side
     # mirror of the Doorkeeper-gated 'oauth/user-data' route declared under AuthMethod.devise? at

--- a/docker/auth/dev.oauth2-proxy-warehouse.cfg
+++ b/docker/auth/dev.oauth2-proxy-warehouse.cfg
@@ -9,19 +9,26 @@ cookie_expire="12h" # When this time is reached, the session is closed and the u
 redirect_url="https://hmis-warehouse.dev.test/oauth2/callback"
 ssl_insecure_skip_verify=true
 
+# requires valid JWT but returns 401 instead of 302 when it's missing/expired. A 302 is only ever
+# right for a request a human could navigate to.
+api_routes=[
+  "^/api/",  # whole namespace is XHR-only; feeds the select2 collection-path widgets
+  "^/messages/(poll|seen)",  # 60s poller on every authenticated page; /messages and /messages/:id are real pages
+  "^/document_exports/[0-9]+$",  # 3s poller in documentExport.js; :id/download is a real navigation
+  "^/cable",  # ActionCable handshake -- a 302 here is opaque to the client
+]
+
 # These paths don't require authentication by oauth2-proxy
 # For HMIS API endpoints, we let them pass through and the backend validates JWT
 skip_auth_routes=[
   "^/$",  # root
-  "^/sign_in",
-  "^/sign_out",
   "^/favicon.ico",
   "^/icon.*",
   "^/healthz",
-  "^/system/status.*",
+  "^/bootz",
+  "^/system_status/",
   "^/mini-profiler-resources.*",
   "^/public_agencies",
-  "^/public_files/.*",
   "^/dev-assets/.*",
   "^/hmis/user\\.json$",  # HMIS user authentication check - backend validates JWT
   "^/hmis/app_settings$",  # HMIS app settings - backend validates JWT

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -74,11 +74,20 @@ module Hmis::Concerns::JwtHmisCurrentUser
       nil
     end
 
-    # HMIS is a JSON SPA API: every auth-failure path returns JSON, overriding the HTML
-    # redirect/render defaults in Idp::JwtAuthentication. render_json_error comes from
-    # Hmis::Concerns::JsonErrors (already included in Hmis::BaseController).
+    # HMIS is a JSON SPA API, so the terminal pages in Idp::JwtAuthentication become JSON here.
+    # render_json_error comes from Hmis::Concerns::JsonErrors (already included in
+    # Hmis::BaseController).
     def idp_handle_unauthenticated
-      render_json_error(401, :unauthenticated)
+      # No 401 for a tokenless request, deliberately. This endpoint doesn't authenticate its own
+      # callers, it trusts the proxy — so there is no legitimate client that arrives without a token,
+      # and api_routes=["^/hmis/"] already 401s the one race the proxy knows about (a request
+      # overlapping a logout) before Rails sees it. One getting through means the proxy was bypassed or
+      # misconfigured, which a 401 would disguise as an ordinary signed-out client.
+      raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
+
+      # 403, not 401: signing in again can't produce an account. A 401 would send the SPA to a
+      # sign-in screen it would come straight back from.
+      render_json_error(403, :no_warehouse_account)
     end
 
     def idp_handle_deactivated

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -14,6 +14,13 @@ require_relative 'login_and_permissions'
 # path returns JSON (the SPA contract) rather than an HTML redirect/render. The JWT examples run
 # only under the AUTH_METHOD=jwt CI process (they lean on the JwtAuthenticationHelper sign_in,
 # included only when AuthMethod.jwt?).
+#
+# find_or_create_from_jwt is deliberately NOT stubbed: sign_in provisions a real
+# Idp::UserAuthenticationSource for the token's (connector_id, connector_user_id), so the real
+# Idp::UserProvisioner resolves the holder off the token's own claims. Pinning the return value
+# would make token→holder resolution unfalsifiable — resolving the wrong user, or ignoring the
+# token entirely, would still pass. The one exception is the no-warehouse-account example, which
+# stubs nil to force a branch that has no reachable fixture.
 RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
   let(:ds) { create :hmis_primary_data_source }
   let(:headers) { { 'HOST' => ds.hmis } }
@@ -21,38 +28,75 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
   describe 'authentication via a forwarded JWT' do
     it 'admits an authenticated JWT request through the filter chain (POST session_keepalive → 200)' do
       user = create(:hmis_user)
-      # idp_token_holder resolves the holder via find_or_create_from_jwt; pin it so resolution is
-      # deterministic (token→user correctness is covered by Idp::JwtCurrentUser's own spec).
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(user.id))
       sign_in(user)
 
       post hmis_session_keepalive_path, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to include('success' => true)
+      # The holder resolved off the token's claims, not off whichever user the DB happened to
+      # return: set_app_user_header reports current_hmis_user, so this is what makes the
+      # unstubbed resolution above load-bearing.
+      expect(response.headers['X-app-user-id'].to_s).to eq(user.id.to_s)
     end
 
-    it 'admits the frontend\'s plain credentialed GET session_keepalive (no CSRF header)' do
+    # GET rather than POST because SessionKeepalivesController aliases show to create, and the SPA
+    # polls the GET. Not a CSRF assertion — config.action_controller.allow_forgery_protection is
+    # false in test, and Rails never verifies the token on GET anyway.
+    it 'admits the aliased GET session_keepalive as well as the POST' do
       user = create(:hmis_user)
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(user.id))
       sign_in(user)
 
       get hmis_session_keepalive_path, headers: headers
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to include('success' => true)
+      expect(response.headers['X-app-user-id'].to_s).to eq(user.id.to_s)
     end
 
-    it 'returns a JSON 401 for an unauthenticated request (no forwarded token), not an HTML redirect' do
+    # Not a JSON 401: nothing authenticates its own callers here, so a tokenless request means the
+    # proxy was bypassed, and a 401 would disguise that as an ordinary signed-out client.
+    it 'raises on a request with no forwarded token rather than answering with a JSON 401' do
+      expect { post hmis_session_keepalive_path, headers: headers }.
+        to raise_error(Idp::UnauthenticatedRequestError)
+    end
+
+    # A good token whose holder has no warehouse account does get JSON, but 403 rather than 401:
+    # signing in again can't produce an account.
+    it 'returns a JSON 403 for a good token whose holder has no warehouse account' do
+      # The one stubbed resolution in the file: Idp::UserProvisioner returns nil only when neither
+      # the connector link nor the email matches, and sign_in provisions both, so there is no
+      # fixture that reaches this branch for real.
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+      sign_in(create(:hmis_user))
+
       post hmis_session_keepalive_path, headers: headers
 
-      expect(response).to have_http_status(:unauthorized)
-      expect(JSON.parse(response.body).dig('error', 'type')).to eq('unauthenticated')
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
+    end
+
+    # The one auth failure the HMIS arm doesn't answer with JSON: the raise bypasses the
+    # idp_handle_unauthenticated override on purpose. A 401 would tell the SPA to show a sign-in
+    # screen for a problem no user can sign their way out of.
+    it 'raises on a refused forwarded token instead of answering with a JSON 401' do
+      refused = instance_double(
+        Idp::JwtHelper,
+        token?: true,
+        valid?: false,
+        invalid_reason: :invalid_audience,
+        invalid_reason_details: { reason: :invalid_audience, expected_audiences: ['hmis'], actual_audience: 'other' },
+      )
+      allow(Idp::JwtHelper).to receive(:new).and_wrap_original do |original_method, **kwargs|
+        kwargs[:access_token] == 'refused-token' ? refused : original_method.call(**kwargs)
+      end
+
+      expect { post hmis_session_keepalive_path, headers: headers.merge('HTTP_X_FORWARDED_ACCESS_TOKEN' => 'refused-token') }.
+        to raise_error(Idp::ForwardedTokenError, /invalid_audience/)
     end
 
     it 'returns a JSON 403 for a locally-deactivated token holder (active = false)' do
       inactive = create(:hmis_user, active: false)
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(inactive.id))
       sign_in(inactive)
 
       post hmis_session_keepalive_path, headers: headers
@@ -62,10 +106,32 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
     end
   end
 
+  # The only route in this file that skips authenticate_hmis_user! (Hmis::UsersController:10), so
+  # it is the one place where "no usable user" has to answer 200-with-no-user instead of raising or
+  # rendering a JSON error. It's the SPA's bootstrap probe, and oauth2-proxy lists it as a
+  # skip_auth_route, so it legitimately arrives with no token at all.
   describe 'GET /hmis/user.json' do
+    it 'answers 200 with no user for a tokenless request, rather than raising as guarded routes do' do
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      # Not merely "no id": the whole payload, so a future change that leaks another user's
+      # values onto the signed-out bootstrap fails here.
+      expect(JSON.parse(response.body)).to eq('impersonating' => false)
+      expect(response.headers['X-app-user-id']).to be_blank
+    end
+
+    it 'answers 200 with no user for a deactivated holder, rather than the JSON 403 guarded routes return' do
+      sign_in(create(:hmis_user, active: false))
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq('impersonating' => false)
+    end
+
     it 'reflects the actual primaryIdp connector value, not just its presence' do
       user = create(:hmis_user)
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(user.id))
       sign_in(user)
       # sign_in (JwtAuthenticationHelper) provisions a real Authentication Source and sets
       # last_connector_id on the user; assert against that value rather than a hardcoded
@@ -95,8 +161,7 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
 
     before do
       # The JWT holder is always the admin; impersonation targets are re-fetched from the session by
-      # id, not from the token (so a single pinned holder exercises the whole round-trip).
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(admin_user.id))
+      # id, not from the token, so one holder exercises the whole round-trip.
       sign_in(admin_user)
     end
 
@@ -132,12 +197,67 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
       expect(JSON.parse(response.body)['id']).to eq(admin_user.id.to_s)
       expect(controller.current_hmis_user).to eq(admin_user)
     end
+
+    # The header comment above claims the next request re-VALIDATES the stored impersonation, but
+    # the round-trip above only proves it re-resolves. Without this example, deleting the
+    # idp_validate_impersonation_permissions guard (Idp::JwtAuthentication:218) leaves the whole
+    # file green, and an admin whose can_impersonate_users? was revoked keeps reading a client's
+    # record as that client for the life of the session.
+    it 'drops the stored impersonation once the admin loses can_impersonate_users?' do
+      post hmis_impersonations_path, params: { user_id: target_user.id }, headers: headers
+      expect(response).to have_http_status(:ok)
+      # Guard against a vacuous pass below: the impersonation really is in force first.
+      get hmis_user_path, headers: headers
+      expect(controller.current_hmis_user).to eq(target_user)
+
+      # Revoke through the role that granted it, using the suite's own helper, rather than stubbing
+      # can_impersonate_users? — so the real permission lookup is what changes its mind.
+      remove_permissions(admin_user.access_controls.first, :can_impersonate_users)
+      expect(Hmis::User.find(admin_user.id).can_impersonate_users?).to eq(false)
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(controller.current_hmis_user).to eq(admin_user)
+      expect(controller.impersonating?).to eq(false)
+      expect(JSON.parse(response.body)['id']).to eq(admin_user.id.to_s)
+    end
+
+    # idp_sync_session_principal! (Idp::JwtAuthentication:161) is what keeps a browser's session from
+    # carrying across holders. Nothing else rotates the Rails session under JWT — there is no
+    # sign-in event — so the session id is what PaperTrail and Hmis::ActivityLog would keep
+    # attributing the new holder's actions to.
+    #
+    # The session ID is the assertion that makes this example load-bearing. Asserting only that the
+    # impersonation didn't carry over does NOT work: the belt-and-braces true_user_id check at
+    # Idp::JwtAuthentication:207-210 clears a foreign impersonation on its own, so deleting
+    # `reset_session if stamped.present?` still yields the right current_hmis_user. Verified by
+    # mutation — that version of this example stayed green.
+    it 'rotates the session id when a different token holder arrives on the same cookie' do
+      post hmis_impersonations_path, params: { user_id: target_user.id }, headers: headers
+      expect(response).to have_http_status(:ok)
+      admin_session_id = session.id.to_s
+      expect(admin_session_id).to be_present
+
+      # A second holder, same cookie jar: sign_in swaps the forwarded token but leaves the
+      # @session_headers the helper has been carrying.
+      other_user = create(:hmis_user, data_source: ds)
+      sign_in(other_user)
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(session.id.to_s).not_to eq(admin_session_id)
+      expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(other_user.id)
+      # And the previous holder's impersonation is gone rather than inherited.
+      expect(controller.current_hmis_user).to eq(other_user)
+      expect(controller.impersonating?).to eq(false)
+    end
   end
 
   describe 'logout' do
     it 'returns the oauth2-proxy sign-out URL as a JSON redirect_url, not an HTTP redirect' do
       user = create(:hmis_user)
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(user.id))
       sign_in(user)
 
       delete destroy_hmis_user_session_path, headers: headers
@@ -154,7 +274,6 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
       create_access_control(admin_user, ds, with_permission: [:can_impersonate_users], user_group: user_group)
       target_user = create(:hmis_user, data_source: ds).tap { |u| user_group.add(u) }
 
-      allow(User).to receive(:find_or_create_from_jwt).and_return(User.find(admin_user.id))
       sign_in(admin_user)
 
       post hmis_impersonations_path, params: { user_id: target_user.id }, headers: headers

--- a/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
+++ b/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
@@ -8,6 +8,8 @@
 
 module LoginAndPermissionsSpecHelper
   def hmis_login(user)
+    return sign_in(user) if AuthMethod.jwt?
+
     post hmis_user_session_path(hmis_user: { email: user.email, password: user.password })
   end
 

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -52,27 +52,47 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       Idp::JwtHelper,
       token?: true,
       valid?: true,
+      invalid_reason: nil,
+      invalid_reason_details: { reason: nil },
       connector_id: 'keycloak',
       expiration_time: 9_999_999_999,
     )
   end
 
   describe '#current_user' do
-    it 'is nil when the token is invalid' do
-      allow(jwt_helper).to receive(:valid?).and_return(false)
-
-      get :index
-
-      expect(response.body).to eq('')
-    end
-
-    it 'is nil when no token is present' do
+    it 'is nil when no token was forwarded' do
       allow(jwt_helper).to receive(:token?).and_return(false)
+      allow(jwt_helper).to receive(:invalid_reason).and_return(:missing)
 
       get :index
 
       expect(response.body).to eq('')
     end
+  end
+
+  # None of these are a signed-out user, and redirecting them to a proxy that still holds a session
+  # is what produces the bounce.
+  describe 'a forwarded token we refuse' do
+    Idp::JwtHelper::INVALID_REASONS.excluding(:missing).each do |reason|
+      it "raises Idp::ForwardedTokenError for #{reason}" do
+        allow(jwt_helper).to receive(:invalid_reason).and_return(reason)
+        allow(jwt_helper).to receive(:invalid_reason_details).and_return({ reason: reason })
+
+        expect { get :index }.to raise_error(Idp::ForwardedTokenError, /#{reason}/)
+      end
+    end
+
+    it 'carries the expected and actual audience into the error message' do
+      allow(jwt_helper).to receive(:invalid_reason).and_return(:invalid_audience)
+      allow(jwt_helper).to receive(:invalid_reason_details).and_return(
+        { reason: :invalid_audience, expected_audiences: ['warehouse'], actual_audience: 'something-else' },
+      )
+
+      expect { get :index }.to raise_error(Idp::ForwardedTokenError, /warehouse.*something-else/)
+    end
+
+    # :missing is excluded from the loop above, and #current_user's 'is nil when no token was
+    # forwarded' is what proves it goes unrefused: a raise there would fail on the raise.
   end
 
   describe '#idp_authenticated_user_from_jwt' do
@@ -96,9 +116,93 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
     end
   end
 
+  # session[:scratch] stands in for ordinary session state. Unlike session[:impersonation] it has no
+  # guard of its own, so its disappearance is what proves reset_session ran.
+  describe 'session principal boundary (#idp_sync_session_principal!)' do
+    let(:principal_key) { Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY }
+    let(:user) { double('User', id: 7, active?: true) }
+
+    before { allow(User).to receive(:find_or_create_from_jwt).and_return(user) }
+
+    it 'stamps the authenticated principal on the session' do
+      get :index
+
+      expect(session[principal_key]).to eq(7)
+    end
+
+    it 'discards session state left behind by a different principal' do
+      session[principal_key] = 99
+      session[:scratch] = 'previous user'
+      session[:impersonation] = { true_user_id: 99, impersonated_user_id: 20 }
+
+      get :index
+
+      expect(response.body).to eq('7')
+      expect(session[:scratch]).to be_nil
+      expect(session[:impersonation]).to be_nil
+      expect(session[principal_key]).to eq(7)
+    end
+
+    # oauth2-proxy refreshes the token mid-session, so this is the common case, not an edge one.
+    it 'keeps the session when the same principal returns' do
+      session[principal_key] = 7
+      session[:scratch] = 'same user'
+
+      get :index
+
+      expect(session[:scratch]).to eq('same user')
+      expect(session[principal_key]).to eq(7)
+    end
+
+    # An anonymous visitor's session, from a page that skips authenticate_user!.
+    it 'stamps an unstamped session without discarding it' do
+      session[:scratch] = 'no stamp yet'
+
+      get :index
+
+      expect(session[:scratch]).to eq('no stamp yet')
+      expect(session[principal_key]).to eq(7)
+    end
+
+    # redis_store hands back an Integer today; this covers a future store that stringifies, where
+    # the failure would be a reset on every request rather than a missed one.
+    it 'treats a stringified stamp as a match' do
+      session[principal_key] = '7'
+      session[:scratch] = 'same user'
+
+      get :index
+
+      expect(session[:scratch]).to eq('same user')
+    end
+
+    # The 403 is terminal, so it must not render on the previous user's session.
+    it 'discards a previous principal session even when the new principal is deactivated' do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(double('User', id: 9, active?: false))
+      session[principal_key] = 99
+      session[:scratch] = 'previous user'
+
+      get :auth
+
+      expect(response).to have_http_status(:forbidden)
+      expect(session[:scratch]).to be_nil
+      expect(session[principal_key]).to eq(9)
+    end
+
+    it 'leaves the session alone when no token resolves a user' do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+      session[principal_key] = 99
+      session[:scratch] = 'previous user'
+
+      get :index
+
+      expect(session[:scratch]).to eq('previous user')
+    end
+  end
+
   describe '#authenticate_user!' do
     it 'sets current_user when a user is present' do
-      user = double('User', id: 5, active?: true)
+      # last_connector_id: the authenticated path also schedules the IdP read-back, which reads it.
+      user = double('User', id: 5, active?: true, last_connector_id: nil)
       allow(User).to receive(:find_or_create_from_jwt).and_return(user)
 
       get :auth
@@ -132,21 +236,36 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       expect(response.body).to eq('')
     end
 
-    # Exercises the real idp_handle_unauthenticated wiring (capture + redirect), including the
-    # real Idp::Oauth2ProxySignInPath builder. No last_connector_id cookie is set here, so
-    # only the rd parameter appears.
-    it 'captures the original URL and redirects to the oauth2 sign-in path when unauthenticated' do
+    # oauth2-proxy owns the sign-in redirect, and the only requests it passes through without a token
+    # are skip_auth_routes, which all skip this filter. So a tokenless request arriving here means the
+    # route surface and the proxy config disagree — ours to fix, not a user's to log in past.
+    it 'raises when a route that requires authentication is reached with no token' do
+      allow(jwt_helper).to receive(:token?).and_return(false)
+      allow(jwt_helper).to receive(:invalid_reason).and_return(:missing)
+
+      expect { get :auth }.to raise_error(Idp::UnauthenticatedRequestError, /\/auth/)
+    end
+
+    # The other way current_user comes back nil: Idp::UserProvisioner returns nil for a good token
+    # with no matching user row when idp/auto_create_user is off, which is routine on a realm shared
+    # with other apps. A real person who needs an account, so a terminal page — not a 500, and not a
+    # redirect the proxy would bounce straight back with the same token.
+    it 'renders a terminal 403 for a good token whose holder has no warehouse account' do
       allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
-      redirect = instance_double(Idp::PostAuthRedirect, capture: '/some/path')
-      allow(Idp::PostAuthRedirect).to receive(:new).and_return(redirect)
 
       get :auth
 
-      expect(redirect).to have_received(:capture)
-      expect(response).to redirect_to('/oauth2/sign_in?rd=%2Fsome%2Fpath')
+      expect(response).to have_http_status(:forbidden)
+      expect(response).to render_template('errors/no_warehouse_account')
     end
   end
 
+  # Deliberately NOT doubling Idp::ImpersonationManager. It is a plain session-backed object with no
+  # I/O, and doubling it costs three things: `clear` becomes a no-op, so deleting either
+  # impersonation_manager.clear from idp_authenticated_user_from_jwt passes; a `.new` stubbed to one
+  # constant value can't see the session swap the source stays un-memoized for (see the comment on
+  # Idp::JwtAuthentication#impersonation_manager); and the double hands back symbol keys directly,
+  # skipping the symbolize_keys the real manager exists to do.
   describe 'impersonation' do
     let(:true_user) do
       User.new.tap do |u|
@@ -167,19 +286,14 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       allow(User).to receive(:find_by).with(id: 10).and_return(true_user)
       allow(User).to receive(:find_by).with(id: 20).and_return(impersonated_user)
 
-      impersonation = double('Idp::ImpersonationManager')
-      allow(impersonation).to receive(:get).and_return(
-        true_user_id: 10,
-        impersonated_user_id: 20,
-      )
-      allow(impersonation).to receive(:clear)
-      allow(Idp::ImpersonationManager).to receive(:new).and_return(impersonation)
+      session[:impersonation] = { true_user_id: 10, impersonated_user_id: 20 }
     end
 
     it 'current_user returns the impersonated user when permissions validate' do
       get :index
 
       expect(response.body).to eq('20')
+      expect(session[:impersonation]).to eq(true_user_id: 10, impersonated_user_id: 20)
     end
 
     it 'true_user returns the true user and impersonating? is true' do
@@ -188,12 +302,24 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       expect(response.body).to eq('10/true')
     end
 
+    # The session store may hand the pair back with string keys; Idp::ImpersonationManager#get
+    # normalizes them. Read through the source's symbol-key access to prove that normalization is
+    # load-bearing — without it this honors nothing and falls through to the true user.
+    it 'honors impersonation stored with string keys' do
+      session[:impersonation] = { 'true_user_id' => 10, 'impersonated_user_id' => 20 }
+
+      get :index
+
+      expect(response.body).to eq('20')
+    end
+
     it 'clears impersonation and returns the true user when the target is not impersonateable_by? the true_user' do
       allow(impersonated_user).to receive(:impersonateable_by?).with(true_user).and_return(false)
 
       get :index
 
       expect(response.body).to eq('10')
+      expect(session[:impersonation]).to be_nil
     end
 
     # Guards the can_impersonate_users? gate independently of impersonateable_by?: a true_user who
@@ -206,8 +332,13 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       get :index
 
       expect(response.body).to eq('10')
+      expect(session[:impersonation]).to be_nil
     end
 
+    # Reaches the belt-and-braces guard in idp_authenticated_user_from_jwt on its own terms: the
+    # session carries no principal stamp, so idp_sync_session_principal! stamps 77 without a
+    # reset_session, and the leftover impersonation survives to the true_user_id comparison. That
+    # guard is the one that has to clear it.
     it 'ignores impersonation when the JWT principal is not the stored true_user' do
       # Leftover session: the token now logs in a different user (77) than the one who
       # started impersonating (10), so the impersonation should be ignored.
@@ -217,6 +348,7 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
       get :index
 
       expect(response.body).to eq('77')
+      expect(session[:impersonation]).to be_nil
     end
   end
 

--- a/spec/models/idp/jwt_helper_spec.rb
+++ b/spec/models/idp/jwt_helper_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
       'aud' => 'test_aud',
       'iss' => 'test_iss',
       'iat' => Time.now.to_i,
+      # A real IdP always stamps exp. Without it here every `valid? == true` example below would be
+      # asserting the never-expires path, and #expiration_time would have nothing to read.
+      'exp' => Time.now.to_i + 3600,
       'name' => '  John   Quincy   Adams  ',
       'federated_claims' => {
         'connector_id' => 'keycloak',
@@ -52,36 +55,11 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
     end
   end
 
+  # #valid? is `invalid_reason.nil?`. Per-reason cases belong under #invalid_reason; what belongs
+  # here is the wiring in both directions plus the forgery attempts.
   describe '#valid?' do
     it 'returns true if token is valid' do
       expect(helper.valid?).to be true
-    end
-
-    it 'returns false if public key is missing' do
-      bad_token = JWT.encode(payload, rsa_key, 'RS256', { kid: 'wrong_kid' })
-      bad_helper = described_class.new(access_token: bad_token)
-      expect(bad_helper.valid?).to be false
-    end
-
-    it 'returns false if token is expired' do
-      expired_payload = payload.merge('exp' => Time.now.to_i - 3600)
-      expired_token = JWT.encode(expired_payload, rsa_key, 'RS256', { kid: kid })
-      expired_helper = described_class.new(access_token: expired_token)
-      expect(expired_helper.valid?).to be false
-    end
-
-    it 'returns false if issuer is invalid' do
-      bad_iss_payload = payload.merge('iss' => 'wrong_iss')
-      bad_iss_token = JWT.encode(bad_iss_payload, rsa_key, 'RS256', { kid: kid })
-      bad_iss_helper = described_class.new(access_token: bad_iss_token)
-      expect(bad_iss_helper.valid?).to be false
-    end
-
-    it 'returns false if audience is invalid' do
-      bad_aud_payload = payload.merge('aud' => 'wrong_aud')
-      bad_aud_token = JWT.encode(bad_aud_payload, rsa_key, 'RS256', { kid: kid })
-      bad_aud_helper = described_class.new(access_token: bad_aud_token)
-      expect(bad_aud_helper.valid?).to be false
     end
 
     it 'rejects a mismatched audience when IDP_AUD is blank (fail-closed)' do
@@ -92,11 +70,119 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
       expect(bad_aud_helper.valid?).to be false
     end
 
-    it 'fails closed (and reports to Sentry) when the JWKS endpoint is unreachable' do
+    # The signing algorithm is the whole basis of trust: every other example here signs with
+    # JWT_ALGORITHM, so widening the allowlist passed to JWT.decode (adding 'none', or accepting a
+    # symmetric alg) would forge tokens at will and leave the rest of this file green. These two pin
+    # the allowlist to exactly the configured algorithm.
+    it 'rejects an unsigned token even when its kid names a key we hold' do
+      unsigned_token = JWT.encode(payload, nil, 'none', { kid: kid })
+      unsigned_helper = described_class.new(access_token: unsigned_token)
+
+      expect(unsigned_helper.valid?).to be false
+      expect(unsigned_helper.invalid_reason).to eq(:malformed)
+    end
+
+    # Classic algorithm-substitution: sign with HMAC using the public key (which anyone can read
+    # from the JWKS) as the shared secret, hoping the verifier treats it as the HMAC key.
+    it 'rejects a token signed with a symmetric algorithm over our public key' do
+      hmac_token = JWT.encode(payload, rsa_key.public_key.to_s, 'HS256', { kid: kid })
+      hmac_helper = described_class.new(access_token: hmac_token)
+
+      expect(hmac_helper.valid?).to be false
+      expect(hmac_helper.invalid_reason).to eq(:malformed)
+    end
+  end
+
+  # Lets a caller tell "nobody is signed in" apart from "our stack is misconfigured". #valid?
+  # collapses both into false, which is why every caller guessed wrong.
+  describe '#invalid_reason' do
+    # The nil-for-a-good-token case is #valid?'s 'returns true if token is valid' above — valid? is
+    # `invalid_reason.nil?`, so it is the same assertion read through the delegation.
+    it 'is :missing when there is no token' do
+      expect(described_class.new(access_token: nil).invalid_reason).to eq(:missing)
+    end
+
+    it 'is :malformed for something that is not a JWT at all' do
+      expect(described_class.new(access_token: 'not-a-jwt').invalid_reason).to eq(:malformed)
+    end
+
+    # Not :malformed: this parses fine and names a key we hold. A token from somewhere else, not a
+    # truncated one.
+    it 'is :bad_signature when the token was signed by another key under a kid we hold' do
+      other_key = OpenSSL::PKey::RSA.generate(2048)
+      token = JWT.encode(payload, other_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).invalid_reason).to eq(:bad_signature)
+    end
+
+    it 'is :unknown_key when the kid is not in the JWKS' do
+      token = JWT.encode(payload, rsa_key, 'RS256', { kid: 'wrong_kid' })
+
+      expect(described_class.new(access_token: token).invalid_reason).to eq(:unknown_key)
+    end
+
+    it 'is :expired for a token past its exp' do
+      token = JWT.encode(payload.merge('exp' => Time.now.to_i - 3600), rsa_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).invalid_reason).to eq(:expired)
+    end
+
+    # ruby-jwt enforces exp only when the claim is present, so without required_claims this token
+    # verifies at any point in the future and nothing on our side can revoke it.
+    it 'is :malformed for a token carrying no exp claim' do
+      token = JWT.encode(payload.except('exp'), rsa_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).invalid_reason).to eq(:malformed)
+    end
+
+    # The :invalid_issuer and :invalid_audience reasons are asserted by the invalid_reason_details
+    # examples below, which carry `reason:` in the hash they compare.
+
+    # Sentry is asserted here because an unreachable IdP is the one reason that means our stack is
+    # broken rather than the caller's token, and nothing else in the request would say so.
+    it 'is :jwks_unreachable when the JWKS endpoint cannot be reached, and reports to Sentry' do
       allow(described_class).to receive(:fetch_jwks).and_raise(SocketError.new('getaddrinfo: Name or service not known'))
       expect(Sentry).to receive(:capture_exception_with_info).with(instance_of(SocketError), anything)
 
-      expect(helper.valid?).to be false
+      expect(helper.invalid_reason).to eq(:jwks_unreachable)
+    end
+
+    it 'covers every reason the class advertises' do
+      expect(described_class::INVALID_REASONS).to contain_exactly(
+        :missing, :malformed, :bad_signature, :unknown_key, :expired,
+        :invalid_issuer, :invalid_audience, :jwks_unreachable
+      )
+    end
+
+    # A wrong IDP_AUD locks out a whole deployment. The only evidence used to be the string
+    # 'Invalid audience'.
+    it 'reports expected and actual audience' do
+      token = JWT.encode(payload.merge('aud' => 'wrong_aud'), rsa_key, 'RS256', { kid: kid })
+
+      details = described_class.new(access_token: token).invalid_reason_details
+
+      expect(details).to eq(reason: :invalid_audience, expected_audiences: ['test_aud'], actual_audience: 'wrong_aud')
+    end
+
+    it 'reports expected and actual issuer' do
+      token = JWT.encode(payload.merge('iss' => 'wrong_iss'), rsa_key, 'RS256', { kid: kid })
+
+      details = described_class.new(access_token: token).invalid_reason_details
+
+      expect(details).to eq(reason: :invalid_issuer, expected_issuer: 'test_iss', actual_issuer: 'wrong_iss')
+    end
+
+    it 'reports the reason alone for a failure that names no expected value' do
+      expect(described_class.new(access_token: 'not-a-jwt').invalid_reason_details).to eq(reason: :malformed)
+    end
+
+    # A request asks more than once, and re-running would re-log and re-report each time.
+    it 'only works the reason out once' do
+      bad_helper = described_class.new(access_token: 'not-a-jwt')
+
+      expect(Rails.logger).to receive(:error).once
+
+      2.times { bad_helper.invalid_reason }
     end
   end
 
@@ -108,9 +194,30 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
     end
   end
 
+  # This is the key User.find_from_jwt matches on, so every normalization here decides which account
+  # a token resolves to. Dropping the strip would provision a second account for the same person;
+  # dropping the presence would hand a blank string to the lookup.
   describe '#payload_email' do
     it 'returns downcased email from payload' do
       expect(helper.payload_email).to eq('test@example.com')
+    end
+
+    it 'strips surrounding whitespace before downcasing' do
+      token = JWT.encode(payload.merge('email' => "  Pad@Example.COM \n"), rsa_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).payload_email).to eq('pad@example.com')
+    end
+
+    it 'is nil rather than a blank string when the claim is whitespace only' do
+      token = JWT.encode(payload.merge('email' => '   '), rsa_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).payload_email).to be_nil
+    end
+
+    it 'is nil when the claim is absent' do
+      token = JWT.encode(payload.except('email'), rsa_key, 'RS256', { kid: kid })
+
+      expect(described_class.new(access_token: token).payload_email).to be_nil
     end
   end
 
@@ -172,6 +279,112 @@ RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
     it 'raises naming the missing key when one is absent' do
       allow(ENV).to receive(:fetch).with('IDP_AUD', '').and_return('')
       expect { described_class.assert_boot_config! }.to raise_error(RuntimeError, /IDP_AUD/)
+    end
+
+    # The other half of this guard. A typo'd AUTH_METHOD doesn't fail loudly on its own: AuthMethod
+    # .jwt? just comes back false and the app quietly boots on Devise with the JWT stack inert. This
+    # raise is what turns that into a failed deploy, so it needs its own example.
+    describe 'AUTH_METHOD' do
+      before { allow(ENV).to receive(:[]).and_call_original }
+
+      it 'raises naming the offending value when AUTH_METHOD is not recognized' do
+        allow(ENV).to receive(:[]).with('AUTH_METHOD').and_return('jwtt')
+
+        expect { described_class.assert_boot_config! }.to raise_error(RuntimeError, /Invalid AUTH_METHOD.*jwtt/)
+      end
+
+      ['jwt', 'devise', nil].each do |auth_method|
+        it "accepts #{auth_method.inspect}" do
+          allow(ENV).to receive(:[]).with('AUTH_METHOD').and_return(auth_method)
+
+          expect { described_class.assert_boot_config! }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  # Every other example in this file stubs .fetch_jwks, so the one method that decides which keys we
+  # trust was never exercised. These drive the real Net::HTTP path against WebMock.
+  describe '.fetch_jwks' do
+    let(:jwks_url) { 'https://idp.example.test/jwks' }
+
+    before { allow(described_class).to receive(:fetch_jwks).and_call_original }
+
+    it 'parses the keyset served by JWKS_URL' do
+      request = stub_request(:get, jwks_url).
+        to_return(body: jwks_hash.to_json, headers: { 'Content-Type' => 'application/json' })
+
+      expect(described_class.fetch_jwks).to eq(jwks_hash)
+      expect(request).to have_been_requested
+    end
+
+    # Not a style point: Net::HTTP defaults to no read timeout, so a wedged IdP would hang every
+    # authenticated request in the pool instead of failing closed via NETWORK_ERRORS.
+    it 'bounds both the connect and the read' do
+      stub_request(:get, jwks_url).to_return(body: jwks_hash.to_json)
+
+      expect(Net::HTTP).to receive(:start).
+        with('idp.example.test', 443, hash_including(use_ssl: true, open_timeout: 5, read_timeout: 5)).
+        and_call_original
+
+      described_class.fetch_jwks
+    end
+
+    # The existing SocketError example hand-raises the exception. This one proves NETWORK_ERRORS
+    # actually names what Net::HTTP raises on a real stall, which a hand-raised error cannot.
+    it 'surfaces a transport stall as :jwks_unreachable rather than a client-token problem' do
+      stub_request(:get, jwks_url).to_timeout
+      allow(Sentry).to receive(:capture_exception_with_info)
+
+      expect(helper.invalid_reason).to eq(:jwks_unreachable)
+    end
+
+    # 200 with a non-JSON body: the status check alone would miss this one.
+    it 'surfaces a 200 with an unparseable body as :jwks_unreachable' do
+      stub_request(:get, jwks_url).to_return(status: 200, body: 'not json')
+      expect(Sentry).to receive(:capture_exception_with_info).
+        with(instance_of(described_class::JwksUnavailableError), anything)
+
+      expect(helper.invalid_reason).to eq(:jwks_unreachable)
+    end
+
+    # 200 with well-formed JSON that isn't a keyset — a gateway answering {"error": ...} without
+    # bothering to set a status. Neither the status check nor the parse guard catches this shape;
+    # unguarded it raises NoMethodError out of #invalid_reason instead of failing closed.
+    [
+      ['a keyless object', '{"foo":"bar"}'],
+      ['keys that are not an array', '{"keys":"nope"}'],
+      ['a bare array', '[]'],
+      ['a JSON literal', 'null'],
+    ].each do |shape, body|
+      it "surfaces #{shape} from the JWKS endpoint as :jwks_unreachable" do
+        stub_request(:get, jwks_url).
+          to_return(status: 200, body: body, headers: { 'Content-Type' => 'application/json' })
+        expect(Sentry).to receive(:capture_exception_with_info).
+          with(instance_of(described_class::JwksUnavailableError), anything)
+
+        expect(helper.invalid_reason).to eq(:jwks_unreachable)
+      end
+    end
+
+    # A failed fetch must not poison the hour-long JWKS cache — otherwise one bad response keeps
+    # rejecting good tokens long after the IdP recovers. The keyless 200 is the dangerous shape: it
+    # looks like a successful fetch, so nothing but the raise keeps it out of memory_cache.
+    [
+      ['a 502 with an HTML body', 502, '<html>bad gateway</html>'],
+      ['a 200 with an error object', 200, '{"error":"service unavailable"}'],
+    ].each do |shape, status, body|
+      it "does not cache #{shape}" do
+        stub_request(:get, jwks_url).to_return(status: status, body: body)
+        allow(Sentry).to receive(:capture_exception_with_info)
+        expect(helper.invalid_reason).to eq(:jwks_unreachable)
+        expect(described_class.memory_cache.read('jwt_helper_jwks')).to be_nil
+
+        stub_request(:get, jwks_url).
+          to_return(body: jwks_hash.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        expect(described_class.new(access_token: access_token).invalid_reason).to be_nil
+      end
     end
   end
 

--- a/spec/requests/api/pings_controller_spec.rb
+++ b/spec/requests/api/pings_controller_spec.rb
@@ -1,0 +1,27 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::PingsController, type: :request, if: AuthMethod.jwt? do
+  let(:user) { create(:user) }
+
+  it 'returns 200 for an authenticated user' do
+    sign_in(user)
+
+    get '/api/ping'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to be_empty
+  end
+
+  it 'returns 500 for a tokenless probe' do
+    get '/api/ping'
+    expect(response).to have_http_status(:error)
+  end
+end

--- a/spec/requests/idp/warehouse_jwt_wiring_spec.rb
+++ b/spec/requests/idp/warehouse_jwt_wiring_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
     # stubbed (find_or_create_from_jwt + JwtHelper.new via sign_in), so they prove the before-action
     # chain admits a resolved user and reaches the action. Token→user resolution correctness (valid?
     # false, find_or_create vs find_from_jwt, impersonation) lives in Idp::JwtCurrentUser's spec. The
-    # deny side of the gate is the unauthenticated example below: it asserts a redirect rather than
+    # deny side of the gate is the unauthenticated example below: it asserts a raise rather than
     # keepalive's own head(:unauthorized), which is what proves authenticate_user! actually guards it.
     it 'admits an authenticated JWT request through the filter chain and reports token expiry (GET → 200)' do
       sign_in(user)
@@ -52,33 +52,146 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
       expect(JSON.parse(response.body)).to include('expiration_time', 'remaining_seconds')
     end
 
-    it 'redirects an unauthenticated request to the oauth2-proxy sign-in (not a Devise form)' do
-      get session_keepalive_path
+    # A redirect here would go to a proxy that still has a session and come straight back with the
+    # same token.
+    describe 'a forwarded token the app refuses' do
+      # Stubbed reason rather than a real bad token: the JWT env keys aren't set in test, so real
+      # validation can't run here. Which reason is which is Idp::JwtHelper's spec.
+      let(:headers) { { 'HTTP_X_FORWARDED_ACCESS_TOKEN' => 'refused-token' } }
 
-      # A redirect (not keepalive's own head(:unauthorized)) is the tell that authenticate_user! ran
-      # ahead of the action — i.e. the shared JWT auth gate is wired onto this route.
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to include('/oauth2/sign_in')
+      before do
+        refused = instance_double(
+          Idp::JwtHelper,
+          token?: true,
+          valid?: false,
+          invalid_reason: :malformed,
+          invalid_reason_details: { reason: :malformed },
+        )
+        allow(Idp::JwtHelper).to receive(:new).and_wrap_original do |original_method, **kwargs|
+          kwargs[:access_token] == 'refused-token' ? refused : original_method.call(**kwargs)
+        end
+      end
+
+      it 'raises rather than reporting the request as signed out' do
+        expect { get edit_account_path, headers: headers }.to raise_error(Idp::ForwardedTokenError, /malformed/)
+      end
+
+      # No per-action exceptions: authenticate_user! runs first everywhere, so every authenticated
+      # route reports the misconfiguration the same way.
+      it 'raises on the session routes too rather than converting it to a 401' do
+        expect { get session_keepalive_path, headers: headers.merge('HTTP_ACCEPT' => 'application/json') }.
+          to raise_error(Idp::ForwardedTokenError, /malformed/)
+      end
+
+      # Sign-out never reaches #destroy, so reset_session doesn't run and the IdP session stays
+      # paired with a live Rails session rather than being silently orphaned.
+      it 'raises on sign-out rather than resetting the session' do
+        expect { delete destroy_user_session_path, headers: headers }.
+          to raise_error(Idp::ForwardedTokenError, /malformed/)
+      end
+    end
+
+    # The raise (not keepalive's own head(:unauthorized)) is the tell that authenticate_user! ran ahead
+    # of the action — i.e. the shared JWT auth gate is wired onto this route. oauth2-proxy never passes
+    # a tokenless request to a route that isn't a skip_auth_route, so reaching Rails is the defect.
+    it 'raises on a request with no forwarded token rather than redirecting to sign-in' do
+      expect { get session_keepalive_path }.to raise_error(Idp::UnauthenticatedRequestError)
+    end
+
+    # root is a skip_auth_route and skips authenticate_user!, so the deactivated wall has to come from
+    # its own filter (reject_deactivated_user!) or it isn't there at all. This is the page the proxy
+    # returns someone to after sign-in, so it's where a switched-off account first finds out.
+    describe 'the public root page' do
+      it 'walls off a deactivated token holder instead of serving the signed-out landing page' do
+        sign_in(user)
+        user.update!(active: false)
+
+        get root_path
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include(Translation.translate('Your warehouse account has been deactivated'))
+      end
+
+      it 'still serves the landing page to a visitor with no token' do
+        get root_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      # Deliberately not walled: on a realm shared with other apps, a valid token from someone who
+      # was never a warehouse user is routine, and the public pages are public for them.
+      it 'still serves the landing page to a token holder with no warehouse account' do
+        sign_in(user)
+        allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+        get root_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      # The wall is an HTML page, so it only stands in front of HTML requests. Answering an image
+      # request with it would replace the asset rather than tell anyone anything.
+      it 'leaves a non-HTML request on a route that skips authentication to its own action' do
+        sign_in(user)
+        user.update!(active: false)
+
+        get logo_path('logo.png')
+
+        expect(response).not_to have_http_status(:forbidden)
+      end
     end
 
     describe 'logout' do
-      it 'resets the session (clearing any session-stored impersonation), separate from the oauth2-proxy/IdP sign-out that follows the redirect' do
+      it 'resets the session, separate from the oauth2-proxy/IdP sign-out that follows the redirect' do
         sign_in(user)
-        # session is only available once an integration request has happened, so establish one
-        # before poking it directly.
         get session_keepalive_path
         expect(response).to have_http_status(:ok)
-
-        # Simulate a leftover impersonation entry (Idp::ImpersonationManager stores this under
-        # session[:impersonation]); reset_session in Idp::SessionsController#destroy should wipe it,
-        # mirroring Devise's sign_out, so it can't silently resume on the next sign-in.
-        session[:impersonation] = { true_user_id: user.id, impersonated_user_id: user.id }
+        # Asserted on a key the app writes (idp_sync_session_principal! stamps it during a normal
+        # request): a session[...]= from the spec never reaches the next request, so it would read as
+        # nil afterwards whether or not reset_session ran. reset_session in
+        # Idp::SessionsController#destroy clears this, mirroring Devise's sign_out, so nothing
+        # session-backed — impersonation included — can silently resume on the next sign-in.
+        expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
 
         delete destroy_user_session_path
 
         expect(response).to have_http_status(:redirect)
         expect(response.location).to include('/oauth2/sign_out')
-        expect(session[:impersonation]).to be_nil
+        expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to be_nil
+      end
+    end
+
+    # The concern spec covers the branches. This covers the bit only the real stack shows: against
+    # the live session store the session.id actually rotates, so two people's audit rows can't
+    # share one.
+    describe 'session boundary between IdP principals' do
+      let(:other_user) { create :user }
+
+      it 'starts a new Rails session when a different user authenticates on the same browser' do
+        allow(other_user).to receive(:training_required?).and_return(false)
+        allow(other_user).to receive(:pending_compliance_requirements).and_return([])
+        # Resolve off the forwarded token rather than the flat stub in the outer before block, so
+        # that signing in as someone else is what actually moves the principal.
+        allow(User).to receive(:find_or_create_from_jwt) do |helper|
+          helper.connector_user_id == jwt_connector_user_id(other_user) ? other_user : user
+        end
+
+        sign_in(user)
+        get session_keepalive_path
+        expect(response).to have_http_status(:ok)
+        expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+        first_session_id = session.id.to_s
+        expect(first_session_id).to be_present
+
+        # Someone else signs in on the same browser — the integration cookie jar carries the
+        # session cookie forward.
+        sign_in(other_user)
+
+        get session_keepalive_path
+
+        expect(response).to have_http_status(:ok)
+        expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(other_user.id)
+        expect(session.id.to_s).not_to eq(first_session_id)
       end
     end
 
@@ -109,10 +222,20 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
   describe ApplicationCable::Connection, type: :channel, if: AuthMethod.jwt? do
     let(:user) { create :user }
 
+    # Only the forwarded token resolves to the double; anything else builds a real Idp::JwtHelper,
+    # which refuses it. That keeps the header the connection reads under test: read the wrong one (or
+    # none) and the accepting examples below fail, rather than passing on a double that answers
+    # valid? to whatever it was handed.
+    def stub_forwarded_token(token, helper)
+      allow(Idp::JwtHelper).to receive(:new).and_wrap_original do |original_method, **kwargs|
+        kwargs[:access_token] == token ? helper : original_method.call(**kwargs)
+      end
+    end
+
     it 'accepts a connection with a valid forwarded token for an active user' do
       # Don't stub active? — the :user factory creates an active row, so the active? gate runs for real.
-      jwt_helper = instance_double(Idp::JwtHelper, token?: true, valid?: true)
-      allow(Idp::JwtHelper).to receive(:new).and_return(jwt_helper)
+      jwt_helper = instance_double(Idp::JwtHelper, token?: true, valid?: true, invalid_reason: nil)
+      stub_forwarded_token('forwarded-token', jwt_helper)
       allow(User).to receive(:find_from_jwt).with(jwt_helper).and_return(user)
 
       connect env: { 'HTTP_X_FORWARDED_ACCESS_TOKEN' => 'forwarded-token' }
@@ -122,8 +245,8 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
 
     it 'rejects a connection for a deactivated user even with a valid forwarded token' do
       inactive_user = create :user, active: false
-      jwt_helper = instance_double(Idp::JwtHelper, token?: true, valid?: true)
-      allow(Idp::JwtHelper).to receive(:new).and_return(jwt_helper)
+      jwt_helper = instance_double(Idp::JwtHelper, token?: true, valid?: true, invalid_reason: nil)
+      stub_forwarded_token('forwarded-token', jwt_helper)
       allow(User).to receive(:find_from_jwt).with(jwt_helper).and_return(inactive_user)
 
       expect { connect env: { 'HTTP_X_FORWARDED_ACCESS_TOKEN' => 'forwarded-token' } }.
@@ -132,6 +255,23 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
 
     it 'rejects a connection with no forwarded token' do
       expect { connect }.to have_rejected_connection
+    end
+
+    # A plain rejection, not the raise the controllers do: a socket has no page to render, and every
+    # page load during the same misconfiguration already reports it with full request context.
+    it 'rejects a refused forwarded token without raising or reporting' do
+      refused = instance_double(
+        Idp::JwtHelper,
+        token?: true,
+        valid?: false,
+        invalid_reason: :malformed,
+        invalid_reason_details: { reason: :malformed },
+      )
+      stub_forwarded_token('refused-token', refused)
+      expect(Sentry).not_to receive(:capture_message)
+
+      expect { connect env: { 'HTTP_X_FORWARDED_ACCESS_TOKEN' => 'refused-token' } }.
+        to have_rejected_connection
     end
   end
 

--- a/spec/support/jwt_authentication_helper.rb
+++ b/spec/support/jwt_authentication_helper.rb
@@ -7,6 +7,14 @@
 # frozen_string_literal: true
 
 module JwtAuthenticationHelper
+  # The id the IdP knows this user by, deliberately not the warehouse user id. Code that confuses
+  # the two — reading current_user.id where it should read the token's federated claim, or vice
+  # versa — has to fail a spec rather than pass by coincidence. Specs that stub Admin API URLs for
+  # a signed-in user build them off this, not off user.id.
+  def jwt_connector_user_id(user)
+    "kc-#{user.id}"
+  end
+
   def sign_in(user)
     mock_token = "mock-jwt-token-#{user.id}-#{SecureRandom.hex(8)}"
     mock_session_id = "mock-session-id-#{user.id}-#{SecureRandom.hex(4)}"
@@ -15,8 +23,9 @@ module JwtAuthenticationHelper
       Idp::JwtHelper,
       token?: true,
       valid?: true,
+      invalid_reason: nil,
       connector_id: 'test',
-      connector_user_id: user.id.to_s,
+      connector_user_id: jwt_connector_user_id(user),
       payload_email: user.email,
       expiration_time: 1.hour.from_now,
       session_id: mock_session_id,
@@ -40,7 +49,7 @@ module JwtAuthenticationHelper
 
     user.user_authentication_sources.find_or_create_by!(
       connector_id: 'test',
-      connector_user_id: user.id.to_s,
+      connector_user_id: jwt_connector_user_id(user),
     )
     user.update_column(:last_connector_id, 'test') if user.last_connector_id != 'test'
 

--- a/spec/support/jwt_helper_test_extensions.rb
+++ b/spec/support/jwt_helper_test_extensions.rb
@@ -26,6 +26,15 @@ module JwtHelperTestExtensions
     super
   end
 
+  # Same bypass as valid?. Without it a mock token reads as :malformed and every JWT path treats it
+  # as a broken stack.
+  def invalid_reason
+    return :missing unless token?
+    return nil if access_token.start_with?('mock-jwt-token-')
+
+    super
+  end
+
   # Override payload to return mock payload for mock tokens
   def payload
     # For mock tokens in system tests, return mock payload

--- a/spec/views/application/inactive_session_modal_spec.rb
+++ b/spec/views/application/inactive_session_modal_spec.rb
@@ -1,0 +1,60 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Exercises the partial's countdown seed on both arms by stubbing AuthMethod.jwt?, so it runs under
+# either CI boot with no `if: AuthMethod.jwt?` guard. The url helpers it renders (session_keepalive_path,
+# destroy_user_session_path) exist on both arms, so the stubbed arm never mismatches routing.
+RSpec.describe 'application/_inactive_session_modal', type: :view do
+  let(:user) { create(:user) }
+
+  before do
+    allow(Translation).to receive(:translate) { |key| key }
+    # current_user / user_session_expires_at are controller helper_methods absent on the bare view
+    # double, so partial-double verification must be relaxed to stub them.
+    without_partial_double_verification do
+      allow(view).to receive(:current_user).and_return(user)
+    end
+  end
+
+  def modal_node
+    render
+    Nokogiri::HTML(rendered).at_css('#inactive-session-modal')
+  end
+
+  context 'on the JWT arm' do
+    let(:expires_at) { 37.minutes.from_now }
+
+    before do
+      allow(AuthMethod).to receive(:jwt?).and_return(true)
+      without_partial_double_verification do
+        allow(view).to receive(:user_session_expires_at).and_return(expires_at)
+      end
+    end
+
+    it 'seeds the countdown from the token expiry rather than the Devise default' do
+      node = modal_node
+
+      expect(node['data-inactive-session-modal-session-expires-at-value']).to eq(expires_at.to_i.to_s)
+      devise_default = Time.current.to_i + Devise.timeout_in.in_seconds.to_i
+      expect(node['data-inactive-session-modal-session-expires-at-value'].to_i).not_to be_within(30).of(devise_default)
+    end
+  end
+
+  context 'on the Devise arm' do
+    before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
+
+    it 'does not seed a token expiry and keeps the Devise lifetime' do
+      node = modal_node
+
+      expect(node['data-inactive-session-modal-session-expires-at-value']).to be_nil
+      expect(node['data-inactive-session-modal-session-lifetime-secs-value']).to eq(Devise.timeout_in.in_seconds.to_s)
+    end
+  end
+end


### PR DESCRIPTION

## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
* JwtHelper#valid? becomes reasoned #invalid_reason; require exp claim; JWKS non-keyset responses fail closed without poisoning cache
* refused forwarded token raises ForwardedTokenError, missing token on a guarded route raises UnauthenticatedRequestError, instead of redirecting into a proxy loop
* deactivated account and no-warehouse-account render terminal 403s; split reject_deactivated_user! into its own before_action so it survives skip_before_action :authenticate_user!
* reset the Rails session when a different IdP principal appears on the same browser
* inactivity countdown seeds from the token's real exp
* add authenticated /api/ping; correct oauth2-proxy api_routes/skip_auth_routes


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
