### PR TITLE
feat: 8458 account email self-service + IdP read-back

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -334,6 +334,8 @@ jobs:
             drivers/hmis/spec/requests/hmis_admin/users_controller_spec.rb
             spec/requests/admin/audits_controller_spec.rb
             spec/requests/idp/accounts_controller_spec.rb
+            spec/requests/idp/account_emails_controller_spec.rb
+            spec/jobs/idp/sync_user_from_idp_job_spec.rb
           )
           AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd "${specs[@]}"
 

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -21,6 +21,7 @@ module Idp::JwtAuthentication
   extend ActiveSupport::Concern
 
   SESSION_PRINCIPAL_KEY = :idp_token_holder_id
+  SESSION_SYNC_KEY = :idp_user_synced
 
   included do
     helper_method :user_session_expires_at
@@ -220,6 +221,26 @@ module Idp::JwtAuthentication
     end
 
     user
+  end
+
+  def idp_schedule_user_sync
+    return if session[SESSION_SYNC_KEY]
+
+    user = idp_token_holder
+    return unless user
+
+    connector_id = user.last_connector_id
+    return if connector_id.blank?
+
+    # Set before the checks below, not after: otherwise a paused or non-self-service connector
+    # re-runs them on every request instead of spending its one per-session attempt.
+    session[SESSION_SYNC_KEY] = true
+
+    # The job no-ops on connectors without email self-service; skip enqueuing one at all.
+    return unless user.email_change_enabled?
+    return if Idp::SyncUserFromIdpJob.connector_paused?(connector_id)
+
+    Idp::SyncUserFromIdpJob.perform_later(user_id: user.id)
   end
 
   # Never redirects to sign-in. oauth2-proxy owns that, and both cases below arrive with the proxy

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -22,7 +22,10 @@ module Idp::JwtCurrentUser
     end
 
     def authenticate_user!
-      return if current_user
+      if current_user
+        idp_schedule_user_sync
+        return
+      end
 
       # A deactivated user holds a valid IdP token
       return idp_handle_deactivated if idp_token_holder && !idp_token_holder.active?

--- a/app/controllers/idp/account_emails_controller.rb
+++ b/app/controllers/idp/account_emails_controller.rb
@@ -1,0 +1,85 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Read-only. The user changes their email at the IdP through an UPDATE_EMAIL deep-link, and we adopt
+# the result the next time we read the account back. There is no local write path.
+class Idp::AccountEmailsController < ApplicationController
+  before_action :set_user
+
+  def edit
+    return unless @user.email_change_enabled?
+    # The sync job already found this connector broken, and this is a page people refresh.
+    return if Idp::SyncUserFromIdpJob.connector_paused?(@user.last_connector_id)
+
+    reconcile_email_from_idp
+    @pending_email = pending_email_from_idp
+  end
+
+  def begin_change
+    action_url = @user.email_change_enabled? && @user.account_action_url(action: 'UPDATE_EMAIL', redirect_uri: edit_account_email_url)
+    raise 'Attempt to change email when feature is not enabled' if action_url.blank?
+
+    Rails.logger.info("User #{@user.id} started an email change at #{@user.idp_service.idp_name}")
+
+    redirect_to action_url, allow_other_host: true
+  end
+
+  # Reconciles on each load of this page to catch email de-synchronization issues. We may replace this
+  # with a custom webhook from keycloak in the future
+  private def reconcile_email_from_idp
+    idp_name = @user.idp_service.idp_name
+
+    # users (app db) and Hmis::Hud::User (warehouse db) are separate connections with no shared
+    # commit, so this isn't atomic. The nesting still rolls the email change back if the HUD sync
+    # raises; only a failure between the two commits can leave them diverged.
+    GrdaWarehouseBase.transaction do
+      @user.transaction do
+        @previous_email = @user.idp_reconcile_email!
+        @user.sync_to_hud_users(previous_email: @previous_email) if @previous_email.present? && HmisEnforcement.hmis_enabled?
+      end
+    end
+    return if @previous_email.blank?
+
+    flash.now[:notice] = 'Account email was updated.'
+  rescue Idp::ServiceError => e
+    # Nothing was written, so there's no state to roll back and no reason to fail the page.
+    Sentry.capture_exception_with_info(e, "Couldn't adopt #{idp_name} email for user #{@user.id}")
+    flash.now[:alert] = "Your email was changed with #{idp_name}, but we couldn't adopt the new address: #{e.message}" if change_expected?
+  rescue ActiveRecord::RecordInvalid => e
+    # The IdP moved the address but we can't store it — taken here, or malformed. Reload to drop the
+    # rejected value. Alerted either way: the records have diverged and only support can close it.
+    reason = e.record.errors.full_messages.join(', ')
+    @user.reload
+    Sentry.capture_exception_with_info(e, "Couldn't adopt #{idp_name} email for user #{@user.id}: #{reason}")
+    flash.now[:alert] = "Your email was changed with #{idp_name}, but we couldn't save the new address here. Please contact support."
+  end
+
+  # Nothing pending to show once reconcile adopted the change: the new address is already live.
+  private def pending_email_from_idp
+    return nil if @previous_email.present?
+
+    @user.idp_pending_email
+  rescue Idp::ServiceError
+    # Display only, and #reconcile_email_from_idp already reported this ServiceError to Sentry.
+    nil
+  end
+
+  # Gates the apology copy, not the reconciliation. An admin-side edit to an unverified address makes
+  # this tab raise on every visit, and a user shouldn't be told we failed at a change they never made.
+  # Set by Keycloak on the return trip from the UPDATE_EMAIL action.
+  private def change_expected?
+    params[:kc_action_status] == 'success'
+  end
+
+  # Token holder, not current_user: under impersonation these differ, and begin_change redirects the
+  # browser to Keycloak under the token holder's session — reconciling current_user would adopt the
+  # change into the impersonated account instead.
+  private def set_user
+    @user = idp_token_holder
+  end
+end

