### PR TITLE
Fix flaky date-based tests

### DIFF
--- a/app/models/concerns/arel_helper.rb
+++ b/app/models/concerns/arel_helper.rb
@@ -166,6 +166,14 @@ module ArelHelper
       nf 'CAST', [exp.as(as)]
     end
 
+    # CAST(col AT TIME ZONE 'UTC' AT TIME ZONE '<app zone>' AS DATE). Timestamp columns hold naive
+    # UTC; a bare date cast would bucket evening local activity into the next day.
+    def local_date(column)
+      at_utc = Arel::Nodes::InfixOperation.new('AT TIME ZONE', column, Arel::Nodes.build_quoted('UTC'))
+      at_local = Arel::Nodes::InfixOperation.new('AT TIME ZONE', at_utc, Arel::Nodes.build_quoted(Time.zone.tzinfo.name))
+      nf 'CAST', [at_local.as('DATE')]
+    end
+
     # NOTE: you must join project and organization for this to work.
     def confidentialized_project_name(column)
       conditions = [
@@ -476,6 +484,6 @@ module ArelHelper
     delegate :she_t, :shs_t, :shsm_t, :s_t, :g_t, :e_t, :ec_t, :ex_t, :ds_t, :c_t, :cn_t, :p_t, :pc_t, :o_t, :i_t, :af_t, :as_t, :asq_t, :ev_t, :ch_t, :hc_t, :wc_t, :wcp_t, :ib_t, :d_t, :hdv_t, :f_t, :cls_t, :enx_t, :hmis_form_t, :hmis_c_t, :c_client_t, :c_c_change_t, :yib_t, :vispdat_t, :r_monthly_t, :hr_ri_t, :r_t, :ag_t, :collection_t, to: 'self.class'
 
     # Other methods
-    delegate :qt, :nf, :unionize, :add_alias, :cl, :ct, :greatest, :bool_or, :confidentialized_project_name, :checksum, :datepart, :seconds_diff, :datediff, :cast, :acase, :lit, to: 'self.class'
+    delegate :qt, :nf, :unionize, :add_alias, :cl, :ct, :greatest, :bool_or, :confidentialized_project_name, :checksum, :datepart, :seconds_diff, :datediff, :cast, :local_date, :acase, :lit, to: 'self.class'
   end
 end

--- a/drivers/access_logs/app/models/access_logs/warehouse_reports/usage_summary.rb
+++ b/drivers/access_logs/app/models/access_logs/warehouse_reports/usage_summary.rb
@@ -35,18 +35,24 @@ class AccessLogs::WarehouseReports::UsageSummary
     { key: url, name: name, unique_visits: user_visits.values.sum, unique_users: user_visits.size, user_visits: user_visits }
   end
 
-  # One grouped query: report_key (via CASE, first-match-wins) x user_id x COUNT(DISTINCT day).
+  # One grouped query: report_key (via CASE, first-match-wins) x user_id x COUNT(DISTINCT local day).
   # ActivityLog.warehouse_report_conditions is the single source of truth for what counts as each
   # report's activity (including any ReportDefinition `reporting_query` override) -- shared with
   # the ActivityLog.warehouse_reports scope used for the WHERE below.
   def grouped_rows
     at = ActivityLog.arel_table
     report_key = acase(ActivityLog.warehouse_report_conditions.map { |url, condition| [condition, url] })
-    visit_day = cast(at[:created_at], 'date')
+    visit_day = local_date(at[:created_at])
 
-    ActivityLog.warehouse_reports.created_in_range(range: @range).
+    ActivityLog.warehouse_reports.created_in_range(range: timestamp_range).
       group(report_key, :user_id).
       pluck(report_key, :user_id, Arel::Nodes::Count.new([visit_day], true))
+  end
+
+  # created_at is a timestamp column; comparing it to bare Date bounds casts the upper bound to
+  # midnight UTC, silently excluding same-day visits made after that (evening Eastern).
+  def timestamp_range
+    @range.begin.beginning_of_day..@range.end.end_of_day
   end
 
   def report_names

--- a/drivers/access_logs/spec/models/access_logs/warehouse_reports/usage_summary_spec.rb
+++ b/drivers/access_logs/spec/models/access_logs/warehouse_reports/usage_summary_spec.rb
@@ -78,6 +78,49 @@ RSpec.describe AccessLogs::WarehouseReports::UsageSummary do
     expect(summary[:reports].map { |r| r[:key] }).to eq(['warehouse_reports/chronic'])
   end
 
+  # created_at is a timestamp column. Both bounds of the Date range must expand to whole
+  # local days, or same-day activity logged after midnight UTC (evening Eastern) is dropped
+  # and pre-range activity logged after midnight UTC is counted.
+  it 'counts a visit logged on the last day of the range after midnight UTC' do
+    travel_to Time.zone.local(2026, 8, 31, 22, 15) do
+      log_visit(user: user_1, path: chronic_path, visited_at: Time.current)
+
+      report = summary[:reports].find { |r| r[:key] == 'warehouse_reports/chronic' }
+
+      expect(report&.dig(:user_visits, user_1.id.to_s)).to eq(1)
+    end
+  end
+
+  it 'excludes a visit from the day before the range starts even when it falls after midnight UTC' do
+    log_visit(user: user_1, path: chronic_path, visited_at: range.begin.beginning_of_day + 21.hours)
+    log_visit(user: user_1, path: chronic_path, visited_at: range.begin.beginning_of_day - 3.hours)
+
+    report = summary[:reports].find { |r| r[:key] == 'warehouse_reports/chronic' }
+
+    expect(report[:user_visits][user_1.id.to_s]).to eq(1)
+  end
+
+  # visit days are counted per local calendar day, so a day boundary in UTC must not split or
+  # merge a user's visits.
+  it 'counts two same-day Eastern visits that straddle midnight UTC as one visit day' do
+    log_visit(user: user_1, path: chronic_path, visited_at: 1.day.ago.beginning_of_day + 19.hours)
+    log_visit(user: user_1, path: chronic_path, visited_at: 1.day.ago.beginning_of_day + 21.hours)
+
+    report = summary[:reports].find { |r| r[:key] == 'warehouse_reports/chronic' }
+
+    expect(report[:user_visits][user_1.id.to_s]).to eq(1)
+    expect(report[:unique_visits]).to eq(1)
+  end
+
+  it 'counts an 11pm visit and a 1am visit on consecutive Eastern days as two visit days' do
+    log_visit(user: user_1, path: chronic_path, visited_at: 2.days.ago.beginning_of_day + 23.hours)
+    log_visit(user: user_1, path: chronic_path, visited_at: 1.day.ago.beginning_of_day + 1.hour)
+
+    report = summary[:reports].find { |r| r[:key] == 'warehouse_reports/chronic' }
+
+    expect(report[:user_visits][user_1.id.to_s]).to eq(2)
+  end
+
   # Nightly Census's sub-routes (/censuses/date_range, /censuses/details) are also used by an
   # AJAX widget embedded on the project show page (app/views/projects/show.haml), so path alone
   # can't tell "visited the report" from "opened a project page that happens to embed its chart."

--- a/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
+++ b/drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb
@@ -1192,20 +1192,6 @@ module HmisCsvImporter::Importer
       batch_clear_pending_deletion(klass, matched_scope, file_name)
     end
 
-    # Arel node: CAST(col AT TIME ZONE 'UTC' AT TIME ZONE '<local>' AS DATE)
-    # The DB stores naive timestamps in UTC; this converts to the app's local
-    # timezone before extracting the date so day boundaries match
-    private def local_date_cast_arel(conn, arel_column)
-      tz = Time.zone.tzinfo.name
-      utc_tz = Arel::Nodes::SqlLiteral.new("'UTC'")
-      local_tz = Arel::Nodes::SqlLiteral.new(conn.quote(tz))
-
-      at_utc = Arel::Nodes::InfixOperation.new('AT TIME ZONE', arel_column, utc_tz)
-      at_local = Arel::Nodes::InfixOperation.new('AT TIME ZONE', at_utc, local_tz)
-
-      Arel::Nodes::NamedFunction.new('CAST', [Arel::Nodes::As.new(at_local, Arel.sql('DATE'))])
-    end
-
     # Clear pending deletion for warehouse rows where the incoming DateUpdated
     # (by local-timezone date) is strictly older than the warehouse value.
     # The warehouse copy is newer, so we keep it and skip the incoming row.
@@ -1222,9 +1208,8 @@ module HmisCsvImporter::Importer
       incoming_scope = klass.should_import.where(importer_log_id: @importer_log.id).
         where.not(DateUpdated: nil)
 
-      conn = klass.connection
-      staging_date = local_date_cast_arel(conn, staging[:DateUpdated])
-      wh_date      = local_date_cast_arel(conn, wh[:DateUpdated])
+      staging_date = local_date(staging[:DateUpdated])
+      wh_date      = local_date(wh[:DateUpdated])
 
       exists = incoming_scope.
         where(staging[klass.hud_key].eq(wh[klass.hud_key])).


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Fixes some date queries that were confused around date boundaries because they didn't account for the timezone
* Updates drivers/hmis_csv_importer/app/models/hmis_csv_importer/importer/importer.rb to use the centralized fix which previously used a similar local fix

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

