### PR TITLE
feat: 8458 back-channel IdP session logout

### DIFF
--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -68,6 +68,76 @@ module Idp::JwtAuthentication
     end
   end
 
+  # Ends the token holder's sessions at the IDP, the one session /oauth2/sign_out doesn't reach: the
+  # proxy ends Dex, but Dex doesn't propagate logout upstream.
+  #
+  # Uses the admin API rather than an RP-initiated logout redirect because the token is Dex's, so we
+  # have no id_token_hint for Keycloak and no client of our own to name.
+  #
+  # This is not single logout: other apps' proxy cookies carry Dex refresh tokens that Dex renews
+  # without re-checking Keycloak, so their sessions outlive this call.
+  #
+  # The id comes off the token rather than current_user because under impersonation current_user is
+  # the impersonated user, and the impersonation-aware accessors are session-backed, so they would
+  # be order-dependent against reset_session. Reading the token is also what lets this run before
+  # reset_session.
+  #
+  # @raise [Idp::SessionLogoutRefused] the call failed, or we couldn't tell whether to make one.
+  #   Either way a session may still be live, so callers fail closed. Returning means nothing to end.
+  def idp_end_token_holder_sessions
+    jwt_helper = idp_jwt_helper_for_request
+    reason = jwt_helper.invalid_reason
+    # No token means nothing to end.
+    return if reason == :missing
+    # Unreachable through the request layer: idp_token_holder already raised for any reason but
+    # :missing. Kept as the fail-closed answer — the proxy vouched for the token, so assume a session
+    # is live and that we can't tell whose.
+    raise Idp::SessionLogoutRefused, "Sign-out refused: oauth2-proxy forwarded a token we refused (#{reason})" if reason
+
+    connector_id = jwt_helper.connector_id
+    connector_user_id = jwt_helper.connector_user_id
+    # Reached on the warehouse arm only; the HMIS arm walls off a token with no resolvable holder
+    # ahead of sign-out. connector_user_id is the claim this turns on: blank with a connector present
+    # would call logout_user_sessions(user_id: nil). A blank connector_id resolves to an
+    # Idp::NullService and would stop at the capability check below anyway.
+    return if connector_id.blank? || connector_user_id.blank?
+
+    service = idp_session_logout_service(connector_id)
+    # nil means resolution failed and was already reported. A service without session logout has no
+    # admin API to call, so there is nothing to end.
+    raise Idp::SessionLogoutRefused, "Sign-out refused: no IDP service for connector #{connector_id}" if service.nil?
+    return unless service.supports_session_logout?
+
+    begin
+      # No deadline here: the service's own socket timeouts bound this, and Timeout.timeout would
+      # raise at an arbitrary point in the thread, including after Keycloak ended the sessions.
+      service.logout_user_sessions(user_id: connector_user_id)
+    rescue StandardError => e
+      Sentry.capture_exception_with_info(
+        e,
+        "Couldn't end IDP sessions for #{connector_id} user #{connector_user_id}; sign-out was refused",
+      )
+      raise Idp::SessionLogoutRefused, "Sign-out refused: #{e.class} ending IDP sessions for #{connector_id} user #{connector_user_id}"
+    end
+
+    nil
+  end
+
+  # Split out so a failure to resolve the service is reported on its own terms: the fix is ours
+  # (connector config, credentials) rather than the IDP's. Callers still fail closed, since an
+  # unresolvable connector tells us nothing about whether a session is live.
+  #
+  # @return [Idp::Service, nil] nil when resolution raised.
+  def idp_session_logout_service(connector_id)
+    Idp::ServiceFactory.for_connector(connector_id)
+  rescue StandardError => e
+    Sentry.capture_exception_with_info(
+      e,
+      "Couldn't resolve the IDP service for connector #{connector_id}; sign-out was refused",
+    )
+    nil
+  end
+
   def idp_validate_impersonation_permissions(true_user, impersonated_user)
     return false unless true_user&.can_impersonate_users?
     return false unless impersonated_user&.impersonateable_by?(true_user)
@@ -174,6 +244,13 @@ module Idp::JwtAuthentication
   # as a JSON 403 for API/HMIS controllers, the same way as idp_handle_unauthenticated.
   def idp_handle_deactivated
     render(template: 'errors/account_deactivated', status: :forbidden)
+  end
+
+  # Shown when idp_end_token_holder_sessions raises Idp::SessionLogoutRefused. A template rather
+  # than render(plain:) because sign-out is a link_to with method: :delete, so the user lands here on
+  # a full page load and needs the layout and a retry link. HMIS overrides this to return JSON.
+  def idp_handle_session_logout_failure
+    render(template: 'errors/sign_out_failed', status: :internal_server_error)
   end
 
   def user_session_expires_at

--- a/app/controllers/idp/sessions_controller.rb
+++ b/app/controllers/idp/sessions_controller.rb
@@ -8,17 +8,30 @@
 
 module Idp
   # Serves the shared session route names (new_user_session / user_session / destroy_user_session /
