### PR TITLE
8458 idp 3 devise unload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,25 +93,30 @@ gem 'marcel'
 gem 'acts-as-taggable-on', '~> 13.0' # major bump for rails 8.1 (AR < 8.2); tagging behavior to verify manually (Release notes: https://github.com/mbleigh/acts-as-taggable-on/blob/master/CHANGELOG.md indicate no breaking changes)
 # gem 'seven_zip_ruby' unless ENV['NO_7ZIP'] == '1'
 
-gem 'devise', '~> 5.0'
-gem 'devise_invitable', '~> 2.0.9'
-gem 'devise-pwned_password'
-gem 'devise-security'
-gem 'devise-two-factor', '~> 6.4' # 6.x is rails-8-compatible; legacy otp secrets read via User#legacy_otp_secret
+# Bundler.require in config/application.rb takes this group only on the Devise arm, so a JWT-arm
+# reference to Devise or Warden raises at boot instead of resolving against a gem that loaded
+# anyway. A Devise-dependent gem added outside this group silences that signal.
+group :devise do
+  gem 'devise', '~> 5.0'
+  gem 'devise_invitable', '~> 2.0.9'
+  gem 'devise-pwned_password'
+  gem 'devise-security'
+  gem 'devise-two-factor', '~> 6.4' # 6.x is rails-8-compatible; legacy otp secrets read via User#legacy_otp_secret
+  gem 'doorkeeper'
+  gem 'omniauth', '~> 2.1'
+  gem 'omniauth-oauth2', '~> 1.7.3'
+  gem 'omniauth-rails_csrf_protection', '~> 2.0' # 2.x drops ActiveSupport::Configurable (deprecated in rails 8.1, removed 8.2)
+  gem 'pretender'
+  gem 'rqrcode'
+  gem 'authtrail' # for logging login attempts
+end
+
 gem 'rack-cors'
-gem 'doorkeeper'
 
 gem 'jwt', '~> 3.1' # Validates IdP-issued JWT access tokens
-gem 'omniauth', '~> 2.1'
-gem 'omniauth-oauth2', '~> 1.7.3'
-gem 'omniauth-rails_csrf_protection', '~> 2.0' # 2.x drops ActiveSupport::Configurable (deprecated in rails 8.1, removed 8.2)
 gem 'faraday', '~> 2.2'
 gem 'oauth2', '>= 2.0.22'
 
-gem 'pretender'
-gem 'rqrcode'
-
-gem 'authtrail' # for logging login attempts
 gem 'maxminddb' # for local geocoding of login attempts
 gem 'geocoder'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,8 +138,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # No AuthMethod guard needed: `devise_controller?` is false under JWT (no Devise controllers are
-  # routed), so this never fires there even though configure_permitted_parameters is Devise-only.
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def append_info_to_payload(payload)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -177,18 +177,19 @@ class ApplicationController < ActionController::Base
   protected
 
   def allowed_setup_controllers
-    controller_path.in?(
-      [
-        'users/sessions',
-        'accounts',
-        'account_two_factors',
-        'account_emails',
-        'account_passwords',
-        'user_training',
-        'compliance_agreements',
-        'content_pages',
-      ],
-    ) || controller_path == 'admin/users' && action_name == 'stop_impersonating'
+    portal_controllers = ['user_training', 'compliance_agreements', 'content_pages']
+
+    # Without the sessions controllers, a user held in the portal, which links to no other
+    # route, can never sign out.
+    account_controllers = if AuthMethod.jwt?
+      ['idp/sessions', 'idp/accounts', 'idp/account_emails']
+    else
+      ['users/sessions', 'accounts', 'account_two_factors', 'account_emails', 'account_passwords']
+    end
+
+    return true if controller_path.in?(portal_controllers + account_controllers)
+
+    controller_path == 'admin/users' && action_name == 'stop_impersonating'
   end
 
   def require_training!

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -13,9 +13,17 @@ module Idp::JwtCurrentUser
 
   included do
     def current_user
-      @current_user ||= idp_authenticated_user_from_jwt(user_class: User)
+      @current_user ||= idp_authenticated_user_from_jwt(user_class: User) || idp_background_render_user
     end
     helper_method :current_user
+
+    # Background renders carry no forwarded JWT: WardenProxyFactory hands the user's proxy to
+    # ActionController::Renderer as the 'warden' rack key. No Warden middleware runs on the JWT
+    # arm, so only those renderers can populate the key.
+    private def idp_background_render_user
+      proxy = request&.env&.dig('warden')
+      proxy.user(:user) if proxy.is_a?(Idp::WardenProxy)
+    end
 
     def warden
       @warden ||= Idp::WardenProxy.new(current_user, session: session)

--- a/app/controllers/concerns/idp/jwt_current_user.rb
+++ b/app/controllers/concerns/idp/jwt_current_user.rb
@@ -118,5 +118,11 @@ module Idp::JwtCurrentUser
     def enforce_2fa!
       nil # no-op for jwt: L2/MFA assurance is gated upstream by the IdP, not the warehouse
     end
+
+    # Devise (unloaded on this arm) is what defines devise_controller?; stub it false so the
+    # Devise-only before_action :configure_permitted_parameters no-ops instead of raising.
+    def devise_controller?
+      false
+    end
   end
 end

--- a/app/controllers/user_training_controller.rb
+++ b/app/controllers/user_training_controller.rb
@@ -80,7 +80,7 @@ class UserTrainingController < ApplicationController
         # If the user has an active account in all configs and has no trainings left to complete, allow them to navigate the warehouse
         elsif account_exists_in_all_configs && course_redirects.blank?
           # All trainings are completed and the user has an account in all training configs
-          redirect_to after_sign_in_path_for(current_user)
+          redirect_to safe_landing(landing_after_training)
           return
         end
         # For all other cases, send the user to the captive portal
@@ -92,11 +92,23 @@ class UserTrainingController < ApplicationController
     end
   end
 
-  # Figure out where we are going after login
-  # stored_location_for is provided by Devise
-  # after_sign_in_path_for is provided by ApplicationController
   def safe_training_redirect_path
-    path = stored_location_for(:user).presence || after_sign_in_path_for(current_user)
+    safe_landing(stored_landing_after_training)
+  end
+
+  def landing_after_training
+    return fallback_redirect_path if AuthMethod.jwt?
+
+    after_sign_in_path_for(current_user)
+  end
+
+  def stored_landing_after_training
+    return fallback_redirect_path if AuthMethod.jwt?
+
+    stored_location_for(:user).presence || after_sign_in_path_for(current_user)
+  end
+
+  def safe_landing(path)
     return fallback_redirect_path if training_path?(path)
 
     path

--- a/app/jobs/background_render/cas_readiness_job.rb
+++ b/app/jobs/background_render/cas_readiness_job.rb
@@ -21,14 +21,7 @@ class BackgroundRender::CasReadinessJob < BackgroundRenderJob
       ).
       find(client_id.to_i)
 
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-      i.set_user(current_user, scope: :user, store: false, run_callbacks: false)
-    end
-
-    renderer = controller_class.renderer.new(
-      'warden' => warden_proxy,
-    )
+    renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(current_user))
     html = renderer.render(
       partial: 'render_content',
       assigns: {

--- a/app/models/concerns/devise_user.rb
+++ b/app/models/concerns/devise_user.rb
@@ -27,6 +27,13 @@ module DeviseUser
   end
 
   included do
+    # Doorkeeper is in the :devise Gemfile group, so Doorkeeper::AccessGrant is undefined under jwt.
+    # dependent: :delete_all resolves that constant in a destroy callback, so declaring these in the
+    # shared User concern would raise on every User destroy under jwt, not only when the association
+    # is read.
+    has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+    has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+
     # Include default devise modules. Others available are:
     devise :invitable,
            :recoverable,

--- a/app/models/concerns/hud_reports/hud_pdf_export_concern.rb
+++ b/app/models/concerns/hud_reports/hud_pdf_export_concern.rb
@@ -64,10 +64,7 @@ module HudReports::HudPdfExportConcern
         template_file = 'hud_reports/download'
         layout = 'layouts/hud_report_export'
 
-        ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-        renderer = controller_class.renderer.new(
-          'warden' => PdfGenerator.warden_proxy(user),
-        )
+        renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(user))
         html = renderer.render(
           template_file,
           layout: layout,

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -34,9 +34,13 @@ module UserConcern
 
     attr_accessor :remember_device, :device_name, :client_access_arbiter, :copy_form_id
 
-    # Doorkeeper
-    has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
-    has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+    # Doorkeeper. Gated because the gem is in the :devise Gemfile group, so Doorkeeper::AccessGrant
+    # is undefined under jwt; `dependent: :delete_all` would then raise on any User destroy, not
+    # just on a read of the association.
+    if AuthMethod.devise?
+      has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+      has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
+    end
 
     # Connect users to login attempts.
     # Only includes Warehouse activity when called on User record, and only HMIS activity for Hmis::User record.

--- a/app/models/concerns/user_concern.rb
+++ b/app/models/concerns/user_concern.rb
@@ -34,14 +34,6 @@ module UserConcern
 
     attr_accessor :remember_device, :device_name, :client_access_arbiter, :copy_form_id
 
-    # Doorkeeper. Gated because the gem is in the :devise Gemfile group, so Doorkeeper::AccessGrant
-    # is undefined under jwt; `dependent: :delete_all` would then raise on any User destroy, not
-    # just on a read of the association.
-    if AuthMethod.devise?
-      has_many :access_grants, class_name: 'Doorkeeper::AccessGrant', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
-      has_many :access_tokens, class_name: 'Doorkeeper::AccessToken', foreign_key: :resource_owner_id, dependent: :delete_all # or :destroy if you need callbacks
-    end
-
     # Connect users to login attempts.
     # Only includes Warehouse activity when called on User record, and only HMIS activity for Hmis::User record.
     has_many :login_activities, as: :user

--- a/app/models/idp/warden_proxy.rb
+++ b/app/models/idp/warden_proxy.rb
@@ -17,6 +17,10 @@
 # every registered mapping, and :hmis_user remains a Devise mapping until seam 6. A raise
 # here would turn a routine "is the hmis_user signed in? no" probe into a 500.
 class Idp::WardenProxy
+  # Not Warden::NotAuthenticated: the :devise Gemfile group is required only on the Devise arm, so
+  # the Warden constant is undefined on the arm this proxy stands in for.
+  class NotAuthenticated < StandardError; end
+
   def initialize(user, session: nil)
     @user = user
     @session = session
@@ -56,7 +60,7 @@ class Idp::WardenProxy
   # gate: fail loudly rather than silently authorize. Dial back to returning nil if too aggressive.
   def authenticate!(*args)
     user = authenticate(*args)
-    raise Warden::NotAuthenticated, "Idp::WardenProxy#authenticate! got no authenticated user for scope #{_scope(args).inspect}" unless user
+    raise NotAuthenticated, "Idp::WardenProxy#authenticate! got no authenticated user for scope #{_scope(args).inspect}" unless user
 
     user
   end

--- a/app/models/idp/warden_proxy.rb
+++ b/app/models/idp/warden_proxy.rb
@@ -17,8 +17,6 @@
 # every registered mapping, and :hmis_user remains a Devise mapping until seam 6. A raise
 # here would turn a routine "is the hmis_user signed in? no" probe into a 500.
 class Idp::WardenProxy
-  # Not Warden::NotAuthenticated: the :devise Gemfile group is required only on the Devise arm, so
-  # the Warden constant is undefined on the arm this proxy stands in for.
   class NotAuthenticated < StandardError; end
 
   def initialize(user, session: nil)

--- a/app/models/pdf_generator.rb
+++ b/app/models/pdf_generator.rb
@@ -66,17 +66,8 @@ class PdfGenerator
     Rails.application.routes.url_helpers.root_url(host: ENV['FQDN'])
   end
 
-  def self.warden_proxy(user)
-    Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-      i.set_user(user, scope: :user, store: false, run_callbacks: false)
-    end
-  end
-
   def self.html(controller:, user:, template: nil, layout: false, assigns:, partial: nil)
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    renderer = controller.renderer.new(
-      'warden' => warden_proxy(user),
-    )
+    renderer = controller.renderer.new(WardenProxyFactory.renderer_env(user))
     if partial.present?
       renderer.render(
         partial: partial,

--- a/app/models/warden_proxy_factory.rb
+++ b/app/models/warden_proxy_factory.rb
@@ -1,0 +1,39 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Builds the object background renders hand to ActionController::Renderer as the 'warden' rack key.
+# The rack env is the only channel the renderer offers for carrying a user into the controller, and
+# both arms read the user back out of it — the JWT arm through Idp::JwtCurrentUser.
+#
+# Warden reaches the app only through the :devise bundler group, which config/application.rb
+# requires only under AuthMethod.devise?, so naming Warden::Proxy outside DeviseArm raises
+# NameError on the JWT arm.
+module WardenProxyFactory
+  module DeviseArm
+    def build(user)
+      Warden::Proxy.new({}, Warden::Manager.new({})).tap do |proxy|
+        proxy.set_user(user, scope: :user, store: false, run_callbacks: false)
+      end
+    end
+  end
+
+  module JwtArm
+    def build(user)
+      Idp::WardenProxy.new(user)
+    end
+  end
+
+  extend(AuthMethod.jwt? ? JwtArm : DeviseArm)
+
+  # Pass this to ActionController::Renderer.new. The 'warden' key name is the contract with the
+  # readers — Idp::JwtCurrentUser on the JWT arm, Devise's helpers on the Devise arm — so it is
+  # spelled here rather than at each render site.
+  def self.renderer_env(user)
+    { 'warden' => build(user) }
+  end
+end

--- a/app/views/admin/configs/index.haml
+++ b/app/views/admin/configs/index.haml
@@ -13,7 +13,8 @@
         = link_to 'TalentLMS', admin_talentlms_path, class: 'nav-item nav-link'
     .col-sm-4
       = render 'schedule'
-      = render 'security', f: f
+      -# Password/lockout/expiration/timeout are Devise settings; the IdP owns them under JWT.
+      = render 'security', f: f if AuthMethod.devise?
       = render 'roi', f: f
       = render 'client_calculations', f: f
       = render 'client_display', f: f

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,11 +15,13 @@ require 'active_record_extended'
 #   * Note, we still use the deprecated behavior for date/time. It's preserved in config/initializers/legacy_rails_conversions.rb
 ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION'] = 'true'
 
+require_relative '../lib/auth_method'
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+# The :devise group is taken only on the Devise arm; see the group in Gemfile.
+Bundler.require(*Rails.groups, *(AuthMethod.devise? ? [:devise] : []))
 
-require_relative '../lib/auth_method'
 require_relative '../lib/util/id_protector'
 require_relative '../lib/util/rails_trusted_proxies_config'
 
@@ -57,7 +59,8 @@ module OpenPath
     # config.autoload_lib(ignore: ['assets', 'tasks'])
 
     config.add_autoload_paths_to_load_path = false
-    config.autoload_paths << Rails.root.join('lib', 'devise')
+    # lib/devise subclasses Devise constants, so it loads only on the arm that requires the gem.
+    config.autoload_paths << Rails.root.join('lib', 'devise') if AuthMethod.devise?
 
     # ActionCable
     config.action_cable.mount_path = '/cable'
@@ -149,7 +152,21 @@ module OpenPath
 
     # additional library paths
     config.eager_load_paths << Rails.root.join('lib', 'util')
-    config.eager_load_paths << Rails.root.join('lib', 'devise')
+    config.eager_load_paths << Rails.root.join('lib', 'devise') if AuthMethod.devise?
+
+    # Each of these subclasses a Devise constant, and their routes are already gated off the JWT
+    # arm. Ignoring them is what lets an unintended JWT-arm reference to Devise or Warden fail at
+    # boot rather than resolve against a class that loaded anyway.
+    unless AuthMethod.devise?
+      Rails.autoloaders.main.ignore(
+        Rails.root.join('app/mailers/account_mailer.rb'),
+        Rails.root.join('app/controllers/users/sessions_controller.rb'),
+        Rails.root.join('app/controllers/users/omniauth_callbacks_controller.rb'),
+        Rails.root.join('app/controllers/users/invitations_controller.rb'),
+        Rails.root.join('drivers/hmis/app/controllers/hmis/sessions_controller.rb'),
+        Rails.root.join('drivers/hmis/app/controllers/hmis/users/omniauth_callbacks_controller.rb'),
+      )
+    end
 
     # Replace rails_drivers gem autoloading — mirrors what the gem's Railtie did
     driver_app_components = ['models', 'controllers', 'mailers', 'helpers', 'jobs', 'graphql'].freeze

--- a/drivers/client_access_control/spec/factories/grda_warehouse/users.rb
+++ b/drivers/client_access_control/spec/factories/grda_warehouse/users.rb
@@ -12,9 +12,11 @@ FactoryBot.define do
     last_name { 'River' }
     sequence(:email) { |n| "user#{n}@greenriver.com" }
     # email 'green.river@mailinator.com'
-    password { Digest::SHA256.hexdigest('abcd1234abcd1234') }
-    password_confirmation { Digest::SHA256.hexdigest('abcd1234abcd1234') }
-    confirmed_at { Date.yesterday }
+    if AuthMethod.devise?
+      password { Digest::SHA256.hexdigest('abcd1234abcd1234') }
+      password_confirmation { Digest::SHA256.hexdigest('abcd1234abcd1234') }
+      confirmed_at { Date.yesterday }
+    end
     notify_on_vispdat_completed { false }
     agency_id { 1 }
   end

--- a/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
+++ b/drivers/hmis/app/controllers/hmis/idp/sessions_controller.rb
@@ -15,13 +15,13 @@ module Hmis
     # via fetch + response.json() rather than following a browser redirect, so the oauth2-proxy
     # sign-out URL comes back as a JSON field instead of an HTTP redirect.
     class SessionsController < Hmis::BaseController
-      # account_deactivated / no_warehouse_account users hold a valid token but no
-      # current_hmis_user; without this skip, #destroy would 403 their sign-out request.
+      # account_deactivated and no_warehouse_account holders carry a valid token but resolve no
+      # current_hmis_user, so restoring this filter renders the JSON 403 they are signing out to escape.
       skip_before_action :authenticate_hmis_user!, only: [:destroy]
 
       def destroy
-        # authenticate_hmis_user! (skipped above) would raise on a tokenless request; reproduce
-        # that so idp_handle_unauthenticated (JwtHmisCurrentUser) runs rather than a login redirect.
+        # Duplicates the raise the skipped authenticate_hmis_user! would make; the reason a tokenless
+        # request must raise rather than answer is in JwtHmisCurrentUser#idp_handle_unauthenticated.
         raise ::Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
         # Ends the Keycloak session that /oauth2/sign_out never reaches. reset_session would clear

--- a/drivers/hmis/spec/models/hmis/hmis_user_extension_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hmis_user_extension_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe User, type: :model do
     expect do
       user.email = new_email
       user.save!
-      user.confirm
+      # Devise reconfirmable stashes the new address in unconfirmed_email until confirm promotes it;
+      # the jwt arm has no :confirmable, so save! already applied it.
+      user.confirm if AuthMethod.devise?
       user.sync_to_hud_users(previous_email: old_email)
       hmis_hud_user.reload
       other_hud_user.reload
@@ -59,7 +61,7 @@ RSpec.describe User, type: :model do
       user.first_name = new_first_name
       user.last_name = new_last_name
       user.save!
-      user.confirm
+      user.confirm if AuthMethod.devise?
       user.sync_to_hud_users(previous_email: old_email)
       hmis_hud_user.reload
       other_hud_user.reload

--- a/drivers/hmis/spec/models/hmis/user_spec.rb
+++ b/drivers/hmis/spec/models/hmis/user_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Hmis::User, type: :model do
       expect(raw_after).to eq(raw_before)
     end
 
-    it 'raises NotPersistedError when called on an unsaved record' do
+    it 'raises NotPersistedError when called on an unsaved record', :devise_only do
       new_user = build(:hmis_user)
       expect { new_user.update_unique_session_id!('x') }.to raise_error(Devise::Models::Compatibility::NotPersistedError)
     end
@@ -101,7 +101,7 @@ RSpec.describe Hmis::User, type: :model do
     end
   end
 
-  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync', :devise_only do
     it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
       attacker_email = 'attacker@example.com'
       victim_email   = 'victim@example.com'

--- a/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/sessions_controller_spec.rb
@@ -15,7 +15,7 @@ require 'support/shared_contexts/timing_attack_mitigation_context'
 
 # Devise-only: drivers/hmis/config/routes.rb mounts Hmis::SessionsController under
 # AuthMethod.devise?; the jwt arm serves hmis/logout from Hmis::Idp::SessionsController instead.
-RSpec.describe Hmis::SessionsController, :devise_only, type: :request do
+RSpec.describe 'Hmis::SessionsController', :devise_only, type: :request do
   let(:user) { create :user }
   let(:hmis_user) { user.as_hmis_user.tap(&:reload) }
   let(:user_2fa) { create :user_2fa }

--- a/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_export_spec.rb
+++ b/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_export_spec.rb
@@ -86,10 +86,7 @@ RSpec.describe HudApr::DocumentExports::HudAprExport, type: :model do
   describe 'the rendered PDF HTML' do
     let(:report) { create(:hud_reports_report_instance, user: user, report_name: report_name, options: {}) }
     let(:rendered_html) do
-      ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-      renderer = HudApr::AprsController.renderer.new(
-        'warden' => PdfGenerator.warden_proxy(user),
-      )
+      renderer = HudApr::AprsController.renderer.new(WardenProxyFactory.renderer_env(user))
       renderer.render(
         'hud_reports/download',
         layout: 'layouts/hud_report_export',

--- a/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_q4a_pdf_regression_spec.rb
+++ b/drivers/hud_apr/spec/models/hud_apr/document_exports/hud_apr_q4a_pdf_regression_spec.rb
@@ -70,10 +70,7 @@ RSpec.describe 'Q4a survives real PDF rendering', type: :model, exclude_fixpoint
   end
 
   it 'renders a real PDF where all Q4a columns (A through Q) survive, in order' do
-    ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-    renderer = HudApr::AprsController.renderer.new(
-      'warden' => PdfGenerator.warden_proxy(user),
-    )
+    renderer = HudApr::AprsController.renderer.new(WardenProxyFactory.renderer_env(user))
     html = renderer.render(
       'hud_reports/download',
       layout: 'layouts/hud_report_export',

--- a/drivers/superset/spec/models/superset_spec.rb
+++ b/drivers/superset/spec/models/superset_spec.rb
@@ -77,7 +77,9 @@ RSpec.describe Superset do
       end
     end
 
-    context 'under AuthMethod.devise?' do
+    # The Devise branch of .available? queries Doorkeeper::Application, a constant in the :devise
+    # Gemfile group that the jwt arm never loads.
+    context 'under AuthMethod.devise?', :devise_only do
       before { allow(AuthMethod).to receive(:jwt?).and_return(false) }
 
       it 'is available when a Doorkeeper::Application is registered for the Superset host' do

--- a/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/attachment_three_report_exports/attachment_three_report_excel_export.rb
@@ -27,14 +27,7 @@ module TxClientReports::AttachmentThreeReportExports
 
     def perform
       with_status_progression do
-        ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-        warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-          i.set_user(user, scope: :user, store: false, run_callbacks: false)
-        end
-
-        renderer = controller_class.renderer.new(
-          'warden' => warden_proxy,
-        )
+        renderer = controller_class.renderer.new(WardenProxyFactory.renderer_env(user))
 
         write_tmp_file(
           renderer.render(

--- a/drivers/tx_client_reports/app/models/tx_client_reports/research_export.rb
+++ b/drivers/tx_client_reports/app/models/tx_client_reports/research_export.rb
@@ -82,13 +82,7 @@ module TxClientReports
     private def excel_content
       controller = TxClientReports::WarehouseReports::ResearchExportsController
       assigns = { filter: filter, format: :xlsx, report: self }
-      ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
-      warden_proxy = Warden::Proxy.new({}, Warden::Manager.new({})).tap do |i|
-        i.set_user(user, scope: :user, store: false, run_callbacks: false)
-      end
-      renderer = controller.renderer.new(
-        'warden' => warden_proxy,
-      )
+      renderer = controller.renderer.new(WardenProxyFactory.renderer_env(user))
       renderer.render(
         action: :index,
         layout: false,

--- a/spec/controllers/accounts_controller_unit_spec.rb
+++ b/spec/controllers/accounts_controller_unit_spec.rb
@@ -8,7 +8,9 @@
 
 require 'rails_helper'
 
-RSpec.describe AccountsController, type: :controller do
+# AccountsController#update calls bypass_sign_in, a Devise controller helper absent under the
+# jwt arm (which updates accounts through Idp::AccountsController).
+RSpec.describe AccountsController, :devise_only, type: :controller do
   let(:user) { create(:user, first_name: 'Original', last_name: 'User', credentials: 'old_creds', email_schedule: 'daily', phone: '1234567890') }
   let(:controller_instance) { described_class.new }
   let(:flash_hash) { {} }

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -10,79 +10,86 @@ require 'rails_helper'
 
 # The invitation routes come from `devise_for :users`, mounted only under AuthMethod.devise?;
 # under jwt the IdP owns provisioning (see Idp::AdminUserCreator).
-RSpec.describe Users::InvitationsController, :devise_only, type: :controller do
-  let(:admin_user) { create(:acl_user) }
-  let(:admin_role) { create :admin_role }
-  let(:no_data_source_collection) { create :collection }
+#
+# The wrapper is here because a controller spec resolves Users::InvitationsController as its
+# described_class when the file loads, and the class is not autoloaded under jwt. The sibling
+# request specs name their controller in a string, which needs no wrapper; that is not open here
+# because rspec-rails instantiates described_class to drive the request.
+if AuthMethod.devise?
+  RSpec.describe Users::InvitationsController, :devise_only, type: :controller do
+    let(:admin_user) { create(:acl_user) }
+    let(:admin_role) { create :admin_role }
+    let(:no_data_source_collection) { create :collection }
 
-  let(:agency) { create(:agency) }
-  let(:valid_params) do
-    {
-      user: {
-        first_name: 'John',
-        last_name: 'Doe',
-        email: 'john.doe@example.com',
-        phone: '123-456-7890',
-        agency_id: agency.id,
-        legacy_role_ids: [],
-        user_group_ids: [],
-      },
-    }
-  end
-
-  let(:invalid_params) do
-    {
-      user: {
-        email: '',
-        first_name: '',
-        last_name: '',
-      },
-    }
-  end
-
-  before do
-    @request.env['devise.mapping'] = Devise.mappings[:user]
-    sign_in admin_user
-    setup_access_control(admin_user, admin_role, no_data_source_collection)
-  end
-
-  describe 'POST #create' do
-    context 'with valid parameters' do
-      it 'creates a new user and redirects to edit_admin_user_path' do
-        expect do
-          post :create, params: valid_params, format: :html
-        end.to change(User, :count).by(1)
-
-        expect(response).to redirect_to(edit_admin_user_path(User.last))
-        expect(flash[:notice]).to eq('An invitation email has been sent to john.doe@example.com.')
-      end
+    let(:agency) { create(:agency) }
+    let(:valid_params) do
+      {
+        user: {
+          first_name: 'John',
+          last_name: 'Doe',
+          email: 'john.doe@example.com',
+          phone: '123-456-7890',
+          agency_id: agency.id,
+          legacy_role_ids: [],
+          user_group_ids: [],
+        },
+      }
     end
 
-    context 'with invalid parameters' do
-      it 'does not create a new user and re-renders the new template' do
-        expect do
-          post :create, params: invalid_params, format: :html
-        end.not_to change(User, :count)
-
-        expect(response).to render_template(:new)
-        expect(assigns(:user).errors).not_to be_empty
-      end
+    let(:invalid_params) do
+      {
+        user: {
+          email: '',
+          first_name: '',
+          last_name: '',
+        },
+      }
     end
 
-    context 'with duplicate email (existing active user)' do
-      let!(:existing_user) { create(:user, email: 'existing@example.com', agency: agency) }
-      let(:duplicate_email_params) do
-        valid_params.deep_merge(user: { email: existing_user.email })
+    before do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in admin_user
+      setup_access_control(admin_user, admin_role, no_data_source_collection)
+    end
+
+    describe 'POST #create' do
+      context 'with valid parameters' do
+        it 'creates a new user and redirects to edit_admin_user_path' do
+          expect do
+            post :create, params: valid_params, format: :html
+          end.to change(User, :count).by(1)
+
+          expect(response).to redirect_to(edit_admin_user_path(User.last))
+          expect(flash[:notice]).to eq('An invitation email has been sent to john.doe@example.com.')
+        end
       end
 
-      it 're-renders new template without raising (partial lookup and @system_alerts)' do
-        expect do
-          post :create, params: duplicate_email_params, format: :html
-        end.not_to change(User, :count)
+      context 'with invalid parameters' do
+        it 'does not create a new user and re-renders the new template' do
+          expect do
+            post :create, params: invalid_params, format: :html
+          end.not_to change(User, :count)
 
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template(:new)
-        expect(assigns(:user).errors).not_to be_empty
+          expect(response).to render_template(:new)
+          expect(assigns(:user).errors).not_to be_empty
+        end
+      end
+
+      context 'with duplicate email (existing active user)' do
+        let!(:existing_user) { create(:user, email: 'existing@example.com', agency: agency) }
+        let(:duplicate_email_params) do
+          valid_params.deep_merge(user: { email: existing_user.email })
+        end
+
+        it 're-renders new template without raising (partial lookup and @system_alerts)' do
+          expect do
+            post :create, params: duplicate_email_params, format: :html
+          end.not_to change(User, :count)
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template(:new)
+          expect(assigns(:user).errors).not_to be_empty
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,7 +71,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     before do
       allow(ENV).to receive(:fetch).with('CLIENT').and_return('test-client')
       allow(helper).to receive(:params).and_return(ActionController::Parameters.new(controller: 'test/nested', action: 'show'))
-      allow(helper).to receive(:current_user).and_return(nil)
+      # Without this wrapper, stubbing current_user verifies under devise (mixed into
+      # ActionController::Base globally) but raises under jwt (defined only on ApplicationController,
+      # which this bare helper spec's controller does not inherit).
+      without_partial_double_verification do
+        allow(helper).to receive(:current_user).and_return(nil)
+      end
       helper.instance_variable_set(:@layout__width, 'lg')
     end
 
@@ -89,7 +94,9 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'with signed in user' do
       before do
-        allow(helper).to receive(:current_user).and_return(double('User'))
+        without_partial_double_verification do
+          allow(helper).to receive(:current_user).and_return(double('User'))
+        end
       end
 
       it 'does not include not-signed-in class' do
@@ -313,7 +320,9 @@ RSpec.describe ApplicationHelper, type: :helper do
         before do
           allow(ENV).to receive(:fetch).with('CLIENT').and_return('test-client')
           allow(helper).to receive(:params).and_return(ActionController::Parameters.new(controller: 'admin/users', action: 'index'))
-          allow(helper).to receive(:current_user).and_return(nil)
+          without_partial_double_verification do
+            allow(helper).to receive(:current_user).and_return(nil)
+          end
           helper.instance_variable_set(:@layout__width, 'md')
         end
 

--- a/spec/initializers/devise_cve_2026_40295_spec.rb
+++ b/spec/initializers/devise_cve_2026_40295_spec.rb
@@ -13,7 +13,7 @@ require 'rails_helper'
 # Devise 5.0.4 fixes this natively (see Devise::Controllers::StoreLocation#extract_path_from_location);
 # the app previously carried a monkey patch backporting this fix, which was removed once the gem upgrade
 # landed. These specs confirm the native behavior still holds.
-RSpec.describe 'CVE-2026-40295 - open redirect via Referer on timeout' do
+RSpec.describe 'CVE-2026-40295 - open redirect via Referer on timeout', :devise_only do
   let(:store_location_host) { Class.new { include Devise::Controllers::StoreLocation }.new }
 
   describe 'extract_path_from_location' do

--- a/spec/lib/auth_method_spec.rb
+++ b/spec/lib/auth_method_spec.rb
@@ -36,4 +36,17 @@ RSpec.describe AuthMethod do
       expect(described_class.devise?).to be false
     end
   end
+
+  # The :devise group in Gemfile is required only on the Devise arm, which is what makes an
+  # unintended reference to Devise or Warden raise here instead of resolving against a loaded gem.
+  # A transitive require from any other gem restores them silently, so assert on the constants.
+  describe 'the :devise bundler group', :jwt_only do
+    it 'leaves Devise unloaded' do
+      expect(defined?(Devise)).to be_nil
+    end
+
+    it 'leaves Warden unloaded' do
+      expect(defined?(Warden)).to be_nil
+    end
+  end
 end

--- a/spec/models/idp/warden_proxy_spec.rb
+++ b/spec/models/idp/warden_proxy_spec.rb
@@ -120,12 +120,12 @@ RSpec.describe Idp::WardenProxy do
     # "no exception" as success.
     it 'raises for a non-:user scope' do
       proxy = described_class.new(user)
-      expect { proxy.authenticate!(:password, scope: :hmis_user) }.to raise_error(Warden::NotAuthenticated)
+      expect { proxy.authenticate!(:password, scope: :hmis_user) }.to raise_error(described_class::NotAuthenticated)
     end
 
     it 'raises when there is no authenticated user for the :user scope' do
       proxy = described_class.new(nil)
-      expect { proxy.authenticate! }.to raise_error(Warden::NotAuthenticated)
+      expect { proxy.authenticate! }.to raise_error(described_class::NotAuthenticated)
     end
   end
 

--- a/spec/models/omniauth_user_provisioner_spec.rb
+++ b/spec/models/omniauth_user_provisioner_spec.rb
@@ -8,7 +8,7 @@
 
 require 'rails_helper'
 
-RSpec.describe OmniauthUserProvisioner, type: :model do
+RSpec.describe OmniauthUserProvisioner, :devise_only, type: :model do
   include ActiveJob::TestHelper
   before(:all) do
     clear_enqueued_jobs

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'invitation handling' do
+  describe 'invitation handling', :devise_only do
     context 'when user has an outstanding invitation' do
       before do
         User.invite!({ email: 'unconfirmed@example.com', first_name: 'Unconfirmed', last_name: 'User', agency_id: agency.id }, User.system_user)
@@ -198,7 +198,7 @@ RSpec.describe User, type: :model do
   # The app previously carried a monkey patch (DeviseUserPatch) working around this on
   # Devise 4; Devise 5.0.4 fixes it natively, so the patch was removed. This spec confirms
   # the native behavior still holds.
-  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync' do
+  describe 'CVE-2026-32700 - confirmation token/unconfirmed_email sync', :devise_only do
     it 'prevents desync when a concurrent request modifies unconfirmed_email mid-flight' do
       attacker_email = 'attacker@example.com'
       victim_email   = 'victim@example.com'
@@ -226,7 +226,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security password_archivable' do
+  describe 'devise-security password_archivable', :devise_only do
     around do |example|
       original = Devise.deny_old_passwords
       Devise.deny_old_passwords = 2
@@ -274,7 +274,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security expirable' do
+  describe 'devise-security expirable', :devise_only do
     let(:user) { create(:user) }
 
     it 'is active when recently active' do
@@ -307,7 +307,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'devise-security secure_validatable password complexity' do
+  describe 'devise-security secure_validatable password complexity', :devise_only do
     around do |example|
       original = Devise.password_complexity
       Devise.password_complexity = { digit: 1, lower: 1, upper: 1, symbol: 1 }

--- a/spec/models/warden_proxy_factory_spec.rb
+++ b/spec/models/warden_proxy_factory_spec.rb
@@ -1,0 +1,112 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WardenProxyFactory, type: :model do
+  let!(:user) { create(:acl_user) }
+  let!(:role) { create(:role, can_view_all_reports: true) }
+  let!(:collection) { create(:collection) }
+
+  before do
+    setup_access_control(user, role, collection)
+  end
+
+  describe '.build' do
+    it 'answers the :user scope with the user it was built for' do
+      proxy = described_class.build(user)
+
+      expect(proxy.user(:user)).to eq(user)
+      expect(proxy.authenticated?(:user)).to be true
+    end
+
+    it 'answers no user for a scope it was not built for' do
+      proxy = described_class.build(user)
+
+      expect(proxy.user(:hmis_user)).to be_nil
+    end
+  end
+
+  describe "a document export rendered through the rack 'warden' key, the only channel it has" do
+    let(:export) do
+      GrdaWarehouse::WarehouseReports::DocumentExports::ActiveClientReportExport.new(user_id: user.id)
+    end
+    let(:rendered_html) { [] }
+
+    before do
+      # Stubbing stops at PdfGenerator.render_pdf, which needs a headless-Chrome binary. Stub
+      # PdfGenerator.html too and the spec still passes while rendering nothing through the proxy.
+      allow(PdfGenerator).to receive(:render_pdf) do |html|
+        rendered_html << html
+        '%PDF-'
+      end
+      allow(PdfGenerator).to receive(:merge_inline_pdfs) { |pdfs| Array.wrap(pdfs).join }
+    end
+
+    it 'renders the report for the user the export runs as' do
+      export.perform
+
+      expect(rendered_html.first).to include(ERB::Util.html_escape(user.name_with_email))
+    end
+
+    it 'completes the export' do
+      export.perform
+
+      expect(export.status).to eq(DocumentExportBehavior::COMPLETED_STATUS)
+      expect(export.file_data).to be_present
+    end
+  end
+
+  describe 'the render sites' do
+    let(:offenders) do
+      paths = Dir.glob(
+        [
+          Rails.root.join('{app,lib,spec}/**/*.rb'),
+          Rails.root.join('drivers/*/{app,lib,spec}/**/*.rb'),
+        ],
+      ) - [Rails.root.join('app/models/warden_proxy_factory.rb').to_s, __FILE__]
+
+      paths.sort.flat_map do |path|
+        File.readlines(path).each_with_index.
+          reject { |line, _index| line.lstrip.start_with?('#') }.
+          select { |line, _index| line.match?(pattern) }.
+          map { |_line, index| "#{Pathname.new(path).relative_path_from(Rails.root)}:#{index + 1}" }
+      end
+    end
+
+    describe 'a Warden::Proxy built outside the factory' do
+      let(:pattern) { /\bWarden::Proxy\.new/ }
+
+      it 'is nowhere' do
+        expect(offenders).to be_empty, <<~MSG
+          Warden loads only in the :devise bundler group, so this raises NameError under
+          AUTH_METHOD=jwt:
+
+          #{offenders.join("\n")}
+
+          Call WardenProxyFactory.renderer_env(user) instead.
+        MSG
+      end
+    end
+
+    describe "a rack 'warden' env key spelled outside the factory" do
+      let(:pattern) { /['"]warden['"]\s*=>/ }
+
+      it 'is nowhere' do
+        expect(offenders).to be_empty, <<~MSG
+          The 'warden' key name is WardenProxyFactory's contract with Idp::JwtCurrentUser, which
+          reads the proxy back out of the rack env:
+
+          #{offenders.join("\n")}
+
+          Pass WardenProxyFactory.renderer_env(user) to ActionController::Renderer.new instead.
+        MSG
+      end
+    end
+  end
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -83,8 +83,6 @@ RSpec.describe 'Content Security Policy', type: :request do
   end
 
   describe 'inline script nonces' do
-    before { get new_user_session_path }
-
     it 'renders inline <script> tags whose nonce matches the CSP header nonce' do
       header_nonce = response.headers['Content-Security-Policy'][/nonce-([A-Za-z0-9+\/=]+)/, 1]
       script_nonces = Capybara.string(response.body).all('script[nonce]', visible: :all).map { |el| el['nonce'] }

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -11,7 +11,7 @@ if ENV['OKTA_DOMAIN'].present?
   # Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
   # Devise-only: the okta callback route is declared inside the `devise_scope :user` block, so it
   # is not mounted under jwt, where the IdP owns federated sign-in.
-  RSpec.describe Users::OmniauthCallbacksController, :devise_only, type: :request do
+  RSpec.describe 'Users::OmniauthCallbacksController', :devise_only, type: :request do
     describe 'GET /users/auth/:provider protects against CVE-2015-9284' do
       it do
         get '/users/auth/okta'

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -13,7 +13,7 @@ require 'support/shared_contexts/login_activity_context'
 
 # Devise-only: Users::SessionsController is reachable only via the `devise_for :users` routes,
 # which config/routes.rb mounts under AuthMethod.devise?.
-RSpec.describe Users::SessionsController, :devise_only, type: :request do
+RSpec.describe 'Users::SessionsController', :devise_only, type: :request do
   let(:user) { create :user }
   let(:user_2fa) { create :user_2fa }
   let(:email) { ActionMailer::Base.deliveries.last }

--- a/spec/requests/user_training_controller_spec.rb
+++ b/spec/requests/user_training_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'UserTrainingController', type: :request do
   end
 
   describe 'GET /user_training' do
-    it 'redirects to the stored location when it is safe' do
+    it 'redirects to the stored location when it is safe', :devise_only do
       # Canary: Verify that stored_location_for exists (from Devise)
       # If Devise is removed, this test will fail and you'll need to reimplement the stored location functionality
       expect(UserTrainingController.instance_methods).to(
@@ -44,7 +44,7 @@ RSpec.describe 'UserTrainingController', type: :request do
       expect(response).to redirect_to('/welcome_back')
     end
 
-    it 'falls back when the stored location points to the training portal' do
+    it 'falls back when the stored location points to the training portal', :devise_only do
       # Canary: Verify that stored_location_for exists (from Devise)
       expect(UserTrainingController.instance_methods).to(
         include(:stored_location_for),
@@ -57,6 +57,17 @@ RSpec.describe 'UserTrainingController', type: :request do
       get user_training_path
 
       expect(response).to redirect_to(root_path)
+    end
+
+    it 'redirects to the user root without reading a stored location', :jwt_only do
+      # Devise defines stored_location_for even under AUTH_METHOD=jwt, so this has something to catch.
+      expect_any_instance_of(UserTrainingController).not_to receive(:stored_location_for)
+
+      allow_any_instance_of(User).to receive(:my_root_path).and_return(censuses_path)
+
+      get user_training_path
+
+      expect(response).to redirect_to(censuses_path)
     end
 
     it 'lets a user continue when all required trainings are completed' do
@@ -91,6 +102,36 @@ RSpec.describe 'UserTrainingController', type: :request do
 
       # Should redirect to after_sign_in_path_for
       expect(response).to redirect_to(root_path)
+    end
+
+    it 'lets a user continue when the portal finds every required training complete' do
+      config = create(:talentlms_config)
+      course = create(
+        :default_course,
+        config: config,
+        courseid: 123,
+      )
+      create(
+        :talentlms_login,
+        user: user,
+        config: config,
+        lms_user_id: 456,
+      )
+
+      allow_any_instance_of(User).to receive(:required_training_courses).and_return([course])
+      allow_any_instance_of(User).to receive(:my_root_path).and_return(censuses_path)
+
+      allow(lms_double).to receive(:any_training_required?).and_return(true)
+      allow(lms_double).to receive(:login).with(config).and_return(true)
+      allow(lms_double).to receive(:enroll).with(config, course.courseid)
+      allow(lms_double).to receive(:training_expired?).with(config, course.courseid).and_return(false)
+      allow(lms_double).to receive(:complete?).with(config, course.courseid).and_return(Date.today)
+      allow(lms_double).to receive(:valid_date?).with(Date.today).and_return(true)
+      allow(lms_double).to receive(:log_course_completion).with(config, course.courseid, Date.today)
+
+      get user_training_path
+
+      expect(response).to redirect_to(censuses_path)
     end
 
     it 'presents the captive portal when a required training is incomplete' do
@@ -128,6 +169,27 @@ RSpec.describe 'UserTrainingController', type: :request do
 
       # Should render the captive portal
       expect(response).to render_template('required_trainings')
+    end
+  end
+
+  describe 'DELETE /users/sign_out while a required training is incomplete' do
+    before do
+      allow_any_instance_of(User).to receive(:training_required?).and_return(true)
+      allow(lms_double).to receive(:any_training_required?).and_return(true)
+    end
+
+    it 'hands the request to the proxy sign-out rather than the portal', :jwt_only do
+      allow_any_instance_of(Idp::SessionsController).to receive(:idp_end_token_holder_sessions)
+
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to("/oauth2/sign_out?rd=#{CGI.escape(root_path)}")
+    end
+
+    it 'runs the Devise sign-out rather than returning to the portal', :devise_only do
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to(root_url)
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
The Devise-family gems move into a `:devise` bundler group that `config/application.rb` requires only under `AuthMethod.devise?`, so a JWT-arm reference to Devise or Warden raises at boot instead of resolving against a gem that loaded anyway.

- Require-time change only: nothing filters the `devise` group at install (CI excludes `production staging`, the Dockerfile `development test doc`), and `Gemfile.lock` is untouched.
- Fallout fixed in the same PR: `WardenProxyFactory` replaces four direct `Warden::Proxy` builds in background renders (plus a `current_user` fallback for jobs, which carry no forwarded token); `devise_controller?` stubbed false; the admin/configs security panel gated; `UserTrainingController` off `stored_location_for`/`after_sign_in_path_for`; `idp/sessions` allowed during setup so users held in the training portal can sign out; Doorkeeper associations gated; `Idp::WardenProxy::NotAuthenticated` replaces `Warden::NotAuthenticated`.
- Spec churn is the evidence: `:devise_only` tags on Devise-dependent examples, and `auth_method_spec` asserts `Devise` and `Warden` are undefined on the JWT arm so a transitive require can't silently restore them.


## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill

