### PR TITLE
[#9352] Boston Client Dashboard

### DIFF
--- a/app/controllers/clients/coordinated_entry_hud_assessments_controller.rb
+++ b/app/controllers/clients/coordinated_entry_hud_assessments_controller.rb
@@ -1,0 +1,40 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# This controller is used specifcally for limited client dashboards when the client dashboard config is set to boston.
+# It exposes full assessment details for Pathways and Transfer assessments only.
+module Clients
+  class CoordinatedEntryHudAssessmentsController < ApplicationController
+    include ClientPathGenerator
+    include AjaxModalRails::Controller
+
+    before_action :client
+    before_action :assessment
+    before_action :require_can_view_coordinated_entry_assessment!
+
+    def show
+      log_client
+    end
+
+    def client
+      @client ||= GrdaWarehouse::Hud::Client.destination_visible_to(current_user).find(params[:client_id].to_i)
+    end
+
+    def assessment
+      @assessment ||= @client.source_assessments.preload(:assessment_questions, :assessment_results, enrollment: :project).
+        find(params[:id].to_i)
+    end
+
+    private def require_can_view_coordinated_entry_assessment!
+      allowed = GrdaWarehouse::Config.get(:client_dashboard).to_s == 'boston' &&
+        current_user&.can_view_limited_client_dashboard? &&
+        @assessment.pathways_or_transfer?
+      not_authorized! unless allowed
+    end
+  end
+end

--- a/app/controllers/concerns/client_show_pages.rb
+++ b/app/controllers/concerns/client_show_pages.rb
@@ -29,6 +29,7 @@ module ClientShowPages
         '/clients/rollup/assessments',
         '/clients/rollup/verifications',
         '/clients/rollup/assessments_without_data',
+        '/clients/rollup/boston_assessments_with_limited_data',
         '/clients/rollup/case_manager',
         '/clients/rollup/chronic_days',
         '/clients/rollup/contact_information',

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -168,6 +168,7 @@ module GrdaWarehouse
       {
         'Default' => :default,
         'VA' => :va,
+        'Boston' => :boston,
       }
     end
 

--- a/app/models/grda_warehouse/hud/assessment.rb
+++ b/app/models/grda_warehouse/hud/assessment.rb
@@ -90,6 +90,10 @@ module GrdaWarehouse::Hud
       where(AssessmentID: GrdaWarehouse::Hud::AssessmentQuestion.transfer.select(:AssessmentID))
     end
 
+    scope :pathways_or_transfer, -> do
+      pathways.or(transfer)
+    end
+
     scope :family_pathways, -> do
       where(AssessmentID: GrdaWarehouse::Hud::AssessmentQuestion.family_pathways.select(:AssessmentID))
     end
@@ -135,6 +139,14 @@ module GrdaWarehouse::Hud
 
     def pathways?
       assessment_questions.any?(&:pathways?)
+    end
+
+    def transfer?
+      assessment_questions.any?(&:transfer?)
+    end
+
+    def pathways_or_transfer?
+      pathways? || transfer?
     end
 
     def family_pathways_2024?

--- a/app/models/grda_warehouse/hud/assessment_question.rb
+++ b/app/models/grda_warehouse/hud/assessment_question.rb
@@ -83,6 +83,10 @@ module GrdaWarehouse::Hud
       self.AssessmentQuestion.to_s == 'c_housing_assessment_name' && human_readable.in?(self.class.pathways_titles)
     end
 
+    def transfer?
+      self.AssessmentQuestion.to_s == 'c_housing_assessment_name' && human_readable.in?(self.class.transfer_titles)
+    end
+
     def self.pathways_titles
       [
         'Pathways',

--- a/app/views/clients/_hud_assessment_details.html.haml
+++ b/app/views/clients/_hud_assessment_details.html.haml
@@ -1,0 +1,37 @@
+.well
+  .d-flex
+    .assessment
+      %h3 Assessment Details
+      %dl
+        %dt Project
+        %dd= assessment.enrollment.project&.name(current_user)
+        %dt Assessment Date
+        %dd= assessment.AssessmentDate
+        %dt Assessment Level
+        %dd= HudHelper.util.assessment_level assessment.AssessmentLevel
+        %dt Assessment Type
+        %dd= HudHelper.util.assessment_type assessment.AssessmentType
+        %dt Prioritization Status
+        %dd= HudHelper.util.prioritization_status assessment.PrioritizationStatus
+        %dt Created
+        %dd= assessment.DateCreated
+        %dt Updated
+        %dd= assessment.DateUpdated
+    - if assessment.assessment_results.any?
+      .assessment-results.ml-8
+        %h3 Assessment Results
+        - assessment.assessment_results.each do |result|
+          %dl
+            %dt Assessment Result Type
+            %dd= result.AssessmentResultType
+            %dt Assessment Result
+            %dd= result.AssessmentResult
+- if assessment.assessment_questions.any?
+  %h2 Questions
+  .well
+    - assessment.assessment_questions.sort_by { |q| [q.AssessmentQuestionGroup, q.AssessmentQuestionOrder] }.each do |q|
+      %dl
+        %dt= Translation.translate(q.AssessmentQuestion)
+        %dd= q.human_readable
+- else
+  .none-found No questions provided.

--- a/app/views/clients/coordinated_entry_hud_assessments/show.haml
+++ b/app/views/clients/coordinated_entry_hud_assessments/show.haml
@@ -1,0 +1,4 @@
+- title = 'Coordinated Entry Assessment'
+- content_for :modal_title, title
+
+= render 'clients/hud_assessment_details', assessment: @assessment

--- a/app/views/clients/hud_assessments/show.haml
+++ b/app/views/clients/hud_assessments/show.haml
@@ -4,40 +4,4 @@
   = link_to enrollment_details_client_path(@client) do
     &laquo; Enrollment Details
 
-.well
-  .d-flex
-    .assessment
-      %h3 Assessment Details
-      %dl
-        %dt Project
-        %dd= @assessment.enrollment.project&.name(current_user)
-        %dt Assessment Date
-        %dd= @assessment.AssessmentDate
-        %dt Assessment Level
-        %dd= HudHelper.util.assessment_level @assessment.AssessmentLevel
-        %dt Assessment Type
-        %dd= HudHelper.util.assessment_type @assessment.AssessmentType
-        %dt Prioritization Status
-        %dd= HudHelper.util.prioritization_status @assessment.PrioritizationStatus
-        %dt Created
-        %dd= @assessment.DateCreated
-        %dt Updated
-        %dd= @assessment.DateUpdated
-    - if @assessment.assessment_results.any?
-      .assessment-results.ml-8
-        %h3 Assessment Results
-        - @assessment.assessment_results.each do |result|
-          %dl
-            %dt Assessment Result Type
-            %dd= result.AssessmentResultType
-            %dt Assessment Result
-            %dd= result.AssessmentResult
-- if @assessment.assessment_questions.any?
-  %h2 Questions
-  .well
-    - @assessment.assessment_questions.sort_by { |q| [q.AssessmentQuestionGroup, q.AssessmentQuestionOrder] }.each do |q|
-      %dl
-        %dt= Translation.translate(q.AssessmentQuestion)
-        %dd= q.human_readable
-- else
-  .none-found No questions provided.
+= render 'clients/hud_assessment_details', assessment: @assessment

--- a/app/views/clients/rollup/_boston_assessments_with_limited_data.html.haml
+++ b/app/views/clients/rollup/_boston_assessments_with_limited_data.html.haml
@@ -2,7 +2,7 @@
 - hmis_forms = @client.source_non_confidential_hmis_forms.select(*hmis_form_columms)&.sort&.group_by(&:assessment_type)
 - ce_assessments = []
 - if GrdaWarehouse::Config.get(:client_dashboard).to_s == 'boston' && can_view_limited_client_dashboard?
-  - ce_assessments = @client.source_assessments.order(AssessmentDate: :desc).preload(:assessment_questions).to_a
+  - ce_assessments = @client.source_assessments.order(AssessmentDate: :desc).preload(:user, assessment_questions: :lookup).to_a
 - if hmis_forms.any? || ce_assessments.any?
   - if hmis_forms.any?
     %table.table

--- a/app/views/clients/rollup/_boston_assessments_with_limited_data.html.haml
+++ b/app/views/clients/rollup/_boston_assessments_with_limited_data.html.haml
@@ -1,0 +1,62 @@
+- hmis_form_columms = (GrdaWarehouse::HmisForm.column_names - ['api_response', 'answers']).map(&:to_sym)
+- hmis_forms = @client.source_non_confidential_hmis_forms.select(*hmis_form_columms)&.sort&.group_by(&:assessment_type)
+- ce_assessments = []
+- if GrdaWarehouse::Config.get(:client_dashboard).to_s == 'boston' && can_view_limited_client_dashboard?
+  - ce_assessments = @client.source_assessments.order(AssessmentDate: :desc).preload(:assessment_questions).to_a
+- if hmis_forms.any? || ce_assessments.any?
+  - if hmis_forms.any?
+    %table.table
+      %thead
+        %tr
+          %th Assessment Type
+          %th Collection Date
+          %th Location
+          %th Staff
+          %th.zero-width
+      %tbody
+        - any_buttons = hmis_forms.values.any?(&:many?)
+        - hmis_forms.each_with_index do |(type, (form, *rest)), i|
+          - cz = "assessment_type_#{i}"
+          %tr{ class: ( 'assessment__new-type' if any_buttons )}
+            %td= form.assessment_type
+            %td= form.collected_at.to_date
+            %td= GrdaWarehouse::Hud::Project.confidentialize_by_name_only(name: form.collection_location)
+            %td= form.staff
+            %td.zero-width
+              - if rest.any?
+                %a.btn.btn-secondary.btn-xs.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
+                  %span.icon-plus
+          - rest.each do |form|
+            %tr{ class: cz, style: 'display:none;' }
+              %td= form.assessment_type
+              %td= form.collected_at.to_date
+              %td= GrdaWarehouse::Hud::Project.confidentialize_by_name_only(name: form.collection_location)
+              %td= form.staff
+  - if ce_assessments.any?
+    %table.table
+      %thead
+        %tr
+          %th Assessment Type
+          %th Collection Date
+          %th Staff
+          %th
+      %tbody
+        - ce_assessments.group_by(&:name).each_with_index do |(name, (assessment, *assessments)), i|
+          - any_buttons = assessments.any?
+          - cz = "assessment_type_#{i}"
+          %tr{ class: ( 'assessment__new-type' if any_buttons )}
+            %td= link_to_if assessment.pathways_or_transfer?, name, client_coordinated_entry_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+            %td= assessment.AssessmentDate
+            %td= assessment.user&.name
+            %td.zero-width
+              - if any_buttons
+                %a.btn.btn-secondary.btn-xs.btn-icon-only.jAssessmentTypeToggle{ href: '#', data: { class: cz } }
+                  %span.icon-plus
+          - assessments.each do |assessment|
+            %tr{ class: cz, style: 'display:none;' }
+              %td= link_to_if assessment.pathways_or_transfer?, name, client_coordinated_entry_hud_assessment_path(@client, assessment), class: 'btn btn-primary btn-muted btn-xs', data: { loads_in_pjax_modal: true }
+              %td= assessment.AssessmentDate
+              %td= assessment.user&.name
+- else
+  .no-data
+    No assessments on file

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -469,6 +469,7 @@ Rails.application.routes.draw do
       # get :enrollment_details
     end
     resources :hud_assessments, only: [:show], controller: 'clients/hud_assessments'
+    resources :coordinated_entry_hud_assessments, only: [:show], controller: 'clients/coordinated_entry_hud_assessments'
     # resource :history, only: [:show], controller: 'clients/history' do
     #   get :pdf, on: :collection
     #   post :queue, on: :collection

--- a/docs/features/warehouse/client-dashboards.md
+++ b/docs/features/warehouse/client-dashboards.md
@@ -1,0 +1,78 @@
+# Client Dashboards
+
+The client dashboard is the page rendered at `/clients/:id` — the summary view a user sees for an individual client. Which sections appear is controlled by two independent settings: an **installation-level layout** (which visual "brand" of dashboard to use) and a **per-role detail level** (whether a given user sees the full dashboard or a reduced one).
+
+## Two Independent Axes
+
+| Axis | Controlled by | Values |
+|---|---|---|
+| Layout / brand | `GrdaWarehouse::Config` app setting `client_dashboard` | `default`, `boston`, `va` |
+| Detail level | Role permission flags | `can_view_full_client_dashboard`, `can_view_limited_client_dashboard` |
+
+The app renders the appropriate client dashboard based on the combination of layout and detail-level.  **NOTE: The VA layout does not make a distinction between limited and full client dashboard.**
+
+```mermaid
+flowchart TD
+  Show["clients#show"] --> Layout{"Config.get(:client_dashboard)"}
+  Layout -->|default| Default["_default.haml"]
+  Layout -->|boston| Boston["_boston.haml"]
+  Layout -->|va| Va["_va.haml"]
+  Default --> Perm{"user permission"}
+  Boston --> Perm
+  Perm -->|can_view_full_client_dashboard| Full["_rollups.haml"]
+  Perm -->|can_view_limited_client_dashboard| Limited["_rollups_limited.haml"]
+  Va --> VaRollups["va/_rollups.haml (always full)"]
+```
+
+## Layout Selection (Config)
+
+`GrdaWarehouse::Config.get(:client_dashboard)` returns a symbol (`:default`, `:boston`, or `:va`), set via the **Client Display** section of the admin config UI (`app/views/admin/configs/_client_display.haml`) and enumerated in `GrdaWarehouse::Config.available_client_dashboards` (`app/models/grda_warehouse/config.rb`).
+
+`ClientAccessControl::Clients#show` (`drivers/client_access_control/app/views/client_access_control/clients/show.haml`) renders that value directly as a partial name:
+
+```haml
+= render GrdaWarehouse::Config.get(:client_dashboard).to_s
+```
+
+Adding a new brand means adding a new value to `available_client_dashboards` and a matching top-level partial in `drivers/client_access_control/app/views/client_access_control/clients/`.
+
+## Detail Level Selection (Role Permissions)
+
+Each of the `default` and `boston` brand partials makes the same choice:
+
+```haml
+- if can_view_full_client_dashboard?
+  = render 'client_access_control/clients/rollups'
+- elsif can_view_limited_client_dashboard?
+  = render 'client_access_control/clients/rollups_limited'
+```
+
+(the `boston` brand renders `boston/rollups` / `boston/rollups_limited` instead).
+
+`can_view_full_client_dashboard` and `can_view_limited_client_dashboard` are Role permission flags defined in `Role.permissions_with_descriptions` (`app/models/role.rb`), both tagged `single_choice_category: 'client_dashboard'`. That tag makes them mutually exclusive in the role-editing UI — a role grants one or the other, never both. A user's effective permission is the union across all their roles, so it's still possible (through multiple roles) for a user to hold both, in which case the full dashboard wins.
+
+`can_view_some_client_dashboard?` (`UserPermissions` concern) is `can_view_full_client_dashboard? || can_view_limited_client_dashboard?` and gates access to the dashboard at all — enforced by `require_can_view_some_client_dashboard!` on `show`, `service_range`, `rollup`, and `image` in both `ClientsController` and `ClientAccessControl::ClientsController`.
+
+**The `va` brand does not check permissions at all** — `_va.haml` always renders `va/_rollups.haml` regardless of full/limited permission. There is no `va/_rollups_limited.haml`. Any installation using the `va` layout must still grant `can_view_full_client_dashboard` or `can_view_limited_client_dashboard` (to pass the `require_can_view_some_client_dashboard!` gate) but the content shown is the same either way.
+
+## Rollup Sections Are Lazy-Loaded
+
+Within either variant, each section is a placeholder div/article with a `data-partial` attribute:
+
+```haml
+.rollup{data: {partial: :demographics}}
+  %h3 Demographics
+```
+
+`ClientShowPages#rollup` (`app/controllers/concerns/client_show_pages.rb`, included by both `ClientsController` and `ClientAccessControl::ClientsController`) serves these via AJAX at `GET /clients/:id/rollup/:partial`. The action checks `partial` against a hardcoded allowlist of `/clients/rollup/*` partial paths before rendering — this prevents arbitrary partial rendering from user input. Adding a new rollup section requires adding its partial path to the allowlist in that concern, in addition to creating the partial itself under `app/views/clients/rollup/`.
+
+## Where Things Live
+
+| Concern | Location |
+|---|---|
+| Config value + admin UI | `app/models/grda_warehouse/config.rb`, `app/views/admin/configs/_client_display.haml` |
+| Brand partials (`_default`, `_boston`, `_va`) | `drivers/client_access_control/app/views/client_access_control/clients/` |
+| Full/limited rollup partials | `.../clients/_rollups.haml`, `.../clients/_rollups_limited.haml` (and `boston/`, `va/` subdirs) |
+| Permission flags | `app/models/role.rb` (`can_view_full_client_dashboard`, `can_view_limited_client_dashboard`) |
+| Combined permission + controller gate | `app/models/concerns/user_permissions.rb`, `ClientShowPages` / `ClientAccessControl::ClientsController` |
+| Individual rollup partial allowlist + AJAX endpoint | `app/controllers/concerns/client_show_pages.rb` |

--- a/drivers/client_access_control/app/views/client_access_control/clients/_boston.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/_boston.haml
@@ -1,0 +1,7 @@
+- if can_access_some_version_of_clients? && ! GrdaWarehouse::Config.get(:multi_coc_installation)
+  %section.o-dashboard__block--primary.client__summary
+    = render 'client_access_control/clients/boston/client_summary'
+- if can_view_full_client_dashboard?
+  = render 'client_access_control/clients/boston/rollups'
+- elsif can_view_limited_client_dashboard?
+  = render 'client_access_control/clients/boston/rollups_limited'

--- a/drivers/client_access_control/app/views/client_access_control/clients/boston/_client_summary.html.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/boston/_client_summary.html.haml
@@ -1,0 +1,34 @@
+.client__main-details
+  - if @client.pii_provider(user: current_user).image?
+    .client__image{ style: "background-image: url(#{ image_client_path })" }
+  %section.o-section-card.mb-0
+    .c-card.c-card--block.c-card--padded.c-card--flush.mb-4
+      = render 'clients/service_summary'
+
+    .d-flex.align-items-start.flex-wrap
+      - unless GrdaWarehouse::Config.get(:cas_calculator) == 'GrdaWarehouse::CasProjectClientCalculator::TcHat'
+        .client-consent-status.d-none--empty.mb-3.mr-8<
+          = render 'clients/consent_form_flags'
+      .mr-8.mb-3.d-none--empty<
+        = render 'clients/chronic_flags', client: @client
+        - if can_view_clients? || @client.consent_form_valid?
+          = render 'clients/cas_housed'
+
+      .d-none--empty.mr-8.mb-6<
+        = render 'clients/vispdat'
+
+      .d-none--empty.mr-8.mb-6<
+        = render 'clients/pathways'
+
+      .d-none--empty.mb-6<
+        = render 'clients/rollup/cohorts'
+        - if can_view_clients?
+          = render 'clients/cas_matches'
+
+      .d-none--empty.mb-6.w-100<
+        = render 'clients/required_documents'
+
+      - if RailsDrivers.loaded.include?(:service_scanning) && GrdaWarehouse::Config.get(:service_register_visible)
+        .d-none--empty.mb-6.w-100<
+          - if can_view_clients? && can_view_service_register_on_client?
+            = render 'service_scanning/scanner_ids/clients/register'

--- a/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups.haml
@@ -1,0 +1,62 @@
+%section.row.o-dashboard__block--primary
+  .col-sm-12
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :demographics}}
+      %header
+        %h1.h3 Demographics
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :residential_enrollments}}
+      %header
+        %h1.h3 Residential Enrollments
+        - if can_view_cached_client_enrollments?
+          .ml-2
+            = link_to enrollment_history_index_path(@client) do
+              %i.icon-settings_backup_restore
+        .c-color-key.ml-auto
+          %span.c-color-key__swatch.enrollment__new-episode--key
+          %span.c-color-key__title New Episode
+
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :other_enrollments}}
+      %header
+        %h1.h3 Other Enrollments
+    - if HmisEnforcement.hmis_enabled? || GrdaWarehouse::Config.get(:eto_api_available) || RailsDrivers.loaded.include?(:eccovia_data) && @client.source_eccovia_case_managers.exists? || @client.source_assessments.pathways_or_rrh.exists?
+      %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :assessments}}
+        %header
+          %h1.h3 Assessments
+      - if @client.disability_verification_sources.exists?
+        %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :verifications}}
+          %header
+            %h1.h3 Verification TouchPoints
+
+%section.row.o-dashboard__block--primary
+  .col-sm-6
+    - if GrdaWarehouse::Config.get(:eto_api_available) || HmisEnforcement.hmis_enabled? || RailsDrivers.loaded.include?(:eccovia_data) && @client.source_eccovia_case_managers.exists?
+      %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :contact_information}}
+        %header
+          %h1.h3 Contact Information
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :services}}
+      %header.d-flex
+        %h1.h3
+          Services &mdash; Aggregated Bed Register
+        .ml-auto.text-small
+          = link_to 'details', enrollment_details_client_path(@client, anchor: 'full_services')
+    - if RailsDrivers.loaded.include?(:custom_imports_boston_service) && @client.source_custom_b_services.client_services.exists?
+      %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: :boston_custom_services}}
+        %header
+          %h1.h3 Custom Services
+  .col-sm-6
+    - if GrdaWarehouse::Config.get(:eto_api_available) || RailsDrivers.loaded.include?(:eccovia_data) && @client.source_eccovia_case_managers.exists?
+      %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: 'case_manager'}}
+        %header
+          %h1.h3 Case Manager
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: 'zip-map'}}
+      %header
+        %h1.h3 Zip Code of Last Permanent Address
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: 'zip-details'}}
+      %header
+        %h1.h3 Zip Details
+
+%section.row.o-dashboard__block--primary
+  .col-sm-12
+    %article.rollup.o-dashboard__block.o-dashboard__block--secondary{data: {partial: 'disability-types'}}
+      %header.d-flex
+        %h1.h3 Disability Types
+        %i.icon-info.ml-2{data: { 'bs-toggle' => :tooltip, 'bs-title' => 'Please note, that when determining if a client has a disabling condition, the most recent enrollment Disabling Condition will take precedence over "No" responses for any of the individual disability categories.  In addition, the following data is ordered by Entry Date and then Information Date, but the calculation will rely on the most-recent Information Date.'}}

--- a/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups_limited.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups_limited.haml
@@ -1,0 +1,40 @@
+- consent_signed = @client.signed_consent_form_fully?
+:css
+  .rollup {
+    margin: 1em 0 1em 0;
+  }
+
+.row
+  .col-sm-12
+    .rollup{data: {partial: :demographics}}
+      %h3 Demographics
+.row
+  - if GrdaWarehouse::Config.get(:eto_api_available)
+    .col-sm-6
+      .rollup{data: {partial: :contact_information}}
+        %h3 Contact Information
+  .col-sm-6
+    .client__current-enrollments.mt-4
+      %h3 Current Program Enrollments
+      = render 'clients/ongoing_enrollments_limited'
+    .client__recent-es-so.mt-6
+      %h3 Recent Unsheltered Contacts
+      = render 'clients/recent_es_so', client: @client
+- if GrdaWarehouse::Config.get(:eto_api_available)
+  .row
+    .col-sm-6
+      .rollup{data: {partial: 'case_manager'}}
+        %h3 Case Manager
+.row
+  .col-sm-12
+    - if GrdaWarehouse::Config.get(:eto_api_available)
+      .rollup{data: {partial: :assessments_without_data}}
+        %h3 Assessments
+    .rollup{data: {partial: :residential_enrollments}}
+      %h3 Residential Enrollments
+    .rollup{data: {partial: :other_enrollments}}
+      %h3 Other Enrollments
+.row
+  .col-sm-6
+    .rollup{data: {partial: 'services_full'}}
+      %h3 Services &mdash; Full Bed Register

--- a/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups_limited.haml
+++ b/drivers/client_access_control/app/views/client_access_control/clients/boston/_rollups_limited.haml
@@ -28,7 +28,7 @@
 .row
   .col-sm-12
     - if GrdaWarehouse::Config.get(:eto_api_available)
-      .rollup{data: {partial: :assessments_without_data}}
+      .rollup{data: {partial: :boston_assessments_with_limited_data}}
         %h3 Assessments
     .rollup{data: {partial: :residential_enrollments}}
       %h3 Residential Enrollments

--- a/drivers/client_access_control/spec/requests/clients_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_spec.rb
@@ -721,5 +721,55 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
         expect(response).to have_http_status(403)
       end
     end
+
+    context 'client_dashboard config variants' do
+      variants = {
+        default: {
+          dispatcher: 'client_access_control/clients/_default',
+          full_rollup: 'client_access_control/clients/_rollups',
+          limited_rollup: 'client_access_control/clients/_rollups_limited',
+        },
+        va: {
+          dispatcher: 'client_access_control/clients/_va',
+          full_rollup: 'client_access_control/clients/va/_rollups',
+          limited_rollup: 'client_access_control/clients/va/_rollups',
+        },
+        boston: {
+          dispatcher: 'client_access_control/clients/_boston',
+          full_rollup: 'client_access_control/clients/boston/_rollups',
+          limited_rollup: 'client_access_control/clients/boston/_rollups_limited',
+        },
+      }
+
+      variants.each do |variant, templates|
+        context "when client_dashboard config is #{variant}" do
+          before { config.update(client_dashboard: variant) }
+
+          it 'renders the full rollups partial for a user with full dashboard permission' do
+            setup_access_control(user, can_view_clients, Collection.system_collection(:window_data_sources))
+            setup_access_control(user, can_search_own_clients, Collection.system_collection(:window_data_sources))
+            setup_access_control(user, can_view_full_client_dashboard, Collection.system_collection(:window_data_sources))
+            sign_in user
+
+            get client_path(window_destination_client)
+
+            expect(response).to render_template(templates[:dispatcher])
+            expect(response).to render_template(templates[:full_rollup])
+          end
+
+          it 'renders the limited rollups partial for a user with limited dashboard permission' do
+            setup_access_control(user, can_view_clients, Collection.system_collection(:window_data_sources))
+            setup_access_control(user, can_search_own_clients, Collection.system_collection(:window_data_sources))
+            setup_access_control(user, can_view_limited_client_dashboard, Collection.system_collection(:window_data_sources))
+            sign_in user
+
+            get client_path(window_destination_client)
+
+            expect(response).to render_template(templates[:dispatcher])
+            expect(response).to render_template(templates[:limited_rollup])
+          end
+        end
+      end
+    end
   end
 end

