### PR TITLE
Remove unused `enabled` col from hmis ProjectConfigs

### DIFF
--- a/db/warehouse/migrate/20260812172057_remove_enabled_from_hmis_project_configs.rb
+++ b/db/warehouse/migrate/20260812172057_remove_enabled_from_hmis_project_configs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RemoveEnabledFromHmisProjectConfigs < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      remove_column :hmis_project_configs, :enabled, :boolean, default: true, null: false
+    end
+  end
+
+  def down
+    add_column :hmis_project_configs, :enabled, :boolean, default: true, null: false
+
+    safety_assured do
+      execute(<<~SQL)
+        UPDATE hmis_project_configs
+        SET enabled = FALSE
+        WHERE deleted_at IS NOT NULL
+      SQL
+    end
+  end
+end
+
+# rails db:migrate:up:warehouse VERSION=20260812172057
+# rails db:migrate:down:warehouse VERSION=20260812172057

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -42577,7 +42577,6 @@ CREATE VIEW public.hmis_project_access_group_members AS
 CREATE TABLE public.hmis_project_configs (
     id bigint NOT NULL,
     type character varying NOT NULL,
-    enabled boolean DEFAULT true NOT NULL,
     config_options jsonb,
     project_type integer,
     organization_id bigint,
@@ -359858,6 +359857,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260812172057'),
 ('20260812160243'),
 ('20260728120000'),
 ('20260717132223'),

--- a/drivers/hmis/app/models/hmis/project_config.rb
+++ b/drivers/hmis/app/models/hmis/project_config.rb
@@ -8,7 +8,6 @@
 
 class Hmis::ProjectConfig < Hmis::HmisBase
   self.table_name = 'hmis_project_configs'
-  self.ignored_columns = ['enabled'] # Dropping `enabled` in favor of `deleted_at`. TODO: migrate to remove the column in a future release
 
   acts_as_paranoid
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description

Stacks with https://github.com/greenriver/hmis-warehouse/pull/6853, but the two should not be merged together; this must go out **in the next release**. (226)

- Drop the now-unused `enabled` column from `hmis_project_configs`
- Add a warehouse migration to remove the column
- Remove the temporary `ignored_columns` from `Hmis::ProjectConfig`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

