### PR TITLE
8458 IdP JWT arm runs without Devise/Warden

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -704,7 +704,6 @@ Lint/RedundantRequireStatement:
 # AdditionalNilMethods: present?, blank?, try, try!
 Lint/RedundantSafeNavigation:
   Exclude:
-    - 'app/models/concerns/hud_reports/util.rb'
     - 'drivers/claims_reporting/app/models/claims_reporting/engagement_trends.rb'
 
 # Offense count: 1

--- a/Gemfile
+++ b/Gemfile
@@ -93,25 +93,30 @@ gem 'marcel'
 gem 'acts-as-taggable-on', '~> 13.0' # major bump for rails 8.1 (AR < 8.2); tagging behavior to verify manually (Release notes: https://github.com/mbleigh/acts-as-taggable-on/blob/master/CHANGELOG.md indicate no breaking changes)
 # gem 'seven_zip_ruby' unless ENV['NO_7ZIP'] == '1'
 
-gem 'devise', '~> 5.0'
-gem 'devise_invitable', '~> 2.0.9'
-gem 'devise-pwned_password'
-gem 'devise-security'
-gem 'devise-two-factor', '~> 6.4' # 6.x is rails-8-compatible; legacy otp secrets read via User#legacy_otp_secret
+# Bundler.require in config/application.rb takes this group only on the Devise arm, so a JWT-arm
+# reference to Devise or Warden raises at boot instead of resolving against a gem that loaded
+# anyway. A Devise-dependent gem added outside this group silences that signal.
+group :devise do
+  gem 'devise', '~> 5.0'
+  gem 'devise_invitable', '~> 2.0.9'
+  gem 'devise-pwned_password'
+  gem 'devise-security'
+  gem 'devise-two-factor', '~> 6.4' # 6.x is rails-8-compatible; legacy otp secrets read via User#legacy_otp_secret
+  gem 'doorkeeper'
+  gem 'omniauth', '~> 2.1'
+  gem 'omniauth-oauth2', '~> 1.7.3'
+  gem 'omniauth-rails_csrf_protection', '~> 2.0' # 2.x drops ActiveSupport::Configurable (deprecated in rails 8.1, removed 8.2)
+  gem 'pretender'
+  gem 'rqrcode'
+  gem 'authtrail' # for logging login attempts
+end
+
 gem 'rack-cors'
-gem 'doorkeeper'
 
 gem 'jwt', '~> 3.1' # Validates IdP-issued JWT access tokens
-gem 'omniauth', '~> 2.1'
-gem 'omniauth-oauth2', '~> 1.7.3'
-gem 'omniauth-rails_csrf_protection', '~> 2.0' # 2.x drops ActiveSupport::Configurable (deprecated in rails 8.1, removed 8.2)
 gem 'faraday', '~> 2.2'
 gem 'oauth2', '>= 2.0.22'
 
-gem 'pretender'
-gem 'rqrcode'
-
-gem 'authtrail' # for logging login attempts
 gem 'maxminddb' # for local geocoding of login attempts
 gem 'geocoder'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,8 +138,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # No AuthMethod guard needed: `devise_controller?` is false under JWT (no Devise controllers are
-  # routed), so this never fires there even though configure_permitted_parameters is Devise-only.
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def append_info_to_payload(payload)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -177,18 +177,19 @@ class ApplicationController < ActionController::Base
   protected
 
   def allowed_setup_controllers
-    controller_path.in?(
-      [
-        'users/sessions',
-        'accounts',
-        'account_two_factors',
-        'account_emails',
-        'account_passwords',
-        'user_training',
-        'compliance_agreements',
-        'content_pages',
-      ],
-    ) || controller_path == 'admin/users' && action_name == 'stop_impersonating'
+    portal_controllers = ['user_training', 'compliance_agreements', 'content_pages']
+
+    # Without the sessions controllers, a user held in the portal, which links to no other
+    # route, can never sign out.
+    account_controllers = if AuthMethod.jwt?
+      ['idp/sessions', 'idp/accounts', 'idp/account_emails']
+    else
+      ['users/sessions', 'accounts', 'account_two_factors', 'account_emails', 'account_passwords']
+    end
+
+    return true if controller_path.in?(portal_controllers + account_controllers)
+
+    controller_path == 'admin/users' && action_name == 'stop_impersonating'
   end
 
   def require_training!

--- a/app/controllers/concerns/devise_current_user.rb
+++ b/app/controllers/concerns/devise_current_user.rb
@@ -117,5 +117,11 @@ module DeviseCurrentUser
       Time.current + (Devise.timeout_in - (Time.now.utc - (session['last_request_at'].presence || 0)).to_i)
     end
     helper_method :user_session_expires_at
+
+    # The inactivity modal's JS rolls this forward on each request, so hand it the full timeout.
+    def inactive_session_countdown_values
+      { session_lifetime_secs_value: Devise.timeout_in.in_seconds }
+    end
+    helper_method :inactive_session_countdown_values
   end
 end

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -97,10 +97,10 @@ module Idp::JwtAuthentication
 
     connector_id = jwt_helper.connector_id
     connector_user_id = jwt_helper.connector_user_id
-    # Reached on the warehouse arm only; the HMIS arm walls off a token with no resolvable holder
-    # ahead of sign-out. connector_user_id is the claim this turns on: blank with a connector present
-    # would call logout_user_sessions(user_id: nil). A blank connector_id resolves to an
-    # Idp::NullService and would stop at the capability check below anyway.
+    # Reached from both arms: Hmis::Idp::SessionsController#destroy also skips authenticate_hmis_user!,
+    # so a claimless HMIS token reaches this guard — the only thing between it and
+    # logout_user_sessions(user_id: nil). connector_user_id is the claim it turns on; a blank
+    # connector_id resolves to an Idp::NullService and stops at the capability check below anyway.
     return if connector_id.blank? || connector_user_id.blank?
 
     service = idp_session_logout_service(connector_id)

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -13,9 +13,17 @@ module Idp::JwtCurrentUser
 
   included do
     def current_user
-      @current_user ||= idp_authenticated_user_from_jwt(user_class: User)
+      @current_user ||= idp_authenticated_user_from_jwt(user_class: User) || idp_background_render_user
     end
     helper_method :current_user
+
+    # Background renders carry no forwarded JWT: WardenProxyFactory hands the user's proxy to
+    # ActionController::Renderer as the 'warden' rack key. No Warden middleware runs on the JWT
+    # arm, so only those renderers can populate the key.
+    private def idp_background_render_user
+      proxy = request&.env&.dig('warden')
+      proxy.user(:user) if proxy.is_a?(Idp::WardenProxy)
+    end
 
     def warden
       @warden ||= Idp::WardenProxy.new(current_user, session: session)

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -56,6 +56,15 @@ module Idp::JwtCurrentUser
     end
     helper_method :user_signed_in?
 
+    # A duration the inactivity modal's JS anchors to the browser clock — never the absolute
+    # server-issued expiry, which server/browser clock skew would read as already expired.
+    def inactive_session_countdown_values
+      return {} unless current_user && (expires_at = user_session_expires_at)
+
+      { session_remaining_secs_value: (expires_at - Time.current).to_i }
+    end
+    helper_method :inactive_session_countdown_values
+
     # The actual authenticated user from the JWT, not the impersonated user.
     def true_user
       return nil unless current_user
@@ -108,6 +117,12 @@ module Idp::JwtCurrentUser
 
     def enforce_2fa!
       nil # no-op for jwt: L2/MFA assurance is gated upstream by the IdP, not the warehouse
+    end
+
+    # Devise (unloaded on this arm) is what defines devise_controller?; stub it false so the
+    # Devise-only before_action :configure_permitted_parameters no-ops instead of raising.
+    def devise_controller?
+      false
     end
   end
 end

--- a/app/controllers/user_training_controller.rb
+++ b/app/controllers/user_training_controller.rb
@@ -80,7 +80,7 @@ class UserTrainingController < ApplicationController
         # If the user has an active account in all configs and has no trainings left to complete, allow them to navigate the warehouse
         elsif account_exists_in_all_configs && course_redirects.blank?
           # All trainings are completed and the user has an account in all training configs
-          redirect_to after_sign_in_path_for(current_user)
+          redirect_to safe_landing(landing_after_training)
           return
         end
         # For all other cases, send the user to the captive portal
@@ -92,11 +92,23 @@ class UserTrainingController < ApplicationController
     end
   end
 
-  # Figure out where we are going after login
-  # stored_location_for is provided by Devise
-  # after_sign_in_path_for is provided by ApplicationController
   def safe_training_redirect_path
-    path = stored_location_for(:user).presence || after_sign_in_path_for(current_user)
+    safe_landing(stored_landing_after_training)
+  end
+
+  def landing_after_training
+    return fallback_redirect_path if AuthMethod.jwt?
+
+    after_sign_in_path_for(current_user)
+  end
+
+  def stored_landing_after_training
+    return fallback_redirect_path if AuthMethod.jwt?
+
+    stored_location_for(:user).presence || after_sign_in_path_for(current_user)
+  end
+
+  def safe_landing(path)
     return fallback_redirect_path if training_path?(path)
 
     path

--- a/app/javascript/controllers/inactive_session_modal_controller.js
+++ b/app/javascript/controllers/inactive_session_modal_controller.js
@@ -29,9 +29,11 @@ export default class extends Controller {
   connect() {
     this.initialUserIdValue = this.data.get('initial-user-id-value');
     this.sessionLifetimeSecsValue = parseInt(this.data.get('session-lifetime-secs-value'));
-    // Absolute token expiry in epoch seconds (JWT arm), not a duration; absent → NaN on Devise.
-    this.sessionExpiresAtValue = parseInt(this.data.get('session-expires-at-value'));
-    this.tokenExpiryDriven = !Number.isNaN(this.sessionExpiresAtValue);
+    // Anchor the forwarded token's remaining seconds to the browser clock, so the countdown never
+    // subtracts browser time from a server-issued instant. Absent on the Devise arm, which seeds a lifetime.
+    const remainingSecs = parseInt(this.data.get('session-remaining-secs-value'));
+    this.tokenExpiryDriven = !Number.isNaN(remainingSecs);
+    this.sessionExpiresAtValue = this.tokenExpiryDriven ? getTimestamp() + remainingSecs : NaN;
     shared.saveValue(UID_KEY, this.initialUserIdValue);
     if (!this.initialUserIdValue) {
       return;
@@ -75,8 +77,9 @@ export default class extends Controller {
     const ts = parseInt(shared.getValue(TS_KEY));
     if (ts) {
       const expires = this.tokenExpiryDriven ? this.sessionExpiresAtValue : ts + this.sessionLifetimeSecsValue;
-      const delta = expires - getTimestamp();
-      const remaining = delta > 0 ? delta : 0;
+      // JWT arm with a current_user but no token expiry: no seed to count down, so hold at
+      // not-expiring (a NaN countdown would otherwise render a false "session expired").
+      const remaining = Number.isFinite(expires) ? Math.max(expires - getTimestamp(), 0) : Number.MAX_VALUE;
       state.remaining = remaining;
       const timeout = remaining > 0 && remaining <= WARNING_WHEN_REMAINING_SECS ? 1000 : DEFAULT_POLL_SECS * 1000;
       this.mainLoopInterval = setTimeout(() => this.mainLoop(), timeout);
@@ -172,10 +175,9 @@ export default class extends Controller {
   }
 
   applyKeepaliveExpiry(data) {
-    if (!this.tokenExpiryDriven || !data) return;
-    const expiresAt = data.expiration_time || (data.remaining_seconds && getTimestamp() + data.remaining_seconds);
-    if (!expiresAt) return;
-    this.sessionExpiresAtValue = parseInt(expiresAt);
+    if (!this.tokenExpiryDriven || !data || !Number.isFinite(data.remaining_seconds)) return;
+    // Browser-clock basis, like connect(): the payload's absolute expiration_time would carry skew.
+    this.sessionExpiresAtValue = getTimestamp() + data.remaining_seconds;
     this.state.remaining = Number.MAX_VALUE;
   }
 }

--- a/app/jobs/background_render/cas_readiness_job.rb
+++ b/app/jobs/background_render/cas_readiness_job.rb
@@ -21,14 +21,7 @@ class BackgroundRender::CasReadinessJob < BackgroundRenderJob
       ).
       find(client_id.to_i)
 
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-      i.set_user(current_user, scope: :user, store: false, run_callbacks: false)
-    end
-
-    renderer = controller_class.renderer.new(
-      'warden' => warden_proxy,
-    )
+    renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(current_user))
     html = renderer.render(
       partial: 'render_content',
       assigns: {

--- a/app/models/concerns/hud_reports/hud_pdf_export_concern.rb
+++ b/app/models/concerns/hud_reports/hud_pdf_export_concern.rb
@@ -64,10 +64,7 @@ module HudReports::HudPdfExportConcern
         template_file = 'hud_reports/download'
         layout = 'layouts/hud_report_export'
 
-        ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-        renderer = controller_class.renderer.new(
-          'warden' => PdfGenerator.warden_proxy(user),
-        )
+        renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(user))
         html = renderer.render(
           template_file,
           layout: layout,

--- a/app/models/concerns/hud_reports/length_of_stays.rb
+++ b/app/models/concerns/hud_reports/length_of_stays.rb
@@ -66,6 +66,16 @@ module HudReports::LengthOfStays
       (nbn_ids + other_ids).uniq
     end
 
+    # Heads of households and adult stayers in the project 365 days or more, including any adult
+    # stayer whose head of household's stay is not longer than 365 days
+    private def hoh_and_adult_lts_stayer_clause
+      # Every adult and hoh members of a households whose head of household is a long-term stayer
+      members_of_lts_stayer_households = a_t[:head_of_household_id].in(hoh_lts_stayer_ids).
+        and(adult_or_hoh_clause)
+      # Plus adult stayers whose own stay is 365 days or more, even when their head of household's is not
+      members_of_lts_stayer_households.or(a_t[:id].in(adult_lts_stayer_ids))
+    end
+
     private def hoh_entry_dates
       @hoh_entry_dates ||= {}.tap do |entries|
         enrollment_scope.where(client_id: client_scope).heads_of_households.

--- a/app/models/concerns/hud_reports/util.rb
+++ b/app/models/concerns/hud_reports/util.rb
@@ -11,16 +11,19 @@ module HudReports::Util
   include ActionView::Helpers::NumberHelper
 
   included do
+    # Earlier enrollments for the same client in the same project where this project start date
+    # falls between the earlier project start date and the earlier project exit date. The spec does
+    # not mention what to do when the earlier enrollment has no exit date, so this mimics the DataLab
+    # implementation of the overlapping enrollments calculation by dropping enrollments with no exit date.
     private def overlapping_enrollments(enrollments, last_enrollment)
-      last_enrollment_end = last_enrollment.last_date_in_program || Date.tomorrow
       enrollments.select do |enrollment|
-        enrollment_end = enrollment.last_date_in_program || Date.tomorrow
+        next false if enrollment.id == last_enrollment.id
+        next false unless enrollment.data_source_id == last_enrollment.data_source_id
+        next false unless enrollment.project_id == last_enrollment.project_id
+        next false if enrollment.exit_date.blank?
 
-        enrollment.id != last_enrollment.id && # Don't include the last enrollment
-          enrollment.data_source_id == last_enrollment.data_source_id &&
-          enrollment.project_id == last_enrollment.project_id &&
-          enrollment.first_date_in_program < last_enrollment_end &&
-          enrollment_end > last_enrollment.first_date_in_program
+        enrollment.entry_date < last_enrollment.entry_date &&
+          last_enrollment.entry_date < enrollment.exit_date
       end.map(&:enrollment_group_id).uniq
     end
 
@@ -54,7 +57,7 @@ module HudReports::Util
     end
 
     private def percentage(value)
-      value = 0 if value.to_f&.nan?
+      value = 0 if value.to_f.nan?
 
       format('%1.4f', value.round(4))
     end

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -34,9 +34,13 @@ module UserConcern
 
     attr_accessor :remember_device, :device_name, :client_access_arbiter, :copy_form_id
 
-    # Doorkeeper
-    has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
-    has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+    # Doorkeeper. Gated because the gem is in the :devise Gemfile group, so Doorkeeper::AccessGrant
+    # is undefined under jwt; `dependent: :delete_all` would then raise on any User destroy, not
+    # just on a read of the association.
+    if AuthMethod.devise?
+      has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+      has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+    end
 
     # Connect users to login attempts.
     # Only includes Warehouse activity when called on User record, and only HMIS activity for Hmis::User record.

--- a/app/models/idp/warden_proxy.rb
+++ b/app/models/idp/warden_proxy.rb
@@ -17,6 +17,10 @@
 # every registered mapping, and :hmis_user remains a Devise mapping until seam 6. A raise
 # here would turn a routine "is the hmis_user signed in? no" probe into a 500.
 class Idp::WardenProxy
+  # Not Warden::NotAuthenticated: the :devise Gemfile group is required only on the Devise arm, so
+  # the Warden constant is undefined on the arm this proxy stands in for.
+  class NotAuthenticated < StandardError; end
+
   def initialize(user, session: nil)
     @user = user
     @session = session
@@ -56,7 +60,7 @@ class Idp::WardenProxy
   # gate: fail loudly rather than silently authorize. Dial back to returning nil if too aggressive.
   def authenticate!(*args)
     user = authenticate(*args)
-    raise Warden::NotAuthenticated, "Idp::WardenProxy#authenticate! got no authenticated user for scope #{_scope(args).inspect}" unless user
+    raise NotAuthenticated, "Idp::WardenProxy#authenticate! got no authenticated user for scope #{_scope(args).inspect}" unless user
 
     user
   end

--- a/app/models/pdf_generator.rb
+++ b/app/models/pdf_generator.rb
@@ -66,17 +66,8 @@ class PdfGenerator
     Rails.application.routes.url_helpers.root_url(host: ENV['FQDN'])
   end
 
-  def self.warden_proxy(user)
-    Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-      i.set_user(user, scope: :user, store: false, run_callbacks: false)
-    end
-  end
-
   def self.html(controller:, user:, template: nil, layout: false, assigns:, partial: nil)
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    renderer = controller.renderer.new(
-      'warden' => warden_proxy(user),
-    )
+    renderer = controller.renderer.new(WardenProxyFactory.renderer_env(user))
     if partial.present?
       renderer.render(
         partial: partial,

--- a/app/models/warden_proxy_factory.rb
+++ b/app/models/warden_proxy_factory.rb
@@ -1,0 +1,39 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Builds the object background renders hand to ActionController::Renderer as the 'warden' rack key.
+# The rack env is the only channel the renderer offers for carrying a user into the controller, and
+# both arms read the user back out of it — the JWT arm through Idp::JwtCurrentUser.
+#
+# Warden reaches the app only through the :devise bundler group, which config/application.rb
+# requires only under AuthMethod.devise?, so naming Warden::Proxy outside DeviseArm raises
+# NameError on the JWT arm.
+module WardenProxyFactory
+  module DeviseArm
+    def build(user)
+      Warden::Proxy.new({}, Warden::Manager.new({})).tap do |proxy|
+        proxy.set_user(user, scope: :user, store: false, run_callbacks: false)
+      end
+    end
+  end
+
+  module JwtArm
+    def build(user)
+      Idp::WardenProxy.new(user)
+    end
+  end
+
+  extend(AuthMethod.jwt? ? JwtArm : DeviseArm)
+
+  # Pass this to ActionController::Renderer.new. The 'warden' key name is the contract with the
+  # readers — Idp::JwtCurrentUser on the JWT arm, Devise's helpers on the Devise arm — so it is
+  # spelled here rather than at each render site.
+  def self.renderer_env(user)
+    { 'warden' => build(user) }
+  end
+end

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -13,7 +13,8 @@
         = link_to 'TalentLMS', admin_talentlms_path, class: 'nav-item nav-link'
     .col-sm-4
       = render 'schedule'
-      = render 'security', f: f
+      -# Password/lockout/expiration/timeout are Devise settings; the IdP owns them under JWT.
+      = render 'security', f: f if AuthMethod.devise?
       = render 'roi', f: f
       = render 'client_calculations', f: f
       = render 'client_display', f: f

--- a/app/views/application/_inactive_session_modal.haml
+++ b/app/views/application/_inactive_session_modal.haml
@@ -3,15 +3,10 @@
     controller: "inactive-session-modal",
     inactive_session_modal: {
       initial_user_id_value: current_user&.id.to_s,
-      session_lifetime_secs_value: Devise.timeout_in.in_seconds,
+      **inactive_session_countdown_values,
     },
     reflex_permanent: true
   }
-  # On JWT the session is owned by oauth2-proxy / the forwarded token, so the Devise.timeout_in seed
-  # above doesn't reflect the real expiry; seed the token's actual expiry instead.
-  if AuthMethod.jwt? && current_user.present? && (session_expires_at = user_session_expires_at)
-    root_data[:inactive_session_modal][:session_expires_at_value] = session_expires_at.to_i
-  end
 #inactive-session-modal{data: root_data}
   .session_expiry__content.d-none{data: {'inactive-session-modal-target': 'alert'}}
     .session_expiry__alert-box

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,11 +15,13 @@ require 'active_record_extended'
 #   * Note, we still use the deprecated behavior for date/time. It's preserved in config/initializers/legacy_rails_conversions.rb
 ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = 'true'
 
+require_relative '../lib/auth_method'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+# The :devise group is taken only on the Devise arm; see the group in Gemfile.
+Bundler.require(*Rails.groups, *(AuthMethod.devise? ? [:devise] : []))
 
-require_relative '../lib/auth_method'
 require_relative '../lib/util/id_protector'
 require_relative '../lib/util/rails_trusted_proxies_config'
 
@@ -57,7 +59,8 @@ module OpenPath
     # config.autoload_lib(ignore: ['assets', 'tasks'])
 
     config.add_autoload_paths_to_load_path = false
-    config.autoload_paths << Rails.root.join('lib', 'devise')
+    # lib/devise subclasses Devise constants, so it loads only on the arm that requires the gem.
+    config.autoload_paths << Rails.root.join('lib', 'devise') if AuthMethod.devise?
 
     # ActionCable
     config.action_cable.mount_path = '/cable'
@@ -149,7 +152,21 @@ module OpenPath
 
     # additional library paths
     config.eager_load_paths << Rails.root.join('lib', 'util')
-    config.eager_load_paths << Rails.root.join('lib', 'devise')
+    config.eager_load_paths << Rails.root.join('lib', 'devise') if AuthMethod.devise?
+
+    # Each of these subclasses a Devise constant, and their routes are already gated off the JWT
+    # arm. Ignoring them is what lets an unintended JWT-arm reference to Devise or Warden fail at
+    # boot rather than resolve against a class that loaded anyway.
+    unless AuthMethod.devise?
+      Rails.autoloaders.main.ignore(
+        Rails.root.join('app/mailers/account_mailer.rb'),
+        Rails.root.join('app/controllers/users/sessions_controller.rb'),
+        Rails.root.join('app/controllers/users/omniauth_callbacks_controller.rb'),
+        Rails.root.join('app/controllers/users/invitations_controller.rb'),
+        Rails.root.join('drivers/hmis/app/controllers/hmis/sessions_controller.rb'),
+        Rails.root.join('drivers/hmis/app/controllers/hmis/users/omniauth_callbacks_controller.rb'),
+      )
+    end
 
     # Replace rails_drivers gem autoloading — mirrors what the gem's Railtie did
     driver_app_components = ['models', 'controllers', 'mailers', 'helpers', 'jobs', 'graphql'].freeze

--- a/drivers/client_access_control/spec/factories/grda_warehouse/users.rb
+++ b/drivers/client_access_control/spec/factories/grda_warehouse/users.rb
@@ -12,9 +12,11 @@ FactoryBot.define do
     last_name { 'River' }
     sequence(:email) { |n| "user#{n}@greenriver.com" }
     # email 'green.river@mailinator.com'
-    password { Digest::SHA256.hexdigest('abcd1234abcd1234') }
-    password_confirmation { Digest::SHA256.hexdigest('abcd1234abcd1234') }
-    confirmed_at { Date.yesterday }
+    if AuthMethod.devise?
+      password { Digest::SHA256.hexdigest('abcd1234abcd1234') }
+      password_confirmation { Digest::SHA256.hexdigest('abcd1234abcd1234') }
+      confirmed_at { Date.yesterday }
+    end
     notify_on_vispdat_completed { false }
     agency_id { 1 }
   end

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -14,14 +14,16 @@ class Hmis::BaseController < ActionController::Base
   before_action :authenticate_hmis_user!
 
   # AUTH_METHOD seam: under JWT, current_hmis_user / authenticate_hmis_user! / true_hmis_user / the
-  # impersonation write-side are provided by Hmis::Concerns::JwtHmisCurrentUser (off a validated
-  # forwarded JWT); under Devise they come from the pretender macro + the devise :hmis_user scope.
+  # impersonation write-side / session_duration_seconds are provided by
+  # Hmis::Concerns::JwtHmisCurrentUser (off a validated forwarded JWT); under Devise they come from
+  # the pretender macro + the devise :hmis_user scope + Hmis::Concerns::DeviseHmisCurrentUser.
   # The before_action :authenticate_hmis_user! (above) and the set_anti_caching_headers
   # hmis_user_signed_in? guard (below) are satisfied either way.
   if AuthMethod.jwt?
     include Hmis::Concerns::JwtHmisCurrentUser
   else
     impersonates :hmis_user, with: ->(id) { Hmis::User.find_by(id: id) }
+    include Hmis::Concerns::DeviseHmisCurrentUser
   end
 
   include Hmis::Concerns::JsonErrors
@@ -101,7 +103,7 @@ class Hmis::BaseController < ActionController::Base
 
   # Shared shape for any endpoint that reports the signed-in HMIS user (user.json, impersonations).
   def current_user_payload
-    payload = current_hmis_user&.current_user_api_values || {}
+    payload = current_hmis_user&.current_user_api_values(session_duration: session_duration_seconds) || {}
     payload[:impersonating] = impersonating?
     payload
   end

--- a/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
@@ -17,5 +17,11 @@ module Hmis::Concerns::DeviseHmisCurrentUser
     def session_duration_seconds
       Devise.timeout_in.in_seconds
     end
+
+    # nil stub of the JWT arm's terminal_account_error, so Hmis::UsersController#show can call it
+    # under both arms without a respond_to? check.
+    def terminal_account_error
+      nil
+    end
   end
 end

--- a/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
@@ -1,0 +1,21 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Devise/Warden-path behavior for HMIS controllers; Hmis::Concerns::JwtHmisCurrentUser is the JWT
+# arm's equivalent. Devise-only HMIS behavior belongs here, so the teardown is a single-file delete.
+module Hmis::Concerns::DeviseHmisCurrentUser
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def session_duration_seconds
+      Devise.timeout_in.in_seconds
+    end
+  end
+end

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -70,6 +70,15 @@ module Hmis::Concerns::JwtHmisCurrentUser
 
     private
 
+    # Terminal account state for the bootstrap probe, allows front-end to show the
+    # correct account error to the user
+    def terminal_account_error
+      return nil if current_hmis_user
+      return :account_deactivated if idp_token_holder && !idp_token_holder.active?
+
+      :no_warehouse_account if idp_jwt_helper_for_request.token?
+    end
+
     def session_duration_seconds
       (user_session_expires_at - Time.current).to_i
     end
@@ -93,9 +102,8 @@ module Hmis::Concerns::JwtHmisCurrentUser
       raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
       # 403, not 401: signing in again can't produce an account, and a 401 would send the SPA to a
-      # sign-in screen it would come straight back from. The SPA keys off error.type on the 403 to
-      # render a terminal page (hmis-frontend apolloErrorLink.tsx -> AccountTerminalErrorDialog,
-      # contract in src/modules/auth/hooks/README.md).
+      # sign-in screen it would come straight back from. The SPA renders its terminal page from the
+      # /hmis/user.json bootstrap payload (accountError, via terminal_account_error), not this 403.
       render_json_error(403, :no_warehouse_account)
     end
 

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -70,6 +70,10 @@ module Hmis::Concerns::JwtHmisCurrentUser
 
     private
 
+    def session_duration_seconds
+      (user_session_expires_at - Time.current).to_i
+    end
+
     # no-op under JWT: session lifetime is governed by the IdP token, not a warehouse-side
     # inactivity timer. Some HMIS controllers prepend this as a before_action
     # (e.g. Hmis::UsersController#show), so the JWT arm must respond to it as the Devise arm does.

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -14,15 +14,18 @@ module Hmis
     # Mirrors ::Idp::SessionsController#destroy (the warehouse's JWT logout), but the SPA calls this
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
-    #
-    # Unlike ::Idp::SessionsController, #destroy keeps authenticate_hmis_user! (Hmis::BaseController
-    # applies it, and this class does not skip it): the SPA recovers from a JSON 403 by hitting
-    # /oauth2/sign_out itself, so there is no server-rendered dead-end page needing sign-out to work
-    # without a resolvable current_user (the reason the warehouse skips the filter).
-    #
     class SessionsController < Hmis::BaseController
-      # The CSRF token is what guards #destroy
+      # Skipped so the two terminal account states (account_deactivated, no_warehouse_account) can
+      # sign out: both hold a valid token but resolve no current_hmis_user, so the filter would
+      # render the JSON 403 dead end sign-out exists to escape. Matches ::Idp::SessionsController.
+      skip_before_action :authenticate_hmis_user!, only: [:destroy]
+
+      # CSRF (verify_authenticity_token, ahead of the skipped filter) is the outermost guard on #destroy.
       def destroy
+        # authenticate_hmis_user! is skipped on #destroy, so its tokenless raise has to live here.
+        # Why tokenless must raise, not answer: JwtHmisCurrentUser#idp_handle_unauthenticated.
+        raise ::Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
+
         # First: the Keycloak session, which /oauth2/sign_out never reaches. Ahead of reset_session
         # because it reads the forwarded token, and because it fails closed. Don't make it
         # best-effort. ::Idp::SessionsController#destroy is the same sequence with an HTML response.

--- a/drivers/hmis/app/controllers/hmis/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/sessions_controller.rb
@@ -9,6 +9,7 @@
 class Hmis::SessionsController < Devise::SessionsController
   include Hmis::Concerns::JsonErrors
   include AuthenticatesWithTwoFactor
+  include Hmis::Concerns::DeviseHmisCurrentUser
 
   # Only respond to JSON requests
   clear_respond_to
@@ -37,7 +38,7 @@ class Hmis::SessionsController < Devise::SessionsController
       clear_reset_password_state(resource)
       set_csrf_cookie
       response.headers['X-app-user-id'] = resource.id
-      render json: resource.current_user_api_values
+      render json: resource.current_user_api_values(session_duration: session_duration_seconds)
     else
       handle_failed_authentication
     end

--- a/drivers/hmis/app/controllers/hmis/users_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/users_controller.rb
@@ -16,7 +16,10 @@ class Hmis::UsersController < Hmis::BaseController
   # This is called by the frontend on initial page load, to determine whether
   # there is a currently active session.
   def show
-    render json: current_user_payload
+    payload = current_user_payload
+    account_error = terminal_account_error
+    payload[:accountError] = account_error if account_error
+    render json: payload
   end
 
   # clear etag to prevent caching

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -250,13 +250,15 @@ class Hmis::User < ApplicationRecord
     @editable_project_ids ||= Hmis::Hud::Project.viewable_by(self).pluck(:id)
   end
 
-  def current_user_api_values
+  # session_duration is a required kwarg, not a Devise default: the devise gem is unloaded under
+  # AuthMethod.jwt?, so a default would NameError for any caller that omits it.
+  def current_user_api_values(session_duration:)
     {
       id: id.to_s,
       name: name,
       email: email,
       phone: phone,
-      sessionDuration: Devise.timeout_in.in_seconds,
+      sessionDuration: session_duration,
       # primary_idp is only defined under AuthMethod.jwt?
       primaryIdp: AuthMethod.jwt? ? primary_idp : nil,
     }

--- a/drivers/hmis/spec/models/hmis/hmis_user_extension_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_user_extension_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe User, type: :model do
     expect do
       user.email = new_email
       user.save!
-      user.confirm
+      # Devise reconfirmable stashes the new address in unconfirmed_email until confirm promotes it;
+      # the jwt arm has no :confirmable, so save! already applied it.
+      user.confirm if AuthMethod.devise?
       user.sync_to_hud_users(previous_email: old_email)
       hmis_hud_user.reload
       other_hud_user.reload
@@ -59,7 +61,7 @@ RSpec.describe User, type: :model do
       user.first_name = new_first_name
       user.last_name = new_last_name
       user.save!
-      user.confirm
+      user.confirm if AuthMethod.devise?
       user.sync_to_hud_users(previous_email: old_email)
       hmis_hud_user.reload
       other_hud_user.reload

--- a/drivers/hmis/spec/models/hmis/user_spec.rb
+++ b/drivers/hmis/spec/models/hmis/user_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hmis::User, type: :model do
       expect(raw_after).to eq(raw_before)
     end
 
-    it 'raises NotPersistedError when called on an unsaved record' do
+    it 'raises NotPersistedError when called on an unsaved record', :devise_only do
       new_user = build(:hmis_user)
       expect { new_user.update_unique_session_id!('x') }.to raise_error(Devise::Models::Compatibility::NotPersistedError)
     end
@@ -101,7 +101,7 @@ RSpec.describe Hmis::User, type: :model do
     end
   end
 
-  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync', :devise_only do
     it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
       attacker_email = 'attacker@example.com'
       victim_email   = 'victim@example.com'

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           response, result = post_graphql(**variables) { query }
           expect(response.status).to eq(200), result.inspect
           expect(result.dig('data', 'ceOpportunity', 'candidates', 'nodesCount')).to eq(53)
-        end.to make_database_queries(count: 20..30)
+        end.to make_database_queries(count: 25..35)
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           response, result = post_graphql(**variables) { query }
           expect(response.status).to eq(200), result.inspect
           expect(result.dig('data', 'ceOpportunity', 'candidateLookup', 'enrollments', 'nodesCount')).to eq(41)
-        end.to make_database_queries(count: 30..40)
+        end.to make_database_queries(count: 35..45)
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'project', 'ceOpportunities', 'nodesCount')).to eq(41)
-          end.to make_database_queries(count: 15..25)
+          end.to make_database_queries(count: 20..30)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -120,13 +120,36 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
       expect(response.headers['X-app-user-id']).to be_blank
     end
 
-    it 'answers 200 with no user for a deactivated holder, rather than the JSON 403 guarded routes return' do
+    it 'answers 200 with an accountError for a deactivated holder, rather than the JSON 403 guarded routes return' do
       sign_in(create(:hmis_user, active: false))
 
       get hmis_user_path, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq('impersonating' => false)
+      # Whole-payload assertion, not include: a change that leaks another user's values onto the
+      # terminal-state bootstrap must fail here.
+      expect(JSON.parse(response.body)).to eq('impersonating' => false, 'accountError' => 'account_deactivated')
+    end
+
+    it 'answers 200 with an accountError for a good token whose holder has no warehouse account' do
+      # find_or_create_from_jwt returns nil only when neither the connector link nor the email
+      # matches, and sign_in provisions both, so no fixture reaches this branch — hence the stub.
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+      sign_in(create(:hmis_user))
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq('impersonating' => false, 'accountError' => 'no_warehouse_account')
+    end
+
+    it 'has no accountError for an active signed-in user' do
+      sign_in(create(:hmis_user))
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).not_to have_key('accountError')
     end
 
     it 'reflects the actual primaryIdp connector value, not just its presence' do

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -428,22 +428,47 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
         expect_signed_out_normally
       end
 
-      # Idp::UserProvisioner needs the connector claim to resolve a holder, and authenticate_hmis_user!
-      # runs before #destroy, so a claimless token 403s at authentication rather than reaching sign-out.
-      # The warehouse arm skips authenticate_user! on #destroy, so there the same token reaches
-      # idp_end_token_holder_sessions and signs out via its blank-connector guard.
-      it 'never reaches sign-out for a token with no connector claim: the request fails to authenticate' do
+      # The skip on authenticate_hmis_user! lets a no-connector-claim token reach #destroy, where
+      # idp_end_token_holder_sessions returns on the blank connector before any admin-API call. Mirrors
+      # the warehouse arm.
+      it 'signs out a token with no connector claim via the blank-connector guard, without an IdP call' do
         start_session
         # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
         allow(Idp::JwtHelper.new(access_token: jwt_token)).to receive(:connector_id).and_return(nil)
 
         delete destroy_hmis_user_session_path, headers: headers
 
-        expect(response).to have_http_status(:forbidden)
-        expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
         # On the service, not on Idp::ServiceFactory: the user payload consults the factory too
         # (see idp_service above), so the factory cannot carry a never-consulted assertion.
         expect(idp_service).not_to have_received(:logout_user_sessions)
+        expect_signed_out_normally
+      end
+
+      # Ending the IdP session for a locked-out deactivated holder looks pointless, but on a shared
+      # machine a surviving session signs the next person in — and the token still carries the connector
+      # claims logout_user_sessions needs. #destroy runs at all only because it skips authenticate_hmis_user!.
+      it 'ends the IdP session and signs out a deactivated token holder' do
+        inactive = create(:hmis_user, active: false)
+        sign_in(inactive)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(inactive))
+        expect_signed_out_normally
+      end
+
+      # No warehouse row, but the token still carries connector_id and connector_user_id — all
+      # idp_end_token_holder_sessions needs — so the IdP session ends exactly as for the deactivated
+      # holder. find_or_create_from_jwt stubbed nil: no reachable fixture hits this branch.
+      it 'ends the IdP session and signs out a good token whose holder has no warehouse account' do
+        allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+        holder = create(:hmis_user)
+        sign_in(holder)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(holder))
+        expect_signed_out_normally
       end
 
       # The whole reason the id comes off the token: current_hmis_user is the impersonated user here,
