### PR TITLE
[#8179] Cohort Name Permissions - OP Analytics

### DIFF
--- a/app/controllers/concerns/authenticates_with_two_factor.rb
+++ b/app/controllers/concerns/authenticates_with_two_factor.rb
@@ -11,8 +11,6 @@
 # == AuthenticatesWithTwoFactor
 #
 # Controller concern to handle two-factor authentication
-#
-# Upon inclusion, skips `require_no_authentication` on `:create`.
 module AuthenticatesWithTwoFactor
   extend ActiveSupport::Concern
 
@@ -87,12 +85,22 @@ module AuthenticatesWithTwoFactor
     user.two_factors_memorized_devices.active.exists?(uuid: cookie_uuid)
   end
 
+  # Included controllers can override this to run logic that must happen on every successful
+  # sign-in, since it completes inside a before_action and Users::SessionsController#create
+  # never runs for this flow.
+  def after_two_factor_sign_in(user)
+  end
+
   private def two_factor_successful(user)
     # Remove any lingering user data from login
     session.delete(:otp_user_id)
 
     user.save!
+    # Calling `sign_in` directly causes devise to skip `require_no_authentication`, which
+    # effectively skips anything in `Users::SessionsController#create`.  We have some logic
+    # that needs to run even after a successful sign-in, so we queue it up with `after_two_factor_sign_in`
     sign_in(two_factor_resource_name, user, message: :two_factor_authenticated, event: :authentication)
+    after_two_factor_sign_in(user)
 
     # add 2fa device if true
     return unless user_params[:remember_device] == 'true' && bypass_2fa_enabled?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,15 +8,23 @@
 
 class Users::SessionsController < Devise::SessionsController
   include AuthenticatesWithTwoFactor
-  # Start the time log before other methods are called in the authentication stack so we can get the server begin time for the login attempt
-  prepend_before_action :begin_time_log, only: :create
   prepend_before_action(
     :authenticate_with_two_factor,
     if: -> { action_name == 'create' && two_factor_enabled? },
   )
+  # Wraps the entire :create callback chain (including authenticate_with_two_factor and Devise's
+  # own filters), so the timing log always runs.
+  prepend_around_action :time_login, only: :create
 
   # Minimum required login processing time for ALL login attempts (seconds)
   MIN_REQ_LOGIN_TIME = 2
+
+  def time_login
+    begin_time_log
+    yield
+  ensure
+    end_time_log
+  end
 
   def begin_time_log
     # Timestamp for tracking login time to help ensure that the application response time is consistent for valid/invalid usernames.
@@ -34,15 +42,22 @@ class Users::SessionsController < Devise::SessionsController
 
   def create
     super do |resource|
-      # User has successfully signed in, so clear any unused reset token
-      resource.update(reset_password_token: nil, reset_password_sent_at: nil) if resource.reset_password_token.present?
-      # Note access for external reporting
-      resource.delay(queue: ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)).populate_external_reporting_permissions!
+      post_sign_in!(resource)
     end
-  ensure
-    # `super` includes a redirect on failed authentication. We want to make sure this check is captured and processed
-    # from a location with access to the server's initial login timestamp.
-    end_time_log
+  end
+
+  # Devise::SessionsController#create never runs for a 2FA login, since require_no_authentication
+  # (a Devise before_action) redirects as soon as authenticate_with_two_factor signs the user in.
+  # This method overrides the no-op for warehouse users to ensure the post-sign-in logic runs.
+  def after_two_factor_sign_in(user)
+    post_sign_in!(user)
+  end
+
+  private def post_sign_in!(resource)
+    # User has successfully signed in, so clear any unused reset token
+    resource.update(reset_password_token: nil, reset_password_sent_at: nil) if resource.reset_password_token.present?
+    # Note access for external reporting for OP Analytics
+    resource.delay(queue: ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)).populate_external_reporting_permissions!
   end
 
   def destroy

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -85,14 +85,19 @@ module GrdaWarehouse
       where.not(project_group_id: nil)
     end
 
-    scope :viewable_by, ->(user, permission: :can_view_cohorts) do
+    # @param permission [Symbol, Array<Symbol>] despite the singular name, this accepts either
+    #   a single permission or an array of permissions to OR together (defaults to
+    #   +viewable_permissions+, i.e. every permission that currently grants cohort visibility)
+    scope :viewable_by, ->(user, permission: viewable_permissions) do
       return none unless user.present?
+
+      permissions = Array.wrap(permission)
 
       # TODO: START_ACL cleanup after permission migration is complete
       if user.using_acls?
-        return none unless user.send("#{permission}?")
+        return none unless permissions.any? { |perm| user.send("#{perm}?") }
 
-        group_ids = user.collections_for_permission(permission)
+        group_ids = permissions.flat_map { |perm| user.collections_for_permission(perm) }.uniq
         return none if group_ids.empty?
 
         ids = GrdaWarehouse::GroupViewableEntity.where(

--- a/app/models/grda_warehouse/cohort.rb
+++ b/app/models/grda_warehouse/cohort.rb
@@ -85,22 +85,20 @@ module GrdaWarehouse
       where.not(project_group_id: nil)
     end
 
-    scope :viewable_by, ->(user) do
+    scope :viewable_by, ->(user, permission: :can_view_cohorts) do
       return none unless user.present?
 
       # TODO: START_ACL cleanup after permission migration is complete
       if user.using_acls?
-        return none unless GrdaWarehouse::Cohort.viewable_permissions.map { |perm| user.send("#{perm}?") }.any?
+        return none unless user.send("#{permission}?")
 
-        ids = GrdaWarehouse::Cohort.viewable_permissions.flat_map do |perm|
-          group_ids = user.collections_for_permission(perm)
-          next [] if group_ids.empty?
+        group_ids = user.collections_for_permission(permission)
+        return none if group_ids.empty?
 
-          GrdaWarehouse::GroupViewableEntity.where(
-            collection_id: group_ids,
-            entity_type: 'GrdaWarehouse::Cohort',
-          ).pluck(:entity_id)
-        end.compact
+        ids = GrdaWarehouse::GroupViewableEntity.where(
+          collection_id: group_ids,
+          entity_type: 'GrdaWarehouse::Cohort',
+        ).pluck(:entity_id)
         return none if ids.empty?
 
         where(id: ids)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,6 +149,18 @@ class User < ApplicationRecord
     batch = ids.uniq.map do |item_id|
       GrdaWarehouse::ExternalReportingCohortPermission.new(user_id: id, email: email, cohort_id: item_id, permission: :can_view_cohorts)
     end
+
+    name_ids = if using_acls?
+      GrdaWarehouse::Cohort.viewable_by(self, permission: :can_view_client_name).pluck(:id)
+    elsif can_view_client_name?
+      ids
+    else
+      []
+    end
+    batch += (ids & name_ids).uniq.map do |item_id|
+      GrdaWarehouse::ExternalReportingCohortPermission.new(user_id: id, email: email, cohort_id: item_id, permission: :can_view_client_name)
+    end
+
     GrdaWarehouse::ExternalReportingCohortPermission.transaction do
       GrdaWarehouse::ExternalReportingCohortPermission.where(user_id: id).delete_all
       GrdaWarehouse::ExternalReportingCohortPermission.import(batch)

--- a/spec/models/grda_warehouse/cohort_spec.rb
+++ b/spec/models/grda_warehouse/cohort_spec.rb
@@ -187,6 +187,24 @@ RSpec.describe GrdaWarehouse::Cohort, type: :model do
         expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: :can_view_client_name).pluck(:id)).to contain_exactly(target_cohort.id)
       end
     end
+
+    context 'when passed an array of permissions' do
+      let!(:other_permission_role) { create(:cohort_client_viewer, can_view_cohorts: false, can_manage_cohort_data: true) }
+      let!(:other_permission_collection) { create :collection, collection_type: 'Cohorts' }
+
+      before do
+        other_permission_collection.set_viewables({ cohorts: [target_cohort.id] })
+        setup_access_control(acl_user, other_permission_role, other_permission_collection)
+      end
+
+      it 'includes the cohort when the granting role matches any permission in the array' do
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: [:can_view_cohorts, :can_manage_cohort_data]).pluck(:id)).to contain_exactly(target_cohort.id)
+      end
+
+      it 'excludes the cohort when checking only a permission the granting role lacks' do
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: :can_view_cohorts).pluck(:id)).to be_empty
+      end
+    end
   end
 
   describe '#owner_name' do

--- a/spec/models/grda_warehouse/cohort_spec.rb
+++ b/spec/models/grda_warehouse/cohort_spec.rb
@@ -144,6 +144,51 @@ RSpec.describe GrdaWarehouse::Cohort, type: :model do
     end
   end
 
+  describe '.viewable_by with permission:' do
+    let!(:acl_user) { create :acl_user }
+    let!(:target_cohort) { create :cohort }
+    let!(:name_role) { create(:cohort_client_viewer, can_view_client_name: true) }
+    let!(:no_name_role) { create(:cohort_client_viewer) }
+    let!(:name_collection) { create :collection, collection_type: 'Cohorts' }
+    let!(:no_name_collection) { create :collection, collection_type: 'Cohorts' }
+
+    context "when the granting collection's role has can_view_client_name" do
+      before do
+        name_collection.set_viewables({ cohorts: [target_cohort.id] })
+        setup_access_control(acl_user, name_role, name_collection)
+      end
+
+      it 'includes the cohort' do
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: :can_view_client_name).pluck(:id)).to contain_exactly(target_cohort.id)
+      end
+    end
+
+    context "when the granting collection's role lacks can_view_client_name" do
+      before do
+        no_name_collection.set_viewables({ cohorts: [target_cohort.id] })
+        setup_access_control(acl_user, no_name_role, no_name_collection)
+      end
+
+      it 'excludes the cohort even though the user can view_cohorts' do
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user).pluck(:id)).to contain_exactly(target_cohort.id)
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: :can_view_client_name).pluck(:id)).to be_empty
+      end
+    end
+
+    context 'when the user reaches the same cohort via two collections, only one granting can_view_client_name' do
+      before do
+        no_name_collection.set_viewables({ cohorts: [target_cohort.id] })
+        setup_access_control(acl_user, no_name_role, no_name_collection)
+        name_collection.set_viewables({ cohorts: [target_cohort.id] })
+        setup_access_control(acl_user, name_role, name_collection)
+      end
+
+      it 'includes the cohort because at least one path grants it' do
+        expect(GrdaWarehouse::Cohort.viewable_by(acl_user, permission: :can_view_client_name).pluck(:id)).to contain_exactly(target_cohort.id)
+      end
+    end
+  end
+
   describe '#owner_name' do
     context 'when no owner is assigned' do
       it 'returns Unassigned by default' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -178,6 +178,61 @@ RSpec.describe User, type: :model do
       expect(cohort_records.map(&:cohort_id)).to contain_exactly(*cohort_ids.uniq)
       expect(cohort_records).to all(have_attributes(user_id: user.id, email: user.email, permission: 'can_view_cohorts'))
     end
