### PR TITLE
Add auth check to enqueue refresh of external form submissions

### DIFF
--- a/drivers/hmis/app/graphql/mutations/refresh_external_submissions.rb
+++ b/drivers/hmis/app/graphql/mutations/refresh_external_submissions.rb
@@ -11,6 +11,10 @@ module Mutations
     field :success, Boolean, null: false
 
     def resolve
+      # Global check: this re-processes the submission queue across all projects, so there is no
+      # single project to authorize against.
+      access_denied! unless policy_for(Hmis::Hud::Project, policy_type: :hmis_project).can_manage_external_form_submissions?
+
       handlers = ['HmisExternalApis::ConsumeExternalFormSubmissionsJob']
       return { success: true } if Delayed::Job.queued?(handlers) || Delayed::Job.running?(handlers)
 

--- a/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
+++ b/drivers/hmis/app/models/hmis/auth_policies/hmis_project_policy.rb
@@ -86,4 +86,17 @@ class Hmis::AuthPolicies::HmisProjectPolicy < Hmis::AuthPolicies::ResourcePolicy
 
     def validate_resource!(arg) = ensure_arg_type!(arg, Hmis::Hud::Project)
   end
+
+  class Global < Hmis::AuthPolicies::BasePolicy
+    # Whether the user can manage external form submissions at any project in the data source.
+    # Used to authorize actions that operate across projects and therefore have no single
+    # project to check against, such as re-processing the external submission queue.
+    def can_manage_external_form_submissions?
+      global_permissions.include?(:can_manage_external_form_submissions)
+    end
+
+    protected
+
+    def validate_resource!(arg) = ensure_arg_class!(arg, Hmis::Hud::Project)
+  end
 end

--- a/drivers/hmis/spec/requests/hmis/refresh_external_submissions_spec.rb
+++ b/drivers/hmis/spec/requests/hmis/refresh_external_submissions_spec.rb
@@ -1,0 +1,60 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative 'login_and_permissions'
+require_relative '../../support/hmis_base_setup'
+
+RSpec.describe 'Refresh External Submissions', type: :request do
+  include_context 'hmis base setup'
+
+  subject(:mutation) do
+    <<~GRAPHQL
+      mutation RefreshExternalSubmissions {
+        refreshExternalSubmissions {
+          success
+        }
+      }
+    GRAPHQL
+  end
+
+  before(:each) { hmis_login(user) }
+
+  def perform_mutation
+    post_graphql { mutation }
+  end
+
+  context 'when the user can manage external form submissions at a project' do
+    let!(:access_control) do
+      create_access_control(hmis_user, p1, with_permission: [:can_manage_external_form_submissions, :can_view_project])
+    end
+
+    it 'enqueues the consume job' do
+      expect do
+        response, result = perform_mutation
+        expect(response.status).to eq(200), result.inspect
+        expect(result.dig('data', 'refreshExternalSubmissions', 'success')).to eq(true)
+      end.to have_enqueued_job(HmisExternalApis::ConsumeExternalFormSubmissionsJob)
+    end
+  end
+
+  context 'when the user lacks can_manage_external_form_submissions' do
+    let!(:access_control) do
+      create_access_control(hmis_user, p1, without_permission: :can_manage_external_form_submissions)
+    end
+
+    it 'denies access and does not enqueue the job' do
+      expect { expect_access_denied perform_mutation }.
+        not_to have_enqueued_job(HmisExternalApis::ConsumeExternalFormSubmissionsJob)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include GraphqlHelpers
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
See https://github.com/open-path/Green-River/issues/9545

## Type of change
Bug fix

## Checklist before requesting review
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [x] If adding a new endpoint / exposing data in a new way, I have:
  - [x] ensured the API can't leak data from other data sources
  - [x] ensured this does not introduce N+1s
  - [x] ensured permissions and visibility checks are performed in the right places
- [x] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)
