### PR TITLE
feat: 8458 invert CI auth arms, run suite under JWT

### DIFF
--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -274,6 +274,9 @@ jobs:
           aws_region: us-east-1
           flags: --recursive
 
+      # Default arm: the AUTH_METHOD=jwt env below is the only arm selector. Don't add a
+      # ~devise_only flag here for symmetry with the Devise step — rails_helper.rb already
+      # excludes :devise_only under a jwt run (filter_run_excluding).
       - name: Run tests
         env:
           MAX_FAILURES: 60
@@ -282,6 +285,11 @@ jobs:
           TODO_OR_DIE_LOG_ONLY: true
           TESTKIT_CHECK_ALL_TABLE_RESULTS: ${{ needs.determine_matrix.outputs.testkit_check_all_table_results }}
           FOCUS_PATH: ${{ matrix.test_group.test_path }}
+          AUTH_METHOD: jwt
+          IDP_AUD: test-aud
+          ISS_URL: https://idp.example.test
+          JWKS_URL: https://idp.example.test/jwks
+          JWT_ALGORITHM: RS256
         run: |
           if [ -n "$FOCUS_PATH" ]; then
             echo "Running focused tests: $FOCUS_PATH"
@@ -305,39 +313,34 @@ jobs:
           MAX_FAILURES: 60
           AWS_ACCESS_KEY_ID: local_access_key
           AWS_SECRET_ACCESS_KEY: local_secret_key
+          # Okta sign-in is Devise/OmniAuth only.
+          AUTH_METHOD: devise
         run: |
           OKTA_DOMAIN=localhost OKTA_CLIENT_ID=x OKTA_CLIENT_SECRET=x bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd spec/requests/omniauth_spec.rb spec/requests/sessions_controller_spec.rb
 
-      - name: Run AUTH_METHOD=jwt tests
-        if: matrix.test_group.jwt
+      # Selective arm, once per CI run. Selection is by tag and not by an enumerated file list, which
+      # would silently drop any spec nobody remembered to add. The broad --pattern is only affordable
+      # because --tag devise_only narrows it: without that tag this re-runs the entire ungated suite.
+      - name: Run AUTH_METHOD=devise tests
+        if: matrix.test_group.devise
         env:
           MAX_FAILURES: 60
           AWS_ACCESS_KEY_ID: local_access_key
           AWS_SECRET_ACCESS_KEY: local_secret_key
-        shell: bash
+          TODO_OR_DIE_LOG_ONLY: true
+          AUTH_METHOD: devise
         run: |
-          specs=(
-            spec/models/user_auth_method_spec.rb
-            drivers/hmis/spec/models/hmis/user_auth_method_spec.rb
-            spec/models/idp/jwt_helper_spec.rb
-            spec/models/concerns/idp/jwt_user_spec.rb
-            spec/models/concerns/idp/support_spec.rb
-            spec/controllers/concerns/idp/jwt_current_user_spec.rb
-            spec/requests/idp/warehouse_jwt_wiring_spec.rb
-            spec/services/idp/service_factory_spec.rb
-            spec/models/idp/service_config_spec.rb
-            drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
-            spec/requests/api/superset_jwt_wiring_spec.rb
-            spec/requests/admin/idp/users_controller_spec.rb
-            spec/requests/admin/idp/inactive_users_controller_spec.rb
-            spec/services/idp/admin_user_creator_spec.rb
-            drivers/hmis/spec/requests/hmis_admin/users_controller_spec.rb
-            spec/requests/admin/audits_controller_spec.rb
-            spec/requests/idp/accounts_controller_spec.rb
-            spec/requests/idp/account_emails_controller_spec.rb
-            spec/jobs/idp/sync_user_from_idp_job_spec.rb
-          )
-          AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd "${specs[@]}"
+          mkdir -p tmp
+          bundle exec rspec --fail-fast=$MAX_FAILURES --color -fd --format json --out tmp/devise_arm_results.json --pattern "spec/**/*_spec.rb,drivers/*/spec/**/*_spec.rb" --tag devise_only --tag ~type:system --tag ~type:rails_system
+
+          # rspec exits 0 on "0 examples, 0 failures", so an empty devise_only selection needs an
+          # explicit failure here or the whole Devise arm goes green while testing nothing.
+          count=$(ruby -rjson -e 'puts JSON.parse(File.read("tmp/devise_arm_results.json")).dig("summary", "example_count").to_i')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::--tag devise_only selected 0 examples. Either no spec carries :devise_only (check for a renamed or misspelled tag) or the filters above exclude them all."
+            exit 1
+          fi
+          echo "AUTH_METHOD=devise arm ran $count examples."
 
       - name: Run logging tests
         if: matrix.test_group.logging || needs.determine_matrix.outputs.logging == 'true'

--- a/app/models/access_control_upload.rb
+++ b/app/models/access_control_upload.rb
@@ -277,7 +277,7 @@ class AccessControlUpload < ApplicationRecord
     agency_ids = Agency.pluck(:name, :id).to_h
     users.each do |item|
       user = User.with_deleted.where(email: item[:email]).first_or_initialize do |u|
-        u.password = Faker::Internet.password(min_length: 16)
+        u.password = Faker::Internet.password(min_length: 16) if u.password_change_enabled?
       end
       user.first_name = item[:first_name]
       user.last_name = item[:last_name]

--- a/bin/ci_matrix_router.rb
+++ b/bin/ci_matrix_router.rb
@@ -128,7 +128,9 @@ class CiMatrixRouter
         }
       end
     end
-    groups << { id: 'ci_default', tag: '~ci_bucket', okta: true, logging: true, jwt: true }
+    # okta, logging and devise each gate a once-per-run step in
+    # .github/workflows/rails_tests.yml; ci_default is the one job that opts into them.
+    groups << { id: 'ci_default', tag: '~ci_bucket', okta: true, logging: true, devise: true }
     groups
   end
 

--- a/docs/developer/keycloak-idp.md
+++ b/docs/developer/keycloak-idp.md
@@ -199,6 +199,11 @@ Additional notes
 - **Credentials:** `docker/auth/keycloak-credentials.env` is committed because its values are
   pre-defined in `realm-import.json` (chosen, not generated). Dev-only — never used in production.
 
+In development, dump the config with
+```
+opt/keycloak/bin/kcadm.sh create realms/openpath/partial-export --config /tmp/kcadm.config -s exportGroupsAndRoles=true -s exportClients=true --server http://localhost:8080 --realm=master --user admin --password 'AdminPassword1!' -o > /tmp/realm-live.json
+```
+
 ## Related
 
 - [User migration (`rails keycloak:*`)](./keycloak-user-migration.md) — seeding Keycloak from legacy

