### PR TITLE
[#9560] Restricted Clients are removed from name and SSN search

### DIFF
--- a/app/controllers/concerns/client_controller.rb
+++ b/app/controllers/concerns/client_controller.rb
@@ -111,11 +111,14 @@ module ClientController
     end
 
     def look_for_existing_match(attr)
+      restricted_ids = GrdaWarehouse::Hud::Client.hmis_restricted_source_client_ids
+
       name_matches = client_search_scope.
         where(
           nf('lower', [c_t[:FirstName]]).eq(attr[:FirstName].downcase).
           and(nf('lower', [c_t[:LastName]]).eq(attr[:LastName].downcase)),
         ).
+        where.not(id: restricted_ids).
         pluck(:id)
 
       ssn_matches = []
@@ -123,6 +126,7 @@ module ClientController
       if ::HudHelper.util.valid_social?(ssn)
         ssn_matches = client_search_scope.
           where(c_t[:SSN].eq(ssn)).
+          where.not(id: restricted_ids).
           pluck(:id)
       end
       birthdate_matches = client_search_scope.

--- a/app/models/concerns/client_search.rb
+++ b/app/models/concerns/client_search.rb
@@ -12,7 +12,9 @@ module ClientSearch
     # @param text [String] search term
     # @param sorted [Boolean] will attempt ordering against search term it seems to be free-text
     # @param resolve_for_join_query [Boolean] return results as sub query of (client_id, score) suitable for joins
-    def self.text_searcher(text, sorted:, resolve_for_join_query: false)
+    # @param exclude_ids_for_name_and_ssn [Enumerable, nil] ids to exclude from the SSN-exact-match and
+    #   free-text name-matching branches only; no-op unless passed
+    def self.text_searcher(text, sorted:, resolve_for_join_query: false, exclude_ids_for_name_and_ssn: nil)
       return none unless text.present?
 
       text = text.strip
@@ -38,6 +40,7 @@ module ClientSearch
         where = sa[:PersonalID].matches(text.gsub('-', ''))
       elsif social
         where = sa[:SSN].eq(text.gsub('-', ''))
+        where = where.and(sa[:id].not_in(exclude_ids_for_name_and_ssn.to_a)) if exclude_ids_for_name_and_ssn.present?
       elsif date
         (month, day, year) = text.split('/')
         where = sa[:DOB].eq("#{year}-#{month}-#{day}")
@@ -70,9 +73,10 @@ module ClientSearch
         unless matches_external_ids
           # short circuit the rest of search. Since no external IDS are found, this seems to be free text and we can just return
           # name search results
-          return ClientSearchUtil::NameSearch.perform_as_joinable_query(term: text, clients: self) if resolve_for_join_query
+          name_search_scope = exclude_ids_for_name_and_ssn.present? ? self.where.not(id: exclude_ids_for_name_and_ssn) : self
+          return ClientSearchUtil::NameSearch.perform_as_joinable_query(term: text, clients: name_search_scope) if resolve_for_join_query
 
-          return ClientSearchUtil::NameSearch.perform(term: text, clients: self, sorted: sorted)
+          return ClientSearchUtil::NameSearch.perform(term: text, clients: name_search_scope, sorted: sorted)
         end
       end
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1829,7 +1829,7 @@ module GrdaWarehouse::Hud
       # Get search results from client scope. Then return the unique destination client records that map to those matching source records
       relation = (client_scope || self) # rubocop:disable Style/RedundantParentheses
       # with resolve_for_join_query, results are client.scope.select(:client_id, :score) suitable for subquery
-      results = relation.searchable.text_searcher(text, sorted: sorted, resolve_for_join_query: true)
+      results = relation.searchable.text_searcher(text, sorted: sorted, resolve_for_join_query: true, exclude_ids_for_name_and_ssn: hmis_restricted_source_client_ids)
       return relation.none if results.nil?
 
       grouped = GrdaWarehouse::WarehouseClient.
@@ -1906,6 +1906,7 @@ module GrdaWarehouse::Hud
         where(id: matching_ids).
         preload(:destination_client).
         map { |m| m.destination_client.id }
+      ids -= hmis_restricted_destination_client_ids(ids).to_a
       where(id: ids)
     end
 

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1420,6 +1420,20 @@ module GrdaWarehouse::Hud
       user.policy_context.client_restricted?(id)
     end
 
+    # All currently HMIS-restricted client ids (source and destination alike -- restriction
+    # applies to the whole warehouse identity, see RestrictedClientLoader).
+    def self.hmis_restricted_source_client_ids
+      GrdaWarehouse::AuthPolicies::ContextLoaders::RestrictedClientLoader.new.restricted_client_ids
+    end
+
+    # The subset of the given destination client ids that are HMIS-restricted.
+    def self.hmis_restricted_destination_client_ids(destination_client_ids)
+      return Set.new if destination_client_ids.blank?
+
+      loader = GrdaWarehouse::AuthPolicies::ContextLoaders::RestrictedClientLoader.new
+      destination_client_ids.select { |id| loader.restricted?(id) }.to_set
+    end
+
     def name
       # Deprecated
       # skip deprecations to avoid test failures. Suggest uncommenting when we are ready to implement pii globally

--- a/app/models/grda_warehouse/hud/client.rb
+++ b/app/models/grda_warehouse/hud/client.rb
@@ -1839,11 +1839,13 @@ module GrdaWarehouse::Hud
     # @param client_scope [GrdaWarehouse::Hud::Client.source] source clients to search in
     # @param sorted [Boolean] order results by closest match to text
     # @param with_score [Boolean] add the match score as a #score attribute on results.
-    def self.text_search(text, client_scope: nil, sorted: false, with_score: false)
+    # @param restricted_source_ids [Set<Integer>] source client ids hidden from name/SSN matching;
+    #   pass a preloaded set when calling repeatedly, otherwise it is loaded per call
+    def self.text_search(text, client_scope: nil, sorted: false, with_score: false, restricted_source_ids: hmis_restricted_source_client_ids)
       # Get search results from client scope. Then return the unique destination client records that map to those matching source records
       relation = (client_scope || self) # rubocop:disable Style/RedundantParentheses
       # with resolve_for_join_query, results are client.scope.select(:client_id, :score) suitable for subquery
-      results = relation.searchable.text_searcher(text, sorted: sorted, resolve_for_join_query: true, exclude_ids_for_name_and_ssn: hmis_restricted_source_client_ids)
+      results = relation.searchable.text_searcher(text, sorted: sorted, resolve_for_join_query: true, exclude_ids_for_name_and_ssn: restricted_source_ids)
       return relation.none if results.nil?
 
       grouped = GrdaWarehouse::WarehouseClient.
@@ -2211,8 +2213,9 @@ module GrdaWarehouse::Hud
     def potential_matches
       @potential_matches ||= {}.tap do |m|
         scores_by_id = {}
+        restricted_source_ids = self.class.hmis_restricted_source_client_ids
         potential_match_search_queries.each do |query|
-          self.class.text_search(query, client_scope: self.class, sorted: true, with_score: true).where.not(id: id).each do |candidate|
+          self.class.text_search(query, client_scope: self.class, sorted: true, with_score: true, restricted_source_ids: restricted_source_ids).where.not(id: id).each do |candidate|
             score = candidate.score.to_f
             scores_by_id[candidate.id] = score if scores_by_id[candidate.id].nil? || score > scores_by_id[candidate.id]
           end

--- a/app/models/hud_reports/report_client_base.rb
+++ b/app/models/hud_reports/report_client_base.rb
@@ -38,13 +38,26 @@ module HudReports
       return scope if columns.empty?
 
       sanitized_term = sanitize_sql_like(search_term).downcase
-      lowered_columns = columns.map { |col| Arel::Nodes::NamedFunction.new('LOWER', [col]) }
+      not_restricted = restricted_condition
 
-      conditions = lowered_columns.map do |col|
-        col.matches("%#{sanitized_term}%")
+      conditions = columns.map do |col|
+        condition = Arel::Nodes::NamedFunction.new('LOWER', [col]).matches("%#{sanitized_term}%")
+        condition = condition.and(not_restricted) if not_restricted && pii_search_columns.include?(col)
+        condition
       end
 
       scope.where(conditions.inject(:or)).distinct
+    end
+
+    # A client that is restricted from search must not be discoverable via name/SSN matches
+    # (see app/models/concerns/client_search.rb), even though exact-ID matches remain allowed.
+    def self.restricted_condition
+      return nil if pii_search_columns.empty? || restricted_client_id_columns.empty?
+
+      restricted_ids = GrdaWarehouse::Hud::Client.hmis_restricted_source_client_ids
+      return nil if restricted_ids.blank?
+
+      restricted_client_id_columns.map { |col| col.not_in(restricted_ids.to_a) }.inject(:and)
     end
 
     def self.searchable?
@@ -56,6 +69,14 @@ module HudReports
     end
 
     def self.search_columns
+      []
+    end
+
+    def self.pii_search_columns
+      []
+    end
+
+    def self.restricted_client_id_columns
       []
     end
 

--- a/app/models/hud_reports/report_client_base.rb
+++ b/app/models/hud_reports/report_client_base.rb
@@ -51,13 +51,14 @@ module HudReports
 
     # A client that is restricted from search must not be discoverable via name/SSN matches
     # (see app/models/concerns/client_search.rb), even though exact-ID matches remain allowed.
+    # `NOT IN` is NULL for a NULL column, which would silently drop rows with no client id
     def self.restricted_condition
       return nil if pii_search_columns.empty? || restricted_client_id_columns.empty?
 
       restricted_ids = GrdaWarehouse::Hud::Client.hmis_restricted_source_client_ids
       return nil if restricted_ids.blank?
 
-      restricted_client_id_columns.map { |col| col.not_in(restricted_ids.to_a) }.inject(:and)
+      restricted_client_id_columns.map { |col| col.not_in(restricted_ids.to_a).or(col.eq(nil)) }.inject(:and)
     end
 
     def self.searchable?

--- a/docs/features/hmis/hmis-restricted-records.md
+++ b/docs/features/hmis/hmis-restricted-records.md
@@ -56,7 +56,7 @@ Not redacted: `age`, alerts, and any associated records to the client that the u
 
 ### Downstream effects in the Warehouse
 
-Restricting an HMIS client also redacts their name, SSN, DOB, photo, and HIV status on the warehouse side — the client dashboard, HUD report drilldowns and detail exports, and cohort grids — for every warehouse user, regardless of role, with no override permission. See [Warehouse Auth Policies → PII Redaction](../warehouse/warehouse-auth-policies.md#pii-redaction) for how this is implemented and its documented coverage limitations (several warehouse reports and exports, and the Superset `analytics.client_piis` view, are not mediated by this mechanism and will continue to show the client's real PII).
+Restricting an HMIS client also redacts their name, SSN, DOB, photo, and HIV status on the warehouse side — the client dashboard, HUD report drilldowns and detail exports, and cohort grids — for every warehouse user, regardless of role, with no override permission, and excludes them from every warehouse-side client search path by name or SSN (DOB and exact-ID/PersonalID lookup still work). See [Warehouse Auth Policies → PII Redaction](../warehouse/warehouse-auth-policies.md#pii-redaction) for how redaction is implemented and its documented coverage limitations, and [Warehouse Auth Policies → Search](../warehouse/warehouse-auth-policies.md#search) for the search exclusion (several warehouse reports and exports, and the Superset `analytics.client_piis` view, are not mediated by either mechanism and will continue to show the client's real PII).
 
 ## Architecture
 

--- a/docs/features/warehouse/warehouse-auth-policies.md
+++ b/docs/features/warehouse/warehouse-auth-policies.md
@@ -121,6 +121,12 @@ An HMIS source client marked restricted (see [HMIS Restricted Records](../hmis/h
 
 **Not bounded data source.** HMIS's `restricted_ids_in_data_source` is limited to the data in a single data source on the HMIS front-end.  When we extend the client restriction to the warehouse, we restrict any related source and destination record.
 
+### Search
+
+Restricted clients are also excluded from every warehouse-side client search path by name or SSN — window/admin search, the client-edit merge-candidate search, the new-client duplicate check, cohort "Add Client to Cohort" search, `potential_matches`, the chronic/HUD-chronic report name filters, and the Coordinated Entry client proxy search. DOB search and exact-ID/PersonalID lookup are unaffected, matching the general rule that restriction blocks PII display and search-by-PII, not record access.
+
+`GrdaWarehouse::Hud::Client.hmis_restricted_source_client_ids` computes the excluded id set (both source and destination ids, since restriction is tracked per source client but some search scopes can return destination rows). `ClientSearch#text_searcher` (`app/models/concerns/client_search.rb`, shared by `GrdaWarehouse::Hud::Client` and `Hmis::Hud::Client`) takes this set through an optional `exclude_ids_for_name_and_ssn:` keyword, applied only to the SSN-exact-match and free-text name-matching branches; the keyword defaults to `nil`; `Hmis::Hud::Client`'s own search methods never pass it, so `Hmis::Hud::Client.searchable_to` (see [HMIS Restricted Records](../hmis/hmis-restricted-records.md)) is unaffected by this mechanism. `GrdaWarehouse::Hud::Client.strict_search` excludes restricted destination clients from its final result set entirely, since its 3-of-4-criteria match can never be satisfied by DOB alone. The one search path that doesn't go through `text_searcher` — the new-client duplicate check (`ClientController#look_for_existing_match`) — applies the same exclusion directly to its SSN and name clauses.
+
 ### Known limitations
 
 Coverage is bounded by what actually calls into `PiiProvider`/the `reporting_policy_for_*` methods. The following do not honor restriction, and continue to show a restricted client's real PII:

--- a/drivers/hmis/spec/models/hmis/hud/client_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/client_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Hmis::Hud::Client, type: :model do
         expect(scope.pluck(:id)).to eq(expected_result.map(&:id)) if expected_result.any?
       end
     end
+
+    it 'still matches a client the warehouse excludes from name/SSN search' do
+      c2.mark_as_restricted!(user: hmis_user)
+
+      scope = Hmis::Hud::Client.matching_search_term('jelly bean')
+
+      expect(scope.pluck(:id)).to eq([c2.id])
+    end
   end
 
   describe 'with multiple names' do

--- a/drivers/hmis/spec/models/hmis/hud/client_spec.rb
+++ b/drivers/hmis/spec/models/hmis/hud/client_spec.rb
@@ -48,14 +48,6 @@ RSpec.describe Hmis::Hud::Client, type: :model do
         expect(scope.pluck(:id)).to eq(expected_result.map(&:id)) if expected_result.any?
       end
     end
-
-    it 'still matches a client the warehouse excludes from name/SSN search' do
-      c2.mark_as_restricted!(user: hmis_user)
-
-      scope = Hmis::Hud::Client.matching_search_term('jelly bean')
-
-      expect(scope.pluck(:id)).to eq([c2.id])
-    end
   end
 
   describe 'with multiple names' do

--- a/drivers/hud_apr/app/models/hud_apr/fy2020/apr_client.rb
+++ b/drivers/hud_apr/app/models/hud_apr/fy2020/apr_client.rb
@@ -65,6 +65,16 @@ module HudApr::Fy2020
       ]
     end
 
+    def self.pii_search_columns
+      table = arel_table
+      [table[:first_name], table[:last_name], table[:ssn]]
+    end
+
+    def self.restricted_client_id_columns
+      table = arel_table
+      [table[:client_id], table[:destination_client_id]]
+    end
+
     def self.pluck_project_ids
       distinct.pluck(:project_id)
     end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/episode.rb
@@ -23,6 +23,8 @@ module HudSpmReport::Fy2023
 
     def self.apply_search_scope(scope) = scope.joins(:enrollments)
     def self.search_columns = HudSpmReport::Fy2023::SpmEnrollment.search_columns
+    def self.pii_search_columns = HudSpmReport::Fy2023::SpmEnrollment.pii_search_columns
+    def self.restricted_client_id_columns = HudSpmReport::Fy2023::SpmEnrollment.restricted_client_id_columns
 
     def self.detail_headers
       client_columns = ['client_id', 'enrollment.first_name', 'enrollment.last_name', 'enrollment.personal_id']

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/return.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/return.rb
@@ -20,6 +20,8 @@ module HudSpmReport::Fy2023
 
     def self.apply_search_scope(scope) = scope.left_outer_joins(:exit_enrollment, :return_enrollment)
     def self.search_columns = HudSpmReport::Fy2023::SpmEnrollment.search_columns
+    def self.pii_search_columns = HudSpmReport::Fy2023::SpmEnrollment.pii_search_columns
+    def self.restricted_client_id_columns = HudSpmReport::Fy2023::SpmEnrollment.restricted_client_id_columns
     def project_id = [exit_enrollment, return_enrollment].detect(&:present?)&.enrollment&.project&.id
     def data_source_id = [exit_enrollment&.enrollment&.data_source_id, return_enrollment&.enrollment&.data_source_id].detect(&:present?)
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2023/spm_enrollment.rb
@@ -38,5 +38,14 @@ module HudSpmReport::Fy2023
         Arel::Nodes::NamedFunction.new('CAST', [t[:client_id].as('TEXT')])
       ]
     end
+
+    def self.pii_search_columns
+      t = arel_table
+      [t[:first_name], t[:last_name]]
+    end
+
+    def self.restricted_client_id_columns
+      [arel_table[:client_id]]
+    end
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/episode.rb
@@ -23,6 +23,8 @@ module HudSpmReport::Fy2024
 
     def self.apply_search_scope(scope) = scope.joins(:enrollments)
     def self.search_columns = HudSpmReport::Fy2024::SpmEnrollment.search_columns
+    def self.pii_search_columns = HudSpmReport::Fy2024::SpmEnrollment.pii_search_columns
+    def self.restricted_client_id_columns = HudSpmReport::Fy2024::SpmEnrollment.restricted_client_id_columns
 
     def self.detail_headers
       client_columns = ['client_id', 'enrollment.first_name', 'enrollment.last_name', 'enrollment.personal_id']

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/return.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/return.rb
@@ -20,6 +20,8 @@ module HudSpmReport::Fy2024
 
     def self.apply_search_scope(scope) = scope.left_outer_joins(:exit_enrollment, :return_enrollment)
     def self.search_columns = HudSpmReport::Fy2024::SpmEnrollment.search_columns
+    def self.pii_search_columns = HudSpmReport::Fy2024::SpmEnrollment.pii_search_columns
+    def self.restricted_client_id_columns = HudSpmReport::Fy2024::SpmEnrollment.restricted_client_id_columns
     def project_id = [exit_enrollment, return_enrollment].detect(&:present?)&.enrollment&.project&.id
     def data_source_id = [exit_enrollment&.enrollment&.data_source_id, return_enrollment&.enrollment&.data_source_id].detect(&:present?)
 

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2024/spm_enrollment.rb
@@ -38,5 +38,14 @@ module HudSpmReport::Fy2024
         Arel::Nodes::NamedFunction.new('CAST', [t[:client_id].as('TEXT')])
       ]
     end
+
+    def self.pii_search_columns
+      t = arel_table
+      [t[:first_name], t[:last_name]]
+    end
+
+    def self.restricted_client_id_columns
+      [arel_table[:client_id]]
+    end
   end
 end

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/episode.rb
@@ -55,6 +55,14 @@ module HudSpmReport::Fy2026
       HudSpmReport::Fy2026::SpmEnrollment.search_columns
     end
 
+    def self.pii_search_columns
+      HudSpmReport::Fy2026::SpmEnrollment.pii_search_columns
+    end
+
+    def self.restricted_client_id_columns
+      HudSpmReport::Fy2026::SpmEnrollment.restricted_client_id_columns
+    end
+
     def self.pluck_project_ids
       project_table = GrdaWarehouse::Hud::Project.arel_table
       joins(enrollments: { enrollment: :project }).distinct.pluck(project_table[:id])

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/return.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/return.rb
@@ -26,6 +26,14 @@ module HudSpmReport::Fy2026
       HudSpmReport::Fy2026::SpmEnrollment.search_columns
     end
 
+    def self.pii_search_columns
+      HudSpmReport::Fy2026::SpmEnrollment.pii_search_columns
+    end
+
+    def self.restricted_client_id_columns
+      HudSpmReport::Fy2026::SpmEnrollment.restricted_client_id_columns
+    end
+
     # duck-types to enrollment
     def project_id
       [exit_enrollment, return_enrollment].detect(&:present?)&.enrollment&.project&.id

--- a/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
+++ b/drivers/hud_spm_report/app/models/hud_spm_report/fy2026/spm_enrollment.rb
@@ -204,6 +204,15 @@ module HudSpmReport::Fy2026
       ]
     end
 
+    def self.pii_search_columns
+      table = arel_table
+      [table[:first_name], table[:last_name]]
+    end
+
+    def self.restricted_client_id_columns
+      [arel_table[:client_id]]
+    end
+
     private_class_method def self.current_income_benefits(enrollment, end_date)
       # Exit assessment for leavers, or most recent annual update within report range for stayers
       if enrollment.exit.present? && enrollment.exit.exit_date <= end_date

--- a/drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb
+++ b/drivers/hud_spm_report/spec/models/fy2026/spm_enrollment_spec.rb
@@ -104,4 +104,40 @@ RSpec.describe HudSpmReport::Fy2026::SpmEnrollment, type: :model, exclude_fixpoi
       expect(spm_enrollments[ds2.id].age).to eq(52)
     end
   end
+
+  describe '.search_clients' do
+    let!(:hmis_ds) { create(:hmis_primary_data_source) }
+    let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+    let!(:restricted_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Restrictedfirst', last_name: 'Restrictedlast') }
+    let!(:open_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Openfirst', last_name: 'Openlast') }
+    let!(:restricted_enrollment) do
+      HudSpmReport::Fy2026::SpmEnrollment.new(
+        first_name: restricted_client.first_name, last_name: restricted_client.last_name,
+        personal_id: restricted_client.personal_id, client_id: restricted_client.id
+      ).tap { |record| record.save!(validate: false) }
+    end
+    let!(:open_enrollment) do
+      HudSpmReport::Fy2026::SpmEnrollment.new(
+        first_name: open_client.first_name, last_name: open_client.last_name,
+        personal_id: open_client.personal_id, client_id: open_client.id
+      ).tap { |record| record.save!(validate: false) }
+    end
+
+    before { restricted_client.mark_as_restricted!(user: hmis_user) }
+
+    it 'excludes a restricted client from a name search' do
+      results = HudSpmReport::Fy2026::SpmEnrollment.search_clients(HudSpmReport::Fy2026::SpmEnrollment.all, 'Restrictedlast')
+      expect(results).not_to include(restricted_enrollment)
+    end
+
+    it 'still returns a non-restricted client from a name search' do
+      results = HudSpmReport::Fy2026::SpmEnrollment.search_clients(HudSpmReport::Fy2026::SpmEnrollment.all, 'Openlast')
+      expect(results).to include(open_enrollment)
+    end
+
+    it 'still returns a restricted client from an exact personal_id search' do
+      results = HudSpmReport::Fy2026::SpmEnrollment.search_clients(HudSpmReport::Fy2026::SpmEnrollment.all, restricted_enrollment.personal_id)
+      expect(results).to include(restricted_enrollment)
+    end
+  end
 end

--- a/spec/controllers/concerns/hud_reports/cell_drilldown_concern_spec.rb
+++ b/spec/controllers/concerns/hud_reports/cell_drilldown_concern_spec.rb
@@ -92,5 +92,37 @@ RSpec.describe HudReports::CellDrilldownConcern, type: :controller do
       expect(response).to redirect_to('/cell')
       expect(flash[:error]).to eq('Search query not found')
     end
+
+    context 'with a restricted client in the drilldown scope' do
+      let!(:hmis_ds) { create(:hmis_primary_data_source) }
+      let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+      let!(:restricted_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Restrictedfirst', last_name: 'Restrictedlast') }
+      let!(:restricted_apr_client) do
+        create(
+          :hud_report_apr_client, first_name: restricted_client.first_name, last_name: restricted_client.last_name,
+                                  personal_id: restricted_client.personal_id, client_id: restricted_client.id,
+                                  destination_client_id: restricted_client.id
+        )
+      end
+
+      before do
+        restricted_client.mark_as_restricted!(user: hmis_user)
+        allow(controller).to(receive(:pagy).and_wrap_original { |_original, scope, **| [double('pagy', offset: 0), scope] })
+      end
+
+      it 'excludes the restricted client when searching by name' do
+        search_query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'Restrictedlast' })
+
+        get :search, params: { report_id: 1, id: 'A1', table: 'T1', query_id: search_query.id }
+        expect(assigns(:clients)).not_to include(restricted_apr_client)
+      end
+
+      it 'still returns the restricted client when searching by personal_id' do
+        search_query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: restricted_apr_client.personal_id })
+
+        get :search, params: { report_id: 1, id: 'A1', table: 'T1', query_id: search_query.id }
+        expect(assigns(:clients)).to include(restricted_apr_client)
+      end
+    end
   end
 end

--- a/spec/models/concerns/client_search_spec.rb
+++ b/spec/models/concerns/client_search_spec.rb
@@ -1,0 +1,46 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClientSearch do
+  let!(:target_client) { create(:authoritative_hud_client, FirstName: 'Zzexclude', LastName: 'Zztarget', SSN: '999887777', DOB: Date.new(1980, 5, 5)) }
+  let!(:other_client) { create(:authoritative_hud_client, FirstName: 'Zzopen', LastName: 'Zzother', SSN: '111223333', DOB: Date.new(1981, 6, 6)) }
+
+  describe '.text_searcher' do
+    it 'excludes a listed id from an SSN match' do
+      results = GrdaWarehouse::Hud::Client.searchable.text_searcher('999-88-7777', sorted: false, exclude_ids_for_name_and_ssn: [target_client.id])
+
+      expect(results.to_a).to eq([])
+    end
+
+    it 'does not exclude an SSN match for an id that is not in the list' do
+      results = GrdaWarehouse::Hud::Client.searchable.text_searcher('999-88-7777', sorted: false, exclude_ids_for_name_and_ssn: [other_client.id])
+
+      expect(results.to_a).to eq([target_client])
+    end
+
+    it 'excludes a listed id from a name match' do
+      results = GrdaWarehouse::Hud::Client.searchable.text_searcher('Zzexclude Zztarget', sorted: false, exclude_ids_for_name_and_ssn: [target_client.id])
+
+      expect(results.to_a).to eq([])
+    end
+
+    it 'does not exclude a DOB match for the same id' do
+      results = GrdaWarehouse::Hud::Client.searchable.text_searcher('05/05/1980', sorted: false, exclude_ids_for_name_and_ssn: [target_client.id])
+
+      expect(results.to_a).to eq([target_client])
+    end
+
+    it 'does not exclude anything when the parameter is omitted' do
+      results = GrdaWarehouse::Hud::Client.searchable.text_searcher('999-88-7777', sorted: false)
+
+      expect(results.to_a).to eq([target_client])
+    end
+  end
+end

--- a/spec/models/grda_warehouse/hud/client_merge_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_merge_spec.rb
@@ -419,5 +419,37 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
 
       expect(matches.count).to eq(GrdaWarehouse::Hud::Client::POTENTIAL_MATCHES_LIMIT)
     end
+
+    context 'with HMIS-restricted candidates' do
+      let!(:hmis_ds) { create(:hmis_primary_data_source) }
+      let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+
+      before do
+        own_source = create(:hud_client, FirstName: 'Roberta', LastName: 'Smithers', data_source_id: source_ds.id)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: client.id, source_id: own_source.id, id_in_source: own_source.PersonalID)
+      end
+
+      it 'excludes candidates whose source client is restricted' do
+        restricted_source = create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Roberta', last_name: 'Smithers')
+        restricted_destination = create(:hud_client, data_source_id: destination_ds.id)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination.id, source_id: restricted_source.id, id_in_source: restricted_source.PersonalID)
+        restricted_source.mark_as_restricted!(user: hmis_user)
+
+        open_source = create(:hud_client, FirstName: 'Roberta', LastName: 'Smithers', data_source_id: source_ds.id)
+        open_destination = create(:hud_client, data_source_id: destination_ds.id)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: open_destination.id, source_id: open_source.id, id_in_source: open_source.PersonalID)
+
+        expect(client.potential_matches[:by_name].to_a).to eq([open_destination])
+      end
+
+      it 'loads the restricted client set once, not once per source-name search' do
+        second_name_source = create(:hud_client, FirstName: 'Zachary', LastName: 'Quinnson', data_source_id: source_ds.id)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: client.id, source_id: second_name_source.id, id_in_source: second_name_source.PersonalID)
+
+        expect(GrdaWarehouse::AuthPolicies::ContextLoaders::RestrictedClientLoader).to receive(:new).once.and_call_original
+
+        client.potential_matches
+      end
+    end
   end
 end

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -170,6 +170,80 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
         whitespace_strict_search_expects(client_leading_whitespace)
       end
     end
+
+    describe 'text_search with HMIS restriction' do
+      let!(:hmis_ds) { create(:hmis_primary_data_source) }
+      let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+      let!(:restricted_source_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrict', last_name: 'Zzclient', ssn: '999887777', dob: Date.new(1980, 5, 5)) }
+      let!(:restricted_destination_client) { create(:grda_warehouse_hud_client) }
+      let!(:unrestricted_source_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzopen', last_name: 'Zzclient', ssn: '111223333', dob: Date.new(1981, 6, 6)) }
+      let!(:unrestricted_destination_client) { create(:grda_warehouse_hud_client) }
+
+      before do
+        GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination_client.id, source_id: restricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: restricted_source_client.id.to_s)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: unrestricted_destination_client.id, source_id: unrestricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: unrestricted_source_client.id.to_s)
+        restricted_source_client.mark_as_restricted!(user: hmis_user)
+      end
+
+      it 'does not find a restricted client by SSN' do
+        expect(GrdaWarehouse::Hud::Client.text_search('999-88-7777').to_a).to eq([])
+      end
+
+      it 'still finds an unrestricted client by SSN' do
+        expect(GrdaWarehouse::Hud::Client.text_search('111-22-3333').to_a).to eq([unrestricted_destination_client])
+      end
+
+      it 'does not find a restricted client by name' do
+        expect(GrdaWarehouse::Hud::Client.text_search('Zzrestrict Zzclient').to_a).to eq([])
+      end
+
+      it 'still finds a restricted client by DOB' do
+        expect(GrdaWarehouse::Hud::Client.text_search('05/05/1980').to_a).to eq([restricted_destination_client])
+      end
+
+      it 'still finds a restricted client by exact PersonalID' do
+        expect(GrdaWarehouse::Hud::Client.text_search(restricted_source_client.PersonalID).to_a).to eq([restricted_destination_client])
+      end
+    end
+
+    describe 'strict_search with HMIS restriction' do
+      let!(:hmis_ds) { create(:hmis_primary_data_source) }
+      let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+      let!(:restricted_source_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrict', last_name: 'Zzclient', ssn: '999887777', dob: Date.new(1980, 5, 5)) }
+      let!(:restricted_destination_client) { create(:grda_warehouse_hud_client) }
+      let!(:unrestricted_source_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzopen', last_name: 'Zzclient', ssn: '111223333', dob: Date.new(1981, 6, 6)) }
+      let!(:unrestricted_destination_client) { create(:grda_warehouse_hud_client) }
+
+      before do
+        GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination_client.id, source_id: restricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: restricted_source_client.id.to_s)
+        GrdaWarehouse::WarehouseClient.create!(destination_id: unrestricted_destination_client.id, source_id: unrestricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: unrestricted_source_client.id.to_s)
+        restricted_source_client.mark_as_restricted!(user: hmis_user)
+      end
+
+      it 'excludes a restricted client matching on name and SSN' do
+        criteria = { first_name: 'Zzrestrict', last_name: 'Zzclient', ssn: '999887777', dob: nil }
+
+        expect(GrdaWarehouse::Hud::Client.strict_search(criteria, client_scope: GrdaWarehouse::Hud::Client).to_a).to eq([])
+      end
+
+      it 'excludes a restricted client matching on name and DOB' do
+        criteria = { first_name: 'Zzrestrict', last_name: 'Zzclient', ssn: nil, dob: Date.new(1980, 5, 5) }
+
+        expect(GrdaWarehouse::Hud::Client.strict_search(criteria, client_scope: GrdaWarehouse::Hud::Client).to_a).to eq([])
+      end
+
+      it 'excludes a restricted client matching on SSN, DOB, and last name' do
+        criteria = { first_name: 'Nomatch', last_name: 'Zzclient', ssn: '999887777', dob: Date.new(1980, 5, 5) }
+
+        expect(GrdaWarehouse::Hud::Client.strict_search(criteria, client_scope: GrdaWarehouse::Hud::Client).to_a).to eq([])
+      end
+
+      it 'still returns an unrestricted client matching the same shape of criteria' do
+        criteria = { first_name: 'Zzopen', last_name: 'Zzclient', ssn: '111223333', dob: nil }
+
+        expect(GrdaWarehouse::Hud::Client.strict_search(criteria, client_scope: GrdaWarehouse::Hud::Client).to_a).to eq([unrestricted_destination_client])
+      end
+    end
   end
 
   describe 'scopes' do

--- a/spec/models/grda_warehouse/hud/client_spec.rb
+++ b/spec/models/grda_warehouse/hud/client_spec.rb
@@ -204,6 +204,12 @@ RSpec.describe GrdaWarehouse::Hud::Client, type: :model do
       it 'still finds a restricted client by exact PersonalID' do
         expect(GrdaWarehouse::Hud::Client.text_search(restricted_source_client.PersonalID).to_a).to eq([restricted_destination_client])
       end
+
+      it 'excludes the caller-supplied restricted_source_ids instead of loading the restricted set' do
+        results = GrdaWarehouse::Hud::Client.text_search('Zzclient', restricted_source_ids: Set[unrestricted_source_client.id])
+
+        expect(results.to_a).to eq([restricted_destination_client])
+      end
     end
 
     describe 'strict_search with HMIS restriction' do

--- a/spec/models/hud_reports/report_client_base_spec.rb
+++ b/spec/models/hud_reports/report_client_base_spec.rb
@@ -149,6 +149,53 @@ RSpec.describe HudReports::ReportClientBase, type: :model do
     end
   end
 
+  describe '.search_clients' do
+    let!(:hmis_ds) { create(:hmis_primary_data_source) }
+    let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+    let!(:restricted_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Restrictedfirst', last_name: 'Restrictedlast') }
+    let!(:open_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Openfirst', last_name: 'Openlast') }
+    let!(:restricted_apr_client) do
+      create(
+        :hud_report_apr_client, first_name: restricted_client.first_name, last_name: restricted_client.last_name,
+                                personal_id: restricted_client.personal_id, client_id: restricted_client.id,
+                                destination_client_id: restricted_client.id
+      )
+    end
+    let!(:open_apr_client) do
+      create(
+        :hud_report_apr_client, first_name: open_client.first_name, last_name: open_client.last_name,
+                                personal_id: open_client.personal_id, client_id: open_client.id,
+                                destination_client_id: open_client.id
+      )
+    end
+
+    before { restricted_client.mark_as_restricted!(user: hmis_user) }
+
+    it 'excludes a restricted client from a name search' do
+      results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, 'Restrictedlast')
+      expect(results).not_to include(restricted_apr_client)
+    end
+
+    it 'still returns a non-restricted client from a name search' do
+      results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, 'Openlast')
+      expect(results).to include(open_apr_client)
+    end
+
+    it 'still returns a restricted client from an exact personal_id search' do
+      results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, restricted_apr_client.personal_id)
+      expect(results).to include(restricted_apr_client)
+    end
+
+    it 'still returns a restricted client from an exact destination_client_id search' do
+      results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, restricted_apr_client.destination_client_id.to_s)
+      expect(results).to include(restricted_apr_client)
+    end
+
+    it 'does not filter models that do not declare pii_search_columns' do
+      expect(HudSpmReport::Fy2020::SpmClient.pii_search_columns).to eq([])
+    end
+  end
+
   describe '#destination_client_id_for_pii' do
     it 'returns destination_client_id when the column exists' do
       apr_client = HudApr::Fy2020::AprClient.new(destination_client_id: 42)

--- a/spec/models/hud_reports/report_client_base_spec.rb
+++ b/spec/models/hud_reports/report_client_base_spec.rb
@@ -181,6 +181,12 @@ RSpec.describe HudReports::ReportClientBase, type: :model do
       expect(results).to include(open_apr_client)
     end
 
+    it 'still returns a name match whose client id columns are null' do
+      orphan_apr_client = create(:hud_report_apr_client, first_name: 'Orphanfirst', last_name: 'Orphanlast', client_id: nil, destination_client_id: nil)
+      results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, 'Orphanlast')
+      expect(results).to include(orphan_apr_client)
+    end
+
     it 'still returns a restricted client from an exact personal_id search' do
       results = HudApr::Fy2020::AprClient.search_clients(HudApr::Fy2020::AprClient.all, restricted_apr_client.personal_id)
       expect(results).to include(restricted_apr_client)

--- a/spec/requests/clients_controller_restricted_duplicate_check_spec.rb
+++ b/spec/requests/clients_controller_restricted_duplicate_check_spec.rb
@@ -1,0 +1,60 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClientsController, '#create restricted client duplicate check', type: :request do
+  let(:source_ds) { create(:source_data_source) }
+  let(:hmis_ds) { create(:hmis_primary_data_source) }
+  let(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
+  let(:user) { create(:user) }
+
+  let!(:restricted_source_client) { create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrict', last_name: 'Zzclient', ssn: '999887777', dob: Date.new(1980, 5, 5)) }
+  let!(:restricted_destination_client) { create(:grda_warehouse_hud_client, FirstName: 'Zzrestrict', LastName: 'Zzclient', SSN: '999887777', DOB: Date.new(1980, 5, 5)) }
+
+  before do
+    GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination_client.id, source_id: restricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: restricted_source_client.id.to_s)
+    restricted_source_client.mark_as_restricted!(user: hmis_user)
+
+    user.legacy_roles << create(:role, can_create_clients: true, can_search_all_clients: true)
+    create(:destination_data_source)
+    sign_in user
+  end
+
+  def base_params(overrides)
+    { client: { FirstName: 'Zzrestrict', LastName: 'Zzclient', DOB: '1980-05-05', SSN: '999-88-7777', data_source_id: source_ds.id }.merge(overrides) }
+  end
+
+  it 'creates the client outright when SSN and DOB match but the only shared name+field pair is SSN+DOB on a restricted client' do
+    expect do
+      post clients_path, params: base_params(FirstName: 'Different', LastName: 'Person')
+    end.to change(GrdaWarehouse::Hud::Client, :count).by(2) # source + destination
+
+    expect(flash[:notice]).to match(/created/)
+  end
+
+  it 'creates the client outright when name and DOB match but SSN differs on a restricted client' do
+    expect do
+      post clients_path, params: base_params(SSN: '111-22-3333')
+    end.to change(GrdaWarehouse::Hud::Client, :count).by(2)
+
+    expect(flash[:notice]).to match(/created/)
+  end
+
+  it 'still flags an obvious duplicate for an unrestricted client matching on name and DOB' do
+    unrestricted_source_client = create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzopen', last_name: 'Zzclient', ssn: '444556666', dob: Date.new(1982, 7, 7))
+    unrestricted_destination_client = create(:grda_warehouse_hud_client, FirstName: 'Zzopen', LastName: 'Zzclient', SSN: '444556666', DOB: Date.new(1982, 7, 7))
+    GrdaWarehouse::WarehouseClient.create!(destination_id: unrestricted_destination_client.id, source_id: unrestricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: unrestricted_source_client.id.to_s)
+
+    expect do
+      post clients_path, params: base_params(FirstName: 'Zzopen', LastName: 'Zzclient', SSN: '999-99-9999', DOB: '1982-07-07')
+    end.not_to change(GrdaWarehouse::Hud::Client, :count)
+
+    expect(flash[:notice]).to be_nil
+  end
+end

--- a/spec/requests/cohorts/clients_spec.rb
+++ b/spec/requests/cohorts/clients_spec.rb
@@ -123,6 +123,24 @@ RSpec.describe Cohorts::ClientsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
 
+      it 'does not show a restricted client matched by name' do
+        hmis_ds = create(:hmis_primary_data_source)
+        hmis_user = create(:hmis_user, data_source: hmis_ds)
+        restricted_source_client = create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrictcohort', last_name: 'Zzclientsensitive')
+        restricted_destination_client = create(:grda_warehouse_hud_client, FirstName: 'Zzrestrictcohort', LastName: 'Zzclientsensitive')
+        GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination_client.id, source_id: restricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: restricted_source_client.id.to_s)
+        restricted_source_client.mark_as_restricted!(user: hmis_user)
+        restricted_query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'Zzrestrictcohort' })
+
+        get cohort_cohort_client_search_query_path(cohort_id: cohort.id, id: restricted_query.id)
+
+        expect(response).to have_http_status(:ok)
+        # 'Zzrestrictcohort' itself is echoed back into the search box's value= attribute
+        # regardless of results, so assert on the last name instead — it only appears if a
+        # client row actually rendered.
+        expect(response.body).not_to include('Zzclientsensitive')
+      end
+
       context 'when a matching client has been marked restricted in HMIS' do
         let!(:hmis_ds) { create(:hmis_primary_data_source, visible_in_window: true) }
         let!(:hmis_user) { create(:hmis_user, data_source: hmis_ds) }