--- a/drivers/client_access_control/spec/requests/clients_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_spec.rb
@@ -773,8 +773,6 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
     end
 
     context 'boston assessments_with_limited_data rollup' do
-      # NOTE: the shared context's `can_view_clients` role bakes in `can_view_limited_client_dashboard: true`,
-      # so these roles are self-contained rather than layered on top of it, to keep full-vs-limited meaningful.
       let!(:limited_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: false, can_view_limited_client_dashboard: true }
       let!(:full_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: true, can_view_limited_client_dashboard: false }
 

--- a/drivers/client_access_control/spec/requests/clients_spec.rb
+++ b/drivers/client_access_control/spec/requests/clients_spec.rb
@@ -771,5 +771,91 @@ RSpec.describe ClientAccessControl::ClientsController, type: :request do
         end
       end
     end
+
+    context 'boston assessments_with_limited_data rollup' do
+      # NOTE: the shared context's `can_view_clients` role bakes in `can_view_limited_client_dashboard: true`,
+      # so these roles are self-contained rather than layered on top of it, to keep full-vs-limited meaningful.
+      let!(:limited_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: false, can_view_limited_client_dashboard: true }
+      let!(:full_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: true, can_view_limited_client_dashboard: false }
+
+      def build_pathways_assessment(date: Date.current)
+        assessment = create(:hud_assessment, data_source_id: window_visible_data_source.id, PersonalID: window_source_client.PersonalID, EnrollmentID: window_enrollment.EnrollmentID, AssessmentDate: date)
+        GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: assessment.AssessmentID.to_s, response_text: 'Pathways 2024')
+        create(
+          :hud_assessment_question,
+          data_source_id: window_visible_data_source.id,
+          AssessmentID: assessment.AssessmentID,
+          AssessmentQuestion: 'c_housing_assessment_name',
+          AssessmentAnswer: assessment.AssessmentID.to_s,
+        )
+        assessment
+      end
+
+      let!(:pathways_assessment) { build_pathways_assessment }
+      let!(:non_qualifying_assessment) do
+        create(:hud_assessment, data_source_id: window_visible_data_source.id, PersonalID: window_source_client.PersonalID, EnrollmentID: window_enrollment.EnrollmentID, AssessmentLevel: 2)
+      end
+
+      it 'shows a link to the pathways assessment when config is boston and the user has limited dashboard permission' do
+        config.update(client_dashboard: :boston)
+        setup_access_control(user, limited_dashboard_role, Collection.system_collection(:window_data_sources))
+        sign_in user
+
+        get rollup_client_path(window_destination_client, partial: :boston_assessments_with_limited_data)
+
+        expect(response.body).to include(client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment))
+      end
+
+      it 'shows a row for a non-qualifying assessment without a link to it, alongside the linked pathways assessment' do
+        config.update(client_dashboard: :boston)
+        setup_access_control(user, limited_dashboard_role, Collection.system_collection(:window_data_sources))
+        sign_in user
+
+        get rollup_client_path(window_destination_client, partial: :boston_assessments_with_limited_data)
+
+        expect(response.body).to include(client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment))
+        expect(response.body).to include(non_qualifying_assessment.name)
+        expect(response.body).not_to include(client_coordinated_entry_hud_assessment_path(window_destination_client, non_qualifying_assessment))
+      end
+
+      it 'collapses multiple assessments of the same type, showing the newest by default with a toggle to expand' do
+        older_pathways_assessment = build_pathways_assessment(date: 6.months.ago.to_date)
+        config.update(client_dashboard: :boston)
+        setup_access_control(user, limited_dashboard_role, Collection.system_collection(:window_data_sources))
+        sign_in user
+
+        get rollup_client_path(window_destination_client, partial: :boston_assessments_with_limited_data)
+
+        doc = Nokogiri::HTML(response.body)
+        newer_link = doc.at_css("a[href='#{client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment)}']")
+        older_link = doc.at_css("a[href='#{client_coordinated_entry_hud_assessment_path(window_destination_client, older_pathways_assessment)}']")
+
+        expect(newer_link).to be_present
+        expect(older_link).to be_present
+        expect(newer_link.ancestors('tr').first[:style]).to be_nil
+        expect(older_link.ancestors('tr').first[:style]).to match(/display:\s*none/)
+        expect(doc.css('.jAssessmentTypeToggle')).to be_present
+      end
+
+      it 'does not show a link when config is default, even with limited dashboard permission' do
+        config.update(client_dashboard: :default)
+        setup_access_control(user, limited_dashboard_role, Collection.system_collection(:window_data_sources))
+        sign_in user
+
+        get rollup_client_path(window_destination_client, partial: :boston_assessments_with_limited_data)
+
+        expect(response.body).not_to include(client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment))
+      end
+
+      it 'does not show a link when config is boston but the user has full (not limited) dashboard permission' do
+        config.update(client_dashboard: :boston)
+        setup_access_control(user, full_dashboard_role, Collection.system_collection(:window_data_sources))
+        sign_in user
+
+        get rollup_client_path(window_destination_client, partial: :boston_assessments_with_limited_data)
+
+        expect(response.body).not_to include(client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment))
+      end
+    end
   end
 end

--- a/spec/models/grda_warehouse/hud/assessment_question_spec.rb
+++ b/spec/models/grda_warehouse/hud/assessment_question_spec.rb
@@ -1,0 +1,36 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Hud::AssessmentQuestion, type: :model do
+  let!(:data_source) { create :source_data_source }
+
+  describe '#transfer?' do
+    it 'is true when the housing assessment name answer is a transfer title' do
+      GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: 'transfer', response_text: 'RRH Transfer 2024')
+      question = create(:hud_assessment_question, data_source_id: data_source.id, AssessmentQuestion: 'c_housing_assessment_name', AssessmentAnswer: 'transfer')
+
+      expect(question.transfer?).to eq(true)
+    end
+
+    it 'is false when the housing assessment name answer is a pathways title, not a transfer title' do
+      GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: 'pathways', response_text: 'Pathways 2024')
+      question = create(:hud_assessment_question, data_source_id: data_source.id, AssessmentQuestion: 'c_housing_assessment_name', AssessmentAnswer: 'pathways')
+
+      expect(question.transfer?).to eq(false)
+    end
+
+    it 'is false when the question is not c_housing_assessment_name, even with a transfer-title answer' do
+      GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'some_other_question', response_code: 'transfer', response_text: 'RRH Transfer 2024')
+      question = create(:hud_assessment_question, data_source_id: data_source.id, AssessmentQuestion: 'some_other_question', AssessmentAnswer: 'transfer')
+
+      expect(question.transfer?).to eq(false)
+    end
+  end
+end

--- a/spec/models/grda_warehouse/hud/assessment_spec.rb
+++ b/spec/models/grda_warehouse/hud/assessment_spec.rb
@@ -1,0 +1,78 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Hud::Assessment, type: :model do
+  let!(:data_source) { create :source_data_source }
+
+  def add_housing_assessment_name_answer(assessment, response_code:, response_text:)
+    GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: response_code, response_text: response_text)
+    create(
+      :hud_assessment_question,
+      data_source_id: data_source.id,
+      AssessmentID: assessment.AssessmentID,
+      AssessmentQuestion: 'c_housing_assessment_name',
+      AssessmentAnswer: response_code,
+    )
+  end
+
+  describe '#transfer?' do
+    it 'is true when an assessment_question answer is a transfer title' do
+      assessment = create(:hud_assessment, data_source_id: data_source.id)
+      add_housing_assessment_name_answer(assessment, response_code: 'a', response_text: 'RRH-PSH Transfer')
+
+      expect(assessment.transfer?).to eq(true)
+    end
+
+    it 'is false when no assessment_question answer is a transfer title' do
+      assessment = create(:hud_assessment, data_source_id: data_source.id)
+      create(:hud_assessment_question, data_source_id: data_source.id, AssessmentID: assessment.AssessmentID, AssessmentQuestion: 'some_other_question', AssessmentAnswer: 'whatever')
+
+      expect(assessment.transfer?).to eq(false)
+    end
+  end
+
+  describe '#pathways_or_transfer?' do
+    it 'is true for a pathways assessment' do
+      assessment = create(:hud_assessment, data_source_id: data_source.id)
+      add_housing_assessment_name_answer(assessment, response_code: 'b', response_text: 'Pathways 2024')
+
+      expect(assessment.pathways_or_transfer?).to eq(true)
+    end
+
+    it 'is true for a transfer assessment' do
+      assessment = create(:hud_assessment, data_source_id: data_source.id)
+      add_housing_assessment_name_answer(assessment, response_code: 'c', response_text: 'RRH Transfer 2024')
+
+      expect(assessment.pathways_or_transfer?).to eq(true)
+    end
+
+    it 'is false for an assessment that is neither pathways nor transfer' do
+      assessment = create(:hud_assessment, data_source_id: data_source.id)
+      create(:hud_assessment_question, data_source_id: data_source.id, AssessmentID: assessment.AssessmentID, AssessmentQuestion: 'some_other_question', AssessmentAnswer: 'whatever')
+
+      expect(assessment.pathways_or_transfer?).to eq(false)
+    end
+  end
+
+  describe '.pathways_or_transfer' do
+    it 'includes pathways and transfer assessments, and excludes other assessments' do
+      pathways_assessment = create(:hud_assessment, data_source_id: data_source.id)
+      add_housing_assessment_name_answer(pathways_assessment, response_code: 'd', response_text: 'Pathways')
+
+      transfer_assessment = create(:hud_assessment, data_source_id: data_source.id)
+      add_housing_assessment_name_answer(transfer_assessment, response_code: 'e', response_text: 'RRH-PSH Transfer 2024')
+
+      other_assessment = create(:hud_assessment, data_source_id: data_source.id)
+      create(:hud_assessment_question, data_source_id: data_source.id, AssessmentID: other_assessment.AssessmentID, AssessmentQuestion: 'some_other_question', AssessmentAnswer: 'whatever')
+
+      expect(GrdaWarehouse::Hud::Assessment.pathways_or_transfer).to contain_exactly(pathways_assessment, transfer_assessment)
+    end
+  end
+end

