### PR TITLE
feat: seed default RDS free-space alert threshold

### DIFF
--- a/db/seed_maker.rb
+++ b/db/seed_maker.rb
@@ -109,6 +109,10 @@ class SeedMaker
     end
   end
 
+  def maintain_db_monitor_defaults
+    AppConfigProperty.where(key: 'wh_db_space_monitor/alert_threshold_pct').first_or_create!(value: 10)
+  end
+
   def maintain_lookups
     GrdaWarehouse::Lookups::CocCode.maintain!
     GrdaWarehouse::Lookups::YesNoEtc.transaction do
@@ -238,6 +242,7 @@ class SeedMaker
     Idp::ServiceConfig.bootstrap_from_env
     setup_fake_user if Rails.env.development?
     maintain_data_sources
+    maintain_db_monitor_defaults
     GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
     maintain_cp_seed
     setup_hmis_admin_access

--- a/spec/db/seed_maker_spec.rb
+++ b/spec/db/seed_maker_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SeedMaker do
       # Neutralize the unrelated deploy steps: a full run_all loads HMIS data, shapefiles,
       # translations, etc. — too heavy and brittle to run here. The IdP seed itself runs for real.
       [
-        :ensure_db_triggers_and_functions, :maintain_data_sources, :maintain_cp_seed, :setup_hmis_admin_access, :load_hmis_data, :install_shapes, :maintain_lookups, :maintain_system_groups, :populate_internal_system_choices
+        :ensure_db_triggers_and_functions, :maintain_data_sources, :maintain_db_monitor_defaults, :maintain_cp_seed, :setup_hmis_admin_access, :load_hmis_data, :install_shapes, :maintain_lookups, :maintain_system_groups, :populate_internal_system_choices
       ].each { |step| allow(seed_maker).to receive(step) }
 
       allow(GrdaWarehouse::WarehouseReports::ReportDefinition).to receive(:maintain_report_definitions)
@@ -63,6 +63,24 @@ RSpec.describe SeedMaker do
         provider: 'keycloak',
         name: 'Keycloak (seeded from ENV)',
       )
+    end
+  end
+
+  describe '#maintain_db_monitor_defaults' do
+    it 'creates the alert threshold with a default that reads as 10' do
+      expect { seed_maker.maintain_db_monitor_defaults }.
+        to change { AppConfigProperty.where(key: 'wh_db_space_monitor/alert_threshold_pct').count }.by(1)
+
+      expect(GrdaWarehouse::DbMonitor::FreeStorageSpaceConfiguration.new.alert_threshold_pct).to eq(10)
+    end
+
+    it 'does not override an existing value' do
+      AppConfigProperty.create!(key: 'wh_db_space_monitor/alert_threshold_pct', value: 20)
+
+      expect { seed_maker.maintain_db_monitor_defaults }.
+        not_to(change { AppConfigProperty.find_by(key: 'wh_db_space_monitor/alert_threshold_pct').value })
+
+      expect(GrdaWarehouse::DbMonitor::FreeStorageSpaceConfiguration.new.alert_threshold_pct).to eq(20)
     end
   end
 end


### PR DESCRIPTION


## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
Seed wh_db_space_monitor/alert_threshold_pct to 10 in SeedMaker so alerting is on by default. Idempotent via first_or_create!

**note**: Seeding alert_threshold_pct: 10 makes FreeStorageSpaceConfiguration#enabled? return true in every environment the seed runs. DbMonitor.assert_healthy!  (called before imports in hmis_csv_importer.rb:12 and expire_base_job.rb:57) then runs resolve_instance on every import. 

## Type of change
New featurete

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] I added spec tests (or not applicable)


