### PR TITLE
feat: 8458 JWT account self-service profile + tabs

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -333,6 +333,7 @@ jobs:
             spec/services/idp/admin_user_creator_spec.rb
             drivers/hmis/spec/requests/hmis_admin/users_controller_spec.rb
             spec/requests/admin/audits_controller_spec.rb
+            spec/requests/idp/accounts_controller_spec.rb
           )
           AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd "${specs[@]}"
 

--- a/app/controllers/idp/account_downloads_controller.rb
+++ b/app/controllers/idp/account_downloads_controller.rb
@@ -1,0 +1,14 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Recent Downloads is auth-agnostic; it forks under JWT only so its own index view can render the
+# JWT tabs partial (which drops the IdP-owned password/2FA/login-history tabs) instead of the
+# Devise one. View lookup falls back to the shared account_downloads templates via the inherited
+# controller prefixes.
+class Idp::AccountDownloadsController < ::AccountDownloadsController
+end

--- a/app/controllers/idp/accounts_controller.rb
+++ b/app/controllers/idp/accounts_controller.rb
@@ -1,0 +1,90 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# JWT-arm account self-management. Credentials (password/2FA) and login history are IdP-owned, so
+# this controller only edits the Warehouse-owned profile and pushes the IdP-owned identity fields
+# (name) back to the IdP when the connector accepts writes. Selected at the route level under
+# AuthMethod.jwt?; the Devise AccountsController is untouched.
+class Idp::AccountsController < ApplicationController
+  before_action :set_user
+
+  def edit
+  end
+
+  def update
+    @user.assign_attributes(account_params)
+
+    if @user.changed?
+      notes = change_notes(@user.changes)
+
+      # Nested rather than atomic: users lives in the app db and Hmis::Hud::User in the warehouse
+      # db, so these are two connections with no shared commit. The nesting still means a failed
+      # HUD sync or IdP push unwinds the local edit, which is the divergence worth preventing.
+      GrdaWarehouseBase.transaction do
+        @user.transaction do
+          @user.save!
+          @user.sync_to_hud_users if HmisEnforcement.hmis_enabled?
+          push_profile_to_idp
+        end
+      end
+      flash[:notice] = notes.join(' ') if notes.present?
+    end
+    redirect_to edit_account_path
+  rescue ActiveRecord::RecordInvalid
+    render :edit
+  rescue Idp::ServiceError => e
+    # The push is inside the transaction, so nothing was saved. Tell the user rather than handing
+    # them a 500, and page — a self-service edit failing means the connector needs attention.
+    Sentry.capture_exception_with_info(e, "Couldn't sync user #{@user.id}'s profile to the identity provider")
+    flash.now[:alert] = "We couldn't save your changes: your identity provider didn't accept them (#{e.message})."
+    render :edit
+  end
+
+  private def change_notes(changes)
+    notes = []
+    notes << 'Account name was updated.' if changes.key?('first_name') || changes.key?('last_name')
+    notes << 'User credentials were changed.' if changes.key?('credentials')
+    notes << 'Email schedule was updated.' if changes.key?('email_schedule')
+    notes << 'Phone number was updated.' if changes.key?('phone')
+    notes
+  end
+
+  # Push a name change to the IdP from inside the caller's transaction, so a refused write takes the
+  # local edit with it. idp_update_profile! no-ops unless the service accepts writes; account_params
+  # already strips these keys when the profile is locked, so a locked user never reaches here with a
+  # change anyway.
+  private def push_profile_to_idp
+    changes = @user.saved_changes.slice('first_name', 'last_name')
+    return if changes.empty?
+
+    attributes = changes.transform_values(&:last).symbolize_keys
+    @user.idp_update_profile!(attributes)
+  end
+
+  private def account_params
+    return @account_params if defined?(@account_params)
+
+    permitted = params.require(:user).
+      permit(
+        :first_name,
+        :last_name,
+        :phone,
+        :email_schedule,
+        :credentials,
+        :theme,
+      )
+    # The form disables name inputs for an IdP-managed profile; strip them defensively so a crafted
+    # request can't rewrite identity fields the IdP owns.
+    permitted = permitted.except(:first_name, :last_name) if @user.profile_managed_by_idp?
+    @account_params = permitted
+  end
+
+  private def set_user
+    @user = current_user
+  end
+end

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -34,6 +34,29 @@ module Idp::Support
     true
   end
 
