### PR TITLE
Fix for query range around date boundaries

### DIFF
--- a/app/models/activity_log.rb
+++ b/app/models/activity_log.rb
@@ -21,8 +21,11 @@ class ActivityLog < ApplicationRecord
 
   before_save :set_reporting_path
 
+  # `range` is a Date..Date; created_at is stored as a UTC instant, so comparing it against bare
+  # date literals drops rows created in the evening (US Eastern), whose UTC-stored date has already
+  # rolled to the next day.
   scope :created_in_range, ->(range:) do
-    where(created_at: range)
+    where(created_at: range.begin.beginning_of_day..range.end.end_of_day)
   end
 
   scope :warehouse_reports, -> do

--- a/spec/models/activity_log_spec.rb
+++ b/spec/models/activity_log_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe ActivityLog do
     end
   end
 
+  describe '.created_in_range' do
+    # created_at is stored as a UTC instant; an evening-Eastern timestamp's UTC-stored date has
+    # already rolled to the next day, so a naive Date-literal comparison silently drops it. Time is
+    # pinned to a fixed evening moment so this doesn't only fail depending on when it happens to run.
+    it 'includes an entry created the previous evening (US Eastern), whose UTC-stored date already rolled to today' do
+      travel_to Time.zone.local(2026, 8, 27, 21, 0, 0) do
+        entry = log(path: '/warehouse_reports/chronic/1')
+        entry.update_column(:created_at, 1.day.ago)
+
+        range = 5.days.ago.to_date..Date.current
+
+        expect(described_class.created_in_range(range: range)).to include(entry)
+      end
+    end
+
+    it 'excludes an entry created before the given range' do
+      travel_to Time.zone.local(2026, 8, 27, 21, 0, 0) do
+        entry = log(path: '/warehouse_reports/chronic/1')
+        entry.update_column(:created_at, 10.days.ago)
+
+        range = 5.days.ago.to_date..Date.current
+
+        expect(described_class.created_in_range(range: range)).not_to include(entry)
+      end
+    end
+  end
+
   describe '#reporting_path' do
     it 'mirrors the first REPORTING_PATH_LENGTH characters of path on save' do
       long_path = "/warehouse_reports/chronic/#{'a' * described_class::REPORTING_PATH_LENGTH}"


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

https://github.com/greenriver/hmis-warehouse/actions/runs/33125603924/job/98703034684 failed because the scope uses plain dates in the query but compares against a datetime.  This fixes that and adds tests.

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

