### PR TITLE
fix: 9561 IdP account creation and local-only accounts

### DIFF
--- a/app/controllers/admin/concerns/user_management_behavior.rb
+++ b/app/controllers/admin/concerns/user_management_behavior.rb
@@ -464,6 +464,12 @@ module Admin
             # User params will never include system user groups in user_group_ids, re-add any of those before saving
             result[:user_group_ids] ||= []
             result[:user_group_ids] += @user.user_groups.system.pluck(:id)
+
+            # users.agency_id has no foreign key (0 is a sentinel for system and JIT-provisioned
+            # accounts), so an id outside agency_scope would save as a dangling or off-limits
+            # reference. Blank it instead and let the presence validation put the admin back on the
+            # form.
+            result[:agency_id] = agency_scope.where(id: result[:agency_id]).pick(:id) if result.key?(:agency_id)
           end.
           except(*externally_managed_param_keys)
       end
@@ -505,7 +511,17 @@ module Admin
       private def set_user
         @user = User.find(params[:id].to_i)
 
-        @agencies = Agency.order(:name)
+        set_agencies
+      end
+
+      private def set_agencies
+        @agencies = agency_scope.order(:name)
+      end
+
+      # The one seam for narrowing which agencies an admin may assign. Both the assignable
+      # collection and the agency_id check in user_params read it, so they can't disagree.
+      private def agency_scope
+        Agency.all
       end
 
       private def perform_search(search_params = {})

--- a/app/controllers/admin/concerns/user_management_behavior.rb
+++ b/app/controllers/admin/concerns/user_management_behavior.rb
@@ -513,8 +513,6 @@ module Admin
         @agencies = agency_scope.order(:name)
       end
 
-      # The one seam for narrowing which agencies an admin may assign. Both the assignable
-      # collection and the agency_id check in user_params read it, so they can't disagree.
       private def agency_scope
         Agency.all
       end

--- a/app/controllers/admin/concerns/user_management_behavior.rb
+++ b/app/controllers/admin/concerns/user_management_behavior.rb
@@ -464,11 +464,6 @@ module Admin
             # User params will never include system user groups in user_group_ids, re-add any of those before saving
             result[:user_group_ids] ||= []
             result[:user_group_ids] += @user.user_groups.system.pluck(:id)
-
-            # users.agency_id has no foreign key (0 is a sentinel for system and JIT-provisioned
-            # accounts), so an id outside agency_scope would save as a dangling or off-limits
-            # reference. Blank it instead and let the presence validation put the admin back on the
-            # form.
             result[:agency_id] = agency_scope.where(id: result[:agency_id]).pick(:id) if result.key?(:agency_id)
           end.
           except(*externally_managed_param_keys)

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -50,7 +50,7 @@ class Admin::Idp::UsersController < ApplicationController
   end
 
   def create
-    return render_missing_connector if new_user_params[:selected_idp_connector_id].blank?
+    return render_missing_connector if new_user_params[:idp_connector_id].blank?
 
     @user = ::Idp::AdminUserCreator.call(
       connector_id: create_connector_id,
@@ -61,7 +61,7 @@ class Admin::Idp::UsersController < ApplicationController
     )
   rescue ActiveRecord::RecordInvalid => e
     @user = e.record
-    @user.selected_idp_connector_id = new_user_params[:selected_idp_connector_id]
+    @user.idp_connector_id = new_user_params[:idp_connector_id]
     flash.now[:error] = 'Please review the form problems below'
     render :new
   rescue ::Idp::ConflictError => e
@@ -152,7 +152,7 @@ class Admin::Idp::UsersController < ApplicationController
 
   private def render_missing_connector
     @user = User.new(new_user_params)
-    @user.errors.add(:selected_idp_connector_id, 'must be chosen')
+    @user.errors.add(:idp_connector_id, 'must be chosen')
     flash.now[:error] = 'Please review the form problems below'
     render :new
   end
@@ -178,15 +178,15 @@ class Admin::Idp::UsersController < ApplicationController
     LOCAL_ONLY_CONNECTOR
   end
 
-  # Constrained to available_connectors so the selected_idp_connector_id param can't target an arbitrary
+  # Constrained to available_connectors so the idp_connector_id param can't target an arbitrary
   # or creation-incapable config. LOCAL_ONLY_CONNECTOR — and anything else unrecognized — means no
   # remote account is provisioned.
   private def create_connector_id
-    chosen = new_user_params[:selected_idp_connector_id]
+    chosen = new_user_params[:idp_connector_id]
     available_connectors.map(&:connector_id).include?(chosen) ? chosen : nil
   end
 
   private def new_user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :agency_id, :selected_idp_connector_id)
+    params.require(:user).permit(:first_name, :last_name, :email, :agency_id, :idp_connector_id)
   end
 end

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -9,9 +9,13 @@
 class Admin::Idp::UsersController < ApplicationController
   include ::Admin::Concerns::UserManagementBehavior
 
-  before_action :require_user_creation_available!, only: [:new, :create]
+  # The create form's "Local account only" choice. Not blank: a blank value matches the record's nil
+  # connector_id and would come back pre-selected on the radios, which must have no default.
+  LOCAL_ONLY_CONNECTOR = 'local-only'
+
   before_action :set_connectors, only: [:new, :create]
-  helper_method :idp_user_creation_available?
+  before_action :set_agencies, only: [:new, :create]
+  helper_method :local_only_connector
 
   # Fall back to the shared admin/users templates for any views this arm doesn't override:
   def _prefixes
@@ -48,26 +52,34 @@ class Admin::Idp::UsersController < ApplicationController
   end
 
   def create
+    # Only the radios (several connectors, no default) can come back unanswered; the checkbox and
+    # hidden-field forms always submit a value. Local-only submits LOCAL_ONLY_CONNECTOR, not blank.
+    return render_missing_connector if @connectors.many? && new_user_params[:connector_id].blank?
+
     @user = ::Idp::AdminUserCreator.call(
       connector_id: create_connector_id,
       email: new_user_params[:email],
       first_name: new_user_params[:first_name],
       last_name: new_user_params[:last_name],
+      agency_id: agency_scope.where(id: new_user_params[:agency_id]).pick(:id),
     )
   rescue ActiveRecord::RecordInvalid => e
     @user = e.record
+    # AdminUserCreator doesn't set the virtual attribute, so put the admin's pick back on the record
+    # for the re-rendered radios.
+    @user.connector_id = new_user_params[:connector_id]
     flash.now[:error] = 'Please review the form problems below'
     render :new
   rescue ::Idp::ConflictError => e
     # The address is registered to a different account in the IdP. AdminUserCreator links to an
     # existing account by email rather than colliding with it, so this is the narrower case of a
     # username/email clash inside the realm — a form problem, not a broken connector.
-    @user = User.new(new_user_params.except(:connector_id))
+    @user = User.new(new_user_params)
     @user.errors.add(:email, "is already registered with #{e.idp_name}")
     flash.now[:error] = 'Please review the form problems below'
     render :new
   rescue ::Idp::ServiceError => e
-    @user = User.new(new_user_params.except(:connector_id))
+    @user = User.new(new_user_params)
     flash.now[:error] = "Couldn't create the account in the identity provider: #{e.message}"
     render :new
   else
@@ -144,6 +156,13 @@ class Admin::Idp::UsersController < ApplicationController
   private def skip_email_reconfirmation
   end
 
+  private def render_missing_connector
+    @user = User.new(new_user_params)
+    @user.errors.add(:connector_id, 'must be chosen')
+    flash.now[:error] = 'Please review the form problems below'
+    render :new
+  end
+
   private def creation_notice(user, emailed:)
     parts = ["Account created for #{user.email}."]
     parts << 'A setup email has been sent.' if emailed
@@ -151,40 +170,32 @@ class Admin::Idp::UsersController < ApplicationController
     parts.join(' ')
   end
 
-  # Active configs whose IdP can provision new accounts; a deployment may have several, one per
-  # realm. Empty under Devise: provisioning relies on Idp::Support, which is only mixed into the
-  # user models under AuthMethod.jwt?.
+  # Active configs that can actually provision accounts; a deployment may have several, one per
+  # realm, or none. A config without a management API is filtered out rather than offered, since
+  # choosing it would create the account locally anyway. Empty under Devise: provisioning relies on
+  # Idp::Support, which is only mixed into the user models under AuthMethod.jwt?.
   private def available_connectors
-    return [] unless AuthMethod.jwt?
-
-    @available_connectors ||= ::Idp::ServiceConfig.active.order(:name, :id)
-  end
-
-  private def idp_user_creation_available?
-    available_connectors.any?
-  end
-
-  private def require_user_creation_available!
-    return if idp_user_creation_available?
-
-    redirect_to admin_users_path, alert: 'Creating user accounts is not available for this identity provider.'
+    @available_connectors ||= ::Idp::ServiceConfig.active.order(:name, :id).
+      select { |config| config.to_service.supports_user_creation? }
   end
 
   private def set_connectors
     @connectors = available_connectors
   end
 
+  private def local_only_connector
+    LOCAL_ONLY_CONNECTOR
+  end
+
   # Constrained to available_connectors so the connector_id param can't target an arbitrary or
-  # creation-incapable config; falls back to the sole available connector when none is chosen.
+  # creation-incapable config. LOCAL_ONLY_CONNECTOR — and anything else unrecognized — means no
+  # remote account is provisioned.
   private def create_connector_id
     chosen = new_user_params[:connector_id]
-    ids = available_connectors.map(&:connector_id)
-    return chosen if chosen.present? && ids.include?(chosen)
-
-    ids.first
+    available_connectors.map(&:connector_id).include?(chosen) ? chosen : nil
   end
 
   private def new_user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :connector_id)
+    params.require(:user).permit(:first_name, :last_name, :email, :agency_id, :connector_id)
   end
 end

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -178,9 +178,7 @@ class Admin::Idp::UsersController < ApplicationController
     LOCAL_ONLY_CONNECTOR
   end
 
-  # Constrained to available_connectors so the idp_connector_id param can't target an arbitrary
-  # or creation-incapable config. LOCAL_ONLY_CONNECTOR — and anything else unrecognized — means no
-  # remote account is provisioned.
+  # Constrained to available_connectors
   private def create_connector_id
     chosen = new_user_params[:idp_connector_id]
     available_connectors.map(&:connector_id).include?(chosen) ? chosen : nil

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -9,8 +9,6 @@
 class Admin::Idp::UsersController < ApplicationController
   include ::Admin::Concerns::UserManagementBehavior
 
-  # The create form's "Local account only" choice. Not blank: a blank value matches the record's nil
-  # connector_id and would come back pre-selected on the radios, which must have no default.
   LOCAL_ONLY_CONNECTOR = 'local-only'
 
   before_action :set_connectors, only: [:new, :create]
@@ -52,9 +50,7 @@ class Admin::Idp::UsersController < ApplicationController
   end
 
   def create
-    # Only the radios (several connectors, no default) can come back unanswered; the checkbox and
-    # hidden-field forms always submit a value. Local-only submits LOCAL_ONLY_CONNECTOR, not blank.
-    return render_missing_connector if @connectors.many? && new_user_params[:connector_id].blank?
+    return render_missing_connector if new_user_params[:selected_idp_connector_id].blank?
 
     @user = ::Idp::AdminUserCreator.call(
       connector_id: create_connector_id,
@@ -65,9 +61,7 @@ class Admin::Idp::UsersController < ApplicationController
     )
   rescue ActiveRecord::RecordInvalid => e
     @user = e.record
-    # AdminUserCreator doesn't set the virtual attribute, so put the admin's pick back on the record
-    # for the re-rendered radios.
-    @user.connector_id = new_user_params[:connector_id]
+    @user.selected_idp_connector_id = new_user_params[:selected_idp_connector_id]
     flash.now[:error] = 'Please review the form problems below'
     render :new
   rescue ::Idp::ConflictError => e
@@ -158,7 +152,7 @@ class Admin::Idp::UsersController < ApplicationController
 
   private def render_missing_connector
     @user = User.new(new_user_params)
-    @user.errors.add(:connector_id, 'must be chosen')
+    @user.errors.add(:selected_idp_connector_id, 'must be chosen')
     flash.now[:error] = 'Please review the form problems below'
     render :new
   end
@@ -184,15 +178,15 @@ class Admin::Idp::UsersController < ApplicationController
     LOCAL_ONLY_CONNECTOR
   end
 
-  # Constrained to available_connectors so the connector_id param can't target an arbitrary or
-  # creation-incapable config. LOCAL_ONLY_CONNECTOR — and anything else unrecognized — means no
+  # Constrained to available_connectors so the selected_idp_connector_id param can't target an arbitrary
+  # or creation-incapable config. LOCAL_ONLY_CONNECTOR — and anything else unrecognized — means no
   # remote account is provisioned.
   private def create_connector_id
-    chosen = new_user_params[:connector_id]
+    chosen = new_user_params[:selected_idp_connector_id]
     available_connectors.map(&:connector_id).include?(chosen) ? chosen : nil
   end
 
   private def new_user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :agency_id, :connector_id)
+    params.require(:user).permit(:first_name, :last_name, :email, :agency_id, :selected_idp_connector_id)
   end
 end

--- a/app/controllers/admin/idp/users_controller.rb
+++ b/app/controllers/admin/idp/users_controller.rb
@@ -170,10 +170,7 @@ class Admin::Idp::UsersController < ApplicationController
     parts.join(' ')
   end
 
-  # Active configs that can actually provision accounts; a deployment may have several, one per
-  # realm, or none. A config without a management API is filtered out rather than offered, since
-  # choosing it would create the account locally anyway. Empty under Devise: provisioning relies on
-  # Idp::Support, which is only mixed into the user models under AuthMethod.jwt?.
+  # Active IdP configs that can actually provision accounts
   private def available_connectors
     @available_connectors ||= ::Idp::ServiceConfig.active.order(:name, :id).
       select { |config| config.to_service.supports_user_creation? }

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -263,9 +263,7 @@ module Idp::JwtAuthentication
     # Idp::UnauthenticatedRequestError for how the proxy config and route surface let it happen.
     raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
-    # A valid token we couldn't resolve or provision an account from. Provisioning is
-    # unconditional now, so the remaining case is a token carrying no usable email claim.
-    # Rendered as a terminal page in the same shape as idp_handle_deactivated.
+    # A valid token we could neither resolve nor provision an account from.
     render(template: 'errors/no_warehouse_account', status: :forbidden)
   end
 

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -171,8 +171,8 @@ module Idp::JwtAuthentication
 
   def idp_authenticated_user_from_jwt(user_class: User)
     # find_or_create_from_jwt provisions a user on first sign-in, and updates the Authentication
-    # Source record on every request (via Idp::UserProvisioner).
-    # idp_token_holder memoizes this so it only happens once per request.
+    # Source record on every request (via Idp::UserProvisioner). idp_token_holder memoizes this
+    # so it only happens once per request.
     authenticated_user = idp_token_holder
     return nil unless authenticated_user
 

--- a/app/controllers/concerns/idp/jwt_authentication.rb
+++ b/app/controllers/concerns/idp/jwt_authentication.rb
@@ -170,8 +170,8 @@ module Idp::JwtAuthentication
   end
 
   def idp_authenticated_user_from_jwt(user_class: User)
-    # find_or_create_from_jwt only creates a user if idp/auto_create_user is set, and it
-    # updates the Authentication Source record on every request (via Idp::UserProvisioner).
+    # find_or_create_from_jwt provisions a user on first sign-in, and updates the Authentication
+    # Source record on every request (via Idp::UserProvisioner).
     # idp_token_holder memoizes this so it only happens once per request.
     authenticated_user = idp_token_holder
     return nil unless authenticated_user
@@ -263,10 +263,9 @@ module Idp::JwtAuthentication
     # Idp::UnauthenticatedRequestError for how the proxy config and route surface let it happen.
     raise Idp::UnauthenticatedRequestError, request.path unless idp_jwt_helper_for_request.token?
 
-    # A valid token whose holder has no warehouse account: Idp::UserProvisioner returns nil when
-    # idp/auto_create_user is off and no row matches, which is routine on a realm shared with other
-    # apps. That is a person who needs an account rather than a misconfiguration, so render a
-    # terminal page in the same shape as idp_handle_deactivated.
+    # A valid token we couldn't resolve or provision an account from. Provisioning is
+    # unconditional now, so the remaining case is a token carrying no usable email claim.
+    # Rendered as a terminal page in the same shape as idp_handle_deactivated.
     render(template: 'errors/no_warehouse_account', status: :forbidden)
   end
 

--- a/app/models/concerns/idp/jwt_user.rb
+++ b/app/models/concerns/idp/jwt_user.rb
@@ -12,8 +12,6 @@ module Idp::JwtUser
   extend ActiveSupport::Concern
 
   class_methods do
-    # Creation is always allowed: a token this stack verified is an authenticated person, and the
-    # IdP realm is the access boundary.
     def find_or_create_from_jwt(jwt_helper)
       Idp::UserProvisioner.call(jwt_helper: jwt_helper, user_class: self, allow_create: true, learn: true)
     end

--- a/app/models/concerns/idp/jwt_user.rb
+++ b/app/models/concerns/idp/jwt_user.rb
@@ -12,9 +12,11 @@ module Idp::JwtUser
   extend ActiveSupport::Concern
 
   class_methods do
+    # Creation is always allowed: a token this stack verified is an authenticated person, and the
+    # IdP realm is the access boundary. Provisioning is not gated on connector config, so a
+    # first sign-in never lands on errors/no_warehouse_account.
     def find_or_create_from_jwt(jwt_helper)
-      allow_create = AppConfigProperty.find_by(key: 'idp/auto_create_user')&.value == 'true'
-      Idp::UserProvisioner.call(jwt_helper: jwt_helper, user_class: self, allow_create: allow_create, learn: true)
+      Idp::UserProvisioner.call(jwt_helper: jwt_helper, user_class: self, allow_create: true, learn: true)
     end
 
     def find_from_jwt(jwt_helper)

--- a/app/models/concerns/idp/jwt_user.rb
+++ b/app/models/concerns/idp/jwt_user.rb
@@ -13,8 +13,7 @@ module Idp::JwtUser
 
   class_methods do
     # Creation is always allowed: a token this stack verified is an authenticated person, and the
-    # IdP realm is the access boundary. Provisioning is not gated on connector config, so a
-    # first sign-in never lands on errors/no_warehouse_account.
+    # IdP realm is the access boundary.
     def find_or_create_from_jwt(jwt_helper)
       Idp::UserProvisioner.call(jwt_helper: jwt_helper, user_class: self, allow_create: true, learn: true)
     end

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -11,9 +11,8 @@ module Idp::Support
   extend ActiveSupport::Concern
 
   included do
-    # Virtual: the realm an admin picks on the account-create form. Never persisted under this name
-    # — a successful create records the choice as a UserAuthenticationSource and last_connector_id —
-    # but it has to live on the record so the form can render the selection back and hang a
+    # Virtual: the realm an admin picks on the account-create form. Never persisted under this
+    # name, but it has to live on the record so the form can render the selection back and hang a
     # validation error on it.
     attr_accessor :connector_id
   end
@@ -41,8 +40,7 @@ module Idp::Support
   # error through their own soft-failure handling.
   def profile_managed_by_idp?
     # No connector on the record: nothing owns this profile but us, so the local fields are the
-    # only copy and stay editable. An account created local-only sits here until its first
-    # sign-in links it, at which point the connector's own answer takes over.
+    # only copy and stay editable (a local-only account, until its first sign-in links it).
     return false if primary_idp.blank?
 
     !idp_service.supports_profile_updates?

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -10,6 +10,14 @@
 module Idp::Support
   extend ActiveSupport::Concern
 
+  included do
+    # Virtual: the realm an admin picks on the account-create form. Never persisted under this name
+    # — a successful create records the choice as a UserAuthenticationSource and last_connector_id —
+    # but it has to live on the record so the form can render the selection back and hang a
+    # validation error on it.
+    attr_accessor :connector_id
+  end
+
   def idp_service
     return @idp_service if defined?(@idp_service)
 
@@ -32,6 +40,11 @@ module Idp::Support
   # default that keeps the admin form renderable; management actions surface the real config
   # error through their own soft-failure handling.
   def profile_managed_by_idp?
+    # No connector on the record: nothing owns this profile but us, so the local fields are the
+    # only copy and stay editable. An account created local-only sits here until its first
+    # sign-in links it, at which point the connector's own answer takes over.
+    return false if primary_idp.blank?
+
     !idp_service.supports_profile_updates?
   rescue Idp::ServiceError
     true

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -11,10 +11,8 @@ module Idp::Support
   extend ActiveSupport::Concern
 
   included do
-    # Virtual: the realm an admin picks on the account-create form. Never persisted under this
-    # name, but it has to live on the record so the form can render the selection back and hang a
-    # validation error on it.
-    attr_accessor :connector_id
+    # Virtual: the IdP connector an admin picks on the account-create form.
+    attr_accessor :selected_idp_connector_id
   end
 
   def idp_service
@@ -39,8 +37,7 @@ module Idp::Support
   # default that keeps the admin form renderable; management actions surface the real config
   # error through their own soft-failure handling.
   def profile_managed_by_idp?
-    # No connector on the record: nothing owns this profile but us, so the local fields are the
-    # only copy and stay editable (a local-only account, until its first sign-in links it).
+    # No connection to external IdP so fields stay editable
     return false if primary_idp.blank?
 
     !idp_service.supports_profile_updates?

--- a/app/models/concerns/idp/support.rb
+++ b/app/models/concerns/idp/support.rb
@@ -12,7 +12,7 @@ module Idp::Support
 
   included do
     # Virtual: the IdP connector an admin picks on the account-create form.
-    attr_accessor :selected_idp_connector_id
+    attr_accessor :idp_connector_id
   end
 
   def idp_service

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -22,7 +22,11 @@ module Idp
     #   happens by email on first JWT sign-in, same as a connector without a management API.
     def initialize(connector_id:, email:, first_name:, last_name:, agency_id: nil, user_class: User)
       @connector_id = connector_id
-      @email = email
+      # Normalize the same way Idp::JwtHelper#payload_email does. User.email is stored verbatim and
+      # never downcased on save, so a mixed-case entry here would miss the email-fallback link
+      # (Idp::UserProvisioner#find_existing_user matches the downcased token email) and provision a
+      # duplicate account on first sign-in.
+      @email = email&.strip&.downcase
       @first_name = first_name
       @last_name = last_name
       @agency_id = agency_id

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -17,9 +17,7 @@ module Idp
     private_class_method :new
 
     # @param connector_id [String, nil] nil creates a local account only: no remote account is
-    #   provisioned and no UserAuthenticationSource is written. Use for a realm we can't
-    #   provision into (one with no management API, or a provider we don't implement) — the link
-    #   happens by email on first JWT sign-in, same as a connector without a management API.
+    #   provisioned and no UserAuthenticationSource is written.
     def initialize(connector_id:, email:, first_name:, last_name:, agency_id: nil, user_class: User)
       @connector_id = connector_id
       # Normalize the same way Idp::JwtHelper#payload_email does. User.email is stored verbatim and
@@ -36,7 +34,6 @@ module Idp
     # @raise [ActiveRecord::RecordInvalid] the local user is invalid (e.g. email already in use)
     # @raise [Idp::ServiceError] the remote create/lookup failed on a management-API connector
     def call
-      # A blank connector_id resolves to a NullService, which reports no user creation.
       service = Idp::ServiceFactory.for_connector(@connector_id)
 
       # Claim the email locally (unique index) before any irreversible remote call, so concurrent

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -80,12 +80,14 @@ module Idp
       if existing
         # A match with no id is contradictory: the IdP claims this email exists but gives us nothing
         # to link on. Creating a new account would duplicate it (or 409), so fail loudly instead.
-        raise Idp::ServiceError.new(
-          "IdP returned a match with no id for #{@email}",
-          idp_name: service.idp_name,
-          operation: :find_user_by_email,
-          transient: false,
-        ) if existing['id'].blank?
+        if existing['id'].blank?
+          raise Idp::ServiceError.new(
+            "IdP returned a match with no id for #{@email}",
+            idp_name: service.idp_name,
+            operation: :find_user_by_email,
+            transient: false,
+          )
+        end
 
         return existing['id']
       end

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -16,17 +16,23 @@ module Idp
 
     private_class_method :new
 
-    def initialize(connector_id:, email:, first_name:, last_name:, user_class: User)
+    # @param connector_id [String, nil] nil creates a local account only: no remote account is
+    #   provisioned and no UserAuthenticationSource is written. Use for a realm we can't
+    #   provision into (one with no management API, or a provider we don't implement) — the link
+    #   happens by email on first JWT sign-in, same as a connector without a management API.
+    def initialize(connector_id:, email:, first_name:, last_name:, agency_id: nil, user_class: User)
       @connector_id = connector_id
       @email = email
       @first_name = first_name
       @last_name = last_name
+      @agency_id = agency_id
       @user_class = user_class
     end
 
     # @raise [ActiveRecord::RecordInvalid] the local user is invalid (e.g. email already in use)
     # @raise [Idp::ServiceError] the remote create/lookup failed on a management-API connector
     def call
+      # A blank connector_id resolves to a NullService, which reports no user creation.
       service = Idp::ServiceFactory.for_connector(@connector_id)
 
       # Claim the email locally (unique index) before any irreversible remote call, so concurrent
@@ -34,7 +40,7 @@ module Idp
       user = build_user
       user.save!
 
-      # No management API: link happens by email on first JWT sign-in instead.
+      # No connector chosen, or no management API: link happens by email on first JWT sign-in.
       return user unless service.supports_user_creation?
 
       begin
@@ -67,7 +73,7 @@ module Idp
         first_name: @first_name,
         last_name: @last_name,
         active: true,
-        agency_id: 0, # required; placeholder until the next user edit sets a real agency.
+        agency_id: @agency_id,
       )
     end
 

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -77,7 +77,18 @@ module Idp
 
     def find_or_create_connector_user_id(service)
       existing = service.find_user_by_email(email: @email)
-      return existing['id'] if existing && existing['id'].present?
+      if existing
+        # A match with no id is contradictory: the IdP claims this email exists but gives us nothing
+        # to link on. Creating a new account would duplicate it (or 409), so fail loudly instead.
+        raise Idp::ServiceError.new(
+          "IdP returned a match with no id for #{@email}",
+          idp_name: service.idp_name,
+          operation: :find_user_by_email,
+          transient: false,
+        ) if existing['id'].blank?
+
+        return existing['id']
+      end
 
       service.create_user(email: @email, first_name: @first_name, last_name: @last_name).fetch(:connector_user_id)
     end

--- a/app/services/idp/admin_user_creator.rb
+++ b/app/services/idp/admin_user_creator.rb
@@ -20,10 +20,7 @@ module Idp
     #   provisioned and no UserAuthenticationSource is written.
     def initialize(connector_id:, email:, first_name:, last_name:, agency_id: nil, user_class: User)
       @connector_id = connector_id
-      # Normalize the same way Idp::JwtHelper#payload_email does. User.email is stored verbatim and
-      # never downcased on save, so a mixed-case entry here would miss the email-fallback link
-      # (Idp::UserProvisioner#find_existing_user matches the downcased token email) and provision a
-      # duplicate account on first sign-in.
+      # Normalize the same way Idp::JwtHelper#payload_email does.
       @email = email&.strip&.downcase
       @first_name = first_name
       @last_name = last_name
@@ -41,7 +38,7 @@ module Idp
       user = build_user
       user.save!
 
-      # No connector chosen, or no management API: link happens by email on first JWT sign-in.
+      # No management API: link happens by email on first JWT sign-in.
       return user unless service.supports_user_creation?
 
       begin

--- a/app/services/idp/user_provisioner.rb
+++ b/app/services/idp/user_provisioner.rb
@@ -50,9 +50,7 @@ module Idp
       @connector_id = @jwt_helper.connector_id
       @connector_user_id = @jwt_helper.connector_user_id
 
-      # Email alone resolves or provisions: a token from a local login, or from a connector we
-      # hold no config for, carries no federated_claims, and that person still needs an account.
-      # The durable connector link is learned only when both claims are present.
+      # Email is the only claim we require as it's used to link accounts on first-login
       @email.present?
     end
 
@@ -61,7 +59,6 @@ module Idp
       @connector_id.present? && @connector_user_id.present?
     end
 
-    # The attributes that identify one IdP link.
     def connector_identity
       { connector_id: @connector_id, connector_user_id: @connector_user_id }
     end

--- a/app/services/idp/user_provisioner.rb
+++ b/app/services/idp/user_provisioner.rb
@@ -26,7 +26,7 @@ module Idp
 
       # Learn the durable connector link for every resolved user (existing or
       # JIT-created), independent of whether JIT-creation was allowed.
-      if @learn
+      if @learn && connector_identity?
         ensure_authentication_source(user)
         update_last_connector(user)
       end
@@ -50,7 +50,15 @@ module Idp
       @connector_id = @jwt_helper.connector_id
       @connector_user_id = @jwt_helper.connector_user_id
 
-      @email.present? && @connector_id.present? && @connector_user_id.present?
+      # Email alone resolves or provisions: a token from a local login, or from a connector we
+      # hold no config for, carries no federated_claims, and that person still needs an account.
+      # The durable connector link is learned only when both claims are present.
+      @email.present?
+    end
+
+    # Both halves of the link or neither: UserAuthenticationSource requires both columns.
+    def connector_identity?
+      @connector_id.present? && @connector_user_id.present?
     end
 
     # The  attributes that identify one IdP link.
@@ -61,13 +69,15 @@ module Idp
     def find_existing_user
       # hot path, called on every authenticated request.
       # use eager_load for one query
-      auth_source = Idp::UserAuthenticationSource.
-        where(connector_identity).
-        eager_load(:user).
-        order(Idp::UserAuthenticationSource.arel_table[:id]).
-        first
+      if connector_identity?
+        auth_source = Idp::UserAuthenticationSource.
+          where(connector_identity).
+          eager_load(:user).
+          order(Idp::UserAuthenticationSource.arel_table[:id]).
+          first
 
-      return auth_source.user if auth_source
+        return auth_source.user if auth_source
+      end
 
       user = @user_class.find_by(email: @email)
       Rails.logger.info("JWT email-fallback lookup matched user id=#{user.id} via connector #{@connector_id}") if user

--- a/app/services/idp/user_provisioner.rb
+++ b/app/services/idp/user_provisioner.rb
@@ -61,7 +61,7 @@ module Idp
       @connector_id.present? && @connector_user_id.present?
     end
 
-    # The  attributes that identify one IdP link.
+    # The attributes that identify one IdP link.
     def connector_identity
       { connector_id: @connector_id, connector_user_id: @connector_user_id }
     end

--- a/app/views/admin/idp/users/index.haml
+++ b/app/views/admin/idp/users/index.haml
@@ -9,11 +9,10 @@
     .o-page__controls
       .o-page__search
         = render_generic_search_form(admin_user_search_queries_path, prompt: @prompt, initial_value: @query, method: :post)
-    - if idp_user_creation_available?
-      .o-page__action.o-page__action--stacked
-        = link_to new_admin_user_path, class: 'btn btn-primary pull-right mb-2' do
-          %span.icon-plus
-          Add a User Account
+    .o-page__action.o-page__action--stacked
+      = link_to new_admin_user_path, class: 'btn btn-primary pull-right mb-2' do
+        %span.icon-plus
+        Add a User Account
 
 = render 'admin/users/tabs', selected_path: admin_users_path
 

--- a/app/views/admin/idp/users/new.haml
+++ b/app/views/admin/idp/users/new.haml
@@ -11,13 +11,13 @@
       = f.input :agency_id, collection: @agencies, label_method: :name, value_method: :id, include_blank: true, as: :select_two, required: true, label: 'Agency'
 
       - if @connectors.none?
-        = f.hidden_field :selected_idp_connector_id, value: local_only_connector
+        = f.hidden_field :idp_connector_id, value: local_only_connector
       - elsif @connectors.one?
-        = f.input :selected_idp_connector_id, as: :boolean, label: 'Manual account setup (advanced)',
+        = f.input :idp_connector_id, as: :boolean, label: 'Manual account setup (advanced)',
           checked_value: local_only_connector, unchecked_value: @connectors.first.connector_id,
           hint: "Leave unchecked unless you are configuring this account manually in an external IdP, such as Okta"
       - else
-        = f.input :selected_idp_connector_id, as: :radio_buttons, required: true, label: 'Identity provider',
+        = f.input :idp_connector_id, as: :radio_buttons, required: true, label: 'Identity provider',
           collection: @connectors.map { |c| [c.name, c.connector_id] } + [['Local account only', local_only_connector]]
 
       .form-actions.mt-4

--- a/app/views/admin/idp/users/new.haml
+++ b/app/views/admin/idp/users/new.haml
@@ -11,13 +11,13 @@
       = f.input :agency_id, collection: @agencies, label_method: :name, value_method: :id, include_blank: true, as: :select_two, required: true, label: 'Agency'
 
       - if @connectors.none?
-        = f.hidden_field :connector_id, value: local_only_connector
+        = f.hidden_field :selected_idp_connector_id, value: local_only_connector
       - elsif @connectors.one?
-        = f.input :connector_id, as: :boolean, label: 'Manual account setup (advanced)',
+        = f.input :selected_idp_connector_id, as: :boolean, label: 'Manual account setup (advanced)',
           checked_value: local_only_connector, unchecked_value: @connectors.first.connector_id,
           hint: "Leave unchecked unless you are configuring this account manually in an external IdP, such as Okta"
       - else
-        = f.input :connector_id, as: :radio_buttons, required: true, label: 'Identity provider',
+        = f.input :selected_idp_connector_id, as: :radio_buttons, required: true, label: 'Identity provider',
           collection: @connectors.map { |c| [c.name, c.connector_id] } + [['Local account only', local_only_connector]]
 
       .form-actions.mt-4

--- a/app/views/admin/idp/users/new.haml
+++ b/app/views/admin/idp/users/new.haml
@@ -4,16 +4,22 @@
   %h1= content_for :title
   = simple_form_for @user, url: admin_users_path, method: :post do |f|
     .form-inputs.well
-      - if @connectors.many?
-        .form-group
-          = label_tag 'user_connector_id', 'Identity provider'
-          = select_tag 'user[connector_id]', options_for_select(@connectors.map { |c| [c.name, c.connector_id] }, params.dig(:user, :connector_id)), class: 'form-control', id: 'user_connector_id'
-          %small.form-text.text-muted Which identity provider realm this account will be created in.
-      - elsif @connectors.one?
-        = hidden_field_tag 'user[connector_id]', @connectors.first.connector_id
+
       = f.input :first_name, required: true
       = f.input :last_name, required: true
       = f.input :email, as: :email, required: true, hint: 'Must match the email for the account in the IdP'
+      = f.input :agency_id, collection: @agencies, label_method: :name, value_method: :id, include_blank: true, as: :select_two, required: true, label: 'Agency'
+
+      - if @connectors.none?
+        = f.hidden_field :connector_id, value: local_only_connector
+      - elsif @connectors.one?
+        = f.input :connector_id, as: :boolean, label: 'Manual account setup (advanced)',
+          checked_value: local_only_connector, unchecked_value: @connectors.first.connector_id,
+          hint: "Leave unchecked unless you are configuring this account manually in an external IdP, such as Okta"
+      - else
+        = f.input :connector_id, as: :radio_buttons, required: true, label: 'Identity provider',
+          collection: @connectors.map { |c| [c.name, c.connector_id] } + [['Local account only', local_only_connector]]
+
       .form-actions.mt-4
         = f.button :submit, 'Create account', class: 'btn btn-primary'
         = link_to 'Cancel', admin_users_path, class: 'btn btn-link'

--- a/app/views/errors/sign_out_failed.html.haml
+++ b/app/views/errors/sign_out_failed.html.haml
@@ -1,5 +1,5 @@
 %h1= Translation.translate('We could not finish signing you out')
-%p= Translation.translate('Your session with the identity provider is still active, so you are still signed in. Green River has been notified.')
+%p= Translation.translate('Your session with the identity provider is still active, so you are still signed in.')
 %p= Translation.translate('If it keeps failing, quitting your browser completely will usually end the session.')
 %p
   = link_to Translation.translate('Try signing out again'), destroy_user_session_path, method: :delete, class: 'btn btn-primary'

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -286,10 +286,10 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
       expect { get :auth }.to raise_error(Idp::UnauthenticatedRequestError, /\/auth/)
     end
 
-    # The other way current_user comes back nil: Idp::UserProvisioner returns nil for a good token
-    # it can neither resolve nor provision from — now only a token carrying no email claim, since
-    # provisioning is unconditional. A terminal page — not a 500, and not a redirect the proxy
-    # would bounce straight back with the same token.
+    # Second case where current_user is nil: the token is valid but Idp::UserProvisioner returned
+    # nil. Provisioning is unconditional, so this means only a token that carries no email claim.
+    # Render a terminal 403, not a 500 and not a redirect — a redirect would send the same token
+    # back to the proxy and loop.
     it 'renders a terminal 403 for a good token whose holder has no warehouse account' do
       allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
 

--- a/spec/controllers/concerns/idp/jwt_current_user_spec.rb
+++ b/spec/controllers/concerns/idp/jwt_current_user_spec.rb
@@ -287,9 +287,9 @@ RSpec.describe Idp::JwtCurrentUser, :jwt_only, type: :controller do
     end
 
     # The other way current_user comes back nil: Idp::UserProvisioner returns nil for a good token
-    # with no matching user row when idp/auto_create_user is off, which is routine on a realm shared
-    # with other apps. A real person who needs an account, so a terminal page — not a 500, and not a
-    # redirect the proxy would bounce straight back with the same token.
+    # it can neither resolve nor provision from — now only a token carrying no email claim, since
+    # provisioning is unconditional. A terminal page — not a 500, and not a redirect the proxy
+    # would bounce straight back with the same token.
     it 'renders a terminal 403 for a good token whose holder has no warehouse account' do
       allow(User).to receive(:find_or_create_from_jwt).and_return(nil)
 

--- a/spec/models/concerns/idp/jwt_user_spec.rb
+++ b/spec/models/concerns/idp/jwt_user_spec.rb
@@ -29,14 +29,19 @@ RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
       expect(User.find_from_jwt(jwt_helper)).to be_nil
     end
 
-    it 'returns nil when connector_id is nil (fail-closed)' do
-      allow(jwt_helper).to receive(:connector_id).and_return(nil)
+    it 'returns nil when the token carries no email' do
+      allow(jwt_helper).to receive(:payload_email).and_return(nil)
       expect(User.find_from_jwt(jwt_helper)).to be_nil
     end
 
-    it 'returns nil when connector_user_id is nil (fail-closed)' do
+    it 'still resolves by email when connector_id is absent' do
+      allow(jwt_helper).to receive(:connector_id).and_return(nil)
+      expect(User.find_from_jwt(jwt_helper)).to eq(user)
+    end
+
+    it 'still resolves by email when connector_user_id is absent' do
       allow(jwt_helper).to receive(:connector_user_id).and_return(nil)
-      expect(User.find_from_jwt(jwt_helper)).to be_nil
+      expect(User.find_from_jwt(jwt_helper)).to eq(user)
     end
 
     it 'finds a user by Authentication Source when one exists' do
@@ -72,9 +77,7 @@ RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
       expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil
     end
 
-    context 'with auto-creation enabled' do
-      before { AppConfigProperty.create!(key: 'idp/auto_create_user', value: 'true') }
-
+    context 'provisioning' do
       it 'finds by auth source even when the JWT email no longer matches' do
         user.user_authentication_sources.create!(
           connector_id: 'test-idp',
@@ -103,25 +106,29 @@ RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
         expect(result.agency_id).to eq(0)
         expect(result.user_authentication_sources.where(connector_id: 'test-idp', connector_user_id: 'ext-user-new')).to exist
       end
-    end
 
-    context 'without auto-creation' do
+      it 'creates a user when the token carries no connector claims' do
+        allow(jwt_helper).to receive(:connector_id).and_return(nil)
+        allow(jwt_helper).to receive(:connector_user_id).and_return(nil)
+        allow(jwt_helper).to receive(:payload_email).and_return('nobody@example.com')
+
+        result = User.find_or_create_from_jwt(jwt_helper)
+        expect(result).to be_persisted
+        expect(result.email).to eq('nobody@example.com')
+        expect(result.user_authentication_sources).to be_empty
+        expect(result.last_connector_id).to be_nil
+      end
+
+      it 'returns nil when the token carries no email' do
+        allow(jwt_helper).to receive(:payload_email).and_return(nil)
+        expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil
+      end
+
       it 'provisions an Authentication Source and last_connector_id for an existing user' do
         result = User.find_or_create_from_jwt(jwt_helper)
         expect(result).to eq(user)
         expect(user.user_authentication_sources.where(connector_id: 'test-idp', connector_user_id: 'ext-user-1')).to exist
         expect(user.reload.last_connector_id).to eq('test-idp')
-      end
-
-      it 'does NOT create a user when idp/auto_create_user is absent' do
-        allow(jwt_helper).to receive(:payload_email).and_return('nobody@example.com')
-        expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil
-      end
-
-      it 'does NOT create a user when idp/auto_create_user is false' do
-        AppConfigProperty.create!(key: 'idp/auto_create_user', value: 'false')
-        allow(jwt_helper).to receive(:payload_email).and_return('nobody@example.com')
-        expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil
       end
     end
 

--- a/spec/models/concerns/idp/jwt_user_spec.rb
+++ b/spec/models/concerns/idp/jwt_user_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
   end
 
   describe '.find_or_create_from_jwt' do
-    # Fail-closed claim checks live in the shared provisioner gate and are
-    # covered exhaustively under .find_from_jwt; this is just a smoke test that
-    # this entry point routes through the same gate.
+    # Claim validation lives in the shared provisioner gate and is covered
+    # exhaustively under .find_from_jwt; this is just a smoke test that this
+    # entry point routes through the same gate.
     it 'returns nil when valid? is false' do
       allow(jwt_helper).to receive(:valid?).and_return(false)
       expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil

--- a/spec/models/concerns/idp/jwt_user_spec.rb
+++ b/spec/models/concerns/idp/jwt_user_spec.rb
@@ -69,9 +69,9 @@ RSpec.describe Idp::JwtUser, :jwt_only, type: :model do
   end
 
   describe '.find_or_create_from_jwt' do
-    # Claim validation lives in the shared provisioner gate and is covered
-    # exhaustively under .find_from_jwt; this is just a smoke test that this
-    # entry point routes through the same gate.
+    # Both entry points validate the token the same way in Idp::UserProvisioner, and
+    # .find_from_jwt tests that fully. This one check confirms this method rejects an
+    # invalid token too.
     it 'returns nil when valid? is false' do
       allow(jwt_helper).to receive(:valid?).and_return(false)
       expect(User.find_or_create_from_jwt(jwt_helper)).to be_nil

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
     let(:new_kc_id) { 'kc-new-id' }
     let(:actions_url) { "#{users_url}/#{new_kc_id}/execute-actions-email" }
     let(:agency) { create(:agency) }
-    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, selected_idp_connector_id: connector_id } } }
+    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, idp_connector_id: connector_id } } }
 
     describe 'GET index' do
       it 'offers an "Add a User Account" button linking to the create form' do
@@ -107,11 +107,11 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         get new_admin_user_path
 
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
-        checkbox = html.at_css('input[type=checkbox][name="user[selected_idp_connector_id]"]')
+        expect(html.css('input[type=radio][name="user[idp_connector_id]"]')).to be_empty
+        checkbox = html.at_css('input[type=checkbox][name="user[idp_connector_id]"]')
         expect(checkbox['value']).to eq(described_class::LOCAL_ONLY_CONNECTOR)
         expect(checkbox['checked']).to be_nil
-        expect(html.at_css('input[type=hidden][name="user[selected_idp_connector_id]"]')['value']).to eq(connector_id)
+        expect(html.at_css('input[type=hidden][name="user[idp_connector_id]"]')['value']).to eq(connector_id)
       end
 
       context 'with several creation-capable connectors' do
@@ -123,7 +123,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
           get new_admin_user_path
 
           html = Nokogiri::HTML(response.body)
-          radios = html.css('input[type=radio][name="user[selected_idp_connector_id]"]')
+          radios = html.css('input[type=radio][name="user[idp_connector_id]"]')
           # Connectors ordered by name, then the local-only option.
           expect(radios.map { |r| r['value'] }).to eq([connector_id, other_config.connector_id, described_class::LOCAL_ONLY_CONNECTOR])
           expect(radios.select { |r| r['checked'] }).to be_empty
@@ -154,7 +154,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when the email is entered with mixed case' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, selected_idp_connector_id: connector_id } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, idp_connector_id: connector_id } } }
 
         before do
           stub_request(:get, users_url).with(query: { email: new_email, exact: 'true' }).to_return(status: 200, body: [].to_json)
@@ -213,7 +213,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when the local-only option is chosen' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, selected_idp_connector_id: described_class::LOCAL_ONLY_CONNECTOR } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, idp_connector_id: described_class::LOCAL_ONLY_CONNECTOR } } }
 
         # The local-only radio is for a realm we can't provision into (an Okta one, say). It must not
         # silently fall back to the sole configured connector and create the account in that realm.
@@ -263,7 +263,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when no agency is chosen' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', selected_idp_connector_id: connector_id } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', idp_connector_id: connector_id } } }
 
         it 're-renders the form and never provisions the IdP' do
           expect { post admin_users_path, params: params }.not_to change(User, :count)
@@ -313,7 +313,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
         expect(response).to have_http_status(:ok)
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
+        expect(html.css('input[type=radio][name="user[idp_connector_id]"]')).to be_empty
         expect(html.css('select#user_agency_id')).to be_present
       end
 
@@ -338,7 +338,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
         expect(response).to have_http_status(:ok)
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
+        expect(html.css('input[type=radio][name="user[idp_connector_id]"]')).to be_empty
         expect(html.css('select#user_agency_id')).to be_present
       end
 
@@ -792,7 +792,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
     it 'refuses to create a user and provisions nothing in the IdP' do
       expect do
-        post admin_users_path, params: { user: { first_name: 'New', last_name: 'Bie', email: 'newbie@example.com', selected_idp_connector_id: connector_id } }
+        post admin_users_path, params: { user: { first_name: 'New', last_name: 'Bie', email: 'newbie@example.com', idp_connector_id: connector_id } }
       end.not_to change(User, :count)
 
       expect(a_request(:get, users_url)).not_to have_been_made

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
     let(:new_email) { 'newbie@example.com' }
     let(:new_kc_id) { 'kc-new-id' }
     let(:actions_url) { "#{users_url}/#{new_kc_id}/execute-actions-email" }
-    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, connector_id: connector_id } } }
+    let(:agency) { create(:agency) }
+    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, connector_id: connector_id } } }
 
     describe 'GET index' do
       it 'offers an "Add a User Account" button linking to the create form' do
@@ -84,10 +85,12 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         expect(response.body).to include(new_admin_user_path)
       end
 
-      it 'omits the create button when there are no active connectors' do
+      # A local-only account is still worth creating with no connector configured: the IdP matches
+      # it by email on first sign-in.
+      it 'still offers the create button when there are no active connectors' do
         ::Idp::ServiceConfig.update_all(active: false)
         get admin_users_path
-        expect(response.body).not_to include(new_admin_user_path)
+        expect(response.body).to include(new_admin_user_path)
       end
     end
 
@@ -95,6 +98,42 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       it 'renders the create form' do
         get new_admin_user_path
         expect(response).to have_http_status(:ok)
+      end
+
+      it 'offers an agency select' do
+        agency # created so it can be selected
+        get new_admin_user_path
+
+        html = Nokogiri::HTML(response.body)
+        expect(html.css('select#user_agency_id option').map { |o| o['value'] }).to include(agency.id.to_s)
+      end
+
+      it 'offers a "Local account only" checkbox that defaults to the sole connector' do
+        get new_admin_user_path
+
+        html = Nokogiri::HTML(response.body)
+        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
+        checkbox = html.at_css('input[type=checkbox][name="user[connector_id]"]')
+        expect(checkbox['value']).to eq(described_class::LOCAL_ONLY_CONNECTOR)
+        expect(checkbox['checked']).to be_nil
+        expect(html.at_css('input[type=hidden][name="user[connector_id]"]')['value']).to eq(connector_id)
+      end
+
+      context 'with several creation-capable connectors' do
+        let!(:other_config) do
+          create(:idp_service_config, connector_id: 'other', provider: 'keycloak', api_url: api_url, keycloak_realm: realm, name: 'Other realm')
+        end
+
+        it 'offers a radio per connector plus local-only, with nothing pre-selected' do
+          get new_admin_user_path
+
+          html = Nokogiri::HTML(response.body)
+          radios = html.css('input[type=radio][name="user[connector_id]"]')
+          # Connectors ordered by name, then the local-only option.
+          expect(radios.map { |r| r['value'] }).to eq([connector_id, other_config.connector_id, described_class::LOCAL_ONLY_CONNECTOR])
+          # No default: creating the account in the wrong realm has to be cleaned up in two places.
+          expect(radios.select { |r| r['checked'] }).to be_empty
+        end
       end
     end
 
@@ -161,6 +200,67 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         end
       end
 
+      context 'when the local-only option is chosen' do
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, connector_id: described_class::LOCAL_ONLY_CONNECTOR } } }
+
+        # The local-only radio is for a realm we can't provision into (an Okta one, say). It must not
+        # silently fall back to the sole configured connector and create the account in that realm.
+        it 'creates a local-only user with no remote call and no connector link' do
+          expect { post admin_users_path, params: params }.to change(User, :count).by(1)
+
+          user = User.find_by(email: new_email)
+          expect(user.agency_id).to eq(agency.id)
+          expect(user.user_authentication_sources).to be_empty
+          expect(user.last_connector_id).to be_nil
+          expect(a_request(:get, users_url)).not_to have_been_made
+          expect(a_request(:post, users_url)).not_to have_been_made
+          expect(response).to redirect_to(edit_admin_user_path(user))
+        end
+      end
+
+      # Distinct from the local-only choice above: no radio was touched at all, which is an
+      # unanswered question, not a request for a local-only account.
+      context 'when the identity provider radio is left untouched' do
+        let!(:other_config) do
+          create(:idp_service_config, connector_id: 'other', provider: 'keycloak', api_url: api_url, keycloak_realm: realm, name: 'Other realm')
+        end
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id } } }
+
+        it 're-renders the form with an error and provisions nothing' do
+          expect { post admin_users_path, params: params }.not_to change(User, :count)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('must be chosen')
+          expect(a_request(:get, users_url)).not_to have_been_made
+          expect(a_request(:post, users_url)).not_to have_been_made
+        end
+      end
+
+      # Not reachable from the checkbox form, which always submits a value.
+      context 'when connector_id is omitted with one connector configured' do
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id } } }
+
+        it 'creates a local-only user with no remote call' do
+          expect { post admin_users_path, params: params }.to change(User, :count).by(1)
+
+          user = User.find_by(email: new_email)
+          expect(user.user_authentication_sources).to be_empty
+          expect(a_request(:post, users_url)).not_to have_been_made
+          expect(response).to redirect_to(edit_admin_user_path(user))
+        end
+      end
+
+      context 'when no agency is chosen' do
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', connector_id: connector_id } } }
+
+        it 're-renders the form and never provisions the IdP' do
+          expect { post admin_users_path, params: params }.not_to change(User, :count)
+
+          expect(response).to have_http_status(:ok)
+          expect(a_request(:post, users_url)).not_to have_been_made
+        end
+      end
+
       context 'when the email already exists locally' do
         let!(:dup) { create(:acl_user, email: new_email) }
 
@@ -213,23 +313,66 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
     end
 
-    # No active connector at all: nothing to provision against, so the form is unavailable.
+    # No active connector at all: nothing to provision against, so the form offers no identity
+    # provider choice and every account it makes is local-only.
     describe 'when there are no active connectors' do
       before { ::Idp::ServiceConfig.update_all(active: false) }
 
-      it 'redirects GET new to the index with an unavailable alert' do
+      it 'renders GET new with no identity provider radios' do
         get new_admin_user_path
 
-        expect(response).to redirect_to(admin_users_path)
-        expect(flash[:alert]).to match(/not available/i)
+        expect(response).to have_http_status(:ok)
+        html = Nokogiri::HTML(response.body)
+        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
+        expect(html.css('select#user_agency_id')).to be_present
       end
 
-      it 'redirects POST create to the index without creating a user' do
-        expect { post admin_users_path, params: params }.not_to change(User, :count)
+      # The submitted connector_id names a config that is no longer active, so it must not be used
+      # to provision: create_connector_id constrains it to available_connectors.
+      it 'creates a local-only user and ignores the submitted connector_id' do
+        expect { post admin_users_path, params: params }.to change(User, :count).by(1)
 
-        expect(response).to redirect_to(admin_users_path)
-        expect(flash[:alert]).to match(/not available/i)
+        user = User.find_by(email: new_email)
+        expect(user.agency_id).to eq(agency.id)
+        expect(user.user_authentication_sources).to be_empty
+        expect(user.last_connector_id).to be_nil
+        expect(a_request(:post, users_url)).not_to have_been_made
+        expect(response).to redirect_to(edit_admin_user_path(user))
       end
+    end
+  end
+
+  # An account created local-only has no connector until its first sign-in links it, so the IdP
+  # holds no copy of the profile to be overwritten by a local edit.
+  describe 'editing an account with no IdP link' do
+    let!(:unlinked) { create(:acl_user, first_name: 'Un', last_name: 'Linked', email: 'unlinked@example.com') }
+
+    it 'leaves the identity fields editable on the form' do
+      get edit_admin_user_path(unlinked)
+
+      html = Nokogiri::HTML(response.body)
+      ['first_name', 'last_name', 'email'].each do |field|
+        expect(html.at_css("input#user_#{field}")['disabled']).to be_nil
+      end
+    end
+
+    it 'saves an identity change locally with no remote call' do
+      patch admin_user_path(unlinked), params: { user: { first_name: 'Renamed', email: 'renamed@example.com' } }
+
+      unlinked.reload
+      expect(unlinked.first_name).to eq('Renamed')
+      expect(unlinked.email).to eq('renamed@example.com')
+      expect(a_request(:put, %r{/admin/realms/})).not_to have_been_made
+    end
+
+    # The linked account is only locked when its IdP refuses profile writes; the 'test' connector
+    # accepts them, so the fields stay editable there too.
+    it 'locks the identity fields for an account linked to an IdP that refuses profile writes' do
+      allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_profile_updates?).and_return(false)
+      get edit_admin_user_path(target)
+
+      html = Nokogiri::HTML(response.body)
+      expect(html.at_css('input#user_email')['disabled']).to eq('disabled')
     end
   end
 
@@ -590,18 +733,20 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
     end
 
-    it 'strips crafted name/email params for a locked (unlinked) profile and never calls Keycloak' do
-      unlinked = create(:acl_user, first_name: 'Locked', last_name: 'User', email: 'locked@example.com')
+    # Locked is the linked IdP refusing profile writes, so crafted params must not slip past the
+    # disabled inputs. Fields the IdP has no opinion about still save.
+    it 'strips crafted name/email params when the linked IdP refuses profile writes' do
+      allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_profile_updates?).and_return(false)
 
-      patch admin_user_path(unlinked), params: {
+      patch admin_user_path(target), params: {
         user: { first_name: 'Hacked', last_name: 'Hacked', email: 'hacked@example.com', notify_on_client_added: '1' },
       }
 
-      unlinked.reload
-      expect(unlinked.first_name).to eq('Locked')
-      expect(unlinked.last_name).to eq('User')
-      expect(unlinked.email).to eq('locked@example.com')
-      expect(unlinked.notify_on_client_added).to be true
+      target.reload
+      expect(target.first_name).to eq('Target')
+      expect(target.last_name).to eq('User')
+      expect(target.email).not_to eq('hacked@example.com')
+      expect(target.notify_on_client_added).to be true
       expect(a_request(:put, /#{Regexp.escape(api_url)}/)).not_to have_been_made
     end
 
@@ -648,8 +793,8 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       expect(flash[:alert]).to include(refusal)
     end
 
-    # new and create carry require_user_creation_available! of their own, and create provisions an
-    # account in the remote IdP, so require_can_edit_users! has to be the filter that runs first.
+    # create provisions an account in the remote IdP, so require_can_edit_users! has to run before
+    # any of the create path's own filters.
     it 'refuses to render the create form' do
       get new_admin_user_path
 

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -126,7 +126,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
           radios = html.css('input[type=radio][name="user[connector_id]"]')
           # Connectors ordered by name, then the local-only option.
           expect(radios.map { |r| r['value'] }).to eq([connector_id, other_config.connector_id, described_class::LOCAL_ONLY_CONNECTOR])
-          # No default: creating the account in the wrong realm has to be cleaned up in two places.
           expect(radios.select { |r| r['checked'] }).to be_empty
         end
       end
@@ -154,9 +153,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         end
       end
 
-      # AdminUserCreator downcases the email before the local save and the IdP lookup, so a mixed-case
-      # entry links to the account the token's downcased email will match on first sign-in rather than
-      # provisioning a duplicate.
       context 'when the email is entered with mixed case' do
         let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, connector_id: connector_id } } }
 
@@ -381,10 +377,8 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       unlinked.reload
       expect(unlinked.first_name).to eq('Renamed')
       expect(unlinked.email).to eq('renamed@example.com')
-      expect(a_request(:put, %r{/admin/realms/})).not_to have_been_made
+      expect(a_request(:put, /\/admin\/realms\//)).not_to have_been_made
     end
-    # Locking the identity fields for a linked account whose IdP refuses profile writes is covered by
-    # the authenticate-only (manage_users:false) GET edit case below, against the real config path.
   end
 
   describe 'GET index (action-menu gating)' do
@@ -743,9 +737,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         expect(Sentry).not_to have_received(:capture_exception_with_info)
       end
     end
-
-    # Stripping crafted name/email params when the linked IdP refuses profile writes is covered by
-    # the authenticate-only (manage_users:false) PATCH update case below, against the real config path.
 
     it 'ignores expired_at (the IdP does not honor local account expiry)' do
       patch admin_user_path(target), params: {

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       it 'still offers the create button when the connector has no management API (local-only pre-create)' do
-        allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_user_creation?).and_return(false)
+        Idp::ServiceConfig.find_by(connector_id: connector_id).update!(manage_users: false)
         get admin_users_path
         expect(response.body).to include(new_admin_user_path)
       end
@@ -95,11 +95,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
     end
 
     describe 'GET new' do
-      it 'renders the create form' do
-        get new_admin_user_path
-        expect(response).to have_http_status(:ok)
-      end
-
       it 'offers an agency select' do
         agency # created so it can be selected
         get new_admin_user_path
@@ -156,6 +151,27 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
           expect(response).to redirect_to(edit_admin_user_path(user))
           expect(flash[:notice]).to match(/setup email has been sent/)
           expect(flash[:notice]).to match(/roles and access/i)
+        end
+      end
+
+      # AdminUserCreator downcases the email before the local save and the IdP lookup, so a mixed-case
+      # entry links to the account the token's downcased email will match on first sign-in rather than
+      # provisioning a duplicate.
+      context 'when the email is entered with mixed case' do
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, connector_id: connector_id } } }
+
+        before do
+          stub_request(:get, users_url).with(query: { email: new_email, exact: 'true' }).to_return(status: 200, body: [].to_json)
+          stub_request(:post, users_url).to_return(status: 201, headers: { 'Location' => "#{users_url}/#{new_kc_id}" })
+          stub_request(:put, actions_url).to_return(status: 204)
+        end
+
+        it 'stores the downcased address locally and looks the IdP up by it' do
+          post admin_users_path, params: params
+
+          expect(User.find_by(email: new_email)).to be_present
+          expect(User.where(email: 'Newbie@Example.com')).to be_empty
+          expect(a_request(:get, users_url).with(query: { email: new_email, exact: 'true' })).to have_been_made
         end
       end
 
@@ -293,13 +309,16 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
     describe 'when the connector has no management API' do
       before do
-        allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_user_creation?).and_return(false)
+        Idp::ServiceConfig.find_by(connector_id: connector_id).update!(manage_users: false)
       end
 
-      it 'renders GET new (the form is available for local-only pre-create)' do
+      it 'renders GET new with no identity provider radios (the form is available for local-only pre-create)' do
         get new_admin_user_path
 
         expect(response).to have_http_status(:ok)
+        html = Nokogiri::HTML(response.body)
+        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
+        expect(html.css('select#user_agency_id')).to be_present
       end
 
       it 'POST create makes a local-only user with no remote call and no connector link' do
@@ -364,16 +383,8 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       expect(unlinked.email).to eq('renamed@example.com')
       expect(a_request(:put, %r{/admin/realms/})).not_to have_been_made
     end
-
-    # The linked account is only locked when its IdP refuses profile writes; the 'test' connector
-    # accepts them, so the fields stay editable there too.
-    it 'locks the identity fields for an account linked to an IdP that refuses profile writes' do
-      allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_profile_updates?).and_return(false)
-      get edit_admin_user_path(target)
-
-      html = Nokogiri::HTML(response.body)
-      expect(html.at_css('input#user_email')['disabled']).to eq('disabled')
-    end
+    # Locking the identity fields for a linked account whose IdP refuses profile writes is covered by
+    # the authenticate-only (manage_users:false) GET edit case below, against the real config path.
   end
 
   describe 'GET index (action-menu gating)' do
@@ -733,22 +744,8 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
     end
 
-    # Locked is the linked IdP refusing profile writes, so crafted params must not slip past the
-    # disabled inputs. Fields the IdP has no opinion about still save.
-    it 'strips crafted name/email params when the linked IdP refuses profile writes' do
-      allow_any_instance_of(::Idp::KeycloakService).to receive(:supports_profile_updates?).and_return(false)
-
-      patch admin_user_path(target), params: {
-        user: { first_name: 'Hacked', last_name: 'Hacked', email: 'hacked@example.com', notify_on_client_added: '1' },
-      }
-
-      target.reload
-      expect(target.first_name).to eq('Target')
-      expect(target.last_name).to eq('User')
-      expect(target.email).not_to eq('hacked@example.com')
-      expect(target.notify_on_client_added).to be true
-      expect(a_request(:put, /#{Regexp.escape(api_url)}/)).not_to have_been_made
-    end
+    # Stripping crafted name/email params when the linked IdP refuses profile writes is covered by
+    # the authenticate-only (manage_users:false) PATCH update case below, against the real config path.
 
     it 'ignores expired_at (the IdP does not honor local account expiry)' do
       patch admin_user_path(target), params: {

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -85,8 +85,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         expect(response.body).to include(new_admin_user_path)
       end
 
-      # A local-only account is still worth creating with no connector configured: the IdP matches
-      # it by email on first sign-in.
       it 'still offers the create button when there are no active connectors' do
         ::Idp::ServiceConfig.update_all(active: false)
         get admin_users_path
@@ -230,8 +228,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         end
       end
 
-      # Distinct from the local-only choice above: no radio was touched at all, which is an
-      # unanswered question, not a request for a local-only account.
       context 'when the identity provider radio is left untouched' do
         let!(:other_config) do
           create(:idp_service_config, connector_id: 'other', provider: 'keycloak', api_url: api_url, keycloak_realm: realm, name: 'Other realm')
@@ -357,8 +353,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
     end
   end
 
-  # An account created local-only has no connector until its first sign-in links it, so the IdP
-  # holds no copy of the profile to be overwritten by a local edit.
   describe 'editing an account with no IdP link' do
     let!(:unlinked) { create(:acl_user, first_name: 'Un', last_name: 'Linked', email: 'unlinked@example.com') }
 

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
     let(:new_kc_id) { 'kc-new-id' }
     let(:actions_url) { "#{users_url}/#{new_kc_id}/execute-actions-email" }
     let(:agency) { create(:agency) }
-    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, connector_id: connector_id } } }
+    let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, selected_idp_connector_id: connector_id } } }
 
     describe 'GET index' do
       it 'offers an "Add a User Account" button linking to the create form' do
@@ -107,11 +107,11 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         get new_admin_user_path
 
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
-        checkbox = html.at_css('input[type=checkbox][name="user[connector_id]"]')
+        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
+        checkbox = html.at_css('input[type=checkbox][name="user[selected_idp_connector_id]"]')
         expect(checkbox['value']).to eq(described_class::LOCAL_ONLY_CONNECTOR)
         expect(checkbox['checked']).to be_nil
-        expect(html.at_css('input[type=hidden][name="user[connector_id]"]')['value']).to eq(connector_id)
+        expect(html.at_css('input[type=hidden][name="user[selected_idp_connector_id]"]')['value']).to eq(connector_id)
       end
 
       context 'with several creation-capable connectors' do
@@ -123,7 +123,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
           get new_admin_user_path
 
           html = Nokogiri::HTML(response.body)
-          radios = html.css('input[type=radio][name="user[connector_id]"]')
+          radios = html.css('input[type=radio][name="user[selected_idp_connector_id]"]')
           # Connectors ordered by name, then the local-only option.
           expect(radios.map { |r| r['value'] }).to eq([connector_id, other_config.connector_id, described_class::LOCAL_ONLY_CONNECTOR])
           expect(radios.select { |r| r['checked'] }).to be_empty
@@ -154,7 +154,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when the email is entered with mixed case' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, connector_id: connector_id } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: 'Newbie@Example.com', agency_id: agency.id, selected_idp_connector_id: connector_id } } }
 
         before do
           stub_request(:get, users_url).with(query: { email: new_email, exact: 'true' }).to_return(status: 200, body: [].to_json)
@@ -213,7 +213,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when the local-only option is chosen' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, connector_id: described_class::LOCAL_ONLY_CONNECTOR } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id, selected_idp_connector_id: described_class::LOCAL_ONLY_CONNECTOR } } }
 
         # The local-only radio is for a realm we can't provision into (an Okta one, say). It must not
         # silently fall back to the sole configured connector and create the account in that realm.
@@ -263,7 +263,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
       end
 
       context 'when no agency is chosen' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', connector_id: connector_id } } }
+        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', selected_idp_connector_id: connector_id } } }
 
         it 're-renders the form and never provisions the IdP' do
           expect { post admin_users_path, params: params }.not_to change(User, :count)
@@ -313,7 +313,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
         expect(response).to have_http_status(:ok)
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
+        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
         expect(html.css('select#user_agency_id')).to be_present
       end
 
@@ -338,7 +338,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
         expect(response).to have_http_status(:ok)
         html = Nokogiri::HTML(response.body)
-        expect(html.css('input[type=radio][name="user[connector_id]"]')).to be_empty
+        expect(html.css('input[type=radio][name="user[selected_idp_connector_id]"]')).to be_empty
         expect(html.css('select#user_agency_id')).to be_present
       end
 
@@ -792,7 +792,7 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
 
     it 'refuses to create a user and provisions nothing in the IdP' do
       expect do
-        post admin_users_path, params: { user: { first_name: 'New', last_name: 'Bie', email: 'newbie@example.com', connector_id: connector_id } }
+        post admin_users_path, params: { user: { first_name: 'New', last_name: 'Bie', email: 'newbie@example.com', selected_idp_connector_id: connector_id } }
       end.not_to change(User, :count)
 
       expect(a_request(:get, users_url)).not_to have_been_made

--- a/spec/requests/admin/idp/users_controller_spec.rb
+++ b/spec/requests/admin/idp/users_controller_spec.rb
@@ -244,20 +244,6 @@ RSpec.describe Admin::Idp::UsersController, :jwt_only, type: :request do
         end
       end
 
-      # Not reachable from the checkbox form, which always submits a value.
-      context 'when connector_id is omitted with one connector configured' do
-        let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: agency.id } } }
-
-        it 'creates a local-only user with no remote call' do
-          expect { post admin_users_path, params: params }.to change(User, :count).by(1)
-
-          user = User.find_by(email: new_email)
-          expect(user.user_authentication_sources).to be_empty
-          expect(a_request(:post, users_url)).not_to have_been_made
-          expect(response).to redirect_to(edit_admin_user_path(user))
-        end
-      end
-
       context 'when no agency is chosen' do
         let(:params) { { user: { first_name: 'New', last_name: 'Bie', email: new_email, agency_id: '', idp_connector_id: connector_id } } }
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -82,8 +82,6 @@ RSpec.describe Admin::UsersController, type: :request do
       end
     end
 
-    # users.agency_id has no foreign key, so an id naming no agency would otherwise save as a
-    # dangling reference.
     context 'when the submitted agency does not exist' do
       let!(:agency) { create(:agency) }
       let(:updated_user) { create(:acl_user, agency_id: agency.id) }

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe Admin::UsersController, type: :request do
       end
     end
 
+    # users.agency_id has no foreign key, so an id naming no agency would otherwise save as a
+    # dangling reference.
+    context 'when the submitted agency does not exist' do
+      let!(:agency) { create(:agency) }
+      let(:updated_user) { create(:acl_user, agency_id: agency.id) }
+
+      it 'keeps the existing agency and re-renders the form' do
+        patch admin_user_path(updated_user), params: { user: { agency_id: agency.id + 1_000 } }
+
+        expect(updated_user.reload.agency_id).to eq(agency.id)
+        expect(response).to render_template :edit
+      end
+
+      it 'accepts a real agency' do
+        other = create(:agency)
+        patch admin_user_path(updated_user), params: { user: { agency_id: other.id } }
+
+        expect(updated_user.reload.agency_id).to eq(other.id)
+      end
+    end
+
     context 'when updating new client notifications' do
       let(:updated_user) { User.not_system.first }
 

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -12,14 +12,17 @@ require 'rails_helper'
 # boot (AUTH_METHOD=jwt); under Devise, User is :secure_validatable and requires one.
 RSpec.describe Idp::AdminUserCreator, :jwt_only do
   let(:connector_id) { 'kc' }
+  let(:agency) { create(:agency) }
   let(:service) { instance_double(Idp::KeycloakService, supports_user_creation?: true, idp_name: 'Keycloak') }
 
   before do
     allow(Idp::ServiceFactory).to receive(:for_connector).with(connector_id).and_return(service)
   end
 
-  def call(email: 'newbie@example.com')
-    described_class.call(connector_id: connector_id, email: email, first_name: 'New', last_name: 'User')
+  def call(email: 'newbie@example.com', **overrides)
+    described_class.call(
+      **{ connector_id: connector_id, email: email, first_name: 'New', last_name: 'User', agency_id: agency.id }.merge(overrides),
+    )
   end
 
   context 'when the email is new to the IdP' do
@@ -32,9 +35,29 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
       user = call
 
       expect(user).to be_persisted
+      expect(user.agency_id).to eq(agency.id)
       expect(user.last_connector_id).to eq(connector_id)
       expect(user.user_authentication_sources.pluck(:connector_id, :connector_user_id)).to eq([[connector_id, 'kc-new']])
       expect(service).to have_received(:create_user).with(email: 'newbie@example.com', first_name: 'New', last_name: 'User')
+    end
+
+    it 'rejects a blank agency before provisioning anything remotely' do
+      expect { call(agency_id: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(service).not_to have_received(:create_user)
+    end
+  end
+
+  # 'None' in the admin form: a realm we can't provision into (Okta, say). The account is matched
+  # by email on first sign-in, so no service is built and no connector link is written.
+  context 'when no connector is chosen' do
+    before { allow(Idp::ServiceFactory).to receive(:for_connector).with(nil).and_call_original }
+
+    it 'resolves a NullService and creates a local-only user with no remote call' do
+      user = call(connector_id: nil)
+
+      expect(user).to be_persisted
+      expect(user.last_connector_id).to be_nil
+      expect(user.user_authentication_sources).to be_empty
     end
   end
 
@@ -94,7 +117,7 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
     end
 
     it 'persists and links an instance of the given class' do
-      user = described_class.call(connector_id: connector_id, email: 'hmis@example.com', first_name: 'H', last_name: 'M', user_class: Hmis::User)
+      user = call(email: 'hmis@example.com', first_name: 'H', last_name: 'M', user_class: Hmis::User)
 
       expect(user).to be_a(Hmis::User)
       expect(user).to be_persisted

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
       expect(user.user_authentication_sources).to be_empty
     end
 
-    # The link happens by email on first sign-in, and payload_email is downcased. A mixed-case
-    # entry here must be stored downcased so it resolves the same account rather than provisioning
-    # a duplicate.
-    it 'downcases the email so first sign-in links the same account instead of duplicating it' do
-      user = call(connector_id: nil, email: 'Mixed.Case@Example.com')
+    # The link happens by email on first sign-in, and payload_email is downcased and stripped. A
+    # mixed-case, space-padded entry here must be stored normalized so it resolves the same account
+    # rather than provisioning a duplicate.
+    it 'normalizes the email so first sign-in links the same account instead of duplicating it' do
+      user = call(connector_id: nil, email: '  Mixed.Case@Example.com  ')
       expect(user.email).to eq('mixed.case@example.com')
 
       jwt_helper = instance_double(
@@ -97,6 +97,43 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
     end
   end
 
+  # A lookup hit that carries no usable id is not a match: Keycloak can return a representation
+  # whose id we can't link on, so fall through to creating the account rather than writing a blank
+  # connector_user_id.
+  context 'when the IdP lookup returns a hash with no usable id' do
+    before do
+      allow(service).to receive(:find_user_by_email).and_return('id' => '')
+      allow(service).to receive(:create_user).and_return(success: true, connector_user_id: 'kc-new')
+    end
+
+    it 'provisions a new remote account and links the created id' do
+      user = call
+
+      expect(user.user_authentication_sources.pluck(:connector_user_id)).to eq(['kc-new'])
+      expect(service).to have_received(:create_user).with(email: 'newbie@example.com', first_name: 'New', last_name: 'User')
+    end
+  end
+
+  # Provisioning claims the email locally first, then calls the remote IdP. A failure after that
+  # local save must roll the local user back, or a failed attempt permanently owns the unique email
+  # and no retry for that address can ever succeed. (The 409 arm of this is exercised end-to-end in
+  # the request spec; here we pin the compensation itself: the raise propagates and nothing is left
+  # behind.)
+  context 'when the remote provisioning call fails' do
+    before do
+      allow(service).to receive(:find_user_by_email).and_return(nil)
+      allow(service).to receive(:create_user).
+        and_raise(Idp::ServiceError.new('boom', idp_name: 'Keycloak', operation: :create_user, transient: true))
+    end
+
+    it 'rolls the local user back and re-raises, leaving the email free to retry' do
+      expect { call }.to raise_error(Idp::ServiceError)
+
+      expect(User.find_by(email: 'newbie@example.com')).to be_nil
+      expect(Idp::UserAuthenticationSource.where(connector_id: connector_id)).to be_empty
+    end
+  end
+
   context 'when the email is already taken locally' do
     let!(:existing) { create(:user, email: 'dup@example.com') }
 
@@ -121,12 +158,6 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
       expect(user.last_connector_id).to be_nil
       expect(user.user_authentication_sources).to be_empty
       expect(service).not_to have_received(:find_user_by_email)
-    end
-
-    it 'still enforces local email uniqueness' do
-      create(:user, email: 'dup@example.com')
-
-      expect { call(email: 'dup@example.com') }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -116,9 +116,7 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
 
   # Provisioning claims the email locally first, then calls the remote IdP. A failure after that
   # local save must roll the local user back, or a failed attempt permanently owns the unique email
-  # and no retry for that address can ever succeed. (The 409 arm of this is exercised end-to-end in
-  # the request spec; here we pin the compensation itself: the raise propagates and nothing is left
-  # behind.)
+  # and no retry for that address can ever succeed.
   context 'when the remote provisioning call fails' do
     before do
       allow(service).to receive(:find_user_by_email).and_return(nil)

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
       expect(user.last_connector_id).to be_nil
       expect(user.user_authentication_sources).to be_empty
     end
+
+    # The link happens by email on first sign-in, and payload_email is downcased. A mixed-case
+    # entry here must be stored downcased so it resolves the same account rather than provisioning
+    # a duplicate.
+    it 'downcases the email so first sign-in links the same account instead of duplicating it' do
+      user = call(connector_id: nil, email: 'Mixed.Case@Example.com')
+      expect(user.email).to eq('mixed.case@example.com')
+
+      jwt_helper = instance_double(
+        Idp::JwtHelper,
+        token?: true,
+        valid?: true,
+        connector_id: nil,
+        connector_user_id: nil,
+        payload_email: 'mixed.case@example.com',
+        first_name: 'Mixed',
+        last_name: 'Case',
+      )
+
+      expect { User.find_or_create_from_jwt(jwt_helper) }.not_to change(User, :count)
+      expect(User.find_or_create_from_jwt(jwt_helper)).to eq(user)
+    end
   end
 
   context 'when the email already exists in the IdP' do

--- a/spec/services/idp/admin_user_creator_spec.rb
+++ b/spec/services/idp/admin_user_creator_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
       expect(user.user_authentication_sources).to be_empty
     end
 
-    # The link happens by email on first sign-in, and payload_email is downcased and stripped. A
-    # mixed-case, space-padded entry here must be stored normalized so it resolves the same account
-    # rather than provisioning a duplicate.
+    # payload_email is downcased and stripped to match
     it 'normalizes the email so first sign-in links the same account instead of duplicating it' do
       user = call(connector_id: nil, email: '  Mixed.Case@Example.com  ')
       expect(user.email).to eq('mixed.case@example.com')
@@ -97,20 +95,18 @@ RSpec.describe Idp::AdminUserCreator, :jwt_only do
     end
   end
 
-  # A lookup hit that carries no usable id is not a match: Keycloak can return a representation
-  # whose id we can't link on, so fall through to creating the account rather than writing a blank
-  # connector_user_id.
-  context 'when the IdP lookup returns a hash with no usable id' do
+  # A match with no id is contradictory: the IdP claims the email exists but gives us nothing to
+  # link on. We raise rather than create a duplicate remote account, and the local user rolls back.
+  context 'when the IdP lookup returns a match with no usable id' do
     before do
       allow(service).to receive(:find_user_by_email).and_return('id' => '')
-      allow(service).to receive(:create_user).and_return(success: true, connector_user_id: 'kc-new')
+      allow(service).to receive(:create_user)
     end
 
-    it 'provisions a new remote account and links the created id' do
-      user = call
-
-      expect(user.user_authentication_sources.pluck(:connector_user_id)).to eq(['kc-new'])
-      expect(service).to have_received(:create_user).with(email: 'newbie@example.com', first_name: 'New', last_name: 'User')
+    it 'raises and does not provision or persist a local user' do
+      expect { call }.to raise_error(Idp::ServiceError, /no id/)
+      expect(service).not_to have_received(:create_user)
+      expect(User.where(email: 'newbie@example.com')).to be_empty
     end
   end
 

--- a/spec/support/shared_examples/auth_method_user_examples.rb
+++ b/spec/support/shared_examples/auth_method_user_examples.rb
@@ -473,9 +473,24 @@ RSpec.shared_examples 'an auth-method-aware user' do |factory, model|
     end
 
     describe 'profile_managed_by_idp?' do
-      it 'follows idp_service.supports_profile_updates?: locked when unlinked (NullService can\'t accept writes)' do
+      # An account created local-only has no connector until its first sign-in links it. Nothing
+      # else owns the profile in the meantime, so the local fields must stay editable.
+      it 'is false when the record names no connector, even though NullService can\'t accept writes' do
         user = model.new
+        expect(user.primary_idp).to be_blank
         expect(user.idp_service.supports_profile_updates?).to be false
+        expect(user.profile_managed_by_idp?).to be false
+      end
+
+      it 'is true when the linked IdP service cannot accept profile writes' do
+        user = model.new(last_connector_id: 'authenticate-only')
+        allow(user).to receive(:idp_service).and_return(instance_double(Idp::KeycloakService, supports_profile_updates?: false))
+        expect(user.profile_managed_by_idp?).to be true
+      end
+
+      it 'is true when the service cannot be built, so a misconfigured connector locks rather than opens the fields' do
+        user = model.new(last_connector_id: 'broken')
+        allow(user).to receive(:idp_service).and_raise(Idp::ServiceError.new('boom', idp_name: 'Keycloak', operation: :get_user))
         expect(user.profile_managed_by_idp?).to be true
       end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description

- remove idp/auto_create_user gate; JWT provisioning is now unconditional
- resolve/provision by email when connector claims are absent, learn the connector link only when both claims are present
- admin create form: select an IdP connector or "Local account only", no default; local-only skips remote provisioning and links by email on sign-in
- require agency on new accounts, validate agency_id against an assignable scope on create and edit (column has no FK)
- allow editing identity fields on accounts not yet linked to an external IdP
- downcase admin-entered email so local-only accounts link instead of duplicating on first sign-in

## Type of change
Bug fix, New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