+  # Under JWT there is no in-app password; credential management is delegated to the IdP
+  def password_change_enabled?
+    false
+  end
+
+  # Deep-link to the IdP's self-service credential console (password/2FA), or nil when the IdP
+  # has none — in which case the account page shows static "managed by your identity provider"
+  # text instead of a link. A service we can't build is treated as no-console.
+  def account_console_url
+    idp_service.account_console_url
+  rescue Idp::ServiceError
+    nil
+  end
+
+  # Deep-link that takes the current user straight into a single self-service action
+  # (password change, 2FA setup) and returns them to redirect_uri. Only valid for the
+  # signed-in user; redirect_uri is supplied by the caller, which owns request context.
+  def account_action_url(action:, redirect_uri:)
+    idp_service.account_action_url(action: action, redirect_uri: redirect_uri)
+  rescue Idp::ServiceError
+    nil
+  end
+
   # Local `expired_at`-based account expiry not supported
   def account_expiry_enabled?
     false

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -241,12 +241,35 @@ module Idp
     end
 
     # Deep-link to the Keycloak Account Console for this realm, where end users
-    # manage their own password and 2FA. Built from the browser-reachable
-    # api_url, consistent with logout_url.
+    # manage their own password and 2FA.
     def account_console_url
-      return nil unless api_url.present?
+      return nil unless browser_url.present?
 
-      "#{api_url}/realms/#{realm}/account"
+      "#{browser_url}/realms/#{realm}/account"
+    end
+
+    # Keycloak Application-Initiated Action: sends the browser through the realm's OIDC
+    # authorize endpoint with kc_action set, so the user completes exactly one action
+    # (password change, TOTP setup, ...) against their existing Keycloak SSO session and
+    # is redirected back to redirect_uri. Only usable for the current user.
+    #
+    # The redirect_uri must be registered under this client's Valid Redirect URIs in
+    # Keycloak, and the client must have the standard (authorization code) flow enabled.
+    #
+    # redirect_uri only governs the return after the *form* is submitted. UPDATE_EMAIL has a second
+    # leg — the confirmation link mailed to the new address — which returns via the client's Base URL
+    # instead, so see #account_client_id too.
+    def account_action_url(action:, redirect_uri:)
+      return nil unless browser_url.present?
+
+      params = {
+        client_id: account_client_id,
+        redirect_uri: redirect_uri,
+        response_type: 'code',
+        scope: 'openid',
+        kc_action: action,
+      }
+      "#{browser_url}/realms/#{realm}/protocol/openid-connect/auth?#{params.to_query}"
     end
 
     # Ping the Admin API to verify credentials and connectivity, using the same

--- a/app/services/idp/service.rb
+++ b/app/services/idp/service.rb
@@ -117,6 +117,13 @@ module Idp
       nil
     end
 
+    # Deep-link that drops the current user straight into a single self-service action
+    # (e.g. UPDATE_PASSWORD, CONFIGURE_TOTP) and returns them to redirect_uri afterward.
+    # Defaults to nil for IDPs that don't support such deep-links.
+    def account_action_url(action:, redirect_uri:) # rubocop:disable Lint/UnusedMethodArgument
+      nil
+    end
+
     protected
 
     def default_config

--- a/app/views/idp/account_downloads/index.haml
+++ b/app/views/idp/account_downloads/index.haml
@@ -1,0 +1,10 @@
+= content_for :title, 'Edit Account'
+%h1= content_for :title
+%hr
+.mb-5= render 'idp/accounts/account_info_tabs'
+
+%h3 Recent Downloads
+- if @items.any?
+  = render 'list'
+- else
+  %p No recent downloads

--- a/app/views/idp/accounts/_account_info_tabs.haml
+++ b/app/views/idp/accounts/_account_info_tabs.haml
@@ -1,0 +1,9 @@
+%ul.nav.nav-tabs{role: "presentation"}
+  %li.nav-item{role: "presentation", class: ('active' if current_page?(edit_account_path))}
+    = link_to 'Accounts Details', edit_account_path, class: 'nav-link'
+  -# Always present: the tab is read-only, so it has something to say (the current address) even
+  -# when the IdP offers no way to change it.
+  %li.nav-item{role: "presentation", class: ('active' if current_page?(edit_account_email_path))}
+    = link_to 'Login & Security', edit_account_email_path, class: 'nav-link'
+  %li.nav-item{role: "presentation", class: ('active' if current_page?(account_downloads_path))}
+    = link_to 'Recent Downloads', account_downloads_path, class: 'nav-link'

--- a/app/views/idp/accounts/_form.haml
+++ b/app/views/idp/accounts/_form.haml
@@ -1,0 +1,18 @@
+= simple_form_for @user, url: account_path do |f|
+  = f.error_notification
+
+  .form-inputs
+    - profile_locked = @user.profile_managed_by_idp?
+    - idp_hint = 'Managed by your identity provider' if profile_locked
+    = f.input :first_name, required: !profile_locked, input_html: { disabled: profile_locked }, hint: idp_hint
+    = f.input :last_name, required: !profile_locked, input_html: { disabled: profile_locked }, hint: idp_hint
+    = f.input :phone
+    - if @user.show_credentials?
+      = f.input :credentials, label: 'Credentials', collection: @user.credential_options, as: :select_two, input_html: { data: {tags: true} }, hint: 'Add a new credential type by typing the name and hitting enter.'
+    = f.association :agency, disabled: true, as: :select_two
+    = f.input :email_schedule, collection: Message::SCHEDULES.map{ |s| [ s.titleize, s ] }, include_blank: false, hint: 'Messages not sent on the "immediate" schedule are sent as a digest.', as: :select_two
+    - unless Rails.env.production?
+      = f.input :theme, collection: ['legacy', 'modern'], as: :select_two
+
+  .form-actions
+    = f.button :submit, value: 'Update Account', class: 'btn btn-primary'

--- a/app/views/idp/accounts/edit.haml
+++ b/app/views/idp/accounts/edit.haml
@@ -1,0 +1,9 @@
+= content_for :title, 'Edit Account'
+%h1= content_for :title
+%hr
+.row
+  .col-sm-12
+    .mb-5= render 'idp/accounts/account_info_tabs'
+    .well(style="max-width: 500px")
+      %h3 Account Details
+      = render 'form'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1009,15 +1009,28 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :account, only: [:edit, :update] do
-    get :locations, on: :member
+  # Auth-method seam: the account self-service surface forks by boot-time arm. Under JWT the IdP
+  # owns credentials (password/2FA) and login history, so those routes are omitted entirely and
+  # the arm's own controllers/views render profile + email. account_downloads forks too — only so
+  # its shared tabs partial resolves to the JWT variant that drops the IdP-owned tabs.
+  if AuthMethod.jwt?
+    resource :account, only: [:edit, :update], controller: 'idp/accounts'
+    # No :update — the JWT arm never writes email locally; the IdP owns the change (see
+    # Idp::AccountEmailsController). begin_change hands the browser off to the IdP and writes nothing
+    # about the address.
+    resource :account_email, only: [:edit], controller: 'idp/account_emails'
+    resources :account_downloads, only: [:index], controller: 'idp/account_downloads'
+  else
+    resource :account, only: [:edit, :update] do
+      get :locations, on: :member
+    end
+    resource :account_email, only: [:edit, :update]
+    resource :account_password, only: [:edit, :update]
+    resource :account_two_factor, only: [:show, :edit, :update, :destroy] do
+      get :remove_device
+    end
+    resources :account_downloads, only: [:index]
   end
-  resource :account_email, only: [:edit, :update]
-  resource :account_password, only: [:edit, :update]
-  resource :account_two_factor, only: [:show, :edit, :update, :destroy] do
-    get :remove_device
-  end
-  resources :account_downloads, only: [:index]
 
   resources :document_exports, only: [:show, :create] do
     get :download, on: :member

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -9,6 +9,6 @@ RUN curl -fsSL -o /tmp/keycloak-bcrypt-1.7.0.jar \
 
 # Stage 2: Final Keycloak image with providers baked in.
 # Version is pinned here — update this line to upgrade Keycloak.
-FROM quay.io/keycloak/keycloak:26.5.4
+FROM quay.io/keycloak/keycloak:26.7.0
 
 COPY --from=downloader /tmp/keycloak-bcrypt-1.7.0.jar /opt/keycloak/providers/keycloak-bcrypt-1.7.0.jar

--- a/docker/keycloak/realm-import.json
+++ b/docker/keycloak/realm-import.json
@@ -26,6 +26,22 @@
       }
     },
     {
+      "clientId": "warehouse-account",
+      "protocol": "openid-connect",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "baseUrl": "https://hmis-warehouse.dev.test/account_email/edit",
+      "redirectUris": [
+        "https://hmis-warehouse.dev.test/account_email/edit",
+        "https://hmis-warehouse.dev.test/account/edit"
+      ],
+      "webOrigins": ["https://hmis-warehouse.dev.test"]
+    },
+    {
       "clientId": "rails-service-account",
       "secret": "rails-service-account-secret-dev",
       "protocol": "openid-connect",

--- a/docs/developer/keycloak-idp.md
+++ b/docs/developer/keycloak-idp.md
@@ -6,8 +6,9 @@ The opt-in local Docker Compose stack that reproduces the production auth chain.
 User → OAuth2-Proxy → Dex (OIDC broker) → Keycloak → Rails (JWT headers)
 ```
 
-The `openpath` realm is auto-imported on first boot with two clients — `dex-connector` (OIDC auth
-code flow for Dex) and `rails-service-account` (client credentials for the Rails admin API) — plus the
+The `openpath` realm is auto-imported on first boot with three clients — `dex-connector` (OIDC auth
+code flow for Dex), `rails-service-account` (client credentials for the Rails admin API) and
+`warehouse-account` (the browser client account self-service deep-links run under) — plus the
 `warehouse-users` and `hmis-users` groups.
 
 ## Setup
@@ -140,7 +141,9 @@ which behaves the same way.
 
 > Heads-up: `realm-import.json` is applied only on the **first** import into a fresh `keycloak`
 > database. If your volume predates the `rails-service-account` client (or its roles), the token
-> grant 401s or the Admin API 403s. Confirm the live client with
+> grant 401s or the Admin API 403s. The same goes for `warehouse-account`, which is newer still: on an
+> older volume, add it by hand (public, standard flow, Base URL `https://hmis-warehouse.dev.test/account_email/edit`)
+> or the email-change return trip lands on the Keycloak account console. Confirm the live client with
 > `kcadm.sh get clients -r openpath -q clientId=rails-service-account --fields clientId,secret,serviceAccountsEnabled`
 > (after `kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin
 > --password 'AdminPassword1!'`), and reset the secret in the admin console or recreate the realm

--- a/spec/requests/idp/accounts_controller_spec.rb
+++ b/spec/requests/idp/accounts_controller_spec.rb
@@ -1,0 +1,303 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# JWT-arm account self-management. These assertions require the app to have booted under
+# AUTH_METHOD=jwt (the dedicated CI step), where the route-level seam mounts Idp::AccountsController
+# and JwtAuthenticationHelper#sign_in is active.
+RSpec.describe Idp::AccountsController, type: :request, if: AuthMethod.jwt? do
+  let(:api_url) { 'http://keycloak.test:8080' }
+  let(:realm) { 'openpath' }
+  let(:connector_id) { 'test' } # matches JwtAuthenticationHelper#sign_in
+  let(:token_url) { "#{api_url}/realms/#{realm}/protocol/openid-connect/token" }
+
+  let!(:user) { create(:acl_user, first_name: 'Self', last_name: 'Serve', phone: '5085551000', email_schedule: 'daily', credentials: 'old') }
+  # sign_in links this user to the 'test' connector at jwt_connector_user_id, which is deliberately
+  # not the warehouse user id — the Admin API is addressed by the IdP's id.
+  let(:target_url) { "#{api_url}/admin/realms/#{realm}/users/#{jwt_connector_user_id(user)}" }
+
+  before(:each) do
+    WebMock.disable_net_connect!
+    stub_request(:post, token_url).to_return(
+      status: 200,
+      body: { access_token: 'test-token', expires_in: 300 }.to_json,
+      headers: { 'Content-Type' => 'application/json' },
+    )
+  end
+
+  after(:each) do
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+
+  # A creation/write-capable Keycloak connector, so primary_idp resolves to a real KeycloakService
+  # (supports_profile_updates? == true, account_console_url present).
+  def configure_keycloak!
+    create(
+      :idp_service_config,
+      connector_id: connector_id,
+      provider: 'keycloak',
+      api_url: api_url,
+      keycloak_realm: realm,
+    )
+  end
+
+  # Asserting the raise rather than a redirect is what shows authenticate_user! ran ahead of the
+  # action; the gate itself is covered in warehouse_jwt_wiring_spec.rb.
+  describe 'with no forwarded token' do
+    it 'refuses the profile tab' do
+      expect { get edit_account_path }.to raise_error(Idp::UnauthenticatedRequestError)
+    end
+
+    it 'refuses a profile write, and writes nothing' do
+      expect do
+        patch account_path, params: { user: { first_name: 'Hacked', last_name: 'Hacked', phone: '5085550000' } }
+      end.to raise_error(Idp::UnauthenticatedRequestError)
+
+      user.reload
+      expect(user.first_name).to eq('Self')
+      expect(user.phone).to eq('5085551000')
+    end
+  end
+
+  describe 'when the connector accepts profile writes (Keycloak)' do
+    before(:each) do
+      configure_keycloak!
+      sign_in user
+    end
+
+    describe 'GET edit' do
+      it 'renders the name fields editable' do
+        get edit_account_path
+
+        expect(response).to have_http_status(:ok)
+        ['first_name', 'last_name'].each do |field|
+          disabled_input = /<input[^>]*name="user\[#{field}\]"[^>]*disabled|<input[^>]*disabled[^>]*name="user\[#{field}\]"/
+          expect(response.body).not_to match(disabled_input)
+        end
+      end
+
+      # Their coverage lives in the Idp::AccountEmailsController spec.
+      it 'leaves the credential self-service links to the Login & Security tab' do
+        get edit_account_path
+
+        expect(response.body).not_to match(/kc_action=UPDATE_PASSWORD/)
+        expect(response.body).not_to match(/kc_action=CONFIGURE_TOTP/)
+      end
+    end
+
+    describe 'PATCH update' do
+      let(:current_representation) { { id: jwt_connector_user_id(user), username: user.email, firstName: 'Self', lastName: 'Serve', email: user.email } }
+
+      before(:each) do
+        stub_request(:get, target_url).to_return(status: 200, body: current_representation.to_json)
+        stub_request(:put, target_url).to_return(status: 204)
+      end
+
+      it 'applies a name change locally and syncs it to Keycloak' do
+        patch account_path, params: { user: { first_name: 'Renamed', last_name: 'Serve', phone: '5085551000', credentials: 'old', email_schedule: 'daily' } }
+
+        expect(user.reload.first_name).to eq('Renamed')
+        expect(
+          a_request(:put, target_url).with(body: current_representation.merge(firstName: 'Renamed')),
+        ).to have_been_made
+        expect(flash[:notice]).to eq('Account name was updated.')
+        expect(response).to redirect_to(edit_account_path)
+      end
+
+      it 'saves local-only fields without calling Keycloak' do
+        patch account_path, params: { user: { first_name: 'Self', last_name: 'Serve', phone: '5085551212', credentials: 'old', email_schedule: 'daily' } }
+
+        expect(user.reload.phone).to eq('5085551212')
+        expect(a_request(:put, target_url)).not_to have_been_made
+        expect(flash[:notice]).to eq('Phone number was updated.')
+      end
+
+      # credentials only renders for health-role users, so a normal submit omits it entirely; the
+      # notice must not fire on that omission.
+      it 'does not report a credentials change when the field was not submitted' do
+        user.update_column(:credentials, 'stored-value')
+
+        patch account_path, params: { user: { first_name: 'Self', last_name: 'Serve', phone: '5085551212', email_schedule: 'daily' } }
+
+        expect(user.reload.credentials).to eq('stored-value')
+        expect(flash[:notice]).to eq('Phone number was updated.')
+      end
+
+      it 'persists a theme-only change even though it has no notice' do
+        patch account_path, params: { user: { first_name: 'Self', last_name: 'Serve', phone: '5085551000', credentials: 'old', email_schedule: 'daily', theme: 'modern' } }
+
+        expect(user.reload.theme).to eq('modern')
+        expect(a_request(:put, target_url)).not_to have_been_made
+        expect(flash[:notice]).to be_blank
+      end
+
+      # The IdP owns the address: a change goes through Idp::AccountEmailsController so the mailbox is
+      # verified before it becomes real. This action writes the same users row, so it has to refuse an
+      # address handed straight to it, and likewise the agency, which the form renders disabled. The
+      # phone change makes the save run, so the assertions can't pass on a skipped update.
+      it 'ignores crafted email and agency params on a request that does save' do
+        # Set explicitly rather than left to the factory's hard-coded agency_id, so the crafted id is
+        # a different row.
+        own_agency = create(:agency)
+        other_agency = create(:agency)
+        user.update_column(:agency_id, own_agency.id)
+        original_email = user.email
+
+        patch account_path, params: { user: { first_name: 'Self', last_name: 'Serve', phone: '5085551212', credentials: 'old', email_schedule: 'daily', email: 'attacker@example.com', agency_id: other_agency.id } }
+
+        user.reload
+        expect(user.phone).to eq('5085551212')
+        expect(user.email).to eq(original_email)
+        expect(user.agency_id).to eq(own_agency.id)
+        expect(a_request(:put, target_url)).not_to have_been_made
+      end
+
+      context 'when HMIS is enabled' do
+        # A real Hmis::Hud::User on an HMIS data source, matched by email the way
+        # User#sync_to_hud_users matches. These examples assert against the row rather than mocking
+        # sync_to_hud_users, so they cover the sync's outcome rather than the call.
+        let!(:hmis_data_source) { create(:hmis_primary_data_source) }
+        let!(:hud_user) { create(:hmis_hud_user, data_source: hmis_data_source, user_email: user.email, user_first_name: 'Self', user_last_name: 'Serve') }
+
+        before { allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true) }
+
+        it 'carries a name change through to the HMIS user rows and on to Keycloak' do
+          patch account_path, params: { user: { first_name: 'Renamed', last_name: 'Serve', phone: '5085551000', credentials: 'old', email_schedule: 'daily' } }
+
+          expect(user.reload.first_name).to eq('Renamed')
+          expect(hud_user.reload.user_first_name).to eq('Renamed')
+          expect(
+            a_request(:put, target_url).with(body: current_representation.merge(firstName: 'Renamed')),
+          ).to have_been_made
+          expect(flash[:notice]).to eq('Account name was updated.')
+        end
+
+        it 'leaves the HMIS user rows alone when nothing changed' do
+          # Stale on purpose: a sync would rewrite this to the user's current name, so the row
+          # standing still is observable evidence the sync was skipped.
+          stale_hud_user = create(:hmis_hud_user, data_source: hmis_data_source, user_email: user.email, user_first_name: 'Stale', user_last_name: 'Row')
+
+          patch account_path, params: { user: { first_name: 'Self', last_name: 'Serve', phone: '5085551000', credentials: 'old', email_schedule: 'daily' } }
+
+          expect(stale_hud_user.reload.user_first_name).to eq('Stale')
+          expect(a_request(:put, target_url)).not_to have_been_made
+          expect(flash[:notice]).to be_blank
+        end
+
+        # The HUD sync shares the local save's transaction, so a rejected Hmis::Hud::User write takes
+        # the profile edit with it rather than leaving HMIS rows naming someone the app no longer does.
+        # any_instance because the controller's @user comes back from User.find_or_create_from_jwt,
+        # not from this example.
+        it 'rolls the local save back when the HUD sync is rejected, and never reaches Keycloak' do
+          allow_any_instance_of(User).to receive(:sync_to_hud_users).and_raise(ActiveRecord::RecordInvalid)
+
+          patch account_path, params: { user: { first_name: 'Renamed', last_name: 'Serve', phone: '5085551000', credentials: 'old', email_schedule: 'daily' } }
+
+          expect(user.reload.first_name).to eq('Self')
+          expect(hud_user.reload.user_first_name).to eq('Self')
+          expect(a_request(:put, target_url)).not_to have_been_made
+          expect(response).to have_http_status(:ok)
+          expect(flash[:notice]).to be_blank
+        end
+      end
+
+      context 'when the Keycloak push fails' do
+        before do
+          stub_request(:put, target_url).to_return(status: 500, body: { error: 'boom' }.to_json)
+          allow(Sentry).to receive(:capture_exception_with_info)
+        end
+
+        # The push shares a transaction with the local save, so a refused push takes the save with
+        # it — the user's profile can't drift from what their IdP holds.
+        it 'saves nothing, pages Sentry, and re-renders saying so' do
+          patch account_path, params: { user: { first_name: 'Renamed', last_name: 'Serve' } }
+
+          expect(user.reload.first_name).to eq('Self')
+          expect(Sentry).to have_received(:capture_exception_with_info)
+          expect(flash[:alert]).to match(/couldn't save your changes/)
+          expect(flash[:notice]).to be_blank
+        end
+      end
+    end
+  end
+
+  describe 'when the connector cannot accept profile writes (unconfigured => NullService)' do
+    before(:each) { sign_in user }
+
+    it 'renders the name fields read-only and shows the managed-by-IdP notice instead of a console link' do
+      get edit_account_path
+
+      expect(response).to have_http_status(:ok)
+      ['first_name', 'last_name'].each do |field|
+        disabled_input = /<input[^>]*name="user\[#{field}\]"[^>]*disabled|<input[^>]*disabled[^>]*name="user\[#{field}\]"/
+        expect(response.body).to match(disabled_input)
+      end
+      expect(response.body).to match(/managed by your identity provider/i)
+    end
+
+    it 'strips crafted name params and never calls the IdP' do
+      patch account_path, params: { user: { first_name: 'Hacked', last_name: 'Hacked', phone: '5085550000' } }
+
+      user.reload
+      expect(user.first_name).to eq('Self')
+      expect(user.last_name).to eq('Serve')
+      expect(user.phone).to eq('5085550000') # local field still saves
+      expect(a_request(:put, /#{Regexp.escape(api_url)}/)).not_to have_been_made
+    end
+  end
+
+  # Same locked-profile behavior as the NullService context above, but on a reachable, *built*
+  # Keycloak (active config, manage_users:false), not an absent config — proving it locks and drops
+  # writes rather than raising.
+  describe 'when the connector authenticates but declines profile writes (manage_users:false)' do
+    before(:each) do
+      create(
+        :idp_service_config,
+        :authenticate_only,
+        connector_id: connector_id,
+        provider: 'keycloak',
+        api_url: api_url,
+        keycloak_realm: realm,
+      )
+      sign_in user
+    end
+
+    it 'renders the name fields read-only with the managed-by-IdP hint' do
+      get edit_account_path
+
+      expect(response).to have_http_status(:ok)
+      ['first_name', 'last_name'].each do |field|
+        disabled_input = /<input[^>]*name="user\[#{field}\]"[^>]*disabled|<input[^>]*disabled[^>]*name="user\[#{field}\]"/
+        expect(response.body).to match(disabled_input)
+      end
+      expect(response.body).to match(/managed by your identity provider/i)
+    end
+
+    it 'strips crafted name params, saves local fields, and never calls the IdP' do
+      patch account_path, params: { user: { first_name: 'Hacked', last_name: 'Hacked', phone: '5085550000' } }
+
+      user.reload
+      expect(user.first_name).to eq('Self')
+      expect(user.last_name).to eq('Serve')
+      expect(user.phone).to eq('5085550000')
+      expect(a_request(:put, /#{Regexp.escape(api_url)}/)).not_to have_been_made
+    end
+  end
+
+  describe 'IdP-owned routes are absent under JWT' do
+    it 'does not generate helpers for password, two-factor, or login-history' do
+      # Bare undefined helpers raise NameError (NoMethodError's parent); the route helpers are gone.
+      expect { edit_account_password_path }.to raise_error(NameError)
+      expect { edit_account_two_factor_path }.to raise_error(NameError)
+      expect { locations_account_path }.to raise_error(NameError)
+    end
+  end
+end

--- a/spec/support/shared_examples/auth_method_user_examples.rb
+++ b/spec/support/shared_examples/auth_method_user_examples.rb
@@ -342,6 +342,17 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
       end
     end
 
+    describe 'password_change_enabled?' do
+      it 'follows DeviseOktaSupport (!external_idp?): local-password users may change it, external-IdP users may not' do
+        user = build(factory)
+        allow(user).to receive(:external_idp?).and_return(false)
+        expect(user.password_change_enabled?).to be true
+
+        allow(user).to receive(:external_idp?).and_return(true)
+        expect(user.password_change_enabled?).to be false
+      end
+    end
+
     describe 'account_expiry_enabled?' do
       it 'is true regardless of external_idp? (Devise enforces expired_at for local and Okta accounts)' do
         user = build(factory)
@@ -487,6 +498,24 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
         allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, supports_profile_updates?: true))
         expect(user.email_change_enabled?).to be true
         expect(user.email_change_enabled?).to eq(!user.profile_managed_by_idp?)
+      end
+    end
+
+    describe 'password_change_enabled?' do
+      it 'is always false (there is no in-app password; credentials are managed in the IdP account console)' do
+        expect(model.new.password_change_enabled?).to be false
+      end
+    end
+
+    describe 'account_console_url' do
+      it 'delegates to the IdP service, and is nil for an unlinked user (NullService has no console)' do
+        expect(model.new.account_console_url).to be_nil
+      end
+
+      it 'returns the linked service console URL when the service exposes one' do
+        user = model.new
+        allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, account_console_url: 'http://kc.test/realms/openpath/account'))
+        expect(user.account_console_url).to eq('http://kc.test/realms/openpath/account')
       end
     end
 


### PR DESCRIPTION


## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
JWT-arm account surface split out of the monolith. Routes fork on AuthMethod.jwt?; password/2FA/login-history tabs dropped (IdP owns them), name fields lock and push to the IdP inside the profile transaction, credential management becomes a Keycloak app-initiated-action deep-link.

New Idp::AccountsController / AccountDownloadsController + views. support.rb gets password_change_enabled?/account_console_url/account_action_url; keycloak_service account_console_url switches api_url -> browser_url and adds account_action_url. warehouse-account public client in the realm import, Keycloak image bump to 26.7.0.

Note, this is a little broken: idp account emails controller is referenced but lands in the next branch (8458-idp-6-account-email)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill

