### PR TITLE
Add soft-deletion to hmis ProjectConfigs

### DIFF
--- a/db/warehouse/migrate/20260812160243_add_deleted_at_to_hmis_project_configs.rb
+++ b/db/warehouse/migrate/20260812160243_add_deleted_at_to_hmis_project_configs.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToHmisProjectConfigs < ActiveRecord::Migration[8.1]
+  def up
+    add_column :hmis_project_configs, :deleted_at, :datetime
+
+    safety_assured do
+      add_index :hmis_project_configs, :deleted_at
+
+      # Preserve disabled configs as soft-deleted. Raw SQL avoids coupling the migration to the model
+      execute(<<~SQL)
+        UPDATE hmis_project_configs
+        SET deleted_at = NOW()
+        WHERE enabled = FALSE AND deleted_at IS NULL
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute(<<~SQL)
+        UPDATE hmis_project_configs
+        SET enabled = FALSE
+        WHERE deleted_at IS NOT NULL
+      SQL
+    end
+
+    remove_index :hmis_project_configs, :deleted_at
+    remove_column :hmis_project_configs, :deleted_at
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260812160243
+# rails db:migrate:down:warehouse VERSION=20260812160243

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -42584,7 +42584,8 @@ CREATE TABLE public.hmis_project_configs (
     project_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    data_source_id bigint NOT NULL
+    data_source_id bigint NOT NULL,
+    deleted_at timestamp(6) without time zone
 );
 
 
@@ -218975,6 +218976,13 @@ CREATE INDEX index_hmis_project_configs_on_data_source_id ON public.hmis_project
 
 
 --
+-- Name: index_hmis_project_configs_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_hmis_project_configs_on_deleted_at ON public.hmis_project_configs USING btree (deleted_at);
+
+
+--
 -- Name: index_hmis_project_configs_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -359850,6 +359858,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260812160243'),
 ('20260728120000'),
 ('20260717132223'),
 ('20260624000001'),

--- a/drivers/hmis/app/models/hmis/hud/project.rb
+++ b/drivers/hmis/app/models/hmis/hud/project.rb
@@ -187,12 +187,12 @@ class Hmis::Hud::Project < Hmis::Hud::Base
 
   # Projects that are open and have CE waitlist referrals enabled
   scope :with_ce_waitlists_enabled, -> do
-    open_on_date.with_configs(Hmis::ProjectCeConfig.active.filter(&:supports_waitlist_referrals?))
+    open_on_date.with_configs(Hmis::ProjectCeConfig.all.filter(&:supports_waitlist_referrals?))
   end
 
   # Projects that are open and have CE enabled
   scope :with_ce_enabled, -> do
-    open_on_date.with_configs(Hmis::ProjectCeConfig.active)
+    open_on_date.with_configs(Hmis::ProjectCeConfig.all)
   end
 
   SORT_OPTIONS = [:organization_and_name, :name].freeze

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -8,6 +8,9 @@
 
 class Hmis::ProjectConfig < Hmis::HmisBase
   self.table_name = 'hmis_project_configs'
+  self.ignored_columns = ['enabled'] # Dropping `enabled` in favor of `deleted_at`. TODO: migrate to remove the column in a future release
+
+  acts_as_paranoid
 
   belongs_to :data_source, class_name: 'GrdaWarehouse::DataSource'
   belongs_to :project, optional: true, class_name: 'Hmis::Hud::Project'
@@ -89,10 +92,6 @@ class Hmis::ProjectConfig < Hmis::HmisBase
     )
   end
 
-  scope :active, -> do
-    where(enabled: true)
-  end
-
   # Filter by GraphQL config type (eg 'AUTO_ENTER', 'AUTO_EXIT', etc.)
   scope :with_config_type, ->(config_type) do
     types = Array.wrap(config_type).map do |type|
@@ -110,7 +109,7 @@ class Hmis::ProjectConfig < Hmis::HmisBase
   end
 
   def self.detect_best_config_for_project(project)
-    configs = for_project(project).active
+    configs = for_project(project)
     return unless configs.exists?
 
     # Selects the most specific rule that applies. The specificity order is Project > Org > ProjectType, so rules that

--- a/drivers/hmis/lib/hmis_util/hmis_project_config_importer.rb
+++ b/drivers/hmis/lib/hmis_util/hmis_project_config_importer.rb
@@ -251,7 +251,6 @@ module HmisUtil
       record = Hmis::ProjectAutoExitConfig.find_or_initialize_by(
         project_id: row[:project].id,
         data_source_id: data_source.id,
-        enabled: true,
       )
       record.length_of_absence_days = row[:auto_exit_days]
       save_config(record, row, 'AutoExit')
@@ -263,7 +262,6 @@ module HmisUtil
       record = Hmis::ProjectAutoEnterConfig.find_or_initialize_by(
         project_id: row[:project].id,
         data_source_id: data_source.id,
-        enabled: true,
       )
       save_config(record, row, 'AutoEnter')
     end
@@ -274,7 +272,6 @@ module HmisUtil
       record = Hmis::ProjectSendsDirectCeReferralsConfig.find_or_initialize_by(
         project_id: row[:project].id,
         data_source_id: data_source.id,
-        enabled: true,
       )
       save_config(record, row, 'CE_SendsReferrals')
     end
@@ -287,9 +284,7 @@ module HmisUtil
       record = Hmis::ProjectCeConfig.find_or_initialize_by(
         project_id: row[:project].id,
         data_source_id: data_source.id,
-        enabled: true,
       )
-      record.enabled = true
       record.receives_direct_referrals = receives unless receives.nil?
       record.supports_waitlist_referrals = waitlists unless waitlists.nil?
       record.receives_direct_referrals_from = row[:ce_from_project_ids] if row[:ce_from_present]
@@ -327,7 +322,7 @@ module HmisUtil
 
       # If there are any active projects that support waitlist referrals in the data source, rebuild pools after import.
       # Relatively cheap, so OK even if this import didn't touch waitlist CE configs.
-      return unless Hmis::ProjectCeConfig.active.where(data_source_id: data_source.id).any?(&:supports_waitlist_referrals?)
+      return unless Hmis::ProjectCeConfig.where(data_source_id: data_source.id).any?(&:supports_waitlist_referrals?)
 
       puts 'Rebuilding CE candidate pools...'
       Hmis::Ce::Match::CandidatePool.lock_for_maintenance! do

--- a/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
+++ b/drivers/hmis/spec/factories/hmis/hud/project_configs.rb
@@ -32,8 +32,6 @@ FactoryBot.define do
   end
 
   factory :hmis_project_ce_config, parent: :hmis_project_config_base, class: 'Hmis::ProjectCeConfig' do
-    enabled { true }
-
     transient do
       receives_direct_referrals { false }
       supports_waitlist_referrals { true }

--- a/drivers/hmis/spec/lib/hmis_util/hmis_project_config_importer_spec.rb
+++ b/drivers/hmis/spec/lib/hmis_util/hmis_project_config_importer_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe HmisUtil::HmisProjectConfigImporter do
 
       auto_exit = Hmis::ProjectAutoExitConfig.find_by!(project: project)
       expect(auto_exit.length_of_absence_days).to eq(45)
-      expect(auto_exit.enabled).to eq(true)
       expect(auto_exit.data_source_id).to eq(data_source.id)
 
       expect(Hmis::ProjectAutoEnterConfig.find_by!(project: project)).to be_present
@@ -292,7 +291,6 @@ RSpec.describe HmisUtil::HmisProjectConfigImporter do
       file = write_csv(['ProjectID', 'AutoEnter'], [['P1', 'false']])
       expect { run_import!(file) }.not_to change(Hmis::ProjectConfig, :count)
       expect(auto_enter.reload).to be_present
-      expect(auto_enter.enabled).to eq(true)
     ensure
       file.close!
     end

--- a/drivers/hmis/spec/models/hmis/hud/project_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/project_spec.rb
@@ -305,10 +305,10 @@ RSpec.describe Hmis::Hud::Project, type: :model do
       end
     end
 
-    context 'with disabled config' do
-      let!(:config) { create(:hmis_project_ce_config, project: project, enabled: false) }
+    context 'with soft-deleted config' do
+      let!(:config) { create(:hmis_project_ce_config, project: project, deleted_at: 1.day.ago) }
 
-      it 'does not return projects with disabled config' do
+      it 'does not return projects with a soft-deleted config' do
         expect(Hmis::Hud::Project.with_ce_enabled).to be_empty
       end
     end

--- a/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe Hmis::ProjectAutoEnterConfig, type: :model do
     expect(config).to be_nil
   end
 
-  it 'should return nil if an auto-enter config exists, but is not enabled' do
+  it 'should return nil if an auto-enter config exists, but is soft-deleted' do
     auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).not_to be_nil
-    auto_enter_config.enabled = false
-    auto_enter_config.save!
+    auto_enter_config.destroy!
+    expect(auto_enter_config.reload.deleted_at).not_to be_nil
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
   end

--- a/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_auto_enter_config_spec.rb
@@ -39,14 +39,4 @@ RSpec.describe Hmis::ProjectAutoEnterConfig, type: :model do
     config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
     expect(config).to be_nil
   end