-  # session_keepalive / logout_talentlms) under AUTH_METHOD=jwt. Login and logout are owned by the
-  # oauth2-proxy sidecar + the IdP, so these actions only bridge the legacy routes to proxy
-  # redirects (sign-in/out) and report the forwarded token's expiry for the inactivity countdown
-  # (keepalive). No Devise/Warden machinery is involved — current_user / authenticate_user! come
-  # from Idp::JwtCurrentUser, which ApplicationController includes under JWT.
+  # session_keepalive / logout_talentlms) under AUTH_METHOD=jwt. Login is owned by the oauth2-proxy
+  # sidecar + the IdP, so these actions mostly bridge the legacy routes to proxy redirects and
+  # report the forwarded token's expiry for the inactivity countdown (keepalive). #destroy is the
+  # exception — it ends the IdP session itself, since the proxy hop doesn't reach Keycloak. No
+  # Devise/Warden machinery is involved — current_user / authenticate_user! come from
+  # Idp::JwtCurrentUser, which ApplicationController includes under JWT.
   #
   # Only mounted by the AuthMethod.jwt? arm of config/routes.rb; the Devise arm routes the same
   # names to Users::SessionsController instead.
   class SessionsController < ApplicationController
     # sign-in is a redirect to the proxy, so these must not bounce off authenticate_user! first.
-    skip_before_action :authenticate_user!, only: [:new, :create]
+    #
+    # :destroy is here for the opposite reason. The terminal 403 pages
+    # (errors/account_deactivated, errors/no_warehouse_account) render for someone who holds a good
+    # token but has no usable current_user, so authenticate_user! sends them back to the same page
+    # and they can never sign out — on a shared machine the next person inherits a live IdP session.
+    # #destroy doesn't need current_user anyway: idp_end_token_holder_sessions reads the forwarded
+    # token, which is also what lets it run before reset_session.
+    #
+    # So #destroy is the one action a token with no resolvable holder reaches, which is why the
+    # blank-claim guard in idp_end_token_holder_sessions is live here and dead on the HMIS arm. A
+    # token we outright refuse still doesn't get through: current_user is resolved by an earlier
+    # filter in the chain, and idp_token_holder raises there.
+    skip_before_action :authenticate_user!, only: [:new, :create, :destroy]
     # Same reason, one filter later: reject_deactivated_user! walls off the routes that skip
     # authenticate_user!, and signing out is the one thing a deactivated user still has to be able to
     # do — otherwise the link on errors/account_deactivated renders that page right back.
@@ -32,15 +45,30 @@ module Idp
     end
     alias_method :create, :new
 
-    # DELETE users/sign_out (and GET logout_talentlms) — clear the proxy session and return to
-    # root_path via the rd parameter. Deliberately uses a relative path since oauth2-proxy is
-    # same-origin; an absolute URL built from request.base_url could be spoofed via the Host header.
+    # DELETE users/sign_out. The rd redirect uses a relative path since oauth2-proxy is same-origin;
+    # an absolute URL built from request.base_url could be spoofed via the Host header.
     def destroy
-      # wipes session so it doesn't outlive this login. Not a substitute for oauth2-proxy/IdP
-      # sign-out the browser performs next via this redirect.
+      # First: reads the token, not the session, and fails closed — a refusal means the SSO session is
+      # still live, so nothing below runs. Cost accepted: while the IdP is unreachable nobody can sign
+      # out. Don't make this best-effort. Hmis::Idp::SessionsController#destroy is the same sequence.
+      idp_end_token_holder_sessions
+
       reset_session
 
       redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+    rescue Idp::SessionLogoutRefused
+      idp_handle_session_logout_failure
+    end
+
+    # GET logout_talentlms — TalentLMS redirects here when the user logs out of the LMS. Renders a
+    # page whose button does the sign-out; must not sign out itself. It's a cross-site GET with no
+    # CSRF token, so a forged one looks identical, and #destroy would end all of that user's IdP
+    # sessions (every browser and device), not just this one — scoped to the token holder, never
+    # realm-wide.
+    #
+    # Don't redirect to /oauth2/sign_out first: that drops the forwarded token the button's DELETE
+    # authenticates with.
+    def logout_talentlms
     end
 
     # GET/POST session_keepalive — report the forwarded token's expiry so the frontend countdown

--- a/app/models/idp/session_logout_refused.rb
+++ b/app/models/idp/session_logout_refused.rb
@@ -1,0 +1,20 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Idp
+  # Couldn't end the token holder's IDP sessions, or couldn't tell whether to try. Either way a
+  # session may still be live, so the sign-out that raised this tears nothing down: a user who
+  # believes they signed out is worse, since on a shared machine the next person inherits the account.
+  #
+  # An exception rather than a false return so an unrescued raise still aborts the action — both
+  # sign-out arms have to honor it. Already alerted to Sentry where it was raised; handlers shouldn't
+  # report it again. Raised in Idp::JwtAuthentication#idp_end_token_holder_sessions, rescued into
+  # idp_handle_session_logout_failure.
+  class SessionLogoutRefused < StandardError
+  end
+end

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -191,6 +191,16 @@ module Idp
       put_full_user(user_id: user_id, patch: { 'enabled' => false }, operation: :deactivate_user, failure: 'Failed to deactivate user')
     end
 
