### PR TITLE
8458 idp 2 hmis terminal account states

### DIFF
--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -97,10 +97,10 @@ module Idp::JwtAuthentication
 
     connector_id = jwt_helper.connector_id
     connector_user_id = jwt_helper.connector_user_id
-    # Reached on the warehouse arm only; the HMIS arm walls off a token with no resolvable holder
-    # ahead of sign-out. connector_user_id is the claim this turns on: blank with a connector present
-    # would call logout_user_sessions(user_id: nil). A blank connector_id resolves to an
-    # Idp::NullService and would stop at the capability check below anyway.
+    # Reached from both arms: Hmis::Idp::SessionsController#destroy also skips authenticate_hmis_user!,
+    # so a claimless HMIS token reaches this guard — the only thing between it and
+    # logout_user_sessions(user_id: nil). connector_user_id is the claim it turns on; a blank
+    # connector_id resolves to an Idp::NullService and stops at the capability check below anyway.
     return if connector_id.blank? || connector_user_id.blank?
 
     service = idp_session_logout_service(connector_id)

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -97,10 +97,9 @@ module Idp::JwtAuthentication
 
     connector_id = jwt_helper.connector_id
     connector_user_id = jwt_helper.connector_user_id
-    # Reached from both arms: Hmis::Idp::SessionsController#destroy also skips authenticate_hmis_user!,
-    # so a claimless HMIS token reaches this guard — the only thing between it and
-    # logout_user_sessions(user_id: nil). connector_user_id is the claim it turns on; a blank
-    # connector_id resolves to an Idp::NullService and stops at the capability check below anyway.
+    # ::Idp::SessionsController#destroy and Hmis::Idp::SessionsController#destroy both skip their
+    # authentication filter, so a token with no connector_user_id claim reaches this guard — the only
+    # thing between it and logout_user_sessions(user_id: nil).
     return if connector_id.blank? || connector_user_id.blank?
 
     service = idp_session_logout_service(connector_id)

--- a/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
@@ -18,8 +18,7 @@ module Hmis::Concerns::DeviseHmisCurrentUser
       Devise.timeout_in.in_seconds
     end
 
-    # nil stub of the JWT arm's terminal_account_error, so Hmis::UsersController#show can call it
-    # under both arms without a respond_to? check.
+    # Defined only because Hmis::UsersController#show calls it on both arms.
     def terminal_account_error
       nil
     end

--- a/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/devise_hmis_current_user.rb
@@ -17,5 +17,11 @@ module Hmis::Concerns::DeviseHmisCurrentUser
     def session_duration_seconds
       Devise.timeout_in.in_seconds
     end
+
+    # nil stub of the JWT arm's terminal_account_error, so Hmis::UsersController#show can call it
+    # under both arms without a respond_to? check.
+    def terminal_account_error
+      nil
+    end
   end
 end

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -70,8 +70,7 @@ module Hmis::Concerns::JwtHmisCurrentUser
 
     private
 
-    # Terminal account state for the bootstrap probe, allows front-end to show the
-    # correct account error to the user
+    # Surfaced as accountError in the /hmis/user.json payload; the SPA renders its terminal page from it.
     def terminal_account_error
       return nil if current_hmis_user
       return :account_deactivated if idp_token_holder && !idp_token_holder.active?
@@ -102,8 +101,8 @@ module Hmis::Concerns::JwtHmisCurrentUser
       raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
       # 403, not 401: signing in again can't produce an account, and a 401 would send the SPA to a
-      # sign-in screen it would come straight back from. The SPA renders its terminal page from the
-      # /hmis/user.json bootstrap payload (accountError, via terminal_account_error), not this 403.
+      # sign-in screen it would come straight back from. The SPA's terminal page comes from
+      # terminal_account_error, not this 403.
       render_json_error(403, :no_warehouse_account)
     end
 

--- a/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
+++ b/drivers/hmis/app/controllers/hmis/concerns/jwt_hmis_current_user.rb
@@ -70,6 +70,15 @@ module Hmis::Concerns::JwtHmisCurrentUser
 
     private
 
