### PR TITLE
Add HMIS access column to the Warehouse User Directory report

### DIFF
--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -189,6 +189,14 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
 
   scope :not_hmis, -> { where(hmis: nil) }
 
+  # Every HMIS installation on this deployment, empty when HMIS is turned off here.
+  # Callers use the emptiness to decide whether to show HMIS at all.
+  def self.enabled_hmis_data_sources
+    return [] unless HmisEnforcement.hmis_enabled?
+
+    hmis.to_a
+  end
+
   scope :scannable, -> do
     where(service_scannable: true)
   end

--- a/drivers/hmis/app/models/hmis/user.rb
+++ b/drivers/hmis/app/models/hmis/user.rb
@@ -283,6 +283,16 @@ class Hmis::User < ApplicationRecord
     Hmis::Filter::ApplicationUserFilter.new(input).filter_scope(self)
   end
 
+  # Batch counterpart to can_access_hmis_data_source?, for listing many users at once.
+  # Returns { user_id => [hmis data source id, ...] }, omitting users with no HMIS access.
+  def self.accessible_hmis_data_source_ids_by_user_id
+    GrdaWarehouse::DataSource.hmis.each_with_object({}) do |data_source, result|
+      with_hmis_access_in_data_source(data_source.id).
+        pluck(:id).
+        each { |user_id| (result[user_id] ||= []) << data_source.id }
+    end
+  end
+
   # Determine whether this user has _any_ access to a given HMIS data source.
   # Returns true even if they can only access 1 project or org within the DS.
   # This doesn't check for permissions (so, they don't necessarily have can_view_projects within the DS).

--- a/drivers/hmis/spec/models/hmis/user_spec.rb
+++ b/drivers/hmis/spec/models/hmis/user_spec.rb
@@ -130,4 +130,65 @@ RSpec.describe Hmis::User, type: :model do
       expect(user.confirmation_token).not_to eq('injected_token')
     end
   end
+  # The batch counterpart to can_access_hmis_data_source?, used by the User Directory
+  # report to avoid a query per user per data source. It delegates the per-data-source
+  # lookup to .with_hmis_access_in_data_source (covered above), so these examples pin
+  # what the batch method itself adds: the shape of the hash, the multi-data-source
+  # keying, and agreement with the per-user checker.
+  describe '.accessible_hmis_data_source_ids_by_user_id' do
+    let!(:ds2) { create(:hmis_data_source) }
+    let!(:ds1_user) { create(:hmis_user, data_source: ds1) }
+    let!(:no_access_user) { create(:hmis_user, data_source: ds1) }
+
+    it 'returns an empty hash when nobody has HMIS access' do
+      expect(described_class.accessible_hmis_data_source_ids_by_user_id).to eq({})
+    end
+
+    it 'maps a user id to the data sources they can reach, omitting users with none' do
+      create_access_control(ds1_user, ds1)
+
+      expect(described_class.accessible_hmis_data_source_ids_by_user_id).to eq(ds1_user.id => [ds1.id])
+    end
+
+    it 'lists every data source a user can reach' do
+      create_access_control(ds1_user, ds1)
+      create_access_control(ds1_user, ds2)
+
+      result = described_class.accessible_hmis_data_source_ids_by_user_id
+      expect(result.keys).to contain_exactly(ds1_user.id)
+      expect(result[ds1_user.id]).to contain_exactly(ds1.id, ds2.id)
+    end
+
+    it 'keys each user separately' do
+      create_access_control(ds1_user, ds1)
+      create_access_control(no_access_user, ds2)
+
+      expect(described_class.accessible_hmis_data_source_ids_by_user_id).
+        to eq(ds1_user.id => [ds1.id], no_access_user.id => [ds2.id])
+    end
+
+    it 'omits the system user' do
+      # Inherited from with_hmis_access_in_data_source, but the directory report relies on
+      # it: the system user would otherwise be listed as an HMIS user.
+      create_access_control(User.system_user.related_hmis_user(ds1), ds1)
+      create_access_control(ds1_user, ds1)
+
+      expect(described_class.accessible_hmis_data_source_ids_by_user_id.keys).
+        not_to include(User.system_user.id)
+    end
+
+    it 'agrees with the per-user checker, for access granted below the data source' do
+      # Access via a project rather than the whole data source, so this also covers the
+      # entity-walking the report depends on.
+      create_access_control(ds1_user, p1)
+      result = described_class.accessible_hmis_data_source_ids_by_user_id
+
+      aggregate_failures do
+        expect(result.fetch(ds1_user.id, []).include?(ds1.id)).
+          to eq(ds1_user.can_access_hmis_data_source?(ds1.id))
+        expect(result.fetch(no_access_user.id, []).include?(ds1.id)).
+          to eq(no_access_user.can_access_hmis_data_source?(ds1.id))
+      end
+    end
+  end
 end

--- a/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
+++ b/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
@@ -87,29 +87,11 @@ module UserDirectoryReport::WarehouseReports
       CasBase.db_exists? && CasAccess::User.take.respond_to?('exclude_from_directory')
     end
 
-    # Every HMIS installation on this deployment; empty when HMIS is off, which is what
-    # hides the column.
-    def hmis_data_sources
-      @hmis_data_sources ||= HmisEnforcement.hmis_enabled? ? GrdaWarehouse::DataSource.hmis.to_a : []
-    end
-
-    # The HMIS installations this user can reach, empty when they can reach none.
-    def hmis_data_sources_for(user)
-      accessible_ids = hmis_access_by_user_id.fetch(user.id, [])
-      hmis_data_sources.select { |hmis_ds| accessible_ids.include?(hmis_ds.id) }
-    end
-
     def hmis_data_source_linkable?(hmis_ds)
       return false unless current_user.can_view_imports_projects_or_organizations?
 
       @viewable_hmis_data_source_ids ||= GrdaWarehouse::DataSource.hmis.viewable_by(current_user).pluck(:id).to_set
       @viewable_hmis_data_source_ids.include?(hmis_ds.id)
-    end
-
-    private def hmis_access_by_user_id
-      return @hmis_access_by_user_id if defined?(@hmis_access_by_user_id)
-
-      @hmis_access_by_user_id = hmis_data_sources.any? ? Hmis::User.accessible_hmis_data_source_ids_by_user_id : {}
     end
   end
 end

--- a/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
+++ b/drivers/user_directory_report/app/controllers/user_directory_report/warehouse_reports/users_controller.rb
@@ -14,6 +14,9 @@ module UserDirectoryReport::WarehouseReports
     helper_method :nav_link_classes
     helper_method :cas_available?
     helper_method :warehouse_user_source?
+    helper_method :hmis_data_sources
+    helper_method :hmis_data_sources_for
+    helper_method :hmis_data_source_linkable?
 
     # Both actions are the same report, and there is no :index for the concern's default
     # derivation to use; the seeded definition is registered under the warehouse action's
@@ -82,6 +85,31 @@ module UserDirectoryReport::WarehouseReports
 
     def cas_available?
       CasBase.db_exists? && CasAccess::User.take.respond_to?('exclude_from_directory')
+    end
+
+    # Every HMIS installation on this deployment; empty when HMIS is off, which is what
+    # hides the column.
+    def hmis_data_sources
+      @hmis_data_sources ||= HmisEnforcement.hmis_enabled? ? GrdaWarehouse::DataSource.hmis.to_a : []
+    end
+
+    # The HMIS installations this user can reach, empty when they can reach none.
+    def hmis_data_sources_for(user)
+      accessible_ids = hmis_access_by_user_id.fetch(user.id, [])
+      hmis_data_sources.select { |hmis_ds| accessible_ids.include?(hmis_ds.id) }
+    end
+
+    def hmis_data_source_linkable?(hmis_ds)
+      return false unless current_user.can_view_imports_projects_or_organizations?
+
+      @viewable_hmis_data_source_ids ||= GrdaWarehouse::DataSource.hmis.viewable_by(current_user).pluck(:id).to_set
+      @viewable_hmis_data_source_ids.include?(hmis_ds.id)
+    end
+
+    private def hmis_access_by_user_id
+      return @hmis_access_by_user_id if defined?(@hmis_access_by_user_id)
+
+      @hmis_access_by_user_id = hmis_data_sources.any? ? Hmis::User.accessible_hmis_data_source_ids_by_user_id : {}
     end
   end
 end