--- a/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
+++ b/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
@@ -1,0 +1,95 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared_contexts/visibility_test_context'
+
+RSpec.describe Clients::CoordinatedEntryHudAssessmentsController, type: :request do
+  include_context 'visibility test context'
+
+  let!(:config) { create :config_b }
+  let!(:user) { create :acl_user }
+  # NOTE: the shared context's `can_view_clients` role bakes in `can_view_limited_client_dashboard: true`
+  # (see visibility_test_context.rb), so these roles are self-contained rather than layered on top of it,
+  # to keep the full-vs-limited distinction meaningful in this spec.
+  let!(:full_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: true, can_view_limited_client_dashboard: false }
+  let!(:limited_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: false, can_view_limited_client_dashboard: true }
+
+  before { Collection.maintain_system_groups }
+
+  def build_assessment(response_text:)
+    assessment = create(:hud_assessment, data_source_id: window_visible_data_source.id, PersonalID: window_source_client.PersonalID, EnrollmentID: window_enrollment.EnrollmentID)
+    GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: assessment.AssessmentID.to_s, response_text: response_text)
+    create(
+      :hud_assessment_question,
+      data_source_id: window_visible_data_source.id,
+      AssessmentID: assessment.AssessmentID,
+      AssessmentQuestion: 'c_housing_assessment_name',
+      AssessmentAnswer: assessment.AssessmentID.to_s,
+    )
+    assessment
+  end
+
+  let!(:pathways_assessment) { build_assessment(response_text: 'Pathways 2024') }
+  let!(:non_qualifying_assessment) { build_assessment(response_text: 'Some Other Assessment') }
+
+  def sign_in_with(role)
+    setup_access_control(user, role, Collection.system_collection(:window_data_sources))
+    sign_in user
+  end
+
+  context 'when client_dashboard config is boston and the user has limited dashboard permission' do
+    before do
+      config.update(client_dashboard: :boston)
+      sign_in_with(limited_dashboard_role)
+    end
+
+    it 'allows access to a pathways assessment' do
+      get client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment)
+      expect(response).to render_template(:show)
+    end
+
+    it 'logs the client access' do
+      # ActivityLogger#compose_activity sets item_id from params[:id] (the assessment) before the action
+      # runs; #log_item's `||=` guard means it only fills in item_model, not item_id, once that's already set.
+      expect { get client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment) }.
+        to change {
+          ActivityLog.where(user_id: user.id, item_model: 'GrdaWarehouse::Hud::Client', item_id: pathways_assessment.id).count
+        }.by(1)
+    end
+
+    it 'blocks access to a non-qualifying assessment' do
+      get client_coordinated_entry_hud_assessment_path(window_destination_client, non_qualifying_assessment)
+      expect(response).to redirect_to(user.my_root_path)
+    end
+  end
+
+  context 'when client_dashboard config is boston but the user has full (not limited) dashboard permission' do
+    before do
+      config.update(client_dashboard: :boston)
+      sign_in_with(full_dashboard_role)
+    end
+
+    it 'blocks access to a pathways assessment' do
+      get client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment)
+      expect(response).to redirect_to(user.my_root_path)
+    end
+  end
+
+  context 'when client_dashboard config is default and the user has limited dashboard permission' do
+    before do
+      config.update(client_dashboard: :default)
+      sign_in_with(limited_dashboard_role)
+    end
+
+    it 'blocks access to a pathways assessment' do
+      get client_coordinated_entry_hud_assessment_path(window_destination_client, pathways_assessment)
+      expect(response).to redirect_to(user.my_root_path)
+    end
+  end
+end

--- a/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
+++ b/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Clients::CoordinatedEntryHudAssessmentsController, type: :request
 
   before { Collection.maintain_system_groups }
 