+    # Ends every session this user has in the realm, other browsers and devices included. Their SSO
+    # cookie stays in the browser but is dead, so the next request re-prompts.
+    # Back channel because Dex won't propagate a logout upstream — see
+    # Idp::JwtAuthentication#idp_end_token_holder_sessions.
+    def logout_user_sessions(user_id:)
+      response = make_request(:post, "/admin/realms/#{realm}/users/#{user_id}/logout")
+
+      handle_response(response, operation: :logout_user_sessions, failure: 'Failed to end IDP sessions') { true }
+    end
+
     # Set Keycloak required actions the user must complete at next login (e.g.
     # ['UPDATE_PASSWORD'] to force a password change).
     def set_required_action(user_id:, actions:)
@@ -215,6 +225,19 @@ module Idp
 
     def supports_account_backfill?
       manage_users?
+    end
+
+    # The endpoint exists on every realm, so the only question is whether this service points at
+    # one — same reading of a blank api_url as browser_url. Defense in depth rather than a reachable
+    # branch: validate_config! has already rejected a blank api_url, so an unconfigured connector
+    # never gets built and Idp::JwtAuthentication refuses the sign-out outright
+    # (Idp::SessionLogoutRefused) instead of ever reading false here. Note which way false points —
+    # the caller takes it as "no IdP session to end" and lets sign-out complete — so this must
+    # answer from configuration, never from a guess about reachability. Whether the service account
+    # may call it (manage-users, granted separately from the user read/write calls) is ops config
+    # and still shows up as a failure.
+    def supports_session_logout?
+      api_url.present?
     end
 
     # Deep-link to the Keycloak Account Console for this realm, where end users

--- a/app/services/idp/null_service.rb
+++ b/app/services/idp/null_service.rb
@@ -50,6 +50,10 @@ module Idp
       raise ServiceError.new('Required actions not supported', idp_name: idp_name, operation: :set_required_action, transient: false)
     end
 
+    def logout_user_sessions(**)
+      raise ServiceError.new('Session logout not supported', idp_name: idp_name, operation: :logout_user_sessions, transient: false)
+    end
+
     def idp_name
       connector_id&.humanize || 'Unknown IDP'
     end

--- a/app/services/idp/service.rb
+++ b/app/services/idp/service.rb
@@ -68,6 +68,11 @@ module Idp
       raise NotImplementedError, "#{self.class.name} must implement #set_required_action"
     end
 
+    # Guarded by #supports_session_logout?.
+    def logout_user_sessions(user_id:)
+      raise NotImplementedError, "#{self.class.name} must implement #logout_user_sessions"
+    end
+
     # @return [String] human-readable IDP name (e.g. "Keycloak")
     def idp_name
       raise NotImplementedError, "#{self.class.name} must implement #idp_name"
@@ -92,18 +97,18 @@ module Idp
       false
     end
 
+    # Whether this IDP can end a user's sessions through its admin API. Sign-out gates on it: an
+    # IDP that only authenticates has no session for us to end.
+    def supports_session_logout?
+      false
+    end
+
     # @return [Hash] { success: Boolean, message: String }
     def test_connection
       {
         success: false,
         message: 'Connection testing not supported for this IDP',
       }
-    end
-
-    # OIDC RP-Initiated Logout URL. Defaults to the post-logout redirect; IDPs
-    # that support OIDC logout override this.
-    def logout_url(post_logout_redirect_uri:, client_id: nil) # rubocop:disable Lint/UnusedMethodArgument
-      post_logout_redirect_uri
     end
 
     # Deep-link to the IDP's self-service credential console (password/2FA).

--- a/app/views/errors/sign_out_failed.html.haml
+++ b/app/views/errors/sign_out_failed.html.haml
@@ -1,0 +1,5 @@
+%h1= Translation.translate('We could not finish signing you out')
+%p= Translation.translate('Your session with the identity provider is still active, so you are still signed in. Green River has been notified.')
+%p= Translation.translate('If it keeps failing, quitting your browser completely will usually end the session.')
+%p
+  = link_to Translation.translate('Try signing out again'), destroy_user_session_path, method: :delete, class: 'btn btn-primary'

--- a/app/views/idp/sessions/logout_talentlms.html.haml
+++ b/app/views/idp/sessions/logout_talentlms.html.haml
@@ -1,0 +1,6 @@
+-# Keep this a real click — no auto-submit, no meta refresh, no onload. A forged cross-site GET can
+-# reach this page, and the click is the only thing distinguishing it from a real sign-out.
+%h1= Translation.translate('Finish signing out')
+%p= Translation.translate('You signed out of the training site. You are still signed in here.')
+%p
+  = link_to Translation.translate('Finish signing out'), destroy_user_session_path, method: :delete, class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,8 @@ Rails.application.routes.draw do
     post   'users/sign_in',     to: 'idp/sessions#create',    as: :user_session
     delete 'users/sign_out',    to: 'idp/sessions#destroy',   as: :destroy_user_session
     match  'session_keepalive', to: 'idp/sessions#keepalive', as: :session_keepalive, via: [:get, :post]
