### PR TITLE
Hide users who can't login from cohort audit active page page

### DIFF
--- a/app/models/audit/cohort_access/base.rb
+++ b/app/models/audit/cohort_access/base.rb
@@ -74,6 +74,7 @@ module Audit
 
           user = users_by_id[user_id]
           next if user.nil? || user.deleted_at.present?
+          next unless user.active_for_authentication?
 
           labels = segs.map { |s| path_label(s.via) }.uniq.sort
           UserAccess.new(user: user, path_labels: labels)

--- a/spec/models/audit/cohort_access/base_spec.rb
+++ b/spec/models/audit/cohort_access/base_spec.rb
@@ -71,6 +71,21 @@ RSpec.describe Audit::CohortAccess::Base do
       expect(audit.current_access.user_accesses.map(&:user)).to all(be_present)
       expect(audit.current_access.users.map(&:id)).not_to include(purged_user_id)
     end
+
+    it 'excludes a deactivated user' do
+      user.update_column(:active, false)
+      expect(audit.current_access.users.map(&:id)).not_to include(user.id)
+    end
+
+    it 'excludes a user whose account has expired' do
+      user.update_column(:expired_at, 1.day.ago)
+      expect(audit.current_access.users.map(&:id)).not_to include(user.id)
+    end
+
+    it 'excludes an unconfirmed user' do
+      user.update_column(:confirmed_at, nil)
+      expect(audit.current_access.users.map(&:id)).not_to include(user.id)
+    end
   end
 
   describe '#events' do
@@ -79,6 +94,12 @@ RSpec.describe Audit::CohortAccess::Base do
       travel_to(Time.zone.parse('2025-01-01 13:00:00')) { group.add(system_user) }
       system_events = audit.events.select { |e| e.affected_user&.id == system_user.id }
       expect(system_events).to be_empty
+    end
+
+    it 'still includes a deactivated user\'s historical grant event' do
+      user.update_column(:active, false)
+      grant_events = audit.events.select { |e| e.affected_user&.id == user.id && e.effect == :granted }
+      expect(grant_events).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Hides inactive users from the list of users who show as being able to see a cohort on the audit page

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