+
+    context 'when the user is on ACLs' do
+      let(:user) { create(:acl_user, email: 'reporter@example.com') }
+      let(:cohort_b) { 404 }
+      let(:cohort_c) { 505 }
+      let(:cohort_ids) { [cohort_a, cohort_b] }
+      let(:name_scope) { instance_double(ActiveRecord::Relation, pluck: [cohort_b, cohort_c]) }
+
+      before do
+        allow(GrdaWarehouse::Cohort).to receive(:viewable_by).with(user, permission: :can_view_client_name).and_return(name_scope)
+      end
+
+      it 'adds a can_view_client_name row only for cohorts that are both viewable and name-permitted' do
+        populate_permissions
+
+        pairs = cohort_records.map { |record| [record.cohort_id, record.permission] }
+        expect(pairs).to contain_exactly(
+          [cohort_a, 'can_view_cohorts'],
+          [cohort_b, 'can_view_cohorts'],
+          [cohort_b, 'can_view_client_name'],
+        )
+      end
+    end
+
+    context 'when the user is on legacy roles' do
+      context 'and none of their roles grant can_view_client_name' do
+        before { user.legacy_roles = [create(:cohort_client_viewer)] }
+
+        it 'does not add a can_view_client_name row' do
+          populate_permissions
+
+          pairs = cohort_records.map { |record| [record.cohort_id, record.permission] }
+          expect(pairs).to contain_exactly([cohort_a, 'can_view_cohorts'])
+        end
+      end
+
+      context 'and a role unrelated to cohort access grants can_view_client_name' do
+        before do
+          user.legacy_roles = [
+            create(:cohort_client_viewer),
+            create(:role, can_view_client_name: true),
+          ]
+        end
+
+        it 'adds a can_view_client_name row for every legacy-viewable cohort' do
+          populate_permissions
+
+          pairs = cohort_records.map { |record| [record.cohort_id, record.permission] }
+          expect(pairs).to contain_exactly(
+            [cohort_a, 'can_view_cohorts'],
+            [cohort_a, 'can_view_client_name'],
+          )
+        end
+      end
+    end
   end
 
   describe '#all_access_group_ids' do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -156,6 +156,52 @@ RSpec.describe Users::SessionsController, type: :request do
       expect(user_2fa.reload.failed_attempts).to eq 2 # double increment bug
     end
 
+    context 'with post-authentication hooks' do
+      def do_login
+        post user_session_path(user: { otp_attempt: user_2fa.current_otp })
+      end
+
+      def do_failed_login
+        post user_session_path(user: { otp_attempt: '-1' })
+      end
+
+      include_context 'with post-authentication hooks'
+
+      # Overrides the shared context's default (`let(:post_auth_user) { user }`); must come after
+      # include_context so this definition wins.
+      let(:post_auth_user) { user_2fa }
+    end
+
+    context 'with external reporting permissions population' do
+      it 'enqueues the job when 2fa is completed successfully' do
+        expect { post user_session_path(user: { otp_attempt: user_2fa.current_otp }) }.
+          to change(Delayed::Job, :count).by(1)
+
+        job = Delayed::Job.last
+        expect(job.payload_object.method_name).to eq(:populate_external_reporting_permissions!)
+        expect(job.payload_object.object).to eq(user_2fa)
+      end
+
+      it 'does not enqueue the job when 2fa fails' do
+        expect { post user_session_path(user: { otp_attempt: '-1' }) }.
+          to_not change(Delayed::Job, :count)
+      end
+    end
+
+    context 'with timing mitigation' do
+      it 'runs end_time_log for an incorrect 2fa attempt' do
+        expect_any_instance_of(Users::SessionsController).to receive(:end_time_log)
+
+        post user_session_path(user: { otp_attempt: '-1' })
+      end
+
+      it 'runs end_time_log for a correct 2fa attempt' do
+        expect_any_instance_of(Users::SessionsController).to receive(:end_time_log)
+
+        post user_session_path(user: { otp_attempt: user_2fa.current_otp })
+      end
+    end
+
     describe 'User does not remember 2FA device' do
       before(:each) do
         post user_session_path(user: { otp_attempt: user_2fa.current_otp, remember_device: nil })
@@ -218,6 +264,19 @@ RSpec.describe Users::SessionsController, type: :request do
           expect(response).to render_template('devise/sessions/two_factor')
         end
       end
+
+      it 'enqueues the external reporting permissions job on the bypass login' do
+        expect { post user_session_path(user: { email: user_2fa.email, password: user_2fa.password }) }.
+          to change(Delayed::Job, :count).by(1)
+      end
+    end
+  end
+
+  describe 'Login with 2FA enabled, prompting for a 2fa code' do
+    it 'runs end_time_log' do
+      expect_any_instance_of(Users::SessionsController).to receive(:end_time_log)
+
+      post user_session_path(user: { email: user_2fa.email, password: user_2fa.password })
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Add `can_view_client_name` rows to external reporting cohort permissions for use in OP Analytics
* Fixes a latent bug for devise 2FA sign-ins that prevented ever running the post-login cleanup

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