-
-  it 'should return nil if an auto-enter config exists, but is soft-deleted' do
-    auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
-    config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
-    expect(config).not_to be_nil
-    auto_enter_config.destroy!
-    expect(auto_enter_config.reload.deleted_at).not_to be_nil
-    config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
-    expect(config).to be_nil
-  end
 end

--- a/drivers/hmis/spec/models/hmis/project_ce_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_ce_config_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hmis::ProjectCeConfig, type: :model do
 
     context 'on update' do
       it 'calls CandidatePoolBuilder when waitlist referrals are supported' do
-        waitlist_config.update!(enabled: false)
+        waitlist_config.update!(receives_direct_referrals: true)
         expect(Hmis::Ce::Match::CandidatePoolBuilder).to have_received(:call)
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Hmis::ProjectCeConfig, type: :model do
           supports_waitlist_referrals: false,
           receives_direct_referrals: true,
         )
-        direct_config.update!(enabled: false)
+        direct_config.update!(receives_direct_referrals_from: [project.id])
         expect(Hmis::Ce::Match::CandidatePoolBuilder).not_to have_received(:call)
       end
     end

--- a/drivers/hmis/spec/models/hmis/project_config_spec.rb
+++ b/drivers/hmis/spec/models/hmis/project_config_spec.rb
@@ -40,14 +40,15 @@ RSpec.describe Hmis::ProjectConfig, type: :model do
     expect(config).to be_nil
   end
 
-  it 'should return nil if an auto-enter config exists, but is not enabled' do
+  it 'soft-deletes a config and excludes it from default queries' do
     auto_enter_config = Hmis::ProjectAutoEnterConfig.create!(project: p1, data_source: ds1)
-    config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
-    expect(config).not_to be_nil
-    auto_enter_config.enabled = false
-    auto_enter_config.save!
-    config = Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)
-    expect(config).to be_nil
+    expect(Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)).to eq(auto_enter_config)
+
+    expect { auto_enter_config.destroy! }.to change(auto_enter_config, :deleted_at).from(nil)
+
+    expect(Hmis::ProjectAutoEnterConfig.find_by(id: auto_enter_config.id)).to be_nil
+    expect(Hmis::ProjectAutoEnterConfig.with_deleted.find(auto_enter_config.id).deleted_at).to be_present
+    expect(Hmis::ProjectAutoEnterConfig.detect_best_config_for_project(p1)).to be_nil
   end
 
   it 'does not allow config type to change once set' do

--- a/drivers/hmis/spec/requests/hmis/delete_project_config_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/delete_project_config_spec.rb
@@ -1,0 +1,54 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'DeleteProjectConfig Mutation', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation DeleteProjectConfig($id: ID!) {
+        deleteProjectConfig(id: $id) {
+          projectConfig {
+            id
+            configType
+          }
+          #{error_fields}
+        }
+      }
+    GRAPHQL
+  end
+
+  let!(:access_control) { create_access_control(hmis_user, ds1) }
+  let!(:project_config) { create(:hmis_project_auto_enter_config, project: p1, data_source: ds1) }
+
+  before(:each) do
+    hmis_login(user)
+  end
+
+  it 'successfully soft-deletes a project config' do
+    response, result = post_graphql(id: project_config.id) { mutation }
+
+    expect(response.status).to eq(200), result.inspect
+    expect(result.dig('data', 'deleteProjectConfig', 'errors')).to be_empty
+    expect(result.dig('data', 'deleteProjectConfig', 'projectConfig')).to include(
+      'id' => project_config.id.to_s,
+      'configType' => 'AUTO_ENTER',
+    )
+    expect(project_config.reload.deleted_at).to be_present
+    expect(Hmis::ProjectAutoEnterConfig.for_project(p1)).to be_empty
+  end
+
+  it 'throws an error when the user does not have access' do
+    remove_permissions(access_control, :can_configure_data_collection)
+    expect_access_denied(post_graphql(id: project_config.id) { mutation })
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
- Migrate to add the `deleted_at` column to the `hmis_project_configs` table. 
- Add the `acts_as_paranoid` concern to the `Hmis::ProjectConfig` model
- Add `enabled` to `ignored_columns` on the model, but don't yet migrate to remove the `enabled` column in the migration, because the old code (that does query the enabled col) may still be running on old pods after the migration in this release has run. See next PR: https://github.com/greenriver/hmis-warehouse/pull/6854
- Remove the `active` scope and all its usages
- Add spec coverage for the `DeleteProjectConfig` mutation, and update other related spec to check for soft-deletion instead of enabled/active

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

