### PR TITLE
[#9340] Prevent importing custom data elements and their definitions if the data source backs HMIS

### DIFF
--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/hmis_csv.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/hmis_csv.rb
@@ -21,16 +21,32 @@ module HmisCsvImporter::HmisCsv
       data_lake_module(version).importable_files_map
     end
 
+    # Filenames whose warehouse tables are owned by the HMIS app itself for an
+    # HMIS-backed data source (see GrdaWarehouse::DataSource#hmis?). Version
+    # modules that don't declare any (2020, 2022, 2024) contribute none.
+    def self.hmis_owned_filenames(version)
+      mod = data_lake_module(version)
+      return [] unless mod.respond_to?(:hmis_owned_filenames)
+
+      mod.hmis_owned_filenames
+    end
+
     def self.data_lake_file_class(module_name:, phase:, name:)
       "#{module_name}::#{phase}::#{name}".constantize
     end
 
     def loadable_files
-      self.class.loadable_files(@current_version)
+      filter_hmis_owned(self.class.loadable_files(@current_version))
     end
 
     def importable_files
-      self.class.importable_files(@current_version)
+      filter_hmis_owned(self.class.importable_files(@current_version))
+    end
+
+    private def filter_hmis_owned(files)
+      return files unless data_source&.hmis?
+
+      files.except(*self.class.hmis_owned_filenames(@current_version))
     end
 
     def self.data_lake_module(version)

--- a/drivers/hmis_csv_importer/spec/models/hmis_csv_importer/hmis_csv_spec.rb
+++ b/drivers/hmis_csv_importer/spec/models/hmis_csv_importer/hmis_csv_spec.rb
@@ -1,0 +1,65 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisCsvImporter::HmisCsv do
+  # Test design: Tier 1 -- these two files back the tables the HMIS app itself
+  # owns for an HMIS-backed data source (see GrdaWarehouse::DataSource#hmis?).
+  # If the pipeline stops excluding them here, the importer's "guilty until
+  # proven innocent" deletion pass would purge HMIS-app-owned rows on the next
+  # CSV import. Real Loader/Importer instances (not stubs) prove the exclusion
+  # holds for both classes, and the vendor case proves normal imports still see
+  # every file -- so a guard that accidentally excludes everyone, or excludes
+  # no one, turns both halves of each pair red.
+  let(:hmis_data_source) { create(:hmis_primary_data_source) }
+  let(:vendor_data_source) { create(:grda_warehouse_data_source) }
+
+  describe HmisCsvImporter::Importer::Importer do
+    def importable_files_for(data_source)
+      loader_log = HmisCsvImporter::Loader::LoaderLog.create!(data_source_id: data_source.id, status: :loaded, version: '2026')
+      described_class.new(loader_id: loader_log.id, data_source_id: data_source.id).importable_files
+    end
+
+    it 'excludes CustomDataElement files for an HMIS-backed data source' do
+      files = importable_files_for(hmis_data_source)
+
+      expect(files.keys).not_to include('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+
+    it 'includes CustomDataElement files for a non-HMIS data source' do
+      files = importable_files_for(vendor_data_source)
+
+      expect(files.keys).to include('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+  end
+
+  describe HmisCsvImporter::Loader::Loader do
+    EXPORT_CSV_HEADER = 'ExportID,SourceType,SourceID,SourceName,SourceContactFirst,SourceContactLast,SourceContactPhone,SourceContactExtension,SourceContactEmail,ExportDate,ExportStartDate,ExportEndDate,SoftwareName,SoftwareVersion,CSVVersion,ExportPeriodType,ExportDirective,HashStatus,ImplementationID'
+    EXPORT_CSV_ROW = 'export1,3,,Test Source,,,,,,2024-01-01 00:00:00,2024-01-01,2024-01-02,Test Software,1,2026 v1.0,3,3,1,Test Source'
+
+    def loadable_files_for(data_source)
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'Export.csv'), "#{EXPORT_CSV_HEADER}\n#{EXPORT_CSV_ROW}\n")
+        described_class.new(data_source_id: data_source.id, file_path: dir, remove_files: false).loadable_files
+      end
+    end
+
+    it 'excludes CustomDataElement files for an HMIS-backed data source' do
+      files = loadable_files_for(hmis_data_source)
+
+      expect(files.keys).not_to include('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+
+    it 'includes CustomDataElement files for a non-HMIS data source' do
+      files = loadable_files_for(vendor_data_source)
+
+      expect(files.keys).to include('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+  end
+end

--- a/drivers/hmis_csv_importer/spec/models/hmis_csv_importer/hmis_csv_spec.rb
+++ b/drivers/hmis_csv_importer/spec/models/hmis_csv_importer/hmis_csv_spec.rb
@@ -9,14 +9,9 @@
 require 'rails_helper'
 
 RSpec.describe HmisCsvImporter::HmisCsv do
-  # Test design: Tier 1 -- these two files back the tables the HMIS app itself
-  # owns for an HMIS-backed data source (see GrdaWarehouse::DataSource#hmis?).
-  # If the pipeline stops excluding them here, the importer's "guilty until
-  # proven innocent" deletion pass would purge HMIS-app-owned rows on the next
-  # CSV import. Real Loader/Importer instances (not stubs) prove the exclusion
-  # holds for both classes, and the vendor case proves normal imports still see
-  # every file -- so a guard that accidentally excludes everyone, or excludes
-  # no one, turns both halves of each pair red.
+  # These files back tables owned by the HMIS for an HMIS-backed data source (see GrdaWarehouse::DataSource#hmis?).
+  # Ensure they are correctly excluded so that the importer's "guilty until
+  # proven innocent" deletion pass doesn't purge rows on the next CSV import.
   let(:hmis_data_source) { create(:hmis_primary_data_source) }
   let(:vendor_data_source) { create(:grda_warehouse_data_source) }
 

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six.rb
@@ -61,6 +61,10 @@ module HmisCsvTwentyTwentySix
     base_importable_files_map.merge(custom_importable_files_map)
   end
 
+  def self.hmis_owned_filenames
+    custom_files_config.hmis_owned_filenames
+  end
+
   def self.required_files
     ['Export.csv', 'Project.csv', 'Organization.csv'] + custom_files_config.required_filenames
   end

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/custom/file_definition.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/custom/file_definition.rb
@@ -39,6 +39,10 @@ module HmisCsvTwentyTwentySix
         @config_data['required'] == true
       end
 
+      def hmis_owned?
+        @config_data['hmis_owned'] == true
+      end
+
       def description
         @config_data['description']
       end

--- a/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/custom/files_config.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/app/models/hmis_csv_twenty_twenty_six/custom/files_config.rb
@@ -43,6 +43,10 @@ module HmisCsvTwentyTwentySix
         @definitions.select(&:required?).map(&:filename)
       end
 
+      def hmis_owned_filenames
+        @definitions.select(&:hmis_owned?).map(&:filename)
+      end
+
       def class_name_mapping
         @definitions.map { |d| [d.filename, "Custom::#{d.class_name}"] }.to_h
       end

--- a/drivers/hmis_csv_twenty_twenty_six/config/custom/custom_data_element.yaml
+++ b/drivers/hmis_csv_twenty_twenty_six/config/custom/custom_data_element.yaml
@@ -7,6 +7,7 @@ custom_files:
     warehouse_key: "CustomDataElementID"
     warehouse_class_name: "GrdaWarehouse::Hud::CustomDataElement"
     export_limiting_column: "RecordType"
+    hmis_owned: true
     columns:
       - name: "CustomDataElementID"
         type: "string"

--- a/drivers/hmis_csv_twenty_twenty_six/config/custom/custom_data_element_definition.yaml
+++ b/drivers/hmis_csv_twenty_twenty_six/config/custom/custom_data_element_definition.yaml
@@ -6,6 +6,7 @@ custom_files:
     description: "Definitions for custom data elements"
     warehouse_key: "CustomDataElementDefinitionID"
     warehouse_class_name: "GrdaWarehouse::Hud::CustomDataElementDefinition"
+    hmis_owned: true
     columns:
       - name: "CustomDataElementDefinitionID"
         type: "string"

--- a/drivers/hmis_csv_twenty_twenty_six/config/custom_file_schema.json
+++ b/drivers/hmis_csv_twenty_twenty_six/config/custom_file_schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "open-path-schemas/csv-2026-custom-file-schema.json",
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "title": "HMIS CSV Twenty Twenty Six Custom File Configuration",
   "type": "object",
@@ -36,6 +36,11 @@
           "description": "Whether this file is required in imports",
           "default": false
         },
+        "hmis_owned": {
+          "type": "boolean",
+          "description": "Whether this file's warehouse table is owned by the HMIS app for HMIS-backed data sources, and should be excluded from loading/importing for them",
+          "default": false
+        },
         "description": {
           "type": "string",
           "description": "Human-readable description of the file's purpose"
@@ -62,6 +67,15 @@
           "type": "string",
           "description": "Full class name of the importer to use for augmentation",
           "pattern": "^[A-Z][A-Za-z0-9:]*$"
+        },
+        "augments_export_class": {
+          "type": "string",
+          "description": "Full class name of the exporter to use for augmentation",
+          "pattern": "^[A-Z][A-Za-z0-9:]*$"
+        },
+        "export_limiting_column": {
+          "type": "string",
+          "description": "Name of the column whose warehouse_column_mapping.value_mappings limits which rows are exported"
         },
         "columns": {
           "type": "array",
@@ -183,6 +197,14 @@
           "type": "string",
           "description": "Target column name in the warehouse table"
         },
+        "export_type": {
+          "type": "string",
+          "description": "Export-specific mapping type; takes precedence over 'type' when exporting (e.g. 'lookup' for a dynamic association join)"
+        },
+        "target_related_column": {
+          "type": "string",
+          "description": "Column on the joined association to select, for an export_type: lookup mapping"
+        },
         "value_mappings": {
           "oneOf": [
             {
@@ -270,20 +292,6 @@
         "type"
       ],
       "allOf": [
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "direct"
-              }
-            }
-          },
-          "then": {
-            "required": [
-              "target_column"
-            ]
-          }
-        },
         {
           "if": {
             "properties": {

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six/custom/file_definition_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six/custom/file_definition_spec.rb
@@ -1,0 +1,40 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisCsvTwentyTwentySix::Custom::FileDefinition do
+  def config_for(extra = {})
+    {
+      'filename' => 'CustomThing.csv',
+      'class_name' => 'CustomThing',
+      'warehouse_class_name' => 'GrdaWarehouse::Hud::CustomDataElement',
+      'columns' => [{ 'name' => 'CustomThingID', 'type' => 'string' }],
+    }.merge(extra)
+  end
+
+  describe '#hmis_owned?' do
+    it 'is true when the config declares hmis_owned: true' do
+      definition = described_class.new(config_for('hmis_owned' => true))
+
+      expect(definition.hmis_owned?).to eq(true)
+    end
+
+    it 'is false when the config omits hmis_owned' do
+      definition = described_class.new(config_for)
+
+      expect(definition.hmis_owned?).to eq(false)
+    end
+
+    it 'is false when the config declares hmis_owned: false' do
+      definition = described_class.new(config_for('hmis_owned' => false))
+
+      expect(definition.hmis_owned?).to eq(false)
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six/custom/files_config_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six/custom/files_config_spec.rb
@@ -1,0 +1,20 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisCsvTwentyTwentySix::Custom::FilesConfig do
+  describe '#hmis_owned_filenames' do
+    it 'includes only the filenames of hmis_owned definitions' do
+      files_config = described_class.new
+      hmis_owned_filenames = files_config.hmis_owned_filenames
+
+      expect(hmis_owned_filenames).to contain_exactly('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/hmis_csv_twenty_twenty_six_spec.rb
@@ -1,0 +1,21 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisCsvTwentyTwentySix do
+  describe '.hmis_owned_filenames' do
+    it 'delegates to the custom files config' do
+      expect(described_class.hmis_owned_filenames).to eq(described_class.custom_files_config.hmis_owned_filenames)
+    end
+
+    it 'includes the CustomDataElement files' do
+      expect(described_class.hmis_owned_filenames).to contain_exactly('CustomDataElement.csv', 'CustomDataElementDefinition.csv')
+    end
+  end
+end

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/importer/hmis_data_source_skips_custom_data_elements_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/importer/hmis_data_source_skips_custom_data_elements_spec.rb
@@ -9,15 +9,10 @@
 require 'rails_helper'
 
 RSpec.describe 'HMIS-backed data source skips CustomDataElement import' do
-  # Test design: Tier 1 -- data destruction & retention. Without the fix, a
-  # routine CSV import into an HMIS-backed data source silently soft-deletes
+  # Without `hmis_owned: true` the CSV import into an HMIS-backed data source silently soft-deletes
   # every pre-existing CustomDataElement(Definition) row for that data source,
   # because involved_warehouse_scope for these two custom files matches every
-  # row regardless of what's in the incoming CSV. This spec runs the real
-  # Loader -> Importer pipeline (not stubs) against the same custom_files
-  # fixture the non-HMIS regression spec (custom_files_integration_spec.rb)
-  # uses, so a fix that merely skips creation but still lets the deletion pass
-  # run would still turn the "pre-existing row survives" examples red.
+  # row regardless of what's in the incoming CSV.
   after(:all) do
     HmisCsvImporter::Utility.clear!
     GrdaWarehouse::Utility.clear!

--- a/drivers/hmis_csv_twenty_twenty_six/spec/models/importer/hmis_data_source_skips_custom_data_elements_spec.rb
+++ b/drivers/hmis_csv_twenty_twenty_six/spec/models/importer/hmis_data_source_skips_custom_data_elements_spec.rb
@@ -1,0 +1,79 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'HMIS-backed data source skips CustomDataElement import' do
+  # Test design: Tier 1 -- data destruction & retention. Without the fix, a
+  # routine CSV import into an HMIS-backed data source silently soft-deletes
+  # every pre-existing CustomDataElement(Definition) row for that data source,
+  # because involved_warehouse_scope for these two custom files matches every
+  # row regardless of what's in the incoming CSV. This spec runs the real
+  # Loader -> Importer pipeline (not stubs) against the same custom_files
+  # fixture the non-HMIS regression spec (custom_files_integration_spec.rb)
+  # uses, so a fix that merely skips creation but still lets the deletion pass
+  # run would still turn the "pre-existing row survives" examples red.
+  after(:all) do
+    HmisCsvImporter::Utility.clear!
+    GrdaWarehouse::Utility.clear!
+  end
+
+  before(:all) do
+    @data_source = create(:hmis_primary_data_source)
+
+    # Rows already present for this data source before the import runs,
+    # simulating data the HMIS app itself created. Neither is referenced by
+    # the incoming CSV fixture, so a broken guard would flag them pending
+    # deletion and purge them.
+    @pre_existing_definition = create(
+      :hud_custom_data_element_definition,
+      data_source_id: @data_source.id,
+      owner_type: 'GrdaWarehouse::Hud::Client',
+      key: 'hmis_app_owned_field',
+    )
+    @pre_existing_element = create(
+      :hud_custom_data_element,
+      data_source_id: @data_source.id,
+      custom_data_element_definition: @pre_existing_definition,
+      owner_type: 'GrdaWarehouse::Hud::Client',
+    )
+
+    temp_dir = Dir.mktmpdir
+    FileUtils.cp_r('drivers/hmis_csv_importer/spec/fixtures/files/twenty_twenty_six/custom_files/.', temp_dir)
+
+    import_hmis_csv_fixture(
+      temp_dir,
+      version: 'AutoMigrate',
+      data_source: @data_source,
+      run_jobs: true,
+      stop_version: '2026',
+    )
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  it 'does not create the CustomDataElementDefinition row present in the CSV' do
+    expect(GrdaWarehouse::Hud::CustomDataElementDefinition.where(data_source_id: @data_source.id, key: 'reason_for_exit')).not_to exist
+  end
+
+  it 'does not create the CustomDataElement row present in the CSV' do
+    expect(GrdaWarehouse::Hud::CustomDataElement.where(data_source_id: @data_source.id, CustomDataElementID: 'A1001')).not_to exist
+  end
+
+  it 'does not soft-delete the pre-existing CustomDataElementDefinition' do
+    expect(@pre_existing_definition.reload.DateDeleted).to be_nil
+  end
+
+  it 'does not soft-delete the pre-existing CustomDataElement' do
+    expect(@pre_existing_element.reload.DateDeleted).to be_nil
+  end
+
+  it 'still imports other custom files unrelated to CustomDataElement' do
+    client = GrdaWarehouse::Hud::Client.find_by(data_source_id: @data_source.id, PersonalID: '2f4b963171644a8b9902bdfe79a4b403')
+    expect(client.GenderNone).to eq(8)
+  end
+end


### PR DESCRIPTION
## _Merging this PR_

- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

This change causes the importer (and loader) to ignore the `CustomDataElement` and `CustomDataElementDefinition` files if the data source being imported into backs an OP HMIS.  If the data source backs an OP HMIS, the HMIS is authoritative for the CDED data.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