--- a/drivers/user_directory_report/app/models/concerns/user_directory_report/directory_users.rb
+++ b/drivers/user_directory_report/app/models/concerns/user_directory_report/directory_users.rb
@@ -24,4 +24,22 @@ module UserDirectoryReport::DirectoryUsers
     scope = scope.text_search(params[:q]) if params[:q].present?
     scope.order(:last_name, :first_name)
   end
+
+  # Every HMIS installation on this deployment; empty when HMIS is off, which is what
+  # hides the HMIS column from both the screen and the spreadsheet.
+  private def hmis_data_sources
+    @hmis_data_sources ||= GrdaWarehouse::DataSource.enabled_hmis_data_sources
+  end
+
+  # The HMIS installations this user can reach, empty when they can reach none.
+  private def hmis_data_sources_for(user)
+    accessible_ids = hmis_access_by_user_id.fetch(user.id, [])
+    hmis_data_sources.select { |hmis_ds| accessible_ids.include?(hmis_ds.id) }
+  end
+
+  private def hmis_access_by_user_id
+    return @hmis_access_by_user_id if defined?(@hmis_access_by_user_id)
+
+    @hmis_access_by_user_id = hmis_data_sources.any? ? Hmis::User.accessible_hmis_data_source_ids_by_user_id : {}
+  end
 end

--- a/drivers/user_directory_report/app/models/user_directory_report/document_exports/warehouse_user_directory_excel_export.rb
+++ b/drivers/user_directory_report/app/models/user_directory_report/document_exports/warehouse_user_directory_excel_export.rb
@@ -34,23 +34,10 @@ module UserDirectoryReport::DocumentExports
       columns
     end
 
-    # Every HMIS installation on this deployment; empty when HMIS is off, which is what
-    # drops the column from the spreadsheet.
-    private def hmis_data_sources
-      @hmis_data_sources ||= HmisEnforcement.hmis_enabled? ? GrdaWarehouse::DataSource.hmis.to_a : []
-    end
-
-    private def hmis_access_by_user_id
-      return @hmis_access_by_user_id if defined?(@hmis_access_by_user_id)
-
-      @hmis_access_by_user_id = hmis_data_sources.any? ? Hmis::User.accessible_hmis_data_source_ids_by_user_id : {}
-    end
-
     # Yes for a single HMIS installation, standing in for the check the screen shows;
     # the name of each data source when there are several, matching its links.
     private def hmis_cell_for(user)
-      accessible_ids = hmis_access_by_user_id.fetch(user.id, [])
-      accessible = hmis_data_sources.select { |hmis_ds| accessible_ids.include?(hmis_ds.id) }
+      accessible = hmis_data_sources_for(user)
       return '' if accessible.none?
       return 'Yes' if hmis_data_sources.one?
 

--- a/drivers/user_directory_report/app/models/user_directory_report/document_exports/warehouse_user_directory_excel_export.rb
+++ b/drivers/user_directory_report/app/models/user_directory_report/document_exports/warehouse_user_directory_excel_export.rb
@@ -11,18 +11,50 @@ module UserDirectoryReport::DocumentExports
     include ApplicationHelper
     include UserDirectoryReport::DirectoryUsers
 
-    HEADERS = [
-      'Name',
-      'Email',
-      'Phone',
-      'Agency',
-      'Roles',
-      'Status',
-      'Last Login',
-    ].freeze
-
     def authorized?
       user.can_view_any_reports?
