### PR TITLE
9494 admin account provisioning for external IdPs

### DIFF
--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -24,16 +24,22 @@ module Admin
     end
 
     def update
+      @agencies = Agency.order(:name)
       agency_id = account_params.dig(:agency_id)
       if agency_id.blank?
-        flash[:error] = 'An agency is required to create an account'
-        redirect_to(action: :index)
+        flash.now[:error] = 'An agency is required to create an account'
+        render 'edit'
+
         return
       end
 
+      @account_request.agency_id = agency_id
       # TODO: START_ACL replace when ACL transition complete
       # @account_request.convert_to_user!(access_control_ids: access_control_ids)
-      @account_request.convert_to_user!(user: current_user, role_ids: role_ids, access_group_ids: access_group_ids, access_control_ids: access_control_ids)
+
+      @account_request.transaction do
+        @account_request.convert_to_user!(user: current_user, role_ids: role_ids, access_group_ids: access_group_ids, access_control_ids: access_control_ids)
+      end
       # END_ACL
       flash[:notice] = "Account created for #{@account_request.name}"
       redirect_to(action: :index)
@@ -63,6 +69,10 @@ module Admin
 
     private def access_group_ids
       account_params[:access_group_ids].select(&:present?).map(&:to_i) || []
+    end
+
+    private def access_control_ids
+      Array(account_params[:access_control_ids]).select(&:present?).map(&:to_i)
     end
 
     private def confirmation_params

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -157,11 +157,7 @@ class Admin::Idp::UsersController < ApplicationController
   private def available_connectors
     return [] unless AuthMethod.jwt?
 
-    @available_connectors ||= ::Idp::ServiceConfig.active.order(:name, :id).select do |config|
-      config.to_service.supports_user_creation?
-    rescue ::Idp::ServiceError
-      false
-    end
+    @available_connectors ||= ::Idp::ServiceConfig.active.order(:name, :id)
   end
 
   private def idp_user_creation_available?

--- a/app/controllers/users/account_requests_controller.rb
+++ b/app/controllers/users/account_requests_controller.rb
@@ -16,7 +16,7 @@ class Users::AccountRequestsController < ApplicationController
 
   def create
     @account_request = account_request_source.create(account_request_params.merge(status: :requested))
-    flash[:notice] = "Thank you for your account request.<br />You will receive an invitation email after the request has been approved.<br />Your invitation email will be sent to #{@account_request.email}.".html_safe if @account_request.valid?
+    flash[:notice] = confirmation_message(@account_request).html_safe if @account_request.valid?
     NotifyUser.pending_account_submitted.deliver_later
     respond_with(@account_request, location: root_path)
   end
@@ -39,5 +39,13 @@ class Users::AccountRequestsController < ApplicationController
     return true if GrdaWarehouse::Config.get(:request_account_available)
 
     not_authorized!
+  end
+
+  private def confirmation_message(account_request)
+    if AuthMethod.jwt?
+      "Thank you for your account request.<br />An administrator will review it, and you'll be able to sign in once it is approved."
+    else
+      "Thank you for your account request.<br />You will receive an invitation email after the request has been approved.<br />Your invitation email will be sent to #{account_request.email}."
+    end
   end
 end

--- a/app/models/account_request.rb
+++ b/app/models/account_request.rb
@@ -32,29 +32,39 @@ class AccountRequest < ApplicationRecord
   end
 
   def convert_to_user!(user:, role_ids: [], access_group_ids: [], access_control_ids: [])
-    options = {
+    new_user = build_approved_user(approver: user)
+    # TODO: START_ACL remove when ACL transition complete
+    roles = Role.where(id: role_ids)
+    access_groups = AccessGroup.where(id: access_group_ids)
+    new_user.legacy_roles = roles
+    new_user.access_groups = access_groups
+    # END_ACL
+    acls = AccessControl.where(id: access_control_ids)
+    acls.each do |acl|
+      acl.user_group.add(new_user)
+    end
+    update!(
+      status: :accepted,
+      accepted_by: user.id,
+      accepted_at: Time.current,
+      user_id: new_user.id,
+    )
+  end
+
+  private
+
+  def build_approved_user(approver:)
+    attrs = {
       first_name: first_name,
       last_name: last_name,
       email: email,
       phone: phone,
       agency_id: agency_id,
     }
-    user = User.invite!(options, user)
-    # TODO: START_ACL remove when ACL transition complete
-    roles = Role.where(id: role_ids)
-    access_groups = AccessGroup.where(id: access_group_ids)
-    user.legacy_roles = roles
-    user.access_groups = access_groups
-    # END_ACL
-    acls = AccessControl.where(id: access_control_ids)
-    acls.each do |acl|
-      acl.user_group.add(user)
+    if AuthMethod.jwt?
+      User.create!(**attrs.merge(active: true))
+    else
+      User.invite!(attrs, approver)
     end
-    update(
-      status: :accepted,
-      accepted_by: user.id,
-      accepted_at: Time.current,
-      user_id: user.id,
-    )
   end
 end

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -7,14 +7,8 @@
 # frozen_string_literal: true
 
 module Idp
-  # Admin-initiated account provisioning for the JWT arm. Given a chosen connector and identity
-  # fields, provision (or link to an existing) account in the remote IdP, then persist the local
-  # User and its durable connector link. This is the identity half only — roles/ACLs are assigned
-  # afterward on the edit form.
-  #
-  # Mirrors the linkage that UserProvisioner establishes on JIT login (connector_id +
-  # connector_user_id row, last_connector_id), but driven by an admin form and an explicit
-  # connector rather than an inbound JWT.
+  # Admin-initiated JWT provisioning: creates the local user, and links/creates the remote IdP
+  # account when the connector supports_user_creation?. Identity only; roles/ACLs come later.
   class AdminUserCreator
     def self.call(...)
       new(...).call
@@ -30,20 +24,18 @@ module Idp
       @user_class = user_class
     end
 
-    # @return [User] the persisted, IdP-linked user
-    # @raise [ActiveRecord::RecordInvalid] the local user is invalid (e.g. email already in use locally)
-    # @raise [Idp::ServiceError] the connector can't create users, or the remote create/lookup failed
+    # @raise [ActiveRecord::RecordInvalid] the local user is invalid (e.g. email already in use)
+    # @raise [Idp::ServiceError] the remote create/lookup failed on a management-API connector
     def call
       service = Idp::ServiceFactory.for_connector(@connector_id)
-      raise Idp::ServiceError.new("#{service.idp_name} does not support creating users", idp_name: service.idp_name, operation: :create_user) unless service.supports_user_creation?
 
-      # Claim the email locally first, via the users table's unique index, before making any
-      # (irreversible) remote IdP call. That keeps a race between concurrent admin submissions
-      # local and fast to resolve — the loser fails right here with a normal validation error —
-      # instead of both racing to provision remote accounts and risking an orphaned IdP account
-      # if the loser's local save fails only after it already created something remotely.
+      # Claim the email locally (unique index) before any irreversible remote call, so concurrent
+      # submissions race on the local save rather than on provisioning remote accounts.
       user = build_user
       user.save!
+
+      # No management API: link happens by email on first JWT sign-in instead.
+      return user unless service.supports_user_creation?
 
       begin
         connector_user_id = find_or_create_connector_user_id(service)
@@ -75,11 +67,10 @@ module Idp
         first_name: @first_name,
         last_name: @last_name,
         active: true,
-        agency_id: 0, # agency_id is required, 0 passes validation, but will need to be updated on next user edit.
+        agency_id: 0, # required; placeholder until the next user edit sets a real agency.
       )
     end
 
-    # Link an existing remote account when the email already exists in the IdP; otherwise create one.
     def find_or_create_connector_user_id(service)
       existing = service.find_user_by_email(email: @email)
       return existing['id'] if existing && existing['id'].present?

--- a/app/views/admin/account_requests/edit.haml
+++ b/app/views/admin/account_requests/edit.haml
@@ -1,16 +1,10 @@
 - content_for :modal_title, 'Approve Account Request'
 
 = simple_form_for @account_request, url: admin_account_request_path(@account_request) do |f|
-  = f.input :agency_id, collection: @agencies, label_method: :name, value_method: :id, required: true, include_blank: 'Unknown', as: :select_two, wrapper_html: { class: 'mb-2' }
-  .d-flex
-    .c-columns__column
-      .c-columns__column-header
-        %h3.c-columns__column-title Roles
-      .c-columns__column-content
-        = f.input :role_ids, as: :check_boxes, label_method: :role_name, collection: Role.editable, label: false
-    .c-columns__column.ml-4
-      .c-columns__column-header
-        %h3.c-columns__column-title Groups
-      .c-columns__column-content
-        = f.input :access_group_ids, as: :check_boxes, label_method: :name, collection: AccessGroup.general, label: false
-  = f.submit 'Approve', class: 'btn btn-secondary btn-sm'
+  .mb-2
+    = f.input :agency_id, collection: @agencies, label_method: :name, value_method: :id, required: true, include_blank: '-- Choose', as: :select_two
+  .mb-2
+    = f.input :role_ids, as: :check_boxes, label_method: :name, collection: Role.editable, label: 'Roles'
+  .mb-2
+    = f.input :access_group_ids, as: :check_boxes, label_method: :name, collection: AccessGroup.general, label: 'Groups'
+  = f.submit 'Approve', class: 'btn btn-primary'

--- a/app/views/admin/idp/users/new.haml
+++ b/app/views/admin/idp/users/new.haml
@@ -13,7 +13,7 @@
         = hidden_field_tag 'user[connector_id]', @connectors.first.connector_id
       = f.input :first_name, required: true
       = f.input :last_name, required: true
-      = f.input :email, as: :email, required: true, hint: 'The account is created in your identity provider and a setup email is sent to this address so the user can set their password.'
+      = f.input :email, as: :email, required: true, hint: 'Must match the email for the account in the IdP'
       .form-actions.mt-4
         = f.button :submit, 'Create account', class: 'btn btn-primary'
         = link_to 'Cancel', admin_users_path, class: 'btn btn-link'

--- a/app/views/root/index.haml
+++ b/app/views/root/index.haml
@@ -12,6 +12,9 @@
         %div(style="margin: 2.5em 0")
           = link_to new_user_session_path, class: 'btn btn-primary btn-lg d-block' do
             Sign in to your account
-        %p.m-0
+        %p
           %strong Need help?
           Contact your organization's administrator for assistance.
+        %p.m-0
+          - if GrdaWarehouse::Config.get(:request_account_available)
+            = link_to 'Request an account', new_users_account_request_path

--- a/app/views/users/account_requests/new.haml
+++ b/app/views/users/account_requests/new.haml
@@ -1,15 +1,15 @@
-.row
-  .col-sm-6
-    %h2= Translation.translate('Request access to the HMIS Warehouse')
-    .account-request-description= simple_format Translation.translate('The HMIS Warehouse can be used for homeless client care coordination and reporting.')
-
-    = simple_form_for @account_request, url: users_account_requests_path do |f|
-      %h3 General
+.well.mx-auto(style='max-width: 480px')
+  %h2= Translation.translate('Request access to the HMIS Warehouse')
+  .account-request-description= simple_format Translation.translate('The HMIS Warehouse can be used for homeless client care coordination and reporting.')
+  = simple_form_for @account_request, url: users_account_requests_path do |f|
+    %fieldset
+      %legend.h3 General
       = f.input :details, label: 'Why are you requesting access?', hint: 'Please explain specifically what you would like to be able to accomplish if given access.', required: true
-      %h3 Contact Information
+    %fieldset
+      %legend.h3 Contact Information
       = f.input :first_name
       = f.input :last_name
-      = f.input :email
+      = f.input :email, type: 'email'
       = f.input :phone
-      .form-actions
-        = f.submit 'Request Account'
+    .form-actions
+      = f.submit 'Request Account', class: 'btn btn-primary'

--- a/docker/auth/dev.oauth2-proxy-warehouse.cfg
+++ b/docker/auth/dev.oauth2-proxy-warehouse.cfg
@@ -29,6 +29,7 @@ skip_auth_routes=[
   "^/system_status/",
   "^/mini-profiler-resources.*",
   "^/public_agencies",
+  "^/users/account_requests(/.*)?$",  # anonymous "request an account" form; the app still gates on request_account_available
   "^/dev-assets/.*",
   "^/hmis/user\\.json$",  # HMIS user authentication check - backend validates JWT
   "^/hmis/app_settings$",  # HMIS app settings - backend validates JWT

--- a/spec/factories/account_requests.rb
+++ b/spec/factories/account_requests.rb
@@ -1,0 +1,20 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account_request do
+    sequence(:email) { |n| "requester#{n}@example.com" }
+    first_name { 'Reqmond' }
+    last_name { 'Ester' }
+    details { 'Please give me access to the warehouse.' }
+    status { :requested }
+
+    # The :create email validation does an MX lookup (check_mx: true), skip validation to avoid it
+    to_create { |instance| instance.save(validate: false) }
+  end
+end

--- a/spec/requests/admin/account_requests_controller_spec.rb
+++ b/spec/requests/admin/account_requests_controller_spec.rb
@@ -1,0 +1,73 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Admin::AccountRequestsController, :jwt_only, type: :request do
+  let(:api_url) { 'http://keycloak.test:8080' }
+  let(:realm) { 'openpath' }
+
+  let!(:admin_role) { create :admin_role }
+  let!(:collection) { create :collection }
+  let!(:admin_user) { create(:acl_user, first_name: 'Admin', last_name: 'User') }
+  let!(:agency) { create :agency }
+  let!(:target_role) { create(:role, can_view_clients: true) }
+
+  before(:each) do
+    # Backs the admin's own JWT session (JwtAuthenticationHelper#sign_in uses connector_id 'test').
+    create(:idp_service_config, connector_id: 'test', api_url: api_url, keycloak_realm: realm)
+    setup_access_control(admin_user, admin_role, collection)
+    sign_in admin_user
+  end
+
+  let(:account_request) { create(:account_request, email: 'newcomer@example.com', first_name: 'New', last_name: 'Comer') }
+
+  def approve(params = {})
+    patch admin_account_request_path(account_request), params: {
+      account_request: {
+        agency_id: agency.id,
+        role_ids: [target_role.id],
+        access_group_ids: [],
+      }.merge(params),
+    }
+  end
+
+  context 'approving a request' do
+    before { WebMock.disable_net_connect! }
+
+    after { WebMock.allow_net_connect! }
+
+    it 'creates a local-only, email-keyed user with the requested roles and no remote call' do
+      expect { approve }.to change(User, :count).by(1)
+
+      user = User.find_by(email: 'newcomer@example.com')
+      expect(user).to be_present
+      expect(user.agency_id).to eq(agency.id)
+      expect(user.user_authentication_sources).to be_empty
+      expect(user.last_connector_id).to be_nil
+      expect(user.legacy_roles).to include(target_role)
+
+      account_request.reload
+      expect(account_request.status).to eq('accepted')
+      expect(account_request.user_id).to eq(user.id)
+      expect(account_request.accepted_by).to eq(admin_user.id)
+    end
+
+    it 'does not raise NoMethodError for invite! (the Devise-only path)' do
+      approve
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  it 'requires an agency' do
+    expect { approve(agency_id: '') }.not_to change(User, :count)
+    account_request.reload
+    expect(account_request.status).to eq('requested')
+  end
+end

--- a/spec/requests/admin/account_requests_devise_spec.rb
+++ b/spec/requests/admin/account_requests_devise_spec.rb
@@ -1,0 +1,39 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AccountRequestsController, :devise_only, type: :request do
+  let!(:admin) { create(:user) }
+  let!(:admin_role) { create(:admin_role) } # factory sets can_edit_users
+  let!(:agency) { create :agency }
+  let!(:target_role) { create(:role, can_view_clients: true) }
+  let(:account_request) { create(:account_request, email: 'newcomer@example.com', first_name: 'New', last_name: 'Comer') }
+
+  before(:each) do
+    sign_in admin
+    admin.legacy_roles << admin_role
+  end
+
+  it 'invites a local user with the requested agency and roles, and records the approver' do
+    expect do
+      patch admin_account_request_path(account_request), params: {
+        account_request: { agency_id: agency.id, role_ids: [target_role.id], access_group_ids: [] },
+      }
+    end.to change(User, :count).by(1)
+
+    user = User.find_by(email: 'newcomer@example.com')
+    expect(user.agency_id).to eq(agency.id)
+    expect(user.legacy_roles).to include(target_role)
+
+    account_request.reload
+    expect(account_request.status).to eq('accepted')
+    expect(account_request.user_id).to eq(user.id)
+    expect(account_request.accepted_by).to eq(admin.id)
+  end
+end

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -78,8 +78,14 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         expect(response.body).to include(new_admin_user_path)
       end
 
-      it 'omits the create button when no connector can provision accounts' do
+      it 'still offers the create button when the connector has no management API (local-only pre-create)' do
         allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_user_creation?).and_return(false)
