### PR TITLE
Use raw IncomeFromAnySource for APR FY2026 Q27i

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_twenty_seven.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/shared/fy2026/question_twenty_seven.rb
@@ -325,7 +325,7 @@ module HudApr::Generators::Shared::Fy2026
             where(youth_adult_or_youth_hoh_clause).
             where(leavers_clause).
             where(a_t[:disabling_condition].in([0, 1])).
-            where(a_t[:income_from_any_source_at_exit].in([0, 1]))
+            where(a_t[:income_from_any_source_at_exit_raw].in([0, 1]))
 
           answer.update(summary: 0) and next if members.count.zero?
 
@@ -413,7 +413,7 @@ module HudApr::Generators::Shared::Fy2026
       ).merge(
         {
           'Other Source' => income_types(:exit).slice(*other_sources).values,
-          'No Sources' => a_t[:income_from_any_source_at_exit].eq(0),
+          'No Sources' => a_t[:income_from_any_source_at_exit_raw].eq(0),
           'Unduplicated Total Youth' => youth_filter,
         },
       )

--- a/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
+++ b/drivers/hud_apr/spec/models/fy2026/datalab_apr/organization_y_sso.rb
@@ -528,12 +528,6 @@ RSpec.shared_context 'datalab organization y sso apr', shared_context: :metadata
       compare_results(
         file_path: result_file_prefix + results_dir,
         question: 'Q27i',
-        skip: [
-          'B17', # expected '2.0000' (2), got '1.0000' (1)
-          'C17', # expected '6.0000' (6), got '5.0000' (5)
-          'D17', # expected '8.0000' (8), got '6.0000' (6)
-          'E17', # expected '0.2500' (0.2500), got '0.1700' (0.1667)
-        ],
       )
     end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Q27i filtered its universe and its "No Sources" row on income_from_any_source_at_exit, which is derived by IncomeBenefit#hud_income_from_any_source. That method reports 1 whenever the income amounts sum positive, overriding a stored 4.02.2 value of 0.

The APR spec keys row 17 on element 4.02.2 as collected, so a leaver with IncomeFromAnySource = 0 and a positive Earned amount belongs in both the Earned Income row and the No Sources row. Datalab reports the contradiction rather than resolving it. Switch both the universe filter and the No Sources clause to income_from_any_source_at_exit_raw, matching Q19b, and drop the four Q27i skips from the Organization Y - SSO spec.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

