### PR TITLE
Update overcommit to prevent direct push to main/staging/production

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -22,8 +22,6 @@ PreCommit:
     enabled: true
   BundleAudit:
     enabled: true
-    flags:
-      - --ignore CVE-2015-9284
   RuboCop:
     enabled: true
     on_warn: fail # Treat all warnings as failures
@@ -31,12 +29,6 @@ PreCommit:
     enabled: true
     description: Update Rubocop TODO
     required_executable: './bin/update_rubocop_todo.rb'
-  # CoffeeLint:
-  #   enabled: true
-  #   required_executable: 'npm'
-  #   command: ['npm', 'run', 'coffeelint']
-
-
   TrailingWhitespace:
     enabled: false
     exclude:
@@ -44,6 +36,15 @@ PreCommit:
       - 'db/**/schema.rb'
       - 'db/structure.rb'
       - 'db/**/structure.rb'
+PrePush:
+  ProtectedBranches:
+    enabled: true
+    destructive_only: false  # false = block all pushes
+    branches:
+      - main
+      - production
+      - staging
+      - gig/overcommit-update
 #
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -44,7 +44,7 @@ PrePush:
       - main
       - production
       - staging
-      - gig/overcommit-update
+
 #
 #PostCheckout:
 #  ALL: # Special hook name that customizes all hooks of this type


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Propose adding an overcommit check to prevent accidental pushing to main/staging/production.
We have github configured to allow direct pushes because of the need to update PRs (I believe).

The check can be bypassed with  `OVERCOMMIT_DISABLE` or `SKIP=ProtectedBranches`

## Type of change
Developer tool

## Checklist before requesting review
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
