### PR TITLE
Included deleted Units in custom export feed

### DIFF
--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_export.rb
@@ -16,19 +16,21 @@ module HmisExternalApis::AcHmis::Exporters
       Rails.logger.info 'Generating Unit export'
       write_row(columns)
       total = units.count
+
       Rails.logger.info "There are #{total} Units to export"
 
       units.each.with_index do |unit, i|
         Rails.logger.info "Processed #{i} of #{total}" if (i % 100).zero?
         # Note: expects certain structure because it assumes HmisDataCleanup::MigrateUnitsToUnitGroups20250828 has run.
         # Once #8157 is completed, unit type relationship may be more tightly enforced.
-        raise 'unexpected: unit missing unit group' unless unit.unit_group
-        raise 'unexpected: unit group missing unit type' unless unit.unit_group.unit_type
+        unit_group = unit_groups_by_id[unit.hmis_unit_group_id]
+        raise 'unexpected: unit missing unit group' unless unit_group
+        raise 'unexpected: unit group missing unit type' unless unit_group.unit_type
 
         values = [
           unit.id, # UnitID
-          unit.unit_group.id, # UnitGroupID
-          unit.unit_group.unit_type.description, # UnitTypeName
+          unit_group.id, # UnitGroupID
+          unit_group.unit_type.description, # UnitTypeName
           unit.project.id, # ProjectID
           unit.project.project_name, # ProjectName
           unit.created_at, # DateCreated
@@ -59,7 +61,14 @@ module HmisExternalApis::AcHmis::Exporters
         joins(:project).
         merge(Hmis::Hud::Project.where(data_source: data_source)).
         order(Hmis::Hud::Project.arel_table[:id], Hmis::Unit.arel_table[:hmis_unit_group_id], Hmis::Unit.arel_table[:id]).
-        preload(:project, unit_group: :unit_type)
+        preload(:project)
+    end
+
+    def unit_groups_by_id
+      @unit_groups_by_id ||= Hmis::UnitGroup.with_deleted.
+        where(id: units.select(:hmis_unit_group_id)).
+        preload(:unit_type).
+        index_by(&:id)
     end
   end
 end

--- a/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_export.rb
+++ b/drivers/hmis_external_apis/app/models/hmis_external_apis/ac_hmis/exporters/unit_export.rb
@@ -7,8 +7,7 @@
 # frozen_string_literal: true
 
 module HmisExternalApis::AcHmis::Exporters
-  # Class to export current Units.
-  # Does not include unit occupancy (which is included in CdeExport currently), just unit capacity per project.
+  # Class to export Units, including deleted units.
   class UnitExport
     include ::HmisExternalApis::AcHmis::Exporters::CsvExporter
     include ::Hmis::Concerns::HmisArelHelper
@@ -34,6 +33,7 @@ module HmisExternalApis::AcHmis::Exporters
           unit.project.project_name, # ProjectName
           unit.created_at, # DateCreated
           unit.updated_at, # DateUpdated
+          unit.deleted_at, # DateDeleted
         ]
         write_row(values)
       end
@@ -50,11 +50,12 @@ module HmisExternalApis::AcHmis::Exporters
         'ProjectName',
         'DateCreated',
         'DateUpdated',
+        'DateDeleted', # Blank for active units; set when the unit was removed. Deleted units are not reactivated.
       ]
     end
 
     def units
-      @units ||= Hmis::Unit.
+      @units ||= Hmis::Unit.with_deleted.
         joins(:project).
         merge(Hmis::Hud::Project.where(data_source: data_source)).
         order(Hmis::Hud::Project.arel_table[:id], Hmis::Unit.arel_table[:hmis_unit_group_id], Hmis::Unit.arel_table[:id]).

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_export_spec.rb
@@ -38,5 +38,29 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::UnitExport, type: :model do
     expect(result.first['ProjectName']).to eq(project.project_name)
     expect(result.first['DateCreated']).to be_present
     expect(result.first['DateUpdated']).to be_present
+    expect(result.first['DateDeleted']).to be_blank
+  end
+
+  context 'when a unit is soft-deleted' do
+    let!(:deleted_unit) { create :hmis_unit, project: project, unit_group: unit_group, unit_type: unit_type }
+
+    before { deleted_unit.destroy! }
+
+    it 'includes both active and deleted units' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(2)
+      expect(result.map { |row| row['UnitID'] }).to contain_exactly(unit.id.to_s, deleted_unit.id.to_s)
+
+      deleted_row = result.find { |row| row['UnitID'] == deleted_unit.id.to_s }
+      expect(deleted_row['DateDeleted']).to eq(deleted_unit.reload.deleted_at.strftime('%Y-%m-%d %H:%M:%S'))
+      expect(deleted_row['UnitGroupID']).to eq(unit_group.id.to_s)
+      expect(deleted_row['UnitTypeName']).to eq(unit_type.description)
+      expect(deleted_row['ProjectID']).to eq(project.id.to_s)
+
+      active_row = result.find { |row| row['UnitID'] == unit.id.to_s }
+      expect(active_row['DateDeleted']).to be_blank
+    end
   end
 end

--- a/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_export_spec.rb
+++ b/drivers/hmis_external_apis/spec/models/hmis_external_apis/ac_hmis/exporters/unit_export_spec.rb
@@ -63,4 +63,24 @@ RSpec.describe HmisExternalApis::AcHmis::Exporters::UnitExport, type: :model do
       expect(active_row['DateDeleted']).to be_blank
     end
   end
+
+  context 'when a unit group is soft-deleted' do
+    before do
+      # Unit type must come from the (deleted) unit group, not the unit's own type association
+      unit.update_column(:unit_type_id, nil)
+      unit_group.destroy!
+    end
+
+    it 'still exports the unit with unit group id and unit type name' do
+      subject.run!
+      result = CSV.parse(output, headers: true)
+
+      expect(result.length).to eq(1)
+      expect(result.first['UnitID']).to eq(unit.id.to_s)
+      expect(result.first['UnitGroupID']).to eq(unit_group.id.to_s)
+      expect(result.first['UnitTypeName']).to eq(unit_type.description)
+      expect(result.first['ProjectID']).to eq(project.id.to_s)
+      expect(result.first['DateDeleted']).to be_present
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Include deleted units in custom export feed.
issue https://github.com/open-path/Green-River/issues/9537
## Type of change
New feature

## Checklist before requesting review
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