--- a/docs/features/warehouse/ci-test-bucketing.md
+++ b/docs/features/warehouse/ci-test-bucketing.md
@@ -16,6 +16,24 @@ A standalone Ruby script determines which test categories (Unit, HMIS System, Wa
 *   **Coverage**: It always adds a "default" job with the `~ci_bucket` tag to catch any tests not explicitly assigned to a bucket, ensuring no tests are skipped.
 *   **Logic**: It determines the matrix based on the event type and commit message flags.
 
+### 4. Auth Arms (`AUTH_METHOD`)
+
+Devise is being sunset, so **CI's default arm is JWT**: every bucket's "Run tests" step sets
+`AUTH_METHOD=jwt` plus the IdP env, and `spec/rails_helper.rb` excludes `:devise_only` from such a
+run. One extra step on `ci_default`, gated on the `devise` matrix flag, runs `--tag devise_only`
+under `AUTH_METHOD=devise`, and fails if the tag selects nothing. An arm-specific spec — or
+`describe`, or single `it` — carries `:devise_only` or `:jwt_only` and nothing else. Do not add an
+`if: AuthMethod.devise?` or `if: AuthMethod.jwt?` gate; `spec/lib/auth_method_arm_tags_spec.rb`
+fails the build on either. `lib/auth_method.rb` still defaults to Devise, so the logging step, both
+system-test jobs, and any local `rspec` run under it.
+
+To reproduce a default-arm CI failure locally:
+
+```bash
+AUTH_METHOD=jwt IDP_AUD=test-aud ISS_URL=https://idp.example.test \
+  JWKS_URL=https://idp.example.test/jwks JWT_ALGORITHM=RS256 bundle exec rspec <path>
+```
+
 ---
 
 ## Developer Workflows

--- a/drivers/client_access_control/spec/controllers/client_access_control/clients_controller_string_mutations_spec.rb
+++ b/drivers/client_access_control/spec/controllers/client_access_control/clients_controller_string_mutations_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe ClientAccessControl::ClientsController, type: :controller do
   end
 
   describe 'controller actions that exercise string mutations' do
+    # perform_search raises unless the user can_use_strict_search?, so stub it — otherwise get :index /
+    # :search never reach assign_client_list_vars, the code under test. The stub only takes effect on the
+    # JWT arm, where the sign_in helper makes current_user the stubbed `user`; on the Devise arm Warden
+    # reloads current_user and the require_* before_action redirects instead.
+    before(:each) do
+      allow(user).to receive(:can_use_strict_search?).and_return(true)
+    end
+
     it 'exercises index action that leads to assign_client_list_vars' do
       allow(GrdaWarehouse::ClientSearchQuery).to receive(:permit_params).and_return(nil)
 

--- a/drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb
+++ b/drivers/client_access_control/spec/requests/client_visibility_legacy_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -151,8 +152,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -274,8 +276,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -361,8 +364,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -450,8 +454,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -665,8 +670,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do

--- a/drivers/client_access_control/spec/requests/client_visibility_spec.rb
+++ b/drivers/client_access_control/spec/requests/client_visibility_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -145,8 +146,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -271,8 +273,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -358,8 +361,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -447,8 +451,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do
@@ -672,8 +677,9 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     describe 'and the user does not have a role' do
       it 'user cannot see any clients' do
         query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'bob' })
-        get client_search_query_path(id: query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get client_search_query_path(id: query.id)
+        end
       end
     end
     describe 'and the user has a role granting can view clients' do

--- a/drivers/client_access_control/spec/requests/clients_history_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_history_spec.rb
@@ -31,13 +31,15 @@ RSpec.describe ClientAccessControl::HistoryController, type: :request do
 
   describe 'logged out' do
     it 'doesn\'t allow show' do
-      get client_history_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get client_history_path(destination)
+      end
     end
 
     it 'doesn\'t allow queue' do
-      post queue_client_history_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        post queue_client_history_path(destination)
+      end
     end
 
     it 'does not allow pdf if client not set to generate pdf' do

--- a/drivers/client_access_control/spec/requests/clients_legacy_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_legacy_spec.rb
@@ -18,63 +18,75 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
 
   describe 'logged out' do
     it 'doesn\'t allow index' do
-      get clients_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get clients_path
+      end
     end
 
     it 'doesn\'t allow show' do
-      get client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get client_path(destination)
+      end
     end
 
     it 'doesn\'t allow new' do
-      get new_client_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get new_client_path
+      end
     end
 
     it 'doesn\'t allow create' do
-      post clients_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        post clients_path
+      end
     end
 
     it 'doesn\'t allow edit' do
-      get edit_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get edit_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow service_range' do
-      get service_range_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get service_range_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow rollup' do
-      get rollup_client_path(destination, partial: :residential_enrollments)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get rollup_client_path(destination, partial: :residential_enrollments)
+      end
     end
 
     it 'doesn\'t allow assessment' do
-      get assessment_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get assessment_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow image' do
-      get image_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get image_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow chronic_days' do
-      get chronic_days_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get chronic_days_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow merge' do
-      patch merge_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch merge_client_path(destination)
+      end
     end
 
     it 'doesn\'t allow unmerge' do
-      patch unmerge_client_path(destination)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch unmerge_client_path(destination)
+      end
     end
   end
 

--- a/drivers/client_access_control/spec/requests/clients_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_spec.rb
@@ -24,69 +24,82 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
 
   describe 'logged out' do
     it 'doesn\'t allow index' do
-      get clients_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get clients_path
+      end
     end
 
     it 'doesn\'t allow search results' do
       query = create(:grda_warehouse_client_search_query)
-      get client_search_query_path(id: query.id)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get client_search_query_path(id: query.id)
+      end
     end
 
     it 'doesn\'t allow show' do
-      get client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow new' do
-      get new_client_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get new_client_path
+      end
     end
 
     it 'doesn\'t allow create' do
-      post clients_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        post clients_path
+      end
     end
 
     it 'doesn\'t allow edit' do
-      get edit_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get edit_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow service_range' do
-      get service_range_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get service_range_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow rollup' do
-      get rollup_client_path(window_destination_client, partial: :residential_enrollments)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get rollup_client_path(window_destination_client, partial: :residential_enrollments)
+      end
     end
 
     it 'doesn\'t allow assessment' do
-      get assessment_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get assessment_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow image' do
-      get image_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get image_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow chronic_days' do
-      get chronic_days_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get chronic_days_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow merge' do
-      patch merge_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch merge_client_path(window_destination_client)
+      end
     end
 
     it 'doesn\'t allow unmerge' do
-      patch unmerge_client_path(window_destination_client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch unmerge_client_path(window_destination_client)
+      end
     end
   end
 

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -88,8 +88,10 @@ module Hmis::Concerns::JwtHmisCurrentUser
       # misconfigured, which a 401 would disguise as an ordinary signed-out client.
       raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
-      # 403, not 401: signing in again can't produce an account. A 401 would send the SPA to a
-      # sign-in screen it would come straight back from.
+      # 403, not 401: signing in again can't produce an account, and a 401 would send the SPA to a
+      # sign-in screen it would come straight back from. The SPA keys off error.type on the 403 to
+      # render a terminal page (hmis-frontend apolloErrorLink.tsx -> AccountTerminalErrorDialog,
+      # contract in src/modules/auth/hooks/README.md).
       render_json_error(403, :no_warehouse_account)
     end
 

--- a/drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/save_assessment_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
     let!(:assessment) { create :hmis_wip_custom_assessment, data_source: ds1, enrollment: e1, assessment_date: e1.entry_date, user: hud_user, created_by_hud_user: hud_user, updated_by_hud_user: hud_user }
 
     before(:each) do
-      delete destroy_hmis_user_session_path
+      hmis_logout
       hmis_login(other_user)
     end
 

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_assessment_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
 
     context 'when assessment is updated by a different user' do
       before(:each) do
-        delete destroy_hmis_user_session_path
+        hmis_logout
         hmis_login(other_user)
       end
 

--- a/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/assessments/submit_household_assessments_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
       let(:other_hud_user) { Hmis::Hud::User.from_user(other_hmis_user) }
 
       before(:each) do
-        delete destroy_hmis_user_session_path
+        hmis_logout
         hmis_login(other_user)
       end
 

--- a/drivers/hmis/spec/requests/hmis/cache_control_headers_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/cache_control_headers_spec.rb
@@ -39,9 +39,13 @@ RSpec.describe 'HMIS Cache-Control headers', type: :request do
     end
   end
 
+  # Not the GraphQL endpoint the authenticated context uses: a tokenless POST to /hmis/hmis-gql raises
+  # under AUTH_METHOD=jwt, leaving no response to read headers off. GET /hmis/user.json answers
+  # without credentials on both arms, because Hmis::UsersController skips authenticate_hmis_user!.
   context 'when not authenticated' do
     before do
-      post '/hmis/hmis-gql', params: { query: query }.to_json, headers: { 'Content-Type' => 'application/json' }
+      get hmis_user_path
+      expect(response).to have_http_status(:ok)
     end
 
     it 'does not set no-store Cache-Control' do

--- a/drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/client_eligible_ce_opportunities_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             expect(response.status).to eq(200), result.inspect
             count = result.dig('data', 'client', 'eligibleCeOpportunities', 'nodesCount')
             expect(count).to eq(32)
-          end.to make_database_queries(count: 15..30)
+          end.to make_database_queries(count: 25..40)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_referrals_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'project', 'ceReferrals', 'nodesCount')).to eq(32), result.inspect
-          end.to make_database_queries(count: 35..50)
+          end.to make_database_queries(count: 45..60)
         end
       end
 

--- a/drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/client_files_controller_spec.rb
@@ -56,9 +56,10 @@ RSpec.describe Hmis::ClientFilesController, type: :request do
 
   describe 'GET /hmis/clients/:client_id/files/:id' do
     context 'when not authenticated' do
-      it 'returns 401' do
-        get(hmis_client_file_path(client_id: c1.id, id: nonconfidential_file.id), headers: request_headers)
-        expect(response).to have_http_status(:unauthorized)
+      it 'refuses the download' do
+        expect_unauthenticated_api_request do
+          get(hmis_client_file_path(client_id: c1.id, id: nonconfidential_file.id), headers: request_headers)
+        end
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/enrollment_last_service_date_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
         _, result = post_graphql(client_id: c1.id, serviceTypeId: bed_night_cst.id) { query }
         enrollments = result.dig('data', 'client', 'enrollments', 'nodes').map(&:deep_symbolize_keys)
         expect(enrollments.map { |e| e[:lastServiceDate] }.compact.size).to eq(enrollments.size)
-      end.to make_database_queries(count: 10..30)
+      end.to make_database_queries(count: 20..40)
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/get_projects_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/get_projects_spec.rb
@@ -97,14 +97,10 @@ RSpec.describe 'GetProjects query', type: :request do
     end
   end
 
-  it 'responds with 401 if not authenticated' do
-    delete destroy_hmis_user_session_path
-    aggregate_failures 'checking response' do
-      expect(response.status).to eq 204
-      response, body = post_graphql { query }
-      expect(response.status).to eq 401
-      expect(body.dig('error', 'type')).to eq 'unauthenticated'
-    end
+  it 'refuses the query once the user has logged out' do
+    hmis_logout
+
+    expect_unauthenticated_api_request { post_graphql { query } }
   end
 
   context 'sorting' do

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -11,9 +11,8 @@ require_relative 'login_and_permissions'
 
 # Proves the HMIS request layer wires the JWT auth path correctly when a Deployment boots with
 # AUTH_METHOD=jwt. Mirrors spec/requests/idp/warehouse_jwt_wiring_spec.rb, but every auth-failure
-# path returns JSON (the SPA contract) rather than an HTML redirect/render. The JWT examples run
-# only under the AUTH_METHOD=jwt CI process (they lean on the JwtAuthenticationHelper sign_in,
-# included only when AuthMethod.jwt?).
+# path returns JSON (the SPA contract) rather than an HTML redirect/render. The JWT examples lean on
+# the JwtAuthenticationHelper sign_in, included only when AuthMethod.jwt?.
 #
 # find_or_create_from_jwt is deliberately NOT stubbed: sign_in provisions a real
 # Idp::UserAuthenticationSource for the token's (connector_id, connector_user_id), so the real
@@ -21,7 +20,7 @@ require_relative 'login_and_permissions'
 # would make token→holder resolution unfalsifiable — resolving the wrong user, or ignoring the
 # token entirely, would still pass. The one exception is the no-warehouse-account example, which
 # stubs nil to force a branch that has no reachable fixture.
-RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
+RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
   let(:ds) { create :hmis_primary_data_source }
   let(:headers) { { 'HOST' => ds.hmis } }
 
@@ -297,6 +296,9 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
       # The token's connector is 'test' (see JwtAuthenticationHelper), which resolves to a
       # NullService, so a service has to be stubbed in to get past the predicate.
       let(:idp_service) do
+        # Idp::Support#idp_service builds a service for the user payload too, so this double answers
+        # every for_connector('test') call an example makes, not only the sign-out's — hence
+        # supports_email_self_service?, which Idp::Support#email_change_enabled? calls on each render.
         instance_double(
           Idp::KeycloakService,
           supports_session_logout?: true,
@@ -398,6 +400,7 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
 
         delete destroy_hmis_user_session_path, headers: headers
 
+        # Not an exact count: the user payload consults the factory too (see idp_service above).
         expect(Idp::ServiceFactory).to have_received(:for_connector).with('test').at_least(:once)
         expect_signed_out_normally
       end
@@ -415,9 +418,9 @@ RSpec.describe 'HMIS JWT wiring', type: :request, if: AuthMethod.jwt? do
 
         expect(response).to have_http_status(:forbidden)
         expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
-        # start_session's keepalive resolves 'test' once (the per-session sync guard); the DELETE adds
-        # none. A fall-through to a NullService sign-out — the regression this guards — would make it two.
-        expect(Idp::ServiceFactory).to have_received(:for_connector).with('test').once
+        # On the service, not on Idp::ServiceFactory: the user payload consults the factory too
+        # (see idp_service above), so the factory cannot carry a never-consulted assertion.
+        expect(idp_service).not_to have_received(:logout_user_sessions)
       end
 
       # The whole reason the id comes off the token: current_hmis_user is the impersonated user here,

--- a/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
+++ b/drivers/hmis/spec/requests/hmis/login_and_permissions.rb
@@ -13,6 +13,32 @@ module LoginAndPermissionsSpecHelper
     post hmis_user_session_path(hmis_user: { email: user.email, password: user.password })
   end
 
+  # Under JWT the credential is the forwarded token, not a cookie the response can clear, so the
+  # sign_out below is what makes the spec tokenless. Drop it and every later request still authenticates.
+  def hmis_logout(headers: {})
+    delete destroy_hmis_user_session_path, headers: headers
+
+    unless AuthMethod.jwt?
+      expect(response).to have_http_status(:no_content)
+      return
+    end
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)['redirect_url']).to start_with('/oauth2/sign_out?rd=')
+    sign_out
+  end
+
+  # The JWT arm raises rather than answering 401: oauth2-proxy owns every /hmis/* path
+  # (api_routes = ^/hmis/ in docker/auth/dev.oauth2-proxy-hmis-backend.cfg), so a tokenless request
+  # means the proxy was bypassed, not that a client is signed out.
+  def expect_unauthenticated_api_request
+    return expect { yield }.to raise_error(Idp::UnauthenticatedRequestError) if AuthMethod.jwt?
+
+    yield
+    expect(response).to have_http_status(:unauthorized)
+    expect(JSON.parse(response.body).dig('error', 'type')).to eq('unauthenticated')
+  end
+
   def viewable_type(entity)
     return :projects if entity.is_a? Hmis::Hud::Project
     return :projects if entity.is_a? GrdaWarehouse::Hud::Project

--- a/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/project_enrollments_performance_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           response, result = post_graphql(**adjusted_variables) { query }
           expect(response.status).to eq(200), result.inspect
           expect(result.dig('data', 'project', 'enrollments', 'nodes').size).to eq(enrollments.size)
-        end.to make_database_queries(count: 10..35)
+        end.to make_database_queries(count: 20..45)
       end
     end
   end

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -13,7 +13,9 @@ require 'support/shared_contexts/post_login_hooks_context'
 require 'support/shared_contexts/login_activity_context'
 require 'support/shared_contexts/timing_attack_mitigation_context'
 
-RSpec.describe Hmis::SessionsController, type: :request do
+# Devise-only: drivers/hmis/config/routes.rb mounts Hmis::SessionsController under
+# AuthMethod.devise?; the jwt arm serves hmis/logout from Hmis::Idp::SessionsController instead.
+RSpec.describe Hmis::SessionsController, :devise_only, type: :request do
   let(:user) { create :user }
   let(:hmis_user) { user.as_hmis_user.tap(&:reload) }
   let(:user_2fa) { create :user_2fa }

--- a/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Hmis::UsersController, type: :request do
         get hmis_user_path
       end
 
-      it 'includes a primaryIdp key (nil under Devise, since there is no connector)' do
+      it 'includes a primaryIdp key (nil under Devise, since there is no connector)', :devise_only do
         expect(response).to have_http_status(:ok)
         parsed = JSON.parse(response.body)
         expect(parsed).to have_key('primaryIdp')
@@ -34,8 +34,18 @@ RSpec.describe Hmis::UsersController, type: :request do
         expect(parsed['name']).to eq(hmis_user.name)
         expect(parsed['email']).to eq(hmis_user.email)
         expect(parsed['phone']).to eq(hmis_user.phone)
-        expect(parsed['sessionDuration']).to eq(Devise.timeout_in.in_seconds)
         expect(parsed['impersonating']).to eq(false)
+      end
+
+      it 'reports the Devise session timeout as sessionDuration', :devise_only do
+        expect(JSON.parse(response.body)['sessionDuration']).to eq(Devise.timeout_in.in_seconds)
+      end
+
+      # Hmis::User reports Devise.timeout_in on both arms (Hmis::User#current_user_api_values),
+      # so tightening this to that value would pass while pinning the JWT arm to a Devise setting —
+      # the credential's lifetime here is the IdP token's.
+      it 'reports a positive sessionDuration', :jwt_only do
+        expect(JSON.parse(response.body)['sessionDuration']).to be > 0
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis_admin/users_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis_admin/users_controller_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe HmisAdmin::UsersController, type: :request, if: AuthMethod.jwt? do
+RSpec.describe HmisAdmin::UsersController, :jwt_only, type: :request do
   let!(:data_source) { create(:hmis_data_source) }
   let!(:admin_user) { create(:acl_user, first_name: 'Admin', last_name: 'User') }
 

--- a/spec/bin/ci_matrix_router_spec.rb
+++ b/spec/bin/ci_matrix_router_spec.rb
@@ -136,6 +136,16 @@ RSpec.describe 'bin/ci_matrix_router.rb' do
         buckets_file.unlink
       end
     end
+
+    # A step whose `if: matrix.test_group.<flag>` is false is skipped, not failed, so dropping a flag
+    # here loses that step's coverage on a green run — for `devise`, the whole AUTH_METHOD=devise arm.
+    it 'puts the once-per-run step flags on ci_default' do
+      output = run_script
+      groups = JSON.parse(output['unit_matrix'])['test_group']
+      ci_default = groups.find { |g| g['id'] == 'ci_default' }
+
+      expect(ci_default).to include('okta' => true, 'logging' => true, 'devise' => true)
+    end
   end
 
   context 'when validating test paths' do

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Idp::JwtCurrentUser, type: :controller, if: AuthMethod.jwt? do
+RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
   controller(ActionController::Base) do
     include Idp::JwtCurrentUser
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe Users::InvitationsController, type: :controller do
+# The invitation routes come from `devise_for :users`, mounted only under AuthMethod.devise?;
+# under jwt the IdP owns provisioning (see Idp::AdminUserCreator).
+RSpec.describe Users::InvitationsController, :devise_only, type: :controller do
   let(:admin_user) { create(:acl_user) }
   let(:admin_role) { create :admin_role }
   let(:no_data_source_collection) { create :collection }

--- a/spec/features/accounts_spec.rb
+++ b/spec/features/accounts_spec.rb
@@ -8,7 +8,10 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Accounts', type: :feature do
+# Devise-only: drives the warehouse password sign-in form and exercises Devise lockable,
+# password expiration, and session_limitable behavior (user.password, force_password_reset!).
+# The jwt arm has no password form — authentication is delegated to the IdP.
+RSpec.describe 'Accounts', :devise_only, type: :feature do
   let(:user) { create(:user) }
 
   before(:each) do

--- a/spec/jobs/idp/sync_user_from_idp_job_spec.rb
+++ b/spec/jobs/idp/sync_user_from_idp_job_spec.rb
@@ -11,9 +11,8 @@ require 'rails_helper'
 # This doubles as the Idp::Support#idp_reconcile_email! spec — the job drives the real method, so
 # the emailVerified gate and case-insensitive no-op are exercised here; there is no separate one.
 #
-# Idp::Support mixes into User only under the JWT arm (UserConcern), so the describe is guarded on
-# AuthMethod.jwt? and these examples run only under AUTH_METHOD=jwt.
-RSpec.describe Idp::SyncUserFromIdpJob, type: :job, if: AuthMethod.jwt? do
+# Idp::Support is only mixed into User under the JWT arm (UserConcern).
+RSpec.describe Idp::SyncUserFromIdpJob, :jwt_only, type: :job do
   let!(:user) { create(:user, email: 'before@example.com', first_name: 'Self', last_name: 'Serve') }
   let(:service) do
     instance_double(

--- a/spec/lib/auth_method_arm_tags_spec.rb
+++ b/spec/lib/auth_method_arm_tags_spec.rb
@@ -1,0 +1,64 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Arm-specific examples must carry the `:devise_only` / `:jwt_only` tag, never a hand-written
+# `if: AuthMethod.devise?` / `if: AuthMethod.jwt?` gate: both `if:` directions fail silently (the two
+# examples below spell out how), and CI reads a silent skip as a pass. The tag keeps the example
+# selected on exactly one arm instead of silently dropping it.
+# See docs/features/warehouse/ci-test-bucketing.md for the arms.
+RSpec.describe 'AUTH_METHOD arm tagging convention' do
+  # Scan every .rb in both spec trees, not just *_spec.rb: a gate can sit in a shared example group
+  # under spec/support that no CI --pattern matches directly. Exclude this file — its own example
+  # descriptions quote the gates as string literals, which the comment-line reject below won't skip.
+  let(:scanned_files) do
+    Dir.glob(
+      [
+        Rails.root.join('spec/**/*.rb'),
+        Rails.root.join('drivers/*/spec/**/*.rb'),
+      ],
+    ).reject { |path| File.expand_path(path) == File.expand_path(__FILE__) }.sort
+  end
+
+  def offenders_for(gate)
+    scanned_files.flat_map do |path|
+      # Skip comment lines: comments elsewhere quote the gates and would be flagged as false offenders.
+      File.readlines(path).each_with_index.
+        reject { |line, _index| line.lstrip.start_with?('#') }.
+        select { |line, _index| line.match?(gate) }.
+        map { |_line, index| "#{Pathname.new(path).relative_path_from(Rails.root)}:#{index + 1}" }
+    end
+  end
+
+  it 'has no spec gated with `if: AuthMethod.devise?`, which would run on neither arm' do
+    offenders = offenders_for(/if:\s*AuthMethod\.devise\?/)
+
+    expect(offenders).to be_empty, <<~MSG
+      Gated to the Devise arm by hand, so the Devise CI step never selects them and they run on
+      neither arm:
+
+      #{offenders.join("\n")}
+
+      Drop the `if:` and tag the block :devise_only instead. spec/rails_helper.rb applies the arm.
+    MSG
+  end
+
+  it 'has no spec gated with `if: AuthMethod.jwt?`, which reports zero examples on the wrong arm' do
+    offenders = offenders_for(/if:\s*AuthMethod\.jwt\?/)
+
+    expect(offenders).to be_empty, <<~MSG
+      Gated to the JWT arm by hand, so running them under AUTH_METHOD=devise silently reports zero
+      examples instead of naming the arm:
+
+      #{offenders.join("\n")}
+
+      Drop the `if:` and tag the block :jwt_only instead. spec/rails_helper.rb applies the arm.
+    MSG
+  end
+end

--- a/spec/models/concerns/idp/jwt_user_spec.rb
+++ b/spec/models/concerns/idp/jwt_user_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Idp::JwtUser, type: :model, if: AuthMethod.jwt? do
+RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
   let(:user) { create(:user) }
   let(:jwt_helper) do
     instance_double(

--- a/spec/models/concerns/idp/support_spec.rb
+++ b/spec/models/concerns/idp/support_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 # resolve it, so config→service resolution is exercised, not stubbed. Only the remote
 # Keycloak calls are stubbed, on the memoized service instance (Idp::Support#idp_service
 # caches, so the op reuses what we stub).
-RSpec.describe Idp::Support, type: :model, if: AuthMethod.jwt? do
+RSpec.describe Idp::Support, :jwt_only, type: :model do
   let(:user) { create(:user) }
   let(:connector_id) { 'test' }
   let(:connector_user_id) { 'kc-user-1' }

--- a/spec/models/idp/jwt_helper_spec.rb
+++ b/spec/models/idp/jwt_helper_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Idp::JwtHelper, if: AuthMethod.jwt? do
+RSpec.describe Idp::JwtHelper, :jwt_only do
   let(:jwks_url) { 'http://example.com/jwks' }
   let(:kid) { 'test_kid' }
   let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }

--- a/spec/models/idp/service_config_spec.rb
+++ b/spec/models/idp/service_config_spec.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-RSpec.describe Idp::ServiceConfig, type: :model, if: AuthMethod.jwt? do
+RSpec.describe Idp::ServiceConfig, :jwt_only, type: :model do
   describe 'validations' do
     subject { build(:idp_service_config) }
 

--- a/spec/models/user_otp_secret_legacy_bridge_spec.rb
+++ b/spec/models/user_otp_secret_legacy_bridge_spec.rb
@@ -12,7 +12,9 @@ require 'rails_helper'
 # but existing users' secrets remain in the legacy attr_encrypted columns
 # (encrypted_otp_secret/_iv/_salt). User#legacy_otp_secret must decrypt those so existing
 # 2FA keeps working with no data migration.
-RSpec.describe 'User OTP secret legacy bridge', type: :model do
+# Devise-only: 2FA is a devise-two-factor feature, and the :two_factor_authenticatable macro that
+# supplies the otp_* accessors is gated off under AUTH_METHOD=jwt, where the IdP owns 2FA.
+RSpec.describe 'User OTP secret legacy bridge', :devise_only, type: :model do
   # Writes a secret into the legacy encrypted_otp_secret* columns the way
   # devise-two-factor <= 4.x did (attr_encrypted, per-attribute iv+salt, aes-256-gcm),
   # i.e. how production secrets are currently stored.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,27 @@ RSpec.configure do |config|
     config.include Devise::Test::ControllerHelpers, type: :controller
     config.include Devise::Test::IntegrationHelpers, type: :request
   end
+
+  # :devise_only / :jwt_only tag examples that only make sense on one arm; rationale for a tag over
+  # an `if:` condition in docs/features/warehouse/ci-test-bucketing.md and
+  # spec/lib/auth_method_arm_tags_spec.rb.
+  #
+  # Both mechanisms are needed, because they cover different invocations. filter_run_excluding covers
+  # bulk runs; the before hook covers `rspec path:line`, --example, and an explicit --tag, where
+  # RSpec's location and tag filters take priority over exclusion filters and would otherwise run the
+  # example against routes that are not mounted.
+  if AuthMethod.jwt?
+    config.filter_run_excluding(:devise_only)
+    config.before(:each, :devise_only) do |example|
+      raise "#{example.location} is tagged :devise_only; re-run it under AUTH_METHOD=devise."
+    end
+  else
+    config.filter_run_excluding(:jwt_only)
+    config.before(:each, :jwt_only) do |example|
+      raise "#{example.location} is tagged :jwt_only; re-run it under AUTH_METHOD=jwt."
+    end
+  end
+
   config.include FactoryBot::Syntax::Methods
   config.include HmisCsvFixtures
   config.include AccessControlSetup
@@ -171,4 +192,15 @@ end
 
 def regex_for_warehouse_sign_in
   /#{Regexp.escape(new_user_session_path)}/
+end
+
+# Arm-aware analogue of LoginAndPermissionsSpecHelper#expect_unauthenticated_api_request for the
+# warehouse redirect surface. The request must run inside the block: under JWT a tokenless request
+# to an authenticated route raises Idp::UnauthenticatedRequestError (oauth2-proxy owns sign-in, so
+# an untokened request reaching Rails was never proxied), rather than redirecting as Devise does.
+def expect_unauthenticated_warehouse_request
+  return expect { yield }.to raise_error(Idp::UnauthenticatedRequestError) if AuthMethod.jwt?
+
+  yield
+  expect(response).to redirect_to(regex_for_warehouse_sign_in)
 end

--- a/spec/requests/account_emails_controller_spec.rb
+++ b/spec/requests/account_emails_controller_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AccountEmailsController, type: :request do
+# Devise-only: the jwt arm never writes email locally — the IdP owns the change, and
+# Idp::AccountEmailsController serves this path instead (spec/requests/idp/).
+RSpec.describe AccountEmailsController, :devise_only, type: :request do
   # TODO: - get auth working in tests
   let(:user) { create :user }
   let(:email)  { ActionMailer::Base.deliveries.last }

--- a/spec/requests/account_passwords_controller_spec.rb
+++ b/spec/requests/account_passwords_controller_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AccountPasswordsController, type: :request do
+# Devise-only: passwords are IdP-owned under jwt, so config/routes.rb omits `resource
+# :account_password` entirely on that arm.
+RSpec.describe AccountPasswordsController, :devise_only, type: :request do
   # TODO: - get auth working in tests
   let(:user) { create :user }
   let(:email)  { ActionMailer::Base.deliveries.last }

--- a/spec/requests/accounts_controller_spec.rb
+++ b/spec/requests/accounts_controller_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AccountsController, type: :request do
+# Devise-only: config/routes.rb points `resource :account` at this controller only on the Devise
+# arm; under jwt the same path is served by Idp::AccountsController (spec/requests/idp/).
+RSpec.describe AccountsController, :devise_only, type: :request do
   # TODO: - get auth working in tests
   let(:user) { create :user }
   let(:email) { ActionMailer::Base.deliveries.last }

--- a/spec/requests/admin/admin_users_search_spec_context.rb
+++ b/spec/requests/admin/admin_users_search_spec_context.rb
@@ -14,8 +14,9 @@ RSpec.shared_context 'admin users search', shared_context: :metadata do
 
     context 'when logged out' do
       it 'redirects to the login page' do
-        post admin_user_search_queries_path, params: search_params
-        expect(response).to redirect_to(new_user_session_path)
+        expect_unauthenticated_warehouse_request do
+          post admin_user_search_queries_path, params: search_params
+        end
       end
     end
 
@@ -60,8 +61,9 @@ RSpec.shared_context 'admin users search', shared_context: :metadata do
 
     context 'when logged out' do
       it 'redirects to the login page' do
-        get user_search_query_admin_users_path(id: search_query.id)
-        expect(response).to redirect_to(new_user_session_path)
+        expect_unauthenticated_warehouse_request do
+          get user_search_query_admin_users_path(id: search_query.id)
+        end
       end
     end
 

--- a/spec/requests/admin/audits_controller_spec.rb
+++ b/spec/requests/admin/audits_controller_spec.rb
@@ -12,10 +12,9 @@ require 'rails_helper'
 # @user.login_locations_enabled? (true for Devise, false for JWT — see Idp::Support and
 # DeviseOktaSupport), so it renders for the Devise arm and is omitted for the JWT arm, where the
 # admin_user_locations_path route helper isn't defined at all and would raise NoMethodError.
-# Runs under whichever AUTH_METHOD the suite is booted with; see the JWT CI step for the
-# AUTH_METHOD=jwt boot of this same file. That CI step names this file explicitly in its rspec
-# invocation — if it's ever dropped from that list, the JWT-arm half of this guard silently stops
-# running (a Devise-arm run can't catch it: admin_user_locations_path exists either way there).
+# Runs under whichever AUTH_METHOD the suite is booted with, and both halves are load-bearing: a
+# Devise-arm run cannot catch a regression in the JWT half, since admin_user_locations_path is
+# defined either way there.
 RSpec.describe 'Admin::Audits', type: :request do
   let(:admin_user) { create(:acl_user) }
   let(:target_user) { create(:user, first_name: 'Test', last_name: 'User') }

--- a/spec/requests/admin/idp/inactive_users_controller_spec.rb
+++ b/spec/requests/admin/idp/inactive_users_controller_spec.rb
@@ -10,8 +10,8 @@ require 'rails_helper'
 require 'webmock/rspec'
 require 'nokogiri'
 
-# JWT-arm inactive-user (reactivation) management. Requires an AUTH_METHOD=jwt boot (CI step).
-RSpec.describe Admin::Idp::InactiveUsersController, type: :request, if: AuthMethod.jwt? do
+# JWT-arm inactive-user (reactivation) management.
+RSpec.describe Admin::Idp::InactiveUsersController, :jwt_only, type: :request do
   let(:api_url) { 'http://keycloak.test:8080' }
   let(:realm) { 'openpath' }
   let(:connector_id) { 'test' } # matches JwtAuthenticationHelper#sign_in

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -10,10 +10,9 @@ require 'rails_helper'
 require 'webmock/rspec'
 require 'nokogiri'
 
-# JWT-arm admin user management. These assertions require the app to have booted under
-# AUTH_METHOD=jwt (the dedicated CI step), where the route-level seam mounts
-# Admin::Idp::UsersController and JwtAuthenticationHelper#sign_in is active.
-RSpec.describe Admin::Idp::UsersController, type: :request, if: AuthMethod.jwt? do
+# JWT-arm admin user management. On this arm the route-level seam mounts Admin::Idp::UsersController
+# and JwtAuthenticationHelper#sign_in is active.
+RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
   # Keycloak/IdP scaffolding: a creation-capable 'test' connector backed by DB credentials,
   # a stubbed token endpoint, and WebMock net isolation.
   let(:api_url) { 'http://keycloak.test:8080' }

--- a/spec/requests/api/pings_controller_spec.rb
+++ b/spec/requests/api/pings_controller_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::PingsController, type: :request, if: AuthMethod.jwt? do
+RSpec.describe Api::PingsController, :jwt_only, type: :request do
   let(:user) { create(:user) }
 
   it 'returns 200 for an authenticated user' do

--- a/spec/requests/api/superset_jwt_wiring_spec.rb
+++ b/spec/requests/api/superset_jwt_wiring_spec.rb
@@ -13,7 +13,7 @@ require 'rails_helper'
 # the role payload Superset needs; the route is entirely absent under Devise, mirroring how
 # /oauth/user-data is absent under JWT (spec/requests/idp/warehouse_jwt_wiring_spec.rb).
 RSpec.describe 'Superset JWT wiring', type: :request do
-  describe 'GET /api/superset/user_roles', if: AuthMethod.jwt? do
+  describe 'GET /api/superset/user_roles', :jwt_only do
     let(:user) { create(:user, superset_roles: ['Report Runner']) }
 
     it 'returns the role payload for a valid bearer token' do

--- a/spec/requests/cohorts/clients_spec.rb
+++ b/spec/requests/cohorts/clients_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Cohorts::ClientsController, type: :request do
 
     context 'when logged out' do
       it 'redirects to the login page' do
-        post cohort_client_search_queries_path(cohort_id: cohort.id), params: search_params
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          post cohort_client_search_queries_path(cohort_id: cohort.id), params: search_params
+        end
       end
     end
 
@@ -76,8 +77,9 @@ RSpec.describe Cohorts::ClientsController, type: :request do
 
     context 'when logged out' do
       it 'redirects to the login page' do
-        get cohort_cohort_client_search_query_path(cohort_id: cohort.id, id: search_query.id)
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          get cohort_cohort_client_search_query_path(cohort_id: cohort.id, id: search_query.id)
+        end
       end
     end
 
@@ -130,8 +132,9 @@ RSpec.describe Cohorts::ClientsController, type: :request do
 
     context 'when logged out' do
       it 'redirects to the login page' do
-        post cohort_cohort_clients_path(cohort_id: cohort.id), params: create_params
-        expect(response).to redirect_to(regex_for_warehouse_sign_in)
+        expect_unauthenticated_warehouse_request do
+          post cohort_cohort_clients_path(cohort_id: cohort.id), params: create_params
+        end
       end
     end
 

--- a/spec/requests/idp/account_emails_controller_spec.rb
+++ b/spec/requests/idp/account_emails_controller_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 # JWT-arm email self-management, read-only.
-RSpec.describe Idp::AccountEmailsController, type: :request, if: AuthMethod.jwt? do
+RSpec.describe Idp::AccountEmailsController, :jwt_only, type: :request do
   let(:api_url) { 'http://keycloak.test:8080' }
   let(:realm) { 'openpath' }
   let(:connector_id) { 'test' } # matches JwtAuthenticationHelper#sign_in

--- a/spec/requests/idp/accounts_controller_spec.rb
+++ b/spec/requests/idp/accounts_controller_spec.rb
@@ -9,10 +9,9 @@
 require 'rails_helper'
 require 'webmock/rspec'
 
-# JWT-arm account self-management. These assertions require the app to have booted under
-# AUTH_METHOD=jwt (the dedicated CI step), where the route-level seam mounts Idp::AccountsController
+# JWT-arm account self-management. On this arm the route-level seam mounts Idp::AccountsController
 # and JwtAuthenticationHelper#sign_in is active.
-RSpec.describe Idp::AccountsController, type: :request, if: AuthMethod.jwt? do
+RSpec.describe Idp::AccountsController, :jwt_only, type: :request do
   let(:api_url) { 'http://keycloak.test:8080' }
   let(:realm) { 'openpath' }
   let(:connector_id) { 'test' } # matches JwtAuthenticationHelper#sign_in

--- a/spec/requests/idp/warehouse_jwt_wiring_spec.rb
+++ b/spec/requests/idp/warehouse_jwt_wiring_spec.rb
@@ -12,7 +12,7 @@ require 'rails_helper'
 # AUTH_METHOD=jwt, leaving the Devise path unchanged. The `if: AuthMethod.jwt?` examples lean on
 # JwtAuthenticationHelper, which is included only when AuthMethod.jwt?.
 RSpec.describe 'Warehouse JWT wiring', type: :request do
-  describe 'authentication via a forwarded JWT', if: AuthMethod.jwt? do
+  describe 'authentication via a forwarded JWT', :jwt_only do
     let(:user) { create :user }
 
     before do
@@ -454,7 +454,7 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
   # Describe the connection class directly: a :channel group mixes in both Connection and Channel
   # TestCase behaviors, so `tests` resolves to the Channel variant (sets _channel_class). Naming the
   # class here makes it the described_class, which connection_class falls back to (else nil <= raises).
-  describe ApplicationCable::Connection, type: :channel, if: AuthMethod.jwt? do
+  describe ApplicationCable::Connection, :jwt_only, type: :channel do
     let(:user) { create :user }
 
     # Only the forwarded token resolves to the double; anything else builds a real Idp::JwtHelper,
@@ -510,7 +510,7 @@ RSpec.describe 'Warehouse JWT wiring', type: :request do
     end
   end
 
-  describe "rack-attack's authenticated? helper", if: AuthMethod.jwt? do
+  describe "rack-attack's authenticated? helper", :jwt_only do
     it 'is true for a valid forwarded token' do
       allow(Idp::JwtHelper).to receive(:authenticated?).with('good-token').and_return(true)
       request = Rack::Attack::Request.new('QUERY_STRING' => '', 'HTTP_X_FORWARDED_ACCESS_TOKEN' => 'good-token')

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -9,7 +9,9 @@
 require 'rails_helper'
 if ENV['OKTA_DOMAIN'].present?
   # Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
-  RSpec.describe Users::OmniauthCallbacksController, type: :request do
+  # Devise-only: the okta callback route is declared inside the `devise_scope :user` block, so it
+  # is not mounted under jwt, where the IdP owns federated sign-in.
+  RSpec.describe Users::OmniauthCallbacksController, :devise_only, type: :request do
     describe 'GET /users/auth/:provider protects against CVE-2015-9284' do
       it do
         get '/users/auth/okta'

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -109,7 +109,10 @@ RSpec.describe Rack::Attack, type: :request do
       end
     end
 
-    describe 'HMIS sign-in end point' do
+    # Devise-only: hmis_user_session_path comes from `devise_for :users, class_name: 'Hmis::User'`,
+    # mounted only under AuthMethod.devise? (drivers/hmis/config/routes.rb). The jwt arm has no HMIS
+    # Devise login route — oauth2-proxy owns sign-in.
+    describe 'HMIS sign-in end point', :devise_only do
       let(:path) { hmis_user_session_path }
       it 'throttles brute-force requests' do
         throttled_at = 20
@@ -120,7 +123,9 @@ RSpec.describe Rack::Attack, type: :request do
       end
     end
 
-    describe 'Password Reset Throttling' do
+    # Devise-only: edit_user_password_path is a Devise :recoverable route, mounted only under
+    # AuthMethod.devise? (config/routes.rb). The jwt arm delegates password reset to the IdP.
+    describe 'Password Reset Throttling', :devise_only do
       let(:path) { edit_user_password_path }
       it 'throttles brute-force password reset requests' do
         throttled_at = 20
@@ -139,7 +144,9 @@ RSpec.describe Rack::Attack, type: :request do
 
     include_examples 'blocks active storage routes'
 
-    describe 'status endpoints' do
+    # Devise-only: asserts Devise :timeoutable expiry via Devise.timeout_in. JWT sessions are not
+    # timed out this way, so the final request stays authenticated (200) rather than 401.
+    describe 'status endpoints', :devise_only do
       let(:excluded_paths) { ['/messages/poll'] }
       let(:session_timeout) { Devise.timeout_in }
 

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -11,7 +11,9 @@ require 'support/shared_contexts/post_login_hooks_context'
 require 'support/shared_contexts/login_activity_context'
 # require 'support/shared_contexts/timing_attack_mitigation_context'
 
-RSpec.describe Users::SessionsController, type: :request do
+# Devise-only: Users::SessionsController is reachable only via the `devise_for :users` routes,
+# which config/routes.rb mounts under AuthMethod.devise?.
+RSpec.describe Users::SessionsController, :devise_only, type: :request do
   let(:user) { create :user }
   let(:user_2fa) { create :user_2fa }
   let(:email) { ActionMailer::Base.deliveries.last }

--- a/spec/requests/source_clients_legacy_spec.rb
+++ b/spec/requests/source_clients_legacy_spec.rb
@@ -15,23 +15,27 @@ RSpec.describe SourceClientsController, type: :request do
 
   describe 'logged out' do
     it 'doesn\'t allow edit' do
-      get edit_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get edit_source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow update' do
-      patch source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow image' do
-      get image_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get image_source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow destination' do
-      get destination_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get destination_source_client_path(client)
+      end
     end
   end
 

--- a/spec/requests/source_clients_spec.rb
+++ b/spec/requests/source_clients_spec.rb
@@ -15,23 +15,27 @@ RSpec.describe SourceClientsController, type: :request do
 
   describe 'logged out' do
     it 'doesn\'t allow edit' do
-      get edit_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get edit_source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow update' do
-      patch source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        patch source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow image' do
-      get image_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get image_source_client_path(client)
+      end
     end
 
     it 'doesn\'t allow destination' do
-      get destination_source_client_path(client)
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get destination_source_client_path(client)
+      end
     end
   end
 

--- a/spec/requests/source_data_controller_spec.rb
+++ b/spec/requests/source_data_controller_spec.rb
@@ -19,13 +19,15 @@ RSpec.describe SourceDataController, type: :request do
 
   describe 'logged out' do
     it 'redirects index to login' do
-      get source_data_path
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get source_data_path
+      end
     end
 
     it 'redirects show to login' do
-      get source_datum_path(id: item.id, type: 'Client')
-      expect(response).to redirect_to(regex_for_warehouse_sign_in)
+      expect_unauthenticated_warehouse_request do
+        get source_datum_path(id: item.id, type: 'Client')
+      end
     end
   end
 

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -10,7 +10,7 @@ require 'rails_helper'
 
 # AdminUserCreator builds a local User without a password, which only validates under the JWT
 # boot (AUTH_METHOD=jwt); under Devise, User is :secure_validatable and requires one.
-RSpec.describe Idp::AdminUserCreator, if: AuthMethod.jwt? do
+RSpec.describe Idp::AdminUserCreator, :jwt_only do
   let(:connector_id) { 'kc' }
   let(:service) { instance_double(Idp::KeycloakService, supports_user_creation?: true, idp_name: 'Keycloak') }
 

--- a/spec/services/idp/keycloak/user_importer_spec.rb
+++ b/spec/services/idp/keycloak/user_importer_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Idp::Keycloak::UserImporter, type: :model do
     end
 
     # devise-two-factor only loads on the devise arm, and only it has 2FA to migrate.
-    context 'with 2FA enabled', if: AuthMethod.devise? do
+    context 'with 2FA enabled', :devise_only do
       # A real Base32 secret stored through devise-two-factor's encryption, so
       # the importer must actually decrypt encrypted_otp_secret to recover it.
       let(:real_otp_secret) { User.generate_otp_secret }

--- a/spec/services/idp/service_factory_spec.rb
+++ b/spec/services/idp/service_factory_spec.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-RSpec.describe Idp::ServiceFactory, type: :model, if: AuthMethod.jwt? do
+RSpec.describe Idp::ServiceFactory, :jwt_only, type: :model do
   describe '.for_connector' do
     context 'with an active database config' do
       let!(:config) do

--- a/spec/support/jwt_authentication_helper.rb
+++ b/spec/support/jwt_authentication_helper.rb
@@ -87,10 +87,18 @@ module JwtAuthenticationHelper
       [:get, :post, :put, :patch, :delete, :head].each do |method|
         define_singleton_method(method) do |*args, **kwargs|
           if defined?(controller) && controller.present?
-            allow(controller).to receive(:current_user).and_return(user)
-            allow(controller).to receive(:user_signed_in?).and_return(true)
-            if defined?(request) && request.present?
-              request.headers['HTTP_X_FORWARDED_ACCESS_TOKEN'] = mock_token
+            # The else branch is what makes #sign_out effective in a controller spec: without it the
+            # current_user stub outlives the token and the signed-out spec still reads a user.
+            if test_instance.jwt_token == mock_token
+              allow(controller).to receive(:current_user).and_return(user)
+              allow(controller).to receive(:user_signed_in?).and_return(true)
+              if defined?(request) && request.present?
+                request.headers['HTTP_X_FORWARDED_ACCESS_TOKEN'] = mock_token
+              end
+            else
+              allow(controller).to receive(:current_user).and_call_original
+              allow(controller).to receive(:user_signed_in?).and_call_original
+              request.headers['HTTP_X_FORWARDED_ACCESS_TOKEN'] = nil if defined?(request) && request.present?
             end
           end
           super(*args, **kwargs)
@@ -129,6 +137,13 @@ module JwtAuthenticationHelper
     end
 
     mock_token
+  end
+
+  # Replaces Devise's sign_out, which spec/rails_helper.rb withholds on the JWT arm.
+  def sign_out(_user = nil)
+    @jwt_token = nil
+    @jwt_session_id = nil
+    @jwt_headers = nil
   end
 
   def jwt_token

--- a/spec/support/shared_examples/auth_method_user_examples.rb
+++ b/spec/support/shared_examples/auth_method_user_examples.rb
@@ -8,15 +8,12 @@
 
 # Behavior of the AuthMethod (devise/JWT) branching that UserConcern mixes into both User and Hmis::User.
 #
-# The branch is resolved at *class-load*, so the suite is split by how CI boots:
-#   - the default (Devise) suite asserts the DeviseUser concern, its macro, and the overrides that `super`
-#     into the macro, and
-#   - the JWT-boot suite (the dedicated AUTH_METHOD=jwt CI step) asserts the macro is absent and the Idp::JwtUser
-#     branches are taken.
+# The branch is resolved at *class-load*, so a booted process is one arm only — no example can
+# cover both, and the two describes below must stay split by arm rather than merged.
 #
 # Pass the factory + model class so the same expectations run against every UserConcern host.
 RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
-  describe 'default (Devise) mode', if: AuthMethod.devise? do
+  describe 'default (Devise) mode', :devise_only do
     it 'includes the Devise auth concern and applies the macro and its injected accessors' do
       expect(model.include?(DeviseUser)).to be true
       expect(model.include?(Idp::JwtUser)).to be false
@@ -413,7 +410,7 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
   end
 
   # These assertions require the class to have *loaded* under AUTH_METHOD=jwt
-  describe 'JWT-boot (AUTH_METHOD=jwt process)', if: AuthMethod.jwt? do
+  describe 'JWT-boot (AUTH_METHOD=jwt process)', :jwt_only do
     it 'omits the Devise auth concern, the macro, and its injected accessors' do
       expect(model.include?(DeviseUser)).to be false
       expect(model.include?(Idp::JwtUser)).to be true


### PR DESCRIPTION

## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Devise is being sunset, so make jwt the default arm in CI and select the Devise-only specs instead of the other way around.

- Run tests: set AUTH_METHOD=jwt + IdP env, add --tag ~devise_only to both the plain and profiling invocations
- Drop the enumerated 19-file jwt spec list; add a once-per-run AUTH_METHOD=devise step selecting on --tag devise_only
- ci_matrix_router: replace the now-consumerless jwt: flag on ci_default with devise:
- Pin the okta step to AUTH_METHOD=devise rather than the absent default
- Tag the Devise-only specs :devise_only + if: AuthMethod.devise?

The enumerated list was already leaking: api/pings_controller_spec.rb is
gated if: AuthMethod.jwt? and was never in it, so it has never run.

auth_method.rb keeps its 'devise' default — the flip is workflow-only and local rspec is unchanged. Devise arm is 102 examples. warden_proxy_spec and devise_cve_2026_40295_spec are deliberately untagged; they pass on both arms and WardenProxy is a jwt-arm class.

Logging step and the system-test jobs are untouched, still Devise.


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill

