### PR TITLE
Use a new column for reporting on report usage

### DIFF
--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -59,10 +59,10 @@ class ActivityLog < ApplicationRecord
   # db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb); run out of band via
   # TaskQueue rather than in that migration, since activity_logs is too large to backfill within a
   # deployment's migration window.
-  def self.backfill_reporting_path!
+  def self.backfill_reporting_path!(batch_size: 1000)
     loop do
       updated = where(reporting_path: nil).
-        limit(1000).
+        limit(batch_size).
         update_all(reporting_path: Arel.sql("left(path, #{REPORTING_PATH_LENGTH})"))
       break if updated.zero?
     end

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -62,6 +62,7 @@ class ActivityLog < ApplicationRecord
   def self.backfill_reporting_path!(batch_size: 1000)
     loop do
       updated = where(reporting_path: nil).
+        where.not(path: nil).
         limit(batch_size).
         update_all(reporting_path: Arel.sql("left(path, #{REPORTING_PATH_LENGTH})"))
       break if updated.zero?

--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -11,6 +11,16 @@ class ActivityLog < ApplicationRecord
 
   belongs_to :user
 
+  # `path` is request.fullpath (path + query string), which is otherwise unbounded and can exceed
+  # Postgres's btree index row limit. `path` also serves as an unmodified audit trail elsewhere, so
+  # it can't be truncated or excluded from anything itself; report-usage matching instead uses
+  # `reporting_path`, an always-short mirror kept in sync by the before_save callback below (and
+  # backfilled for existing rows in db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb).
+  # Report urls are always far shorter than this, so no report-matching condition is affected by it.
+  REPORTING_PATH_LENGTH = 200
+
+  before_save :set_reporting_path
+
   scope :created_in_range, ->(range:) do
     where(created_at: range)
   end
@@ -38,11 +48,24 @@ class ActivityLog < ApplicationRecord
   # 'warehouse_reports/chronic_housed' traffic too, misattributing it via first-match-wins).
   def self.default_report_condition(url)
     at = arel_table
-    at[:path].eq("/#{url}").or(at[:path].matches("/#{url}/%")).or(at[:path].matches("/#{url}?%"))
+    at[:reporting_path].eq("/#{url}").or(at[:reporting_path].matches("/#{url}/%")).or(at[:reporting_path].matches("/#{url}?%"))
   end
 
   def clean_object_name
     item_model&.gsub('GrdaWarehouse::Hud::', '')
+  end
+
+  # Backfills reporting_path for rows that predate it (see
+  # db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb); run out of band via
+  # TaskQueue rather than in that migration, since activity_logs is too large to backfill within a
+  # deployment's migration window.
+  def self.backfill_reporting_path!
+    loop do
+      updated = where(reporting_path: nil).
+        limit(1000).
+        update_all(reporting_path: Arel.sql("left(path, #{REPORTING_PATH_LENGTH})"))
+      break if updated.zero?
+    end
   end
 
   # increment can be: minute, hour, day, week, month, year
@@ -118,5 +141,9 @@ class ActivityLog < ApplicationRecord
       row[:path] = row[:path].sub("/reports/#{id}/", "/reports/#{name.parameterize}/")
     end
     row
+  end
+
+  private def set_reporting_path
+    self.reporting_path = path&.first(REPORTING_PATH_LENGTH)
   end
 end

--- a/app/models/grda_warehouse/warehouse_reports/report_definition.rb
+++ b/app/models/grda_warehouse/warehouse_reports/report_definition.rb
@@ -583,8 +583,8 @@ module GrdaWarehouse::WarehouseReports
             # sub-routes when they were actually referred from the report page itself; a plain
             # /censuses visit always counts. Used by AccessLogs::WarehouseReports::UsageSummary.
             reporting_query: ->(at) {
-              at[:path].eq('/censuses').or(
-                at[:path].matches('/censuses/%').and(
+              at[:reporting_path].eq('/censuses').or(
+                at[:reporting_path].matches('/censuses/%').and(
                   at[:referrer].matches('%/censuses').
                     or(at[:referrer].matches('%/censuses/%')).
                     or(at[:referrer].matches('%/censuses?%')),

--- a/app/models/task_queue.rb
+++ b/app/models/task_queue.rb
@@ -111,5 +111,11 @@ class TaskQueue < ApplicationRecord
     config.queued_tasks[:repair_cohort_column_state] = -> do
       GrdaWarehouse::Cohorts::RepairColumnState.run!
     end
+
+    # Backfill ActivityLog#reporting_path for rows that predate it (see
+    # db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb)
+    config.queued_tasks[:backfill_activity_log_reporting_path] = -> do
+      ActivityLog.backfill_reporting_path!
+    end
   end
 end

--- a/db/migrate/20260820120000_add_path_and_created_at_index_to_activity_logs.rb
+++ b/db/migrate/20260820120000_add_path_and_created_at_index_to_activity_logs.rb
@@ -7,20 +7,11 @@
 # frozen_string_literal: true
 
 class AddPathAndCreatedAtIndexToActivityLogs < ActiveRecord::Migration[7.2]
-  # activity_logs is a large, frequently-written-to table; a plain (transactional)
-  # index build would hold a long-lived lock against it. This migration only adds
-  # the index, so a failed concurrent build just leaves an invalid index to drop
-  # and retry, without affecting any other migration.
-  # rubocop:disable Migrations/DisableDdlTransaction
-  disable_ddl_transaction!
-
+  # This migration originally added an index directly on `path`, which is unbounded and can exceed
+  # Postgres's ~2704 byte btree row limit on some installations. Left as a no-op rather than edited
+  # further, since it has already run (successfully or not) in deployed environments; the index it
+  # would have built is dropped, and replaced with one on ActivityLog#reporting_path, in
+  # db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb.
   def change
-    safety_assured do
-      add_index :activity_logs, [:path, :created_at],
-                name: 'index_activity_logs_on_path_and_created_at',
-                opclass: { path: :varchar_pattern_ops },
-                algorithm: :concurrently
-    end
   end
-  # rubocop:enable Migrations/DisableDdlTransaction
 end

--- a/db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb
+++ b/db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb
@@ -1,0 +1,34 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddReportingPathToActivityLogs < ActiveRecord::Migration[7.2]
+  # rubocop:disable Migrations/DisableDdlTransaction
+  disable_ddl_transaction!
+
+  # `path` is an unmodified audit trail elsewhere and can't be bounded, so report-usage matching
+  # instead uses this always-short mirror; see ActivityLog#reporting_path. Also drops the index
+  # db/migrate/20260820120000_add_path_and_created_at_index_to_activity_logs.rb would have built
+  # directly on `path`, for installations where it already ran before that became a no-op.
+  #
+  # Existing rows are backfilled out of band via TaskQueue (see
+  # TaskQueue.register_tasks' :backfill_activity_log_reporting_path) rather than here, so this
+  # migration stays fast regardless of table size; new rows get reporting_path immediately via
+  # ActivityLog's before_save callback.
+  def up
+    safety_assured do
+      remove_index :activity_logs, name: 'index_activity_logs_on_path_and_created_at', algorithm: :concurrently, if_exists: true
+    end
+
+    add_column :activity_logs, :reporting_path, :string
+  end
+
+  def down
+    remove_column :activity_logs, :reporting_path
+  end
+  # rubocop:enable Migrations/DisableDdlTransaction
+end

--- a/db/migrate/20260827151000_add_reporting_path_index_to_activity_logs.rb
+++ b/db/migrate/20260827151000_add_reporting_path_index_to_activity_logs.rb
@@ -1,0 +1,28 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddReportingPathIndexToActivityLogs < ActiveRecord::Migration[7.2]
+  # activity_logs is a large, frequently-written-to table; a plain (transactional)
+  # index build would hold a long-lived lock against it. This migration only adds
+  # the index, so a failed concurrent build just leaves an invalid index to drop
+  # and retry, without affecting any other migration.
+  # rubocop:disable Migrations/DisableDdlTransaction
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_index(
+        :activity_logs, [:reporting_path, :created_at],
+        name: 'index_activity_logs_on_reporting_path_and_created_at',
+        opclass: { reporting_path: :varchar_pattern_ops },
+        algorithm: :concurrently
+      )
+    end
+  end
+  # rubocop:enable Migrations/DisableDdlTransaction
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -363,7 +363,8 @@ CREATE TABLE public.activity_logs (
     session_hash character varying,
     referrer text,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    reporting_path character varying
 );
 
 
@@ -3581,10 +3582,10 @@ CREATE INDEX index_activity_logs_on_item_model_and_user_id_and_created_at ON pub
 
 
 --
--- Name: index_activity_logs_on_path_and_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_activity_logs_on_reporting_path_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_activity_logs_on_path_and_created_at ON public.activity_logs USING btree (path varchar_pattern_ops, created_at);
+CREATE INDEX index_activity_logs_on_reporting_path_and_created_at ON public.activity_logs USING btree (reporting_path varchar_pattern_ops, created_at);
 
 
 --
@@ -4243,6 +4244,8 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260827151000'),
+('20260827150000'),
 ('20260820120000'),
 ('20260805120000'),
 ('20260804130000'),

--- a/spec/models/activity_log_spec.rb
+++ b/spec/models/activity_log_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe ActivityLog do
 
       expect(described_class.warehouse_reports).to include(entry)
     end
+
+    it 'excludes an entry whose path matches a report url but whose reporting_path has not been backfilled' do
+      entry = log(path: '/warehouse_reports/chronic/1234')
+      entry.update_column(:reporting_path, nil)
+
+      expect(described_class.warehouse_reports).not_to include(entry)
+    end
   end
 
   describe '.warehouse_report_conditions' do
@@ -123,6 +130,15 @@ RSpec.describe ActivityLog do
       described_class.backfill_reporting_path!
 
       expect(entry.reload.reporting_path).to eq('/something/else')
+    end
+
+    it 'backfills every row across multiple batches, not just the first' do
+      entries = Array.new(5) { |i| log(path: "/warehouse_reports/chronic/#{i}") }
+      entries.each { |entry| entry.update_column(:reporting_path, nil) }
+
+      described_class.backfill_reporting_path!(batch_size: 2)
+
+      expect(entries.map { |entry| entry.reload.reporting_path }).to eq(entries.map(&:path))
     end
   end
 

--- a/spec/models/activity_log_spec.rb
+++ b/spec/models/activity_log_spec.rb
@@ -75,4 +75,67 @@ RSpec.describe ActivityLog do
       expect(described_class.where(condition_for('warehouse_reports/chronic'))).to include(entry)
     end
   end
+
+  describe '#reporting_path' do
+    it 'mirrors the first REPORTING_PATH_LENGTH characters of path on save' do
+      long_path = "/warehouse_reports/chronic/#{'a' * described_class::REPORTING_PATH_LENGTH}"
+      entry = log(path: long_path)
+
+      expect(entry.reload.reporting_path).to eq(long_path.first(described_class::REPORTING_PATH_LENGTH))
+    end
+
+    it 'does not modify the stored path of an entry longer than REPORTING_PATH_LENGTH' do
+      long_path = "/warehouse_reports/chronic/#{'a' * described_class::REPORTING_PATH_LENGTH}"
+      entry = log(path: long_path)
+
+      expect(entry.reload.path).to eq(long_path)
+    end
+  end
+
+  describe '.backfill_reporting_path!' do
+    # Existing rows predate the reporting_path column (see
+    # db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb) and this runs out of band
+    # via TaskQueue rather than in that migration; simulate that pre-backfill state directly since
+    # the before_save callback would otherwise always populate reporting_path on save.
+    it 'sets reporting_path from path for a row that predates the column' do
+      entry = log(path: '/warehouse_reports/chronic/1234')
+      entry.update_column(:reporting_path, nil)
+
+      described_class.backfill_reporting_path!
+
+      expect(entry.reload.reporting_path).to eq('/warehouse_reports/chronic/1234')
+    end
+
+    it 'truncates to REPORTING_PATH_LENGTH characters for a path longer than that' do
+      long_path = "/warehouse_reports/chronic/#{'a' * (described_class::REPORTING_PATH_LENGTH * 2)}"
+      entry = log(path: long_path)
+      entry.update_column(:reporting_path, nil)
+
+      described_class.backfill_reporting_path!
+
+      expect(entry.reload.reporting_path).to eq(long_path.first(described_class::REPORTING_PATH_LENGTH))
+    end
+
+    it 'leaves a row with a reporting_path already set untouched' do
+      entry = log(path: '/warehouse_reports/chronic/1234')
+      entry.update_column(:reporting_path, '/something/else')
+
+      described_class.backfill_reporting_path!
+
+      expect(entry.reload.reporting_path).to eq('/something/else')
+    end
+  end
+
+  describe '.warehouse_reports with a path longer than REPORTING_PATH_LENGTH' do
+    # `path` can't be indexed directly (see db/migrate/20260827150000_add_reporting_path_to_activity_logs.rb
+    # for why), but report urls are always far shorter than REPORTING_PATH_LENGTH, so a matching
+    # entry is still counted correctly however long the real path's query string runs beyond that --
+    # unlike the excluded-outlier approach this replaced, oversized report traffic isn't dropped.
+    it 'still includes a matching entry whose path runs well past REPORTING_PATH_LENGTH' do
+      long_path = "/warehouse_reports/chronic/#{'a' * (described_class::REPORTING_PATH_LENGTH * 2)}"
+      entry = log(path: long_path)
+
+      expect(described_class.warehouse_reports).to include(entry)
+    end
+  end
 end


### PR DESCRIPTION
## _Merging this PR_

- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Hotfix for an index that can't build because the source data is too large.  
This creates a new column on the activity logs table specifically for reporting (first 200 chars of `path`) which can be indexed.
Data is populated to this new column with a before save hook in normal usage, but also populated via a task queue task to keep the data migraiton out of the DB migrations.

Also updates references that were using `path` for the report to `reporting_path`.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

