### PR TITLE
[#9527] Ensure primary key for LSA Report when needed

### DIFF
--- a/lib/rds_sql_server/lsa/fy2026/lsa_report_summary.rb
+++ b/lib/rds_sql_server/lsa/fy2026/lsa_report_summary.rb
@@ -11,6 +11,13 @@ require_relative 'lsa_sql_server' unless ENV['NO_LSA_RDS'].present?
 module LsaSqlServer
   class LSAReportSummary
     def fetch_summary
+      # lsa_Report has no primary key; add_missing_identity_columns gives it a
+      # temporary `id` column earlier in the run, ensure we have one here so `.first` works.
+      remove_primary_key = false
+      if LsaSqlServer::LSAReport.primary_key.blank?
+        LsaSqlServer::LSAReport.primary_key = 'id'
+        remove_primary_key = true
+      end
       rep = LsaSqlServer::LSAReport.first
       report_columns.map do |column, title|
         [
@@ -18,6 +25,8 @@ module LsaSqlServer
           rep[column],
         ]
       end.to_h
+    ensure
+      LsaSqlServer::LSAReport.primary_key = nil if remove_primary_key
     end
 
     private def report_columns


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Fixes a Rails 8 regression with the new default `raise_on_missing_required_finder_order_columns = true`.

The LSA CI didn't catch this because test data is loaded differently than production and the class in't instantiated until after the temporary column is added by another process.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