@@ -149,11 +167,11 @@ RSpec.describe Cohorts::ClientsController, type: :request do
           setup_access_control(user, cohort_role, hmis_ds_viewable_collection)
         end
 
-        it 'redacts the restricted client while leaving the unrestricted client intact' do
+        it 'excludes the restricted client entirely from a name search, while leaving the unrestricted client intact' do
           get cohort_cohort_client_search_query_path(cohort_id: cohort.id, id: search_query.id)
 
           expect(response).to have_http_status(:ok)
-          expect(response.body).to include('Name Redacted')
+          expect(response.body).not_to include('Name Redacted')
           expect(response.body).not_to include('Sensitive')
           expect(response.body).not_to include('111223333')
 

--- a/spec/requests/cohorts/clients_spec.rb
+++ b/spec/requests/cohorts/clients_spec.rb
@@ -124,20 +124,36 @@ RSpec.describe Cohorts::ClientsController, type: :request do
       end
 
       it 'does not show a restricted client matched by name' do
-        hmis_ds = create(:hmis_primary_data_source)
+        hmis_ds = create(:hmis_primary_data_source, visible_in_window: true)
         hmis_user = create(:hmis_user, data_source: hmis_ds)
+        hmis_ds_viewable_collection = create(:collection)
+        hmis_ds_viewable_collection.add_viewable(hmis_ds)
+        setup_access_control(user, cohort_role, hmis_ds_viewable_collection)
+        # source_data_source_ids/destination_data_source_ids are cached for an hour (see
+        # GrdaWarehouse::DataSource); invalidate so the newly-created HMIS data source is
+        # picked up by full-text search.
+        Rails.cache.delete(:source_data_source_ids)
+        Rails.cache.delete(:destination_data_source_ids)
+
         restricted_source_client = create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrictcohort', last_name: 'Zzclientsensitive')
         restricted_destination_client = create(:grda_warehouse_hud_client, FirstName: 'Zzrestrictcohort', LastName: 'Zzclientsensitive')
         GrdaWarehouse::WarehouseClient.create!(destination_id: restricted_destination_client.id, source_id: restricted_source_client.id, data_source_id: hmis_ds.id, id_in_source: restricted_source_client.id.to_s)
         restricted_source_client.mark_as_restricted!(user: hmis_user)
+        # Unrestricted sibling matching the same search term, so the assertions below can't
+        # pass merely because the search returned nothing at all.
+        open_source_client = create(:hmis_hud_client, data_source: hmis_ds, first_name: 'Zzrestrictcohort', last_name: 'Zzclientopen')
+        open_destination_client = create(:grda_warehouse_hud_client, FirstName: 'Zzrestrictcohort', LastName: 'Zzclientopen')
+        GrdaWarehouse::WarehouseClient.create!(destination_id: open_destination_client.id, source_id: open_source_client.id, data_source_id: hmis_ds.id, id_in_source: open_source_client.id.to_s)
         restricted_query = create(:grda_warehouse_client_search_query, created_by: user, params: { q: 'Zzrestrictcohort' })
 
         get cohort_cohort_client_search_query_path(cohort_id: cohort.id, id: restricted_query.id)
 
         expect(response).to have_http_status(:ok)
-        # 'Zzrestrictcohort' itself is echoed back into the search box's value= attribute
-        # regardless of results, so assert on the last name instead — it only appears if a
-        # client row actually rendered.
+        expect(response.body).to include('Zzclientopen')
+        # The restricted client must be excluded from the result set entirely, not merely
+        # redacted in place — a generic "Name Redacted" row would also satisfy the older,
+        # weaker assertion that just checked for the absence of the real last name.
+        expect(response.body).not_to include('Name Redacted')
         expect(response.body).not_to include('Zzclientsensitive')
       end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adjusts the various methods of searching for clients so that restricted clients will not show in search results when searching by name or SSN.  They continue to show when searching by DOB, PersonalID, or warehouse ID.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [x] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

