### PR TITLE
Update expected VisionLink payload

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -255,19 +255,21 @@ module HmisExternalApis::AcHmis
     end
 
     # Parses a VisionLink generator entry. Accepts any numeric score (including -999, which means
-    # no score but may still carry eligibility flags). Metadata field types are preserved as returned
-    # by the API (booleans stay boolean, numeric flags stay numeric).
+    # no score but may still carry eligibility flags). Every eligibility flag must be a boolean;
+    # the API previously sent 0/1 integers, so an entry carrying any other type is rejected rather
+    # than coerced, to avoid reporting a client as ineligible if the shape changes again.
     #
     # Example:
     #   score_obj: {
     #     'score' => -999,
     #     'generator' => 'VisionLink',
     #     'metadata' => {
-    #       'is_eligible_ra' => false, 'section_8' => 0, 'city_of_pittsburgh' => 0
+    #       'is_eligible_ra' => false, 'section_8' => true, 'city_of_pittsburgh' => false,
+    #       'subsidized_housing' => false, 'recent_eviction_case' => false
     #     },
     #   }
     #   dw_client_id: '100000022'
-    #   => AhaScores::VisionLinkResult(score: -999, is_eligible_ra: false, is_eligible_cc: true, ...)
+    #   => AhaScores::VisionLinkResult(score: -999, is_eligible_ra: false, section_8: true, ...)
     def parse_visionlink_entry(score_obj, dw_client_id)
       score_value = score_obj.dig('score')
       raise ArgumentError, 'Received blank score' if score_value.blank?
@@ -284,8 +286,9 @@ module HmisExternalApis::AcHmis
 
       # If some flags were missing but not all, log to Sentry so we can investigate (unexpected behavior)
       Sentry.capture_message("VisionLink metadata missing fields: #{missing_fields.join(', ')}") if missing_fields.any?
-      # If some expected_fields flags have non-boolean values, log to Sentry so we can investigate (unexpected behavior)
-      Sentry.capture_message("VisionLink metadata contains non-boolean values: #{metadata.slice(*expected_fields).inspect}") if metadata.slice(*expected_fields).any? { |_, value| !value.in?([true, false]) }
+      # If some expected_fields flags have non-boolean values, raise (unexpected behavior)
+      non_boolean = metadata.slice(*expected_fields).reject { |_, value| value.in?([true, false]) }
+      raise ArgumentError, "Received non-boolean eligibility flags: #{non_boolean.keys.join(', ')}" if non_boolean.any?
 
       AhaScores::VisionLinkResult.new(
         score: score_value,

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/aha.rb
@@ -284,16 +284,18 @@ module HmisExternalApis::AcHmis
 
       # If some flags were missing but not all, log to Sentry so we can investigate (unexpected behavior)
       Sentry.capture_message("VisionLink metadata missing fields: #{missing_fields.join(', ')}") if missing_fields.any?
+      # If some expected_fields flags have non-boolean values, log to Sentry so we can investigate (unexpected behavior)
+      Sentry.capture_message("VisionLink metadata contains non-boolean values: #{metadata.slice(*expected_fields).inspect}") if metadata.slice(*expected_fields).any? { |_, value| !value.in?([true, false]) }
 
       AhaScores::VisionLinkResult.new(
         score: score_value,
         dw_client_id: dw_client_id,
         generator: score_obj['generator'],
-        is_eligible_ra: metadata['is_eligible_ra'] == true,          # 'Risk of Homelessness Flag'
-        section_8: metadata['section_8'] == 1,                       # 'Section 8 Housing Flag'
-        city_of_pittsburgh: metadata['city_of_pittsburgh'] == 1,     # 'City of Pittsburgh Flag'
-        subsidized_housing: metadata['subsidized_housing'] == 1,     # 'Subsidized Housing Flag'
-        recent_eviction_case: metadata['recent_eviction_case'] == 1, # 'Recent Eviction Case Flag'
+        is_eligible_ra: metadata['is_eligible_ra'] == true,             # 'Risk of Homelessness Flag'
+        section_8: metadata['section_8'] == true,                       # 'Section 8 Housing Flag'
+        city_of_pittsburgh: metadata['city_of_pittsburgh'] == true,     # 'City of Pittsburgh Flag'
+        subsidized_housing: metadata['subsidized_housing'] == true,     # 'Subsidized Housing Flag'
+        recent_eviction_case: metadata['recent_eviction_case'] == true, # 'Recent Eviction Case Flag'
       )
     end
 

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -483,31 +483,34 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       expect(Sentry).not_to have_received(:capture_message)
     end
 
-    it 'treats numeric 1/0 flags as ineligible and logs to Sentry' do
-      allow(Sentry).to receive(:capture_message)
-      numeric_metadata = {
-        'is_eligible_ra' => true,
-        'section_8' => 1,
-        'city_of_pittsburgh' => 0,
-        'subsidized_housing' => 1,
-        'recent_eviction_case' => 0,
-      }
-      response = mock_api_response(
-        client_data(
-          dw_client_id: mci_unique_id.value,
-          scores: [visionlink_score_hash(score: 2, metadata: numeric_metadata)],
-        ),
-      )
-      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+    # A non-boolean flag is dropped rather than coerced, so staff see no eligibility data instead
+    # of a client incorrectly reported as ineligible.
+    [1, 0, 'true', 'false', nil].each do |non_boolean_value|
+      it "skips the entry and logs to Sentry when a flag is #{non_boolean_value.inspect}" do
+        allow(Sentry).to receive(:capture_message)
+        response = mock_api_response(
+          client_data(
+            dw_client_id: mci_unique_id.value,
+            scores: [
+              visionlink_score_hash(
+                score: 2,
+                metadata: {
+                  'is_eligible_ra' => true,
+                  'section_8' => non_boolean_value,
+                  'city_of_pittsburgh' => false,
+                  'subsidized_housing' => false,
+                  'recent_eviction_case' => false,
+                },
+              ),
+            ],
+          ),
+        )
+        setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
 
-      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
-      expect(result.is_eligible_ra).to eq(true)
-      expect(result.section_8).to eq(false)
-      expect(result.city_of_pittsburgh).to eq(false)
-      expect(result.subsidized_housing).to eq(false)
-      expect(result.recent_eviction_case).to eq(false)
-      expect(Sentry).to have_received(:capture_message).
-        with("VisionLink metadata contains non-boolean values: #{numeric_metadata.inspect}")
+        expect(aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]).to be_nil
+        expect(Sentry).to have_received(:capture_message).
+          with('AHA received invalid VisionLink score entry: Received non-boolean eligibility flags: section_8')
+      end
     end
 
     it 'returns nil when all eligibility metadata fields are missing' do

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/aha_spec.rb
@@ -44,9 +44,10 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       'generator' => generator,
       'metadata' => metadata || {
         'is_eligible_ra' => false,
-        'section_8' => 0,
-        'subsidized_housing' => 0,
-        'recent_eviction_case' => 0,
+        'section_8' => false,
+        'city_of_pittsburgh' => false,
+        'subsidized_housing' => false,
+        'recent_eviction_case' => false,
       },
     }
   end
@@ -446,12 +447,14 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       expect(result.score).to eq(4.25)
       expect(result.is_eligible_ra).to eq(false)
       expect(result.section_8).to eq(false)
+      expect(result.city_of_pittsburgh).to eq(false)
       expect(result.subsidized_housing).to eq(false)
       expect(result.recent_eviction_case).to eq(false)
       expect(result).to be_a(HmisExternalApis::AcHmis::AhaScores::VisionLinkResult)
     end
 
-    it 'normalizes VisionLink flags from API values' do
+    it 'treats boolean true as eligible and boolean false as ineligible' do
+      allow(Sentry).to receive(:capture_message)
       response = mock_api_response(
         client_data(
           dw_client_id: mci_unique_id.value,
@@ -460,9 +463,10 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
               score: 2,
               metadata: {
                 'is_eligible_ra' => true,
-                'section_8' => 1,
-                'subsidized_housing' => 1,
-                'recent_eviction_case' => 0,
+                'section_8' => true,
+                'city_of_pittsburgh' => false,
+                'subsidized_housing' => true,
+                'recent_eviction_case' => false,
               },
             ),
           ],
@@ -473,8 +477,37 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
       result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
       expect(result.is_eligible_ra).to eq(true)
       expect(result.section_8).to eq(true)
+      expect(result.city_of_pittsburgh).to eq(false)
       expect(result.subsidized_housing).to eq(true)
       expect(result.recent_eviction_case).to eq(false)
+      expect(Sentry).not_to have_received(:capture_message)
+    end
+
+    it 'treats numeric 1/0 flags as ineligible and logs to Sentry' do
+      allow(Sentry).to receive(:capture_message)
+      numeric_metadata = {
+        'is_eligible_ra' => true,
+        'section_8' => 1,
+        'city_of_pittsburgh' => 0,
+        'subsidized_housing' => 1,
+        'recent_eviction_case' => 0,
+      }
+      response = mock_api_response(
+        client_data(
+          dw_client_id: mci_unique_id.value,
+          scores: [visionlink_score_hash(score: 2, metadata: numeric_metadata)],
+        ),
+      )
+      setup_api_expectation(mci_unique_ids: mci_unique_id.value, response: response)
+
+      result = aha.fetch_score(client, requested_generators: [:visionlink])[:visionlink]
+      expect(result.is_eligible_ra).to eq(true)
+      expect(result.section_8).to eq(false)
+      expect(result.city_of_pittsburgh).to eq(false)
+      expect(result.subsidized_housing).to eq(false)
+      expect(result.recent_eviction_case).to eq(false)
+      expect(Sentry).to have_received(:capture_message).
+        with("VisionLink metadata contains non-boolean values: #{numeric_metadata.inspect}")
     end
 
     it 'returns nil when all eligibility metadata fields are missing' do
@@ -507,9 +540,9 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
               score: 1,
               metadata: {
                 'is_eligible_ra' => false,
-                'section_8' => 0,
-                'subsidized_housing' => 0,
-                'recent_eviction_case' => 0,
+                'section_8' => false,
+                'subsidized_housing' => false,
+                'recent_eviction_case' => false,
                 'row_id' => '123',
                 'mci_uniq_id' => mci_unique_id.value,
               },
@@ -532,7 +565,7 @@ RSpec.describe HmisExternalApis::AcHmis::Aha, type: :model do
               score: -999,
               metadata: {
                 'is_eligible_ra' => false,
-                'section_8' => 1,
+                'section_8' => true,
               },
             ),
           ],


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/9533

In Staging, these fields returned 0/1 integers. They have since been updated to return true/false flags.

Fix and add `ArgumentError` so we are alerted if the shape changes again in the future (and so the end-user doesn't see incomplete/inaccurate response)

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)