-    get    'logout_talentlms',  to: 'idp/sessions#destroy',   as: :logout_talentlms
+    # Not #destroy — cross-site GET with no CSRF token, so it renders a logout form
+    get    'logout_talentlms',  to: 'idp/sessions#logout_talentlms', as: :logout_talentlms
   end
 
   namespace :users do

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -93,5 +93,11 @@ module Hmis::Concerns::JwtHmisCurrentUser
     def idp_handle_deactivated
       render_json_error(403, :account_deactivated)
     end
+
+    # 500, not a 4xx: the request was fine, we couldn't reach the IdP. No message — the SPA's
+    # LogoutFailedDialog writes its own copy and never reads the body.
+    def idp_handle_session_logout_failure
+      render_json_error(500, :sign_out_failed)
+    end
   end
 end

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -14,21 +14,34 @@ module Hmis
     # Mirrors ::Idp::SessionsController#destroy (the warehouse's JWT logout), but the SPA calls this
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
+    #
     class SessionsController < Hmis::BaseController
-      # Skipped defensively: the only stateful side effect here is reset_session (below), and a
-      # forged cross-site request triggering that is a forced-logout nuisance at worst, not a
-      # meaningful escalation - the actual credential (the oauth2-proxy/IdP session) is untouched
-      # here regardless and only ends when the browser follows the returned redirect_url.
-      skip_before_action :verify_authenticity_token, only: :destroy
-
+      # The CSRF token is what guards #destroy
       def destroy
-        # wipes session so it doesn't outlive this login. Not a substitute for oauth2-proxy/IdP
-        # sign-out the browser performs next via this redirect.
+        # First: the Keycloak session, which /oauth2/sign_out never reaches. Ahead of reset_session
+        # because it reads the forwarded token, and because it fails closed. Don't make it
+        # best-effort. ::Idp::SessionsController#destroy is the same sequence with an HTML response.
+        idp_end_token_holder_sessions
+
+        # Second: the Rails session, so it doesn't outlive this login.
         reset_session
 
-        # Deliberately a relative path since oauth2-proxy is same-origin; an absolute URL built from
+        # Third, once the SPA navigates to this. Relative on purpose — an absolute URL built from
         # request.base_url could be spoofed via the Host header.
         render json: { redirect_url: "/oauth2/sign_out?rd=#{CGI.escape(root_path)}" }
+      rescue ::Idp::SessionLogoutRefused
+        idp_handle_session_logout_failure
+      end
+
+      private
+
+      # Deliberately doesn't call up to Hmis::BaseController's version, which resets the session
+      # first. Under JWT that reset signs nobody out — the credential is the forwarded token — but it
+      # drops any impersonation and strands the CSRF-Token cookie the browser holds, since
+      # set_csrf_cookie is a later before_action and never runs once this one halts the chain. The
+      # user's own retry of the sign-out would then fail the same way. 401 and no side effect.
+      def handle_unverified_request
+        render_json_error(401, :unverified_request)
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -289,6 +289,238 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
       expect(controller.current_hmis_user).to eq(admin_user)
       expect(controller.impersonating?).to eq(false)
     end
+
+    # The session /oauth2/sign_out never reaches, since Dex doesn't propagate logout to Keycloak.
+    # Mirrors spec/requests/idp/warehouse_jwt_wiring_spec.rb's set, JSON instead of HTML.
+    describe 'ending the IdP session' do
+      let(:user) { create(:hmis_user) }
+      # The token's connector is 'test' (see JwtAuthenticationHelper), which resolves to a
+      # NullService, so a service has to be stubbed in to get past the predicate.
+      let(:idp_service) do
+        instance_double(
+          Idp::KeycloakService,
+          supports_session_logout?: true,
+          logout_user_sessions: true,
+        )
+      end
+
+      before do
+        allow(Idp::ServiceFactory).to receive(:for_connector).and_call_original
+        allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_return(idp_service)
+      end
+
+      def start_session(as: user)
+        sign_in(as)
+        get hmis_session_keepalive_path, headers: headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      def expect_signed_out_normally
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['redirect_url']).to start_with('/oauth2/sign_out?rd=')
+      end
+
+      # The body is the whole contract with the SPA — throwMaybeHmisError reads the type, and no
+      # redirect_url, since the SPA must not be handed a sign-out URL for a sign-out that didn't
+      # happen.
+      def expect_refused_sign_out
+        expect(response).to have_http_status(:internal_server_error)
+        expect(JSON.parse(response.body)).to eq('error' => { 'type' => 'sign_out_failed' })
+        # Real session state, written by the app during start_session. reset_session clears it, and
+        # fail-closed means reset_session never ran.
+        expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+      end
+
+      it 'ends the token holder\'s IdP sessions, then resets and renders the sign-out URL' do
+        start_session
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user))
+        expect_signed_out_normally
+      end
+
+      # Fail closed, deliberately: better than reporting a sign-out that didn't happen.
+      it 'aborts sign-out and leaves the session intact when the IdP call raises' do
+        start_session
+        allow(idp_service).to receive(:logout_user_sessions).
+          and_raise(Idp::ServiceError.new('boom', idp_name: 'Keycloak', operation: :logout_user_sessions))
+        expect(Sentry).to receive(:capture_exception_with_info)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect_refused_sign_out
+      end
+
+      # A hung IdP reaches the controller as the socket timeout the service didn't convert, so this
+      # covers an exception that isn't an Idp::ServiceError taking the same fail-closed path.
+      it 'aborts sign-out when the IdP call times out' do
+        start_session
+        allow(idp_service).to receive(:logout_user_sessions).and_raise(Net::ReadTimeout)
+        allow(Sentry).to receive(:capture_exception_with_info)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect_refused_sign_out
+        # One report, not one per rescue on the way out.
+        expect(Sentry).to have_received(:capture_exception_with_info).once
+      end
+
+      # Can't tell whether a session is live, so this fails closed too, with its own alert.
+      it 'aborts sign-out when the connector\'s service can\'t be resolved' do
+        start_session
+        allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_raise(StandardError.new('bad config'))
+        expect(Sentry).to receive(:capture_exception_with_info).
+          with(anything, /Couldn't resolve the IDP service for connector test/)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect_refused_sign_out
+      end
+
+      it 'signs out normally, without attempting a call, when the connector has no admin API' do
+        allow(idp_service).to receive(:supports_session_logout?).and_return(false)
+        start_session
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).not_to have_received(:logout_user_sessions)
+        expect_signed_out_normally
+      end
+
+      # The real NullService, not the double. Its logout_user_sessions RAISES (Idp::NullService:53),
+      # so this is what proves the supports_session_logout? guard runs before the call rather than
+      # after: drop the guard and this goes red with a 500 sign_out_failed.
+      it 'signs out normally, without attempting a call, for an unknown connector (NullService)' do
+        allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_call_original
+        start_session
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(Idp::ServiceFactory).to have_received(:for_connector).with('test')
+        expect_signed_out_normally
+      end
+
+      # Not "signs out normally": a token with no connector claim can't authenticate at all, because
+      # Idp::UserProvisioner requires the claim to resolve a holder and authenticate_hmis_user! runs
+      # before the sign-out action. So the blank-connector guard in idp_end_token_holder_sessions is
+      # unreachable from this arm, and asserting "signed out normally, no call" here would have
+      # described behavior this arm doesn't have. The warehouse arm skips authenticate_user! on
+      # sign-out, so there the same token does reach that guard and does sign out normally.
+      it 'never reaches sign-out for a token with no connector claim: the request fails to authenticate' do
+        start_session
+        # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
+        allow(Idp::JwtHelper.new(access_token: jwt_token)).to receive(:connector_id).and_return(nil)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
+        # The guard the previous wording claimed to cover: the factory is never consulted, so this
+        # can't pass by falling through to a NullService the way the old assertion could.
+        expect(Idp::ServiceFactory).not_to have_received(:for_connector).with('test')
+      end
+
+      # The whole reason the id comes off the token: current_hmis_user is the impersonated user here,
+      # so sourcing it there ends a third party's sessions and not the admin's.
+      it 'ends the token holder\'s sessions, not the impersonated user\'s, while impersonating' do
+        user_group = create(:hmis_user_group)
+        admin_user = create(:hmis_user, data_source: ds)
+        create_access_control(admin_user, ds, with_permission: [:can_impersonate_users], user_group: user_group)
+        target_user = create(:hmis_user, data_source: ds).tap { |u| user_group.add(u) }
+
+        start_session(as: admin_user)
+        post hmis_impersonations_path, params: { user_id: target_user.id }, headers: headers
+        expect(response).to have_http_status(:ok)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(response).to have_http_status(:ok)
+        # The claim value, and exactly one call: rules out the impersonated user and both warehouse
+        # ids, which are a different string again.
+        expect(idp_service).to have_received(:logout_user_sessions).
+          with(user_id: jwt_connector_user_id(admin_user)).once
+      end
+
+      # Why a forged DELETE reaches this action at all, and what it would cost: see
+      # Hmis::Idp::SessionsController. allow_forgery_protection is false in the test environment
+      # (config/environments/test.rb:55), so these examples turn it on — without that they pass
+      # whether or not #destroy verifies the token.
+      describe 'CSRF verification' do
+        around do |example|
+          ActionController::Base.allow_forgery_protection = true
+          example.run
+        ensure
+          ActionController::Base.allow_forgery_protection = false
+        end
+
+        # Mirrors the SPA: fetchWithCsrf reads the CSRF-Token cookie set_csrf_cookie writes on every
+        # Hmis::BaseController response and forwards it as X-CSRF-Token.
+        def csrf_token_from_last_response
+          response.cookies['CSRF-Token'].tap { |token| expect(token).to be_present }
+        end
+
+        it 'still signs out and still ends the IdP sessions when the request carries the token' do
+          start_session
+          token = csrf_token_from_last_response
+
+          delete destroy_hmis_user_session_path, headers: headers.merge('X-CSRF-Token' => token)
+
+          expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user))
+          expect_signed_out_normally
+        end
+
+        it 'rejects a request with no token, without reaching the realm-wide logout' do
+          start_session
+
+          delete destroy_hmis_user_session_path, headers: headers
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)).to eq('error' => { 'type' => 'unverified_request' })
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+        end
+
+        # Guards the handle_unverified_request override on Hmis::Idp::SessionsController, through a
+        # real retry rather than by reading `session` after the rejected request: that read reports
+        # the request's inbound session, so it shows the pre-reset contents either way and stays
+        # green with the override deleted.
+        it 'leaves a rejected sign-out retryable with the token the browser already holds' do
+          start_session
+          token = csrf_token_from_last_response
+
+          delete destroy_hmis_user_session_path, headers: headers
+          expect(response).to have_http_status(:unauthorized)
+
+          delete destroy_hmis_user_session_path, headers: headers.merge('X-CSRF-Token' => token)
+
+          expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user)).once
+          expect_signed_out_normally
+        end
+
+        # Same claim, the other piece of session state a reset would take: an admin mid-impersonation
+        # would silently revert to acting as themselves, with the "Acting as" banner still on screen
+        # from the last render.
+        it 'leaves a rejected sign-out with the session-stored impersonation still in force' do
+          user_group = create(:hmis_user_group)
+          admin_user = create(:hmis_user, data_source: ds)
+          create_access_control(admin_user, ds, with_permission: [:can_impersonate_users], user_group: user_group)
+          target_user = create(:hmis_user, data_source: ds).tap { |u| user_group.add(u) }
+
+          start_session(as: admin_user)
+          post hmis_impersonations_path,
+               params: { user_id: target_user.id },
+               headers: headers.merge('X-CSRF-Token' => csrf_token_from_last_response)
+          expect(response).to have_http_status(:ok)
+
+          delete destroy_hmis_user_session_path, headers: headers
+          expect(response).to have_http_status(:unauthorized)
+
+          get hmis_user_path, headers: headers
+          expect(controller.current_hmis_user).to eq(target_user)
+          expect(controller.true_hmis_user).to eq(admin_user)
+        end
+      end
+    end
   end
 
   describe '#info_for_paper_trail' do