--- a/app/jobs/idp/sync_user_from_idp_job.rb
+++ b/app/jobs/idp/sync_user_from_idp_job.rb
@@ -1,0 +1,93 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Idp
+  # Adopts an IdP-side email change after login. The JWT can't report one — oauth2-proxy still holds a
+  # token minted before the change.
+  class SyncUserFromIdpJob < BaseJob
+    queue_as ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)
+
+    COOLDOWN_TTL = 5.minutes
+
+    def perform(user_id:)
+      user = User.find_by(id: user_id)
+      return unless user
+      return unless user.email_change_enabled?
+
+      previous_email = reconcile(user)
+      return if previous_email.blank?
+
+      Rails.logger.info("Adopted IdP email for user #{user.id} (was #{previous_email})")
+    rescue Idp::ServiceError => e
+      # Stops a broken connector collecting a job per sign-in. This user's retry still runs.
+      self.class.pause_connector!(user&.last_connector_id)
+      raise e
+    end
+
+    # One retry covers a blip. Further attempts just duplicate the Sentry event.
+    def calculated_attempts
+      [0, Delayed::Worker.max_attempts - 2].max
+    end
+
+    # A re-run is a get_user that no-ops when the address hasn't moved.
+    def self.supports_idempotent_retry?
+      true
+    end
+
+    def self.connector_paused?(connector_id)
+      return false if connector_id.blank?
+
+      Rails.cache.exist?(cooldown_key(connector_id))
+    end
+
+    def self.pause_connector!(connector_id)
+      return if connector_id.blank?
+
+      Rails.cache.write(cooldown_key(connector_id), true, expires_in: COOLDOWN_TTL)
+    end
+
+    def self.cooldown_key(connector_id)
+      "idp_sync_cooldown:#{connector_id}"
+    end
+
+    private
+
+    # Two databases, no shared commit, so nested rather than atomic: a failed HUD sync rolls back the
+    # adopted address.
+    def reconcile(user)
+      previous_email = nil
+      GrdaWarehouseBase.transaction do
+        user.transaction do
+          previous_email = user.idp_reconcile_email!
+          user.sync_to_hud_users(previous_email: previous_email) if previous_email.present? && HmisEnforcement.hmis_enabled?
+        end
+      end
+      previous_email
+    rescue ActiveRecord::RecordInvalid => e
+      # The new address is taken here, or malformed. No retry fixes that.
+      Sentry.capture_exception_with_info(
+        e,
+        "Couldn't adopt IdP email for user #{user.id}",
+        {
+          user_id: user.id,
+          attempted_email: user.email, # rolled back, but still dirty in memory
+          retained_email: user.email_was,
+          invalid_record: e.record.class.name,
+          reason: e.record.errors.full_messages.join(', '),
+        },
+      )
+      nil
+    rescue Idp::ServiceError => e
+      # #perform owns the cooldown. Non-transient means the same answer comes back, so don't retry.
+      raise e if e.transient?
+
+      Sentry.capture_exception_with_info(e, "Couldn't adopt IdP email for user #{user.id}: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -20,9 +20,12 @@ module Idp::Support
     last_connector_id.presence || primary_auth_source&.connector_id
   end
 
-  # The IdP owns the user's identity fields unless its service can push our edits back to it
+  # Whether the IdP offers a self-service email change. The Warehouse never edits email in this
+  # arm, so this gates the deep-link handoff, not an in-app form.
   def email_change_enabled?
-    !profile_managed_by_idp?
+    idp_service.supports_email_self_service?
+  rescue Idp::ServiceError
+    false
   end
 
   # A service we can't even build (e.g. misconfigured Keycloak) is treated as locked — the safe
@@ -116,6 +119,56 @@ module Idp::Support
     idp_service.send_execute_actions_email(user_id: idp_connector_user_id!, actions: ['UPDATE_PASSWORD', 'VERIFY_EMAIL'])
   end
 
+  # Adopt the IdP's address after the user completed an Update Email action there — the IdP verified
+  # the mailbox, so it is authoritative.
+  #
+  # The JWT claim can't serve here: oauth2-proxy still holds the pre-change token when the browser
+  # returns, so payload_email is the old address (and under email-as-username, the old username).
+  #
+  # @return [String, nil] the address we replaced, for callers re-pointing HMIS user rows keyed on
+  #   it; nil when nothing moved
+  # @raise [Idp::ServiceError] the IdP holds the new address but hasn't verified the mailbox
+  # @raise [ActiveRecord::RecordInvalid] the new address can't be stored here (taken, or malformed)
+  def idp_reconcile_email!
+    return nil unless primary_idp
+    # Callers gate on email_change_enabled? (supports_email_self_service?), but the get_user below
+    # is an Admin API read that a manage_users:false realm can't serve while self-service stays on.
+    return nil unless idp_service.supports_user_management?
+
+    representation = idp_user_representation
+    remote_email = representation['email'].presence
+    return nil if remote_email.blank? || remote_email.casecmp?(email)
+
+    # Require a verified mailbox rather than trusting realm config: with Verify Email off, Keycloak
+    # applies the new address immediately, and adopting that unverified value into users.email is
+    # the exact outcome routing the change through the IdP exists to prevent.
+    unless representation['emailVerified']
+      raise Idp::ServiceError.new(
+        "#{idp_service.idp_name} has not verified #{remote_email}",
+        idp_name: idp_service.idp_name,
+        operation: :get_user,
+        # Non-transient: re-reading returns the same unverified answer until an operator enables Verify Email.
+        transient: false,
+      )
+    end
+
+    previous_email = email
+    update!(email: remote_email)
+
+    previous_email
+  end
+
+  # Unconfirmed address at the IdP, or nil. Display only — #idp_reconcile_email! still trusts nothing
+  # but a verified address.
+  #
+  # @raise [Idp::ServiceError] the IdP couldn't be reached
+  def idp_pending_email
+    return nil unless primary_idp
+    return nil unless idp_service.supports_user_management?
+
+    idp_service.pending_email_from_representation(idp_user_representation)
+  end
+
   # Push admin-edited first_name/last_name/email to the IdP. No-ops unless the service can accept
   # the write back (the same capability that unlocks the fields in the first place).
   def idp_update_profile!(attributes)
@@ -126,6 +179,13 @@ module Idp::Support
   end
 
   private
+
+  # idp_reconcile_email! and idp_pending_email both read this on one account-page render; memoized
+  # to spend one Admin API read, not two.
+  # @raise [Idp::ServiceError] the read failed
+  def idp_user_representation
+    @idp_user_representation ||= idp_service.get_user(user_id: idp_connector_user_id!)
+  end
 
   # Unlike the render-time predicates above, this deliberately does not rescue Idp::ServiceError. A
   # deactivated or removed config resolves to a NullService (returns false) and the local write still

--- a/app/services/idp/keycloak_service.rb
+++ b/app/services/idp/keycloak_service.rb
@@ -19,6 +19,10 @@ module Idp
   class KeycloakService < Service
     UPDATABLE_ATTRIBUTES = [:first_name, :last_name, :email].freeze
 
+    # Where Keycloak stores an unconfirmed address (`UserModel.EMAIL_PENDING`), clearing the
+    # attribute on confirmation.
+    EMAIL_PENDING_ATTRIBUTE = 'kc.email.pending'
+
     # Most calls are on a request path, so the default budget is short enough that a hung Keycloak
     # fails the request rather than holding the thread.
     OPEN_TIMEOUT_SECONDS = 2
@@ -182,6 +186,14 @@ module Idp
       end
     end
 
+    def pending_email(user_id:)
+      pending_email_from_representation(get_user(user_id: user_id))
+    end
+
+    def pending_email_from_representation(representation)
+      Array(representation.dig('attributes', EMAIL_PENDING_ATTRIBUTE)).first.presence
+    end
+
     def reactivate_user(user_id:)
       put_full_user(user_id: user_id, patch: { 'enabled' => true }, operation: :reactivate_user, failure: 'Failed to reactivate user')
     end
@@ -217,6 +229,12 @@ module Idp
 
     def supports_profile_updates?
       manage_users?
+    end
+
+    # Returns true unconditionally: the Update Email required action and realm Verify Email are
+    # operator prerequisites documented in docs/developer/keycloak-idp.md, not probed at render time.
+    def supports_email_self_service?
+      true
     end
 
     def supports_user_creation?

--- a/app/services/idp/service.rb
+++ b/app/services/idp/service.rb
@@ -93,6 +93,13 @@ module Idp
       false
     end
 
+    # Whether the user can change their own email address *at the IdP*, with the IdP owning
+    # collection and mailbox verification. Distinct from #supports_profile_updates?, which is
+    # about the Warehouse pushing an already-committed edit in.
+    def supports_email_self_service?
+      false
+    end
+
     def supports_account_backfill?
       false
     end
@@ -121,6 +128,20 @@ module Idp
     # (e.g. UPDATE_PASSWORD, CONFIGURE_TOTP) and returns them to redirect_uri afterward.
     # Defaults to nil for IDPs that don't support such deep-links.
     def account_action_url(action:, redirect_uri:) # rubocop:disable Lint/UnusedMethodArgument
+      nil
+    end
+
+    # Address the user asked for but hasn't confirmed yet, for IDPs that hold one alongside the live
+    # address. Display only; nil for an IDP with no such concept.
+    # @return [String, nil]
+    def pending_email(user_id:) # rubocop:disable Lint/UnusedMethodArgument
+      nil
+    end
+
+    # Takes an already-fetched representation so a caller that holds one — the account page, which
+    # just read it to reconcile — needn't spend a second Admin API read.
+    # @return [String, nil]
+    def pending_email_from_representation(representation) # rubocop:disable Lint/UnusedMethodArgument
       nil
     end
 

--- a/app/views/idp/account_emails/_content.haml
+++ b/app/views/idp/account_emails/_content.haml
@@ -1,0 +1,35 @@
+-# Email is changed at the IdP via deep-link; this tab has no local write path for the address.
+
+- if impersonating?
+  %p.text-muted You can't change login and security settings for another user while impersonating.
+- else
+  - change_password_url = @user.account_action_url(action: 'UPDATE_PASSWORD', redirect_uri: edit_account_email_url)
+  - change_email_available = @user.email_change_enabled? && @user.account_action_url(action: 'UPDATE_EMAIL', redirect_uri: edit_account_email_url).present?
+
+  %p.lead
+    Your email is:
+    = @user.email
+
+  - if @pending_email.present?
+    %p.text-muted
+      Waiting for you to confirm
+      %strong= @pending_email
+      \. Check that inbox for the confirmation link, then
+      = link_to 'check for changes', edit_account_email_path
+      \.
+
+  - unless change_email_available
+    %p.text-muted Your email is managed by your identity provider.
+
+  - btn_class = 'btn btn-primary btn-sm'
+  - if change_email_available || change_password_url
+    - if change_email_available
+      .my-2
+        -# A POST rather than the deep-link itself, so the controller can log the change first.
+        = button_to 'Change Email', begin_change_account_email_path, class: btn_class
+    - if change_password_url
+      .my-2
+        = link_to "Change password", change_password_url, class: btn_class
+      .mt-2
+        - totp_url = @user.account_action_url(action: 'CONFIGURE_TOTP', redirect_uri: edit_account_email_url)
+        = link_to "Set up two-factor authentication", totp_url, class: btn_class

--- a/app/views/idp/account_emails/edit.haml
+++ b/app/views/idp/account_emails/edit.haml
@@ -1,0 +1,9 @@
+= content_for :title, 'Edit Account'
+%h1= content_for :title
+%hr
+.row
+  .col-sm-12
+    .mb-5= render 'idp/accounts/account_info_tabs'
+    .well(style="max-width: 500px")
+      %h3 Login & Security
+      = render 'content'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1018,7 +1018,9 @@ Rails.application.routes.draw do
     # No :update — the JWT arm never writes email locally; the IdP owns the change (see
     # Idp::AccountEmailsController). begin_change hands the browser off to the IdP and writes nothing
     # about the address.
-    resource :account_email, only: [:edit], controller: 'idp/account_emails'
+    resource :account_email, only: [:edit], controller: 'idp/account_emails' do
+      post :begin_change
+    end
     resources :account_downloads, only: [:index], controller: 'idp/account_downloads'
   else
     resource :account, only: [:edit, :update] do

--- a/docker/keycloak/realm-import.json
+++ b/docker/keycloak/realm-import.json
@@ -5,6 +5,7 @@
   "registrationAllowed": false,
   "resetPasswordAllowed": true,
   "loginWithEmailAllowed": true,
+  "registrationEmailAsUsername": true,
   "clients": [
     {
       "clientId": "dex-connector",

--- a/docs/developer/keycloak-idp.md
+++ b/docs/developer/keycloak-idp.md
@@ -149,6 +149,46 @@ which behaves the same way.
 > --password 'AdminPassword1!'`), and reset the secret in the admin console or recreate the realm
 > from a clean DB if it drifted.
 
+## Realm prerequisites for account email self-service
+
+Under the JWT arm a user changes their own email **inside Keycloak**, not in the Warehouse. The Email
+tab is read-only and hands the browser to Keycloak's `UPDATE_EMAIL` application-initiated action.
+Keycloak collects the new address, mails a confirmation link to it, and applies it only once that
+link is clicked.
+
+The Warehouse adopts the result the next time it reads the account back from the Admin API, and only
+when Keycloak reports the mailbox verified — so no self-service path can put an unproven address in
+`users.email`. Two things read it back: every render of the Email tab, and a background sync job on
+authenticated requests. Adoption therefore does not depend on the user landing back on the tab, which
+matters because we do not control where Keycloak drops them.
+
+(The **admin** path is separate and unchanged: an admin-supplied address is written locally and
+pushed with `emailVerified: false`, so an admin can still put an unverified address in `users.email`.)
+
+The service **asserts** the realm is set up for this rather than probing it, so the items below are
+operator setup for every realm running the JWT arm. Miss one and the tab still renders and still
+offers the button, but the flow misbehaves in the ways noted.
+
+| Requirement | Where | If missing |
+| --- | --- | --- |
+| **Update Email** required action **enabled** | Authentication → Required actions | Keycloak rejects the `kc_action=UPDATE_EMAIL` link; the user gets no way to change their address |
+| Email verification **in effect for this action** | Realm settings → Login → **Verify email**, or Authentication → Required actions → Update Email → **Force Email Verification** | Keycloak applies the new address **immediately, unverified**. The Warehouse refuses to adopt it, so Keycloak and `users.email` diverge until the realm is fixed |
+| Working **SMTP** on the realm | Realm settings → Email | The verification mail never sends, so a change can never complete |
+
+Either verification lever is enough — the realm-wide **Verify email** setting, or **Force Email
+Verification** on the Update Email required action (off by default), which turns it on for this
+action regardless of the realm setting. The per-action one is more precise, since it leaves password
+resets and admin-provisioned accounts on the realm default.
+
+Additional notes
+
+- **Email is the login name.** The realm runs **Email as username**
+  (`registrationEmailAsUsername: true`), so Keycloak keeps `username` tracking `email` — matching the
+  legacy Devise model where email *is* the login.
+- **Starting a change can ask for a password.** The Update Email required action carries a **Maximum
+  Age of Authentication** (`max_auth_age`, default **300** seconds). If the browser's Keycloak session
+  last authenticated longer ago than that, Keycloak re-authenticates the user before showing the form.
+
 ## Notes
 
 - **Warehouse-only?** `oauth2-proxy-hmis` upstreams to Vite on the host (`host.docker.internal:5173`)

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -18,7 +18,10 @@ module Hmis::Concerns::JwtHmisCurrentUser
     helper_method :current_hmis_user
 
     def authenticate_hmis_user!
-      return if current_hmis_user
+      if current_hmis_user
+        idp_schedule_user_sync
+        return
+      end
 
       # A deactivated user holds a valid IdP token
       return idp_handle_deactivated if idp_token_holder && !idp_token_holder.active?

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -15,6 +15,11 @@ module Hmis
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
     #
+    # Unlike ::Idp::SessionsController, #destroy keeps authenticate_hmis_user! (Hmis::BaseController
+    # applies it, and this class does not skip it): the SPA recovers from a JSON 403 by hitting
+    # /oauth2/sign_out itself, so there is no server-rendered dead-end page needing sign-out to work
+    # without a resolvable current_user (the reason the warehouse skips the filter).
+    #
     class SessionsController < Hmis::BaseController
       # The CSRF token is what guards #destroy
       def destroy

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -301,6 +301,7 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
           Idp::KeycloakService,
           supports_session_logout?: true,
           logout_user_sessions: true,
+          supports_email_self_service?: false,
         )
       end
 
@@ -397,16 +398,14 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
 
         delete destroy_hmis_user_session_path, headers: headers
 
-        expect(Idp::ServiceFactory).to have_received(:for_connector).with('test')
+        expect(Idp::ServiceFactory).to have_received(:for_connector).with('test').at_least(:once)
         expect_signed_out_normally
       end
 
-      # Not "signs out normally": a token with no connector claim can't authenticate at all, because
-      # Idp::UserProvisioner requires the claim to resolve a holder and authenticate_hmis_user! runs
-      # before the sign-out action. So the blank-connector guard in idp_end_token_holder_sessions is
-      # unreachable from this arm, and asserting "signed out normally, no call" here would have
-      # described behavior this arm doesn't have. The warehouse arm skips authenticate_user! on
-      # sign-out, so there the same token does reach that guard and does sign out normally.
+      # Idp::UserProvisioner needs the connector claim to resolve a holder, and authenticate_hmis_user!
+      # runs before #destroy, so a claimless token 403s at authentication rather than reaching sign-out.
+      # The warehouse arm skips authenticate_user! on #destroy, so there the same token reaches
+      # idp_end_token_holder_sessions and signs out via its blank-connector guard.
       it 'never reaches sign-out for a token with no connector claim: the request fails to authenticate' do
         start_session
         # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
@@ -416,9 +415,9 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
 
         expect(response).to have_http_status(:forbidden)
         expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
-        # The guard the previous wording claimed to cover: the factory is never consulted, so this
-        # can't pass by falling through to a NullService the way the old assertion could.
-        expect(Idp::ServiceFactory).not_to have_received(:for_connector).with('test')
+        # start_session's keepalive resolves 'test' once (the per-session sync guard); the DELETE adds
+        # none. A fall-through to a NullService sign-out — the regression this guards — would make it two.
+        expect(Idp::ServiceFactory).to have_received(:for_connector).with('test').once
       end
 
       # The whole reason the id comes off the token: current_hmis_user is the impersonated user here,

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -394,6 +394,93 @@ RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
     end
   end
 
+  describe 'scheduling the IdP read-back (#idp_schedule_user_sync)' do
+    let(:user) { double('User', id: 7, active?: true, last_connector_id: 'keycloak', email_change_enabled?: true) }
+
+    before do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(user)
+      # NullStore holds nothing, so the connector pause would never engage.
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    end
+
+    it 'enqueues a sync once the request is authenticated' do
+      expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+
+    # travel past the cooldown so only the session guard can refuse: two back-to-back requests would
+    # also be refused by the per-connector cooldown, masking the session guard this test targets.
+    it 'does not enqueue again however long the session lasts' do
+      get :auth
+
+      travel(3.days) do
+        expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+      end
+    end
+
+    it 'enqueues again for a new session' do
+      get :auth
+      session.delete(Idp::JwtAuthentication::SESSION_SYNC_KEY)
+
+      expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+
+    # idp_sync_session_principal! resets the session when the principal changes, which takes the
+    # guard with it.
+    it 'enqueues for a user who inherits a browser from someone else' do
+      session[Idp::JwtAuthentication::SESSION_PRINCIPAL_KEY] = 99
+      session[Idp::JwtAuthentication::SESSION_SYNC_KEY] = true
+
+      expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+
+    # Uses the no-account case (find returns nil); a missing token would raise further up instead.
+    it 'does not enqueue for a request that resolves no user' do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+      expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+    end
+
+    it 'does not enqueue while the connector is paused' do
+      Idp::SyncUserFromIdpJob.pause_connector!('keycloak')
+
+      expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+    end
+
+    # Otherwise every request in a session that started mid-outage retries until the pause lifts.
+    it 'spends the session attempt even when the connector is paused' do
+      Idp::SyncUserFromIdpJob.pause_connector!('keycloak')
+      get :auth
+
+      travel(Idp::SyncUserFromIdpJob::COOLDOWN_TTL + 1.minute) do
+        expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+      end
+    end
+
+    it 'does not enqueue for a user with no connector on file' do
+      allow(user).to receive(:last_connector_id).and_return(nil)
+
+      expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+    end
+
+    # Duplicates the gate the job itself applies, to keep no-op jobs off the queue.
+    it 'does not enqueue when the connector offers no email self-service' do
+      allow(user).to receive(:email_change_enabled?).and_return(false)
+
+      expect { get :auth }.not_to have_enqueued_job(Idp::SyncUserFromIdpJob)
+    end
+
+    it 'syncs the token holder, not the account being impersonated' do
+      impersonated_user = double('User', id: 20, active?: true, last_connector_id: 'keycloak')
+      allow(user).to receive(:can_impersonate_users?).and_return(true)
+      allow(impersonated_user).to receive(:impersonateable_by?).with(user).and_return(true)
+      allow(User).to receive(:find_by).with(id: 7).and_return(user)
+      allow(User).to receive(:find_by).with(id: 20).and_return(impersonated_user)
+      session[:impersonation] = { true_user_id: 7, impersonated_user_id: 20 }
+
+      expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+  end
+
   describe 'dropped methods (regression guard for the subtractions)' do
     it 'does not define forced-logout / provisioning / activity methods' do
       [:check_token_denylist!, :handle_denylisted_token, :ensure_authentication_source, :update_user_activity, :handle_inactive_user].each do |method_name|

--- a/spec/jobs/idp/sync_user_from_idp_job_spec.rb
+++ b/spec/jobs/idp/sync_user_from_idp_job_spec.rb
@@ -1,0 +1,240 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This doubles as the Idp::Support#idp_reconcile_email! spec — the job drives the real method, so
+# the emailVerified gate and case-insensitive no-op are exercised here; there is no separate one.
+#
+# Idp::Support mixes into User only under the JWT arm (UserConcern), so the describe is guarded on
+# AuthMethod.jwt? and these examples run only under AUTH_METHOD=jwt.
+RSpec.describe Idp::SyncUserFromIdpJob, type: :job, if: AuthMethod.jwt? do
+  let!(:user) { create(:user, email: 'before@example.com', first_name: 'Self', last_name: 'Serve') }
+  let(:service) do
+    instance_double(
+      Idp::KeycloakService,
+      idp_name: 'Keycloak',
+      supports_email_self_service?: true,
+      supports_user_management?: true,
+    )
+  end
+
+  before(:each) do
+    user.user_authentication_sources.create!(connector_id: 'test', connector_user_id: 'kc-1')
+    user.update_column(:last_connector_id, 'test')
+    allow(Idp::ServiceFactory).to receive(:for_connector).with('test').and_return(service)
+    # NullStore can't hold the cooldown flag.
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+  end
+
+  def remote_user(email:, verified: true)
+    { 'id' => 'kc-1', 'email' => email, 'emailVerified' => verified }
+  end
+
+  it 'adopts an address the IdP has verified' do
+    allow(service).to receive(:get_user).with(user_id: 'kc-1').and_return(remote_user(email: 'after@example.com'))
+
+    described_class.new.perform(user_id: user.id)
+
+    expect(user.reload.email).to eq('after@example.com')
+  end
+
+  it 'leaves the local address alone when the IdP still holds it' do
+    allow(service).to receive(:get_user).and_return(remote_user(email: 'before@example.com'))
+
+    described_class.new.perform(user_id: user.id)
+
+    expect(user.reload.email).to eq('before@example.com')
+  end
+
+  # HUD user rows are keyed on the address, so adopting a new one without re-pointing them leaves
+  # those rows stale.
+  it 're-points HMIS HUD user rows from the previous address' do
+    allow(service).to receive(:get_user).and_return(remote_user(email: 'after@example.com'))
+    allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    expect(user).to receive(:sync_to_hud_users).with(previous_email: 'before@example.com')
+
+    described_class.new.perform(user_id: user.id)
+  end
+
+  # Adopting a case-only difference would still write the column and fire a re-point whose
+  # previous_email differs from the new address only in case.
+  it 'treats a case-only difference as no change' do
+    allow(service).to receive(:get_user).and_return(remote_user(email: 'BEFORE@example.com'))
+    allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    expect(user).not_to receive(:sync_to_hud_users)
+
+    described_class.new.perform(user_id: user.id)
+
+    expect(user.reload.email).to eq('before@example.com')
+  end
+
+  # Two databases, no shared commit: adopting is only safe if a failed HUD re-point rolls the new
+  # address back out of users.email.
+  it 'unwinds the adopted address when the HMIS re-point fails' do
+    allow(service).to receive(:get_user).and_return(remote_user(email: 'after@example.com'))
+    allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    allow(user).to receive(:sync_to_hud_users).and_raise(ActiveRecord::RecordInvalid.new(user))
+    allow(Sentry).to receive(:capture_exception_with_info)
+
+    described_class.new.perform(user_id: user.id)
+
+    expect(user.reload.email).to eq('before@example.com')
+  end
+
+  it 'does not re-point HMIS rows when the address has not moved' do
+    allow(service).to receive(:get_user).and_return(remote_user(email: 'before@example.com'))
+    allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+    allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+    expect(user).not_to receive(:sync_to_hud_users)
+
+    described_class.new.perform(user_id: user.id)
+  end
+
+  it 'never reaches the IdP when it offers no email self-service' do
+    allow(service).to receive(:supports_email_self_service?).and_return(false)
+    expect(service).not_to receive(:get_user)
+
+    described_class.new.perform(user_id: user.id)
+  end
+
+  it 'tolerates a user deleted between enqueue and run' do
+    expect(service).not_to receive(:get_user)
+
+    expect { described_class.new.perform(user_id: user.id + 1_000) }.not_to raise_error
+  end
+
+  describe 'a connector fault' do
+    let(:error) { Idp::ServiceError.new('Failed to fetch user', idp_name: 'Keycloak', operation: :get_user) }
+
+    before(:each) do
+      allow(service).to receive(:get_user).and_raise(error)
+    end
+
+    # sentry-delayed_job reports whatever escapes the job, so raising is what reaches Sentry.
+    it 'raises so the failure retries and reaches Sentry' do
+      expect { described_class.new.perform(user_id: user.id) }.to raise_error(error)
+    end
+
+    it 'starts the connector cooldown so a broken connector stops enqueueing a job per sign-in' do
+      expect { described_class.new.perform(user_id: user.id) }.to raise_error(Idp::ServiceError)
+
+      expect(described_class.connector_paused?('test')).to be true
+      expect(described_class.connector_paused?('other-connector')).to be false
+    end
+  end
+
+  # Refused, and neither retried nor cooled down: the same unverified address comes back until an
+  # operator turns Verify Email on for the realm.
+  describe 'an address the IdP never verified' do
+    before(:each) do
+      allow(service).to receive(:get_user).and_return(remote_user(email: 'after@example.com', verified: false))
+      allow(Sentry).to receive(:capture_exception_with_info)
+    end
+
+    it 'reports to Sentry rather than raising' do
+      expect(Sentry).to receive(:capture_exception_with_info).with(
+        kind_of(Idp::ServiceError),
+        /Couldn't adopt IdP email for user #{user.id}/,
+      )
+
+      expect { described_class.new.perform(user_id: user.id) }.not_to raise_error
+    end
+
+    it 'leaves the local address in place' do
+      described_class.new.perform(user_id: user.id)
+
+      expect(user.reload.email).to eq('before@example.com')
+    end
+
+    # Otherwise one misconfigured realm pauses the connector and nobody else on the connector syncs.
+    it 'does not pause the connector' do
+      described_class.new.perform(user_id: user.id)
+
+      expect(described_class.connector_paused?('test')).to be false
+    end
+  end
+
+  # No retry resolves an address another user already holds, so report and stop.
+  describe 'an address we cannot store' do
+    before(:each) do
+      allow(service).to receive(:get_user).and_return(remote_user(email: 'after@example.com'))
+      allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+      allow(user).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(user))
+    end
+
+    it 'reports to Sentry rather than raising' do
+      expect(Sentry).to receive(:capture_exception_with_info).with(
+        kind_of(ActiveRecord::RecordInvalid),
+        /Couldn't adopt IdP email for user #{user.id}/,
+        hash_including(user_id: user.id),
+      )
+
+      expect { described_class.new.perform(user_id: user.id) }.not_to raise_error
+    end
+
+    it 'leaves the local address in place' do
+      allow(Sentry).to receive(:capture_exception_with_info)
+
+      described_class.new.perform(user_id: user.id)
+
+      expect(user.reload.email).to eq('before@example.com')
+    end
+
+    it 'does not pause the connector — the connector is fine' do
+      allow(Sentry).to receive(:capture_exception_with_info)
+
+      described_class.new.perform(user_id: user.id)
+
+      expect(described_class.connector_paused?('test')).to be false
+    end
+  end
+
+  # last_connector_id names a live connector the user has no user_authentication_sources row for —
+  # the row was deleted, or the connector renamed. Local data, not a connector fault, so the
+  # connector is not paused.
+  describe 'a user with no identity row for their connector' do
+    before(:each) do
+      user.user_authentication_sources.destroy_all
+      allow(Sentry).to receive(:capture_exception_with_info)
+    end
+
+    it 'never reaches the IdP — there is no account to ask about' do
+      expect(service).not_to receive(:get_user)
+
+      described_class.new.perform(user_id: user.id)
+    end
+
+    it 'reports to Sentry rather than raising' do
+      expect(Sentry).to receive(:capture_exception_with_info).with(
+        kind_of(Idp::ServiceError),
+        /Couldn't adopt IdP email for user #{user.id}/,
+      )
+
+      expect { described_class.new.perform(user_id: user.id) }.not_to raise_error
+    end
+
+    # Otherwise one user's missing row stops the connector: Idp::JwtAuthentication and
+    # Idp::AccountEmailsController both skip the sync for anyone on a paused connector.
+    it 'does not pause the connector, so other users still sync' do
+      described_class.new.perform(user_id: user.id)
+
+      expect(described_class.connector_paused?('test')).to be false
+    end
+  end
+
+  it 'is bounded to two attempts' do
+    job = described_class.new
+    allow(job).to receive(:delayed_job).and_return(nil)
+
+    expect(Delayed::Worker.max_attempts - job.calculated_attempts).to eq(2)
+  end
+end

--- a/spec/models/concerns/idp/support_spec.rb
+++ b/spec/models/concerns/idp/support_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Idp::Support, type: :model, if: AuthMethod.jwt? do
     user.update_column(:last_connector_id, connector_id)
   end
 
-  # reconcile_email! is deliberately excluded from this shared set: alone among the ops it has no
-  # capability gate, so it raises rather than no-ops and diverges per class (see each context).
+  # reconcile_email! is excluded from this shared set: it gates on supports_user_management? like
+  # these ops, but no-ops to nil (its "nothing moved" value) rather than :unmanaged/false.
   shared_examples 'management ops no-op without raising' do
     it 'idp_deactivate! returns :unmanaged' do
       expect(user.idp_deactivate!).to eq(:unmanaged)
@@ -86,13 +86,11 @@ RSpec.describe Idp::Support, type: :model, if: AuthMethod.jwt? do
       expect(user.idp_send_account_setup_email!).to be false
     end
 
-    # idp_reconcile_email! is the one surviving latent raise — it gates on primary_idp alone and
-    # reaches NullService#get_user, which raises. The controller can never reach this (the
-    # change-email tab gates off when supports_email_self_service? is false), so this model-layer
-    # assertion is the only place it is exercised. Pins that a caller must gate or rescue rather
-    # than call it blind on a null-attached user.
-    it 'idp_reconcile_email! raises Idp::ServiceError (the surviving latent caller-discipline case)' do
-      expect { user.idp_reconcile_email! }.to raise_error(Idp::ServiceError)
+    # A NullService reports supports_user_management? false, so idp_reconcile_email! self-gates
+    # before reaching the raising NullService#get_user.
+    it 'idp_reconcile_email! stays inert instead of reaching the raising NullService method' do
+      expect(user.idp_service).not_to receive(:get_user)
+      expect(user.idp_reconcile_email!).to be_nil
     end
   end
 
@@ -175,10 +173,11 @@ RSpec.describe Idp::Support, type: :model, if: AuthMethod.jwt? do
       expect(service.supports_session_logout?).to be true
     end
 
-    it 'idp_reconcile_email! is ungated by capability and still reaches the admin-API get_user' do
-      allow(service).to receive(:get_user).and_return('email' => user.email, 'emailVerified' => true)
-      user.idp_reconcile_email!
-      expect(service).to have_received(:get_user).with(user_id: connector_user_id)
+    # get_user is an Admin API read this realm can't serve, so the reconcile no-ops rather than
+    # firing a doomed request per eligible login (which would pause the connector).
+    it 'idp_reconcile_email! self-gates on the missing management capability' do
+      expect(service).not_to receive(:get_user)
+      expect(user.idp_reconcile_email!).to be_nil
     end
   end
 

--- a/spec/requests/idp/account_emails_controller_spec.rb
+++ b/spec/requests/idp/account_emails_controller_spec.rb
@@ -1,0 +1,474 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# JWT-arm email self-management, read-only.
+RSpec.describe Idp::AccountEmailsController, type: :request, if: AuthMethod.jwt? do
+  let(:api_url) { 'http://keycloak.test:8080' }
+  let(:realm) { 'openpath' }
+  let(:connector_id) { 'test' } # matches JwtAuthenticationHelper#sign_in
+  let(:token_url) { "#{api_url}/realms/#{realm}/protocol/openid-connect/token" }
+
+  let!(:user) { create(:acl_user, first_name: 'Self', last_name: 'Serve', email: 'before@example.com') }
+  # The Admin API addresses users by their IdP id, which jwt_connector_user_id supplies; sign_in
+  # links this user to the 'test' connector under that id, which is not the warehouse user id.
+  let(:target_url) { "#{api_url}/admin/realms/#{realm}/users/#{jwt_connector_user_id(user)}" }
+
+  before(:each) do
+    WebMock.disable_net_connect!
+    stub_request(:post, token_url).to_return(
+      status: 200,
+      body: { access_token: 'test-token', expires_in: 300 }.to_json,
+      headers: { 'Content-Type' => 'application/json' },
+    )
+    # The connector pause lives in the cache, which the test env nulls out.
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    ActionMailer::Base.deliveries.clear
+  end
+
+  after(:each) do
+    WebMock.reset!
+    WebMock.allow_net_connect!
+  end
+
+  def configure_keycloak!
+    create(
+      :idp_service_config,
+      connector_id: connector_id,
+      provider: 'keycloak',
+      api_url: api_url,
+      keycloak_realm: realm,
+    )
+  end
+
+  it 'exposes no update route — this arm never writes email locally' do
+    expect { Rails.application.routes.recognize_path('/account_email', method: :patch) }.
+      to raise_error(ActionController::RoutingError)
+  end
+
+  # The JWT arm raises rather than redirects when the request carries no authenticated user, so these
+  # assert a raise. The auth gate itself is covered in warehouse_jwt_wiring_spec.rb.
+  describe 'with no forwarded token' do
+    it 'refuses the read-only tab' do
+      expect { get edit_account_email_path }.to raise_error(Idp::UnauthenticatedRequestError)
+    end
+
+    it 'refuses to start a change' do
+      expect { post begin_change_account_email_path }.to raise_error(Idp::UnauthenticatedRequestError)
+    end
+  end
+
+  describe 'when the IdP offers email self-service (Keycloak)' do
+    # Every render reads the account back; this baseline is the address we already hold.
+    let(:remote_representation) { { id: jwt_connector_user_id(user), username: 'before@example.com', firstName: 'Self', lastName: 'Serve', email: 'before@example.com', emailVerified: true } }
+
+    before(:each) do
+      configure_keycloak!
+      stub_request(:get, target_url).to_return(status: 200, body: remote_representation.to_json)
+      sign_in user
+    end
+
+    describe 'GET edit' do
+      it 'shows the current address read-only and offers a POST that starts the change' do
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('before@example.com')
+        expect(response.body).not_to include('name="user[email]"')
+        expect(response.body).to include(begin_change_account_email_path)
+        # The deep-link is built when that POST is handled, so the tab no longer carries it.
+        expect(response.body).not_to match(/kc_action=UPDATE_EMAIL/)
+      end
+
+      it 'deep-links into the Keycloak password and 2FA actions' do
+        get edit_account_email_path
+
+        expect(response.body).to include("/realms/#{realm}/protocol/openid-connect/auth")
+        expect(response.body).to match(/kc_action=UPDATE_PASSWORD/)
+        expect(response.body).to match(/kc_action=CONFIGURE_TOTP/)
+      end
+
+      it 'sends both deep-linked actions back to this tab' do
+        get edit_account_email_path
+
+        links = response.body.scan(/\/realms\/#{realm}\/protocol\/openid-connect\/auth\?[^"]+/)
+        expect(links.count).to eq(2)
+        expect(links).to all(match(/redirect_uri=[^&]*account_email/))
+      end
+
+      it 'keeps the Login & Security tab in the nav' do
+        get edit_account_path
+
+        expect(response.body).to include(edit_account_email_path)
+      end
+
+      # Reconciliation runs on every render, not only on a return trip: Keycloak chooses where it
+      # drops the user after a confirmation link, often not here. kc_action_status only gates the
+      # apology copy (via #change_expected?), so it never decides whether we adopt.
+      it 'adopts a verified address on an ordinary visit, with no return-trip status' do
+        stub_request(:get, target_url).to_return(
+          status: 200,
+          body: remote_representation.merge(username: 'after@example.com', email: 'after@example.com').to_json,
+        )
+
+        get edit_account_email_path
+
+        expect(user.reload.email).to eq('after@example.com')
+        expect(response.body).to include('after@example.com')
+        expect(flash[:notice]).to eq('Account email was updated.')
+        # Adopting an address the IdP already confirmed is not a thing to mail anyone about.
+        expect(ActionMailer::Base.deliveries).to be_empty
+      end
+
+      it 'says nothing on an ordinary visit when the address has not moved' do
+        get edit_account_email_path
+
+        expect(user.reload.email).to eq('before@example.com')
+        expect(flash[:notice]).to be_blank
+        expect(flash[:alert]).to be_blank
+      end
+    end
+
+    # The controls edit the token holder (the admin), not the impersonated user, so the tab hides them.
+    describe 'while impersonating another user' do
+      let!(:impersonated_user) { create(:acl_user, first_name: 'Other', last_name: 'Person', email: 'other@example.com') }
+
+      before(:each) do
+        allow(impersonated_user).to receive(:training_required?).and_return(false)
+        allow(impersonated_user).to receive(:pending_compliance_requirements).and_return([])
+        allow(user).to receive(:can_edit_users?).and_return(true)
+        allow(user).to receive(:can_impersonate_users?).and_return(true)
+        allow(impersonated_user).to receive(:impersonateable_by?).with(user).and_return(true)
+        # sign_in stubs find_from_jwt, but idp_token_holder resolves current_user via
+        # find_or_create_from_jwt; without this the can_impersonate_users? stub above is silently ignored.
+        allow(User).to receive(:find_or_create_from_jwt).and_return(user)
+        # The impersonation path re-reads both users by id; without these stubs they come back as
+        # plain rows missing the permissions above and the stored impersonation is discarded.
+        allow(User).to receive(:find_by).and_call_original
+        allow(User).to receive(:find_by).with(id: user.id).and_return(user)
+        allow(User).to receive(:find_by).with(id: impersonated_user.id).and_return(impersonated_user)
+
+        post impersonate_admin_user_path(user, become_id: impersonated_user.id)
+      end
+
+      it 'replaces the login & security controls with a message' do
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/can't change login and security settings for another user while impersonating/i)
+        expect(response.body).not_to include(begin_change_account_email_path)
+        expect(response.body).not_to match(/kc_action=UPDATE_PASSWORD/)
+        expect(response.body).not_to match(/kc_action=CONFIGURE_TOTP/)
+      end
+    end
+
+    describe 'POST begin_change' do
+      # The client the action runs under is what decides where Keycloak returns the user from the
+      # confirmation link it mails, so it has to be the one configured for this deployment.
+      it 'runs the action under the configured account client, and returns here from the form' do
+        # account_client_id is a per-realm config column, not a request-time ENV read.
+        Idp::ServiceConfig.find_by(connector_id: connector_id).update!(account_client_id: 'warehouse-account')
+
+        post begin_change_account_email_path
+
+        query = Rack::Utils.parse_query(URI(response.location).query)
+        expect(query['client_id']).to eq('warehouse-account')
+        expect(query['kc_action']).to eq('UPDATE_EMAIL')
+        expect(query['redirect_uri']).to include('account_email')
+      end
+
+      it 'writes nothing about the address, here or at the IdP' do
+        post begin_change_account_email_path
+
+        expect(user.reload.email).to eq('before@example.com')
+        expect(a_request(:put, target_url)).not_to have_been_made
+      end
+    end
+
+    describe 'while a change is in flight' do
+      it 'names the address the IdP is waiting on' do
+        stub_request(:get, target_url).to_return(
+          status: 200,
+          body: remote_representation.merge(attributes: { 'kc.email.pending' => ['after@example.com'] }).to_json,
+        )
+
+        get edit_account_email_path
+
+        expect(response.body).to match(/waiting for you to confirm/i)
+        expect(response.body).to include('after@example.com')
+      end
+
+      it 'says nothing about a pending address when the IdP holds none' do
+        get edit_account_email_path
+
+        expect(response.body).not_to match(/waiting for you to confirm/i)
+      end
+    end
+
+    # An admin-console edit lands unverified, so this tab raises on every visit by that user until
+    # someone fixes it — ours to notice (Sentry), not to alarm them about.
+    describe 'an unverified address at the IdP' do
+      before(:each) do
+        allow(Sentry).to receive(:capture_exception_with_info)
+        stub_request(:get, target_url).to_return(
+          status: 200,
+          body: remote_representation.merge(email: 'after@example.com', emailVerified: false).to_json,
+        )
+      end
+
+      it 'tells a casual visitor nothing, and pages Sentry' do
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.email).to eq('before@example.com')
+        expect(response.body).to include('before@example.com')
+        expect(flash[:alert]).to be_blank
+        expect(Sentry).to have_received(:capture_exception_with_info)
+      end
+    end
+
+    describe 'while the connector is paused' do
+      before(:each) do
+        Idp::SyncUserFromIdpJob.pause_connector!(connector_id)
+      end
+
+      it 'renders the address we hold without reading the IdP back' do
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('before@example.com')
+        expect(a_request(:get, target_url)).not_to have_been_made
+      end
+
+      # The cooldown is about reaching the connector, not about what the user is entitled to do.
+      it 'still offers the change' do
+        get edit_account_email_path
+
+        expect(response.body).to include(begin_change_account_email_path)
+      end
+    end
+
+    describe 'returning from the IdP action' do
+      let(:remote_representation) { { id: jwt_connector_user_id(user), username: 'after@example.com', firstName: 'Self', lastName: 'Serve', email: 'after@example.com', emailVerified: true } }
+
+      # any_instance: the controller resolves its own User from the token, a different instance than
+      # the spec's `user`.
+      it 'syncs HUD users with the previous email when HMIS is enabled' do
+        allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+        expect_any_instance_of(User).to receive(:sync_to_hud_users).with(previous_email: 'before@example.com')
+
+        get edit_account_email_path(kc_action_status: 'success')
+
+        expect(user.reload.email).to eq('after@example.com')
+      end
+
+      # See Idp::AccountEmailsController for why the adopt and HUD sync share a nested transaction.
+      it 'unwinds the adopted address when the HUD sync fails' do
+        allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+        allow_any_instance_of(User).to receive(:sync_to_hud_users).and_raise(StandardError, 'HUD sync failed')
+
+        expect { get edit_account_email_path(kc_action_status: 'success') }.
+          to raise_error(StandardError, 'HUD sync failed')
+
+        expect(user.reload.email).to eq('before@example.com')
+      end
+
+      # The IdP still holding the old address is what keeps us off it — not kc_action_status, which
+      # only hints at intent. So 'cancelled' and 'success' take the same path when it hasn't moved.
+      {
+        'cancelled' => 'the user cancelled',
+        'success' => 'the action succeeded but the address did not move',
+      }.each do |status, scenario|
+        it "leaves the address alone and says nothing when #{scenario}" do
+          stub_request(:get, target_url).to_return(
+            status: 200,
+            body: remote_representation.merge(username: 'before@example.com', email: 'before@example.com').to_json,
+          )
+
+          get edit_account_email_path(kc_action_status: status)
+
+          expect(user.reload.email).to eq('before@example.com')
+          expect(flash[:notice]).to be_blank
+        end
+      end
+
+      # A realm with Verify Email off applies the new address immediately, so the Admin API can hand
+      # back an address nobody has proven. Adopting it would defeat the point of the deep-link.
+      it 'refuses an address the IdP has not verified, and warns' do
+        allow(Sentry).to receive(:capture_exception_with_info)
+        stub_request(:get, target_url).to_return(
+          status: 200,
+          body: remote_representation.merge(emailVerified: false).to_json,
+        )
+
+        get edit_account_email_path(kc_action_status: 'success')
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.email).to eq('before@example.com')
+        expect(response.body).to include('before@example.com')
+        expect(flash[:alert]).to match(/not verified after@example.com/)
+        expect(Sentry).to have_received(:capture_exception_with_info)
+      end
+
+      # A rejected write leaves Keycloak and users.email diverged until support intervenes — no
+      # retry closes it — so it has to be loud rather than silent.
+      it 'warns and pages Sentry when the new address is already taken in the Warehouse' do
+        allow(Sentry).to receive(:capture_exception_with_info)
+        create(:acl_user, first_name: 'Some', last_name: 'Body', email: 'after@example.com')
+
+        get edit_account_email_path(kc_action_status: 'success')
+
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.email).to eq('before@example.com')
+        # The rejected value is dropped, so the read-only tab shows what we actually hold.
+        expect(response.body).to include('before@example.com')
+        expect(response.body).not_to include('after@example.com')
+        expect(flash[:alert]).to match(/couldn't save the new address/)
+        expect(Sentry).to have_received(:capture_exception_with_info)
+      end
+
+      context 'when the Admin API read fails' do
+        before do
+          stub_request(:get, target_url).to_return(status: 500, body: { error: 'boom' }.to_json)
+          allow(Sentry).to receive(:capture_exception_with_info)
+        end
+
+        it 'still renders, keeps the old address, and pages Sentry' do
+          get edit_account_email_path(kc_action_status: 'success')
+
+          expect(response).to have_http_status(:ok)
+          expect(user.reload.email).to eq('before@example.com')
+          expect(Sentry).to have_received(:capture_exception_with_info)
+          expect(flash[:alert]).to be_present
+        end
+
+        # flash.now: the warning belongs to the request that renders it. A plain flash would persist
+        # and warn the user again on their next visit to a tab where nothing went wrong.
+        it 'does not carry the warning into the next request' do
+          get edit_account_email_path(kc_action_status: 'success')
+          expect(flash[:alert]).to be_present
+
+          get edit_account_email_path
+
+          expect(flash[:alert]).to be_blank
+        end
+      end
+    end
+  end
+
+  describe 'when the IdP service cannot be built (misconfigured Keycloak)' do
+    before(:each) do
+      sign_in user
+      allow_any_instance_of(User).to receive(:idp_service).
+        and_raise(Idp::ServiceError.new('Keycloak misconfigured, missing: realm'))
+    end
+
+    it 'renders the read-only tab with its explanatory copy instead of erroring' do
+      get edit_account_email_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(/managed by your identity provider/i)
+    end
+
+    it 'does not attempt reconciliation on a return trip' do
+      get edit_account_email_path(kc_action_status: 'success')
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.email).to eq('before@example.com')
+    end
+
+    it 'refuses to start a change' do
+      expect { post begin_change_account_email_path }.to raise_error(RuntimeError, /not enabled/)
+    end
+  end
+
+  describe 'when the IdP offers no email self-service (unconfigured => NullService)' do
+    before(:each) { sign_in user }
+
+    it 'still renders the tab, with the address and an explanation instead of a link' do
+      get edit_account_email_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('before@example.com')
+      expect(response.body).to match(/managed by your identity provider/i)
+      expect(response.body).not_to match(/kc_action=UPDATE_EMAIL/)
+      expect(response.body).not_to include('name="user[email]"')
+    end
+
+    it 'never calls the IdP' do
+      get edit_account_email_path
+
+      expect(a_request(:any, /#{Regexp.escape(api_url)}/)).not_to have_been_made
+    end
+
+    # Without email self-service there was no UPDATE_EMAIL action, so the return-trip status is
+    # spurious — nothing to reconcile or apologise for.
+    it 'ignores a return-trip status rather than warning about it' do
+      get edit_account_email_path(kc_action_status: 'success')
+
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.email).to eq('before@example.com')
+      expect(a_request(:any, /#{Regexp.escape(api_url)}/)).not_to have_been_made
+      expect(flash[:alert]).to be_blank
+    end
+
+    it 'refuses to start a change' do
+      expect { post begin_change_account_email_path }.to raise_error(RuntimeError, /not enabled/)
+    end
+  end
+
+  describe 'when the connector is authenticate-only (manage_users:false, app-1kz)' do
+    let(:remote_representation) { { id: jwt_connector_user_id(user), username: 'before@example.com', firstName: 'Self', lastName: 'Serve', email: 'before@example.com', emailVerified: true } }
+
+    before(:each) do
+      create(
+        :idp_service_config,
+        :authenticate_only,
+        connector_id: connector_id,
+        provider: 'keycloak',
+        api_url: api_url,
+        keycloak_realm: realm,
+      )
+      sign_in user
+    end
+
+    describe 'GET edit' do
+      it 'keeps the email change and credential deep-links live' do
+        stub_request(:get, target_url).to_return(status: 200, body: remote_representation.to_json)
+
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(begin_change_account_email_path)
+        expect(response.body).to match(/kc_action=UPDATE_PASSWORD/)
+        expect(response.body).not_to match(/managed by your identity provider/i)
+      end
+
+      it 'makes no Admin API call: both IdP reads gate off the missing management capability' do
+        stub_request(:get, target_url)
+
+        get edit_account_email_path
+
+        expect(response).to have_http_status(:ok)
+        expect(a_request(:get, target_url)).not_to have_been_made
+      end
+    end
+
+    describe 'POST begin_change' do
+      it 'redirects into the IdP email-change action without any Admin API call' do
+        post begin_change_account_email_path
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.location).to match(/kc_action=UPDATE_EMAIL/)
+        expect(a_request(:get, target_url)).not_to have_been_made
+      end
+    end
+  end
+end

--- a/spec/requests/idp/warehouse_jwt_wiring_spec.rb
+++ b/spec/requests/idp/warehouse_jwt_wiring_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
             Idp::KeycloakService,
             supports_session_logout?: true,
             logout_user_sessions: true,
+            supports_email_self_service?: false,
           )
         end
 

--- a/spec/support/shared_examples/auth_method_user_examples.rb
+++ b/spec/support/shared_examples/auth_method_user_examples.rb
@@ -490,14 +490,19 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
     end
 
     describe 'email_change_enabled?' do
-      it 'is the inverse of profile_managed_by_idp?' do
+      it 'follows idp_service.supports_email_self_service?, not profile_managed_by_idp?' do
         user = model.new
+        expect(user.idp_service.supports_email_self_service?).to be false
         expect(user.email_change_enabled?).to be false
-        expect(user.email_change_enabled?).to eq(!user.profile_managed_by_idp?)
 
-        allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, supports_profile_updates?: true))
+        allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, supports_email_self_service?: true))
         expect(user.email_change_enabled?).to be true
-        expect(user.email_change_enabled?).to eq(!user.profile_managed_by_idp?)
+      end
+
+      it 'is false when the service cannot be built, so the read-only tab keeps its explanatory copy' do
+        user = model.new
+        allow(user).to receive(:idp_service).and_raise(Idp::ServiceError.new('Keycloak misconfigured'))
+        expect(user.email_change_enabled?).to be false
       end
     end
 


### PR DESCRIPTION

## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
User changes email at Keycloak via UPDATE_EMAIL; Warehouse adopts it on read-back only when the mailbox is verified. Two readers hit the Admin API: the Email tab render and a once-per- session SyncUserFromIdpJob with a 5-minute per-connector cooldown.

- idp_reconcile_email! / idp_pending_email / idp_user_representation on Idp::Support; email_change_enabled? follows the service's supports_email_self_service?
- pending_email / pending_email_from_representation on KeycloakService and base Service, plus supports_email_self_service?
- Idp::AccountEmailsController (read-only tab, begin_change hands off to the IdP), account_emails views, begin_change route
- idp_schedule_user_sync wired into authenticate_user! / authenticate_hmis_user!, marks the session spent before the pause check
- realm registrationEmailAsUsername, keycloak-idp.md realm prereqs

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill

