### PR TITLE
Background the Client Personal ID Lookup XLSX export

### DIFF
--- a/app/controllers/document_exports_controller_base.rb
+++ b/app/controllers/document_exports_controller_base.rb
@@ -118,6 +118,7 @@ class DocumentExportsControllerBase < ApplicationController
       'GrdaWarehouse::DocumentExports::AccessControlsAuditExport',
       'HudSpmReport::DocumentExports::CellDetailExport',
       'HudApr::DocumentExports::CellDetailExport',
+      'GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExport',
     ]
   end
 end

--- a/app/controllers/warehouse_reports/client_lookups_controller.rb
+++ b/app/controllers/warehouse_reports/client_lookups_controller.rb
@@ -14,30 +14,6 @@ module WarehouseReports
       @filter = ::Filters::ClientLookup.new(user_id: current_user.id, enforce_one_year_range: false)
       @filter.update(report_params)
       @map_enrollments = map_enrollments?
-      respond_to do |format|
-        format.html {}
-        format.xlsx do
-          unless @filter.any_effective_project_ids?
-            message = 'At least one Data Source, Organization, or Project must be selected'
-            redirect_to warehouse_reports_client_lookups_path(report: redirect_report_params), alert: message
-            next
-          end
-
-          @report = WarehouseReports::ClientLookups::Report.new(
-            filter: @filter,
-            user: current_user,
-            map_enrollments: @map_enrollments,
-          )
-          unless @report.any_authorized_projects?
-            message = 'you do not have permission to view the selected project(s) for this report'
-            redirect_to warehouse_reports_client_lookups_path(report: redirect_report_params), alert: message
-            next
-          end
-
-          @rows = @report.rows
-          send_data @report.to_xlsx(@rows), filename: 'client_lookups.xlsx', type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-        end
-      end
     end
 
     private def report_params
@@ -48,13 +24,6 @@ module WarehouseReports
 
     private def map_enrollments?
       ActiveModel::Type::Boolean.new.cast(params.dig(:report, :map_enrollments))
-    end
-
-    # `map_enrollments` isn't part of `@filter.known_params`, so `report_params` drops it.
-    # Carry it through the guard-clause redirects so the checkbox re-renders in the state
-    # the user submitted instead of silently reverting to unchecked.
-    private def redirect_report_params
-      report_params.to_h.merge(map_enrollments: @map_enrollments)
     end
   end
 end

--- a/app/javascript/controllers/client_lookup_export_controller.js
+++ b/app/javascript/controllers/client_lookup_export_controller.js
@@ -76,7 +76,7 @@ export default class extends Controller {
   queryString() {
     const params = this.fields().filter((field) => field.name.startsWith('report['))
     // cache bust so reports can be re-generated if the data changes.
-    params.push({ name: 'report[generated_on]', value: this.today() })
+    params.push({ name: 'report[generated_at]', value: this.currentHour() })
 
     return window.$.param(params)
   }
@@ -85,10 +85,10 @@ export default class extends Controller {
     return window.$(this.element).serializeArray()
   }
 
-  today() {
+  currentHour() {
     const now = new Date()
     const pad = (n) => String(n).padStart(2, '0')
 
-    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}`
   }
 }

--- a/app/javascript/controllers/client_lookup_export_controller.js
+++ b/app/javascript/controllers/client_lookup_export_controller.js
@@ -1,0 +1,94 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Select2 fires its own events; `change` alone misses selections made through it.
+const CHANGE_EVENTS = 'change select2:select select2:unselect select2:close'
+
+// Selecting none of these leaves the filter matching nothing, and the export would fail
+// server-side with only the modal's generic error state to show for it.
+const SCOPE_FIELDS = [
+  'report[data_source_ids][]',
+  'report[organization_ids][]',
+  'report[project_ids][]',
+]
+
+export default class extends Controller {
+  static get targets() {
+    return ['button', 'tooltip']
+  }
+
+  connect() {
+    this.$element = window.$(this.element)
+    this.onChange = () => this.refresh()
+    this.$element.on(CHANGE_EVENTS, this.onChange)
+
+    if (this.hasTooltipTarget && window.bootstrap) {
+      this.tooltip = window.bootstrap.Tooltip.getOrCreateInstance(this.tooltipTarget)
+    }
+
+    this.refresh()
+  }
+
+  disconnect() {
+    if (this.$element) this.$element.off(CHANGE_EVENTS, this.onChange)
+    if (this.tooltip) this.tooltip.dispose()
+  }
+
+  // Keeps the button's disabled state, and the tooltip explaining it, in step with the
+  // filter, so the explanation can't outlive the problem it describes.
+  refresh() {
+    const enabled = this.hasScope()
+
+    if (this.hasButtonTarget) {
+      this.buttonTarget.classList.toggle('disabled', !enabled)
+      this.buttonTarget.setAttribute('aria-disabled', String(!enabled))
+    }
+
+    if (!this.tooltip) return
+
+    if (enabled) {
+      // hide() first: disable() alone leaves an open tooltip on screen if the user
+      // satisfies the filter while hovering the button.
+      this.tooltip.hide()
+      this.tooltip.disable()
+    } else {
+      this.tooltip.enable()
+    }
+  }
+
+  download(event) {
+    if (!this.hasScope()) {
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      return
+    }
+
+    // jQuery's .data() cache is what documentExport.js reads, so set it through jQuery
+    // rather than via setAttribute -- the latter would be ignored once .data() is warm.
+    window.$(this.buttonTarget).data('query-string', this.queryString())
+  }
+
+  hasScope() {
+    return this.fields().some(
+      (field) => SCOPE_FIELDS.includes(field.name) && field.value !== ''
+    )
+  }
+
+  queryString() {
+    const params = this.fields().filter((field) => field.name.startsWith('report['))
+    // cache bust so reports can be re-generated if the data changes.
+    params.push({ name: 'report[generated_on]', value: this.today() })
+
+    return window.$.param(params)
+  }
+
+  fields() {
+    return window.$(this.element).serializeArray()
+  }
+
+  today() {
+    const now = new Date()
+    const pad = (n) => String(n).padStart(2, '0')
+
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -33,3 +33,6 @@ application.register("ajax-modal-content", AjaxModalContentController)
 
 import PollReplaceController from "./poll_replace_controller.js"
 application.register("poll-replace", PollReplaceController)
+
+import ClientLookupExportController from "./client_lookup_export_controller.js"
+application.register("client-lookup-export", ClientLookupExportController)

--- a/app/models/grda_warehouse/warehouse_reports/document_exports/client_lookup_export.rb
+++ b/app/models/grda_warehouse/warehouse_reports/document_exports/client_lookup_export.rb
@@ -1,0 +1,76 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module GrdaWarehouse::WarehouseReports::DocumentExports
+  class ClientLookupExport < ::GrdaWarehouse::DocumentExport
+    REPORT_URL = 'warehouse_reports/client_lookups'
+
+    def authorized?
+      user.can_view_any_reports? &&
+        report_definition_source.viewable_by(user).exists? &&
+        filter.any_effective_project_ids? &&
+        report.any_authorized_projects?
+    end
+
+    def download_title
+      'Client Personal ID Lookup'
+    end
+
+    def perform
+      with_status_progression do
+        self.filename = "client-lookups-#{Date.current.to_fs(:db)}.xlsx"
+        self.file_data = report.to_xlsx(report.rows)
+        self.mime_type = EXCEL_MIME_TYPE
+      end
+    end
+
+    def report
+      @report ||= ::WarehouseReports::ClientLookups::Report.new(
+        filter: filter,
+        user: user,
+        map_enrollments: map_enrollments,
+      )
+    end
+
+    # Overrides the base, which builds a bare `Filters::FilterBase`. This report has no
+    # CoC picker, and `Filters::ClientLookup` exists to keep CoC codes from contributing
+    # to project scoping (see its comment); using the base filter here would silently
+    # widen the project scope. `enforce_one_year_range: false` matches the form, which
+    # allows multi-year ranges.
+    def filter
+      @filter ||= begin
+        f = ::Filters::ClientLookup.new(user_id: user.id, enforce_one_year_range: false)
+        f.update(report_params.slice(*known_filter_keys(f)))
+        f
+      end
+    end
+
+    # `known_params` mixes plain symbols with a trailing hash of array-valued params
+    # (`project_ids: []`, ...). Flatten it to the string keys the parsed query string
+    # uses, so slicing here permits exactly what the controller's `permit` does.
+    private def known_filter_keys(filter)
+      filter.known_params.flat_map { |param| param.is_a?(Hash) ? param.keys : param }.map(&:to_s)
+    end
+
+    # `map_enrollments` is deliberately not part of `filter.known_params`, so it has to
+    # be carried separately out of the submitted query string.
+    protected def map_enrollments
+      ActiveModel::Type::Boolean.new.cast(report_params['map_enrollments'])
+    end
+
+    # The filter form serializes its inputs under `report[...]`, matching what
+    # `ClientLookupsController` reads from the request.
+    protected def report_params
+      params['report'].presence || {}
+    end
+
+    protected def report_definition_source
+      GrdaWarehouse::WarehouseReports::ReportDefinition.where(url: REPORT_URL)
+    end
+  end
+end

--- a/app/views/warehouse_reports/client_lookups/index.haml
+++ b/app/views/warehouse_reports/client_lookups/index.haml
@@ -7,7 +7,7 @@
 = render '/warehouse_reports/breadcrumbs'
 %p Export a lookup table for cross-walks with HMIS. The exported file will include Data Source, Personal ID (from HMIS), Warehouse Client ID, first name, and last name, for any client with an open enrollment within the date range and project set chosen.
 
-= simple_form_for @filter, as: :report, url: warehouse_reports_client_lookups_path(format: :xlsx), html: {method: :get} do |f|
+= simple_form_for @filter, as: :report, url: warehouse_reports_client_lookups_path, html: {method: :get, data: {controller: 'client-lookup-export'}} do |f|
   - content_for :filters_col_full do
     .row
       .col-sm-3
@@ -30,8 +30,9 @@
           %span.hint Include HMIS "Enrollment ID" and "Warehouse Enrollment ID", one row per enrollment instead of one row per client.
 
   - content_for :filter_actions do
-    .row
-      .col-sm-3
-        = f.submit 'Download XLSX', class: 'btn btn-primary', data: { disable_with: false }
+    - download_data = { type: 'GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExport', url: document_exports_path, 'client-lookup-export-target' => 'button', action: 'client-lookup-export#download' }
+    - scoped = @filter.any_effective_project_ids?
+    %span.d-inline-block{data: {'client-lookup-export-target' => 'tooltip'}, title: 'Select at least one Data Source, Organization, or Project'}
+      %a.btn.btn-primary.text-nowrap.j-document-exports{href: '#', class: ('disabled' unless scoped), aria: {disabled: !scoped}, data: download_data} Download XLSX
 
   = render 'warehouse_reports/filters', f:f

--- a/spec/requests/warehouse_reports/client_lookup_export_spec.rb
+++ b/spec/requests/warehouse_reports/client_lookup_export_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExp
   # export from a query string (rather than handing it a ready-made filter) is
   # deliberate: reconstructing the filter -- and `map_enrollments`, which travels
   # outside `known_params` -- is the most likely place for a silent regression.
-  def query_string_for(project_ids:, map_enrollments: false, data_source_ids: [source_ds.id], organization_ids: [], generated_on: Date.current)
+  def query_string_for(project_ids:, map_enrollments: false, data_source_ids: [source_ds.id], organization_ids: [], generated_at: Time.current)
     {
       report: {
         start: start_date,
@@ -128,7 +128,7 @@ RSpec.describe GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExp
         organization_ids: organization_ids,
         data_source_ids: data_source_ids,
         map_enrollments: map_enrollments ? '1' : '0',
-        generated_on: generated_on.to_s,
+        generated_at: generated_at.strftime('%Y-%m-%dT%H'),
       },
     }.to_query
   end
@@ -768,7 +768,7 @@ RSpec.describe GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExp
       expect(described_class.last.status).to eq(described_class::PENDING_STATUS)
     end
 
-    it 'reuses a completed export built the same day' do
+    it 'reuses a completed export built the same hour' do
       post_export
       completed = described_class.last
       completed.update!(status: described_class::COMPLETED_STATUS)
@@ -777,15 +777,14 @@ RSpec.describe GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExp
       expect(response.parsed_body['downloadUrl']).to include(completed.id.to_s)
     end
 
-    # Guards the `generated_on` cache buster: without it the 8-hour reuse window would
-    # match a late-evening export the next morning, handing back a crosswalk built
-    # against the prior import.
-    it 'does not reuse a completed export carrying the previous day' do
+    # Guards the `generated_at` cache buster: without it the 8-hour reuse window would
+    # hand back a crosswalk built hours earlier, against an older import.
+    it 'does not reuse a completed export carrying an earlier hour' do
       post(
         document_exports_path,
         params: {
           type: described_class.name,
-          query_string: query_string_for(project_ids: [viewable_project.id], generated_on: Date.current - 1.day),
+          query_string: query_string_for(project_ids: [viewable_project.id], generated_at: Time.current - 1.hour),
         },
       )
       described_class.last.update!(status: described_class::COMPLETED_STATUS)

--- a/spec/requests/warehouse_reports/client_lookup_export_spec.rb
+++ b/spec/requests/warehouse_reports/client_lookup_export_spec.rb
@@ -1,0 +1,818 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'roo'
+
+# Baseline coverage for the Client PersonalID Lookup (Client Lookups) crosswalk report.
+#
+# This report builds a 5-column XLSX (Data Source, PersonalID, warehouse destination
+# Client ID, FirstName, LastName) for source clients enrolled in a selected set of
+# projects during a date range, with two additional columns (Enrollment ID, Warehouse
+# Enrollment ID) when "Map enrollments" is checked. See
+# app/models/grda_warehouse/warehouse_reports/document_exports/client_lookup_export.rb
+# and app/models/warehouse_reports/client_lookups/report.rb.
+#
+# The export runs in a background job (there is no synchronous download), so these
+# specs drive the export object directly: they build it from the same `query_string`
+# the filter form posts, which exercises the filter reconstruction users actually hit.
+#
+# The report scopes its project filter through `Project.viewable_by(user,
+# permission: :can_view_assigned_reports)` (see `Report#project_source`), the way
+# sibling reports (e.g. EntryExitServiceController) do. The "project-level
+# authorization" and "confidential project" groups below are regression guards for that
+# scoping: they submit project ids the user was never granted, or that are
+# confidential, and assert the resulting rows exclude them. All groups in this file are
+# expected to stay green; a regression in `project_source` or its `merge` into the
+# report query should turn one of these red.
+RSpec.describe GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExport, type: :request do
+  include AccessControlSetup
+
+  before(:all) do
+    # Other specs leak warehouse data that would break our row assertions.
+    GrdaWarehouse::Utility.clear!
+  end
+
+  after(:all) do
+    GrdaWarehouse::Utility.clear!
+  end
+
+  let(:start_date) { Date.new(2023, 1, 1) }
+  let(:end_date) { Date.new(2023, 12, 31) }
+
+  # A "source" data source holds the as-imported HMIS client/enrollment records the
+  # report queries; the "destination" data source holds the deduplicated warehouse
+  # identity that supplies the destination_id column.
+  let!(:source_ds) { create(:source_data_source) }
+  let!(:destination_ds) { create(:destination_data_source) }
+
+  let(:organization) { create(:hud_organization, data_source_id: source_ds.id) }
+
+  # Defaults to `organization`/`source_ds`; pass `organization:`/`data_source:` for a
+  # project in a different org or data source (e.g. a confidential org).
+  def create_project(confidential:, organization: self.organization, data_source: source_ds)
+    create(
+      :hud_project,
+      data_source_id: data_source.id,
+      OrganizationID: organization.OrganizationID,
+      confidential: confidential,
+    )
+  end
+
+  let!(:viewable_project) { create_project(confidential: false) }
+  let!(:unauthorized_project) { create_project(confidential: false) }
+  # Project the user is allowed to see, but which is flagged confidential.
+  let!(:confidential_project) { create_project(confidential: true) }
+
+  let(:user) { create(:acl_user) }
+  let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: true) }
+  let(:collection) { create(:collection) }
+  let!(:report_definition) { create(:client_lookups_report) }
+
+  # Grants report visibility plus access to the given projects via `collection`.
+  def grant_projects(*projects)
+    collection.set_viewables(reports: [report_definition.id], projects: projects.map(&:id))
+  end
+
+  before do
+    # Grant report visibility and access to the two "authorized" projects
+    # (viewable_project + confidential_project), but NOT unauthorized_project.
+    grant_projects(viewable_project, confidential_project)
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  # Build the full crosswalk graph (source client -> warehouse client -> destination
+  # client, plus an enrollment in `project`) and return the destination (warehouse) id
+  # and the created enrollment, since some tests need the enrollment's HUD/DB ids too.
+  def create_crosswalk(project: viewable_project, personal_id: 'PID-VIEWABLE', first_name: 'Ada', last_name: 'Lovelace', entry_date: start_date + 1.day, data_source: source_ds)
+    source_client = create(
+      :grda_warehouse_hud_client,
+      data_source: data_source,
+      PersonalID: personal_id,
+      FirstName: first_name,
+      LastName: last_name,
+    )
+    destination_client = create(:grda_warehouse_hud_client, data_source: destination_ds)
+    create(
+      :warehouse_client,
+      source: source_client,
+      destination: destination_client,
+      data_source: data_source,
+    )
+    enrollment = create(
+      :grda_warehouse_hud_enrollment,
+      data_source_id: data_source.id,
+      PersonalID: personal_id,
+      ProjectID: project.ProjectID,
+      EntryDate: entry_date,
+    )
+    { destination_id: destination_client.id, enrollment: enrollment }
+  end
+
+  # The exact params the filter form serializes into `data-query-string`. Building the
+  # export from a query string (rather than handing it a ready-made filter) is
+  # deliberate: reconstructing the filter -- and `map_enrollments`, which travels
+  # outside `known_params` -- is the most likely place for a silent regression.
+  def query_string_for(project_ids:, map_enrollments: false, data_source_ids: [source_ds.id], organization_ids: [], generated_on: Date.current)
+    {
+      report: {
+        start: start_date,
+        end: end_date,
+        project_ids: project_ids,
+        organization_ids: organization_ids,
+        data_source_ids: data_source_ids,
+        map_enrollments: map_enrollments ? '1' : '0',
+        generated_on: generated_on.to_s,
+      },
+    }.to_query
+  end
+
+  def build_export(export_user: user, **filter_args)
+    described_class.new(user_id: export_user.id, query_string: query_string_for(**filter_args))
+  end
+
+  # Sets `@export` and, when the export is authorized, `@rows` -- the same rows
+  # `perform` writes into the workbook.
+  def get_report(**filter_args)
+    @export = build_export(**filter_args)
+    @rows = @export.report.rows if @export.authorized?
+    @export
+  end
+
+  # The report plucks [Data Source name, PersonalID, destination_id, FirstName,
+  # LastName, ...]; pull out just the warehouse (destination) ids so we can assert
+  # which clients were included.
+  def reported_destination_ids
+    @rows.map { |row| row[2] }
+  end
+
+  # Parse the generated XLSX (not the `@rows` array it was built from) so tests can
+  # catch bugs in Report#to_xlsx itself, e.g. a wrong header, dropped column, or
+  # reordered fields that row-only assertions would miss entirely.
+  def rendered_workbook_rows
+    excel_file = Tempfile.new(['client_lookups', '.xlsx'])
+    begin
+      excel_file.binmode
+      excel_file.write(@export.file_data)
+      excel_file.close
+
+      spreadsheet = Roo::Excelx.new(excel_file.path)
+      sheet = spreadsheet.sheet(0)
+      (1..sheet.last_row).map { |i| sheet.row(i) }
+    ensure
+      excel_file.unlink
+    end
+  end
+
+  describe 'current behavior (should remain green)' do
+    it 'includes a client enrolled in an allowed project during the range' do
+      destination_id = create_crosswalk.fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(destination_id)
+      expect(@rows).to include([source_ds.name, 'PID-VIEWABLE', destination_id, 'Ada', 'Lovelace'])
+    end
+  end
+
+  describe 'date range boundary (regression guard)' do
+    it 'includes an enrollment whose EntryDate falls exactly on the end of the range' do
+      destination_id = create_crosswalk(
+        project: viewable_project,
+        personal_id: 'PID-ENTRY-ON-END',
+        first_name: 'Rosalind',
+        last_name: 'Franklin',
+        entry_date: end_date,
+      ).fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(destination_id)
+    end
+
+    it 'excludes an enrollment whose EntryDate falls one day after the end of the range' do
+      destination_id = create_crosswalk(
+        project: viewable_project,
+        personal_id: 'PID-ENTRY-AFTER-END',
+        first_name: 'Marie',
+        last_name: 'Curie',
+        entry_date: end_date + 1.day,
+      ).fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).not_to include(destination_id)
+    end
+
+    it 'includes an enrollment that exited exactly on the start of the range' do
+      crosswalk = create_crosswalk(
+        project: viewable_project,
+        personal_id: 'PID-EXIT-ON-START',
+        first_name: 'Rosalind',
+        last_name: 'Franklin',
+        entry_date: start_date - 30.days,
+      )
+      create(
+        :hud_exit,
+        data_source: source_ds,
+        EnrollmentID: crosswalk.fetch(:enrollment).EnrollmentID,
+        PersonalID: 'PID-EXIT-ON-START',
+        ExitDate: start_date,
+      )
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(crosswalk.fetch(:destination_id))
+    end
+
+    it 'excludes an enrollment that exited one day before the start of the range' do
+      crosswalk = create_crosswalk(
+        project: viewable_project,
+        personal_id: 'PID-EXIT-BEFORE-START',
+        first_name: 'Marie',
+        last_name: 'Curie',
+        entry_date: start_date - 30.days,
+      )
+      create(
+        :hud_exit,
+        data_source: source_ds,
+        EnrollmentID: crosswalk.fetch(:enrollment).EnrollmentID,
+        PersonalID: 'PID-EXIT-BEFORE-START',
+        ExitDate: start_date - 1.day,
+      )
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).not_to include(crosswalk.fetch(:destination_id))
+    end
+  end
+
+  describe 'rendered file (regression guard)' do
+    it 'writes the header row and client data into the actual XLSX output' do
+      destination_id = create_crosswalk.fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id])
+      @export.perform
+
+      expect(@export).to be_completed
+      expect(@export.filename).to eq("client-lookups-#{Date.current.to_fs(:db)}.xlsx")
+      expect(@export.mime_type).to eq(described_class::EXCEL_MIME_TYPE)
+
+      rows = rendered_workbook_rows
+      expect(rows.first).to eq(
+        ['Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)'],
+      )
+      expect(rows[1..]).to include([source_ds.name, 'PID-VIEWABLE', destination_id, 'Ada', 'Lovelace'])
+    end
+
+    it 'writes the additional enrollment columns when "Map enrollments" is requested' do
+      crosswalk = create_crosswalk
+
+      get_report(project_ids: [viewable_project.id], map_enrollments: true)
+      @export.perform
+
+      expect(@export).to be_completed
+
+      rows = rendered_workbook_rows
+      expect(rows.first).to eq(
+        [
+          'Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)',
+          'Enrollment ID (from HMIS)', 'Warehouse Enrollment ID'
+        ],
+      )
+      # Roo reads a numeric-looking string cell (EnrollmentID) back as a Numeric, not a
+      # String, so compare it numerically rather than against the pluck'd String value.
+      expect(rows[1..]).to include(
+        [
+          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
+          crosswalk.fetch(:enrollment).EnrollmentID.to_i, crosswalk.fetch(:enrollment).id
+        ],
+      )
+    end
+  end
+
+  describe 'report-level authorization (should remain green)' do
+    let(:role) { create(:role, can_view_assigned_reports: false) }
+
+    it 'refuses to run the export for a user who cannot view any reports' do
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).not_to be_authorized
+    end
+  end
+
+  describe 'project-level authorization (regression guard)' do
+    it 'excludes clients whose only enrollment is in a project the user cannot view, even when its id is submitted' do
+      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
+      forbidden_destination_id = create_crosswalk(
+        project: unauthorized_project,
+        personal_id: 'PID-FORBIDDEN',
+        first_name: 'Mallory',
+        last_name: 'Malicious',
+      ).fetch(:destination_id)
+
+      # A user can hand-craft the params and submit a project id they were never granted.
+      get_report(project_ids: [viewable_project.id, unauthorized_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(allowed_destination_id)
+      expect(reported_destination_ids).not_to include(forbidden_destination_id)
+    end
+
+    it 'refuses the export instead of silently producing nothing when the only selected project is unauthorized' do
+      # Regression guard: a single unauthorized (but hand-craftable) project id passes
+      # `any_effective_project_ids?` (which doesn't check authorization) and would
+      # otherwise silently produce a zero-row export via the `project_source` merge.
+      get_report(project_ids: [unauthorized_project.id], data_source_ids: [])
+
+      expect(@export.filter.any_effective_project_ids?).to be true
+      expect(@export.report.any_authorized_projects?).to be false
+      expect(@export).not_to be_authorized
+    end
+
+    it 'excludes clients from a project the user can view but did not select in the filter' do
+      # A second non-confidential project the user is granted access to via their
+      # collection, distinct from viewable_project (which is the only one selected below).
+      other_viewable_project = create_project(confidential: false)
+      grant_projects(viewable_project, confidential_project, other_viewable_project)
+
+      selected_destination_id = create_crosswalk(personal_id: 'PID-SELECTED').fetch(:destination_id)
+      unselected_destination_id = create_crosswalk(
+        project: other_viewable_project,
+        personal_id: 'PID-UNSELECTED-BUT-VIEWABLE',
+        first_name: 'Not',
+        last_name: 'Selected',
+      ).fetch(:destination_id)
+
+      # Only viewable_project is selected in the filter (data_source_ids/organization_ids
+      # are cleared so effective_project_ids comes purely from project_ids), even though
+      # other_viewable_project is also granted to the user. The project_source (viewable_by)
+      # merge must not silently widen the query back out to every project the user can view.
+      get_report(project_ids: [viewable_project.id], data_source_ids: [])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(selected_destination_id)
+      expect(reported_destination_ids).not_to include(unselected_destination_id)
+    end
+  end
+
+  describe 'confidential project exclusion (regression guard)' do
+    it 'excludes clients whose only enrollment is in a confidential project' do
+      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
+      confidential_destination_id = create_crosswalk(
+        project: confidential_project,
+        personal_id: 'PID-CONFIDENTIAL',
+        first_name: 'Secret',
+        last_name: 'Client',
+      ).fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id, confidential_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(allowed_destination_id)
+      expect(reported_destination_ids).not_to include(confidential_destination_id)
+    end
+
+    it 'excludes clients whose only enrollment is in a non-confidential project of a confidential organization' do
+      confidential_org = create(:hud_organization, data_source_id: source_ds.id, confidential: true)
+      org_confidential_project = create_project(confidential: false, organization: confidential_org)
+      grant_projects(viewable_project, confidential_project, org_confidential_project)
+
+      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
+      org_confidential_destination_id = create_crosswalk(
+        project: org_confidential_project,
+        personal_id: 'PID-ORG-CONFIDENTIAL',
+        first_name: 'Org',
+        last_name: 'Secret',
+      ).fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id, org_confidential_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids).to include(allowed_destination_id)
+      expect(reported_destination_ids).not_to include(org_confidential_destination_id)
+    end
+  end
+
+  describe 'source data source disambiguation (regression guard)' do
+    it 'does not conflate clients with the same PersonalID from different source data sources' do
+      other_source_ds = create(:source_data_source, name: 'Other HMIS Vendor')
+      other_organization = create(:hud_organization, data_source_id: other_source_ds.id)
+      other_project = create_project(confidential: false, organization: other_organization, data_source: other_source_ds)
+      grant_projects(viewable_project, confidential_project, other_project)
+
+      # HUD PersonalID is only unique within a data source; the same PersonalID here
+      # identifies two different people in two different source data sources. The Data
+      # Source column is what lets the export disambiguate them.
+      destination_id_a = create_crosswalk(personal_id: 'DUPLICATE-PID').fetch(:destination_id)
+      destination_id_b = create_crosswalk(
+        project: other_project,
+        personal_id: 'DUPLICATE-PID',
+        first_name: 'Grace',
+        last_name: 'Hopper',
+        data_source: other_source_ds,
+      ).fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id, other_project.id])
+
+      expect(@export).to be_authorized
+      expect(destination_id_a).not_to eq(destination_id_b)
+      expect(@rows).to include([source_ds.name, 'DUPLICATE-PID', destination_id_a, 'Ada', 'Lovelace'])
+      expect(@rows).to include([other_source_ds.name, 'DUPLICATE-PID', destination_id_b, 'Grace', 'Hopper'])
+    end
+  end
+
+  describe 'duplicate enrollments (regression guard)' do
+    it 'includes a client only once when they have overlapping enrollments in two allowed projects' do
+      second_viewable_project = create_project(confidential: false)
+      grant_projects(viewable_project, confidential_project, second_viewable_project)
+
+      destination_id = create_crosswalk(personal_id: 'PID-DOUBLE-ENROLLED').fetch(:destination_id)
+      # A second enrollment for the same source client, in the other allowed project.
+      create(
+        :grda_warehouse_hud_enrollment,
+        data_source_id: source_ds.id,
+        PersonalID: 'PID-DOUBLE-ENROLLED',
+        ProjectID: second_viewable_project.ProjectID,
+        EntryDate: start_date + 1.day,
+      )
+
+      get_report(project_ids: [viewable_project.id, second_viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(reported_destination_ids.count { |id| id == destination_id }).to eq(1)
+    end
+  end
+
+  describe 'deduplicated identity with multiple PersonalIDs (regression guard)' do
+    it 'emits one row per PersonalID (not per enrollment) when two source records in the same data source share a warehouse client and name' do
+      # Two source client records in the SAME data source, deduplicated to a SINGLE
+      # warehouse (destination) client, sharing first/last name but differing only by
+      # PersonalID. Grouping in Report#rows relies on rows sharing a display_key
+      # sorting contiguously; if PersonalID is missing from the query's ORDER BY, these
+      # rows interleave by enrollment id and the client is emitted as duplicate rows.
+      destination_client = create(:grda_warehouse_hud_client, data_source: destination_ds)
+
+      source_client_a = create(
+        :grda_warehouse_hud_client,
+        data_source: source_ds,
+        PersonalID: 'PID-DEDUP-A',
+        FirstName: 'Ada',
+        LastName: 'Lovelace',
+      )
+      source_client_b = create(
+        :grda_warehouse_hud_client,
+        data_source: source_ds,
+        PersonalID: 'PID-DEDUP-B',
+        FirstName: 'Ada',
+        LastName: 'Lovelace',
+      )
+      create(:warehouse_client, source: source_client_a, destination: destination_client, data_source: source_ds)
+      create(:warehouse_client, source: source_client_b, destination: destination_client, data_source: source_ds)
+
+      # Interleave enrollment creation so their (auto-incrementing) warehouse enrollment
+      # ids alternate between the two PersonalIDs. Without PersonalID in the ORDER BY the
+      # rows come back A, B, A, B — non-contiguous groups that flush as four rows.
+      ['PID-DEDUP-A', 'PID-DEDUP-B', 'PID-DEDUP-A', 'PID-DEDUP-B'].each do |personal_id|
+        create(
+          :grda_warehouse_hud_enrollment,
+          data_source_id: source_ds.id,
+          PersonalID: personal_id,
+          ProjectID: viewable_project.ProjectID,
+          EntryDate: start_date + 1.day,
+        )
+      end
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      dedup_rows = @rows.select { |row| row[2] == destination_client.id }
+      expect(dedup_rows.length).to eq(2)
+      expect(dedup_rows.map { |row| row[1] }).to contain_exactly('PID-DEDUP-A', 'PID-DEDUP-B')
+    end
+  end
+
+  describe 'map enrollments (regression guard)' do
+    it 'omits the enrollment columns by default' do
+      create_crosswalk
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      expect(@export.report.headers).to eq(
+        ['Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)'],
+      )
+      expect(@rows.first.length).to eq(5)
+    end
+
+    it 'adds the Enrollment ID and Warehouse Enrollment ID columns when requested, one row per enrollment' do
+      crosswalk = create_crosswalk
+      second_viewable_project = create_project(confidential: false)
+      grant_projects(viewable_project, confidential_project, second_viewable_project)
+      # A second enrollment for the same source client, in another allowed project;
+      # "no dedup" means this must yield a second row, not collapse into one.
+      second_enrollment = create(
+        :grda_warehouse_hud_enrollment,
+        data_source_id: source_ds.id,
+        PersonalID: 'PID-VIEWABLE',
+        ProjectID: second_viewable_project.ProjectID,
+        EntryDate: start_date + 1.day,
+      )
+
+      get_report(project_ids: [viewable_project.id, second_viewable_project.id], map_enrollments: true)
+
+      expect(@export).to be_authorized
+      expect(@export.report.headers).to eq(
+        [
+          'Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)',
+          'Enrollment ID (from HMIS)', 'Warehouse Enrollment ID'
+        ],
+      )
+      rows = @rows
+      expect(rows).to include(
+        [
+          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
+          crosswalk.fetch(:enrollment).EnrollmentID, crosswalk.fetch(:enrollment).id
+        ],
+      )
+      expect(rows).to include(
+        [
+          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
+          second_enrollment.EnrollmentID, second_enrollment.id
+        ],
+      )
+      expect(rows.count { |row| row[2] == crosswalk.fetch(:destination_id) }).to eq(2)
+    end
+  end
+
+  describe 'filter requirement (regression guard)' do
+    it 'refuses the export when no project, organization, or data source is selected' do
+      create_crosswalk
+
+      get_report(project_ids: [], data_source_ids: [], organization_ids: [])
+
+      expect(@export.filter.any_effective_project_ids?).to be false
+      expect(@export).not_to be_authorized
+    end
+
+    it 'allows the export when a project is selected without a data source' do
+      create_crosswalk
+
+      get_report(project_ids: [viewable_project.id], data_source_ids: [])
+
+      expect(@export).to be_authorized
+    end
+
+    # On a multi-CoC installation, FilterBase#update seeds coc_codes from the user's CoC
+    # codes when the form submits none. Filters::ClientLookup overrides
+    # effective_project_ids_from_coc_codes so those codes don't expand the project scope
+    # behind the guard. viewable_project is linked to the granted CoC so that, without the
+    # override, it would satisfy any_effective_project_ids? and pass the check.
+    it 'still refuses when the installation is multi-CoC and the user has CoC codes assigned' do
+      create(:config, multi_coc_installation: true)
+      coc = create(:lookup_coc)
+      create(
+        :hud_project_coc,
+        data_source_id: viewable_project.data_source_id,
+        ProjectID: viewable_project.ProjectID,
+        CoCCode: coc.coc_code,
+      )
+      collection.set_viewables(
+        reports: [report_definition.id],
+        projects: [viewable_project.id, confidential_project.id],
+        coc_codes: [coc.id],
+      )
+      create_crosswalk
+
+      get_report(project_ids: [], data_source_ids: [], organization_ids: [])
+
+      expect(@export.filter.coc_codes).to include(coc.coc_code)
+      expect(@export.filter.any_effective_project_ids?).to be false
+      expect(@export).not_to be_authorized
+    end
+  end
+
+  describe 'client name PII policy (regression guard)' do
+    let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: false) }
+
+    it 'redacts first and last name when the user cannot view client names for the project' do
+      destination_id = create_crosswalk.fetch(:destination_id)
+
+      get_report(project_ids: [viewable_project.id])
+
+      expect(@export).to be_authorized
+      row = @rows.find { |r| r[2] == destination_id }
+      expect(row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+      expect(row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+    end
+
+    it 'shows the name when at least one of the client\'s projects allows it, with map_enrollments off' do
+      second_viewable_project = create_project(confidential: false)
+      grant_projects(viewable_project, confidential_project, second_viewable_project)
+      permissive_role = create(:role, can_view_assigned_reports: true, can_view_client_name: true)
+      permissive_collection = create(:collection)
+      permissive_collection.set_viewables(projects: [second_viewable_project.id])
+      setup_access_control(user, permissive_role, permissive_collection)
+
+      destination_id = create_crosswalk(personal_id: 'PID-MULTI').fetch(:destination_id)
+      create(
+        :grda_warehouse_hud_enrollment,
+        data_source_id: source_ds.id,
+        PersonalID: 'PID-MULTI',
+        ProjectID: second_viewable_project.ProjectID,
+        EntryDate: start_date + 1.day,
+      )
+
+      get_report(project_ids: [viewable_project.id, second_viewable_project.id])
+
+      expect(@export).to be_authorized
+      row = @rows.find { |r| r[2] == destination_id }
+      expect(row[3]).to eq('Ada')
+      expect(row[4]).to eq('Lovelace')
+    end
+
+    context 'when the org has disabled PII in detail downloads' do
+      # can_view_client_name alone is not sufficient for a "download"-mode PII policy
+      # (see User#reporting_policy_for_project): the org-wide include_pii_in_detail_downloads
+      # config must also be enabled, or every project's policy denies the name regardless of role.
+      let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: true) }
+
+      before { GrdaWarehouse::Config.first_or_create.update!(include_pii_in_detail_downloads: false) }
+
+      it 'redacts the name even though the role otherwise allows viewing it' do
+        destination_id = create_crosswalk.fetch(:destination_id)
+
+        get_report(project_ids: [viewable_project.id])
+
+        expect(@export).to be_authorized
+        row = @rows.find { |r| r[2] == destination_id }
+        expect(row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+        expect(row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+      end
+    end
+
+    it 'redacts each row independently by its own enrollment\'s project when "Map enrollments" is requested' do
+      # Unlike the map_enrollments-off case above (which aggregates "can view via any
+      # project"), each mapped row is redacted using that specific enrollment's project
+      # policy, so the same client can have one visible and one redacted row.
+      second_viewable_project = create_project(confidential: false)
+      grant_projects(viewable_project, confidential_project, second_viewable_project)
+      permissive_role = create(:role, can_view_assigned_reports: true, can_view_client_name: true)
+      permissive_collection = create(:collection)
+      permissive_collection.set_viewables(projects: [second_viewable_project.id])
+      setup_access_control(user, permissive_role, permissive_collection)
+
+      crosswalk = create_crosswalk(personal_id: 'PID-MIXED')
+      second_enrollment = create(
+        :grda_warehouse_hud_enrollment,
+        data_source_id: source_ds.id,
+        PersonalID: 'PID-MIXED',
+        ProjectID: second_viewable_project.ProjectID,
+        EntryDate: start_date + 1.day,
+      )
+
+      get_report(project_ids: [viewable_project.id, second_viewable_project.id], map_enrollments: true)
+
+      expect(@export).to be_authorized
+      rows = @rows
+      denied_row = rows.find { |r| r[5] == crosswalk.fetch(:enrollment).EnrollmentID }
+      allowed_row = rows.find { |r| r[5] == second_enrollment.EnrollmentID }
+      expect(denied_row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+      expect(denied_row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+      expect(allowed_row[3]).to eq('Ada')
+      expect(allowed_row[4]).to eq('Lovelace')
+    end
+  end
+
+  describe '#authorized?' do
+    it 'is true for a user granted the report and an authorized project' do
+      expect(build_export(project_ids: [viewable_project.id])).to be_authorized
+    end
+
+    it 'is false for a user who cannot view any reports' do
+      other_user = create(:acl_user)
+      other_role = create(:role, can_view_assigned_reports: false)
+      other_collection = create(:collection)
+      other_collection.set_viewables(reports: [report_definition.id], projects: [viewable_project.id])
+      setup_access_control(other_user, other_role, other_collection)
+
+      expect(build_export(export_user: other_user, project_ids: [viewable_project.id])).not_to be_authorized
+    end
+
+    it 'is false when the report definition is not viewable by the user' do
+      # Same project access, but the collection does not grant this report.
+      other_user = create(:acl_user)
+      other_collection = create(:collection)
+      other_collection.set_viewables(projects: [viewable_project.id])
+      setup_access_control(other_user, role, other_collection)
+
+      expect(build_export(export_user: other_user, project_ids: [viewable_project.id])).not_to be_authorized
+    end
+  end
+
+  describe 'filter reconstruction from the submitted query string' do
+    # `map_enrollments` is not part of `filter.known_params`, so it travels outside the
+    # filter and has to be carried through the query string separately. A regression
+    # here is silent: the export succeeds, just without the enrollment columns.
+    it 'carries map_enrollments through the query string' do
+      expect(build_export(project_ids: [viewable_project.id], map_enrollments: true).report.headers.length).to eq(7)
+      expect(build_export(project_ids: [viewable_project.id], map_enrollments: false).report.headers.length).to eq(5)
+    end
+
+    it 'produces the same effective_project_ids as a filter built the way the page builds it' do
+      page_filter = ::Filters::ClientLookup.new(user_id: user.id, enforce_one_year_range: false)
+      page_filter.update(
+        start: start_date,
+        end: end_date,
+        project_ids: [viewable_project.id],
+        data_source_ids: [source_ds.id],
+        organization_ids: [organization.id],
+      )
+
+      export_filter = build_export(
+        project_ids: [viewable_project.id],
+        data_source_ids: [source_ds.id],
+        organization_ids: [organization.id],
+      ).filter
+
+      expect(export_filter.effective_project_ids).to match_array(page_filter.effective_project_ids)
+      expect(export_filter.start).to eq(start_date)
+      expect(export_filter.end).to eq(end_date)
+      expect(export_filter.enforce_one_year_range).to be false
+    end
+  end
+
+  describe 'POST /document_exports' do
+    let(:query_string) { query_string_for(project_ids: [viewable_project.id]) }
+
+    def post_export
+      post(document_exports_path, params: { type: described_class.name, query_string: query_string })
+    end
+
+    it 'creates one export and enqueues one job' do
+      expect { post_export }.to change(described_class, :count).by(1).
+        and have_enqueued_job(DocumentExportJob).exactly(:once)
+
+      expect(response).to have_http_status(:success)
+      expect(described_class.last.status).to eq(described_class::PENDING_STATUS)
+    end
+
+    it 'reuses a completed export built the same day' do
+      post_export
+      completed = described_class.last
+      completed.update!(status: described_class::COMPLETED_STATUS)
+
+      expect { post_export }.not_to change(described_class, :count)
+      expect(response.parsed_body['downloadUrl']).to include(completed.id.to_s)
+    end
+
+    # Guards the `generated_on` cache buster: without it the 8-hour reuse window would
+    # match a late-evening export the next morning, handing back a crosswalk built
+    # against the prior import.
+    it 'does not reuse a completed export carrying the previous day' do
+      post(
+        document_exports_path,
+        params: {
+          type: described_class.name,
+          query_string: query_string_for(project_ids: [viewable_project.id], generated_on: Date.current - 1.day),
+        },
+      )
+      described_class.last.update!(status: described_class::COMPLETED_STATUS)
+
+      expect { post_export }.to change(described_class, :count).by(1)
+    end
+
+    it 'creates a separate export when the filter differs' do
+      post_export
+
+      expect do
+        post(
+          document_exports_path,
+          params: {
+            type: described_class.name,
+            query_string: query_string_for(project_ids: [viewable_project.id], map_enrollments: true),
+          },
+        )
+      end.to change(described_class, :count).by(1)
+    end
+
+    it 'refuses an unauthorized export without creating a record' do
+      expect do
+        post(document_exports_path, params: { type: described_class.name, query_string: query_string_for(project_ids: [unauthorized_project.id], data_source_ids: []) })
+      end.not_to change(described_class, :count)
+
+      expect(response).not_to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/warehouse_reports/client_lookups_controller_spec.rb
+++ b/spec/requests/warehouse_reports/client_lookups_controller_spec.rb
@@ -7,665 +7,141 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'roo'
 
-# Baseline coverage for the Client PersonalID Lookup (Client Lookups) crosswalk report.
-#
-# This report renders a 5-column XLSX (Data Source, PersonalID, warehouse destination
-# Client ID, FirstName, LastName) for source clients enrolled in a selected set of
-# projects during a date range, with two additional columns (Enrollment ID, Warehouse
-# Enrollment ID) when "Map enrollments" is checked. See
-# app/controllers/warehouse_reports/client_lookups_controller.rb and
-# app/models/warehouse_reports/client_lookups/report.rb.
-#
-# The report scopes its project filter through `Project.viewable_by(current_user,
-# permission: :can_view_assigned_reports)` (see `Report#project_source`), the way
-# sibling reports (e.g. EntryExitServiceController) do. The "project-level
-# authorization" and "confidential project" groups below are regression guards for that
-# scoping: they submit project ids the user was never granted, or that are
-# confidential, and assert the resulting rows exclude them. All groups in this file are
-# expected to stay green; a regression in `project_source` or its `merge` into the
-# report query should turn one of these red.
+# The controller renders the filter page and nothing else -- the XLSX is built by
+# GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExport in a background
+# job (see spec/requests/warehouse_reports/client_lookup_export_spec.rb for the report's
+# rows, PII redaction, and project scoping).
 RSpec.describe WarehouseReports::ClientLookupsController, type: :request do
   include AccessControlSetup
 
-  before(:all) do
-    # Other specs leak warehouse data that would break our row assertions.
-    GrdaWarehouse::Utility.clear!
-  end
-
-  after(:all) do
-    GrdaWarehouse::Utility.clear!
-  end
-
-  let(:start_date) { Date.new(2023, 1, 1) }
-  let(:end_date) { Date.new(2023, 12, 31) }
-
-  # A "source" data source holds the as-imported HMIS client/enrollment records the
-  # report queries; the "destination" data source holds the deduplicated warehouse
-  # identity that supplies the destination_id column.
-  let!(:source_ds) { create(:source_data_source) }
-  let!(:destination_ds) { create(:destination_data_source) }
-
+  let(:source_ds) { create(:source_data_source) }
   let(:organization) { create(:hud_organization, data_source_id: source_ds.id) }
-
-  # Defaults to `organization`/`source_ds`; pass `organization:`/`data_source:` for a
-  # project in a different org or data source (e.g. a confidential org).
-  def create_project(confidential:, organization: self.organization, data_source: source_ds)
+  let!(:viewable_project) do
     create(
       :hud_project,
-      data_source_id: data_source.id,
+      data_source_id: source_ds.id,
       OrganizationID: organization.OrganizationID,
-      confidential: confidential,
+      confidential: false,
     )
   end
 
-  let!(:viewable_project) { create_project(confidential: false) }
-  let!(:unauthorized_project) { create_project(confidential: false) }
-  # Project the user is allowed to see, but which is flagged confidential.
-  let!(:confidential_project) { create_project(confidential: true) }
-
   let(:user) { create(:acl_user) }
-  let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: true) }
+  let(:role) { create(:role, can_view_assigned_reports: true) }
   let(:collection) { create(:collection) }
   let!(:report_definition) { create(:client_lookups_report) }
-
-  # Grants report visibility plus access to the given projects via `collection`.
-  def grant_projects(*projects)
-    collection.set_viewables(reports: [report_definition.id], projects: projects.map(&:id))
-  end
+  let(:viewable_reports) { [report_definition.id] }
 
   before do
-    # Grant report visibility and access to the two "authorized" projects
-    # (viewable_project + confidential_project), but NOT unauthorized_project.
-    grant_projects(viewable_project, confidential_project)
+    collection.set_viewables(reports: viewable_reports, projects: [viewable_project.id])
     setup_access_control(user, role, collection)
     sign_in(user)
   end
 
-  # Build the full crosswalk graph (source client -> warehouse client -> destination
-  # client, plus an enrollment in `project`) and return the destination (warehouse) id
-  # and the created enrollment, since some tests need the enrollment's HUD/DB ids too.
-  def create_crosswalk(project: viewable_project, personal_id: 'PID-VIEWABLE', first_name: 'Ada', last_name: 'Lovelace', entry_date: start_date + 1.day, data_source: source_ds)
-    source_client = create(
-      :grda_warehouse_hud_client,
-      data_source: data_source,
-      PersonalID: personal_id,
-      FirstName: first_name,
-      LastName: last_name,
-    )
-    destination_client = create(:grda_warehouse_hud_client, data_source: destination_ds)
-    create(
-      :warehouse_client,
-      source: source_client,
-      destination: destination_client,
-      data_source: data_source,
-    )
-    enrollment = create(
-      :grda_warehouse_hud_enrollment,
-      data_source_id: data_source.id,
-      PersonalID: personal_id,
-      ProjectID: project.ProjectID,
-      EntryDate: entry_date,
-    )
-    { destination_id: destination_client.id, enrollment: enrollment }
-  end
-
-  def get_report(project_ids:, map_enrollments: false, data_source_ids: [source_ds.id], organization_ids: [])
-    get(
-      warehouse_reports_client_lookups_path(format: :xlsx),
-      params: {
-        report: {
-          start: start_date,
-          end: end_date,
-          project_ids: project_ids,
-          organization_ids: organization_ids,
-          data_source_ids: data_source_ids,
-          map_enrollments: map_enrollments ? '1' : '0',
-        },
-      },
-    )
-  end
-
-  # The report plucks [Data Source name, PersonalID, destination_id, FirstName,
-  # LastName, ...]; pull out just the warehouse (destination) ids so we can assert
-  # which clients were included.
-  def reported_destination_ids
-    assigns(:rows).map { |row| row[2] }
-  end
-
-  # Parse the actual rendered XLSX response body (not the controller's @rows ivar) so
-  # tests can catch bugs in Report#to_xlsx itself, e.g. a wrong header, dropped column,
-  # or reordered fields that assigns(:rows)-only assertions would miss entirely.
-  def rendered_workbook_rows
-    excel_file = Tempfile.new(['client_lookups', '.xlsx'])
-    begin
-      excel_file.binmode
-      excel_file.write(response.body)
-      excel_file.close
-
-      spreadsheet = Roo::Excelx.new(excel_file.path)
-      sheet = spreadsheet.sheet(0)
-      (1..sheet.last_row).map { |i| sheet.row(i) }
-    ensure
-      excel_file.unlink
-    end
-  end
-
-  describe 'current behavior (should remain green)' do
-    it 'includes a client enrolled in an allowed project during the range' do
-      destination_id = create_crosswalk.fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id])
+  describe 'GET #index' do
+    it 'renders the filter page' do
+      get warehouse_reports_client_lookups_path
 
       expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(destination_id)