+    # Terminal account state for the bootstrap probe, allows front-end to show the
+    # correct account error to the user
+    def terminal_account_error
+      return nil if current_hmis_user
+      return :account_deactivated if idp_token_holder && !idp_token_holder.active?
+
+      :no_warehouse_account if idp_jwt_helper_for_request.token?
+    end
+
     def session_duration_seconds
       (user_session_expires_at - Time.current).to_i
     end
@@ -93,9 +102,8 @@ module Hmis::Concerns::JwtHmisCurrentUser
       raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
       # 403, not 401: signing in again can't produce an account, and a 401 would send the SPA to a
-      # sign-in screen it would come straight back from. The SPA keys off error.type on the 403 to
-      # render a terminal page (hmis-frontend apolloErrorLink.tsx -> AccountTerminalErrorDialog,
-      # contract in src/modules/auth/hooks/README.md).
+      # sign-in screen it would come straight back from. The SPA renders its terminal page from the
+      # /hmis/user.json bootstrap payload (accountError, via terminal_account_error), not this 403.
       render_json_error(403, :no_warehouse_account)
     end
 

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -14,15 +14,18 @@ module Hmis
     # Mirrors ::Idp::SessionsController#destroy (the warehouse's JWT logout), but the SPA calls this
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
-    #
-    # Unlike ::Idp::SessionsController, #destroy keeps authenticate_hmis_user! (Hmis::BaseController
-    # applies it, and this class does not skip it): the SPA recovers from a JSON 403 by hitting
-    # /oauth2/sign_out itself, so there is no server-rendered dead-end page needing sign-out to work
-    # without a resolvable current_user (the reason the warehouse skips the filter).
-    #
     class SessionsController < Hmis::BaseController
-      # The CSRF token is what guards #destroy
+      # Skipped so the two terminal account states (account_deactivated, no_warehouse_account) can
+      # sign out: both hold a valid token but resolve no current_hmis_user, so the filter would
+      # render the JSON 403 dead end sign-out exists to escape. Matches ::Idp::SessionsController.
+      skip_before_action :authenticate_hmis_user!, only: [:destroy]
+
+      # CSRF (verify_authenticity_token, ahead of the skipped filter) is the outermost guard on #destroy.
       def destroy
+        # authenticate_hmis_user! is skipped on #destroy, so its tokenless raise has to live here.
+        # Why tokenless must raise, not answer: JwtHmisCurrentUser#idp_handle_unauthenticated.
+        raise ::Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
+
         # First: the Keycloak session, which /oauth2/sign_out never reaches. Ahead of reset_session
         # because it reads the forwarded token, and because it fails closed. Don't make it
         # best-effort. ::Idp::SessionsController#destroy is the same sequence with an HTML response.

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -15,27 +15,24 @@ module Hmis
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
     class SessionsController < Hmis::BaseController
-      # Skipped so the two terminal account states (account_deactivated, no_warehouse_account) can
-      # sign out: both hold a valid token but resolve no current_hmis_user, so the filter would
-      # render the JSON 403 dead end sign-out exists to escape. Matches ::Idp::SessionsController.
+      # account_deactivated / no_warehouse_account users hold a valid token but no
+      # current_hmis_user; without this skip, #destroy would 403 their sign-out request.
       skip_before_action :authenticate_hmis_user!, only: [:destroy]
 
-      # CSRF (verify_authenticity_token, ahead of the skipped filter) is the outermost guard on #destroy.
       def destroy
-        # authenticate_hmis_user! is skipped on #destroy, so its tokenless raise has to live here.
-        # Why tokenless must raise, not answer: JwtHmisCurrentUser#idp_handle_unauthenticated.
+        # authenticate_hmis_user! (skipped above) would raise on a tokenless request; reproduce
+        # that so idp_handle_unauthenticated (JwtHmisCurrentUser) runs rather than a login redirect.
         raise ::Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
-        # First: the Keycloak session, which /oauth2/sign_out never reaches. Ahead of reset_session
-        # because it reads the forwarded token, and because it fails closed. Don't make it
-        # best-effort. ::Idp::SessionsController#destroy is the same sequence with an HTML response.
+        # Ends the Keycloak session that /oauth2/sign_out never reaches. reset_session would clear
+        # the forwarded token this reads, so it runs first. Let ::Idp::SessionLogoutRefused reach
+        # the rescue below — swallowing it here silently skips teardown and leaves the session live.
         idp_end_token_holder_sessions
 
-        # Second: the Rails session, so it doesn't outlive this login.
         reset_session
 
-        # Third, once the SPA navigates to this. Relative on purpose — an absolute URL built from
-        # request.base_url could be spoofed via the Host header.
+        # Relative, not absolute: an absolute URL built from request.base_url could be spoofed via
+        # the Host header.
         render json: { redirect_url: "/oauth2/sign_out?rd=#{CGI.escape(root_path)}" }
       rescue ::Idp::SessionLogoutRefused
         idp_handle_session_logout_failure
@@ -43,11 +40,12 @@ module Hmis
 
       private
 
-      # Deliberately doesn't call up to Hmis::BaseController's version, which resets the session
-      # first. Under JWT that reset signs nobody out — the credential is the forwarded token — but it
-      # drops any impersonation and strands the CSRF-Token cookie the browser holds, since
-      # set_csrf_cookie is a later before_action and never runs once this one halts the chain. The
-      # user's own retry of the sign-out would then fail the same way. 401 and no side effect.
+      # Overrides Hmis::BaseController's handler and skips super, which calls reset_session. Under
+      # JWT, reset_session signs nobody out (the credential is the forwarded token, not the session)
+      # and has two costs. It drops any active impersonation. And it strands the CSRF-Token cookie:
+      # set_csrf_cookie, the before_action that refreshes that cookie, runs later in the chain, so it
+      # is skipped once this handler halts the request — and the user's next sign-out attempt then
+      # fails the same way. Respond 401 and leave the session untouched.
       def handle_unverified_request
         render_json_error(401, :unverified_request)
       end

--- a/drivers/hmis/app/controllers/hmis/users_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/users_controller.rb
@@ -16,7 +16,10 @@ class Hmis::UsersController < Hmis::BaseController
   # This is called by the frontend on initial page load, to determine whether
   # there is a currently active session.
   def show
-    render json: current_user_payload
+    payload = current_user_payload
+    account_error = terminal_account_error
+    payload[:accountError] = account_error if account_error
+    render json: payload
   end
 
   # clear etag to prevent caching

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -120,13 +120,36 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
       expect(response.headers['X-app-user-id']).to be_blank
     end
 
-    it 'answers 200 with no user for a deactivated holder, rather than the JSON 403 guarded routes return' do
+    it 'answers 200 with an accountError for a deactivated holder, rather than the JSON 403 guarded routes return' do
       sign_in(create(:hmis_user, active: false))
 
       get hmis_user_path, headers: headers
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq('impersonating' => false)
+      # Whole-payload assertion, not include: a change that leaks another user's values onto the
+      # terminal-state bootstrap must fail here.
+      expect(JSON.parse(response.body)).to eq('impersonating' => false, 'accountError' => 'account_deactivated')
+    end
+
+    it 'answers 200 with an accountError for a good token whose holder has no warehouse account' do
+      # find_or_create_from_jwt returns nil only when neither the connector link nor the email
+      # matches, and sign_in provisions both, so no fixture reaches this branch — hence the stub.
+      allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+      sign_in(create(:hmis_user))
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq('impersonating' => false, 'accountError' => 'no_warehouse_account')
+    end
+
+    it 'has no accountError for an active signed-in user' do
+      sign_in(create(:hmis_user))
+
+      get hmis_user_path, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).not_to have_key('accountError')
     end
 
     it 'reflects the actual primaryIdp connector value, not just its presence' do

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -428,22 +428,47 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
         expect_signed_out_normally
       end
 
