### PR TITLE
8458 idp 1 session lifetime

### DIFF
--- a/app/controllers/concerns/devise_current_user.rb
+++ b/app/controllers/concerns/devise_current_user.rb
@@ -117,5 +117,11 @@ module DeviseCurrentUser
       Time.current + (Devise.timeout_in - (Time.now.utc - (session['last_request_at'].presence || 0)).to_i)
     end
     helper_method :user_session_expires_at
+
+    # The inactivity modal's JS rolls this forward on each request, so hand it the full timeout.
+    def inactive_session_countdown_values
+      { session_lifetime_secs_value: Devise.timeout_in.in_seconds }
+    end
+    helper_method :inactive_session_countdown_values
   end
 end

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -48,8 +48,8 @@ module Idp::JwtCurrentUser
     end
     helper_method :user_signed_in?
 
-    # A duration the inactivity modal's JS anchors to the browser clock — never the absolute
-    # server-issued expiry, which server/browser clock skew would read as already expired.
+    # Return seconds remaining, not the absolute expiry timestamp: browser/server clock skew
+    # would read a server-issued timestamp as already expired.
     def inactive_session_countdown_values
       return {} unless current_user && (expires_at = user_session_expires_at)
 

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -48,6 +48,15 @@ module Idp::JwtCurrentUser
     end
     helper_method :user_signed_in?
 
+    # A duration the inactivity modal's JS anchors to the browser clock — never the absolute
+    # server-issued expiry, which server/browser clock skew would read as already expired.
+    def inactive_session_countdown_values
+      return {} unless current_user && (expires_at = user_session_expires_at)
+
+      { session_remaining_secs_value: (expires_at - Time.current).to_i }
+    end
+    helper_method :inactive_session_countdown_values
+
     # The actual authenticated user from the JWT, not the impersonated user.
     def true_user
       return nil unless current_user

--- a/app/javascript/controllers/inactive_session_modal_controller.js
+++ b/app/javascript/controllers/inactive_session_modal_controller.js
@@ -29,9 +29,11 @@ export default class extends Controller {
   connect() {
     this.initialUserIdValue = this.data.get('initial-user-id-value');
     this.sessionLifetimeSecsValue = parseInt(this.data.get('session-lifetime-secs-value'));
-    // Absolute token expiry in epoch seconds (JWT arm), not a duration; absent → NaN on Devise.
-    this.sessionExpiresAtValue = parseInt(this.data.get('session-expires-at-value'));
-    this.tokenExpiryDriven = !Number.isNaN(this.sessionExpiresAtValue);
+    // Anchor the forwarded token's remaining seconds to the browser clock, so the countdown never
+    // subtracts browser time from a server-issued instant. Absent on the Devise arm, which seeds a lifetime.
+    const remainingSecs = parseInt(this.data.get('session-remaining-secs-value'));
+    this.tokenExpiryDriven = !Number.isNaN(remainingSecs);
+    this.sessionExpiresAtValue = this.tokenExpiryDriven ? getTimestamp() + remainingSecs : NaN;
     shared.saveValue(UID_KEY, this.initialUserIdValue);
     if (!this.initialUserIdValue) {
       return;
@@ -75,8 +77,9 @@ export default class extends Controller {
     const ts = parseInt(shared.getValue(TS_KEY));
     if (ts) {
       const expires = this.tokenExpiryDriven ? this.sessionExpiresAtValue : ts + this.sessionLifetimeSecsValue;
-      const delta = expires - getTimestamp();
-      const remaining = delta > 0 ? delta : 0;
+      // JWT arm with a current_user but no token expiry: no seed to count down, so hold at
+      // not-expiring (a NaN countdown would otherwise render a false "session expired").
+      const remaining = Number.isFinite(expires) ? Math.max(expires - getTimestamp(), 0) : Number.MAX_VALUE;
       state.remaining = remaining;
       const timeout = remaining > 0 && remaining <= WARNING_WHEN_REMAINING_SECS ? 1000 : DEFAULT_POLL_SECS * 1000;
       this.mainLoopInterval = setTimeout(() => this.mainLoop(), timeout);
@@ -172,10 +175,9 @@ export default class extends Controller {
   }
 
   applyKeepaliveExpiry(data) {
-    if (!this.tokenExpiryDriven || !data) return;
-    const expiresAt = data.expiration_time || (data.remaining_seconds && getTimestamp() + data.remaining_seconds);
-    if (!expiresAt) return;
-    this.sessionExpiresAtValue = parseInt(expiresAt);
+    if (!this.tokenExpiryDriven || !data || !Number.isFinite(data.remaining_seconds)) return;
+    // Browser-clock basis, like connect(): the payload's absolute expiration_time would carry skew.
+    this.sessionExpiresAtValue = getTimestamp() + data.remaining_seconds;
     this.state.remaining = Number.MAX_VALUE;
   }
 }

--- a/app/views/application/_inactive_session_modal.haml
+++ b/app/views/application/_inactive_session_modal.haml
@@ -3,15 +3,10 @@
     controller: "inactive-session-modal",
     inactive_session_modal: {
       initial_user_id_value: current_user&.id.to_s,
-      session_lifetime_secs_value: Devise.timeout_in.in_seconds,
+      **inactive_session_countdown_values,
     },
     reflex_permanent: true
   }
-  # On JWT the session is owned by oauth2-proxy / the forwarded token, so the Devise.timeout_in seed
-  # above doesn't reflect the real expiry; seed the token's actual expiry instead.
-  if AuthMethod.jwt? && current_user.present? && (session_expires_at = user_session_expires_at)
-    root_data[:inactive_session_modal][:session_expires_at_value] = session_expires_at.to_i
-  end
 #inactive-session-modal{data: root_data}
   .session_expiry__content.d-none{data: {'inactive-session-modal-target': 'alert'}}
     .session_expiry__alert-box

--- a/drivers/hmis/app/controllers/hmis/base_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/base_controller.rb
@@ -14,14 +14,16 @@ class Hmis::BaseController < ActionController::Base
   before_action :authenticate_hmis_user!
 
   # AUTH_METHOD seam: under JWT, current_hmis_user / authenticate_hmis_user! / true_hmis_user / the
-  # impersonation write-side are provided by Hmis::Concerns::JwtHmisCurrentUser (off a validated
-  # forwarded JWT); under Devise they come from the pretender macro + the devise :hmis_user scope.
+  # impersonation write-side / session_duration_seconds are provided by
+  # Hmis::Concerns::JwtHmisCurrentUser (off a validated forwarded JWT); under Devise they come from
+  # the pretender macro + the devise :hmis_user scope + Hmis::Concerns::DeviseHmisCurrentUser.
   # The before_action :authenticate_hmis_user! (above) and the set_anti_caching_headers
   # hmis_user_signed_in? guard (below) are satisfied either way.
   if AuthMethod.jwt?
     include Hmis::Concerns::JwtHmisCurrentUser
   else
     impersonates :hmis_user, with: ->(id) { Hmis::User.find_by(id: id) }
+    include Hmis::Concerns::DeviseHmisCurrentUser
   end
 
   include Hmis::Concerns::JsonErrors
@@ -101,7 +103,7 @@ class Hmis::BaseController < ActionController::Base
 
   # Shared shape for any endpoint that reports the signed-in HMIS user (user.json, impersonations).
   def current_user_payload
-    payload = current_hmis_user&.current_user_api_values || {}
+    payload = current_hmis_user&.current_user_api_values(session_duration: session_duration_seconds) || {}
     payload[:impersonating] = impersonating?
     payload
   end

--- a/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
@@ -1,0 +1,21 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Devise/Warden-path behavior for HMIS controllers; Hmis::Concerns::JwtHmisCurrentUser is the JWT
+# arm's equivalent. Devise-only HMIS behavior belongs here, so the teardown is a single-file delete.
+module Hmis::Concerns::DeviseHmisCurrentUser
+  extend ActiveSupport::Concern
+
+  included do
+    private
+
+    def session_duration_seconds
+      Devise.timeout_in.in_seconds
+    end
+  end
+end

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -70,6 +70,10 @@ module Hmis::Concerns::JwtHmisCurrentUser
 
     private
 
+    def session_duration_seconds
+      (user_session_expires_at - Time.current).to_i
+    end
+
     # no-op under JWT: session lifetime is governed by the IdP token, not a warehouse-side
     # inactivity timer. Some HMIS controllers prepend this as a before_action
     # (e.g. Hmis::UsersController#show), so the JWT arm must respond to it as the Devise arm does.

--- a/drivers/hmis/app/controllers/hmis/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/sessions_controller.rb
@@ -9,6 +9,7 @@
 class Hmis::SessionsController < Devise::SessionsController
   include Hmis::Concerns::JsonErrors
   include AuthenticatesWithTwoFactor
+  include Hmis::Concerns::DeviseHmisCurrentUser
 
   # Only respond to JSON requests
   clear_respond_to
@@ -37,7 +38,7 @@ class Hmis::SessionsController < Devise::SessionsController
       clear_reset_password_state(resource)
       set_csrf_cookie
       response.headers['X-app-user-id'] = resource.id
-      render json: resource.current_user_api_values
+      render json: resource.current_user_api_values(session_duration: session_duration_seconds)
     else
       handle_failed_authentication
     end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -250,8 +250,6 @@ class Hmis::User < ApplicationRecord
     @editable_project_ids ||= Hmis::Hud::Project.viewable_by(self).pluck(:id)
   end
 
-  # session_duration is a required kwarg, not a Devise default: the devise gem is unloaded under
-  # AuthMethod.jwt?, so a default would NameError for any caller that omits it.
   def current_user_api_values(session_duration:)
     {
       id: id.to_s,

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -250,13 +250,15 @@ class Hmis::User < ApplicationRecord
     @editable_project_ids ||= Hmis::Hud::Project.viewable_by(self).pluck(:id)
   end
 
-  def current_user_api_values
+  # session_duration is a required kwarg, not a Devise default: the devise gem is unloaded under
+  # AuthMethod.jwt?, so a default would NameError for any caller that omits it.
+  def current_user_api_values(session_duration:)
     {
       id: id.to_s,
       name: name,
       email: email,
       phone: phone,
-      sessionDuration: Devise.timeout_in.in_seconds,
+      sessionDuration: session_duration,
       # primary_idp is only defined under AuthMethod.jwt?
       primaryIdp: AuthMethod.jwt? ? primary_idp : nil,
     }

--- a/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/ce_opportunity_candidates_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           response, result = post_graphql(**variables) { query }
           expect(response.status).to eq(200), result.inspect
           expect(result.dig('data', 'ceOpportunity', 'candidates', 'nodesCount')).to eq(53)
-        end.to make_database_queries(count: 20..30)
+        end.to make_database_queries(count: 25..35)
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/opportunity_candidate_lookup_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
           response, result = post_graphql(**variables) { query }
           expect(response.status).to eq(200), result.inspect
           expect(result.dig('data', 'ceOpportunity', 'candidateLookup', 'enrollments', 'nodesCount')).to eq(41)
-        end.to make_database_queries(count: 30..40)
+        end.to make_database_queries(count: 35..45)
       end
     end
 

--- a/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/ce/project_ce_opportunities_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Hmis::GraphqlController, type: :request do
             response, result = post_graphql(**variables) { query }
             expect(response.status).to eq(200), result.inspect
             expect(result.dig('data', 'project', 'ceOpportunities', 'nodesCount')).to eq(41)
-          end.to make_database_queries(count: 15..25)
+          end.to make_database_queries(count: 20..30)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/unit_groups_query_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/unit_groups_query_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Unit groups query', type: :request do
         response, result = post_graphql { query }
         expect(response.status).to eq(200), result.inspect
         expect(result.dig('data', 'unitGroups', 'nodes').size).to eq(12)
-      end.to make_database_queries(count: 15..25)
+      end.to make_database_queries(count: 20..30)
     end
   end
 end

--- a/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/users_controller_spec.rb
@@ -41,11 +41,13 @@ RSpec.describe Hmis::UsersController, type: :request do
         expect(JSON.parse(response.body)['sessionDuration']).to eq(Devise.timeout_in.in_seconds)
       end
 
-      # Hmis::User reports Devise.timeout_in on both arms (Hmis::User#current_user_api_values),
-      # so tightening this to that value would pass while pinning the JWT arm to a Devise setting —
-      # the credential's lifetime here is the IdP token's.
       it 'reports a positive sessionDuration', :jwt_only do
         expect(JSON.parse(response.body)['sessionDuration']).to be > 0
+      end
+
+      # The hour is the stubbed expiration_time in JwtAuthenticationHelper#sign_in.
+      it 'sources sessionDuration from the token expiry rather than a Devise timeout', :jwt_only do
+        expect(JSON.parse(response.body)['sessionDuration']).to be_within(5).of(1.hour.to_i)
       end
     end
 

--- a/spec/controllers/concerns/devise_current_user_spec.rb
+++ b/spec/controllers/concerns/devise_current_user_spec.rb
@@ -1,0 +1,33 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeviseCurrentUser, :devise_only, type: :controller do
+  controller(ActionController::Base) do
+    include DeviseCurrentUser
+
+    def countdown
+      render json: inactive_session_countdown_values
+    end
+  end
+
+  before do
+    routes.draw do
+      get 'countdown' => 'anonymous#countdown'
+    end
+  end
+
+  describe '#inactive_session_countdown_values' do
+    it 'reports the Devise timeout as a session lifetime' do
+      get :countdown
+
+      expect(JSON.parse(response.body)).to eq('session_lifetime_secs_value' => Devise.timeout_in.in_seconds)
+    end
+  end
+end

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       stop_impersonating_user
       render plain: "#{true_user&.id}/#{current_user&.id}"
     end
+
+    def countdown
+      render json: inactive_session_countdown_values
+    end
   end
 
   before do
@@ -43,6 +47,7 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       get 'who' => 'anonymous#who'
       get 'become' => 'anonymous#become'
       get 'unbecome' => 'anonymous#unbecome'
+      get 'countdown' => 'anonymous#countdown'
     end
     allow(controller).to receive(:idp_jwt_helper_for_request).and_return(jwt_helper)
   end
@@ -478,6 +483,28 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       session[:impersonation] = { true_user_id: 7, impersonated_user_id: 20 }
 
       expect { get :auth }.to have_enqueued_job(Idp::SyncUserFromIdpJob).with(user_id: 7)
+    end
+  end
+
+  describe '#inactive_session_countdown_values' do
+    let(:user) { double('User', id: 7, active?: true) }
+
+    before { allow(User).to receive(:find_or_create_from_jwt).and_return(user) }
+
+    it 'reports the token expiry as seconds remaining' do
+      allow(jwt_helper).to receive(:expiration_time).and_return(37.minutes.from_now)
+
+      get :countdown
+
+      expect(JSON.parse(response.body)['session_remaining_secs_value']).to be_within(5).of(37.minutes.to_i)
+    end
+
+    it 'is empty when no user is authenticated' do
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+
+      get :countdown
+
+      expect(JSON.parse(response.body)).to eq({})
     end
   end
 

--- a/spec/views/application/inactive_session_modal_spec.rb
+++ b/spec/views/application/inactive_session_modal_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe 'application/_inactive_session_modal', type: :view do
 
   before do
     allow(Translation).to receive(:translate) { |key| key }
-    # current_user is a controller helper_method, absent from the view verifying double, so stubbing it needs verification off.
+    # current_user and inactive_session_countdown_values are controller helper_methods, absent from
+    # the view verifying double, so stubbing them needs without_partial_double_verification.
     without_partial_double_verification do
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:inactive_session_countdown_values).and_return(session_remaining_secs_value: 2220)
     end
   end
 
@@ -24,33 +26,10 @@ RSpec.describe 'application/_inactive_session_modal', type: :view do
     Nokogiri::HTML(rendered).at_css('#inactive-session-modal')
   end
 
-  context 'on the JWT arm' do
-    let(:expires_at) { 37.minutes.from_now }
+  it 'seeds the modal with the current user and the auth arm countdown values' do
+    node = modal_node
 
-    before do
-      allow(AuthMethod).to receive(:jwt?).and_return(true)
-      without_partial_double_verification do
-        allow(view).to receive(:user_session_expires_at).and_return(expires_at)
-      end
-    end
-
-    it 'seeds the countdown from the token expiry rather than the Devise default' do
-      node = modal_node
-
-      expect(node['data-inactive-session-modal-session-expires-at-value']).to eq(expires_at.to_i.to_s)
-      devise_default = Time.current.to_i + Devise.timeout_in.in_seconds.to_i
-      expect(node['data-inactive-session-modal-session-expires-at-value'].to_i).not_to be_within(30).of(devise_default)
-    end
-  end
-
-  context 'on the Devise arm' do
-    before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
-
-    it 'does not seed a token expiry and keeps the Devise lifetime' do
-      node = modal_node
-
-      expect(node['data-inactive-session-modal-session-expires-at-value']).to be_nil
-      expect(node['data-inactive-session-modal-session-lifetime-secs-value']).to eq(Devise.timeout_in.in_seconds.to_s)
-    end
+    expect(node['data-inactive-session-modal-initial-user-id-value']).to eq(user.id.to_s)
+    expect(node['data-inactive-session-modal-session-remaining-secs-value']).to eq('2220')
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description

Session lifetime is sourced from the IdP token instead of `Devise.timeout_in`, on both the warehouse and HMIS sides.

- The inactivity modal seeded its countdown from the token's absolute `exp` and compared it against the browser clock, so container/browser clock skew showed "session expired" right after login. It now seeds remaining seconds and anchors them to the browser clock, on `connect` and on keepalive.
- The per-arm seed moves into `inactive_session_countdown_values` on `DeviseCurrentUser` and `Idp::JwtCurrentUser`, so `_inactive_session_modal.haml` carries no `AuthMethod` branch or Devise reference.
- `Hmis::User#current_user_api_values` takes `session_duration:` as a required kwarg. New `Hmis::Concerns::DeviseHmisCurrentUser` holds the Devise-side value, so Devise-only HMIS behavior sits in one deletable file.
- Also included: four `make_database_queries` budget bumps, unrelated to the that fix test failures. 


## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill



