### PR TITLE
[#9500] Data Source index page performance

### DIFF
--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -20,10 +20,11 @@ class DataSourcesController < ApplicationController
     else
       data_source_scope
     end
-    @pagy, @data_sources = pagy(@data_sources.order(name: :asc))
-    # @data_spans_by_id = GrdaWarehouse::DataSource.data_spans_by_id
-    @client_counts = @data_sources.map { |ds| [ds.id, ds.client_count] }.to_h
-    @project_counts = @data_sources.map { |ds| [ds.id, ds.project_count] }.to_h
+    @pagy, @data_sources = pagy(@data_sources.includes(:hmis_import_config).order(name: :asc))
+    data_source_ids = @data_sources.map(&:id)
+    @client_counts = GrdaWarehouse::DataSource.client_counts_by_id(data_source_ids)
+    @project_counts = GrdaWarehouse::DataSource.project_counts_by_id(data_source_ids)
+    @unprocessed_enrollment_counts = GrdaWarehouse::DataSource.unprocessed_enrollment_counts_by_id(data_source_ids)
   end
 
   def show

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -20,7 +20,7 @@ class DataSourcesController < ApplicationController
     else
       data_source_scope
     end
-    @pagy, @data_sources = pagy(@data_sources.includes(:hmis_import_config).order(name: :asc))
+    @pagy, @data_sources = pagy(@data_sources.order(name: :asc))
     data_source_ids = @data_sources.map(&:id)
     @client_counts = GrdaWarehouse::DataSource.client_counts_by_id(data_source_ids)
     @project_counts = GrdaWarehouse::DataSource.project_counts_by_id(data_source_ids)

--- a/app/controllers/data_sources_controller.rb
+++ b/app/controllers/data_sources_controller.rb
@@ -25,6 +25,7 @@ class DataSourcesController < ApplicationController
     @client_counts = GrdaWarehouse::DataSource.client_counts_by_id(data_source_ids)
     @project_counts = GrdaWarehouse::DataSource.project_counts_by_id(data_source_ids)
     @unprocessed_enrollment_counts = GrdaWarehouse::DataSource.unprocessed_enrollment_counts_by_id(data_source_ids)
+    @stalled_dates = GrdaWarehouse::DataSource.stalled_dates_by_id(data_source_ids)
   end
 
   def show

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -735,6 +735,25 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     projects.joins(:organization).count
   end
 
+  # Batched form of #client_count for a page of data sources, to avoid one query per row.
+  def self.client_counts_by_id(data_source_ids)
+    Hash.new(0).merge(GrdaWarehouse::Hud::Client.where(data_source_id: data_source_ids).group(:data_source_id).count)
+  end
+
+  # Batched form of #project_count for a page of data sources, to avoid one query per row.
+  def self.project_counts_by_id(data_source_ids)
+    Hash.new(0).merge(GrdaWarehouse::Hud::Project.joins(:organization).where(data_source_id: data_source_ids).group(:data_source_id).count)
+  end
+
+  # Batched form of #unprocessed_enrollment_count for a page of data sources, to avoid one query per row.
+  def self.unprocessed_enrollment_counts_by_id(data_source_ids)
+    Hash.new(0).merge(
+      GrdaWarehouse::Hud::Enrollment.unprocessed_with_resolvable_project_and_client.
+        where(data_source_id: data_source_ids).
+        group(:data_source_id).count,
+    )
+  end
+
   # Below this size and dominance, a data source's organizations page can render
   # everything at once; otherwise it's large or fragmented enough that the user
   # should pick a CoC to filter by first.

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -544,61 +544,97 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     @unprocessed_enrollment_count ||= enrollments.unprocessed_with_resolvable_project_and_client.count
   end
 
-  # Returns the date of the most recent fully successful import if the import is stalled, nil if it is not stalled
-  # @return [Date, nil] The date the import stalled, or nil if not stalled.
-  def stalled_date
-    return nil if import_paused
-    return nil unless hmis_import_config&.active
+  # Batched form of the stalled-date business rules for a page of data sources, to avoid one
+  # query per row. Every requested id is present in the result; nil means not stalled.
+  def self.stalled_dates_by_id(data_source_ids)
+    return {} if data_source_ids.blank?
 
-    # hmis_import_config.file_count is the expected number of uploads for a given day
-    # fetch the expected number, and confirm they all arrived within a 24 hour window
-    most_recent_uploads = uploads.completed.
-      # limit look back to 6 months to improve performance, but to potentially highlight missing data
-      where(user_id: User.system_user.id, completed_at: 6.months.ago..Time.current).
-      order(completed_at: :desc, created_at: :desc).
-      select(:id, :data_source_id, :user_id, :completed_at, :created_at).
-      distinct.
-      first(hmis_import_config.file_count)
-    # We didn't find any uploads in the last 6 months, assume this isn't connected yet
-    return nil unless most_recent_uploads.present?
+    ds_t = arel_table
+    ic_t = GrdaWarehouse::HmisImportConfig.arel_table
+    file_counts = GrdaWarehouse::DataSource.
+      where(id: data_source_ids, import_paused: false).
+      joins(:hmis_import_config).
+      merge(GrdaWarehouse::HmisImportConfig.active).
+      pluck(ds_t[:id], ic_t[:file_count]).to_h
 
-    min_completion_time = most_recent_uploads.minimum(:completed_at)
-    received_files_count = most_recent_uploads.count
+    return data_source_ids.index_with { nil } if file_counts.empty?
 
-    # If we only expected one file
-    if hmis_import_config.file_count == 1
-      # and it came in the last 24 hours, we're good
-      return nil if min_completion_time > 24.hours.ago
+    max_file_count = file_counts.values.max
 
-      # if not, return the last time we received a file
-      return min_completion_time.to_date
+    # file_count is the expected number of uploads per day; capping at rn <= max_file_count
+    # keeps this query from pulling the full 6-month lookback's uploads into Ruby.
+    ranked = GrdaWarehouse::Upload.
+      completed.
+      where(
+        user_id: User.system_user.id,
+        data_source_id: file_counts.keys,
+        # limit look back to 6 months to improve performance, but to potentially highlight missing data
+        completed_at: 6.months.ago..Time.current,
+      ).
+      define_window(:per_data_source).
+      partition_by(:data_source_id, order_by: { completed_at: :desc, created_at: :desc }).
+      select_window(:row_number, over: :per_data_source, as: :rn).
+      select(:data_source_id, :completed_at)
+
+    # Use GrdaWarehouse::Upload.unscoped as ranked already ignores deleted uploads.
+    top_uploads = GrdaWarehouse::Upload.unscoped.from(ranked, :ranked_uploads).
+      where('ranked_uploads.rn <= ?', max_file_count).
+      order('ranked_uploads.data_source_id, ranked_uploads.rn').
+      pluck('ranked_uploads.data_source_id', 'ranked_uploads.completed_at')
+    completion_times_by_data_source_id = top_uploads.group_by(&:first).transform_values { |rows| rows.map(&:second) }
+
+    data_source_ids.index_with do |id|
+      file_count = file_counts[id]
+      next nil unless file_count
+
+      # Trim back down to this id's own file_count - the query above capped every id at
+      # max_file_count across the whole batch, which can be larger than this one's own.
+      completion_times = completion_times_by_data_source_id[id]&.first(file_count)
+      # We didn't find any uploads in the last 6 months, assume this isn't connected yet
+      next nil if completion_times.blank?
+
+      min_completion_time = completion_times.min
+      received_files_count = completion_times.size
+
+      if file_count == 1
+        next nil if min_completion_time > 24.hours.ago
+
+        next min_completion_time.to_date
+      end
+
+      next nil if min_completion_time > 24.hours.ago && received_files_count >= file_count
+
+      min_completion_time.to_date
     end
-
-    # If we processed the expected number of files within a 24 hour period, we're good
-    return nil if min_completion_time > 24.hours.ago && received_files_count >= hmis_import_config.file_count
-
-    # Note the last time we received a file
-    min_completion_time.to_date
   end
 
   def self.import_advisory_lock_name(data_source_id)
     "enforce_sequential_data_source_imports_for_#{data_source_id}"
   end
 
-  def self.stalled_imports?(user)
-    Rails.cache.fetch(['data_source_stalled_imports', user], expires_in: 1.hours) do
-      stalled = false
-      viewable_by(user).each do |data_source|
-        next if stalled
+  # Batched form of the per-row import_logs.maximum(:completed_at) lookup.
+  # Ids with no import logs are absent from the result.
+  def self.last_import_completed_ats_by_id(data_source_ids)
+    return {} if data_source_ids.blank?
 
-        most_recently_completed = data_source.import_logs.maximum(:completed_at)
-        if most_recently_completed.present?
-          stalled = true if data_source.stalled_date.present?
-        end
-      end
+    GrdaWarehouse::ImportLog.where(data_source_id: data_source_ids).group(:data_source_id).maximum(:completed_at)
+  end
 
-      stalled
+  # Cached globally for an hour - user-independent;
+  # stalled_imports?'s viewability filter limits to user-relevant data sources.
+  def self.stalled_data_source_ids
+    Rails.cache.fetch('data_source_stalled_ids', expires_in: 1.hours) do
+      ids = GrdaWarehouse::DataSource.pluck(:id)
+      last_completed_by_id = last_import_completed_ats_by_id(ids)
+      stall_date_by_id = stalled_dates_by_id(ids)
+
+      ids.select { |id| last_completed_by_id[id].present? && stall_date_by_id[id].present? }
     end
+  end
+
+  def self.stalled_imports?(user)
+    viewable_ids = viewable_by(user).pluck(:id)
+    (stalled_data_source_ids & viewable_ids).any?
   end
 
   def self.options_for_select(user:, ids: nil, permission: :can_view_projects)

--- a/app/views/data_sources/index.haml
+++ b/app/views/data_sources/index.haml
@@ -59,10 +59,11 @@
           %td.text-center= checkmark(data_source.authoritative)
           %td
             = most_recently_completed
-            - if data_source.unprocessed_enrollment_count.positive?
+            - unprocessed_enrollment_count = @unprocessed_enrollment_counts[data_source.id]
+            - if unprocessed_enrollment_count.positive?
               .mt-2
                 %em
-                  = link_to "Enrollments remaining to process: #{data_source.unprocessed_enrollment_count}", data_source_unprocessed_enrollments_path(data_source)
+                  = link_to "Enrollments remaining to process: #{unprocessed_enrollment_count}", data_source_unprocessed_enrollments_path(data_source)
           %td
             -# NOTE: this will only show the data source as stalled if the files were brought in by the system user
             - if most_recently_completed.present?

--- a/app/views/data_sources/index.haml
+++ b/app/views/data_sources/index.haml
@@ -67,7 +67,7 @@
           %td
             -# NOTE: this will only show the data source as stalled if the files were brought in by the system user
             - if most_recently_completed.present?
-              - stall_date = data_source.stalled_date
+              - stall_date = @stalled_dates[data_source.id]
               - if stall_date
                 .label.label-warning
                   same file since: #{stall_date}

--- a/drivers/data_source_report/app/controllers/data_source_report/warehouse_reports/reports_controller.rb
+++ b/drivers/data_source_report/app/controllers/data_source_report/warehouse_reports/reports_controller.rb
@@ -16,8 +16,10 @@ module DataSourceReport::WarehouseReports
     def index
       @data_sources = data_source_scope.order(name: :asc)
       @pagy, @data_sources = pagy(@data_sources)
+      data_source_ids = @data_sources.map(&:id)
       @client_counts = @data_sources.map { |ds| [ds.id, ds.client_count] }.to_h
       @project_counts = @data_sources.map { |ds| [ds.id, ds.project_count] }.to_h
+      @stalled_dates = GrdaWarehouse::DataSource.stalled_dates_by_id(data_source_ids)
     end
 
     private def data_source_source

--- a/drivers/data_source_report/app/controllers/data_source_report/warehouse_reports/reports_controller.rb
+++ b/drivers/data_source_report/app/controllers/data_source_report/warehouse_reports/reports_controller.rb
@@ -17,8 +17,10 @@ module DataSourceReport::WarehouseReports
       @data_sources = data_source_scope.order(name: :asc)
       @pagy, @data_sources = pagy(@data_sources)
       data_source_ids = @data_sources.map(&:id)
-      @client_counts = @data_sources.map { |ds| [ds.id, ds.client_count] }.to_h
-      @project_counts = @data_sources.map { |ds| [ds.id, ds.project_count] }.to_h
+      @client_counts = GrdaWarehouse::DataSource.client_counts_by_id(data_source_ids)
+      @project_counts = GrdaWarehouse::DataSource.project_counts_by_id(data_source_ids)
+      @unprocessed_enrollment_counts = GrdaWarehouse::DataSource.unprocessed_enrollment_counts_by_id(data_source_ids)
+      @last_import_completed_ats = GrdaWarehouse::DataSource.last_import_completed_ats_by_id(data_source_ids)
       @stalled_dates = GrdaWarehouse::DataSource.stalled_dates_by_id(data_source_ids)
     end
 

--- a/drivers/data_source_report/app/views/data_source_report/warehouse_reports/reports/index.haml
+++ b/drivers/data_source_report/app/views/data_source_report/warehouse_reports/reports/index.haml
@@ -37,7 +37,7 @@
             %td
               -# NOTE: this will only show the data source as stalled if the files were brought in by the system user
               - if most_recently_completed.present?
-                - stall_date = data_source.stalled_date
+                - stall_date = @stalled_dates[data_source.id]
                 - if stall_date
                   .label.label-warning
                     same file since: #{stall_date}

--- a/drivers/data_source_report/app/views/data_source_report/warehouse_reports/reports/index.haml
+++ b/drivers/data_source_report/app/views/data_source_report/warehouse_reports/reports/index.haml
@@ -23,17 +23,18 @@
           %td= number_with_delimiter(GrdaWarehouse::Hud::Client.destination.count)
           %td{colspan: 5}
         - @data_sources.each do |data_source|
-          - most_recently_completed = data_source.import_logs.maximum(:completed_at)&.localtime
+          - most_recently_completed = @last_import_completed_ats[data_source.id]&.localtime
           %tr
             %td= data_source.name
             %td= number_with_delimiter(@client_counts[data_source.id])
             %td= number_with_delimiter(@project_counts[data_source.id])
             %td
               = most_recently_completed
-              - if data_source.unprocessed_enrollment_count.positive?
+              - unprocessed_enrollment_count = @unprocessed_enrollment_counts[data_source.id]
+              - if unprocessed_enrollment_count.positive?
                 .mt-2
                   %em
-                    Enrollments remaining to process: #{data_source.unprocessed_enrollment_count}
+                    Enrollments remaining to process: #{unprocessed_enrollment_count}
             %td
               -# NOTE: this will only show the data source as stalled if the files were brought in by the system user
               - if most_recently_completed.present?

--- a/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
+++ b/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
@@ -33,7 +33,14 @@ RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :req
       expect(response.body).to include('same file since:')
     end
 
-    it 'shows no stalled-import label for a data source with no import history' do
+    it 'shows no stalled-import label for a data source whose most recent import is current' do
+      # An import log and a recent upload put this row through the same stall check the stale
+      # row above takes, so the label's absence is attributable to the stall rule rather than
+      # to the outer `most_recently_completed.present?` gate in the view.
+      create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: 1)
+      create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: data_source, completed_at: 2.hours.ago)
+
       get data_source_report_warehouse_reports_reports_path
 
       expect(response).to have_http_status(:ok)
@@ -61,6 +68,11 @@ RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :req
       ds
     end
 
+    # Each data source row leads with its name; the leading warehouse-totals row is dropped.
+    def rendered_data_source_names(body)
+      Nokogiri::HTML(body).css('tbody tr').drop(1).map { |row| row.at_css('td').text.strip }
+    end
+
     it 'runs a bounded number of queries regardless of how many data sources are on the page' do
       count_queries = lambda do |&block|
         count = 0
@@ -79,7 +91,7 @@ RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :req
       expect(response).to have_http_status(:ok)
 
       small_queries = count_queries.call { get data_source_report_warehouse_reports_reports_path }
-      expect(response).to have_http_status(:ok)
+      expect(rendered_data_source_names(response.body)).to match_array(small_batch.map(&:name))
 
       large_batch = small_batch + Array.new(9) { |i| build_data_source_with_data(name: "Large Vendor #{i}", destination_data_source: destination_data_source) }
       collection.set_viewables(reports: [report_definition.id], data_sources: large_batch.map(&:id), projects: [])
@@ -89,7 +101,10 @@ RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :req
       expect(large_batch.size).to be <= Pagy::DEFAULT[:items]
 
       large_queries = count_queries.call { get data_source_report_warehouse_reports_reports_path }
-      expect(response).to have_http_status(:ok)
+      # The query comparison below is only meaningful if the nine additional data sources
+      # actually rendered; a page that kept showing three rows would match on query count
+      # while exercising none of the added load.
+      expect(rendered_data_source_names(response.body)).to match_array(large_batch.map(&:name))
 
       # A regression to a per-row query pattern (client/project/unprocessed-enrollment counts
       # and last-import timestamps each queried once per row) would make large_queries scale

--- a/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
+++ b/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
@@ -40,4 +40,62 @@ RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :req
       expect(response.body).not_to include('same file since:')
     end
   end
+
+  describe 'GET #index query efficiency' do
+    def create_linked_client(within_data_source, destination_data_source)
+      source_client = create(:hud_client, data_source: within_data_source)
+      destination_client = source_client.dup
+      destination_client.data_source = destination_data_source
+      destination_client.save!
+      create(:warehouse_client, destination_id: destination_client.id, source_id: source_client.id)
+      source_client
+    end
+
+    def build_data_source_with_data(name:, destination_data_source:)
+      ds = create(:source_data_source, name: name)
+      org = create(:hud_organization, data_source: ds)
+      project = create(:hud_project, data_source: ds, OrganizationID: org.OrganizationID)
+      create_list(:hud_client, 2, data_source: ds)
+      create(:hud_enrollment, data_source: ds, project: project, client: create_linked_client(ds, destination_data_source), processed_as: nil)
+      GrdaWarehouse::ImportLog.create!(data_source: ds, completed_at: 1.day.ago)
+      ds
+    end
+
+    it 'runs a bounded number of queries regardless of how many data sources are on the page' do
+      count_queries = lambda do |&block|
+        count = 0
+        callback = ->(*) { count += 1 }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+        count
+      end
+
+      destination_data_source = create(:destination_data_source)
+      small_batch = Array.new(3) { |i| build_data_source_with_data(name: "Small Vendor #{i}", destination_data_source: destination_data_source) }
+      collection.set_viewables(reports: [report_definition.id], data_sources: small_batch.map(&:id), projects: [])
+
+      # Warm up one-time schema-cache/connection-setup queries so they don't confound
+      # the small-vs-large comparison below.
+      get data_source_report_warehouse_reports_reports_path
+      expect(response).to have_http_status(:ok)
+
+      small_queries = count_queries.call { get data_source_report_warehouse_reports_reports_path }
+      expect(response).to have_http_status(:ok)
+
+      large_batch = small_batch + Array.new(9) { |i| build_data_source_with_data(name: "Large Vendor #{i}", destination_data_source: destination_data_source) }
+      collection.set_viewables(reports: [report_definition.id], data_sources: large_batch.map(&:id), projects: [])
+      # This comparison only holds if every data source in large_batch lands on page 1;
+      # otherwise large_queries would undercount and the assertion below would pass for
+      # the wrong reason.
+      expect(large_batch.size).to be <= Pagy::DEFAULT[:items]
+
+      large_queries = count_queries.call { get data_source_report_warehouse_reports_reports_path }
+      expect(response).to have_http_status(:ok)
+
+      # A regression to a per-row query pattern (client/project/unprocessed-enrollment counts
+      # and last-import timestamps each queried once per row) would make large_queries scale
+      # with data source count (9 more data sources here); a small constant tolerance
+      # accommodates incidental preload-boundary variance without masking that regression.
+      expect(large_queries).to be_within(5).of(small_queries)
+    end
+  end
 end

--- a/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
+++ b/drivers/data_source_report/spec/requests/data_source_report/warehouse_reports/reports_controller_spec.rb
@@ -1,0 +1,43 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataSourceReport::WarehouseReports::ReportsController, type: :request do
+  let(:user) { create(:acl_user) }
+  let(:role) { create(:role, can_view_assigned_reports: true, can_view_projects: true) }
+  let(:collection) { create(:collection) }
+  let!(:report_definition) { create(:data_source_report) }
+  let!(:data_source) { create(:source_data_source, name: 'Stale Vendor') }
+
+  before do
+    collection.set_viewables(reports: [report_definition.id], data_sources: [data_source.id], projects: [])
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET #index' do
+    it 'shows the stalled-import label for a data source whose most recent import is stale' do
+      create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: 1)
+      create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: data_source, completed_at: 30.hours.ago)
+
+      get data_source_report_warehouse_reports_reports_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('same file since:')
+    end
+
+    it 'shows no stalled-import label for a data source with no import history' do
+      get data_source_report_warehouse_reports_reports_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include('same file since:')
+    end
+  end
+end

--- a/spec/factories/grda_warehouse/warehouse_reports/report_definition.rb
+++ b/spec/factories/grda_warehouse/warehouse_reports/report_definition.rb
@@ -49,6 +49,13 @@ FactoryBot.define do
     description { 'Mapping table to translate warehouse IDs to HMIS Personal IDs' }
   end
 
+  factory :data_source_report, class: 'GrdaWarehouse::WarehouseReports::ReportDefinition' do
+    report_group { 'Operational Reports' }
+    url { 'data_source_report/warehouse_reports/reports' }
+    name { 'Data Source Report' }
+    description { '' }
+  end
+
   factory :access_logs_report, class: 'GrdaWarehouse::WarehouseReports::ReportDefinition' do
     report_group { 'Audit' }
     url { 'access_logs/warehouse_reports/reports' }

--- a/spec/models/grda_warehouse/data_source_spec.rb
+++ b/spec/models/grda_warehouse/data_source_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe model, type: :model do
   user_ids = ->(user) { model.viewable_by(user, permission: :can_view_projects).pluck(:id).sort }
   ids = ->(*sources) { sources.map(&:id).sort }
 
+  def build_data_source_with_upload(file_count:, completed_at:)
+    data_source = create(:source_data_source)
+    create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: file_count)
+    create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: completed_at)
+    data_source
+  end
+
   describe 'scopes' do
     describe 'viewability' do
       describe 'ordinary user' do
@@ -140,56 +147,235 @@ RSpec.describe model, type: :model do
     end
   end
 
-  describe 'importer' do
-    let!(:imports) { create_list :grda_warehouse_upload, 12, data_source_id: ds1.id, user_id: User.system_user.id, percent_complete: 100, completed_at: 2.years.ago }
-
+  describe '.stalled_dates_by_id' do
     describe 'when expecting one file' do
-      let!(:import_config) { create :grda_warehouse_hmis_import_config, file_count: 1, data_source_id: ds1.id }
       it 'is not stalled when there are no prior imports in the past 6 months' do
-        expect(ds1.stalled_date).to eq(nil)
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 7.months.ago)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
       end
 
-      it 'is stalled when the last import was over 24 hours ago' do
-        imports.each.with_index { |import, i| import.update(completed_at: (i + 1).days.ago - 2.minutes) }
-        expect(ds1.stalled_date).to_not eq(nil)
+      it 'is stalled, since its single most recent upload, when the last import was over 24 hours ago' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+        most_recent_completed_at = 30.hours.ago
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: most_recent_completed_at)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 50.hours.ago)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(most_recent_completed_at.to_date)
       end
 
-      it 'is not stalled when there was an import yesterday' do
-        # 2-hour buffer so tests don't fail across DST boundaries
-        imports.each.with_index { |import, i| import.update(completed_at: i.days.ago + 2.hours) }
-        expect(ds1.stalled_date).to eq(nil)
-      end
+      it 'is not stalled when there was an import within the last 24 hours' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
 
-      it 'is stalled when the last import was 26 hours ago' do
-        imports.each.with_index do |import, i|
-          time = i.days.ago - 26.hours
-          import.update(completed_at: time)
-        end
-        expect(ds1.stalled_date).to_not eq(nil)
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
       end
     end
 
-    describe 'when expecting multiple file' do
-      let!(:import_config) { create :grda_warehouse_hmis_import_config, file_count: 3, data_source_id: ds1.id }
+    describe 'when expecting multiple files' do
       it 'is not stalled when there are no prior imports in the past 6 months' do
-        expect(ds1.stalled_date).to eq(nil)
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 3)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 7.months.ago)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
       end
 
-      it 'is stalled when there was a partial import yesterday' do
-        # Move one file into the expected range
-        imports.each.with_index { |import, i| import.update(completed_at: i.days.ago) }
-        expect(ds1.stalled_date).to_not eq(nil)
+      it 'is stalled since the oldest of the most recent N uploads, when they span more than 24 hours' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 3)
+        oldest_of_the_three = 50.hours.ago
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 26.hours.ago)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: oldest_of_the_three)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(oldest_of_the_three.to_date)
       end
 
-      it 'is stalled when there was a full import recently, but nothing in the past 24 hours' do
-        imports.first(3).each { |import| import.update(completed_at: 25.hours.ago) }
-        expect(ds1.stalled_date).to_not eq(nil)
+      it 'is stalled when a full set of uploads arrived recently, but not within the last 24 hours' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 3)
+        all_three_completed_at = 25.hours.ago
+        create_list(:grda_warehouse_upload, 3, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: all_three_completed_at)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(all_three_completed_at.to_date)
       end
 
-      it 'is not stalled when there was a full import within the last 24 hours' do
-        imports.first(3).each { |import| import.update(completed_at: 23.hours.ago) }
-        expect(ds1.stalled_date).to eq(nil)
+      it 'is not stalled when a full set of uploads arrived within the last 24 hours' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 3)
+        create_list(:grda_warehouse_upload, 3, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 23.hours.ago)
+
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
       end
+    end
+
+    it 'is not stalled when the import is paused, regardless of upload history' do
+      create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
+      ds1.update!(import_paused: true)
+
+      expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
+    end
+
+    it 'is not stalled when the import config is inactive, regardless of upload history' do
+      create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1, active: false)
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
+
+      expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
+    end
+
+    it "trims each data source to its own file_count instead of the batch's shared cap, when file counts differ" do
+      # file_count: 1, but has 3 historical uploads - only the single most recent may count.
+      single_file_ds = create(:source_data_source)
+      create(:grda_warehouse_hmis_import_config, data_source: single_file_ds, file_count: 1)
+      most_recent_for_single_file_ds = 30.hours.ago
+      create(:grda_warehouse_upload, data_source: single_file_ds, user: User.system_user, percent_complete: 100, completed_at: most_recent_for_single_file_ds)
+      create(:grda_warehouse_upload, data_source: single_file_ds, user: User.system_user, percent_complete: 100, completed_at: 50.hours.ago)
+      create(:grda_warehouse_upload, data_source: single_file_ds, user: User.system_user, percent_complete: 100, completed_at: 70.hours.ago)
+
+      # file_count: 3, sets the batch's shared row cap above 1.
+      multi_file_ds = build_data_source_with_upload(file_count: 3, completed_at: 1.hour.ago)
+      create(:grda_warehouse_upload, data_source: multi_file_ds, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+      create(:grda_warehouse_upload, data_source: multi_file_ds, user: User.system_user, percent_complete: 100, completed_at: 3.hours.ago)
+
+      result = GrdaWarehouse::DataSource.stalled_dates_by_id([single_file_ds.id, multi_file_ds.id])
+
+      # If the shared cap (3, from multi_file_ds) leaked into single_file_ds's own calculation
+      # instead of being trimmed back down to its file_count of 1, this would incorrectly equal
+      # 70.hours.ago.to_date (the oldest of all three uploads) instead of the single most recent one.
+      expect(result[single_file_ds.id]).to eq(most_recent_for_single_file_ds.to_date)
+      expect(result[multi_file_ds.id]).to eq(nil)
+    end
+
+    it "returns each requested id's own result independently in one call, without cross-contamination" do
+      stalled_ds = build_data_source_with_upload(file_count: 1, completed_at: 30.hours.ago)
+      fresh_ds = build_data_source_with_upload(file_count: 1, completed_at: 2.hours.ago)
+
+      result = GrdaWarehouse::DataSource.stalled_dates_by_id([stalled_ds.id, fresh_ds.id])
+
+      expect(result[stalled_ds.id]).to eq(30.hours.ago.to_date)
+      expect(result[fresh_ds.id]).to eq(nil)
+    end
+
+    it 'excludes a soft-deleted upload from the ranking' do
+      create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+      real_completed_at = 30.hours.ago
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: real_completed_at)
+      deleted_upload = create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+      deleted_upload.destroy
+
+      # The deleted upload is more recent than the real one, so if it leaked into the
+      # ranking (e.g. an `.unscoped` applied too broadly), rn=1 would pick it instead and
+      # this would incorrectly return nil (not stalled) rather than the real upload's date.
+      expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(real_completed_at.to_date)
+    end
+  end
+
+  describe '.stalled_dates_by_id query efficiency' do
+    it 'runs a bounded number of queries regardless of how many data sources are checked' do
+      count_queries = lambda do |&block|
+        count = 0
+        callback = ->(*) { count += 1 }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+        count
+      end
+
+      small_batch = Array.new(3) { build_data_source_with_upload(file_count: 1, completed_at: 30.hours.ago) }
+
+      # Warm up one-time schema-cache/connection-setup queries so they don't confound
+      # the small-vs-large comparison below.
+      GrdaWarehouse::DataSource.stalled_dates_by_id(small_batch.map(&:id))
+
+      small_queries = count_queries.call { GrdaWarehouse::DataSource.stalled_dates_by_id(small_batch.map(&:id)) }
+
+      large_batch = small_batch + Array.new(9) { build_data_source_with_upload(file_count: 1, completed_at: 30.hours.ago) }
+      large_queries = count_queries.call { GrdaWarehouse::DataSource.stalled_dates_by_id(large_batch.map(&:id)) }
+
+      # A regression to a per-row query pattern would make large_queries scale with data
+      # source count (9 more data sources here); a small constant tolerance accommodates
+      # incidental variance without masking that regression.
+      expect(large_queries).to be_within(2).of(small_queries)
+    end
+  end
+
+  describe '.stalled_imports?' do
+    def make_stalled(data_source)
+      create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: 1)
+      create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: data_source, completed_at: 30.hours.ago)
+    end
+
+    def make_fresh(data_source)
+      create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: 1)
+      create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: data_source, completed_at: 2.hours.ago)
+    end
+
+    it 'returns true when a data source the user can view has a stalled import' do
+      make_stalled(ds1)
+      empty_collection.set_viewables({ data_sources: [ds1.id] })
+      setup_access_control(user, can_view_projects, empty_collection)
+
+      expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(true)
+    end
+
+    it 'returns false when the only stalled data source is outside what the user can view' do
+      make_stalled(ds1)
+      empty_collection.set_viewables({ data_sources: [ds2.id] })
+      setup_access_control(user, can_view_projects, empty_collection)
+
+      expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(false)
+    end
+
+    it 'returns false when the viewable data source has recent, non-stalled imports' do
+      make_fresh(ds1)
+      empty_collection.set_viewables({ data_sources: [ds1.id] })
+      setup_access_control(user, can_view_projects, empty_collection)
+
+      expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(false)
+    end
+  end
+
+  describe '.stalled_imports? query efficiency' do
+    it 'runs a bounded number of queries regardless of how many data sources the user can view' do
+      count_queries = lambda do |&block|
+        count = 0
+        callback = ->(*) { count += 1 }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+        count
+      end
+
+      small_batch = Array.new(3) { create(:source_data_source) }
+      empty_collection.set_viewables({ data_sources: small_batch.map(&:id) })
+      setup_access_control(user, can_view_projects, empty_collection)
+
+      # Warm up one-time schema-cache/connection-setup queries so they don't confound
+      # the small-vs-large comparison below.
+      GrdaWarehouse::DataSource.stalled_imports?(user)
+      small_queries = count_queries.call { GrdaWarehouse::DataSource.stalled_imports?(user) }
+
+      large_batch = small_batch + Array.new(9) { create(:source_data_source) }
+      empty_collection.set_viewables({ data_sources: large_batch.map(&:id) })
+      large_queries = count_queries.call { GrdaWarehouse::DataSource.stalled_imports?(user) }
+
+      expect(large_queries).to be_within(3).of(small_queries)
+    end
+  end
+
+  describe '.last_import_completed_ats_by_id' do
+    it 'returns the most recent completed_at per data source, keyed by id' do
+      GrdaWarehouse::ImportLog.create!(data_source: ds1, completed_at: 2.days.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: ds1, completed_at: 1.day.ago)
+      GrdaWarehouse::ImportLog.create!(data_source: ds2, completed_at: 3.days.ago)
+
+      result = GrdaWarehouse::DataSource.last_import_completed_ats_by_id([ds1.id, ds2.id])
+
+      expect(result[ds1.id]).to be_within(1.second).of(1.day.ago)
+      expect(result[ds2.id]).to be_within(1.second).of(3.days.ago)
+    end
+
+    it 'omits an id with no import logs at all, so callers can tell "never imported" apart from "imported long ago"' do
+      result = GrdaWarehouse::DataSource.last_import_completed_ats_by_id([ds1.id])
+
+      expect(result).not_to have_key(ds1.id)
     end
   end
 

--- a/spec/models/grda_warehouse/data_source_spec.rb
+++ b/spec/models/grda_warehouse/data_source_spec.rb
@@ -332,6 +332,54 @@ RSpec.describe model, type: :model do
 
       expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(false)
     end
+
+    # The test environment uses config.cache_store = :null_store (config/environments/test.rb),
+    # so Rails.cache.fetch always re-runs its block. Swap in a real store here so these examples
+    # can actually observe caching behavior instead of it being a no-op.
+    describe 'caching' do
+      around do |example|
+        original_cache_store = Rails.cache
+        Rails.cache = ActiveSupport::Cache::MemoryStore.new
+        example.run
+        Rails.cache = original_cache_store
+      end
+
+      def count_queries(&block)
+        count = 0
+        callback = ->(*) { count += 1 }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+        count
+      end
+
+      it 'reuses the cached result on a second call instead of recomputing it' do
+        make_stalled(ds1)
+
+        expect(GrdaWarehouse::DataSource.stalled_data_source_ids).to eq([ds1.id])
+
+        queries_on_second_call = count_queries { GrdaWarehouse::DataSource.stalled_data_source_ids }
+
+        expect(queries_on_second_call).to eq(0)
+      end
+
+      it 'is keyed globally rather than per-user, so a second user reuses the first user\'s cached result' do
+        make_stalled(ds1)
+        other_user = create(:acl_user)
+        empty_collection.set_viewables({ data_sources: [ds1.id, ds2.id] })
+        setup_access_control(user, can_view_projects, empty_collection)
+        setup_access_control(other_user, can_view_projects, empty_collection)
+
+        expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(true)
+
+        # ds2 becomes stalled after the cache was warmed by `user`'s call above. If the cache
+        # key were accidentally scoped per-user, `other_user` would trigger its own
+        # recomputation and see ds2's fresh stall - instead it should see the same cached
+        # (now stale) id set the first user warmed, proving the key is shared globally.
+        make_stalled(ds2)
+
+        expect(GrdaWarehouse::DataSource.stalled_data_source_ids).to eq([ds1.id])
+        expect(GrdaWarehouse::DataSource.stalled_imports?(other_user)).to eq(true)
+      end
+    end
   end
 
   describe '.stalled_imports? query efficiency' do
@@ -376,6 +424,74 @@ RSpec.describe model, type: :model do
       result = GrdaWarehouse::DataSource.last_import_completed_ats_by_id([ds1.id])
 
       expect(result).not_to have_key(ds1.id)
+    end
+  end
+
+  describe '.client_counts_by_id' do
+    it "matches each data source's own #client_count" do
+      create_list(:hud_client, 2, data_source_id: ds1.id)
+      create(:hud_client, data_source_id: ds2.id)
+
+      result = GrdaWarehouse::DataSource.client_counts_by_id([ds1.id, ds2.id])
+
+      expect(result[ds1.id]).to eq(ds1.client_count)
+      expect(result[ds2.id]).to eq(ds2.client_count)
+      expect(result[ds1.id]).to eq(2)
+      expect(result[ds2.id]).to eq(1)
+    end
+
+    it 'defaults to 0 for a data source with no clients, rather than omitting its key' do
+      result = GrdaWarehouse::DataSource.client_counts_by_id([ds1.id])
+
+      expect(result[ds1.id]).to eq(0)
+    end
+  end
+
+  describe '.project_counts_by_id' do
+    it "matches each data source's own #project_count" do
+      result = GrdaWarehouse::DataSource.project_counts_by_id([ds1.id, ds2.id])
+
+      # ds1 has p1-p4, ds2 has p5-p8 (see the fixture hierarchy at the top of this file).
+      expect(result[ds1.id]).to eq(ds1.project_count)
+      expect(result[ds2.id]).to eq(ds2.project_count)
+      expect(result[ds1.id]).to eq(4)
+      expect(result[ds2.id]).to eq(4)
+    end
+
+    it 'defaults to 0 for a data source with no projects, rather than omitting its key' do
+      empty_ds = create(:source_data_source)
+
+      result = GrdaWarehouse::DataSource.project_counts_by_id([empty_ds.id])
+
+      expect(result[empty_ds.id]).to eq(0)
+    end
+  end
+
+  describe '.unprocessed_enrollment_counts_by_id' do
+    def create_resolvable_enrollment(data_source:, project:, processed_as:)
+      source_client = create(:hud_client, data_source: data_source)
+      destination_client = source_client.dup
+      destination_client.data_source = create(:destination_data_source)
+      destination_client.save!
+      create(:warehouse_client, destination_id: destination_client.id, source_id: source_client.id)
+      create(:hud_enrollment, data_source: data_source, project: project, client: source_client, processed_as: processed_as)
+    end
+
+    it "matches each data source's own #unprocessed_enrollment_count" do
+      create_resolvable_enrollment(data_source: ds1, project: p1, processed_as: nil)
+      create_resolvable_enrollment(data_source: ds1, project: p1, processed_as: { 'a' => 1 })
+
+      result = GrdaWarehouse::DataSource.unprocessed_enrollment_counts_by_id([ds1.id, ds2.id])
+
+      expect(result[ds1.id]).to eq(ds1.unprocessed_enrollment_count)
+      expect(result[ds1.id]).to eq(1)
+      expect(result[ds2.id]).to eq(0)
+    end
+
+    it 'defaults to 0 for a data source with no unprocessed enrollments, rather than omitting its key' do
+      result = GrdaWarehouse::DataSource.unprocessed_enrollment_counts_by_id([ds1.id])
+
+      expect(result[ds1.id]).to eq(0)
     end
   end
 

--- a/spec/models/grda_warehouse/data_source_spec.rb
+++ b/spec/models/grda_warehouse/data_source_spec.rb
@@ -51,6 +51,12 @@ RSpec.describe model, type: :model do
   user_ids = ->(user) { model.viewable_by(user, permission: :can_view_projects).pluck(:id).sort }
   ids = ->(*sources) { sources.map(&:id).sort }
 
+  # A fixed instant clear of midnight and of any daylight-saving transition, so the 24-hour
+  # stall boundary and the `.to_date` assertions in the stall examples can't drift.
+  def import_stall_evaluated_at
+    Time.zone.local(2026, 6, 15, 12, 0, 0)
+  end
+
   def build_data_source_with_upload(file_count:, completed_at:)
     data_source = create(:source_data_source)
     create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: file_count)
@@ -148,6 +154,10 @@ RSpec.describe model, type: :model do
   end
 
   describe '.stalled_dates_by_id' do
+    around do |example|
+      travel_to(import_stall_evaluated_at) { example.run }
+    end
+
     describe 'when expecting one file' do
       it 'is not stalled when there are no prior imports in the past 6 months' do
         create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
@@ -205,6 +215,17 @@ RSpec.describe model, type: :model do
 
         expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
       end
+
+      it 'is stalled when fewer than the expected number of uploads arrived, even though all of them arrived within the last 24 hours' do
+        create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 3)
+        oldest_of_the_two = 5.hours.ago
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+        create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: oldest_of_the_two)
+
+        # Both uploads are recent, so recency alone would clear this data source; only the
+        # count check distinguishes a partial delivery from a complete one.
+        expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(oldest_of_the_two.to_date)
+      end
     end
 
     it 'is not stalled when the import is paused, regardless of upload history' do
@@ -220,6 +241,28 @@ RSpec.describe model, type: :model do
       create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
 
       expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(nil)
+    end
+
+    it 'ignores uploads brought in by anyone other than the system user' do
+      create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+      system_user_completed_at = 30.hours.ago
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: system_user_completed_at)
+      create(:grda_warehouse_upload, data_source: ds1, user: user, percent_complete: 100, completed_at: 2.hours.ago)
+
+      # The hand-uploaded file is the more recent of the two, so without the system-user
+      # filter it would take rn=1 and clear the data source.
+      expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(system_user_completed_at.to_date)
+    end
+
+    it 'ignores an upload that has not finished importing' do
+      create(:grda_warehouse_hmis_import_config, data_source: ds1, file_count: 1)
+      finished_completed_at = 30.hours.ago
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 100, completed_at: finished_completed_at)
+      create(:grda_warehouse_upload, data_source: ds1, user: User.system_user, percent_complete: 50, completed_at: 2.hours.ago)
+
+      # The in-flight upload is the more recent of the two, so without the completed filter
+      # it would take rn=1 and clear the data source.
+      expect(GrdaWarehouse::DataSource.stalled_dates_by_id([ds1.id])[ds1.id]).to eq(finished_completed_at.to_date)
     end
 
     it "trims each data source to its own file_count instead of the batch's shared cap, when file counts differ" do
@@ -297,6 +340,10 @@ RSpec.describe model, type: :model do
   end
 
   describe '.stalled_imports?' do
+    around do |example|
+      travel_to(import_stall_evaluated_at) { example.run }
+    end
+
     def make_stalled(data_source)
       create(:grda_warehouse_hmis_import_config, data_source: data_source, file_count: 1)
       create(:grda_warehouse_upload, data_source: data_source, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
@@ -341,6 +388,7 @@ RSpec.describe model, type: :model do
         original_cache_store = Rails.cache
         Rails.cache = ActiveSupport::Cache::MemoryStore.new
         example.run
+      ensure
         Rails.cache = original_cache_store
       end
 
@@ -361,23 +409,24 @@ RSpec.describe model, type: :model do
         expect(queries_on_second_call).to eq(0)
       end
 
-      it 'is keyed globally rather than per-user, so a second user reuses the first user\'s cached result' do
-        make_stalled(ds1)
+      it 'shares one cached set of stalled ids across users rather than computing one per user' do
         other_user = create(:acl_user)
-        empty_collection.set_viewables({ data_sources: [ds1.id, ds2.id] })
+        other_collection = create(:collection)
+        empty_collection.set_viewables({ data_sources: [ds1.id] })
+        other_collection.set_viewables({ data_sources: [ds2.id] })
         setup_access_control(user, can_view_projects, empty_collection)
-        setup_access_control(other_user, can_view_projects, empty_collection)
+        setup_access_control(other_user, can_view_projects, other_collection)
 
+        # Warms the cache while ds1 is the only stalled data source.
+        make_stalled(ds1)
         expect(GrdaWarehouse::DataSource.stalled_imports?(user)).to eq(true)
 
-        # ds2 becomes stalled after the cache was warmed by `user`'s call above. If the cache
-        # key were accidentally scoped per-user, `other_user` would trigger its own
-        # recomputation and see ds2's fresh stall - instead it should see the same cached
-        # (now stale) id set the first user warmed, proving the key is shared globally.
+        # ds2 stalls only after that warm-up, and other_user can view ds2 alone. Under a
+        # per-user cache key other_user would compute a fresh set and see ds2; one shared
+        # entry keeps ds2 out until the entry expires.
         make_stalled(ds2)
 
-        expect(GrdaWarehouse::DataSource.stalled_data_source_ids).to eq([ds1.id])
-        expect(GrdaWarehouse::DataSource.stalled_imports?(other_user)).to eq(true)
+        expect(GrdaWarehouse::DataSource.stalled_imports?(other_user)).to eq(false)
       end
     end
   end

--- a/spec/requests/data_sources_controller_spec.rb
+++ b/spec/requests/data_sources_controller_spec.rb
@@ -296,6 +296,24 @@ RSpec.describe DataSourcesController, type: :request do
         expect(cells[3].text.strip).to eq('0')
         expect(row_without_data.text).not_to include('Enrollments remaining to process')
       end
+
+      it 'shows the stalled-import label only for a data source whose most recent import is stale' do
+        ds_with_data.update!(last_imported_at: 30.hours.ago)
+        create(:grda_warehouse_hmis_import_config, data_source: ds_with_data, file_count: 1)
+        create(:grda_warehouse_upload, data_source: ds_with_data, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
+
+        get data_sources_path
+        expect(response).to have_http_status(:ok)
+
+        doc = Nokogiri::HTML(response.body)
+        rows = doc.css('tbody tr')
+
+        row_with_data = rows.find { |r| r.at_css('td a')&.text == 'Alpha Vendor' }
+        expect(row_with_data.text).to include('same file since:')
+
+        row_without_data = rows.find { |r| r.at_css('td a')&.text == 'Zeta Vendor' }
+        expect(row_without_data.text).not_to include('same file since:')
+      end
     end
 
     context 'query efficiency' do

--- a/spec/requests/data_sources_controller_spec.rb
+++ b/spec/requests/data_sources_controller_spec.rb
@@ -340,6 +340,10 @@ RSpec.describe DataSourcesController, type: :request do
 
         large_batch = small_batch + Array.new(9) { |i| build_data_source_with_data(name: "Large Vendor #{i}") }
         collection.set_viewables({ data_sources: large_batch.map(&:id) })
+        # This comparison only holds if every data source in large_batch lands on page 1;
+        # otherwise large_queries would undercount and the assertion below would pass for
+        # the wrong reason.
+        expect(large_batch.size).to be <= Pagy::DEFAULT[:items]
 
         large_queries = count_queries.call { get data_sources_path }
         expect(response).to have_http_status(:ok)

--- a/spec/requests/data_sources_controller_spec.rb
+++ b/spec/requests/data_sources_controller_spec.rb
@@ -256,6 +256,12 @@ RSpec.describe DataSourcesController, type: :request do
       ds
     end
 
+    # The first cell of each data source row links to that data source; the leading
+    # warehouse-totals row has no link.
+    def rendered_data_source_names(body)
+      Nokogiri::HTML(body).css('tbody tr').filter_map { |row| row.at_css('td a')&.text&.strip }
+    end
+
     context 'with counts to render' do
       let!(:ds_with_data) { create(:source_data_source, name: 'Alpha Vendor') }
       let!(:ds_without_data) { create(:source_data_source, name: 'Zeta Vendor') }
@@ -302,6 +308,13 @@ RSpec.describe DataSourcesController, type: :request do
         create(:grda_warehouse_hmis_import_config, data_source: ds_with_data, file_count: 1)
         create(:grda_warehouse_upload, data_source: ds_with_data, user: User.system_user, percent_complete: 100, completed_at: 30.hours.ago)
 
+        # Zeta has imported too, so its row reaches the same stall check Alpha's does and the
+        # label's absence there is attributable to the stall rule rather than to the outer
+        # `last_imported_at.present?` gate in the view.
+        ds_without_data.update!(last_imported_at: 2.hours.ago)
+        create(:grda_warehouse_hmis_import_config, data_source: ds_without_data, file_count: 1)
+        create(:grda_warehouse_upload, data_source: ds_without_data, user: User.system_user, percent_complete: 100, completed_at: 2.hours.ago)
+
         get data_sources_path
         expect(response).to have_http_status(:ok)
 
@@ -336,7 +349,7 @@ RSpec.describe DataSourcesController, type: :request do
         expect(response).to have_http_status(:ok)
 
         small_queries = count_queries.call { get data_sources_path }
-        expect(response).to have_http_status(:ok)
+        expect(rendered_data_source_names(response.body)).to match_array(small_batch.map(&:name))
 
         large_batch = small_batch + Array.new(9) { |i| build_data_source_with_data(name: "Large Vendor #{i}") }
         collection.set_viewables({ data_sources: large_batch.map(&:id) })
@@ -346,7 +359,10 @@ RSpec.describe DataSourcesController, type: :request do
         expect(large_batch.size).to be <= Pagy::DEFAULT[:items]
 
         large_queries = count_queries.call { get data_sources_path }
-        expect(response).to have_http_status(:ok)
+        # The query comparison below is only meaningful if the nine additional data sources
+        # actually rendered; a page that kept showing three rows would match on query count
+        # while exercising none of the added load.
+        expect(rendered_data_source_names(response.body)).to match_array(large_batch.map(&:name))
 
         # A regression to the old per-row query pattern (client/project/unprocessed-enrollment
         # counts each queried once per row) would make large_queries scale with data source

--- a/spec/requests/data_sources_controller_spec.rb
+++ b/spec/requests/data_sources_controller_spec.rb
@@ -235,6 +235,106 @@ RSpec.describe DataSourcesController, type: :request do
     end
   end
 
+  describe 'GET #index' do
+    let(:destination_data_source) { create(:destination_data_source) }
+
+    def create_linked_client(within_data_source)
+      source_client = create(:grda_warehouse_hud_client, data_source: within_data_source)
+      destination_client = source_client.dup
+      destination_client.data_source = destination_data_source
+      destination_client.save!
+      create(:warehouse_client, destination_id: destination_client.id, source_id: source_client.id)
+      source_client
+    end
+
+    def build_data_source_with_data(name:)
+      ds = create(:source_data_source, name: name)
+      org = create(:hud_organization, data_source: ds)
+      project = create(:hud_project, data_source: ds, OrganizationID: org.OrganizationID)
+      create_list(:hud_client, 2, data_source: ds)
+      create(:hud_enrollment, data_source: ds, project: project, client: create_linked_client(ds), processed_as: nil)
+      ds
+    end
+
+    context 'with counts to render' do
+      let!(:ds_with_data) { create(:source_data_source, name: 'Alpha Vendor') }
+      let!(:ds_without_data) { create(:source_data_source, name: 'Zeta Vendor') }
+      let!(:org) { create(:hud_organization, data_source: ds_with_data) }
+      let!(:project) { create(:hud_project, data_source: ds_with_data, OrganizationID: org.OrganizationID) }
+      let!(:clients) { create_list(:hud_client, 2, data_source: ds_with_data) }
+      let!(:eligible_enrollment) do
+        create(:hud_enrollment, data_source: ds_with_data, project: project, client: create_linked_client(ds_with_data), processed_as: nil)
+      end
+      let!(:processed_enrollment) do
+        create(:hud_enrollment, data_source: ds_with_data, project: project, client: create_linked_client(ds_with_data), processed_as: { 'a' => 1 })
+      end
+
+      before do
+        collection.set_viewables({ data_sources: [ds_with_data.id, ds_without_data.id] })
+        setup_access_control(user, role, collection)
+        sign_in user
+      end
+
+      it 'shows accurate client, project, and unprocessed-enrollment counts per data source, including a data source with none' do
+        get data_sources_path
+        expect(response).to have_http_status(:ok)
+
+        doc = Nokogiri::HTML(response.body)
+        rows = doc.css('tbody tr')
+
+        row_with_data = rows.find { |r| r.at_css('td a')&.text == 'Alpha Vendor' }
+        cells = row_with_data.css('td')
+        # 2 explicit clients plus the 2 source clients created by create_linked_client
+        # for the eligible/processed enrollments below.
+        expect(cells[2].text.strip).to eq('4')
+        expect(cells[3].text.strip).to eq('1')
+        expect(row_with_data.text).to include('Enrollments remaining to process: 1')
+
+        row_without_data = rows.find { |r| r.at_css('td a')&.text == 'Zeta Vendor' }
+        cells = row_without_data.css('td')
+        expect(cells[2].text.strip).to eq('0')
+        expect(cells[3].text.strip).to eq('0')
+        expect(row_without_data.text).not_to include('Enrollments remaining to process')
+      end
+    end
+
+    context 'query efficiency' do
+      it 'runs a bounded number of queries regardless of how many data sources are on the page' do
+        count_queries = lambda do |&block|
+          count = 0
+          callback = ->(*) { count += 1 }
+          ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+          count
+        end
+
+        small_batch = Array.new(3) { |i| build_data_source_with_data(name: "Small Vendor #{i}") }
+        collection.set_viewables({ data_sources: small_batch.map(&:id) })
+        setup_access_control(user, role, collection)
+        sign_in user
+
+        # Warm up one-time schema-cache/connection-setup queries so they don't confound
+        # the small-vs-large comparison below.
+        get data_sources_path
+        expect(response).to have_http_status(:ok)
+
+        small_queries = count_queries.call { get data_sources_path }
+        expect(response).to have_http_status(:ok)
+
+        large_batch = small_batch + Array.new(9) { |i| build_data_source_with_data(name: "Large Vendor #{i}") }
+        collection.set_viewables({ data_sources: large_batch.map(&:id) })
+
+        large_queries = count_queries.call { get data_sources_path }
+        expect(response).to have_http_status(:ok)
+
+        # A regression to the old per-row query pattern (client/project/unprocessed-enrollment
+        # counts each queried once per row) would make large_queries scale with data source
+        # count (9 more data sources here); a small constant tolerance accommodates incidental
+        # preload-boundary variance without masking that regression.
+        expect(large_queries).to be_within(5).of(small_queries)
+      end
+    end
+  end
+
   describe 'with permission to edit the data source' do
     let(:edit_role) { create(:role, can_view_projects: true, can_edit_data_sources: true) }
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Overall performance cleanup of the data sources index page.  This should be functionally equivalent to the existing code.

This batches queries for:
* Import stall detaction
* Import last run
* counts of clients per data source
* counts of projects per data source
* counts of un-processed enrollments per data source

Additionally, it move the cache to a global cache and filters cached counts per-user, which should mean only one person every hour needs to refresh the cache.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Code clean-up

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