-      expect(assigns(:rows)).to include([source_ds.name, 'PID-VIEWABLE', destination_id, 'Ada', 'Lovelace'])
-    end
-  end
-
-  describe 'date range boundary (regression guard)' do
-    it 'includes an enrollment whose EntryDate falls exactly on the end of the range' do
-      destination_id = create_crosswalk(
-        project: viewable_project,
-        personal_id: 'PID-ENTRY-ON-END',
-        first_name: 'Rosalind',
-        last_name: 'Franklin',
-        entry_date: end_date,
-      ).fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(destination_id)
+      expect(response.body).to include('Export Client Personal ID Lookup')
     end
 
-    it 'excludes an enrollment whose EntryDate falls one day after the end of the range' do
-      destination_id = create_crosswalk(
-        project: viewable_project,
-        personal_id: 'PID-ENTRY-AFTER-END',
-        first_name: 'Marie',
-        last_name: 'Curie',
-        entry_date: end_date + 1.day,
-      ).fetch(:destination_id)
+    it 'renders a download button wired to the export class' do
+      get warehouse_reports_client_lookups_path
 
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).not_to include(destination_id)
+      expect(response.body).to include('j-document-exports')
+      expect(response.body).to include('GrdaWarehouse::WarehouseReports::DocumentExports::ClientLookupExport')
     end
 
-    it 'includes an enrollment that exited exactly on the start of the range' do
-      crosswalk = create_crosswalk(
-        project: viewable_project,
-        personal_id: 'PID-EXIT-ON-START',
-        first_name: 'Rosalind',
-        last_name: 'Franklin',
-        entry_date: start_date - 30.days,
-      )
-      create(
-        :hud_exit,
-        data_source: source_ds,
-        EnrollmentID: crosswalk.fetch(:enrollment).EnrollmentID,
-        PersonalID: 'PID-EXIT-ON-START',
-        ExitDate: start_date,
-      )
+    it 'mounts the client-lookup-export controller on the filter form' do
+      get warehouse_reports_client_lookups_path
 
-      get_report(project_ids: [viewable_project.id])
+      # Rails' form helper and Haml's literal attributes quote differently, so match on
+      # the attribute values rather than a quoting style.
+      body = CGI.unescapeHTML(response.body).tr('"', "'")
 
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(crosswalk.fetch(:destination_id))
+      expect(body).to include("data-controller='client-lookup-export'")
+      expect(body).to include("data-action='client-lookup-export#download'")
+      expect(body).to include("data-client-lookup-export-target='button'")
     end
 
-    it 'excludes an enrollment that exited one day before the start of the range' do
-      crosswalk = create_crosswalk(
-        project: viewable_project,
-        personal_id: 'PID-EXIT-BEFORE-START',
-        first_name: 'Marie',
-        last_name: 'Curie',
-        entry_date: start_date - 30.days,
-      )
-      create(
-        :hud_exit,
-        data_source: source_ds,
-        EnrollmentID: crosswalk.fetch(:enrollment).EnrollmentID,
-        PersonalID: 'PID-EXIT-BEFORE-START',
-        ExitDate: start_date - 1.day,
-      )
+    # The controller renders its message into the layout's flash region rather than a
+    # container of its own, so the page has to actually provide one.
+    it 'renders inside the layout flash region' do
+      get warehouse_reports_client_lookups_path
 
-      get_report(project_ids: [viewable_project.id])
+      expect(response.body).to include('utility')
+    end
 
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).not_to include(crosswalk.fetch(:destination_id))
+    # The export reconstructs the filter from a query string built off this form at click
+    # time, so a query string rendered into the page would be stale by definition.
+    it 'does not render a query string on the button' do
+      get warehouse_reports_client_lookups_path
+
+      expect(response.body).not_to include('data-query-string')
+    end
+
+    # The removed synchronous path redirected with this message when nothing was
+    # selected; the disabled button can't deliver it on click, so the wrapper carries it
+    # as a tooltip the Stimulus controller enables while the filter has no scope.
+    it 'wraps the button in a tooltip explaining the requirement' do
+      get warehouse_reports_client_lookups_path
+
+      wrapper = response.body[/<span[^>]*client-lookup-export-target[^>]*>/]
+
+      expect(wrapper).to match(/title=.Select at least one Data Source, Organization, or Project/)
+    end
+
+    # Rendered disabled up front so the state is correct before the Stimulus controller
+    # connects, rather than flashing enabled on load.
+    it 'ships the download button disabled when the filter has no project scope' do
+      get warehouse_reports_client_lookups_path
+
+      button = response.body[/<a[^>]*j-document-exports[^>]*>/]
+
+      expect(button).to include('disabled')
+      expect(button).to include('aria-disabled')
+    end
+
+    it 'ships the download button enabled once a project is selected' do
+      get warehouse_reports_client_lookups_path, params: { report: { project_ids: [viewable_project.id] } }
+
+      button = response.body[/<a[^>]*j-document-exports[^>]*>/]
+
+      # Haml omits a false-valued attribute entirely, so an enabled button carries no
+      # `aria-disabled` rather than `aria-disabled='false'`.
+      expect(button).not_to include('disabled')
+    end
+
+    it 'keeps the Map Enrollment IDs checkbox checked when it was submitted' do
+      get warehouse_reports_client_lookups_path, params: { report: { map_enrollments: '1' } }
+
+      expect(response.body).to match(/name=.report\[map_enrollments\].[^>]*checked/)
     end
   end
 