+    end
+
+    # Column title => how to fill that cell for one user, in spreadsheet column order: a
+    # symbol to read the attribute, or a lambda for anything computed. The header and every
+    # row are both derived from this, so a column can be added, reordered, or dropped in
+    # one place. 'Status' is fixed per sheet.
+    private def columns_for(status)
+      columns = {
+        'Name' => :name,
+        'Email' => :email,
+        'Phone' => :phone_for_directory,
+        'Agency' => :agency_name,
+        'Roles' => ->(directory_user) { directory_user.unique_role_names&.sort&.join('; ') },
+        'Status' => ->(_directory_user) { status },
+        'HMIS Access' => ->(directory_user) { hmis_cell_for(directory_user) },
+        'Last Login' => :last_sign_in_at,
+      }
+      columns.delete('HMIS Access') if hmis_data_sources.none?
+      columns
+    end
+
+    # Every HMIS installation on this deployment; empty when HMIS is off, which is what
+    # drops the column from the spreadsheet.
+    private def hmis_data_sources
+      @hmis_data_sources ||= HmisEnforcement.hmis_enabled? ? GrdaWarehouse::DataSource.hmis.to_a : []
+    end
+
+    private def hmis_access_by_user_id
+      return @hmis_access_by_user_id if defined?(@hmis_access_by_user_id)
+
+      @hmis_access_by_user_id = hmis_data_sources.any? ? Hmis::User.accessible_hmis_data_source_ids_by_user_id : {}
+    end
+
+    # Yes for a single HMIS installation, standing in for the check the screen shows;
+    # the name of each data source when there are several, matching its links.
+    private def hmis_cell_for(user)
+      accessible_ids = hmis_access_by_user_id.fetch(user.id, [])
+      accessible = hmis_data_sources.select { |hmis_ds| accessible_ids.include?(hmis_ds.id) }
+      return '' if accessible.none?
+      return 'Yes' if hmis_data_sources.one?
+
+      accessible.map(&:name).join('; ')
     end
 
     def perform
@@ -42,21 +74,12 @@ module UserDirectoryReport::DocumentExports
     end
 
     private def add_sheet(workbook, name, users, status)
+      columns = columns_for(status)
       workbook.add_worksheet(name: name[0, 30]) do |sheet|
         title = sheet.styles.add_style(sz: 12, b: true, alignment: { horizontal: :center })
-        sheet.add_row(HEADERS, style: title)
-        users.each do |user|
-          sheet.add_row(
-            [
-              user.name,
-              user.email,
-              user.phone_for_directory,
-              user.agency_name,
-              user.unique_role_names&.sort&.join('; '),
-              status,
-              user.last_sign_in_at,
-            ],
-          )
+        sheet.add_row(columns.keys, style: title)
+        users.each do |directory_user|
+          sheet.add_row(columns.each_value.map { |cell| cell.to_proc.call(directory_user) })
         end
       end
     end

--- a/drivers/user_directory_report/app/views/user_directory_report/warehouse_reports/users/_listing.haml
+++ b/drivers/user_directory_report/app/views/user_directory_report/warehouse_reports/users/_listing.haml
@@ -1,3 +1,5 @@
+- show_hmis_column = warehouse_user_source? && hmis_data_sources.any?
+- single_hmis = show_hmis_column && hmis_data_sources.one?
 - if @pagy.count.positive?
   .text-right.mb-4
     = render 'report_downloads/report_download', export: @pdf_export, excel_export: @excel_export, excel_download_path: nil
@@ -12,6 +14,8 @@
           %th Agency
           %th Roles 
           %th Status
+          - if show_hmis_column
+            %th HMIS Access
           %th Last Login
       %tbody
         - @users.each do |user|
@@ -25,6 +29,16 @@
                 .role-name= name
               
             %td= @user_source == 'inactive' ? 'Inactive' : (user.active ? 'Active': 'Inactive')
+            - if show_hmis_column
+              %td
+                - user_hmis_data_sources = hmis_data_sources_for(user)
+                - if single_hmis
+                  - if user_hmis_data_sources.any?
+                    %i.icon-checkmark.o-color--positive
+                - else
+                  - user_hmis_data_sources.each do |hmis_ds|
+                    .hmis-data-source
+                      = link_to_if hmis_data_source_linkable?(hmis_ds), hmis_ds.name, data_source_path(hmis_ds)
             %td= user.last_sign_in_at
   = render 'common/pagination_bottom', item_name: 'user'
 - else

--- a/drivers/user_directory_report/spec/models/user_directory_report/document_exports/warehouse_user_directory_excel_export_spec.rb
+++ b/drivers/user_directory_report/spec/models/user_directory_report/document_exports/warehouse_user_directory_excel_export_spec.rb
@@ -1,0 +1,211 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'roo'
+
+# The xlsx download behind the Warehouse User Directory report: one sheet of active
+# warehouse users and one of inactive, with the same columns the html listing shows.
+#
+RSpec.describe UserDirectoryReport::DocumentExports::WarehouseUserDirectoryExcelExport, type: :model do
+  let(:reader) { create(:acl_user, first_name: 'Report', last_name: 'Reader') }
+  let(:collection) { create(:collection) }
+
+  # The user whose row the column assertions read. Named distinctly so the row can be
+  # found by name, and so a name assertion cannot match some other user's row.
+  let!(:listed_user) { create(:acl_user, first_name: 'Directory', last_name: 'Listing') }
+
+  # The row that must stay blank in the HMIS column. Without it, "no check for a user
+  # without access" would pass even if the column were filled in unconditionally.
+  let!(:no_access_user) { create(:acl_user, first_name: 'NoHmis', last_name: 'Access') }
+
+  let(:export) { described_class.new(user_id: reader.id) }
+
+  # Wires up the user_group -> access_control -> collection -> data source chain that
+  # Hmis::User.accessible_hmis_data_source_ids_by_user_id walks. Mirrors the helper in
+  # the request spec for this report.
+  def grant_hmis_access(target_user, data_source)
+    hmis_user_group = create(:hmis_user_group)
+    hmis_user_group.add(target_user.related_hmis_user(data_source))
+    create(
+      :hmis_access_control,
+      role: create(:hmis_role),
+      user_group: hmis_user_group,
+      access_group: create(:hmis_access_group, with_entities: [data_source]),
+    )
+  end
+
+  # Generates the spreadsheet and reads it back, so every assertion below is made against
+  # the bytes a user would download rather than against the column definitions.
+  def workbook
+    @workbook ||= begin
+      export.perform
+      file = Tempfile.new(['warehouse_user_directory', '.xlsx'])
+      begin
+        file.binmode
+        file.write(export.file_data)
+        file.close
+        Roo::Excelx.new(file.path)
+      ensure
+        file.unlink
+      end
+    end
+  end
+
+  def headers(sheet_name)
+    workbook.sheet(sheet_name).row(1)
+  end
+
+  # The row for one user, as { column title => cell }. Cells are compared as strings so
+  # an empty cell reads as '' whether the writer stored '' or nothing at all.
+  def row_for(sheet_name, user_name)
+    sheet = workbook.sheet(sheet_name)
+    titles = sheet.row(1)
+    row = (2..sheet.last_row).map { |number| sheet.row(number) }.detect { |cells| cells.first == user_name }
+    return nil unless row
+
+    titles.each_with_index.to_h { |title, index| [title, row[index].to_s] }
+  end
+
+  def user_names(sheet_name)
+    sheet = workbook.sheet(sheet_name)
+    (2..sheet.last_row).map { |number| sheet.row(number).first }
+  end
+
+  describe '#authorized?' do
+    it 'is true for a reader who can view reports' do
+      setup_access_control(reader, create(:role, can_view_assigned_reports: true), collection)
+
+      expect(export.authorized?).to eq(true)
+    end
+
+    it 'is false for a reader with no report permission' do
+      setup_access_control(reader, create(:role, can_view_clients: true), collection)
+
+      expect(export.authorized?).to eq(false)
+    end
+  end
+
+  describe '#perform' do
+    it 'writes both sheets, splitting users by active status' do
+      inactive_user = create(:acl_user, first_name: 'Retired', last_name: 'Person', active: false)
+
+      aggregate_failures do
+        expect(user_names('Active Warehouse Users')).to include('Directory Listing')
+        expect(user_names('Active Warehouse Users')).not_to include('Retired Person')
+        expect(user_names('Inactive Warehouse Users')).to contain_exactly('Retired Person')
+        expect(inactive_user.reload.active).to eq(false)
+      end
+    end
+
+    it 'labels the status column per sheet' do
+      create(:acl_user, first_name: 'Retired', last_name: 'Person', active: false)
+
+      aggregate_failures do
+        expect(row_for('Active Warehouse Users', 'Directory Listing')['Status']).to eq('Active')
+        expect(row_for('Inactive Warehouse Users', 'Retired Person')['Status']).to eq('Inactive')
+      end
+    end
+
+    it 'fills each column of a user row' do
+      # Pins the header-to-cell mapping: every column reads from the user it names. A
+      # column inserted or reordered without updating the row builder moves these values.
+      agency = create(:agency, name: 'Housing Partners')
+      listed_user.update!(agency: agency, phone: '555-0100')
+      setup_access_control(listed_user, create(:role, name: 'Directory Role'), collection)
+
+      row = row_for('Active Warehouse Users', 'Directory Listing')
+
+      aggregate_failures do
+        expect(row['Name']).to eq('Directory Listing')
+        expect(row['Email']).to eq(listed_user.email)
+        expect(row['Phone']).to eq('555-0100')
+        expect(row['Agency']).to eq('Housing Partners')
+        expect(row['Roles']).to eq('Directory Role')
+      end
+    end
+
+    it 'omits the phone of a user who keeps it out of the directory' do
+      listed_user.update!(phone: '555-0100', exclude_phone_from_directory: true)
+
+      expect(row_for('Active Warehouse Users', 'Directory Listing')['Phone']).to eq('')
+    end
+  end
+
+  describe 'the HMIS access column' do
+    # ENABLE_HMIS_API is set for the spec container, so both halves of the gate are
+    # stubbed rather than left to the environment -- otherwise these two examples would
+    # pass or fail depending on where they run.
+    it 'is absent when HMIS is not enabled' do
+      # An HMIS data source with a grant on it exists, so the column's absence is
+      # attributable to the enabled check rather than to there being nothing to report.
+      data_source = create(:hmis_data_source, name: 'Solo Data Source')
+      grant_hmis_access(listed_user, data_source)
+      allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(false)
+
+      aggregate_failures do
+        expect(headers('Active Warehouse Users')).
+          to eq(['Name', 'Email', 'Phone', 'Agency', 'Roles', 'Status', 'Last Login'])
+        expect(workbook.sheet('Active Warehouse Users').row(2)).not_to include('Yes')
+      end
+    end
+
+    it 'is absent when HMIS is enabled but no HMIS data source is configured' do
+      allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+
+      expect(headers('Active Warehouse Users')).
+        to eq(['Name', 'Email', 'Phone', 'Agency', 'Roles', 'Status', 'Last Login'])
+    end
+
+    describe 'with a single HMIS data source' do
+      before { allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true) }
+
+      let!(:hmis_data_source) { create(:hmis_data_source, name: 'Solo Data Source') }
+
+      it 'says Yes for a user with access, and nothing for one without' do
+        grant_hmis_access(listed_user, hmis_data_source)
+
+        aggregate_failures do
+          expect(row_for('Active Warehouse Users', 'Directory Listing')['HMIS Access']).to eq('Yes')
+          expect(row_for('Active Warehouse Users', 'NoHmis Access')['HMIS Access']).to eq('')
+        end
+      end
+
+      it 'reports the access of an inactive user too' do
+        inactive_user = create(:acl_user, first_name: 'Retired', last_name: 'Person', active: false)
+        grant_hmis_access(inactive_user, hmis_data_source)
+
+        expect(row_for('Inactive Warehouse Users', 'Retired Person')['HMIS Access']).to eq('Yes')
+      end
+    end
+
+    describe 'with several HMIS data sources' do
+      before { allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true) }
+
+      let!(:first_data_source) { create(:hmis_data_source, name: 'First HMIS') }
+      let!(:second_data_source) { create(:hmis_data_source, name: 'Second HMIS') }
+
+      it 'names only the data sources the user can reach' do
+        grant_hmis_access(listed_user, second_data_source)
+
+        aggregate_failures do
+          expect(row_for('Active Warehouse Users', 'Directory Listing')['HMIS Access']).to eq('Second HMIS')
+          expect(row_for('Active Warehouse Users', 'NoHmis Access')['HMIS Access']).to eq('')
+        end
+      end
+
+      it 'names every data source a user can reach' do
+        grant_hmis_access(listed_user, first_data_source)
+        grant_hmis_access(listed_user, second_data_source)
+
+        expect(row_for('Active Warehouse Users', 'Directory Listing')['HMIS Access'].split('; ')).
+          to contain_exactly('First HMIS', 'Second HMIS')
+      end
+    end
+  end
+end