--- a/spec/requests/idp/warehouse_jwt_wiring_spec.rb
+++ b/spec/requests/idp/warehouse_jwt_wiring_spec.rb
@@ -8,12 +8,9 @@
 
 require 'rails_helper'
 
-# Proves the warehouse request layer wires the JWT auth path correctly when a Deployment boots with
-# AUTH_METHOD=jwt, while the Devise path is unchanged. The JWT examples run only under the
-# AUTH_METHOD=jwt CI process (they lean on the JwtAuthenticationHelper, which is included only when
-# AuthMethod.jwt?). This includes the paper-trail whodunnit regression: it asserts the JWT arm's
-# current_user/true_user behavior, while the Devise arm keeps its warden.user whodunnit verbatim. The
-# route-surface and forced-logout examples are mode-agnostic.
+# Proves the warehouse request layer wires the JWT auth path when a Deployment boots with
+# AUTH_METHOD=jwt, leaving the Devise path unchanged. The `if: AuthMethod.jwt?` examples lean on
+# JwtAuthenticationHelper, which is included only when AuthMethod.jwt?.
 RSpec.describe 'Warehouse JWT wiring', type: :request do
   describe 'authentication via a forwarded JWT', if: AuthMethod.jwt? do
     let(:user) { create :user }
@@ -158,6 +155,243 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
         expect(response).to have_http_status(:redirect)
         expect(response.location).to include('/oauth2/sign_out')
         expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to be_nil
