### PR TITLE
Scope cronjob and VPA cleanup to the intended resources

### DIFF
--- a/config/deploy/docker/lib/cronjob.rb
+++ b/config/deploy/docker/lib/cronjob.rb
@@ -44,19 +44,18 @@ class Cronjob
   def clear!
     cron_list.each do |cron|
       Rails.logger.info "Deleting #{cron.metadata.namespace}/#{cron.metadata.name} (#{cron.metadata.annotations&.description})"
-      crons.delete(cron.name)
     end
+    crons.delete_collection(labelSelector: { 'cron-source' => 'rails' })
   end
 
   def clear_defunct_vpas!
     Rails.logger.info 'Looking for orphaned VPAs'
     existing_crons = Set.new(cron_list.map { |cron| cron.metadata.name })
-
     vpa_list.each do |vpa|
-      if existing_crons.exclude?(vpa.metadata.labels['cronjob-name'])
-        Rails.logger.warn "Deleting #{vpa.metadata.name} which is orphaned"
-        vpas.delete(vpa.name)
-      end
+      next if existing_crons.include?(vpa.metadata.labels['cronjob-name'])
+
+      Rails.logger.warn "Deleting #{vpa.metadata.name} which is orphaned"
+      vpas.delete_resource(vpa) # was: vpas.delete(vpa.name) -> nil -> wiped every VPA
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

K8s::Resource has no top-level `name`, so `cron.name` and `vpa.name` returned nil. ResourceClient#delete builds the collection path when name is nil, turning each call into an unscoped namespace-wide deletecollection that removed cronjobs and VPAs this installer does not own. Delete cronjobs via an explicit cron-source=rails label selector, and orphaned VPAs via delete_resource, which reads the name from metadata.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