-  def build_assessment(response_text:)
-    assessment = create(:hud_assessment, data_source_id: window_visible_data_source.id, PersonalID: window_source_client.PersonalID, EnrollmentID: window_enrollment.EnrollmentID)
+  def build_assessment(response_text:, data_source_id: window_visible_data_source.id, personal_id: window_source_client.PersonalID, enrollment_id: window_enrollment.EnrollmentID)
+    assessment = create(:hud_assessment, data_source_id: data_source_id, PersonalID: personal_id, EnrollmentID: enrollment_id)
     GrdaWarehouse::AssessmentAnswerLookup.create!(assessment_question: 'c_housing_assessment_name', response_code: assessment.AssessmentID.to_s, response_text: response_text)
     create(
       :hud_assessment_question,
-      data_source_id: window_visible_data_source.id,
+      data_source_id: data_source_id,
       AssessmentID: assessment.AssessmentID,
       AssessmentQuestion: 'c_housing_assessment_name',
       AssessmentAnswer: assessment.AssessmentID.to_s,
@@ -63,6 +63,19 @@ RSpec.describe Clients::CoordinatedEntryHudAssessmentsController, type: :request
     it 'blocks access to a non-qualifying assessment' do
       get client_coordinated_entry_hud_assessment_path(window_destination_client, non_qualifying_assessment)
       expect(response).to redirect_to(user.my_root_path)
+    end
+
+    it 'blocks access to a qualifying assessment that belongs to a different client' do
+      other_clients_pathways_assessment = build_assessment(
+        response_text: 'Pathways 2024',
+        data_source_id: non_window_visible_data_source.id,
+        personal_id: non_window_source_client.PersonalID,
+        enrollment_id: non_window_enrollment.EnrollmentID,
+      )
+
+      get client_coordinated_entry_hud_assessment_path(window_destination_client, other_clients_pathways_assessment)
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
+++ b/spec/requests/clients/coordinated_entry_hud_assessments_controller_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe Clients::CoordinatedEntryHudAssessmentsController, type: :request
 
   let!(:config) { create :config_b }
   let!(:user) { create :acl_user }
-  # NOTE: the shared context's `can_view_clients` role bakes in `can_view_limited_client_dashboard: true`
-  # (see visibility_test_context.rb), so these roles are self-contained rather than layered on top of it,
-  # to keep the full-vs-limited distinction meaningful in this spec.
   let!(:full_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: true, can_view_limited_client_dashboard: false }
   let!(:limited_dashboard_role) { create :role, can_view_clients: true, can_view_client_name: true, can_search_own_clients: true, can_view_full_client_dashboard: false, can_view_limited_client_dashboard: true }
 

--- a/spec/requests/clients/hud_assessments_controller_spec.rb
+++ b/spec/requests/clients/hud_assessments_controller_spec.rb
@@ -1,0 +1,44 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Clients::HudAssessmentsController, type: :request do
+  let!(:user) { create :acl_user }
+  let!(:can_view_enrollment_details) { create :role, can_view_enrollment_details: true, can_view_client_name: true, can_search_own_clients: true }
+  let!(:warehouse_client) { create :authoritative_warehouse_client }
+  let!(:client) { warehouse_client.destination }
+  let!(:source_client) { warehouse_client.source }
+  let!(:project) { create(:hud_project, data_source_id: source_client.data_source_id) }
+  let!(:enrollment) { create(:hud_enrollment, data_source_id: source_client.data_source_id, PersonalID: source_client.PersonalID, ProjectID: project.ProjectID) }
+  let!(:assessment) { create(:hud_assessment, data_source_id: source_client.data_source_id, PersonalID: source_client.PersonalID, EnrollmentID: enrollment.EnrollmentID) }
+  let!(:no_data_source_collection) { create :collection }
+
+  before { no_data_source_collection.set_viewables({ data_sources: GrdaWarehouse::DataSource.authoritative.pluck(:id) }) }
+
+  context 'when the user has can_view_enrollment_details' do
+    before do
+      setup_access_control(user, can_view_enrollment_details, no_data_source_collection)
+      sign_in user
+    end
+
+    it 'renders the assessment details' do
+      get client_hud_assessment_path(client, assessment)
+      expect(response).to render_template(:show)
+    end
+  end
+
+  context 'when the user lacks can_view_enrollment_details' do
+    before { sign_in user }
+
+    it 'blocks access' do
+      get client_hud_assessment_path(client, assessment)
+      expect(response).to redirect_to(user.my_root_path)
+    end
+  end
+end

--- a/spec/requests/clients/hud_assessments_controller_spec.rb
+++ b/spec/requests/clients/hud_assessments_controller_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe Clients::HudAssessmentsController, type: :request do
       get client_hud_assessment_path(client, assessment)
       expect(response).to render_template(:show)
     end
+
+    it 'renders the specifically requested assessment when the client has more than one' do
+      assessment.update!(AssessmentDate: Date.new(2024, 6, 15))
+      other_assessment = create(:hud_assessment, data_source_id: source_client.data_source_id, PersonalID: source_client.PersonalID, EnrollmentID: enrollment.EnrollmentID, AssessmentDate: Date.new(2020, 1, 1))
+
+      get client_hud_assessment_path(client, other_assessment)
+      expect(response.body).to include(other_assessment.AssessmentDate.to_s)
+      expect(response.body).not_to include(assessment.AssessmentDate.to_s)
+
+      get client_hud_assessment_path(client, assessment)
+      expect(response.body).to include(assessment.AssessmentDate.to_s)
+      expect(response.body).not_to include(other_assessment.AssessmentDate.to_s)
+    end
   end
 
   context 'when the user lacks can_view_enrollment_details' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adds a new global client dashboard option (Boston)
* Duplicates default client dashboards into the new Boston-specific views
* Expands the Assessment section for Boston-specific client dashboards for limited-dashboard users to include CE assessments and allow drill-down for Pathways and Transfer assessments 

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