+      end
+
+      describe 'ending the IdP session' do
+        # The token's connector is 'test' (see JwtAuthenticationHelper), which ServiceFactory
+        # resolves to a NullService, so a service has to be stubbed in to get past the predicate.
+        let(:idp_service) do
+          instance_double(
+            Idp::KeycloakService,
+            supports_session_logout?: true,
+            logout_user_sessions: true,
+          )
+        end
+
+        before do
+          allow(Idp::ServiceFactory).to receive(:for_connector).and_call_original
+          allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_return(idp_service)
+        end
+
+        def start_session
+          sign_in(user)
+          get session_keepalive_path
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'ends the token holder\'s IdP sessions, then resets and redirects' do
+          start_session
+
+          delete destroy_user_session_path
+
+          expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user))
+          expect(response).to redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+        end
+
+        describe 'from the terminal 403 pages (account_deactivated, no_warehouse_account)' do
+          it 'signs out a user deactivated mid-session' do
+            start_session
+            user.update!(active: false)
+
+            delete destroy_user_session_path
+
+            expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user))
+            expect(response).to redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+          end
+
+          it 'signs out a token holder with no warehouse account' do
+            start_session
+            allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+            delete destroy_user_session_path
+
+            expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(user))
+            expect(response).to redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+          end
+
+          # The link has to be on the page for any of the above to be reachable by a real user.
+          it 'puts the sign-out control on errors/account_deactivated' do
+            start_session
+            user.update!(active: false)
+
+            get edit_account_path
+
+            expect(response).to have_http_status(:forbidden)
+            expect(response.body).to include("href=\"#{destroy_user_session_path}\"", 'data-method="delete"')
+          end
+
+          it 'puts the sign-out control on errors/no_warehouse_account' do
+            start_session
+            allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+            get edit_account_path
+
+            expect(response).to have_http_status(:forbidden)
+            expect(response.body).to include("href=\"#{destroy_user_session_path}\"", 'data-method="delete"')
+          end
+        end
+
+        # Cross-site GET with no CSRF token, so it renders instead of acting — otherwise any page
+        # could end every session the user holds in the realm. The 200 also rules out a hop to
+        # /oauth2/sign_out, which would strip the token the button's DELETE needs.
+        it 'renders a confirmation page on GET logout_talentlms without ending any session' do
+          start_session
+
+          get logout_talentlms_path
+
+          expect(response).to have_http_status(:ok)
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+          expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+          expect(response.body).to include("href=\"#{destroy_user_session_path}\"", 'data-method="delete"')
+        end
+
+        # #destroy reads the id from the token rather than current_user precisely so impersonation
+        # is safe: while impersonating, current_user is the impersonated user, so taking the id from
+        # there would end that third party's sessions and leave the admin (the token holder) signed in.
+        it 'ends the token holder\'s sessions, not the impersonated user\'s, while impersonating' do
+          impersonated_user = create :user
+          allow(impersonated_user).to receive(:training_required?).and_return(false)
+          allow(impersonated_user).to receive(:pending_compliance_requirements).and_return([])
+          allow(user).to receive(:can_edit_users?).and_return(true)
+          allow(user).to receive(:can_impersonate_users?).and_return(true)
+          allow(impersonated_user).to receive(:impersonateable_by?).with(user).and_return(true)
+          # The impersonation path re-reads the true and impersonated users by id, and these two
+          # objects carry the permission stubs above; without this they come back as plain rows and
+          # the stored impersonation is discarded as unauthorized.
+          allow(User).to receive(:find_by).and_call_original
+          allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+          allow(User).to receive(:find_by).with(id: impersonated_user.id).and_return(impersonated_user)
+
+          start_session
+          # Impersonate through the app rather than assigning session[:impersonation] here: a spec's
+          # session writes don't cross the request boundary, so poking it leaves the sign-out below
+          # running with no impersonation at all, which passes just as well if the id comes off
+          # current_user.
+          post impersonate_admin_user_path(user, become_id: impersonated_user.id)
+          expect(response).to have_http_status(:redirect)
+          # X-app-user-id comes from current_user, so this is the app confirming the impersonation is
+          # live on the session the sign-out reads.
+          get session_keepalive_path
+          expect(response.headers['X-app-user-id'].to_s).to eq(impersonated_user.id.to_s)
+
+          delete destroy_user_session_path
+
+          # The claim value, and exactly one call: rules out the impersonated user, and rules out
+          # current_user.id / the token holder's warehouse id, which are a different string again.
+          expect(idp_service).to have_received(:logout_user_sessions).
+            with(user_id: jwt_connector_user_id(user)).once
+          # The app wrote this entry, so reset_session dropping it is a real observation.
+          expect(session[:impersonation]).to be_nil
+        end
+
+        # Fail closed: a failed IdP call aborts sign-out rather than reporting success it didn't
+        # achieve. Deliberate, not an oversight.
+        it 'aborts sign-out and leaves the session intact when the IdP call raises' do
+          start_session
+          allow(idp_service).to receive(:logout_user_sessions).
+            and_raise(Idp::ServiceError.new('boom', idp_name: 'Keycloak', operation: :logout_user_sessions))
+          expect(Sentry).to receive(:capture_exception_with_info)
+
+          delete destroy_user_session_path
+
+          expect(response).to have_http_status(:internal_server_error)
+          # A rendered page in the app's layout, not bare text: the user arrives here on a full page
+          # load and needs the retry link on it.
+          expect(response).to render_template('errors/sign_out_failed')
+          # The app writes this during start_session, so it's real session state — a value the spec
+          # assigned directly wouldn't survive the request boundary. reset_session clears it.
+          expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+        end
+
+        # Not knowing whether there's a session to end is not the same as knowing there isn't, so
+        # this fails closed too — but with its own alert, since the fix is our config, not the IdP.
+        it 'aborts sign-out when the connector\'s service can\'t be resolved' do
+          start_session
+          allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_raise(StandardError.new('bad config'))
+          expect(Sentry).to receive(:capture_exception_with_info).
+            with(anything, /Couldn't resolve the IDP service for connector test/)
+
+          delete destroy_user_session_path
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+        end
+
+        # A hung IdP reaches the controller as the socket timeout the service didn't convert, so this
+        # covers an exception that isn't an Idp::ServiceError taking the same fail-closed path.
+        it 'aborts sign-out when the IdP call times out' do
+          start_session
+          allow(idp_service).to receive(:logout_user_sessions).and_raise(Net::ReadTimeout)
+          allow(Sentry).to receive(:capture_exception_with_info)
+
+          delete destroy_user_session_path
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(response).to render_template('errors/sign_out_failed')
+          expect(session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY]).to eq(user.id)
+          # One report, not one per rescue on the way out.
+          expect(Sentry).to have_received(:capture_exception_with_info).once
+        end
+
+        # A refused forwarded token must abort sign-out loudly rather than sign the user out locally
+        # while the IdP session stays live. The refusal raises out of idp_token_holder, in the filter
+        # that resolves current_user (#destroy itself skips authenticate_user!), so no session is
+        # reset, no redirect issued, and no Keycloak teardown attempted.
+        it 'refuses the sign-out when the forwarded token is refused' do
+          start_session
+          # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
+          helper = Idp::JwtHelper.new(access_token: jwt_token)
+          allow(helper).to receive(:invalid_reason).and_return(:bad_signature)
+          allow(helper).to receive(:invalid_reason_details).and_return({ reason: :bad_signature })
+
+          expect { delete destroy_user_session_path }.to raise_error(Idp::ForwardedTokenError, /bad_signature/)
+
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+        end
+
+        it 'signs out normally, without attempting a call, when the connector has no admin API' do
+          allow(idp_service).to receive(:supports_session_logout?).and_return(false)
+          start_session
+
+          delete destroy_user_session_path
+
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+          expect(response).to have_http_status(:redirect)
+          expect(response.location).to include('/oauth2/sign_out')
+        end
+
+        it 'signs out normally, without attempting a call, for an unknown connector (NullService)' do
+          allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_call_original
+          start_session
+
+          delete destroy_user_session_path
+
+          expect(response).to have_http_status(:redirect)
+          expect(response.location).to include('/oauth2/sign_out')
+        end
+
+        # #destroy skips authenticate_user!, so a token the provisioner can't resolve still reaches
+        # the action and the blank-connector guard is what answers it. The HMIS arm walls the same
+        # token off at authenticate_hmis_user! and answers 403 instead.
+        it 'signs out normally, without attempting a call, when the token carries no connector claim' do
+          start_session
+          # No holder, rather than the outer block's pinned user: Idp::UserProvisioner needs the
+          # connector claims to resolve one, so pinning it would hide that this token can't
+          # authenticate at all.
+          allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+          # sign_in memoizes one JwtHelper double per token, so this hands back the same object the
+          # request will read.
+          allow(Idp::JwtHelper.new(access_token: jwt_token)).to receive(:connector_id).and_return(nil)
+
+          delete destroy_user_session_path
+
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+          # The guard short-circuits ahead of service resolution, so this can't pass by falling
+          # through to a NullService whose capability predicate answers false.
+          expect(Idp::ServiceFactory).not_to have_received(:for_connector).with(nil)
+          expect(response).to have_http_status(:redirect)
+          expect(response.location).to include('/oauth2/sign_out')
+        end
       end
     end
 