-  describe 'rendered file (regression guard)' do
-    it 'writes the header row and client data into the actual XLSX output' do
-      destination_id = create_crosswalk.fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id])
-
-      rows = rendered_workbook_rows
-      expect(rows.first).to eq(
-        ['Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)'],
-      )
-      expect(rows[1..]).to include([source_ds.name, 'PID-VIEWABLE', destination_id, 'Ada', 'Lovelace'])
-    end
-
-    it 'writes the additional enrollment columns when "Map enrollments" is requested' do
-      crosswalk = create_crosswalk
-
-      get_report(project_ids: [viewable_project.id], map_enrollments: true)
-
-      rows = rendered_workbook_rows
-      expect(rows.first).to eq(
-        [
-          'Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)',
-          'Enrollment ID (from HMIS)', 'Warehouse Enrollment ID'
-        ],
-      )
-      # Roo reads a numeric-looking string cell (EnrollmentID) back as a Numeric, not a
-      # String, so compare it numerically rather than against the pluck'd String value.
-      expect(rows[1..]).to include(
-        [
-          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
-          crosswalk.fetch(:enrollment).EnrollmentID.to_i, crosswalk.fetch(:enrollment).id
-        ],
-      )
-    end
-  end
-
-  describe 'report-level authorization (should remain green)' do
-    let(:role) { create(:role, can_view_assigned_reports: false) }
-
-    it 'refuses to render the report for a user who cannot view any reports' do
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:redirect)
-    end
-  end
-
-  describe 'project-level authorization (regression guard)' do
-    it 'excludes clients whose only enrollment is in a project the user cannot view, even when its id is submitted' do
-      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
-      forbidden_destination_id = create_crosswalk(
-        project: unauthorized_project,
-        personal_id: 'PID-FORBIDDEN',
-        first_name: 'Mallory',
-        last_name: 'Malicious',
-      ).fetch(:destination_id)
-
-      # A user can hand-craft the params and submit a project id they were never granted.
-      get_report(project_ids: [viewable_project.id, unauthorized_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(allowed_destination_id)
-      expect(reported_destination_ids).not_to include(forbidden_destination_id)
-    end
-
-    it 'redirects with a clear message instead of silently exporting nothing when the only selected project is unauthorized' do
-      # Regression guard: previously a single unauthorized (but hand-craftable) project
-      # id would pass `any_effective_project_ids?` (which doesn't check authorization)
-      # and then silently produce a zero-row export via the `project_source` merge.
-      get_report(project_ids: [unauthorized_project.id], data_source_ids: [])
-
-      expect(response).to have_http_status(:redirect)
-      expect(response.location).to include("project_ids%5D%5B%5D=#{unauthorized_project.id}")
-      expect(flash[:alert]).to eq('you do not have permission to view the selected project(s) for this report')
-    end
-
-    it 'excludes clients from a project the user can view but did not select in the filter' do
-      # A second non-confidential project the user is granted access to via their
-      # collection, distinct from viewable_project (which is the only one selected below).
-      other_viewable_project = create_project(confidential: false)
-      grant_projects(viewable_project, confidential_project, other_viewable_project)
-
-      selected_destination_id = create_crosswalk(personal_id: 'PID-SELECTED').fetch(:destination_id)
-      unselected_destination_id = create_crosswalk(
-        project: other_viewable_project,
-        personal_id: 'PID-UNSELECTED-BUT-VIEWABLE',
-        first_name: 'Not',
-        last_name: 'Selected',
-      ).fetch(:destination_id)
-
-      # Only viewable_project is selected in the filter (data_source_ids/organization_ids
-      # are cleared so effective_project_ids comes purely from project_ids), even though
-      # other_viewable_project is also granted to the user. The project_source (viewable_by)
-      # merge must not silently widen the query back out to every project the user can view.
-      get_report(project_ids: [viewable_project.id], data_source_ids: [])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(selected_destination_id)
-      expect(reported_destination_ids).not_to include(unselected_destination_id)
-    end
-  end
-
-  describe 'confidential project exclusion (regression guard)' do
-    it 'excludes clients whose only enrollment is in a confidential project' do
-      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
-      confidential_destination_id = create_crosswalk(
-        project: confidential_project,
-        personal_id: 'PID-CONFIDENTIAL',
-        first_name: 'Secret',
-        last_name: 'Client',
-      ).fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id, confidential_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(allowed_destination_id)
-      expect(reported_destination_ids).not_to include(confidential_destination_id)
-    end
-
-    it 'excludes clients whose only enrollment is in a non-confidential project of a confidential organization' do
-      confidential_org = create(:hud_organization, data_source_id: source_ds.id, confidential: true)
-      org_confidential_project = create_project(confidential: false, organization: confidential_org)
-      grant_projects(viewable_project, confidential_project, org_confidential_project)
-
-      allowed_destination_id = create_crosswalk(personal_id: 'PID-ALLOWED').fetch(:destination_id)
-      org_confidential_destination_id = create_crosswalk(
-        project: org_confidential_project,
-        personal_id: 'PID-ORG-CONFIDENTIAL',
-        first_name: 'Org',
-        last_name: 'Secret',
-      ).fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id, org_confidential_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids).to include(allowed_destination_id)
-      expect(reported_destination_ids).not_to include(org_confidential_destination_id)
-    end
-  end
-
-  describe 'source data source disambiguation (regression guard)' do
-    it 'does not conflate clients with the same PersonalID from different source data sources' do
-      other_source_ds = create(:source_data_source, name: 'Other HMIS Vendor')
-      other_organization = create(:hud_organization, data_source_id: other_source_ds.id)
-      other_project = create_project(confidential: false, organization: other_organization, data_source: other_source_ds)
-      grant_projects(viewable_project, confidential_project, other_project)
-
-      # HUD PersonalID is only unique within a data source; the same PersonalID here
-      # identifies two different people in two different source data sources. The Data
-      # Source column is what lets the export disambiguate them.
-      destination_id_a = create_crosswalk(personal_id: 'DUPLICATE-PID').fetch(:destination_id)
-      destination_id_b = create_crosswalk(
-        project: other_project,
-        personal_id: 'DUPLICATE-PID',
-        first_name: 'Grace',
-        last_name: 'Hopper',
-        data_source: other_source_ds,
-      ).fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id, other_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(destination_id_a).not_to eq(destination_id_b)
-      expect(assigns(:rows)).to include([source_ds.name, 'DUPLICATE-PID', destination_id_a, 'Ada', 'Lovelace'])
-      expect(assigns(:rows)).to include([other_source_ds.name, 'DUPLICATE-PID', destination_id_b, 'Grace', 'Hopper'])
-    end
-  end
-
-  describe 'duplicate enrollments (regression guard)' do
-    it 'includes a client only once when they have overlapping enrollments in two allowed projects' do
-      second_viewable_project = create_project(confidential: false)
-      grant_projects(viewable_project, confidential_project, second_viewable_project)
-
-      destination_id = create_crosswalk(personal_id: 'PID-DOUBLE-ENROLLED').fetch(:destination_id)
-      # A second enrollment for the same source client, in the other allowed project.
-      create(
-        :grda_warehouse_hud_enrollment,
-        data_source_id: source_ds.id,
-        PersonalID: 'PID-DOUBLE-ENROLLED',
-        ProjectID: second_viewable_project.ProjectID,
-        EntryDate: start_date + 1.day,
-      )
-
-      get_report(project_ids: [viewable_project.id, second_viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(reported_destination_ids.count { |id| id == destination_id }).to eq(1)
-    end
-  end
-
-  describe 'deduplicated identity with multiple PersonalIDs (regression guard)' do
-    it 'emits one row per PersonalID (not per enrollment) when two source records in the same data source share a warehouse client and name' do
-      # Two source client records in the SAME data source, deduplicated to a SINGLE
-      # warehouse (destination) client, sharing first/last name but differing only by
-      # PersonalID. Grouping in Report#rows relies on rows sharing a display_key
-      # sorting contiguously; if PersonalID is missing from the query's ORDER BY, these
-      # rows interleave by enrollment id and the client is emitted as duplicate rows.
-      destination_client = create(:grda_warehouse_hud_client, data_source: destination_ds)
-
-      source_client_a = create(
-        :grda_warehouse_hud_client,
-        data_source: source_ds,
-        PersonalID: 'PID-DEDUP-A',
-        FirstName: 'Ada',
-        LastName: 'Lovelace',
-      )
-      source_client_b = create(
-        :grda_warehouse_hud_client,
-        data_source: source_ds,
-        PersonalID: 'PID-DEDUP-B',
-        FirstName: 'Ada',
-        LastName: 'Lovelace',
-      )
-      create(:warehouse_client, source: source_client_a, destination: destination_client, data_source: source_ds)
-      create(:warehouse_client, source: source_client_b, destination: destination_client, data_source: source_ds)
-
-      # Interleave enrollment creation so their (auto-incrementing) warehouse enrollment
-      # ids alternate between the two PersonalIDs. Without PersonalID in the ORDER BY the
-      # rows come back A, B, A, B — non-contiguous groups that flush as four rows.
-      ['PID-DEDUP-A', 'PID-DEDUP-B', 'PID-DEDUP-A', 'PID-DEDUP-B'].each do |personal_id|
-        create(
-          :grda_warehouse_hud_enrollment,
-          data_source_id: source_ds.id,
-          PersonalID: personal_id,
-          ProjectID: viewable_project.ProjectID,
-          EntryDate: start_date + 1.day,
-        )
-      end
-
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      dedup_rows = assigns(:rows).select { |row| row[2] == destination_client.id }
-      expect(dedup_rows.length).to eq(2)
-      expect(dedup_rows.map { |row| row[1] }).to contain_exactly('PID-DEDUP-A', 'PID-DEDUP-B')
-    end
-  end
-
-  describe 'map enrollments (regression guard)' do
-    it 'omits the enrollment columns by default' do
-      create_crosswalk
-
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      expect(assigns(:report).headers).to eq(
-        ['Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)'],
-      )
-      expect(assigns(:rows).first.length).to eq(5)
-    end
-
-    it 'adds the Enrollment ID and Warehouse Enrollment ID columns when requested, one row per enrollment' do
-      crosswalk = create_crosswalk
-      second_viewable_project = create_project(confidential: false)
-      grant_projects(viewable_project, confidential_project, second_viewable_project)
-      # A second enrollment for the same source client, in another allowed project;
-      # "no dedup" means this must yield a second row, not collapse into one.
-      second_enrollment = create(
-        :grda_warehouse_hud_enrollment,
-        data_source_id: source_ds.id,
-        PersonalID: 'PID-VIEWABLE',
-        ProjectID: second_viewable_project.ProjectID,
-        EntryDate: start_date + 1.day,
-      )
-
-      get_report(project_ids: [viewable_project.id, second_viewable_project.id], map_enrollments: true)
-
-      expect(response).to have_http_status(:success)
-      expect(assigns(:report).headers).to eq(
-        [
-          'Data Source', 'Personal ID (from HMIS)', 'Warehouse Client ID', 'First Name (from HMIS)', 'Last Name (from HMIS)',
-          'Enrollment ID (from HMIS)', 'Warehouse Enrollment ID'
-        ],
-      )
-      rows = assigns(:rows)
-      expect(rows).to include(
-        [
-          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
-          crosswalk.fetch(:enrollment).EnrollmentID, crosswalk.fetch(:enrollment).id
-        ],
-      )
-      expect(rows).to include(
-        [
-          source_ds.name, 'PID-VIEWABLE', crosswalk.fetch(:destination_id), 'Ada', 'Lovelace',
-          second_enrollment.EnrollmentID, second_enrollment.id
-        ],
-      )
-      expect(rows.count { |row| row[2] == crosswalk.fetch(:destination_id) }).to eq(2)
-    end
-  end
-
-  describe 'filter requirement (regression guard)' do
-    it 'refuses to render the xlsx when no project, organization, or data source is selected' do
-      create_crosswalk
-
-      get_report(project_ids: [], data_source_ids: [], organization_ids: [])
-
-      expect(response).to have_http_status(:redirect)
-      follow_redirect!
-      expect(response.body).to include('Data Source')
-    end
-
-    it 'renders the xlsx when a project is selected without a data source' do
-      create_crosswalk
-
-      get_report(project_ids: [viewable_project.id], data_source_ids: [])
-
-      expect(response).to have_http_status(:success)
-    end
-
-    # On a multi-CoC installation, FilterBase#update seeds coc_codes from the user's CoC
-    # codes when the form submits none. Filters::ClientLookup overrides
-    # effective_project_ids_from_coc_codes so those codes don't expand the project scope
-    # behind the guard. viewable_project is linked to the granted CoC so that, without the
-    # override, it would satisfy any_effective_project_ids? and skip the redirect.
-    it 'still redirects when the installation is multi-CoC and the user has CoC codes assigned' do
-      create(:config, multi_coc_installation: true)
-      coc = create(:lookup_coc)
-      create(
-        :hud_project_coc,
-        data_source_id: viewable_project.data_source_id,
-        ProjectID: viewable_project.ProjectID,
-        CoCCode: coc.coc_code,
-      )
-      collection.set_viewables(
-        reports: [report_definition.id],
-        projects: [viewable_project.id, confidential_project.id],
-        coc_codes: [coc.id],
-      )
-      create_crosswalk
-
-      get_report(project_ids: [], data_source_ids: [], organization_ids: [])
-
-      expect(response).to have_http_status(:redirect)
-      expect(flash[:alert]).to include('Data Source')
-    end
-  end
-
-  describe 'client name PII policy (regression guard)' do
-    let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: false) }
-
-    it 'redacts first and last name when the user cannot view client names for the project' do
-      destination_id = create_crosswalk.fetch(:destination_id)
-
-      get_report(project_ids: [viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      row = assigns(:rows).find { |r| r[2] == destination_id }
-      expect(row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
-      expect(row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
-    end
-
-    it 'shows the name when at least one of the client\'s projects allows it, with map_enrollments off' do
-      second_viewable_project = create_project(confidential: false)
-      grant_projects(viewable_project, confidential_project, second_viewable_project)
-      permissive_role = create(:role, can_view_assigned_reports: true, can_view_client_name: true)
-      permissive_collection = create(:collection)
-      permissive_collection.set_viewables(projects: [second_viewable_project.id])
-      setup_access_control(user, permissive_role, permissive_collection)
-
-      destination_id = create_crosswalk(personal_id: 'PID-MULTI').fetch(:destination_id)
-      create(
-        :grda_warehouse_hud_enrollment,
-        data_source_id: source_ds.id,
-        PersonalID: 'PID-MULTI',
-        ProjectID: second_viewable_project.ProjectID,
-        EntryDate: start_date + 1.day,
-      )
-
-      get_report(project_ids: [viewable_project.id, second_viewable_project.id])
-
-      expect(response).to have_http_status(:success)
-      row = assigns(:rows).find { |r| r[2] == destination_id }
-      expect(row[3]).to eq('Ada')
-      expect(row[4]).to eq('Lovelace')
-    end
-
-    context 'when the org has disabled PII in detail downloads' do
-      # can_view_client_name alone is not sufficient for a "download"-mode PII policy
-      # (see User#reporting_policy_for_project): the org-wide include_pii_in_detail_downloads
-      # config must also be enabled, or every project's policy denies the name regardless of role.
-      let(:role) { create(:role, can_view_assigned_reports: true, can_view_client_name: true) }
-
-      before { GrdaWarehouse::Config.first_or_create.update!(include_pii_in_detail_downloads: false) }
-
-      it 'redacts the name even though the role otherwise allows viewing it' do
-        destination_id = create_crosswalk.fetch(:destination_id)
-
-        get_report(project_ids: [viewable_project.id])
-
-        expect(response).to have_http_status(:success)
-        row = assigns(:rows).find { |r| r[2] == destination_id }
-        expect(row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
-        expect(row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
+  # Regression guards on `WarehouseReportAuthorization`, which is the only authorization
+  # the page itself enforces. The export re-checks both before running, but a user who
+  # cannot see the report should not reach the form in the first place.
+  describe 'authorization' do
+    context 'when the user cannot view any reports' do
+      let(:role) { create(:role, can_view_assigned_reports: false) }
+
+      it 'refuses to render the page' do
+        get warehouse_reports_client_lookups_path
+
+        expect(response).to have_http_status(:redirect)
       end
     end
 
-    it 'redacts each row independently by its own enrollment\'s project when "Map enrollments" is requested' do
-      # Unlike the map_enrollments-off case above (which aggregates "can view via any
-      # project"), each mapped row is redacted using that specific enrollment's project
-      # policy, so the same client can have one visible and one redacted row.
-      second_viewable_project = create_project(confidential: false)
-      grant_projects(viewable_project, confidential_project, second_viewable_project)
-      permissive_role = create(:role, can_view_assigned_reports: true, can_view_client_name: true)
-      permissive_collection = create(:collection)
-      permissive_collection.set_viewables(projects: [second_viewable_project.id])
-      setup_access_control(user, permissive_role, permissive_collection)
+    context 'when the report is not viewable by the user' do
+      let(:viewable_reports) { [] }
 
-      crosswalk = create_crosswalk(personal_id: 'PID-MIXED')
-      second_enrollment = create(
-        :grda_warehouse_hud_enrollment,
-        data_source_id: source_ds.id,
-        PersonalID: 'PID-MIXED',
-        ProjectID: second_viewable_project.ProjectID,
-        EntryDate: start_date + 1.day,
-      )
+      it 'refuses to render the page' do
+        get warehouse_reports_client_lookups_path
 
-      get_report(project_ids: [viewable_project.id, second_viewable_project.id], map_enrollments: true)
-
-      expect(response).to have_http_status(:success)
-      rows = assigns(:rows)
-      denied_row = rows.find { |r| r[5] == crosswalk.fetch(:enrollment).EnrollmentID }
-      allowed_row = rows.find { |r| r[5] == second_enrollment.EnrollmentID }
-      expect(denied_row[3]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
-      expect(denied_row[4]).to eq(GrdaWarehouse::PiiProvider::REDACTED)
-      expect(allowed_row[3]).to eq('Ada')
-      expect(allowed_row[4]).to eq('Lovelace')
+        expect(response).to have_http_status(:redirect)
+      end
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

- Moves the Client Personal ID Lookup export off the old direct-download button and onto the same background-export system other reports already use.
- Users click Download, the file generates in the background, and they get notified when it's ready — instead of waiting on the page for the download to start.
- The Download button now stays disabled (with a tooltip) until a Data Source, Organization, or Project is selected, instead of only showing an error after clicking.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

