### PR TITLE
Add gem caching into CI

### DIFF
--- a/.github/workflows/container_setup/action.yml
+++ b/.github/workflows/container_setup/action.yml
@@ -113,6 +113,14 @@ runs:
       shell: bash
       run: git config --global --add safe.directory /__w/hmis-warehouse/hmis-warehouse
 
+    - name: Cache gems
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: /usr/local/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-${{ hashFiles('.ruby-version') }}-
+
     - name: Install gems
       shell: bash
       run: |


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adds a caching step for gems keyed on os, ruby-version, and gem lock.
* If no exact match is found, falls back to the most recent os, ruby-version match and then runs bundle install against it to bring it up-to speed.
* If no match is found at all, runs bundle install as usual

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