--- a/spec/services/idp/null_service_spec.rb
+++ b/spec/services/idp/null_service_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe Idp::NullService, type: :model do
       reactivate_user: ['User reactivation not supported', { user_id: 'user-123' }],
       deactivate_user: ['User deactivation not supported', { user_id: 'user-123' }],
       set_required_action: ['Required actions not supported', { user_id: 'user-123', actions: ['UPDATE_PASSWORD'] }],
+      # supports_session_logout? means nothing should reach this. If something does it must be loud,
+      # not a silent no-op that reads as "the IdP session was ended".
+      logout_user_sessions: ['Session logout not supported', { user_id: 'user-123' }],
     }.each do |method, (message, args)|
       describe "##{method}" do
         it 'raises ServiceError tagged with the operation and the IdP name' do
@@ -111,6 +114,14 @@ RSpec.describe Idp::Service, type: :model do
   describe '#supports_session_logout?' do
     it 'defaults to false on the base contract' do
       expect(described_class.new.supports_session_logout?).to be false
+    end
+  end
+
+  describe '#logout_user_sessions' do
+    it 'raises NotImplementedError on the base contract' do
+      expect do
+        described_class.new.logout_user_sessions(user_id: 'user-123')
+      end.to raise_error(NotImplementedError, /must implement #logout_user_sessions/)
     end
   end
 end


### PR DESCRIPTION


## _Merging this PR_

- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Sign-out now ends the token holder's Keycloak sessions through the Admin API, the one session /oauth2/sign_out never reaches since Dex doesn't propagate logout upstream. Reads the id off the forwarded token, not current_user, so it works under impersonation and before reset_session.

Fails closed: a refused logout raises Idp::SessionLogoutRefused and aborts sign-out rather than telling the user they signed out. Warehouse renders errors/sign_out_failed; HMIS returns a JSON 500.

logout_talentlms stops acting on its cross-site GET and renders a page whose button does the real DELETE. HMIS regains CSRF verification on sign-out. #destroy skips authenticate_user! so the terminal 403 pages remain signable-out. Drops logout_url from Idp::Service.

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