--- a/drivers/user_directory_report/spec/requests/users_controller_spec.rb
+++ b/drivers/user_directory_report/spec/requests/users_controller_spec.rb
@@ -177,4 +177,183 @@ RSpec.describe UserDirectoryReport::WarehouseReports::UsersController, type: :re
     # pre-existing bug in the action (it predates the authorization gate added here) and
     # is tracked separately; the deny example above is what pins the gate itself.
   end
+  describe 'the HMIS access column' do
+    # The rendered check. Matched on the full attribute rather than the class name alone,
+    # which also appears in the icon sprite's <symbol id="icon-checkmark"> on every page.
+    check_markup = %(<i class='icon-checkmark o-color--positive'>)
+
+    let(:granted_role) { create(:role, can_view_assigned_reports: true) }
+
+    # Wires up the user_group -> access_control -> collection -> data source chain that
+    # Hmis::User.accessible_hmis_data_source_ids_by_user_id walks.
+    def grant_hmis_access(target_user, data_source)
+      hmis_collection = create(:hmis_access_group, with_entities: [data_source])
+      hmis_user_group = create(:hmis_user_group)
+      hmis_user_group.add(target_user.related_hmis_user(data_source))
+      create(
+        :hmis_access_control,
+        role: create(:hmis_role),
+        user_group: hmis_user_group,
+        access_group: hmis_collection,
+      )
+    end
+
+    # ENABLE_HMIS_API is set for the spec container, so the gate is stubbed rather than
+    # left to the environment, and a data source with a grant on it is created: the
+    # column's absence is then attributable to the gate rather than to there being
+    # nothing to report.
+    it 'is absent when HMIS is not enabled' do
+      grant_hmis_access(listed_user, create(:hmis_data_source, name: 'Solo Data Source'))
+      allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(false)
+      sign_in_with(granted_role, grant_report: true)
+
+      get warehouse_user_directory_report_warehouse_reports_users_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('HMIS Access')
+      end
+    end
+
+    it 'is absent when HMIS is enabled but no HMIS data source is configured' do
+      allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true)
+      sign_in_with(granted_role, grant_report: true)
+
+      get warehouse_user_directory_report_warehouse_reports_users_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('HMIS Access')
+      end
+    end
+
+    describe 'with a single HMIS data source' do
+      before { allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true) }
+
+      # A distinctive name: the factory default is 'HMIS', which also appears in the page
+      # title and nav, so an absence-of-name assertion could never fail with it.
+      let!(:hmis_data_source) { create(:hmis_data_source, name: 'Solo Data Source') }
+
+      it 'shows a check, and not the data source name, for a user with access' do
+        grant_hmis_access(listed_user, hmis_data_source)
+        sign_in_with(granted_role, grant_report: true)
+
+        get warehouse_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('HMIS Access')
+          expect(response.body).to include(check_markup)
+          # With one installation the name carries no information, so it is not rendered.
+          expect(response.body).not_to include('Solo Data Source')
+        end
+      end
+
+      it 'shows no check when no user has HMIS access' do
+        sign_in_with(granted_role, grant_report: true)
+
+        get warehouse_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('HMIS Access')
+          expect(response.body).not_to include(check_markup)
+        end
+      end
+
+      # The inactive listing is the same partial with a different scope, and an inactive
+      # user's HMIS access is exactly what a reader auditing that tab is looking for.
+      it 'is shown on the inactive listing too' do
+        inactive_user = create(:acl_user, active: false)
+        grant_hmis_access(inactive_user, hmis_data_source)
+        sign_in_with(granted_role, grant_report: true)
+
+        get inactive_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(assigns(:users)).to include(inactive_user)
+          expect(response.body).to include('HMIS Access')
+          expect(response.body).to include(check_markup)
+        end
+      end
+    end
+
+    describe 'with several HMIS data sources' do
+      before { allow(HmisEnforcement).to receive(:hmis_enabled?).and_return(true) }
+
+      let!(:first_data_source) { create(:hmis_data_source) }
+      let!(:second_data_source) { create(:hmis_data_source, name: 'Second HMIS') }
+
+      before { grant_hmis_access(listed_user, second_data_source) }
+
+      it 'names each accessible data source instead of showing a check' do
+        sign_in_with(granted_role, grant_report: true)
+
+        get warehouse_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('Second HMIS')
+          expect(response.body).not_to include(check_markup)
+        end
+      end
+
+      it 'links the name when the reader has both the permission and the grant' do
+        sign_in_with(
+          # can_view_imports_projects_or_organizations is derived, not a role column;
+          # viewable_by requires can_view_projects specifically for an ACL user.
+          create(:role, can_view_assigned_reports: true, can_view_projects: true),
+          grant_report: true,
+        )
+        # After sign_in_with, which resets the collection's viewables to the report alone.
+        collection.set_viewables(reports: [report_definition.id], data_sources: [second_data_source.id])
+
+        get warehouse_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include(%(href="#{data_source_path(second_data_source)}"))
+        end
+      end
+
+      it 'leaves the name unlinked when the reader has the permission but not the grant' do
+        # DataSourcesController#show finds through viewable_by, so a link here would raise
+        # RecordNotFound for this reader even though the before_action would let them in.
+        sign_in_with(
+          create(:role, can_view_assigned_reports: true, can_view_projects: true),
+          grant_report: true,
+        )
+
+        get warehouse_user_directory_report_warehouse_reports_users_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('Second HMIS')
+          expect(response.body).not_to include(%(href="#{data_source_path(second_data_source)}"))
+        end
+      end
+
+      it 'leaves the name unlinked when the reader lacks the permission, grant aside' do
+        # Pins the permission guard in hmis_data_source_linkable?. That guard exists for
+        # legacy (non-ACL) readers, whose viewable_by branch is pure entity visibility with
+        # no permission check -- an entity grant alone would otherwise produce a link that
+        # show's before_action rejects. It cannot be reproduced with an ACL reader here,
+        # since viewable_by's ACL branch returns none without can_view_projects anyway.
+        sign_in_with(granted_role, grant_report: true)
+        # After sign_in_with, which resets the collection's viewables to the report alone.
+        collection.set_viewables(reports: [report_definition.id], data_sources: [second_data_source.id])
+
+        aggregate_failures do
+          expect(user.can_view_imports_projects_or_organizations?).to eq(false)
+
+          get warehouse_user_directory_report_warehouse_reports_users_path
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('Second HMIS')
+          expect(response.body).not_to include(%(href="#{data_source_path(second_data_source)}"))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