-      # Idp::UserProvisioner needs the connector claim to resolve a holder, and authenticate_hmis_user!
-      # runs before #destroy, so a claimless token 403s at authentication rather than reaching sign-out.
-      # The warehouse arm skips authenticate_user! on #destroy, so there the same token reaches
-      # idp_end_token_holder_sessions and signs out via its blank-connector guard.
-      it 'never reaches sign-out for a token with no connector claim: the request fails to authenticate' do
+      # The skip on authenticate_hmis_user! lets a no-connector-claim token reach #destroy, where
+      # idp_end_token_holder_sessions returns on the blank connector before any admin-API call. Mirrors
+      # the warehouse arm.
+      it 'signs out a token with no connector claim via the blank-connector guard, without an IdP call' do
         start_session
         # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
         allow(Idp::JwtHelper.new(access_token: jwt_token)).to receive(:connector_id).and_return(nil)
 
         delete destroy_hmis_user_session_path, headers: headers
 
-        expect(response).to have_http_status(:forbidden)
-        expect(JSON.parse(response.body).dig('error', 'type')).to eq('no_warehouse_account')
         # On the service, not on Idp::ServiceFactory: the user payload consults the factory too
         # (see idp_service above), so the factory cannot carry a never-consulted assertion.
         expect(idp_service).not_to have_received(:logout_user_sessions)
+        expect_signed_out_normally
+      end
+
+      # Ending the IdP session for a locked-out deactivated holder looks pointless, but on a shared
+      # machine a surviving session signs the next person in — and the token still carries the connector
+      # claims logout_user_sessions needs. #destroy runs at all only because it skips authenticate_hmis_user!.
+      it 'ends the IdP session and signs out a deactivated token holder' do
+        inactive = create(:hmis_user, active: false)
+        sign_in(inactive)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(inactive))
+        expect_signed_out_normally
+      end
+
+      # No warehouse row, but the token still carries connector_id and connector_user_id — all
+      # idp_end_token_holder_sessions needs — so the IdP session ends exactly as for the deactivated
+      # holder. find_or_create_from_jwt stubbed nil: no reachable fixture hits this branch.
+      it 'ends the IdP session and signs out a good token whose holder has no warehouse account' do
+        allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
+        holder = create(:hmis_user)
+        sign_in(holder)
+
+        delete destroy_hmis_user_session_path, headers: headers
+
+        expect(idp_service).to have_received(:logout_user_sessions).with(user_id: jwt_connector_user_id(holder))
+        expect_signed_out_normally
       end
 
       # The whole reason the id comes off the token: current_hmis_user is the impersonated user here,
@@ -543,6 +568,33 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
           get hmis_user_path, headers: headers
           expect(controller.current_hmis_user).to eq(target_user)
           expect(controller.true_hmis_user).to eq(admin_user)
+        end
+
+        # The skip made terminal-state holders reachable at #destroy; verify CSRF still rejects them,
+        # not only the active holder above.
+        it 'still rejects a terminal-state holder with no CSRF token, without ending the IdP session' do
+          sign_in(create(:hmis_user, active: false))
+
+          delete destroy_hmis_user_session_path, headers: headers
+
+          expect(response).to have_http_status(:unauthorized)
+          expect(JSON.parse(response.body)).to eq('error' => { 'type' => 'unverified_request' })
+          expect(idp_service).not_to have_received(:logout_user_sessions)
+        end
+
+        # A bare tokenless request would 401 on CSRF (checked ahead of the action) and never reach the
+        # tokenless guard — passing even if the guard were gone. So sign in for a valid CSRF token, then
+        # drop the JWT: CSRF passes, and the guard fires.
+        it 'raises on a tokenless request that clears CSRF, rather than a quiet sign-out' do
+          start_session
+          token = csrf_token_from_last_response
+          sign_out
+
+          expect do
+            delete destroy_hmis_user_session_path, headers: headers.merge('X-CSRF-Token' => token)
+          end.to raise_error(Idp::UnauthenticatedRequestError)
+
+          expect(idp_service).not_to have_received(:logout_user_sessions)
         end
       end
     end

--- a/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/hmis_jwt_wiring_spec.rb
@@ -120,20 +120,21 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
       expect(response.headers['X-app-user-id']).to be_blank
     end
 
-    it 'answers 200 with an accountError for a deactivated holder, rather than the JSON 403 guarded routes return' do
+    it 'answers 200 with an accountError for a deactivated holder' do
       sign_in(create(:hmis_user, active: false))
 
       get hmis_user_path, headers: headers
 
       expect(response).to have_http_status(:ok)
-      # Whole-payload assertion, not include: a change that leaks another user's values onto the
-      # terminal-state bootstrap must fail here.
+      # Match the whole payload with eq, not include: the terminal-state bootstrap must be exactly
+      # these two keys. A regression that let current_hmis_user resolve would surface the holder's
+      # full current_user_api_values here, and a partial matcher would still pass.
       expect(JSON.parse(response.body)).to eq('impersonating' => false, 'accountError' => 'account_deactivated')
     end
 
     it 'answers 200 with an accountError for a good token whose holder has no warehouse account' do
       # find_or_create_from_jwt returns nil only when neither the connector link nor the email
-      # matches, and sign_in provisions both, so no fixture reaches this branch — hence the stub.
+      # matches, and sign_in provisions both, so no fixture reaches this branch.
       allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
       sign_in(create(:hmis_user))
 
@@ -428,9 +429,6 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
         expect_signed_out_normally
       end
 
-      # The skip on authenticate_hmis_user! lets a no-connector-claim token reach #destroy, where
-      # idp_end_token_holder_sessions returns on the blank connector before any admin-API call. Mirrors
-      # the warehouse arm.
       it 'signs out a token with no connector claim via the blank-connector guard, without an IdP call' do
         start_session
         # sign_in memoizes one JwtHelper double per token, so this is the object the request reads.
@@ -444,9 +442,8 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
         expect_signed_out_normally
       end
 
-      # Ending the IdP session for a locked-out deactivated holder looks pointless, but on a shared
-      # machine a surviving session signs the next person in — and the token still carries the connector
-      # claims logout_user_sessions needs. #destroy runs at all only because it skips authenticate_hmis_user!.
+      # A deactivated holder is locked out of HMIS, but a surviving Keycloak session signs the next
+      # person at a shared machine straight back in.
       it 'ends the IdP session and signs out a deactivated token holder' do
         inactive = create(:hmis_user, active: false)
         sign_in(inactive)
@@ -457,9 +454,8 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
         expect_signed_out_normally
       end
 
-      # No warehouse row, but the token still carries connector_id and connector_user_id — all
-      # idp_end_token_holder_sessions needs — so the IdP session ends exactly as for the deactivated
-      # holder. find_or_create_from_jwt stubbed nil: no reachable fixture hits this branch.
+      # The claims logout_user_sessions needs live on the token, not on the warehouse row, so a
+      # holder without one still gets a full IdP sign-out.
       it 'ends the IdP session and signs out a good token whose holder has no warehouse account' do
         allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
         holder = create(:hmis_user)
@@ -570,8 +566,6 @@ RSpec.describe 'HMIS JWT wiring', :jwt_only, type: :request do
           expect(controller.true_hmis_user).to eq(admin_user)
         end
 
-        # The skip made terminal-state holders reachable at #destroy; verify CSRF still rejects them,
-        # not only the active holder above.
         it 'still rejects a terminal-state holder with no CSRF token, without ending the IdP session' do
           sign_in(create(:hmis_user, active: false))
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description

Deactivated and no-warehouse-account holders were trapped in a sign-in loop under JWT: they got the same empty payload as a signed-out visitor, and couldn't sign out.

- `terminal_account_error` classifies the request without authenticating; `/hmis/user.json` returns it as `accountError` in a 200. Tokenless requests are unchanged.
- `Hmis::Idp::SessionsController#destroy` skips `authenticate_hmis_user!` so those users can sign out, matching the warehouse arm. CSRF is the outermost guard; the tokenless raise the skipped filter used to provide now lives in `#destroy`.
- The SPA-side change lands separately — this PR provides the `accountError` payload it reads.


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