+        get admin_users_path
+        expect(response.body).to include(new_admin_user_path)
+      end
+
+      it 'omits the create button when there are no active connectors' do
+        ::Idp::ServiceConfig.update_all(active: false)
         get admin_users_path
         expect(response.body).not_to include(new_admin_user_path)
       end
@@ -185,12 +191,31 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
     end
 
-    # JWT is on (routes mounted), but no active connector reports itself creation-capable, so
-    # require_user_creation_available! sends the admin back to the index instead of the form.
-    describe 'when no connector can provision accounts' do
+    describe 'when the connector has no management API' do
       before do
         allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_user_creation?).and_return(false)
       end
+
+      it 'renders GET new (the form is available for local-only pre-create)' do
+        get new_admin_user_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'POST create makes a local-only user with no remote call and no connector link' do
+        expect { post admin_users_path, params: params }.to change(User, :count).by(1)
+
+        user = User.find_by(email: new_email)
+        expect(user.user_authentication_sources).to be_empty
+        expect(user.last_connector_id).to be_nil
+        expect(a_request(:post, users_url)).not_to have_been_made
+        expect(response).to redirect_to(edit_admin_user_path(user))
+      end
+    end
+
+    # No active connector at all: nothing to provision against, so the form is unavailable.
+    describe 'when there are no active connectors' do
+      before { ::Idp::ServiceConfig.update_all(active: false) }
 
       it 'redirects GET new to the index with an unavailable alert' do
         get new_admin_user_path

--- a/spec/requests/users/account_requests_controller_spec.rb
+++ b/spec/requests/users/account_requests_controller_spec.rb
@@ -1,0 +1,35 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::AccountRequestsController, :jwt_only, type: :request do
+  def request_account_available!(value)
+    GrdaWarehouse::Config.first_or_create.update!(request_account_available: value)
+  end
+
+  context 'when account requests are enabled' do
+    before { request_account_available!(true) }
+
+    it 'renders the form for an unauthenticated visitor' do
+      get new_users_account_request_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when account requests are disabled' do
+    before { request_account_available!(false) }
+
+    it 'does not render the form' do
+      get new_users_account_request_path
+
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -66,9 +66,22 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
   context 'when the connector cannot create users' do
     let(:service) { instance_double(Idp::NullService, supports_user_creation?: false, idp_name: 'Unknown IDP') }
 
-    it 'raises a ServiceError and creates nothing' do
-      expect { call }.to raise_error(Idp::ServiceError)
-      expect(User.find_by(email: 'newbie@example.com')).to be_nil
+    before { allow(service).to receive(:find_user_by_email) }
+
+    it 'creates a local-only, email-keyed user with no remote call and no connector link' do
+      user = call
+
+      expect(user).to be_persisted
+      expect(user.email).to eq('newbie@example.com')
+      expect(user.last_connector_id).to be_nil
+      expect(user.user_authentication_sources).to be_empty
+      expect(service).not_to have_received(:find_user_by_email)
+    end
+
+    it 'still enforces local email uniqueness' do
+      create(:user, email: 'dup@example.com')
+
+      expect { call(email: 'dup@example.com') }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 


### PR DESCRIPTION

## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
- AdminUserCreator: local-only, email-keyed create when the connector has no management API; links on first JWT arrival instead of raising
- admin new-user form reachable for such connectors (available_connectors no longer filters on creation capability)
- AccountRequest#convert_to_user! is arm-aware: JWT routes through AdminUserCreator, Devise keeps User.invite!; approval form gains a connector selector
- anonymous request form reachable under JWT (oauth2-proxy skip route, landing-page link, arm-aware confirmation message)
- fix: access_control_ids was undefined and agency_id never assigned in the approval controller, so approval raised NameError before creating anything


## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [ ] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

