### PR TITLE
Activate 2026 LSA version in HIC

### DIFF
--- a/drivers/hud_lsa/app/controllers/hud_lsa/lsa_hics_controller.rb
+++ b/drivers/hud_lsa/app/controllers/hud_lsa/lsa_hics_controller.rb
@@ -64,7 +64,7 @@ module HudLsa
       {
         'FY 2023' => { slug: :fy2023, active: false },
         'FY 2024' => { slug: :fy2024, active: false },
-        'FY 2026' => { slug: :fy2026, active: false },
+        'FY 2026' => { slug: :fy2026, active: true },
         'FY 2027' => { slug: :fy2027, active: true },
       }.freeze
     end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Set the 2026 HIC to active to match the LSA. This allows the 2026 LSA version to be used in the HIC

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug Fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