- Adds an "HMIS Access" column to the Warehouse User Directory report (active and inactive listings, plus the xlsx download). Hidden when HMIS is off or no HMIS data source is configured.
- One HMIS data source: a checkmark on screen, `Yes` in the spreadsheet. Several: the names of the data sources the user can reach, joined with `; ` in the spreadsheet.
- Data source names link to the data source only when the reader has both `can_view_imports_projects_or_organizations?` and a viewable grant on it — `DataSourcesController#show` finds through `viewable_by`, so an unqualified link would 404.
- New `Hmis::User.accessible_hmis_data_source_ids_by_user_id` — batch counterpart to `can_access_hmis_data_source?`, returning `{ user_id => [data_source_id, ...] }`, two queries per HMIS data source instead of one per user per data source.
- `WarehouseUserDirectoryExcelExport`: replaces the fixed `HEADERS` array with a column-title => cell-builder hash (`columns_for`), so header and rows derive from one definition and the HMIS column can be dropped conditionally.
- Specs: new `warehouse_user_directory_excel_export_spec.rb` (13 examples, generates the xlsx and reads it back with Roo); HMIS-column request specs; `Hmis::User` model specs for the batch method. `HmisEnforcement.hmis_enabled?` is stubbed explicitly in both spec files — `ENABLE_HMIS_API` is set in the spec container, so leaving it to the environment made the "HMIS disabled" cases pin the wrong branch.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