@@ -543,6 +568,33 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
           get hmis_user_path, headers: headers
           expect(controller.current_hmis_user).to eq(target_user)
           expect(controller.true_hmis_user).to eq(admin_user)
+        end
+
+        # The skip made terminal-state holders reachable at #destroy; verify CSRF still rejects them,
+        # not only the active holder above.
+        it 'still rejects a terminal-state holder with no CSRF token, without ending the IdP session' do
+          sign_in(create(:hmis_user, active: false))
+
+          delete destroy_hmis_user_session_path, headers: headers
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)).to eq('error' => { 'type' => 'unverified_request' })
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+        end
+
+        # A bare tokenless request would 401 on CSRF (checked ahead of the action) and never reach the
+        # tokenless guard — passing even if the guard were gone. So sign in for a valid CSRF token, then
+        # drop the JWT: CSRF passes, and the guard fires.
+        it 'raises on a tokenless request that clears CSRF, rather than a quiet sign-out' do
+          start_session
+          token = csrf_token_from_last_response
+          sign_out
+
+          expect do
+            delete destroy_hmis_user_session_path, headers: headers.merge('X-CSRF-Token' => token)
+          end.to raise_error(Idp::UnauthenticatedRequestError)
+
+          expect(idp_service).not_to have_received(:logout_user_sessions)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -15,7 +15,7 @@ require 'support/shared_contexts/timing_attack_mitigation_context'
 
 # Devise-only: drivers/hmis/config/routes.rb mounts Hmis::SessionsController under
 # AuthMethod.devise?; the jwt arm serves hmis/logout from Hmis::Idp::SessionsController instead.
-RSpec.describe Hmis::SessionsController, :devise_only, type: :request do
+RSpec.describe 'Hmis::SessionsController', :devise_only, type: :request do
   let(:user) { create :user }
   let(:hmis_user) { user.as_hmis_user.tap(&:reload) }
   let(:user_2fa) { create :user_2fa }

--- a/drivers/hmis/spec/requests/hmis/unit_groups_query_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/unit_groups_query_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Unit groups query', type: :request do
         response, result = post_graphql { query }
         expect(response.status).to eq(200), result.inspect
         expect(result.dig('data', 'unitGroups', 'nodes').size).to eq(12)
-      end.to make_database_queries(count: 15..25)
+      end.to make_database_queries(count: 20..30)
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe Hmis::UsersController, type: :request do
         expect(JSON.parse(response.body)['sessionDuration']).to eq(Devise.timeout_in.in_seconds)
       end
 
-      # Hmis::User reports Devise.timeout_in on both arms (Hmis::User#current_user_api_values),
-      # so tightening this to that value would pass while pinning the JWT arm to a Devise setting —
-      # the credential's lifetime here is the IdP token's.
       it 'reports a positive sessionDuration', :jwt_only do
         expect(JSON.parse(response.body)['sessionDuration']).to be > 0
+      end
+
+      # The hour is the stubbed expiration_time in JwtAuthenticationHelper#sign_in.
+      it 'sources sessionDuration from the token expiry rather than a Devise timeout', :jwt_only do
+        expect(JSON.parse(response.body)['sessionDuration']).to be_within(5).of(1.hour.to_i)
       end
     end
 

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/base.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/base.rb
@@ -86,7 +86,10 @@ module HudApr::Generators::Shared::Fy2026
 
           hh_id = get_hh_id(last_service_history_enrollment)
           hoh_enrollment = hoh_enrollments[hh_id]
-          household_assessment_required[last_service_history_enrollment.client_id] = annual_assessment_expected?(hoh_enrollment: hoh_enrollment, enrollment: last_service_history_enrollment, report_end_date: @report.end_date)
+          # The annual assessment anniversary follows the household's earliest head of household, who may
+          # have exited before the report period and so may not be in hoh_enrollments
+          annual_hoh_enrollment = household_hoh_enrollments[hh_id] || hoh_enrollment
+          household_assessment_required[last_service_history_enrollment.client_id] = annual_assessment_expected?(hoh_enrollment: annual_hoh_enrollment, enrollment: last_service_history_enrollment, report_end_date: @report.end_date)
           end_date = if needs_ce_assessments?
             # Only HoHs get CE assessments, so we prefer their entry date
             hoh_enrollment&.first_date_in_program || last_service_history_enrollment.first_date_in_program
@@ -116,6 +119,9 @@ module HudApr::Generators::Shared::Fy2026
           hh_id = get_hh_id(last_service_history_enrollment)
           # Fetch the Head of Household's enrollment, but if we don't have a head, just use ours
           hoh_enrollment = hoh_enrollments[hh_id] || last_service_history_enrollment
+          # Annual assessment timing is anchored on the household's HoH even when they exited before
+          # the report period, so it does not use the HoH enrollment above
+          annual_hoh_enrollment = household_hoh_enrollments[hh_id] || hoh_enrollment
           if needs_ce_assessments?
             ce_latest_assessment = latest_ce_assessment(last_service_history_enrollment, hoh_enrollment)
             ce_latest_event = latest_ce_event(last_service_history_enrollment, hoh_enrollment, ce_latest_assessment)
@@ -156,16 +162,17 @@ module HudApr::Generators::Shared::Fy2026
           exit_record = last_service_history_enrollment.enrollment if exit_date.present? && exit_date <= @report.end_date
 
           income_at_start = enrollment.income_benefits_at_entry
-          income_at_annual_assessment = annual_assessment(enrollment, hoh_enrollment.first_date_in_program)
+          income_at_annual_assessment = annual_assessment(enrollment, annual_hoh_enrollment.first_date_in_program)
           income_at_exit = exit_record&.income_benefits_at_exit
 
           disabilities = enrollment.disabilities.select { |disability| [1, 2, 3].include?(disability.DisabilityResponse) }
-
-          disabilities_at_entry = enrollment.disabilities.select { |d| d.DataCollectionStage == 1 }
-          disabilities_at_exit = enrollment.disabilities.select { |d| d.DataCollectionStage == 3 }
-          max_disability_date = enrollment.disabilities.select { |d| d.InformationDate <= @report.end_date }.
-            map(&:InformationDate).max
-          disabilities_latest = enrollment.disabilities.select { |d| d.InformationDate == max_disability_date }
+          relevant_disability_records = enrollment.disabilities.select { |d| d.InformationDate <= @report.end_date }
+          disabilities_at_entry = relevant_disability_records.select { |d| d.DataCollectionStage == 1 }
+          disabilities_at_exit = relevant_disability_records.select { |d| d.DataCollectionStage == 3 }
+          max_disability_date_in_report = relevant_disability_records.map(&:InformationDate).select { |date| date <= @report.end_date }.max
+          disabilities_latest_in_report = relevant_disability_records.select { |d| d.InformationDate == max_disability_date_in_report }
+          max_disability_date_overall = enrollment.disabilities.map(&:InformationDate).max
+          disabilities_latest_overall = enrollment.disabilities.select { |d| d.InformationDate == max_disability_date_overall }
 
           # Need to sort by information date, then DateUpdated to catch the most-recent
           # added for the Datalab test kit
@@ -203,7 +210,7 @@ module HudApr::Generators::Shared::Fy2026
           # else
           #   household_types[hh_id]
           # end
-          hoh_anniversary_date = anniversary_date(entry_date: hoh_enrollment.first_date_in_program, report_end_date: @report.end_date)
+          hoh_anniversary_date = anniversary_date(entry_date: annual_hoh_enrollment.first_date_in_program, report_end_date: @report.end_date)
           # Households with required assessments are calculated earlier for performance reasons.
           # An APR is being submitted to verify assessment requirements for non-HoH adults entering the HH at a different date than the HoH.
           # e.g. If an adult enters 1 day prior HoH assessment date, is their assessment required on the HoH date (1 day later) or on the following year (1 year + 1 day later)
@@ -250,15 +257,15 @@ module HudApr::Generators::Shared::Fy2026
             age: age,
             alcohol_abuse_entry: [1, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             alcohol_abuse_exit: [1, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
-            alcohol_abuse_latest: [1, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
+            alcohol_abuse_latest: [1, 3].include?(disabilities_latest_in_report.detect(&:substance?)&.DisabilityResponse),
             annual_assessment_expected: annual_assessment_expected,
             # anniversary dates are always based on HoH enrollment
-            annual_assessment_in_window: annual_assessment_in_window?(hoh_enrollment, income_at_annual_assessment&.InformationDate),
+            annual_assessment_in_window: annual_assessment_in_window?(annual_hoh_enrollment, income_at_annual_assessment&.InformationDate),
             approximate_time_to_move_in: approximate_move_in_dates[last_service_history_enrollment.client_id],
             came_from_street_last_night: enrollment.PreviousStreetESSH,
             chronic_disability_entry: disabilities_at_entry.detect(&:chronic?)&.DisabilityResponse,
             chronic_disability_exit: disabilities_at_exit.detect(&:chronic?)&.DisabilityResponse,
-            chronic_disability_latest: disabilities_latest.detect(&:chronic?)&.DisabilityResponse,
+            chronic_disability_latest: disabilities_latest_in_report.detect(&:chronic?)&.DisabilityResponse,
             chronic_disability: disabilities.detect(&:chronic?).present?,
             chronically_homeless: chronic_source.try(:[], :chronic_status) || false,
             chronically_homeless_detail: chronic_source.try(:[], :chronic_detail) || {},
@@ -281,7 +288,7 @@ module HudApr::Generators::Shared::Fy2026
             destination: destination,
             developmental_disability_entry: disabilities_at_entry.detect(&:developmental?)&.DisabilityResponse,
             developmental_disability_exit: disabilities_at_exit.detect(&:developmental?)&.DisabilityResponse,
-            developmental_disability_latest: disabilities_latest.detect(&:developmental?)&.DisabilityResponse,
+            developmental_disability_latest: disabilities_latest_in_report.detect(&:developmental?)&.DisabilityResponse,
             developmental_disability: disabilities.detect(&:developmental?).present?,
             disabling_condition: enrollment.DisablingCondition,
             dob_quality: apr_client_dob_quality(source_client),
@@ -291,7 +298,7 @@ module HudApr::Generators::Shared::Fy2026
             domestic_violence_occurred: health_and_dv&.WhenOccurred,
             drug_abuse_entry: [2, 3].include?(disabilities_at_entry.detect(&:substance?)&.DisabilityResponse),
             drug_abuse_exit: [2, 3].include?(disabilities_at_exit.detect(&:substance?)&.DisabilityResponse),
-            drug_abuse_latest: [2, 3].include?(disabilities_latest.detect(&:substance?)&.DisabilityResponse),
+            drug_abuse_latest: [2, 3].include?(disabilities_latest_in_report.detect(&:substance?)&.DisabilityResponse),
             enrollment_coc: enrollment.enrollment_coc,
             enrollment_created: enrollment.DateCreated || enrollment.DateUpdated || DateTime.current,
             exit_created: exit_record&.exit&.DateCreated,
@@ -303,7 +310,7 @@ module HudApr::Generators::Shared::Fy2026
             head_of_household: last_service_history_enrollment[:head_of_household],
             hiv_aids_entry: disabilities_at_entry.detect(&:hiv?)&.DisabilityResponse,
             hiv_aids_exit: disabilities_at_exit.detect(&:hiv?)&.DisabilityResponse,
-            hiv_aids_latest: disabilities_latest.detect(&:hiv?)&.DisabilityResponse,
+            hiv_aids_latest: disabilities_latest_in_report.detect(&:hiv?)&.DisabilityResponse,
             hiv_aids: disabilities.detect(&:hiv?).present?,
             household_id: get_hh_id(last_service_history_enrollment),
             household_members: household_member_data(last_service_history_enrollment, household_calculation_date),
@@ -333,7 +340,7 @@ module HudApr::Generators::Shared::Fy2026
             income_total_at_exit: income_at_exit&.hud_total_monthly_income,
             income_total_at_start: income_at_start&.hud_total_monthly_income,
             # NOTE: this is used for data quality, and should only look at the most recent disability
-            indefinite_and_impairs: disabilities_latest.detect(&:indefinite_and_impairs?),
+            indefinite_and_impairs: disabilities_latest_overall.detect(&:indefinite_and_impairs?),
             insurance_from_any_source_at_annual_assessment: income_at_annual_assessment&.InsuranceFromAnySource,
             insurance_from_any_source_at_exit: income_at_exit&.InsuranceFromAnySource,
             insurance_from_any_source_at_start: income_at_start&.InsuranceFromAnySource,
@@ -343,7 +350,7 @@ module HudApr::Generators::Shared::Fy2026
             length_of_stay: stay_length(last_service_history_enrollment),
             mental_health_problem_entry: disabilities_at_entry.detect(&:mental?)&.DisabilityResponse,
             mental_health_problem_exit: disabilities_at_exit.detect(&:mental?)&.DisabilityResponse,
-            mental_health_problem_latest: disabilities_latest.detect(&:mental?)&.DisabilityResponse,
+            mental_health_problem_latest: disabilities_latest_in_report.detect(&:mental?)&.DisabilityResponse,
             mental_health_problem: disabilities.detect(&:mental?).present?,
             months_homeless: enrollment.MonthsHomelessPastThreeYears,
             move_in_date: last_service_history_enrollment.move_in_date,
@@ -373,7 +380,7 @@ module HudApr::Generators::Shared::Fy2026
             pit_enrollments: pit_enrollment_info(enrollments),
             physical_disability_entry: disabilities_at_entry.detect(&:physical?)&.DisabilityResponse,
             physical_disability_exit: disabilities_at_exit.detect(&:physical?)&.DisabilityResponse,
-            physical_disability_latest: disabilities_latest.detect(&:physical?)&.DisabilityResponse,
+            physical_disability_latest: disabilities_latest_in_report.detect(&:physical?)&.DisabilityResponse,
             physical_disability: disabilities.detect(&:physical?).present?,
             prior_length_of_stay: enrollment.LengthOfStay,
             prior_living_situation: enrollment.LivingSituation,
@@ -390,7 +397,7 @@ module HudApr::Generators::Shared::Fy2026
             subsidy_information: last_service_history_enrollment.enrollment.exit&.SubsidyInformation,
             substance_abuse_entry: disabilities_at_entry.detect(&:substance?)&.DisabilityResponse,
             substance_abuse_exit: disabilities_at_exit.detect(&:substance?)&.DisabilityResponse,
-            substance_abuse_latest: disabilities_latest.detect(&:substance?)&.DisabilityResponse,
+            substance_abuse_latest: disabilities_latest_in_report.detect(&:substance?)&.DisabilityResponse,
             substance_abuse: disabilities.detect(&:substance?).present?,
             time_to_move_in: times_to_move_in[last_service_history_enrollment.client_id],
             times_homeless: enrollment.TimesHomelessPastThreeYears,
@@ -627,30 +634,80 @@ module HudApr::Generators::Shared::Fy2026
       scope
     end
 
-    private def pit_enrollment_info(enrollments)
-      pit_dates = [1, 4, 7, 10].map { |month| pit_date(month: month, before: @report.end_date) }
-      pit_dates.map do |pit_date|
-        enrollments_for_date = enrollments.select do |enrollment|
-          enrolled = if enrollment.project_type.in?([3, 13]) || enrollment.enrollment.project.pay_for_success?
-            # PSH/RRH OR project type 7 (other) with Funder 35 (Pay for Success)
-            move_in_date = calculate_hh_move_in_date(enrollment.household_id, enrollment)
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) && # Exclude exit date
-              move_in_date.present? && # Check that move in date is present and is before the PIT data and on or after the entry date
-              move_in_date <= pit_date &&
-              move_in_date >= enrollment.first_date_in_program
-          elsif enrollment.project_type.in?([0, 1, 2, 8, 9, 10]) # Other residential
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) # Exclude exit date
-          else # Other project types (4, 6, 7, 11, 12, 14)
-            enrollment.first_date_in_program <= pit_date &&
-              (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program >= pit_date) # Include the exit date
-          end
-          next false unless enrolled
-          next true if enrollment.project_type != 1 || enrollment.project_tracking_method != 3 # Not ES or ES and not NbN
+    # The earliest head of household enrollment for each household, whose entry date the Annual Assessment
+    # section of the HMIS Reporting Glossary uses as the anniversary date, per: in the event a household has
+    # more than one head of household active in the report range, (i.e., if the first HoH exited and another
+    # household member became the HoH), the later HoH's [project start date] will be back-dated to the first
+    # HoH's [project start date].
+    # Deliberately ignores the report date range so that a household whose head of household exited before
+    # the report period, and where no other member was recorded as the head of household, still has an
+    # anniversary.  Datalab does the same, calculating annual_assessment_dates from the unfiltered
+    # Enrollment table rather than from the enrollments included in the report.
+    private def household_hoh_enrollments
+      @household_hoh_enrollments ||= begin
+        household_ids = enrollment_scope_without_preloads.where.not(household_id: nil).select(:household_id)
+        scope = GrdaWarehouse::ServiceHistoryEnrollment.entry.heads_of_households.where(household_id: household_ids)
+        scope = scope.in_project(@report.project_ids) if @report.project_ids.present?
+        scope.group_by(&:household_id).transform_values { |enrollments| enrollments.min_by(&:first_date_in_program) }
+      end
+    end
 
-          enrollment.service_history_services.bed_night.on_date(pit_date).exists?
-        end.map do |enrollment|
+    private def pit_dates
+      @pit_dates ||= [1, 4, 7, 10].map { |month| pit_date(month: month, before: @report.end_date) }
+    end
+
+    # Bed nights on each PIT date, as the ids of the enrollments that have one, and the ids of their
+    # households keyed to match get_hh_id
+    private def pit_bed_nights
+      @pit_bed_nights ||= pit_dates.index_with do |pit_date|
+        rows = enrollment_scope_without_preloads.
+          joins(:service_history_services).
+          merge(GrdaWarehouse::ServiceHistoryService.bed_night.where(date: pit_date)).
+          distinct.
+          pluck(:id, :household_id, :enrollment_group_id)
+        {
+          enrollment_ids: rows.map(&:shift).to_set,
+          household_ids: rows.map { |household_id, enrollment_group_id| household_id || "#{enrollment_group_id || ''}*HH" }.to_set,
+        }
+      end
+    end
+
+    # Returns :client, :household (Q8b only, see below), or nil
+    private def pit_presence(enrollment, pit_date)
+      return nil unless enrollment.first_date_in_program <= pit_date
+
+      if enrollment.project_type == 1
+        bed_nights = pit_bed_nights[pit_date]
+        # Night-by-night shelters must use bed night records indicating household presence on each
+        # point in time night, so the exit date is not compared
+        return :client if bed_nights[:enrollment_ids].include?(enrollment.id)
+        # Q8b reports a household via its HoH, so include the HoH when only other members were present
+        return :household if enrollment.head_of_household? && bed_nights[:household_ids].include?(get_hh_id(enrollment))
+
+        return nil
+      end
+
+      present = if enrollment.project_type.in?([3, 13]) || enrollment.enrollment.project.pay_for_success?
+        # PSH/RRH OR project type 7 (other) with Funder 35 (Pay for Success)
+        move_in_date = calculate_hh_move_in_date(enrollment.household_id, enrollment)
+        (enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date) && # Exclude exit date
+          move_in_date.present? && # Check that move in date is present and is before the PIT data and on or after the entry date
+          move_in_date <= pit_date &&
+          move_in_date >= enrollment.first_date_in_program
+      elsif enrollment.project_type.in?([0, 2, 8, 9, 10]) # Other residential
+        enrollment.last_date_in_program.nil? || enrollment.last_date_in_program > pit_date # Exclude exit date
+      else # Other project types (4, 6, 7, 11, 12, 14)
+        enrollment.last_date_in_program.nil? || enrollment.last_date_in_program >= pit_date # Include the exit date
+      end
+      present ? :client : nil
+    end
+
+    private def pit_enrollment_info(enrollments)
+      pit_dates.map do |pit_date|
+        enrollments_for_date = enrollments.filter_map do |enrollment|
+          presence = pit_presence(enrollment, pit_date)
+          next unless presence
+
           {
             first_date_in_program: enrollment.first_date_in_program,
             last_date_in_program: enrollment.last_date_in_program,
@@ -658,6 +715,7 @@ module HudApr::Generators::Shared::Fy2026
             project_tracking_method: enrollment.project_tracking_method,
             move_in_date: calculate_hh_move_in_date(enrollment.household_id, enrollment),
             relationship_to_hoh: enrollment.enrollment.relationship_to_hoh,
+            household_presence_only: presence == :household,
           }
         end
         [pit_date, enrollments_for_date]

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_four.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_four.rb
@@ -158,13 +158,7 @@ module HudApr::Generators::Shared::Fy2026::Dq::QuestionFour
       answer.update(summary: members.count)
 
       # HMIS Reporting Glossary Reference: Data Quality - Q1-17: Heads of households and adult stayers in the project 365 days or more
-      # Per HMIS Glossary, ES-NBN (project_type 1) uses bed_nights, all others use length_of_stay
-      stayers_over_365_days = adults_and_hohs.where(
-        stayers_clause.and(
-          a_t[:project_type].eq(1).and(a_t[:bed_nights].gteq(365)).
-            or(a_t[:project_type].not_eq(1).and(a_t[:length_of_stay].gteq(365))),
-        ),
-      )
+      stayers_over_365_days = adults_and_hohs.where(hoh_and_adult_lts_stayer_clause)
 
       answer = @report.answer(question: table_name, cell: 'F4')
       answer.update(summary: percentage(members.count / stayers_over_365_days.count.to_f))

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_one.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_one.rb
@@ -127,14 +127,9 @@ module HudApr::Generators::Shared::Fy2026::Dq::QuestionOne
             and(a_t[:head_of_household].eq(true)),
         },
         # HoH and adult stayers in project 365 days or more
-        # "...any adult stayer present when the head of household’s stay is 365 days or more,
-        # even if that adult has not been in the household that long"
-        # Per HUD clarification: include adult stayers with 365+ days even when HoH has < 365 days.
         {
           row: '17',
-          clause: a_t[:head_of_household_id].in(hoh_lts_stayer_ids).
-            and(adult_clause.or(a_t[:head_of_household].eq(true))).
-            or(a_t[:id].in(adult_lts_stayer_ids)),
+          clause: hoh_and_adult_lts_stayer_clause,
         },
       ]
     end

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_three.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/dq/question_three.rb
@@ -136,23 +136,16 @@ module HudApr::Generators::Shared::Fy2026::Dq::QuestionThree
       )
       missing_cell = sheet.update_cell_members(
         cell: 'C6',
-        members: universe_members.where(a_t[:disabling_condition].eq(99).or(a_t[:disabling_condition].eq(99))),
+        members: universe_members.where(a_t[:disabling_condition].eq(99).or(a_t[:disabling_condition].eq(nil))),
       )
 
-      qualifies_for_disability = [
-        a_t[:developmental_disability_latest].eq(1).or(a_t[:hiv_aids_latest].eq(1)),
-        a_t[:indefinite_and_impairs].eq(true).and(
-          [
-            a_t[:physical_disability_latest].eq(1),
-            a_t[:chronic_disability_latest].eq(1),
-            a_t[:mental_health_problem_latest].eq(1),
-            a_t[:substance_abuse_latest].in([1, 2, 3]),
-          ].inject(&:or),
-        ),
-      ].inject(&:or)
+      # indefinite_and_impairs covers the whole rule: a developmental disability or HIV/AIDS response
+      # of yes, or a physical disability, chronic health condition, mental health disorder, or
+      # substance use disorder response of yes that also substantially impairs the ability to live
+      # independently.
       issue_cell = sheet.update_cell_members(
         cell: 'D6',
-        members: universe_members.where(a_t[:disabling_condition].eq(0)).where(qualifies_for_disability),
+        members: universe_members.where(a_t[:disabling_condition].eq(0)).where(a_t[:indefinite_and_impairs].eq(true)),
       )
 
       total_cell = sheet.update_cell_value(cell: 'E6', value: [dkpntr_cell, missing_cell, issue_cell].map(&:value).sum)

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_eight.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_eight.rb
@@ -207,6 +207,7 @@ module HudApr::Generators::Shared::Fy2026
       # have a record for the PIT date
       # The client we return may not be an HoH in relation to the rest of the APR, but they
       # must be an HoH for the enrollment that was open on the PIT date
+      # For night-by-night shelters the HoH is recorded whenever any member had a bed night
       query = <<~SQL
         pit_enrollments ? '#{pit_date.iso8601}'
         AND pit_enrollments -> '#{pit_date.iso8601}' @> '[{"relationship_to_hoh": 1}]'

--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_seven.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_seven.rb
@@ -294,7 +294,12 @@ module HudApr::Generators::Shared::Fy2026
       # Logic for step 4 is enforced when adding PIT dates to the client record
       # If a client doesn't have any overlapping enrollments that qualify, they won't
       # have a record for the PIT date
-      universe.members.where("pit_enrollments ? '#{pit_date.iso8601}'")
+      # Q7b counts people, so it ignores enrollments only present to represent their household
+      query = <<~SQL
+        pit_enrollments ? '#{pit_date.iso8601}'
+        AND pit_enrollments -> '#{pit_date.iso8601}' @> '[{"household_presence_only": false}]'
+      SQL
+      universe.members.where(query)
     end
   end
 end

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_v_psh.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_v_psh.rb
@@ -70,11 +70,6 @@ RSpec.shared_context 'datalab organization v psh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6b',
-        skip: [
-          'D3', # expected '0.0000' (0), got '2.0000' (2)
-          'E3', # expected '0.0000' (0), got '2.0000' (2)
-          'F3', # expected '0.0000' (0.0000), got '0.0400' (0.0426)
-        ],
       )
     end
 
@@ -82,9 +77,6 @@ RSpec.shared_context 'datalab organization v psh apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6c',
-        skip: [
-          'F4', # expected '0.9100' (0.9091), got '1.0000' (1.0000)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
@@ -288,10 +288,6 @@ RSpec.shared_context 'datalab organization y sso apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q21',
-        skip: [
-          'C14', # expected '2.0000' (2), got '1.0000' (1)
-          'C15', # expected '1.0000' (1), got '2.0000' (2)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_j_es.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_j_es.rb
@@ -74,10 +74,6 @@ RSpec.shared_context 'datalab organization j es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6b',
-        skip: [
-          'D6', # expected '23.0000' (23), got '22.0000' (22)
-          'E6', # expected '31.0000' (31), got '30.0000' (30)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_es.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_es.rb
@@ -70,10 +70,6 @@ RSpec.shared_context 'datalab organization t es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6b',
-        skip: [
-          'D6', # expected '7.0000' (7), got '6.0000' (6)
-          'E6', # expected '10.0000' (10), got '9.0000' (9)
-        ],
       )
     end
 
@@ -121,20 +117,6 @@ RSpec.shared_context 'datalab organization t es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q7b',
-        skip: [
-          'B2', # expected '39.0000' (39), got '67.0000' (67)
-          'C2', # expected '27.0000' (27), got '46.0000' (46)
-          'D2', # expected '12.0000' (12), got '21.0000' (21)
-          'B3', # expected '35.0000' (35), got '68.0000' (68)
-          'C3', # expected '22.0000' (22), got '49.0000' (49)
-          'D3', # expected '13.0000' (13), got '19.0000' (19)
-          'B4', # expected '35.0000' (35), got '57.0000' (57)
-          'C4', # expected '22.0000' (22), got '34.0000' (34)
-          'D4', # expected '13.0000' (13), got '23.0000' (23)
-          'B5', # expected '27.0000' (27), got '62.0000' (62)
-          'C5', # expected '21.0000' (21), got '42.0000' (42)
-          'D5', # expected '6.0000' (6), got '20.0000' (20)
-        ],
       )
     end
 
@@ -149,18 +131,6 @@ RSpec.shared_context 'datalab organization t es caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q8b',
-        skip: [
-          'B2', # expected '33.0000' (33), got '52.0000' (52)
-          'C2', # expected '26.0000' (26), got '45.0000' (45)
-          'B3', # expected '26.0000' (26), got '52.0000' (52)
-          'C3', # expected '23.0000' (23), got '48.0000' (48)
-          'D3', # expected '3.0000' (3), got '4.0000' (4)
-          'B4', # expected '27.0000' (27), got '38.0000' (38)
-          'C4', # expected '22.0000' (22), got '33.0000' (33)
-          'B5', # expected '25.0000' (25), got '47.0000' (47)
-          'C5', # expected '21.0000' (21), got '42.0000' (42)
-          'D5', # expected '4.0000' (4), got '5.0000' (5)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_hp.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_caper/organization_t_hp.rb
@@ -52,15 +52,11 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       )
     end
 
-    # pending https://www.hudexchange.info/program-support/my-question/?askaquestionaction=public%3Amain.answer&key=20077029-802F-4997-903A87560D233223
+    # previous https://www.hudexchange.info/program-support/my-question/?askaquestionaction=public%3Amain.answer&key=20077029-802F-4997-903A87560D233223
     it 'Q5a' do
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q5a',
-        skip: [
-          'B17', # expected '1.0000' (1), got '0.0000' (0)
-          'C17', # expected '1.0000' (1), got '0.0000' (0)
-        ],
       )
     end
 
@@ -82,11 +78,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q6c',
-        skip: [
-          'C4', # expected '1.0000' (1), got '0.0000' (0)
-          'E4', # expected '1.0000' (1), got '0.0000' (0)
-          'F4', # expected '1.0000' (1.0000), got '0.0000' (0.0000)
-        ],
       )
     end
 
@@ -243,10 +234,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q16',
-        skip: [
-          'C12', # expected '50.0000' (50), got '51.0000' (51)
-          'C13', # expected '1.0000' (1), got '0.0000' (0)
-        ],
       )
     end
 
@@ -278,10 +265,6 @@ RSpec.shared_context 'datalab organization t hp caper', shared_context: :metadat
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q21',
-        skip: [
-          'C14', # expected '1.0000' (1), got '0.0000' (0)
-          'C15', # expected '86.0000' (86), got '87.0000' (87)
-        ],
       )
     end
 

--- a/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_export_spec.rb
+++ b/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_export_spec.rb
@@ -86,10 +86,7 @@ RSpec.describe HudApr::DocumentExports::HudAprExport, type: :model do
   describe 'the rendered PDF HTML' do
     let(:report) { create(:hud_reports_report_instance, user: user, report_name: report_name, options: {}) }
     let(:rendered_html) do
-      ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-      renderer = HudApr::AprsController.renderer.new(
-        'warden' => PdfGenerator.warden_proxy(user),
-      )
+      renderer = HudApr::AprsController.renderer.new(WardenProxyFactory.renderer_env(user))
       renderer.render(
         'hud_reports/download',
         layout: 'layouts/hud_report_export',

--- a/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_q4a_pdf_regression_spec.rb
+++ b/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_q4a_pdf_regression_spec.rb
@@ -70,10 +70,7 @@ RSpec.describe 'Q4a survives real PDF rendering', type: :model, exclude_fixpoint
   end
 
   it 'renders a real PDF where all Q4a columns (A through Q) survive, in order' do
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    renderer = HudApr::AprsController.renderer.new(
-      'warden' => PdfGenerator.warden_proxy(user),
-    )
+    renderer = HudApr::AprsController.renderer.new(WardenProxyFactory.renderer_env(user))
     html = renderer.render(
       'hud_reports/download',
       layout: 'layouts/hud_report_export',

--- a/drivers/superset/spec/models/superset_spec.rb
+++ b/drivers/superset/spec/models/superset_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe Superset do
       end
     end
 
-    context 'under AuthMethod.devise?' do
+    # The Devise branch of .available? queries Doorkeeper::Application, a constant in the :devise
+    # Gemfile group that the jwt arm never loads.
+    context 'under AuthMethod.devise?', :devise_only do
       before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
 
       it 'is available when a Doorkeeper::Application is registered for the Superset host' do

--- a/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
@@ -27,14 +27,7 @@ module TxClientReports::AttachmentThreeReportExports
 
     def perform
       with_status_progression do
-        ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-        warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-          i.set_user(user, scope: :user, store: false, run_callbacks: false)
-        end
-
-        renderer = controller_class.renderer.new(
-          'warden' => warden_proxy,
-        )
+        renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(user))
 
         write_tmp_file(
           renderer.render(

--- a/drivers/tx_client_reports/app/models/tx_client_reports/research_export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/research_export.rb
@@ -82,13 +82,7 @@ module TxClientReports
     private def excel_content
       controller = TxClientReports::WarehouseReports::ResearchExportsController
       assigns = { filter: filter, format: :xlsx, report: self }
-      ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-      warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-        i.set_user(user, scope: :user, store: false, run_callbacks: false)
-      end
-      renderer = controller.renderer.new(
-        'warden' => warden_proxy,
-      )
+      renderer = controller.renderer.new(WardenProxyFactory.renderer_env(user))
       renderer.render(
         action: :index,
         layout: false,

--- a/spec/controllers/accounts_controller_unit_spec.rb
+++ b/spec/controllers/accounts_controller_unit_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AccountsController, type: :controller do
+# AccountsController#update calls bypass_sign_in, a Devise controller helper absent under the
+# jwt arm (which updates accounts through Idp::AccountsController).
+RSpec.describe AccountsController, :devise_only, type: :controller do
   let(:user) { create(:user, first_name: 'Original', last_name: 'User', credentials: 'old_creds', email_schedule: 'daily', phone: '1234567890') }
   let(:controller_instance) { described_class.new }
   let(:flash_hash) { {} }

--- a/spec/controllers/concerns/devise_current_user_spec.rb
+++ b/spec/controllers/concerns/devise_current_user_spec.rb
@@ -1,0 +1,33 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeviseCurrentUser, :devise_only, type: :controller do
+  controller(ActionController::Base) do
+    include DeviseCurrentUser
+
+    def countdown
+      render json: inactive_session_countdown_values
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'countdown' => 'anonymous#countdown'
+    end
+  end
+
+  describe '#inactive_session_countdown_values' do
+    it 'reports the Devise timeout as a session lifetime' do
+      get :countdown
+
+      expect(JSON.parse(response.body)).to eq('session_lifetime_secs_value' => Devise.timeout_in.in_seconds)
+    end
+  end
+end

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       stop_impersonating_user
       render plain: "#{true_user&.id}/#{current_user&.id}"
     end
+
+    def countdown
+      render json: inactive_session_countdown_values
+    end
   end
 
   before do
@@ -43,6 +47,7 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       get 'who' => 'anonymous#who'
       get 'become' => 'anonymous#become'
       get 'unbecome' => 'anonymous#unbecome'
+      get 'countdown' => 'anonymous#countdown'
     end
     allow(controller).to receive(:idp_jwt_helper_for_request).and_return(jwt_helper)
   end
@@ -478,6 +483,28 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       session[:impersonation] = { true_user_id: 7, impersonated_user_id: 20 }
 
       expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+  end
+
+  describe '#inactive_session_countdown_values' do
+    let(:user) { double('User', id: 7, active?: true) }
+
+    before { allow(User).to receive(:find_or_create_from_jwt).and_return(user) }
+
+    it 'reports the token expiry as seconds remaining' do
+      allow(jwt_helper).to receive(:expiration_time).and_return(37.minutes.from_now)
+
+      get :countdown
+
+      expect(JSON.parse(response.body)['session_remaining_secs_value']).to be_within(5).of(37.minutes.to_i)
+    end
+
+    it 'is empty when no user is authenticated' do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+      get :countdown
+
+      expect(JSON.parse(response.body)).to eq({})
     end
   end
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -10,79 +10,86 @@ require 'rails_helper'
 
 # The invitation routes come from `devise_for :users`, mounted only under AuthMethod.devise?;
 # under jwt the IdP owns provisioning (see Idp::AdminUserCreator).
-RSpec.describe Users::InvitationsController, :devise_only, type: :controller do
-  let(:admin_user) { create(:acl_user) }
-  let(:admin_role) { create :admin_role }
-  let(:no_data_source_collection) { create :collection }
+#
+# The wrapper is here because a controller spec resolves Users::InvitationsController as its
+# described_class when the file loads, and the class is not autoloaded under jwt. The sibling
+# request specs name their controller in a string, which needs no wrapper; that is not open here
+# because rspec-rails instantiates described_class to drive the request.
+if AuthMethod.devise?
+  RSpec.describe Users::InvitationsController, :devise_only, type: :controller do
+    let(:admin_user) { create(:acl_user) }
+    let(:admin_role) { create :admin_role }
+    let(:no_data_source_collection) { create :collection }
 
-  let(:agency) { create(:agency) }
-  let(:valid_params) do
-    {
-      user: {
-        first_name: 'John',
-        last_name: 'Doe',
-        email: 'john.doe@example.com',
-        phone: '123-456-7890',
-        agency_id: agency.id,
-        legacy_role_ids: [],
-        user_group_ids: [],
-      },
-    }
-  end
-
-  let(:invalid_params) do
-    {
-      user: {
-        email: '',
-        first_name: '',
-        last_name: '',
-      },
-    }
-  end
-
-  before do
-    @request.env['devise.mapping'] = Devise.mappings[:user]
-    sign_in admin_user
-    setup_access_control(admin_user, admin_role, no_data_source_collection)
-  end
-
-  describe 'POST #create' do
-    context 'with valid parameters' do
-      it 'creates a new user and redirects to edit_admin_user_path' do
-        expect do
-          post :create, params: valid_params, format: :html
-        end.to change(User, :count).by(1)
-
-        expect(response).to redirect_to(edit_admin_user_path(User.last))
-        expect(flash[:notice]).to eq('An invitation email has been sent to john.doe@example.com.')
-      end
+    let(:agency) { create(:agency) }
+    let(:valid_params) do
+      {
+        user: {
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john.doe@example.com',
+          phone: '123-456-7890',
+          agency_id: agency.id,
+          legacy_role_ids: [],
+          user_group_ids: [],
+        },
+      }
     end
 
-    context 'with invalid parameters' do
-      it 'does not create a new user and re-renders the new template' do
-        expect do
-          post :create, params: invalid_params, format: :html
-        end.not_to change(User, :count)
-
-        expect(response).to render_template(:new)
-        expect(assigns(:user).errors).not_to be_empty
-      end
+    let(:invalid_params) do
+      {
+        user: {
+          email: '',
+          first_name: '',
+          last_name: '',
+        },
+      }
     end
 
-    context 'with duplicate email (existing active user)' do
-      let!(:existing_user) { create(:user, email: 'existing@example.com', agency: agency) }
-      let(:duplicate_email_params) do
-        valid_params.deep_merge(user: { email: existing_user.email })
+    before do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in admin_user
+      setup_access_control(admin_user, admin_role, no_data_source_collection)
+    end
+
+    describe 'POST #create' do
+      context 'with valid parameters' do
+        it 'creates a new user and redirects to edit_admin_user_path' do
+          expect do
+            post :create, params: valid_params, format: :html
+          end.to change(User, :count).by(1)
+
+          expect(response).to redirect_to(edit_admin_user_path(User.last))
+          expect(flash[:notice]).to eq('An invitation email has been sent to john.doe@example.com.')
+        end
       end
 
-      it 're-renders new template without raising (partial lookup and @system_alerts)' do
-        expect do
-          post :create, params: duplicate_email_params, format: :html
-        end.not_to change(User, :count)
+      context 'with invalid parameters' do
+        it 'does not create a new user and re-renders the new template' do
+          expect do
+            post :create, params: invalid_params, format: :html
+          end.not_to change(User, :count)
 
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:new)
-        expect(assigns(:user).errors).not_to be_empty
+          expect(response).to render_template(:new)
+          expect(assigns(:user).errors).not_to be_empty
+        end
+      end
+
+      context 'with duplicate email (existing active user)' do
+        let!(:existing_user) { create(:user, email: 'existing@example.com', agency: agency) }
+        let(:duplicate_email_params) do
+          valid_params.deep_merge(user: { email: existing_user.email })
+        end
+
+        it 're-renders new template without raising (partial lookup and @system_alerts)' do
+          expect do
+            post :create, params: duplicate_email_params, format: :html
+          end.not_to change(User, :count)
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template(:new)
+          expect(assigns(:user).errors).not_to be_empty
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,7 +71,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     before do
       allow(ENV).to receive(:fetch).with('CLIENT').and_return('test-client')
       allow(helper).to receive(:params).and_return(ActionController::Parameters.new(controller: 'test/nested', action: 'show'))
-      allow(helper).to receive(:current_user).and_return(nil)
+      # Without this wrapper, stubbing current_user verifies under devise (mixed into
+      # ActionController::Base globally) but raises under jwt (defined only on ApplicationController,
+      # which this bare helper spec's controller does not inherit).
+      without_partial_double_verification do
+        allow(helper).to receive(:current_user).and_return(nil)
+      end
       helper.instance_variable_set(:@layout__width, 'lg')
     end
 
@@ -89,7 +94,9 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'with signed in user' do
       before do
-        allow(helper).to receive(:current_user).and_return(double('User'))
+        without_partial_double_verification do
+          allow(helper).to receive(:current_user).and_return(double('User'))
+        end
       end
 
       it 'does not include not-signed-in class' do
@@ -313,7 +320,9 @@ RSpec.describe ApplicationHelper, type: :helper do
         before do
           allow(ENV).to receive(:fetch).with('CLIENT').and_return('test-client')
           allow(helper).to receive(:params).and_return(ActionController::Parameters.new(controller: 'admin/users', action: 'index'))
-          allow(helper).to receive(:current_user).and_return(nil)
+          without_partial_double_verification do
+            allow(helper).to receive(:current_user).and_return(nil)
+          end
           helper.instance_variable_set(:@layout__width, 'md')
         end
 

--- a/spec/initializers/devise_cve_2026_40295_spec.rb
+++ b/spec/initializers/devise_cve_2026_40295_spec.rb
@@ -13,7 +13,7 @@ require 'rails_helper'
 # Devise 5.0.4 fixes this natively (see Devise::Controllers::StoreLocation#extract_path_from_location);
 # the app previously carried a monkey patch backporting this fix, which was removed once the gem upgrade
 # landed. These specs confirm the native behavior still holds.
-RSpec.describe 'CVE-2026-40295 - open redirect via Referer on timeout' do
+RSpec.describe 'CVE-2026-40295 - open redirect via Referer on timeout', :devise_only do
   let(:store_location_host) { Class.new { include Devise::Controllers::StoreLocation }.new }
 
   describe 'extract_path_from_location' do

--- a/spec/lib/auth_method_spec.rb
+++ b/spec/lib/auth_method_spec.rb
@@ -36,4 +36,17 @@ RSpec.describe AuthMethod do
       expect(described_class.devise?).to be false
     end
   end
+
+  # The :devise group in Gemfile is required only on the Devise arm, which is what makes an
+  # unintended reference to Devise or Warden raise here instead of resolving against a loaded gem.
+  # A transitive require from any other gem restores them silently, so assert on the constants.
+  describe 'the :devise bundler group', :jwt_only do
+    it 'leaves Devise unloaded' do
+      expect(defined?(Devise)).to be_nil
+    end
+
+    it 'leaves Warden unloaded' do
+      expect(defined?(Warden)).to be_nil
+    end
+  end
 end

--- a/spec/models/idp/warden_proxy_spec.rb
+++ b/spec/models/idp/warden_proxy_spec.rb
@@ -120,12 +120,12 @@ RSpec.describe Idp::WardenProxy do
     # "no exception" as success.
     it 'raises for a non-:user scope' do
       proxy = described_class.new(user)
-      expect { proxy.authenticate!(:password, scope: :hmis_user) }.to raise_error(Warden::NotAuthenticated)
+      expect { proxy.authenticate!(:password, scope: :hmis_user) }.to raise_error(described_class::NotAuthenticated)
     end
 
     it 'raises when there is no authenticated user for the :user scope' do
       proxy = described_class.new(nil)
-      expect { proxy.authenticate! }.to raise_error(Warden::NotAuthenticated)
+      expect { proxy.authenticate! }.to raise_error(described_class::NotAuthenticated)
     end
   end
 

--- a/spec/models/omniauth_user_provisioner_spec.rb
+++ b/spec/models/omniauth_user_provisioner_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe OmniauthUserProvisioner, type: :model do
+RSpec.describe OmniauthUserProvisioner, :devise_only, type: :model do
   include ActiveJob::TestHelper
   before(:all) do
     clear_enqueued_jobs

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'invitation handling' do
+  describe 'invitation handling', :devise_only do
     context 'when user has an outstanding invitation' do
       before do
         User.invite!({ email: 'unconfirmed@example.com', first_name: 'Unconfirmed', last_name: 'User', agency_id: agency.id }, User.system_user)
@@ -198,7 +198,7 @@ RSpec.describe User, type: :model do
   # The app previously carried a monkey patch (DeviseUserPatch) working around this on
   # Devise 4; Devise 5.0.4 fixes it natively, so the patch was removed. This spec confirms
   # the native behavior still holds.
-  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync', :devise_only do
     it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
       attacker_email = 'attacker@example.com'
       victim_email   = 'victim@example.com'
@@ -226,7 +226,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security password_archivable' do
+  describe 'devise-security password_archivable', :devise_only do
     around do |example|
       original = Devise.deny_old_passwords
       Devise.deny_old_passwords = 2
@@ -274,7 +274,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security expirable' do
+  describe 'devise-security expirable', :devise_only do
     let(:user) { create(:user) }
 
     it 'is active when recently active' do
@@ -307,7 +307,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security secure_validatable password complexity' do
+  describe 'devise-security secure_validatable password complexity', :devise_only do
     around do |example|
       original = Devise.password_complexity
       Devise.password_complexity = { digit: 1, lower: 1, upper: 1, symbol: 1 }

--- a/spec/models/warden_proxy_factory_spec.rb
+++ b/spec/models/warden_proxy_factory_spec.rb
@@ -1,0 +1,112 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WardenProxyFactory, type: :model do
+  let!(:user) { create(:acl_user) }
+  let!(:role) { create(:role, can_view_all_reports: true) }
+  let!(:collection) { create(:collection) }
+
+  before do
+    setup_access_control(user, role, collection)
+  end
+
+  describe '.build' do
+    it 'answers the :user scope with the user it was built for' do
+      proxy = described_class.build(user)
+
+      expect(proxy.user(:user)).to eq(user)
+      expect(proxy.authenticated?(:user)).to be true
+    end
+
+    it 'answers no user for a scope it was not built for' do
+      proxy = described_class.build(user)
+
+      expect(proxy.user(:hmis_user)).to be_nil
+    end
+  end
+
+  describe "a document export rendered through the rack 'warden' key, the only channel it has" do
+    let(:export) do
+      GrdaWarehouse::WarehouseReports::DocumentExports::ActiveClientReportExport.new(user_id: user.id)
+    end
+    let(:rendered_html) { [] }
+
+    before do
+      # Stubbing stops at PdfGenerator.render_pdf, which needs a headless-Chrome binary. Stub
+      # PdfGenerator.html too and the spec still passes while rendering nothing through the proxy.
+      allow(PdfGenerator).to receive(:render_pdf) do |html|
+        rendered_html << html
+        '%PDF-'
+      end
+      allow(PdfGenerator).to receive(:merge_inline_pdfs) { |pdfs| Array.wrap(pdfs).join }
+    end
+
+    it 'renders the report for the user the export runs as' do
+      export.perform
+
+      expect(rendered_html.first).to include(ERB::Util.html_escape(user.name_with_email))
+    end
+
+    it 'completes the export' do
+      export.perform
+
+      expect(export.status).to eq(DocumentExportBehavior::COMPLETED_STATUS)
+      expect(export.file_data).to be_present
+    end
+  end
+
+  describe 'the render sites' do
+    let(:offenders) do
+      paths = Dir.glob(
+        [
+          Rails.root.join('{app,lib,spec}/**/*.rb'),
+          Rails.root.join('drivers/*/{app,lib,spec}/**/*.rb'),
+        ],
+      ) - [Rails.root.join('app/models/warden_proxy_factory.rb').to_s, __FILE__]
+
+      paths.sort.flat_map do |path|
+        File.readlines(path).each_with_index.
+          reject { |line, _index| line.lstrip.start_with?('#') }.
+          select { |line, _index| line.match?(pattern) }.
+          map { |_line, index| "#{Pathname.new(path).relative_path_from(Rails.root)}:#{index + 1}" }
+      end
+    end
+
+    describe 'a Warden::Proxy built outside the factory' do
+      let(:pattern) { /\bWarden::Proxy\.new/ }
+
+      it 'is nowhere' do
+        expect(offenders).to be_empty, <<~MSG
+          Warden loads only in the :devise bundler group, so this raises NameError under
+          AUTH_METHOD=jwt:
+
+          #{offenders.join("\n")}
+
+          Call WardenProxyFactory.renderer_env(user) instead.
+        MSG
+      end
+    end
+
+    describe "a rack 'warden' env key spelled outside the factory" do
+      let(:pattern) { /['"]warden['"]\s*=>/ }
+
+      it 'is nowhere' do
+        expect(offenders).to be_empty, <<~MSG
+          The 'warden' key name is WardenProxyFactory's contract with Idp::JwtCurrentUser, which
+          reads the proxy back out of the rack env:
+
+          #{offenders.join("\n")}
+
+          Pass WardenProxyFactory.renderer_env(user) to ActionController::Renderer.new instead.
+        MSG
+      end
+    end
+  end
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -83,8 +83,6 @@ RSpec.describe 'Content Security Policy', type: :request do
   end
 
   describe 'inline script nonces' do
-    before { get new_user_session_path }
-
     it 'renders inline <script> tags whose nonce matches the CSP header nonce' do
       header_nonce = response.headers['Content-Security-Policy'][/nonce-([A-Za-z0-9+\/=]+)/, 1]
       script_nonces = Capybara.string(response.body).all('script[nonce]', visible: :all).map { |el| el['nonce'] }

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -11,7 +11,7 @@ if ENV['OKTA_DOMAIN'].present?
   # Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
   # Devise-only: the okta callback route is declared inside the `devise_scope :user` block, so it
   # is not mounted under jwt, where the IdP owns federated sign-in.
-  RSpec.describe Users::OmniauthCallbacksController, :devise_only, type: :request do
+  RSpec.describe 'Users::OmniauthCallbacksController', :devise_only, type: :request do
     describe 'GET /users/auth/:provider protects against CVE-2015-9284' do
       it do
         get '/users/auth/okta'

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -13,7 +13,7 @@ require 'support/shared_contexts/login_activity_context'
 
 # Devise-only: Users::SessionsController is reachable only via the `devise_for :users` routes,
 # which config/routes.rb mounts under AuthMethod.devise?.
-RSpec.describe Users::SessionsController, :devise_only, type: :request do
+RSpec.describe 'Users::SessionsController', :devise_only, type: :request do
   let(:user) { create :user }
   let(:user_2fa) { create :user_2fa }
   let(:email) { ActionMailer::Base.deliveries.last }

--- a/spec/requests/user_training_controller_spec.rb
+++ b/spec/requests/user_training_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'UserTrainingController', type: :request do
   end
 
   describe 'GET /user_training' do
-    it 'redirects to the stored location when it is safe' do
+    it 'redirects to the stored location when it is safe', :devise_only do
       # Canary: Verify that stored_location_for exists (from Devise)
       # If Devise is removed, this test will fail and you'll need to reimplement the stored location functionality
       expect(UserTrainingController.instance_methods).to(
@@ -44,7 +44,7 @@ RSpec.describe 'UserTrainingController', type: :request do
       expect(response).to redirect_to('/welcome_back')
     end
 
-    it 'falls back when the stored location points to the training portal' do
+    it 'falls back when the stored location points to the training portal', :devise_only do
       # Canary: Verify that stored_location_for exists (from Devise)
       expect(UserTrainingController.instance_methods).to(
         include(:stored_location_for),
@@ -57,6 +57,17 @@ RSpec.describe 'UserTrainingController', type: :request do
       get user_training_path
 
       expect(response).to redirect_to(root_path)
+    end
+
+    it 'redirects to the user root without reading a stored location', :jwt_only do
+      # Devise defines stored_location_for even under AUTH_METHOD=jwt, so this has something to catch.
+      expect_any_instance_of(UserTrainingController).not_to receive(:stored_location_for)
+
+      allow_any_instance_of(User).to receive(:my_root_path).and_return(censuses_path)
+
+      get user_training_path
+
+      expect(response).to redirect_to(censuses_path)
     end
 
     it 'lets a user continue when all required trainings are completed' do
@@ -91,6 +102,36 @@ RSpec.describe 'UserTrainingController', type: :request do
 
       # Should redirect to after_sign_in_path_for
       expect(response).to redirect_to(root_path)
+    end
+
+    it 'lets a user continue when the portal finds every required training complete' do
+      config = create(:talentlms_config)
+      course = create(
+        :default_course,
+        config: config,
+        courseid: 123,
+      )
+      create(
+        :talentlms_login,
+        user: user,
+        config: config,
+        lms_user_id: 456,
+      )
+
+      allow_any_instance_of(User).to receive(:required_training_courses).and_return([course])
+      allow_any_instance_of(User).to receive(:my_root_path).and_return(censuses_path)
+
+      allow(lms_double).to receive(:any_training_required?).and_return(true)
+      allow(lms_double).to receive(:login).with(config).and_return(true)
+      allow(lms_double).to receive(:enroll).with(config, course.courseid)
+      allow(lms_double).to receive(:training_expired?).with(config, course.courseid).and_return(false)
+      allow(lms_double).to receive(:complete?).with(config, course.courseid).and_return(Date.today)
+      allow(lms_double).to receive(:valid_date?).with(Date.today).and_return(true)
+      allow(lms_double).to receive(:log_course_completion).with(config, course.courseid, Date.today)
+
+      get user_training_path
+
+      expect(response).to redirect_to(censuses_path)
     end
 
     it 'presents the captive portal when a required training is incomplete' do
@@ -128,6 +169,27 @@ RSpec.describe 'UserTrainingController', type: :request do
 
       # Should render the captive portal
       expect(response).to render_template('required_trainings')
+    end
+  end
+
+  describe 'DELETE /users/sign_out while a required training is incomplete' do
+    before do
+      allow_any_instance_of(User).to receive(:training_required?).and_return(true)
+      allow(lms_double).to receive(:any_training_required?).and_return(true)
+    end
+
+    it 'hands the request to the proxy sign-out rather than the portal', :jwt_only do
+      allow_any_instance_of(Idp::SessionsController).to receive(:idp_end_token_holder_sessions)
+
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+    end
+
+    it 'runs the Devise sign-out rather than returning to the portal', :devise_only do
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to(root_url)
     end
   end
 end

--- a/spec/views/application/inactive_session_modal_spec.rb
+++ b/spec/views/application/inactive_session_modal_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe 'application/_inactive_session_modal', type: :view do
 
   before do
     allow(Translation).to receive(:translate) { |key| key }
-    # current_user is a controller helper_method, absent from the view verifying double, so stubbing it needs verification off.
+    # current_user and inactive_session_countdown_values are controller helper_methods, absent from
+    # the view verifying double, so stubbing them needs without_partial_double_verification.
     without_partial_double_verification do
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:inactive_session_countdown_values).and_return(session_remaining_secs_value: 2220)
     end
   end
 
@@ -24,33 +26,10 @@ RSpec.describe 'application/_inactive_session_modal', type: :view do
     Nokogiri::HTML(rendered).at_css('#inactive-session-modal')
   end
 
-  context 'on the JWT arm' do
-    let(:expires_at) { 37.minutes.from_now }
+  it 'seeds the modal with the current user and the auth arm countdown values' do
+    node = modal_node
 
-    before do
-      allow(AuthMethod).to receive(:jwt?).and_return(true)
-      without_partial_double_verification do
-        allow(view).to receive(:user_session_expires_at).and_return(expires_at)
-      end
-    end
-
-    it 'seeds the countdown from the token expiry rather than the Devise default' do
-      node = modal_node
-
-      expect(node['data-inactive-session-modal-session-expires-at-value']).to eq(expires_at.to_i.to_s)
-      devise_default = Time.current.to_i + Devise.timeout_in.in_seconds.to_i
-      expect(node['data-inactive-session-modal-session-expires-at-value'].to_i).not_to be_within(30).of(devise_default)
-    end
-  end
-
-  context 'on the Devise arm' do
-    before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
-
-    it 'does not seed a token expiry and keeps the Devise lifetime' do
-      node = modal_node
-
-      expect(node['data-inactive-session-modal-session-expires-at-value']).to be_nil
-      expect(node['data-inactive-session-modal-session-lifetime-secs-value']).to eq(Devise.timeout_in.in_seconds.to_s)
-    end
+    expect(node['data-inactive-session-modal-initial-user-id-value']).to eq(user.id.to_s)
+    expect(node['data-inactive-session-modal-session-remaining-secs-value']).to eq('2220')
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description


The warehouse boots on one of two auth arms — legacy Devise/Warden or the new forwarded-IdP-JWT arm. This branch makes the JWT arm fully independent of the Devise/Warden gems and fixes the seam-related test failures under it (#6681).

**The core move:** Devise, Warden, and their satellites (doorkeeper, omniauth, pretender, etc.) now live in a `group :devise` that only loads on the Devise arm. Everything downstream follows from that — any code path that used to lean on a Devise/Warden constant now either gets an arm-aware substitute or is gated so a stray reference fails at boot instead of silently resolving.

**What that touched:**
- **Rendering** — the five background/PDF render sites that built a raw `Warden::Proxy` now go through a new `WardenProxyFactory`, which hands back an `Idp::WardenProxy` on the JWT arm. A guard spec greps the tree so a bare `Warden::Proxy.new` can't creep back in.
- **HMIS session duration** — `sessionDuration` now comes from the JWT token expiry on the JWT arm instead of the hard-coded Devise timeout.
- **Sign-out from the training portal** — the captive-portal controller allow-list is now arm-aware so a JWT user held in the portal can still reach sign-out.
- **Smaller gates** — Doorkeeper associations, a new `NotAuthenticated` exception, factory password fields, and autoload paths are each conditioned on the arm.
- **Tests** — Devise-only specs tagged `:devise_only` (with `:jwt_only` counterparts added), and specs referencing now-unloaded constants switched to string describes / `if AuthMethod.devise?` guards.

**Why it matters:** the JWT arm can now boot clean without the Devise gems present, and misuse surfaces loudly at boot or in CI rather than as a silent fallback.

## Type of change
Bug fix, misc

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

